### PR TITLE
8335922: Incorrect @Stable usage of LambdaForm$Name.index

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1339,7 +1339,7 @@ class LambdaForm {
 
     static final class Name {
         final BasicType type;
-        @Stable short flippedIndex; // uses -1..-256 for slots, 0 for unset
+        @Stable short offsetIndex; // slot + 1, reserves 0 for unset
         final NamedFunction function;
         final Object constraint;  // additional type information, if not null
         @Stable final Object[] arguments;
@@ -1347,7 +1347,7 @@ class LambdaForm {
         private static final Object[] EMPTY_ARGS = new Object[0];
 
         private Name(int index, BasicType type, NamedFunction function, Object[] arguments) {
-            this.flippedIndex = (short)~index;
+            this.offsetIndex = (short) (index + 1);
             this.type = type;
             this.function = function;
             this.arguments = arguments;
@@ -1355,7 +1355,7 @@ class LambdaForm {
             assert(this.index() == index && typesMatch(function, this.arguments));
         }
         private Name(Name that, Object constraint) {
-            this.flippedIndex = that.flippedIndex;
+            this.offsetIndex = that.offsetIndex;
             this.type = that.type;
             this.function = that.function;
             this.arguments = that.arguments;
@@ -1393,11 +1393,11 @@ class LambdaForm {
         Name(BasicType type) { this(-1, type); }
 
         BasicType type() { return type; }
-        int index() { return ~flippedIndex; }
+        int index() { return offsetIndex - 1; }
         boolean initIndex(int i) {
-            if (flippedIndex != ~i) {
-                if (flippedIndex != 0)  return false;
-                flippedIndex = (short)~i;
+            if (offsetIndex != i + 1) {
+                if (offsetIndex != 0)  return false;
+                offsetIndex = (short) (i + 1);
             }
             return true;
         }
@@ -1519,7 +1519,7 @@ class LambdaForm {
         }
 
         public String toString() {
-            return (isParam() ? "a" : "t") + (flippedIndex != 0 ? index() : System.identityHashCode(this)) + ":" + typeChar();
+            return (isParam() ? "a" : "t") + (offsetIndex != 0 ? index() : System.identityHashCode(this)) + ":" + typeChar();
         }
         public String debugString() {
             String s = paramString();

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1339,7 +1339,7 @@ class LambdaForm {
 
     static final class Name {
         final BasicType type;
-        @Stable short offsetIndex; // slot + 1, reserves 0 for unset
+        private @Stable short offsetIndex; // slot + 1, reserves 0 for unset
         final NamedFunction function;
         final Object constraint;  // additional type information, if not null
         @Stable final Object[] arguments;
@@ -1395,9 +1395,10 @@ class LambdaForm {
         BasicType type() { return type; }
         int index() { return offsetIndex - 1; }
         boolean initIndex(int i) {
-            if (offsetIndex != i + 1) {
+            short index = (short) (i + 1);
+            if (offsetIndex != index) {
                 if (offsetIndex != 0)  return false;
-                offsetIndex = (short) (i + 1);
+                offsetIndex = index;
             }
             return true;
         }

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1384,6 +1384,7 @@ class LambdaForm {
         }
 
         Name withIndex(int i) {
+            if (i == this.index) return this;
             return new Name(i, type, function, arguments, constraint);
         }
 

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -567,7 +567,7 @@ class LambdaForm {
             assert(n.index() == i);
             for (Object arg : n.arguments) {
                 if (arg instanceof Name n2) {
-                    int i2 = n2.index;
+                    int i2 = n2.index();
                     assert(0 <= i2 && i2 < names.length) : n.debugString() + ": 0 <= i2 && i2 < names.length: 0 <= " + i2 + " < " + names.length;
                     assert(names[i2] == n2) : Arrays.asList("-1-", i, "-2-", n.debugString(), "-3-", i2, "-4-", n2.debugString(), "-5-", names[i2].debugString(), "-6-", this);
                     assert(i2 < i);  // ref must come after def!
@@ -1339,7 +1339,7 @@ class LambdaForm {
 
     static final class Name {
         final BasicType type;
-        @Stable short index;
+        @Stable short flippedIndex; // uses -1..-256 for slots, 0 for unset
         final NamedFunction function;
         final Object constraint;  // additional type information, if not null
         @Stable final Object[] arguments;
@@ -1347,15 +1347,15 @@ class LambdaForm {
         private static final Object[] EMPTY_ARGS = new Object[0];
 
         private Name(int index, BasicType type, NamedFunction function, Object[] arguments) {
-            this.index = (short)index;
+            this.flippedIndex = (short)~index;
             this.type = type;
             this.function = function;
             this.arguments = arguments;
             this.constraint = null;
-            assert(this.index == index && typesMatch(function, this.arguments));
+            assert(this.index() == index && typesMatch(function, this.arguments));
         }
         private Name(Name that, Object constraint) {
-            this.index = that.index;
+            this.flippedIndex = that.flippedIndex;
             this.type = that.type;
             this.function = that.function;
             this.arguments = that.arguments;
@@ -1393,11 +1393,11 @@ class LambdaForm {
         Name(BasicType type) { this(-1, type); }
 
         BasicType type() { return type; }
-        int index() { return index; }
+        int index() { return ~flippedIndex; }
         boolean initIndex(int i) {
-            if (index != i) {
-                if (index != -1)  return false;
-                index = (short)i;
+            if (flippedIndex != ~i) {
+                if (flippedIndex != 0)  return false;
+                flippedIndex = (short)~i;
             }
             return true;
         }
@@ -1446,7 +1446,7 @@ class LambdaForm {
         eachArg:
             for (int j = 0; j < arguments.length; j++) {
                 if (arguments[j] instanceof Name n) {
-                    int check = n.index;
+                    int check = n.index();
                     // harmless check to see if the thing is already in newNames:
                     if (check >= 0 && check < newNames.length && n == newNames[check])
                         continue eachArg;
@@ -1473,7 +1473,7 @@ class LambdaForm {
             Object[] arguments = this.arguments;
             for (int j = 0; j < arguments.length; j++) {
                 if (arguments[j] instanceof Name n) {
-                    if (n.isParam() && n.index < INTERNED_ARGUMENT_LIMIT)
+                    if (n.isParam() && n.index() < INTERNED_ARGUMENT_LIMIT)
                         arguments[j] = internArgument(n);
                 }
             }
@@ -1519,7 +1519,7 @@ class LambdaForm {
         }
 
         public String toString() {
-            return (isParam()?"a":"t")+(index >= 0 ? index : System.identityHashCode(this))+":"+typeChar();
+            return (isParam() ? "a" : "t") + (flippedIndex != 0 ? index() : System.identityHashCode(this)) + ":" + typeChar();
         }
         public String debugString() {
             String s = paramString();
@@ -1619,7 +1619,7 @@ class LambdaForm {
         @Override
         public int hashCode() {
             if (isParam())
-                return index | (type.ordinal() << 8);
+                return index() | (type.ordinal() << 8);
             return function.hashCode() ^ Arrays.hashCode(arguments);
         }
     }
@@ -1628,7 +1628,7 @@ class LambdaForm {
      *  Return -1 if the name is not used.  Return names.length if it is the return value.
      */
     int lastUseIndex(Name n) {
-        int ni = n.index, nmax = names.length;
+        int ni = n.index(), nmax = names.length;
         assert(names[ni] == n);
         if (result == ni)  return nmax;  // live all the way beyond the end
         for (int i = nmax; --i > ni; ) {
@@ -1640,8 +1640,8 @@ class LambdaForm {
 
     /** Return the number of times n is used as an argument or return value. */
     int useCount(Name n) {
-        int count = (result == n.index) ? 1 : 0;
-        int i = Math.max(n.index + 1, arity);
+        int count = (result == n.index()) ? 1 : 0;
+        int i = Math.max(n.index() + 1, arity);
         while (i < names.length) {
             count += names[i++].useCount(n);
         }
@@ -1655,9 +1655,9 @@ class LambdaForm {
     }
     static Name internArgument(Name n) {
         assert(n.isParam()) : "not param: " + n;
-        assert(n.index < INTERNED_ARGUMENT_LIMIT);
+        assert(n.index() < INTERNED_ARGUMENT_LIMIT);
         if (n.constraint != null)  return n;
-        return argument(n.index, n.type);
+        return argument(n.index(), n.type);
     }
     static Name[] arguments(int extra, MethodType types) {
         int length = types.parameterCount();

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1339,7 +1339,7 @@ class LambdaForm {
 
     static final class Name {
         final BasicType type;
-        private @Stable short offsetIndex; // slot + 1, reserves 0 for unset
+        @Stable short offsetIndex; // slot + 1, reserves 0 for unset
         final NamedFunction function;
         final Object constraint;  // additional type information, if not null
         @Stable final Object[] arguments;
@@ -1395,10 +1395,9 @@ class LambdaForm {
         BasicType type() { return type; }
         int index() { return offsetIndex - 1; }
         boolean initIndex(int i) {
-            short index = (short) (i + 1);
-            if (offsetIndex != index) {
+            if (offsetIndex != i + 1) {
                 if (offsetIndex != 0)  return false;
-                offsetIndex = index;
+                offsetIndex = (short) (i + 1);
             }
             return true;
         }

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -395,7 +395,7 @@ class LambdaForm {
         Name[] names = arguments(isVoid ? 0 : 1, mt);
         if (!isVoid) {
             Name zero = new Name(constantZero(basicType(mt.returnType())));
-            names[arity] = zero.newIndex(arity);
+            names[arity] = zero.withIndex(arity);
         }
         assert(namesOK(arity, names));
         return names;
@@ -495,28 +495,18 @@ class LambdaForm {
      *  @return true if we can interpret
      */
     private static boolean normalizeNames(int arity, Name[] names) {
-        Name[] oldNames = null;
+        Name[] oldNames = names.clone();
         int maxOutArity = 0;
-        int changesStart = 0;
         for (int i = 0; i < names.length; i++) {
             Name n = names[i];
-            if (!n.initIndex(i)) {
-                if (oldNames == null) {
-                    oldNames = names.clone();
-                    changesStart = i;
-                }
-                names[i] = n.cloneWithIndex(i);
-            }
+            names[i] = n.withIndex(i);
             if (n.arguments != null && maxOutArity < n.arguments.length)
                 maxOutArity = n.arguments.length;
         }
         if (oldNames != null) {
-            int startFixing = arity;
-            if (startFixing <= changesStart)
-                startFixing = changesStart+1;
-            for (int i = startFixing; i < names.length; i++) {
-                Name fixed = names[i].replaceNames(oldNames, names, changesStart, i);
-                names[i] = fixed.newIndex(i);
+            for (int i = Math.max(1, arity); i < names.length; i++) {
+                Name fixed = names[i].replaceNames(oldNames, names, 0, i);
+                names[i] = fixed.withIndex(i);
             }
         }
         int maxInterned = Math.min(arity, INTERNED_ARGUMENT_LIMIT);
@@ -1339,30 +1329,24 @@ class LambdaForm {
 
     static final class Name {
         final BasicType type;
-        @Stable short index;
+        final short index;
         final NamedFunction function;
         final Object constraint;  // additional type information, if not null
         @Stable final Object[] arguments;
 
         private static final Object[] EMPTY_ARGS = new Object[0];
 
-        private Name(int index, BasicType type, NamedFunction function, Object[] arguments) {
+        private Name(int index, BasicType type, NamedFunction function, Object[] arguments, Object constraint) {
             this.index = (short)index;
             this.type = type;
             this.function = function;
             this.arguments = arguments;
-            this.constraint = null;
-            assert(this.index == index && typesMatch(function, this.arguments));
-        }
-        private Name(Name that, Object constraint) {
-            this.index = that.index;
-            this.type = that.type;
-            this.function = that.function;
-            this.arguments = that.arguments;
             this.constraint = constraint;
+            assert(this.index == index && typesMatch(function, arguments));
             assert(constraint == null || isParam());  // only params have constraints
             assert(constraint == null || constraint instanceof ClassSpecializer.SpeciesData || constraint instanceof Class);
         }
+
         Name(MethodHandle function, Object... arguments) {
             this(new NamedFunction(function), arguments);
         }
@@ -1374,49 +1358,40 @@ class LambdaForm {
             this(new NamedFunction(function), arguments);
         }
         Name(NamedFunction function) {
-            this(-1, function.returnType(), function, EMPTY_ARGS);
+            this(-1, function.returnType(), function, EMPTY_ARGS, null);
         }
         Name(NamedFunction function, Object arg) {
-            this(-1, function.returnType(), function, new Object[] { arg });
+            this(-1, function.returnType(), function, new Object[] { arg }, null);
         }
         Name(NamedFunction function, Object arg0, Object arg1) {
-            this(-1, function.returnType(), function, new Object[] { arg0, arg1 });
+            this(-1, function.returnType(), function, new Object[] { arg0, arg1 }, null);
         }
         Name(NamedFunction function, Object... arguments) {
-            this(-1, function.returnType(), function, Arrays.copyOf(arguments, arguments.length, Object[].class));
+            this(-1, function.returnType(), function, Arrays.copyOf(arguments, arguments.length, Object[].class), null);
         }
         /** Create a raw parameter of the given type, with an expected index. */
         Name(int index, BasicType type) {
-            this(index, type, null, null);
+            this(index, type, null, null, null);
         }
         /** Create a raw parameter of the given type. */
         Name(BasicType type) { this(-1, type); }
 
         BasicType type() { return type; }
         int index() { return index; }
-        boolean initIndex(int i) {
-            if (index != i) {
-                if (index != -1)  return false;
-                index = (short)i;
-            }
-            return true;
-        }
+
         char typeChar() {
             return type.btChar;
         }
 
-        Name newIndex(int i) {
-            if (initIndex(i))  return this;
-            return cloneWithIndex(i);
+        Name withIndex(int i) {
+            return new Name(i, type, function, arguments, constraint);
         }
-        Name cloneWithIndex(int i) {
-            Object[] newArguments = (arguments == null) ? null : arguments.clone();
-            return new Name(i, type, function, newArguments).withConstraint(constraint);
-        }
+
         Name withConstraint(Object constraint) {
             if (constraint == this.constraint)  return this;
-            return new Name(this, constraint);
+            return new Name(index, type, function, arguments, constraint);
         }
+
         Name replaceName(Name oldName, Name newName) {  // FIXME: use replaceNames uniformly
             if (oldName == newName)  return this;
             @SuppressWarnings("LocalVariableHidesMemberVariable")

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -1339,7 +1339,7 @@ class LambdaForm {
 
     static final class Name {
         final BasicType type;
-        @Stable short offsetIndex; // slot + 1, reserves 0 for unset
+        @Stable short flippedIndex; // uses -1..-256 for slots, 0 for unset
         final NamedFunction function;
         final Object constraint;  // additional type information, if not null
         @Stable final Object[] arguments;
@@ -1347,7 +1347,7 @@ class LambdaForm {
         private static final Object[] EMPTY_ARGS = new Object[0];
 
         private Name(int index, BasicType type, NamedFunction function, Object[] arguments) {
-            this.offsetIndex = (short) (index + 1);
+            this.flippedIndex = (short)~index;
             this.type = type;
             this.function = function;
             this.arguments = arguments;
@@ -1355,7 +1355,7 @@ class LambdaForm {
             assert(this.index() == index && typesMatch(function, this.arguments));
         }
         private Name(Name that, Object constraint) {
-            this.offsetIndex = that.offsetIndex;
+            this.flippedIndex = that.flippedIndex;
             this.type = that.type;
             this.function = that.function;
             this.arguments = that.arguments;
@@ -1393,11 +1393,11 @@ class LambdaForm {
         Name(BasicType type) { this(-1, type); }
 
         BasicType type() { return type; }
-        int index() { return offsetIndex - 1; }
+        int index() { return ~flippedIndex; }
         boolean initIndex(int i) {
-            if (offsetIndex != i + 1) {
-                if (offsetIndex != 0)  return false;
-                offsetIndex = (short) (i + 1);
+            if (flippedIndex != ~i) {
+                if (flippedIndex != 0)  return false;
+                flippedIndex = (short)~i;
             }
             return true;
         }
@@ -1519,7 +1519,7 @@ class LambdaForm {
         }
 
         public String toString() {
-            return (isParam() ? "a" : "t") + (offsetIndex != 0 ? index() : System.identityHashCode(this)) + ":" + typeChar();
+            return (isParam() ? "a" : "t") + (flippedIndex != 0 ? index() : System.identityHashCode(this)) + ":" + typeChar();
         }
         public String debugString() {
             String s = paramString();

--- a/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -775,7 +775,7 @@ class LambdaFormEditor {
         // and expressions are
         var newParameters = new TreeMap<Name, Integer>(new Comparator<>() {
             public int compare(Name n1, Name n2) {
-                return n1.index - n2.index;
+                return n1.index() - n2.index();
             }
         });
 

--- a/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaFormEditor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -775,7 +775,7 @@ class LambdaFormEditor {
         // and expressions are
         var newParameters = new TreeMap<Name, Integer>(new Comparator<>() {
             public int compare(Name n1, Name n2) {
-                return n1.index() - n2.index();
+                return n1.index - n2.index;
             }
         });
 


### PR DESCRIPTION
The `@Stable` on the `index` field is incorrect, as stable only avoids inlining `0`. On a strategic view, this index field should just become final so that `Name` becomes eligible for value class migration once valhalla comes. This patch makes the `index` field final and updates the usages correspondingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335922](https://bugs.openjdk.org/browse/JDK-8335922): Incorrect @<!---->Stable usage of LambdaForm$Name.index (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) 🔄 Re-review required (review applies to [db805834](https://git.openjdk.org/jdk/pull/20178/files/db805834d7117e5752bebcbd671afa6c85ff2cf0))
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20178/head:pull/20178` \
`$ git checkout pull/20178`

Update a local copy of the PR: \
`$ git checkout pull/20178` \
`$ git pull https://git.openjdk.org/jdk.git pull/20178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20178`

View PR using the GUI difftool: \
`$ git pr show -t 20178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20178.diff">https://git.openjdk.org/jdk/pull/20178.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20178#issuecomment-2227584592)