### PR TITLE
8336474: Problemlist compiler/interpreter/Test6833129 on x86_32

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -71,6 +71,8 @@ compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
 compiler/vectorization/TestFloat16VectorConvChain.java 8335860 generic-all
 
+compiler/interpreter/Test6833129.java 8335266i generic-i586
+
 #############################################################################
 
 # :hotspot_gc

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -71,7 +71,7 @@ compiler/codecache/CodeCacheFullCountTest.java 8332954 generic-all
 
 compiler/vectorization/TestFloat16VectorConvChain.java 8335860 generic-all
 
-compiler/interpreter/Test6833129.java 8335266i generic-i586
+compiler/interpreter/Test6833129.java 8335266 generic-i586
 
 #############################################################################
 


### PR DESCRIPTION
Routinely shows up in GHA now. Should be problemlisted to remove noise. x86_32 port is likely going away soon, there is no point in trying to solve the underlying issue yet.

Additional testing:
 - [x] GHA x86_32, test is skipped
 - [x]  GHA x86_64, test runs and passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336474](https://bugs.openjdk.org/browse/JDK-8336474): Problemlist compiler/interpreter/Test6833129 on x86_32 (**Sub-task** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) 🔄 Re-review required (review applies to [f81e6ba7](https://git.openjdk.org/jdk/pull/20194/files/f81e6ba785f9c6054baa5e88819c3f8ac684a048))
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20194/head:pull/20194` \
`$ git checkout pull/20194`

Update a local copy of the PR: \
`$ git checkout pull/20194` \
`$ git pull https://git.openjdk.org/jdk.git pull/20194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20194`

View PR using the GUI difftool: \
`$ git pr show -t 20194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20194.diff">https://git.openjdk.org/jdk/pull/20194.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20194#issuecomment-2230830552)