### PR TITLE
8336040: Missing closing anchor element in Docs.gmk

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -1,4 +1,4 @@
-# Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -714,7 +714,7 @@ SPEC_HEADER_BLOCK := \
     <div class="navbar"> \
         <div>$(HEADER_RIGHT_SIDE_INFO)</div> \
         <nav><ul><li><a href="PATH_TO_SPECS/../api/index.html">API</a> \
-        <li><a href="PATH_TO_SPECS/index.html">OTHER SPECIFICATIONS \
+        <li><a href="PATH_TO_SPECS/index.html">OTHER SPECIFICATIONS</a> \
         <li><a href="PATH_TO_SPECS/man/index.html">TOOL GUIDES</a></ul></nav> \
     </div> \
 </header>


### PR DESCRIPTION
Can I please have a review for this bug fix to make file used to generate the OpenJDK documentation. It adds the missing `</a>` tag after `OTHER SPECIFICATIONS`, this should help remove some HTML warnings in out generated docs.

Thanks in advance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336040](https://bugs.openjdk.org/browse/JDK-8336040): Missing closing anchor element in Docs.gmk (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20195/head:pull/20195` \
`$ git checkout pull/20195`

Update a local copy of the PR: \
`$ git checkout pull/20195` \
`$ git pull https://git.openjdk.org/jdk.git pull/20195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20195`

View PR using the GUI difftool: \
`$ git pr show -t 20195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20195.diff">https://git.openjdk.org/jdk/pull/20195.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20195#issuecomment-2231053390)