### PR TITLE
8336420: Add JVMTI setfldw001 and setfmodw001 tests to Xcomp problem list

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -28,6 +28,12 @@
 #############################################################################
 
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
+
+vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java#id0 8205957 generic-all
+vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java#logging 8205957 generic-all
+vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java#id0 8205957 linux-x64,windows-x64
+vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java#logging 8205957 linux-x64,windows-x64
+
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 linux-x64,windows-x64

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -29,10 +29,10 @@
 
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
 
-vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java#id0 8205957 generic-all
-vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java#logging 8205957 generic-all
-vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java#id0 8205957 linux-x64,windows-x64
-vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java#logging 8205957 linux-x64,windows-x64
+vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java#id0            8205957 generic-all
+vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java#logging        8205957 generic-all
+vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java#id0     8205957 generic-all
+vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java#logging 8205957 generic-all
 
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 


### PR DESCRIPTION
The following two Xcomp problem list entries were removed:

vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java 8205957 linux-x64,windows-x64

Each of these tests now has #id0 and #logging versions, and they are failing, so they need to be problem listed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336420](https://bugs.openjdk.org/browse/JDK-8336420): Add JVMTI setfldw001 and setfmodw001 tests to Xcomp problem list (**Sub-task** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20201/head:pull/20201` \
`$ git checkout pull/20201`

Update a local copy of the PR: \
`$ git checkout pull/20201` \
`$ git pull https://git.openjdk.org/jdk.git pull/20201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20201`

View PR using the GUI difftool: \
`$ git pr show -t 20201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20201.diff">https://git.openjdk.org/jdk/pull/20201.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20201#issuecomment-2231638521)