### PR TITLE
8336091: Fix HTML warnings in the generated HTML files

### DIFF
--- a/make/jdk/src/classes/build/tools/fixuppandoc/Main.java
+++ b/make/jdk/src/classes/build/tools/fixuppandoc/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/make/jdk/src/classes/build/tools/fixuppandoc/Main.java
+++ b/make/jdk/src/classes/build/tools/fixuppandoc/Main.java
@@ -638,7 +638,7 @@ public class Main {
                 index++;
             }
             boolean updateEndTd = false;
-            Pattern styleAttr = Pattern.compile("(?<before>.*style=\")(?<style>[^\"]*)(?<after>\".*)");
+            Pattern styleAttr = Pattern.compile("(?s)(?<before>.*style=\")(?<style>[^\"]*)(?<after>\".*)");
             for (Entry e : entries) {
                 if (simple && e.column == maxIndex) {
                     String attrs = e.html.substring(3, e.html.length() - 1);


### PR DESCRIPTION
Can I please have a review for this bug fix? This regex to avoid duplicate "style" tags in our generated HTML, It can now match it even if the text contains a newline character. 

Thanks in advance!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336091](https://bugs.openjdk.org/browse/JDK-8336091): Fix HTML warnings in the generated HTML files (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20196/head:pull/20196` \
`$ git checkout pull/20196`

Update a local copy of the PR: \
`$ git checkout pull/20196` \
`$ git pull https://git.openjdk.org/jdk.git pull/20196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20196`

View PR using the GUI difftool: \
`$ git pr show -t 20196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20196.diff">https://git.openjdk.org/jdk/pull/20196.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20196#issuecomment-2231077764)