### PR TITLE
8336421: ciMethod() constructor should use ConditionalMutexLocker(Compile_lock)

### DIFF
--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -109,7 +109,8 @@ ciMethod::ciMethod(const methodHandle& h_m, ciInstanceKlass* holder) :
   ciEnv *env = CURRENT_ENV;
   if (env->jvmti_can_hotswap_or_post_breakpoint()) {
     // 6328518 check hotswap conditions under the right lock.
-    MutexLocker locker(Compile_lock);
+    bool should_take_Compile_lock = !Compile_lock->owned_by_self();
+    ConditionalMutexLocker locker(Compile_lock, should_take_Compile_lock, Mutex::_safepoint_check_flag);
     if (Dependencies::check_evol_method(h_m()) != nullptr) {
       _is_c1_compilable = false;
       _is_c2_compilable = false;


### PR DESCRIPTION
During Leyden testing with `-XX:+LogCompilation` flag I hit assert because `ciMethod()` could be called from `ciEnv::register_method()` which already holds `Compile_lock` lock. See call stack in JBS report.
Use `ConditionalMutexLocker` in `ciMethod()`.
This is normal code pattern used in other places where we can have nested locking: [compileBroker.cpp#L2847](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/compiler/compileBroker.cpp#L2847).

Tested tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336421](https://bugs.openjdk.org/browse/JDK-8336421): ciMethod() constructor should use ConditionalMutexLocker(Compile_lock) (**Bug** - P3)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20187/head:pull/20187` \
`$ git checkout pull/20187`

Update a local copy of the PR: \
`$ git checkout pull/20187` \
`$ git pull https://git.openjdk.org/jdk.git pull/20187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20187`

View PR using the GUI difftool: \
`$ git pr show -t 20187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20187.diff">https://git.openjdk.org/jdk/pull/20187.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20187#issuecomment-2229780894)