### PR TITLE
8336346: Fix -Wzero-as-null-pointer-constant warnings in jvmciJavaClasses.cpp

### DIFF
--- a/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
@@ -626,7 +626,7 @@ JVMCI_CLASSES_DO(EMPTY2, EMPTY0, FIELD2, FIELD2, FIELD2, FIELD2, FIELD2, FIELD3,
   void JNIJVMCI::className::check(JVMCIEnv* jvmciEnv, JVMCIObject obj, const char* field_name, jfieldID offset) {                 \
     assert(obj.is_non_null(), "null field access of %s.%s", #className, field_name);                                              \
     assert(jvmciEnv->isa_##className(obj), "wrong class, " #className " expected, found %s", jvmciEnv->klass_name(obj));          \
-    assert(offset != nullptr, "must be valid offset");                                                                                  \
+    assert(offset != nullptr, "must be valid offset");                                                                            \
   }                                                                                                                               \
   jclass JNIJVMCI::className::_class = nullptr;
 

--- a/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
+++ b/src/hotspot/share/jvmci/jvmciJavaClasses.cpp
@@ -584,7 +584,7 @@ void JNIJVMCI::register_natives(JNIEnv* env) {
 #define EMPTY2(x,y)
 #define FIELD3(className, name, sig) FIELD2(className, name)
 #define FIELD2(className, name) \
-  jfieldID JNIJVMCI::className::_##name##_field_id = 0; \
+  jfieldID JNIJVMCI::className::_##name##_field_id = nullptr; \
   int HotSpotJVMCI::className::_##name##_offset = 0;
 #define METHOD(jniCallType, jniGetMethod, hsCallType, returnType, className, methodName, signatureSymbolName)
 #define CONSTRUCTOR(className, signature)
@@ -626,7 +626,7 @@ JVMCI_CLASSES_DO(EMPTY2, EMPTY0, FIELD2, FIELD2, FIELD2, FIELD2, FIELD2, FIELD3,
   void JNIJVMCI::className::check(JVMCIEnv* jvmciEnv, JVMCIObject obj, const char* field_name, jfieldID offset) {                 \
     assert(obj.is_non_null(), "null field access of %s.%s", #className, field_name);                                              \
     assert(jvmciEnv->isa_##className(obj), "wrong class, " #className " expected, found %s", jvmciEnv->klass_name(obj));          \
-    assert(offset != 0, "must be valid offset");                                                                                  \
+    assert(offset != nullptr, "must be valid offset");                                                                                  \
   }                                                                                                                               \
   jclass JNIJVMCI::className::_class = nullptr;
 


### PR DESCRIPTION
Please review this trivial change to remove -Wzero-as-null-pointer-constant
warnings (when enabled), triggered by assignment to or comparison with a
jfieldID (a pointer type) with a value of 0.  Changing the value to nullptr
removes the warnings.

Because these changes are in macros that are used many times, this change
removes about 100 warnings.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336346](https://bugs.openjdk.org/browse/JDK-8336346): Fix -Wzero-as-null-pointer-constant warnings in jvmciJavaClasses.cpp (**Enhancement** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20175/head:pull/20175` \
`$ git checkout pull/20175`

Update a local copy of the PR: \
`$ git checkout pull/20175` \
`$ git pull https://git.openjdk.org/jdk.git pull/20175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20175`

View PR using the GUI difftool: \
`$ git pr show -t 20175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20175.diff">https://git.openjdk.org/jdk/pull/20175.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20175#issuecomment-2227323139)