### PR TITLE
8335817: javac AssertionError addLocalVar checkNull

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,6 +78,7 @@ import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import com.sun.tools.javac.code.Symbol.RecordComponent;
 import com.sun.tools.javac.code.Type;
 import static com.sun.tools.javac.code.TypeTag.BOT;
+import static com.sun.tools.javac.code.TypeTag.VOID;
 import com.sun.tools.javac.jvm.PoolConstant.LoadableConstant;
 import com.sun.tools.javac.jvm.Target;
 import com.sun.tools.javac.tree.JCTree;
@@ -1260,7 +1261,11 @@ public class TransPatterns extends TreeTranslator {
                 tree.body = translate(tree.body);
                 if (deconstructorCalls != null) {
                     if (tree.body instanceof JCExpression value) {
-                        tree.body = make.Block(0, List.of(make.Return(value)));
+                        if (value.type.hasTag(VOID)) {
+                            tree.body = make.Block(0, List.of(make.Exec(value)));
+                        } else {
+                            tree.body = make.Block(0, List.of(make.Return(value)));
+                        }
                     }
                     if (tree.body instanceof JCBlock block) {
                         preparePatternMatchingCatchIfNeeded(block);

--- a/test/langtools/tools/javac/patterns/MatchExceptionLambdaExpression.java
+++ b/test/langtools/tools/javac/patterns/MatchExceptionLambdaExpression.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8335817
+ * @summary Verify synthetic catches for deconstruction patterns work properly in expression lambdas
+ * @compile MatchExceptionLambdaExpression.java
+ * @run main MatchExceptionLambdaExpression
+ */
+public class MatchExceptionLambdaExpression {
+
+    public static void main(String[] args) {
+        try {
+            doRunPrimitiveVoid(new A("", true), o -> checkPrimitiveVoid(o instanceof A(String s, _), true));
+            throw new AssertionError("Didn't gete the expected exception!");
+        } catch (MatchException ex) {
+            if (ex.getCause() instanceof RequestedException) {
+                //correct
+            } else {
+                throw ex;
+            }
+        }
+        try {
+            doRunPrimitiveVoid(new A("", true), o -> checkVoidBox(o instanceof A(String s, _), true));
+            throw new AssertionError("Didn't gete the expected exception!");
+        } catch (MatchException ex) {
+            if (ex.getCause() instanceof RequestedException) {
+                //correct
+            } else {
+                throw ex;
+            }
+        }
+        try {
+            doRunPrimitiveVoid(new A("", true), o -> checkNonVoid(o instanceof A(String s, _), true));
+            throw new AssertionError("Didn't gete the expected exception!");
+        } catch (MatchException ex) {
+            if (ex.getCause() instanceof RequestedException) {
+                //correct
+            } else {
+                throw ex;
+            }
+        }
+        try {
+            doRunVoidBox(new A("", true), o -> checkVoidBox(o instanceof A(String s, _), true));
+            throw new AssertionError("Didn't gete the expected exception!");
+        } catch (MatchException ex) {
+            if (ex.getCause() instanceof RequestedException) {
+                //correct
+            } else {
+                throw ex;
+            }
+        }
+        try {
+            doRunNonVoid(new A("", true), o -> checkVoidBox(o instanceof A(String s, _), true));
+            throw new AssertionError("Didn't gete the expected exception!");
+        } catch (MatchException ex) {
+            if (ex.getCause() instanceof RequestedException) {
+                //correct
+            } else {
+                throw ex;
+            }
+        }
+        try {
+            doRunNonVoid(new A("", true), o -> checkNonVoid(o instanceof A(String s, _), true));
+            throw new AssertionError("Didn't gete the expected exception!");
+        } catch (MatchException ex) {
+            if (ex.getCause() instanceof RequestedException) {
+                //correct
+            } else {
+                throw ex;
+            }
+        }
+    }
+
+    static void doRunPrimitiveVoid(Object inp, PrimitiveVoidFI toRun) {
+       toRun.run(inp);
+    }
+
+    static void doRunVoidBox(Object inp, VoidBoxFI toRun) {
+       toRun.run(inp);
+    }
+
+    static void doRunNonVoid(Object inp, NonVoidFI toRun) {
+       toRun.run(inp);
+    }
+
+    static void checkPrimitiveVoid(boolean a, boolean shouldNotBeCalled) {
+        if (shouldNotBeCalled) {
+            throw new AssertionError("Should not be called.");
+        }
+    }
+
+    static Void checkVoidBox(boolean a, boolean shouldNotBeCalled) {
+        if (shouldNotBeCalled) {
+            throw new AssertionError("Should not be called.");
+        }
+        return null;
+    }
+
+    static Object checkNonVoid(boolean a, boolean shouldNotBeCalled) {
+        if (shouldNotBeCalled) {
+            throw new AssertionError("Should not be called.");
+        }
+        return null;
+    }
+
+    interface PrimitiveVoidFI {
+        public void run(Object o);
+    }
+
+    interface VoidBoxFI {
+        public Void run(Object o);
+    }
+
+    interface NonVoidFI {
+        public Object run(Object o);
+    }
+
+    record A(String s, boolean fail) {
+        public String s() {
+            if (fail) {
+                throw new RequestedException();
+            }
+            return s;
+        }
+    }
+
+    static class RequestedException extends RuntimeException {}
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [2b0adfc2](https://github.com/openjdk/jdk/commit/2b0adfc2decf47f6f49f072549c96f301f275285) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 15 Jul 2024 and was reviewed by Vicente Romero and Maurizio Cimadamore.

Thanks!

Original description:
Consider pattern matching with deconstruction patter, like:
```
boolean b = o instanceof R(String s);
```

This will get desugared into code similar to `o instanceof R r && r.component() instanceof String s`, except that the call to `component()` is guarded with a try-catch, wrapping any exception with a `MatchException`. The internal javac implementation is to create a synthetic catch clause, and attach it to the relevant enclosing block.

Now, consider an expression lambda with a deconstruction pattern matching, like `o -> o instanceof R(String s)`. There is no block in the lambda to which the catch could be attached. So, `TransPatterns` will expand the expression lambda to a block lambda, and inject the synthetic catches. But, `TransPatterns` will always do `return <expression-body>;`, even if the type of `<expression-body>` is void. This then leads to a crash during Gen, as a variable of type `void` is created.

The patch proposed here avoid creating `return <expression-body>;` for void-type expression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8335817: javac AssertionError addLocalVar checkNull`

### Issue
 * [JDK-8335817](https://bugs.openjdk.org/browse/JDK-8335817): javac AssertionError addLocalVar checkNull (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20183/head:pull/20183` \
`$ git checkout pull/20183`

Update a local copy of the PR: \
`$ git checkout pull/20183` \
`$ git pull https://git.openjdk.org/jdk.git pull/20183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20183`

View PR using the GUI difftool: \
`$ git pr show -t 20183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20183.diff">https://git.openjdk.org/jdk/pull/20183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20183#issuecomment-2228728875)