### PR TITLE
8336463: Parallel: Add PSOldGen::expand_and_allocate

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -189,7 +189,12 @@ bool MutableSpace::cas_deallocate(HeapWord *obj, size_t size) {
 
 // Only used by oldgen allocation.
 bool MutableSpace::needs_expand(size_t word_size) const {
-  assert_lock_strong(PSOldGenExpand_lock);
+#ifdef ASSERT
+  // If called by VM thread, locking is not needed.
+  if (!Thread::current()->is_VM_thread()) {
+    assert_lock_strong(PSOldGenExpand_lock);
+  }
+#endif
   // Holding the lock means end is stable.  So while top may be advancing
   // via concurrent allocations, there is no need to order the reads of top
   // and end here, unlike in cas_allocate.

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -129,7 +129,7 @@ class MutableSpace: public CHeapObj<mtGC> {
   // Return true if this space needs to be expanded in order to satisfy an
   // allocation request of the indicated size.  Concurrent allocations and
   // resizes may change the result of a later call.  Used by oldgen allocator.
-  // precondition: holding PSOldGenExpand_lock
+  // precondition: holding PSOldGenExpand_lock if not VM thread
   bool needs_expand(size_t word_size) const;
 
   // Iteration.

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -434,8 +434,7 @@ HeapWord* ParallelScavengeHeap::expand_heap_and_allocate(size_t size, bool is_tl
 
   result = young_gen()->allocate(size);
   if (result == nullptr && !is_tlab) {
-    // auto expand inside
-    result = old_gen()->allocate(size);
+    result = old_gen()->expand_and_allocate(size);
   }
   return result;   // Could be null if we are out of space.
 }

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -126,6 +126,9 @@ HeapWord* PSOldGen::expand_and_allocate(size_t word_size) {
   if (object_space()->needs_expand(word_size)) {
     expand(word_size*HeapWordSize);
   }
+
+  // Reuse the CAS API even though this is VM thread in safepoint. This method
+  // is not invoked repeatedly, so the CAS overhead should be negligible.
   return cas_allocate_noexpand(word_size);
 }
 

--- a/src/hotspot/share/gc/parallel/psOldGen.cpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.cpp
@@ -120,6 +120,15 @@ void PSOldGen::initialize_performance_counters(const char* perf_data_name, int l
                                       _object_space, _gen_counters);
 }
 
+HeapWord* PSOldGen::expand_and_allocate(size_t word_size) {
+  assert(SafepointSynchronize::is_at_safepoint(), "precondition");
+  assert(Thread::current()->is_VM_thread(), "precondition");
+  if (object_space()->needs_expand(word_size)) {
+    expand(word_size*HeapWordSize);
+  }
+  return cas_allocate_noexpand(word_size);
+}
+
 size_t PSOldGen::num_iterable_blocks() const {
   return (object_space()->used_in_bytes() + IterateBlockSize - 1) / IterateBlockSize;
 }
@@ -170,9 +179,13 @@ bool PSOldGen::expand_for_allocate(size_t word_size) {
 }
 
 bool PSOldGen::expand(size_t bytes) {
-  assert_lock_strong(PSOldGenExpand_lock);
+#ifdef ASSERT
+  if (!Thread::current()->is_VM_thread()) {
+    assert_lock_strong(PSOldGenExpand_lock);
+  }
   assert_locked_or_safepoint(Heap_lock);
   assert(bytes > 0, "precondition");
+#endif
   const size_t alignment = virtual_space()->alignment();
   size_t aligned_bytes  = align_up(bytes, alignment);
   size_t aligned_expand_bytes = align_up(MinHeapDeltaBytes, alignment);
@@ -208,8 +221,6 @@ bool PSOldGen::expand(size_t bytes) {
 }
 
 bool PSOldGen::expand_by(size_t bytes) {
-  assert_lock_strong(PSOldGenExpand_lock);
-  assert_locked_or_safepoint(Heap_lock);
   assert(bytes > 0, "precondition");
   bool result = virtual_space()->expand_by(bytes);
   if (result) {
@@ -244,9 +255,6 @@ bool PSOldGen::expand_by(size_t bytes) {
 }
 
 bool PSOldGen::expand_to_reserved() {
-  assert_lock_strong(PSOldGenExpand_lock);
-  assert_locked_or_safepoint(Heap_lock);
-
   bool result = false;
   const size_t remaining_bytes = virtual_space()->uncommitted_size();
   if (remaining_bytes > 0) {

--- a/src/hotspot/share/gc/parallel/psOldGen.hpp
+++ b/src/hotspot/share/gc/parallel/psOldGen.hpp
@@ -118,6 +118,7 @@ class PSOldGen : public CHeapObj<mtGC> {
   // Calculating new sizes
   void resize(size_t desired_free_space);
 
+  // Invoked by mutators and GC-workers.
   HeapWord* allocate(size_t word_size) {
     HeapWord* res;
     do {
@@ -126,6 +127,9 @@ class PSOldGen : public CHeapObj<mtGC> {
     } while ((res == nullptr) && expand_for_allocate(word_size));
     return res;
   }
+
+  // Invoked by VM thread inside a safepoint.
+  HeapWord* expand_and_allocate(size_t word_size);
 
   // Iteration.
   void oop_iterate(OopIterateClosure* cl) { object_space()->oop_iterate(cl); }


### PR DESCRIPTION
Simple adding an API to old-gen to support calls by VM thread in safepoint.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336463](https://bugs.openjdk.org/browse/JDK-8336463): Parallel: Add PSOldGen::expand_and_allocate (**Enhancement** - P4)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**) 🔄 Re-review required (review applies to [52782508](https://git.openjdk.org/jdk/pull/20189/files/52782508f096c0f5a75ab552514f9f0cb97f9778))
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20189/head:pull/20189` \
`$ git checkout pull/20189`

Update a local copy of the PR: \
`$ git checkout pull/20189` \
`$ git pull https://git.openjdk.org/jdk.git pull/20189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20189`

View PR using the GUI difftool: \
`$ git pr show -t 20189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20189.diff">https://git.openjdk.org/jdk/pull/20189.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20189#issuecomment-2230513371)