### PR TITLE
8336587: failure_handler lldb command times out on macosx-aarch64 core file

### DIFF
--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -71,7 +71,7 @@ native.core.timeout=600000
 cores=native.lldb
 native.lldb.app=lldb
 native.lldb.delimiter=\0
-# Core files can be very big and take a long time to load on macosx--aarch64.
+# Core files can be very big and take a long time to load on macosx-aarch64.
 # The 20 seconds default timeout is not nearly enough.
 native.lldb.timeout=120000
 # Assume that java standard laucher has been used

--- a/test/failure_handler/src/share/conf/mac.properties
+++ b/test/failure_handler/src/share/conf/mac.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,9 @@ native.core.timeout=600000
 cores=native.lldb
 native.lldb.app=lldb
 native.lldb.delimiter=\0
+# Core files can be very big and take a long time to load on macosx--aarch64.
+# The 20 seconds default timeout is not nearly enough.
+native.lldb.timeout=120000
 # Assume that java standard laucher has been used
 native.lldb.args=--core\0%p\0%java\0-o\0thread backtrace all\0-o\0quit
 


### PR DESCRIPTION
I was looking at the failure_handler output for the lldb command on a macosx-aarch64 core file (it is trying to use lldb to get a back trace of all threads), and noticed it timed out:

```
----------------------------------------
[2024-07-15 05:15:47] [<snip>/usr/bin/lldb, --core, <snip>/core.92643, <snip>/bin/java, -o, thread backtrace all, -o, quit] timeout=20000 in <snip>
----------------------------------------
(lldb) target create "<snip>/bin/java" --core "<snip>/core.92643"
WARNING: tool timed out: killed process after 20000 ms
----------------------------------------
[2024-07-15 05:16:07] exit code: -2 time: 20163 ms
----------------------------------------
```

20 seconds is the failure_handler default timeout for all commands. Core files on macosx-aarch64 tend to be very large. This one was over 13gb. On my MBPro it took 30 seconds. I bumped up the timeout to 60 seconds and reproduce the same crash in mach5 (more than once), and it usually took about 55 seconds for the lldb command, but it did succeed with the longer timeout. I think we should change the timeout to even more than 60 seconds just to make sure we won't see timeouts. 120 seconds is probably a good amount.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336587](https://bugs.openjdk.org/browse/JDK-8336587): failure_handler lldb command times out on macosx-aarch64 core file (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20206/head:pull/20206` \
`$ git checkout pull/20206`

Update a local copy of the PR: \
`$ git checkout pull/20206` \
`$ git pull https://git.openjdk.org/jdk.git pull/20206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20206`

View PR using the GUI difftool: \
`$ git pr show -t 20206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20206.diff">https://git.openjdk.org/jdk/pull/20206.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20206#issuecomment-2232037054)