### PR TITLE
8331194: NPE in ArrayCreationTree.java with -XX:-UseCompressedOops

### DIFF
--- a/src/hotspot/share/opto/machnode.hpp
+++ b/src/hotspot/share/opto/machnode.hpp
@@ -870,6 +870,10 @@ public:
     assert(verify_jvms(jvms), "jvms must match");
     return in(_jvmadj + jvms->monitor_box_offset(idx));
   }
+  Node* scalarized_obj(const JVMState* jvms, uint idx) const {
+    assert(verify_jvms(jvms), "jvms must match");
+    return in(_jvmadj + jvms->scloff() + idx);
+  }
   void  set_local(const JVMState* jvms, uint idx, Node *c) {
     assert(verify_jvms(jvms), "jvms must match");
     set_req(_jvmadj + jvms->locoff() + idx, c);

--- a/src/hotspot/share/opto/output.hpp
+++ b/src/hotspot/share/opto/output.hpp
@@ -209,6 +209,9 @@ public:
 
   bool starts_bundle(const Node *n) const;
   bool contains_as_owner(GrowableArray<MonitorValue*> *monarray, ObjectValue *ov) const;
+  bool contains_as_scalarized_obj(JVMState* jvms, MachSafePointNode* sfn,
+                                  GrowableArray<ScopeValue*>* objs,
+                                  ObjectValue* ov) const;
 
   // Dump formatted assembly
 #if defined(SUPPORT_OPTO_ASSEMBLY)

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndNestedScalarized.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndNestedScalarized.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331194
+ * @summary Check that Reduce Allocation Merges doesn't crash when an input
+ *          of the Phi is not the _current_ output of the Phi but said input
+ *          needs to be rematerialized because it's used regardless of the
+ *          Phi output.
+ * @run main/othervm -XX:CompileCommand=dontinline,*TestReduceAllocationAndNestedScalarized*::test
+ *                   -XX:CompileCommand=compileonly,*TestReduceAllocationAndNestedScalarized*::test
+ *                   -XX:CompileCommand=compileonly,*Picture*::*init*
+ *                   -XX:CompileCommand=compileonly,*Point*::*init*
+ *                   -XX:CompileCommand=exclude,*Unloaded*::*
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-TieredCompilation
+ *                   -XX:-UseCompressedOops
+ *                   -Xcomp
+ *                   -server
+ *                   compiler.escapeAnalysis.TestReduceAllocationAndNestedScalarized
+ * @run main compiler.escapeAnalysis.TestReduceAllocationAndNestedScalarized
+ */
+
+package compiler.escapeAnalysis;
+
+public class TestReduceAllocationAndNestedScalarized {
+    static class Picture {
+        public Point first;
+        public Point second;
+    }
+
+    static class Point {
+        int x;
+    }
+
+    static class Unloaded {
+    }
+
+    static int test(boolean cond) {
+        Picture p = new Picture();
+        p.first = new Point();
+        Point p2 = p.first;
+
+        if (cond) p2 = new Point();
+
+        p.second = p2;
+
+        new Unloaded();
+
+        return p.first.x;
+    }
+
+    public static void main(String[] args) {
+        Picture pic = new Picture();
+        Point pnt   = new Point();
+        int res     = test(true);
+        System.out.println("Result is: " + res);
+    }
+}


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [005fb67e](https://github.com/openjdk/jdk/commit/005fb67e99370ef2bd15dae621a3924e1cf00124) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Cesar Soares Lucas on 16 Jul 2024 and was reviewed by Vladimir Kozlov.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331194](https://bugs.openjdk.org/browse/JDK-8331194): NPE in ArrayCreationTree.java with -XX:-UseCompressedOops (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20210/head:pull/20210` \
`$ git checkout pull/20210`

Update a local copy of the PR: \
`$ git checkout pull/20210` \
`$ git pull https://git.openjdk.org/jdk.git pull/20210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20210`

View PR using the GUI difftool: \
`$ git pr show -t 20210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20210.diff">https://git.openjdk.org/jdk/pull/20210.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20210#issuecomment-2232442493)