### PR TITLE
8336300: DateFormatSymbols#getInstanceRef returns non-cached instance

### DIFF
--- a/src/java.base/share/classes/java/text/DateFormatSymbols.java
+++ b/src/java.base/share/classes/java/text/DateFormatSymbols.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -344,20 +344,6 @@ public class DateFormatSymbols implements Serializable, Cloneable {
      * @since 1.6
      */
     public static final DateFormatSymbols getInstance(Locale locale) {
-        DateFormatSymbols dfs = getProviderInstance(locale);
-        if (dfs != null) {
-            return dfs;
-        }
-        throw new RuntimeException("DateFormatSymbols instance creation failed.");
-    }
-
-    /**
-     * Returns a DateFormatSymbols provided by a provider or found in
-     * the cache. Note that this method returns a cached instance,
-     * not its clone. Therefore, the instance should never be given to
-     * an application.
-     */
-    static final DateFormatSymbols getInstanceRef(Locale locale) {
         DateFormatSymbols dfs = getProviderInstance(locale);
         if (dfs != null) {
             return dfs;

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -623,7 +623,7 @@ public class SimpleDateFormat extends DateFormat {
 
         initializeCalendar(locale);
         this.pattern = pattern;
-        this.formatData = DateFormatSymbols.getInstance(locale);
+        formatData = DateFormatSymbols.getInstance(locale);
         this.locale = locale;
         initialize(locale);
     }
@@ -644,7 +644,7 @@ public class SimpleDateFormat extends DateFormat {
         }
 
         this.pattern = pattern;
-        this.formatData = (DateFormatSymbols) formatSymbols.clone();
+        formatData = (DateFormatSymbols) formatSymbols.clone();
         this.locale = Locale.getDefault(Locale.Category.FORMAT);
         initializeCalendar(this.locale);
         initialize(this.locale);

--- a/src/java.base/share/classes/java/text/SimpleDateFormat.java
+++ b/src/java.base/share/classes/java/text/SimpleDateFormat.java
@@ -623,7 +623,7 @@ public class SimpleDateFormat extends DateFormat {
 
         initializeCalendar(locale);
         this.pattern = pattern;
-        this.formatData = DateFormatSymbols.getInstanceRef(locale);
+        this.formatData = DateFormatSymbols.getInstance(locale);
         this.locale = locale;
         initialize(locale);
     }


### PR DESCRIPTION
Removing a redundant private method, which has the same implementation with the public sibling and obsolete method description.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336300](https://bugs.openjdk.org/browse/JDK-8336300): DateFormatSymbols#getInstanceRef returns non-cached instance (**Bug** - P4)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Andrey Turbanov](https://openjdk.org/census#aturbanov) (@turbanoff - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20199/head:pull/20199` \
`$ git checkout pull/20199`

Update a local copy of the PR: \
`$ git checkout pull/20199` \
`$ git pull https://git.openjdk.org/jdk.git pull/20199/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20199`

View PR using the GUI difftool: \
`$ git pr show -t 20199`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20199.diff">https://git.openjdk.org/jdk/pull/20199.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20199#issuecomment-2231369014)