### PR TITLE
8336378: Parallel: Rename allocate to expand_and_allocate in PSOldGen

### DIFF
--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -406,7 +406,7 @@ HeapWord* ParallelScavengeHeap::mem_allocate_work(size_t size,
 
 HeapWord* ParallelScavengeHeap::allocate_old_gen_and_record(size_t size) {
   assert_locked_or_safepoint(Heap_lock);
-  HeapWord* res = old_gen()->allocate(size);
+  HeapWord* res = old_gen()->expand_and_allocate(size);
   if (res != nullptr) {
     _size_policy->tenured_allocation(size * HeapWordSize);
   }
@@ -434,8 +434,7 @@ HeapWord* ParallelScavengeHeap::expand_heap_and_allocate(size_t size, bool is_tl
 
   result = young_gen()->allocate(size);
   if (result == nullptr && !is_tlab) {
-    // auto expand inside
-    result = old_gen()->allocate(size);
+    result = old_gen()->expand_and_allocate(size);
   }
   return result;   // Could be null if we are out of space.
 }
@@ -851,7 +850,7 @@ void ParallelScavengeHeap::resize_old_gen(size_t desired_free_space) {
 }
 
 HeapWord* ParallelScavengeHeap::allocate_loaded_archive_space(size_t size) {
-  return _old_gen->allocate(size);
+  return _old_gen->expand_and_allocate(size);
 }
 
 void ParallelScavengeHeap::complete_loaded_archive_space(MemRegion archive_space) {

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -118,7 +118,7 @@ class PSOldGen : public CHeapObj<mtGC> {
   // Calculating new sizes
   void resize(size_t desired_free_space);
 
-  HeapWord* allocate(size_t word_size) {
+  HeapWord* expand_and_allocate(size_t word_size) {
     HeapWord* res;
     do {
       res = cas_allocate_noexpand(word_size);

--- a/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psPromotionManager.inline.hpp
@@ -215,13 +215,13 @@ inline oop PSPromotionManager::copy_unmarked_to_survivor_space(oop o,
         // Do we allocate directly, or flush and refill?
         if (new_obj_size > (OldPLABSize / 2)) {
           // Allocate this object directly
-          new_obj = cast_to_oop(old_gen()->allocate(new_obj_size));
+          new_obj = cast_to_oop(old_gen()->expand_and_allocate(new_obj_size));
           promotion_trace_event(new_obj, o, new_obj_size, age, true, nullptr);
         } else {
           // Flush and fill
           _old_lab.flush();
 
-          HeapWord* lab_base = old_gen()->allocate(OldPLABSize);
+          HeapWord* lab_base = old_gen()->expand_and_allocate(OldPLABSize);
           if(lab_base != nullptr) {
             _old_lab.initialize(MemRegion(lab_base, OldPLABSize));
             // Try the old lab allocation again.


### PR DESCRIPTION
Trivial renaming a method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336378](https://bugs.openjdk.org/browse/JDK-8336378): Parallel: Rename allocate to expand_and_allocate in PSOldGen (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20181/head:pull/20181` \
`$ git checkout pull/20181`

Update a local copy of the PR: \
`$ git checkout pull/20181` \
`$ git pull https://git.openjdk.org/jdk.git pull/20181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20181`

View PR using the GUI difftool: \
`$ git pr show -t 20181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20181.diff">https://git.openjdk.org/jdk/pull/20181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20181#issuecomment-2228081592)