### PR TITLE
8336316: JFR: Use SettingControl::getValue() instead of setValue() for ActiveSetting event

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,15 +108,18 @@ final class Control {
             // VM events requires no access control context
             try {
                 delegate.setValue(value);
+                lastValue = delegate.getValue();
             } catch (Throwable t) {
                 Logger.log(LogTag.JFR_SETTING, LogLevel.WARN, "Exception occurred when setting value \"" + value + "\" for " + getClass());
+                lastValue = null;
             }
         } else {
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
+            lastValue = AccessController.doPrivileged(new PrivilegedAction<String>() {
                 @Override
-                public Void run() {
+                public String run() {
                     try {
                         delegate.setValue(value);
+                        return delegate.getValue();
                     } catch (Throwable t) {
                         // Prevent malicious user to propagate exception callback in the wrong context
                         Logger.log(LogTag.JFR_SETTING, LogLevel.WARN, "Exception occurred when setting value \"" + value + "\" for " + getClass());
@@ -125,7 +128,6 @@ final class Control {
                 }
             }, context);
         }
-        lastValue = value;
     }
 
 


### PR DESCRIPTION
Could I have a review of a change that makes the ActiveSetting event act differently when an invalid value is specified.

Previously the last set value was used, but now the result of getValue() is returned. In case Control::getLastValue() returns null, the default value  is used.  Benefit of this change is to make it easier to diagnose setting related issues. The event will report the actual state of the event setting, not what happens to have been specified.

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336316](https://bugs.openjdk.org/browse/JDK-8336316): JFR: Use SettingControl::getValue() instead of setValue() for ActiveSetting event (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20172/head:pull/20172` \
`$ git checkout pull/20172`

Update a local copy of the PR: \
`$ git checkout pull/20172` \
`$ git pull https://git.openjdk.org/jdk.git pull/20172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20172`

View PR using the GUI difftool: \
`$ git pr show -t 20172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20172.diff">https://git.openjdk.org/jdk/pull/20172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20172#issuecomment-2242555590)