### PR TITLE
8336499: Failure when creating non-CRT RSA private keys in SunPKCS11

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -561,47 +561,81 @@ abstract class P11Key implements Key, Length {
         static P11RSAPrivateKeyInternal of(Session session, long keyID,
                 String algorithm, int keyLength, CK_ATTRIBUTE[] attrs,
                 boolean keySensitive) {
-            if (keySensitive) {
-                return new P11RSAPrivateKeyInternal(session, keyID, algorithm,
-                        keyLength, attrs);
-            } else {
-                CK_ATTRIBUTE[] rsaAttrs = new CK_ATTRIBUTE[] {
-                        new CK_ATTRIBUTE(CKA_MODULUS),
-                        new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
-                        new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
-                        new CK_ATTRIBUTE(CKA_PRIME_1),
-                        new CK_ATTRIBUTE(CKA_PRIME_2),
-                        new CK_ATTRIBUTE(CKA_EXPONENT_1),
-                        new CK_ATTRIBUTE(CKA_EXPONENT_2),
-                        new CK_ATTRIBUTE(CKA_COEFFICIENT),
-                };
-                boolean isCRT = true;
-                Session tempSession = null;
+            P11RSAPrivateKeyInternal p11Key = null;
+            if (!keySensitive) {
+                // Key is not sensitive: try to interpret as CRT or non-CRT.
+                Session opSession = null;
                 try {
-                    tempSession = session.token.getOpSession();
-                    session.token.p11.C_GetAttributeValue(tempSession.id(),
-                            keyID, rsaAttrs);
-                    for (CK_ATTRIBUTE attr : rsaAttrs) {
-                        isCRT &= (attr.pValue instanceof byte[]);
-                        if (!isCRT) break;
+                    opSession = session.token.getOpSession();
+                    p11Key = asCRT(session, opSession, keyID, algorithm,
+                            keyLength, attrs);
+                    if (p11Key == null) {
+                        p11Key = asNonCRT(session, opSession, keyID, algorithm,
+                                keyLength, attrs);
                     }
-                } catch (PKCS11Exception e) {
-                    // ignore, assume not available
-                    isCRT = false;
+                } catch (PKCS11Exception ignored) {
+                    // Error getting an OpSession, unlikely.
                 } finally {
-                    session.token.releaseSession(tempSession);
-                }
-                BigInteger n = rsaAttrs[0].getBigInteger();
-                BigInteger d = rsaAttrs[1].getBigInteger();
-                if (isCRT) {
-                    return new P11RSAPrivateKey(session, keyID, algorithm,
-                           keyLength, attrs, n, d,
-                           Arrays.copyOfRange(rsaAttrs, 2, rsaAttrs.length));
-                } else {
-                    return new P11RSAPrivateNonCRTKey(session, keyID,
-                           algorithm, keyLength, attrs, n, d);
+                    session.token.releaseSession(opSession);
                 }
             }
+            if (p11Key == null) {
+                // Key is sensitive or there was a failure while querying its
+                // attributes: handle as opaque.
+                p11Key = new P11RSAPrivateKeyInternal(session, keyID, algorithm,
+                        keyLength, attrs);
+            }
+            return p11Key;
+        }
+
+        private static P11RSAPrivateKeyInternal asCRT(Session session,
+                Session opSession, long keyID, String algorithm, int keyLength,
+                CK_ATTRIBUTE[] attrs) {
+            CK_ATTRIBUTE[] rsaCRTAttrs = new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_MODULUS),
+                    new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
+                    new CK_ATTRIBUTE(CKA_PUBLIC_EXPONENT),
+                    new CK_ATTRIBUTE(CKA_PRIME_1),
+                    new CK_ATTRIBUTE(CKA_PRIME_2),
+                    new CK_ATTRIBUTE(CKA_EXPONENT_1),
+                    new CK_ATTRIBUTE(CKA_EXPONENT_2),
+                    new CK_ATTRIBUTE(CKA_COEFFICIENT),
+            };
+            try {
+                session.token.p11.C_GetAttributeValue(opSession.id(),
+                        keyID, rsaCRTAttrs);
+                for (CK_ATTRIBUTE attr : rsaCRTAttrs) {
+                    if (!(attr.pValue instanceof byte[])) {
+                        return null;
+                    }
+                }
+                return new P11RSAPrivateKey(session, keyID, algorithm,
+                        keyLength, attrs, rsaCRTAttrs[0].getBigInteger(),
+                        rsaCRTAttrs[1].getBigInteger(),
+                        Arrays.copyOfRange(rsaCRTAttrs, 2, rsaCRTAttrs.length));
+            } catch (PKCS11Exception ignored) {
+                // ignore, assume not available
+            }
+            return null;
+        }
+
+        private static P11RSAPrivateKeyInternal asNonCRT(Session session,
+                Session opSession, long keyID, String algorithm, int keyLength,
+                CK_ATTRIBUTE[] attrs) {
+            CK_ATTRIBUTE[] rsaNonCRTAttrs = new CK_ATTRIBUTE[] {
+                    new CK_ATTRIBUTE(CKA_MODULUS),
+                    new CK_ATTRIBUTE(CKA_PRIVATE_EXPONENT),
+            };
+            try {
+                session.token.p11.C_GetAttributeValue(opSession.id(), keyID,
+                        rsaNonCRTAttrs);
+                return new P11RSAPrivateNonCRTKey(session, keyID, algorithm,
+                        keyLength, attrs, rsaNonCRTAttrs[0].getBigInteger(),
+                        rsaNonCRTAttrs[1].getBigInteger());
+            } catch (PKCS11Exception ignored) {
+                // ignore, assume not available
+            }
+            return null;
         }
 
         protected transient BigInteger n;


### PR DESCRIPTION
Hi,

I'd like to make a proposal to fix [JDK-8336499](https://bugs.openjdk.org/browse/JDK-8336499).

With the proposed change, a non-sensitive RSA private key is first interpreted as a CRT key. If that fails (e.g. one of the attributes is not available), a second attempt is made to interpret the key as a non-CRT key. In this second attempt, only the required attributes (`CKA_MODULUS` and `CKA_PRIVATE_EXPONENT`) are queried. If this still fails, the key is handled as an opaque key. Most non-sensitive key cases will require a single query, retaining the performance improvement made in [8271566](https://bugs.openjdk.org/browse/JDK-8271566). No changes were made to sensitive keys: they are still handled as opaque keys.

No regressions observed in `jdk/sun/security/pkcs11`.

As explained in a [JBS comment](https://bugs.openjdk.org/browse/JDK-8336499?focusedId=14690278&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14690278), a regression test for this fix is not easy because the NSS Software Token cannot create non-CRT RSA private keys without a `CKA_PUBLIC_EXPONENT` (as required by the PKCS 11 standard v2.40 and above). A call to `P11RSAKeyFactory::generatePrivate` would fail and the key is never wrapped in a `P11Key` object. A PKCS 11 library implementing a standard previous to 2.40 would be required. With that said, I manually exercised the `asNonCRT` path in the proposed change by using a CRT key and forcing `asCRT` to fail with the debugger.

Thanks,
Martin.-

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336499](https://bugs.openjdk.org/browse/JDK-8336499): Failure when creating non-CRT RSA private keys in SunPKCS11 (**Bug** - P4)


### Reviewers
 * [Francisco Ferrari Bihurriet](https://openjdk.org/census#fferrari) (@franferrax - Author)
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)

### Contributors
 * Francisco Ferrari Bihurriet `<fferrari@openjdk.org>`
 * Martin Balao `<mbalao@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20204/head:pull/20204` \
`$ git checkout pull/20204`

Update a local copy of the PR: \
`$ git checkout pull/20204` \
`$ git pull https://git.openjdk.org/jdk.git pull/20204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20204`

View PR using the GUI difftool: \
`$ git pr show -t 20204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20204.diff">https://git.openjdk.org/jdk/pull/20204.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20204#issuecomment-2232039223)