### PR TITLE
8335288: SunPKCS11 initialization will call C_GetMechanismInfo on unsupported mechanisms

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -370,6 +370,10 @@ final class Config {
         return nssOptimizeSpace;
     }
 
+    Set<Long> getDisabledMechanisms() {
+        return disabledMechanisms;
+    }
+
     private static String expand(final String s) throws IOException {
         try {
             return PropertyExpander.expand(s);

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -370,10 +370,6 @@ final class Config {
         return nssOptimizeSpace;
     }
 
-    Set<Long> getDisabledMechanisms() {
-        return disabledMechanisms;
-    }
-
     private static String expand(final String s) throws IOException {
         try {
             return PropertyExpander.expand(s);

--- a/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.cfg
+++ b/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.cfg
@@ -1,0 +1,14 @@
+name = NSS
+
+#showInfo = true
+
+slot = 1
+
+library = ${pkcs11test.nss.lib}
+
+disabledMechanisms = {
+    CKM_SHA224_HMAC
+    CKM_SHA256_HMAC
+}
+
+nssArgs = "configdir='${pkcs11test.nss.db}' certPrefix='' keyPrefix=''"

--- a/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.cfg
+++ b/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.cfg
@@ -1,6 +1,6 @@
 name = NSS
 
-#showInfo = true
+showInfo = true
 
 slot = 1
 

--- a/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.java
+++ b/test/jdk/sun/security/pkcs11/Provider/RequiredMechCheck.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8335288
+ * @library /test/lib ..
+ * @modules jdk.crypto.cryptoki
+ * @summary check that if any required mech is unavailable, then the
+ * mechanism will be unavailable as well.
+ * @run testng/othervm RequiredMechCheck
+ */
+import java.nio.file.Path;
+import java.security.Provider;
+import java.security.NoSuchAlgorithmException;
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKeyFactory;
+
+import jtreg.SkippedException;
+import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class RequiredMechCheck extends PKCS11Test {
+
+    private static record TestData(String serviceType, String algo,
+            boolean disabled) {}
+
+    private static TestData[] testValues = {
+        new TestData("MAC", "HmacPBESHA1", false),
+        new TestData("MAC", "HmacPBESHA224", true),
+        new TestData("MAC", "HmacPBESHA256", true),
+        new TestData("MAC", "HmacPBESHA384", false),
+        new TestData("MAC", "HmacPBESHA512", false),
+        new TestData("SKF", "PBEWithHmacSHA1AndAES_128", false),
+        new TestData("SKF", "PBEWithHmacSHA224AndAES_128", true),
+        new TestData("SKF", "PBEWithHmacSHA256AndAES_128", true),
+        new TestData("SKF", "PBEWithHmacSHA384AndAES_128", false),
+        new TestData("SKF", "PBEWithHmacSHA512AndAES_128", false),
+        new TestData("CIP", "PBEWithHmacSHA1AndAES_128", false),
+        new TestData("CIP", "PBEWithHmacSHA224AndAES_128", true),
+        new TestData("CIP", "PBEWithHmacSHA256AndAES_128", true),
+        new TestData("CIP", "PBEWithHmacSHA384AndAES_128", false),
+        new TestData("CIP", "PBEWithHmacSHA512AndAES_128", false),
+    };
+
+    @BeforeClass
+    public void setUp() throws Exception {
+        Path configPath = Path.of(BASE).resolve("RequiredMechCheck.cfg");
+        System.setProperty("CUSTOM_P11_CONFIG", configPath.toString());
+    }
+
+    @Test
+    public void test() throws Exception {
+        try {
+            main(new RequiredMechCheck());
+        } catch (SkippedException se) {
+            throw new SkipException("One or more tests are skipped");
+        }
+    }
+
+    public void main(Provider p) throws Exception {
+        for (TestData td : testValues) {
+            String desc = td.serviceType + " " + td.algo;
+            Object t;
+            try {
+                switch (td.serviceType) {
+                    case "MAC":
+                        t = Mac.getInstance(td.algo, p);
+                    break;
+                    case "SKF":
+                        t = SecretKeyFactory.getInstance(td.algo, p);
+                    break;
+                    case "CIP":
+                        t = Cipher.getInstance(td.algo, p);
+                    break;
+                    default:
+                        throw new RuntimeException("Unsupported Test Type!");
+                }
+
+                if (td.disabled) {
+                    throw new RuntimeException("Fail, no NSAE for " + desc);
+                } else {
+                    System.out.println("Ok, getInstance() works for " + desc);
+                }
+            } catch (NoSuchAlgorithmException e) {
+                if (td.disabled) {
+                    System.out.println("Ok, NSAE thrown for " + desc);
+                } else {
+                    throw new RuntimeException("Unexpected Ex for " + desc, e);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can someone help review this fix? Changed the required-mechanism check by checking if the particular mechanism is inside the list of enabled supported mechanisms. This should be more reliable than calling C_GetMechanismInfo(..) on the required mechanism given vendors may return various sorts of error codes.

Thanks,
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335288](https://bugs.openjdk.org/browse/JDK-8335288): SunPKCS11 initialization will call C_GetMechanismInfo on unsupported mechanisms (**Bug** - P3)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer) Review applies to [a37ab014](https://git.openjdk.org/jdk/pull/20207/files/a37ab014c0ba5beb553ff800901b2b24d6fdfaf5)
 * [Martin Balao](https://openjdk.org/census#mbalao) (@martinuy - Committer)
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20207/head:pull/20207` \
`$ git checkout pull/20207`

Update a local copy of the PR: \
`$ git checkout pull/20207` \
`$ git pull https://git.openjdk.org/jdk.git pull/20207/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20207`

View PR using the GUI difftool: \
`$ git pr show -t 20207`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20207.diff">https://git.openjdk.org/jdk/pull/20207.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20207#issuecomment-2232086241)