### PR TITLE
8336498: [macos] [build]: install-file macro may run into permission denied error

### DIFF
--- a/make/common/FileUtils.gmk
+++ b/make/common/FileUtils.gmk
@@ -136,6 +136,7 @@ ifeq ($(call isTargetOs, macosx), true)
 	  $(CP) -fRP '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'; \
 	fi
 	if [ -n "`$(XATTR) -ls '$(call DecodeSpace, $@)'`" ]; then \
+          $(CHMOD) u+w '$(call DecodeSpace, $@)'; \
 	  $(XATTR) -cs '$(call DecodeSpace, $@)'; \
 	fi
   endef


### PR DESCRIPTION
On MacOS, files may have extended attributes attached. These attributes are copied together with the files. To prevent issues during further processing, the extended attributes of the copies must be removed. This action was implemented as solution of an older bug.

The solution is incomplete because it does not handle files with read-only permissions correctly. Without write permission, matter cannot remove the extended attributes. The action is rejected with a "permission denied" error.

The issue is present in all releases. I reproduced it in 11, 17, ... 23, head

The solution is to "chmod u+w" only those files which need to have their extended attributes removed.

Backport note: in releases prior to jdk23, the change needs to go into file MakeBase.gmk.

Testing @SAP completed without any related issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336498](https://bugs.openjdk.org/browse/JDK-8336498): [macos] [build]: install-file macro may run into permission denied error (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20203/head:pull/20203` \
`$ git checkout pull/20203`

Update a local copy of the PR: \
`$ git checkout pull/20203` \
`$ git pull https://git.openjdk.org/jdk.git pull/20203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20203`

View PR using the GUI difftool: \
`$ git pr show -t 20203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20203.diff">https://git.openjdk.org/jdk/pull/20203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20203#issuecomment-2231817862)