### PR TITLE
8317980: Optimization for Integer.parseInt and Long.parseLong 

### DIFF
--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -260,6 +260,7 @@ class CharacterDataLatin1 extends CharacterData {
     //     System.out.printf("%2d, ", v);
     // }
     //
+    // Unlike DIGITS, which supports all radixes (2 to 36), DECIMAL_DIGITS is optimized for decimal (radix = 10).
     // Analysis has shown that generating the whole array allows the JIT to generate
     // better code compared to a slimmed down array, such as one cutting off after '9'
     @Stable

--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@
 package java.lang;
 
 import jdk.internal.vm.annotation.IntrinsicCandidate;
+import jdk.internal.vm.annotation.Stable;
 
 /** The CharacterData class encapsulates the large tables found in
     Java.lang.Character. */
@@ -249,6 +250,26 @@ class CharacterDataLatin1 extends CharacterData {
         int value = DIGITS[ch];
         return (value >= 0 && value < radix && radix >= Character.MIN_RADIX
                 && radix <= Character.MAX_RADIX) ? value : -1;
+    }
+
+    @Stable
+    private static final byte[] DECIMAL_DIGITS = new byte[] {
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+        -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1 };
+
+    static int digit(byte ch) {
+        return DECIMAL_DIGITS[ch & 0xFF];
     }
 
     int getNumericValue(int ch) {

--- a/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
+++ b/src/java.base/share/classes/java/lang/CharacterDataLatin1.java.template
@@ -252,6 +252,16 @@ class CharacterDataLatin1 extends CharacterData {
                 && radix <= Character.MAX_RADIX) ? value : -1;
     }
 
+    // Digit values for codePoints in the 0-255 range. Contents generated using:
+    // for (char i = 0; i < 256; i++) {
+    //     int v = -1;
+    //     if (i >= '0' && i <= '9') { v = i - '0'; }
+    //     if (i % 20 == 0) System.out.println();
+    //     System.out.printf("%2d, ", v);
+    // }
+    //
+    // Analysis has shown that generating the whole array allows the JIT to generate
+    // better code compared to a slimmed down array, such as one cutting off after '9'
     @Stable
     private static final byte[] DECIMAL_DIGITS = new byte[] {
         -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -547,45 +547,39 @@ public final class Integer extends Number
          */
 
         if (s == null) {
-            throw new NumberFormatException("Cannot parse null string");
+            throw NumberFormatException.forNull();
         }
 
-        if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+        if (radix != 10 || !s.isLatin1()) {
+            return parseInt(s, 0, s.length(), radix);
         }
 
-        if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
-        }
-
-        int len = s.length();
-        if (len == 0) {
-            throw NumberFormatException.forInputString("", radix);
-        }
-        int digit = ~0xFF;
-        int i = 0;
-        char firstChar = s.charAt(i++);
-        if (firstChar != '-' && firstChar != '+') {
-            digit = digit(firstChar, radix);
-        }
-        if (digit >= 0 || digit == ~0xFF && len > 1) {
-            int limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
-            int multmin = limit / radix;
-            int result = -(digit & 0xFF);
-            boolean inRange = true;
-            /* Accumulating negatively avoids surprises near MAX_VALUE */
-            while (i < len && (digit = digit(s.charAt(i++), radix)) >= 0
-                    && (inRange = result > multmin
-                        || result == multmin && digit <= radix * multmin - limit)) {
-                result = radix * result - digit;
+        byte[] value = s.value();
+        int len = value.length;
+        if (len != 0) {
+            int digit = ~0xFF;
+            int i = 0;
+            byte firstChar = value[i++];
+            if (firstChar != '-' && firstChar != '+') {
+                digit = CharacterDataLatin1.digit(firstChar);
             }
-            if (inRange && i == len && digit >= 0) {
-                return firstChar != '-' ? -result : result;
+            if (digit >= 0 || digit == ~0xFF && len > 1) {
+                int limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
+                int multmin = -214748364; // actual limit / 10;
+                int result = -(digit & 0xFF);
+                boolean inRange = true;
+                /* Accumulating negatively avoids surprises near MAX_VALUE */
+                while (i < len && (digit = CharacterDataLatin1.digit(value[i++])) >= 0
+                        && (inRange = result > multmin
+                            || result == multmin && digit <= 10 * multmin - limit)) {
+                    result = 10 * result - digit;
+                }
+                if (inRange && i == len && digit >= 0) {
+                    return firstChar != '-' ? -result : result;
+                }
             }
         }
-        throw NumberFormatException.forInputString(s, radix);
+        throw NumberFormatException.forInputString(s, 10);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -556,30 +556,31 @@ public final class Integer extends Number
 
         byte[] value = s.value();
         int len = value.length;
-        if (len != 0) {
-            int digit = ~0xFF;
-            int i = 0;
-            byte firstChar = value[i++];
-            if (firstChar != '-' && firstChar != '+') {
-                digit = CharacterDataLatin1.digit(firstChar);
+        if (len == 0) {
+            throw NumberFormatException.forInputString("", radix);
+        }
+        int digit = ~0xFF;
+        int i = 0;
+        byte firstChar = value[i++];
+        if (firstChar != '-' && firstChar != '+') {
+            digit = CharacterDataLatin1.digit(firstChar);
+        }
+        if (digit >= 0 || digit == ~0xFF && len > 1) {
+            int limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
+            int multmin = -214748364; // actual limit / 10;
+            int result = -(digit & 0xFF);
+            boolean inRange = true;
+            /* Accumulating negatively avoids surprises near MAX_VALUE */
+            while (i < len && (digit = CharacterDataLatin1.digit(value[i++])) >= 0
+                    && (inRange = result > multmin
+                        || result == multmin && digit <= radix * multmin - limit)) {
+                result = radix * result - digit;
             }
-            if (digit >= 0 || digit == ~0xFF && len > 1) {
-                int limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
-                int multmin = -214748364; // actual limit / 10;
-                int result = -(digit & 0xFF);
-                boolean inRange = true;
-                /* Accumulating negatively avoids surprises near MAX_VALUE */
-                while (i < len && (digit = CharacterDataLatin1.digit(value[i++])) >= 0
-                        && (inRange = result > multmin
-                            || result == multmin && digit <= 10 * multmin - limit)) {
-                    result = 10 * result - digit;
-                }
-                if (inRange && i == len && digit >= 0) {
-                    return firstChar != '-' ? -result : result;
-                }
+            if (inRange && i == len && digit >= 0) {
+                return firstChar != '-' ? -result : result;
             }
         }
-        throw NumberFormatException.forInputString(s, 10);
+        throw NumberFormatException.forInputString(s, radix);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -577,45 +577,39 @@ public final class Long extends Number
     public static long parseLong(String s, int radix)
                 throws NumberFormatException {
         if (s == null) {
-            throw new NumberFormatException("Cannot parse null string");
+            throw NumberFormatException.forNull();
         }
 
-        if (radix < Character.MIN_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s less than Character.MIN_RADIX", radix));
+        if (radix != 10 || !s.isLatin1()) {
+            return parseLong(s, 0, s.length(), radix);
         }
 
-        if (radix > Character.MAX_RADIX) {
-            throw new NumberFormatException(String.format(
-                "radix %s greater than Character.MAX_RADIX", radix));
-        }
-
-        int len = s.length();
-        if (len == 0) {
-            throw NumberFormatException.forInputString("", radix);
-        }
-        int digit = ~0xFF;
-        int i = 0;
-        char firstChar = s.charAt(i++);
-        if (firstChar != '-' && firstChar != '+') {
-            digit = digit(firstChar, radix);
-        }
-        if (digit >= 0 || digit == ~0xFF && len > 1) {
-            long limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
-            long multmin = limit / radix;
-            long result = -(digit & 0xFF);
-            boolean inRange = true;
-            /* Accumulating negatively avoids surprises near MAX_VALUE */
-            while (i < len && (digit = digit(s.charAt(i++), radix)) >= 0
-                    && (inRange = result > multmin
-                        || result == multmin && digit <= (int) (radix * multmin - limit))) {
-                result = radix * result - digit;
+        byte[] value = s.value();
+        int len = value.length;
+        if (len != 0) {
+            int digit = ~0xFF;
+            int i = 0;
+            byte firstChar = value[i++];
+            if (firstChar != '-' && firstChar != '+') {
+                digit = CharacterDataLatin1.digit(firstChar);
             }
-            if (inRange && i == len && digit >= 0) {
-                return firstChar != '-' ? -result : result;
+            if (digit >= 0 || digit == ~0xFF && len > 1) {
+                long limit = firstChar != '-' ? MIN_VALUE + 1 : MIN_VALUE;
+                long multmin = -922337203685477580L; // actual limit / 10
+                long result = -(digit & 0xFF);
+                boolean inRange = true;
+                /* Accumulating negatively avoids surprises near MAX_VALUE */
+                while (i < len && (digit = CharacterDataLatin1.digit(value[i++])) >= 0
+                        && (inRange = result > multmin
+                            || result == multmin && digit <= (int) (10 * multmin - limit))) {
+                    result = 10 * result - digit;
+                }
+                if (inRange && i == len && digit >= 0) {
+                    return firstChar != '-' ? -result : result;
+                }
             }
         }
-        throw NumberFormatException.forInputString(s, radix);
+        throw NumberFormatException.forInputString(s, 10);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/NumberFormatException.java
+++ b/src/java.base/share/classes/java/lang/NumberFormatException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -81,5 +81,9 @@ public class NumberFormatException extends IllegalArgumentException {
         return new NumberFormatException("Error at index "
                 + (errorIndex - beginIndex) + " in: \""
                 + s.subSequence(beginIndex, endIndex) + "\"");
+    }
+
+    static NumberFormatException forNull() {
+        return new NumberFormatException("Cannot parse null string");
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -75,6 +75,13 @@ public class Longs {
     public void toStringSmall(Blackhole bh) {
         for (long value : longArraySmall) {
             bh.consume(Long.toString(value));
+        }
+    }
+
+    @Benchmark
+    public void parseLong(Blackhole bh) {
+        for (String s : strings) {
+            bh.consume(Long.parseLong(s));
         }
     }
 


### PR DESCRIPTION
Currently, about 25% of the time spent by the Integer.parseInt and Long.parseLong methods is spent on the Character.digit method.

The Character.digit method is common to all radixes. We can use a digit method optimized for Latin1 encoding radix 10 to improve the performance of Integer.parseInt and Long.parseLong methods.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317980](https://bugs.openjdk.org/browse/JDK-8317980): Optimization for Integer.parseInt and Long.parseLong (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20168/head:pull/20168` \
`$ git checkout pull/20168`

Update a local copy of the PR: \
`$ git checkout pull/20168` \
`$ git pull https://git.openjdk.org/jdk.git pull/20168/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20168`

View PR using the GUI difftool: \
`$ git pr show -t 20168`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20168.diff">https://git.openjdk.org/jdk/pull/20168.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20168#issuecomment-2226547618)