### PR TITLE
8336465: C2: EA incorrectly/unnecessarily checks for clinits

### DIFF
--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -86,10 +86,10 @@ static bool is_init_with_ea(ciMethod* callee_method,
   if (!C->do_escape_analysis() || !EliminateAllocations) {
     return false; // EA is off
   }
-  if (callee_method->is_initializer()) {
+  if (callee_method->is_object_initializer()) {
     return true; // constructor
   }
-  if (caller_method->is_initializer() &&
+  if (caller_method->is_object_initializer() &&
       caller_method != C->method() &&
       caller_method->holder()->is_subclass_of(callee_method->holder())) {
     return true; // super constructor is called from inlined constructor


### PR DESCRIPTION
As shown in [JDK-8336103](https://bugs.openjdk.org/browse/JDK-8336103), EA code uses `is_initializer` where we expect to only check for constructors. This PR rewrites it appropriately. This nominally changes the EA behavior, but I do not think it would actually show up anywhere.

Additional testing:
 - [x] Linux AArch64 server fastdebug, all (includes Fuzzer and CTW tests), passed as part of JDK-8336103 testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336465](https://bugs.openjdk.org/browse/JDK-8336465): C2: EA incorrectly/unnecessarily checks for clinits (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20190/head:pull/20190` \
`$ git checkout pull/20190`

Update a local copy of the PR: \
`$ git checkout pull/20190` \
`$ git pull https://git.openjdk.org/jdk.git pull/20190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20190`

View PR using the GUI difftool: \
`$ git pr show -t 20190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20190.diff">https://git.openjdk.org/jdk/pull/20190.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20190#issuecomment-2230529811)