### PR TITLE
8335921: Fix HotSpot VM build without JVMTI

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -84,7 +84,7 @@ ifneq ($(call check-jvm-feature, jvmti), true)
       jvmtiImpl.cpp jvmtiManageCapabilities.cpp jvmtiRawMonitor.cpp jvmtiUtil.cpp jvmtiTrace.cpp \
       jvmtiCodeBlobEvents.cpp jvmtiEnv.cpp jvmtiRedefineClasses.cpp jvmtiEnvBase.cpp jvmtiEnvThreadState.cpp \
       jvmtiTagMap.cpp jvmtiEventController.cpp evmCompat.cpp jvmtiEnter.xsl jvmtiExport.cpp \
-      jvmtiClassFileReconstituter.cpp jvmtiTagMapTable.cpp jvmtiAgent.cpp jvmtiAgentList.cpp
+      jvmtiClassFileReconstituter.cpp jvmtiTagMapTable.cpp jvmtiAgent.cpp jvmtiAgentList.cpp jfrJvmtiAgent.cpp
 endif
 
 ifneq ($(call check-jvm-feature, jvmci), true)

--- a/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.hpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,10 +32,10 @@ class JfrJvmtiAgent : public JfrCHeapObj {
  private:
   JfrJvmtiAgent();
   ~JfrJvmtiAgent();
-  static bool create();
-  static void destroy();
+  static bool create() NOT_JVMTI_RETURN_(true);
+  static void destroy() NOT_JVMTI_RETURN;
  public:
-  static void retransform_classes(JNIEnv* env, jobjectArray classes, TRAPS);
+  static void retransform_classes(JNIEnv* env, jobjectArray classes, TRAPS) NOT_JVMTI_RETURN;
 };
 
 #endif // SHARE_JFR_INSTRUMENTATION_JFRJVMTIAGENT_HPP

--- a/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
+++ b/src/hotspot/share/jfr/periodic/jfrPeriodic.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -280,6 +280,7 @@ TRACE_REQUEST_FUNC(SystemProcess) {
   }
 }
 
+#if INCLUDE_JVMTI
 template <typename AgentEvent>
 static void send_agent_event(AgentEvent& event, const JvmtiAgent* agent) {
   event.set_name(agent->name());
@@ -316,6 +317,10 @@ TRACE_REQUEST_FUNC(NativeAgent) {
   const JvmtiAgentList::Iterator xrun_agents_it = JvmtiAgentList::xrun_agents();
   send_native_agent_events(xrun_agents_it);
 }
+#else  // INCLUDE_JVMTI
+TRACE_REQUEST_FUNC(JavaAgent)   {}
+TRACE_REQUEST_FUNC(NativeAgent) {}
+#endif // INCLUDE_JVMTI
 
 TRACE_REQUEST_FUNC(ThreadContextSwitchRate) {
   double rate = 0.0;

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -238,7 +238,7 @@ bool JfrRecorder::on_create_vm_2() {
 }
 
 bool JfrRecorder::on_create_vm_3() {
-  assert(JvmtiEnvBase::get_phase() == JVMTI_PHASE_LIVE, "invalid init sequence");
+  JVMTI_ONLY( assert(JvmtiEnvBase::get_phase() == JVMTI_PHASE_LIVE, "invalid init sequence"); )
   return CDSConfig::is_dumping_archive() || launch_command_line_recordings(JavaThread::current());
 }
 

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.hpp
@@ -126,12 +126,14 @@ class CompilerToVM {
     // Minimum alignment of an offset into CodeBuffer::SECT_CONSTS
     static int data_section_item_alignment;
 
+#if INCLUDE_JVMTI
     /*
      * Pointer to JvmtiExport::_should_notify_object_alloc.
      * Exposed as an int* instead of an address so the
      * underlying type is part of the JVMCIVMStructs definition.
      */
     static int* _should_notify_object_alloc;
+#endif
 
    public:
      static void initialize(JVMCI_TRAPS);

--- a/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVMInit.cpp
@@ -144,7 +144,7 @@ address CompilerToVM::Data::symbol_clinit;
 
 int CompilerToVM::Data::data_section_item_alignment;
 
-int* CompilerToVM::Data::_should_notify_object_alloc;
+JVMTI_ONLY( int* CompilerToVM::Data::_should_notify_object_alloc; )
 
 void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
   Klass_vtable_start_offset = in_bytes(Klass::vtable_start_offset());
@@ -230,7 +230,7 @@ void CompilerToVM::Data::initialize(JVMCI_TRAPS) {
 
   data_section_item_alignment = relocInfo::addr_unit();
 
-  _should_notify_object_alloc = &JvmtiExport::_should_notify_object_alloc;
+  JVMTI_ONLY( _should_notify_object_alloc = &JvmtiExport::_should_notify_object_alloc; )
 
   BarrierSet* bs = BarrierSet::barrier_set();
   if (bs->is_a(BarrierSet::CardTableBarrierSet)) {

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -138,7 +138,7 @@
                                                                                                                                      \
   static_field(CompilerToVM::Data,             data_section_item_alignment,            int)                                          \
                                                                                                                                      \
-  static_field(CompilerToVM::Data,             _should_notify_object_alloc,            int*)                                         \
+  JVMTI_ONLY(static_field(CompilerToVM::Data,  _should_notify_object_alloc,            int*))                                         \
                                                                                                                                      \
   static_field(Abstract_VM_Version,            _features,                              uint64_t)                                     \
                                                                                                                                      \

--- a/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestAgentEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import jdk.test.lib.jfr.TestClassLoader;
  * @test
  * @key jfr
  * @summary Tests Agent Loaded event by starting native and Java agents
- * @requires vm.hasJFR
+ * @requires vm.hasJFR & vm.jvmti
  *
  * @library /test/lib
  * @modules java.instrument


### PR DESCRIPTION
Citing David Holmes from bug report:
"We provided the ability to leave out certain VM services (JVMTI, GC's other than serial, ...) as part of the design of the MinimalVM to support Java SE Embedded, along with the Compact Profiles of JDK 8. This manifested in the source code as a set of INCLUDE_XXX ifdef guards. The build system later exposed these as individual --with-jvm-features=xxx,yyy support. However, it was never intended (and certainly not tested) that you could mix-and-match arbitrary subsets of these VM features at will. Consequently if you start trying to do this you will find things that need fixing."

I added `INCLUDE_JVMTI` guards in two places where it was missed: JVMCI and JFR.  Affected code was added recently, in the past year. After that I was able to build VM on all supported platforms.

Note: building VM without JVMTI is not officially supported feature. We are not testing it and such failures (missing guards) are not unexpected.

A lot of tests failed with VM without JVMTI. All are expected failures. I listed failed tests in bug report.
I fixed (added requires `vm.jvmti`) only one which was part of [JDK-8257967](https://bugs.openjdk.org/browse/JDK-8257967) changes which introduced JFR code without `INCLUDE_JVMTI` guards.

I ran 2 rounds of testing:

First, only **tier1** with VM built without JVMTI to see if builds passed and which tests affected. I wrote comment in bug report which tests failed (all expected to fail without JVMTI).

Second round of testing with JVMTI in VM: tier1-4
