### PR TITLE
8162500: Receiver annotations of inner classes of local classes not found at runtime

### DIFF
--- a/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
+++ b/src/java.base/share/classes/sun/reflect/annotation/AnnotatedTypeFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,11 +87,12 @@ public final class AnnotatedTypeFactory {
         if (isArray(type))
             return addTo;
         if (type instanceof Class<?> clz) {
-            if (clz.getEnclosingClass() == null)
+            // local and anonymous class are top-level in annotated types
+            if (clz.getDeclaringClass() == null)
                 return addTo;
             if (Modifier.isStatic(clz.getModifiers()))
                 return addTo;
-            return nestingForType(clz.getEnclosingClass(), addTo.pushInner());
+            return nestingForType(clz.getDeclaringClass(), addTo.pushInner());
         } else if (type instanceof ParameterizedType t) {
             if (t.getOwnerType() == null)
                 return addTo;

--- a/test/jdk/java/lang/annotation/typeAnnotations/ConstructorReceiverTest.java
+++ b/test/jdk/java/lang/annotation/typeAnnotations/ConstructorReceiverTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8023651 8044629
+ * @bug 8023651 8044629 8162500
  * @summary Test that the receiver annotations and the return annotations of
  *          constructors behave correctly.
  * @run testng ConstructorReceiverTest
@@ -62,6 +62,7 @@ public class ConstructorReceiverTest {
         { ConstructorReceiverTest.Nested.NestedMiddle.NestedInner.class, ConstructorReceiverTest.Nested.NestedMiddle.class, Integer.valueOf(2000), Integer.valueOf(2500)},
         { ConstructorReceiverTest.Nested.NestedMiddle.NestedInnerNoReceiver.class, ConstructorReceiverTest.Nested.NestedMiddle.class, Integer.valueOf(4000), EMPTY_ANNOTATED_TYPE},
         { ConstructorReceiverTest.Nested.NestedMiddle.SecondNestedInnerNoReceiver.class, ConstructorReceiverTest.Nested.NestedMiddle.class, Integer.valueOf(5000), EMPTY_ANNOTATED_TYPE},
+        { getLocalsMember(), getLocalsMember().getDeclaringClass(), Integer.valueOf(2635), Integer.valueOf(2732)},
     };
 
 
@@ -167,6 +168,15 @@ public class ConstructorReceiverTest {
                 @Annot(5000) public SecondNestedInnerNoReceiver(NestedMiddle NestedMiddle.this) {}
             }
         }
+    }
+
+    public static Class<?> getLocalsMember() {
+        class Local {
+            class Member {
+                @Annot(2635) Member(@Annot(2732) Local Local.this) {}
+            }
+        }
+        return Local.Member.class;
     }
 
     @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
In annotated types, local and inner class types should be annotated as "top-level" types. For example, in the test here
```java
    public static Class<?> getLocalsMember() {
        class Local {
            class Member {
                @Annot(2635) Member(@Annot(2732) Local Local.this) {}
            }
        }
        return Local.Member.class;
    }
```

The `Local` occurrences cannot be qualified with the enclosing class type, even if the local class may be compiled to capture the enclosing class.

However, core reflection had a bug where it looks for an enclosing class instead of a declaring class; this meant that for said `Local`, core reflection was treating the outer class as the top-level in type annotations, while the top level should be the local class instead. This patch fixes this bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8162500](https://bugs.openjdk.org/browse/JDK-8162500): Receiver annotations of inner classes of local classes not found at runtime (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20200/head:pull/20200` \
`$ git checkout pull/20200`

Update a local copy of the PR: \
`$ git checkout pull/20200` \
`$ git pull https://git.openjdk.org/jdk.git pull/20200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20200`

View PR using the GUI difftool: \
`$ git pr show -t 20200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20200.diff">https://git.openjdk.org/jdk/pull/20200.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20200#issuecomment-2231514353)
</details>
