### PR TITLE
8336342: Fix known X11 library locations in sysroot

### DIFF
--- a/make/autoconf/lib-x11.m4
+++ b/make/autoconf/lib-x11.m4
@@ -71,9 +71,9 @@ AC_DEFUN_ONCE([LIB_SETUP_X11],
           elif test -f "$SYSROOT/usr/lib/libX11.so"; then
             x_libraries="$SYSROOT/usr/lib"
           elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libX11.so"; then
-            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libX11.so"
+            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI"
           elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libX11.so"; then
-            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libX11.so"
+            x_libraries="$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI"
           fi
         fi
       fi


### PR DESCRIPTION
In [JDK-8257913](https://bugs.openjdk.org/browse/JDK-8257913), we added the search paths for X11 libraries, but they point explicitly to `libX11.so`. First, this is not really correct, as `x_libraries` would be added to a search path. Second, this apparently does not work for sysroots created by crosstool-ng, likely because it wants to find other libraries in the same location. Debootstrap-ed GHA seem to work because they find the X11 libraries before hitting this code, apparently.

We should just drop the `libX11.so` parts, and leave only the path.

Additional testing:
 - [x] JDK 23, 21, 17, 11 builds with the patch and crosstool-ng without problems now
 - [x] GHA
 - [x] A matrix of Server/Zero builds with GCC 10

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336342](https://bugs.openjdk.org/browse/JDK-8336342): Fix known X11 library locations in sysroot (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20170/head:pull/20170` \
`$ git checkout pull/20170`

Update a local copy of the PR: \
`$ git checkout pull/20170` \
`$ git pull https://git.openjdk.org/jdk.git pull/20170/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20170`

View PR using the GUI difftool: \
`$ git pr show -t 20170`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20170.diff">https://git.openjdk.org/jdk/pull/20170.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20170#issuecomment-2226911833)