### PR TITLE
8336466: C2: Parser incorrectly/unnecessarily checks for clinits

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -1601,10 +1601,8 @@ AllocateNode::AllocateNode(Compile* C, const TypeFunc *atype,
 
 void AllocateNode::compute_MemBar_redundancy(ciMethod* initializer)
 {
-  assert(initializer != nullptr &&
-         initializer->is_initializer() &&
-         !initializer->is_static(),
-             "unexpected initializer method");
+  assert(initializer != nullptr && initializer->is_object_initializer(),
+         "unexpected initializer method");
   BCEscapeAnalyzer* analyzer = initializer->get_bcea();
   if (analyzer == nullptr) {
     return;

--- a/src/hotspot/share/opto/parse1.cpp
+++ b/src/hotspot/share/opto/parse1.cpp
@@ -1009,7 +1009,7 @@ void Parse::do_exits() {
   // such unusual early publications.  But no barrier is needed on
   // exceptional returns, since they cannot publish normally.
   //
-  if (method()->is_initializer() &&
+  if (method()->is_object_initializer() &&
        (wrote_final() ||
          (AlwaysSafeConstructors && wrote_fields()) ||
          (support_IRIW_for_not_multiple_copy_atomic_cpu && wrote_volatile()))) {


### PR DESCRIPTION
As shown in [JDK-8336103](https://bugs.openjdk.org/browse/JDK-8336103), C2 Parser code uses `is_initializer` in the code where we expect to only check for constructors. The fix nominally changes the behavior for C2. I do not believe this is something readily observable, but need to be more explicit.

Additional testing:
 - [x]  Linux AArch64 server fastdebug, all (includes Fuzzer and CTW tests), passed as part of JDK-8336103 testing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336466](https://bugs.openjdk.org/browse/JDK-8336466): C2: Parser incorrectly/unnecessarily checks for clinits (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20191/head:pull/20191` \
`$ git checkout pull/20191`

Update a local copy of the PR: \
`$ git checkout pull/20191` \
`$ git pull https://git.openjdk.org/jdk.git pull/20191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20191`

View PR using the GUI difftool: \
`$ git pr show -t 20191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20191.diff">https://git.openjdk.org/jdk/pull/20191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20191#issuecomment-2230536830)