### PR TITLE
8336343: Add more known sysroot library locations for ALSA

### DIFF
--- a/make/autoconf/lib-alsa.m4
+++ b/make/autoconf/lib-alsa.m4
@@ -71,6 +71,25 @@ AC_DEFUN_ONCE([LIB_SETUP_ALSA],
       fi
     fi
     if test "x$ALSA_FOUND" = xno; then
+      # If we have sysroot set, and no explicit library location is set,
+      # look at known locations in sysroot.
+      if test "x$SYSROOT" != "x" && test "x${with_alsa_lib}" == x; then
+        if test -f "$SYSROOT/usr/lib64/libasound.so" && test "x$OPENJDK_TARGET_CPU_BITS" = x64; then
+          ALSA_LIBS="-L$SYSROOT/usr/lib64 -lasound"
+          ALSA_FOUND=yes
+        elif test -f "$SYSROOT/usr/lib/libasound.so"; then
+          ALSA_LIBS="-L$SYSROOT/usr/lib -lasound"
+          ALSA_FOUND=yes
+        elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libasound.so"; then
+          ALSA_LIBS="-L$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI -lasound"
+          ALSA_FOUND=yes
+        elif test -f "$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI/libasound.so"; then
+          ALSA_LIBS="-L$SYSROOT/usr/lib/$OPENJDK_TARGET_CPU_AUTOCONF-$OPENJDK_TARGET_OS-$OPENJDK_TARGET_ABI -lasound"
+          ALSA_FOUND=yes
+        fi
+      fi
+    fi
+    if test "x$ALSA_FOUND" = xno; then
       AC_CHECK_HEADERS([alsa/asoundlib.h],
           [
             ALSA_FOUND=yes


### PR DESCRIPTION
Following [JDK-8257913](https://bugs.openjdk.org/browse/JDK-8257913), it would be more convenient to search into more paths in sysroot for ALSA as well. Currently, this is the only thing that is missing for me to build from the crosstool-ng generated sysroot. Without these, we have to provide the additional `--with-alsa-lib` configuration param.

We do a similar thing for X11: https://github.com/openjdk/jdk/blob/6f325db49365d3d06add5d194d4696a1428675fa/make/autoconf/lib-x11.m4#L55-L79

Additional testing:
 - [x] JDK mainline builds with the patch and crosstool-ng without problems now
 - [x] GHA
 - [x] A matrix of Server/Zero builds with GCC 10

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336343](https://bugs.openjdk.org/browse/JDK-8336343): Add more known sysroot library locations for ALSA (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20173/head:pull/20173` \
`$ git checkout pull/20173`

Update a local copy of the PR: \
`$ git checkout pull/20173` \
`$ git pull https://git.openjdk.org/jdk.git pull/20173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20173`

View PR using the GUI difftool: \
`$ git pr show -t 20173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20173.diff">https://git.openjdk.org/jdk/pull/20173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20173#issuecomment-2226995100)