### PR TITLE
8336375: Crash on paste to JShell

### DIFF
--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/ffm/Kernel32.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/ffm/Kernel32.java
@@ -236,7 +236,7 @@ final class Kernel32 {
         MethodHandle mh$ = requireNonNull(ScrollConsoleScreenBufferW$MH, "ScrollConsoleScreenBuffer");
         try {
             return (int)
-                    mh$.invokeExact(hConsoleOutput, lpScrollRectangle, lpClipRectangle, dwDestinationOrigin, lpFill);
+                    mh$.invokeExact(hConsoleOutput, lpScrollRectangle.seg, lpClipRectangle.seg, dwDestinationOrigin.seg, lpFill.seg);
         } catch (Throwable ex$) {
             throw new AssertionError("should not reach here", ex$);
         }


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [b9b0b850](https://github.com/openjdk/jdk/commit/b9b0b8504ec989ad0687188de4bccfe2c04e5d64) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jan Lahoda on 17 Jul 2024 and was reviewed by Jorn Vernee.

Thanks!

Original description:
On Windows, the `ScrollConsoleScreenBufferW` function is being looked like this:
https://github.com/openjdk/jdk/blob/a253e0ff4b88541d01596b0e73ede4b96a258fca/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/ffm/Kernel32.java#L406
I.e. the parameters are `MemorySegment`s/pointers. But, it is being invoked like this:
https://github.com/openjdk/jdk/blob/a253e0ff4b88541d01596b0e73ede4b96a258fca/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/ffm/Kernel32.java#L239
I.e. with values rather than with pointers. This then fails at runtime when the function is called with an exception like:
```
Caused by: java.lang.invoke.WrongMethodTypeException: handle's method type (MemorySegment,MemorySegment,MemorySegment,MemorySegment,MemorySegment)int but found (MemorySegment,SMALL_RECT,SMALL_RECT,COORD,CHAR_INFO)int
        at java.base/java.lang.invoke.Invokers.newWrongMethodTypeException(Invokers.java:521)
        at java.base/java.lang.invoke.Invokers.checkExactType(Invokers.java:530)
        at jdk.internal.le/jdk.internal.org.jline.terminal.impl.ffm.Kernel32.ScrollConsoleScreenBuffer(Kernel32.java:239)
```

The proposal here is to use MemorySegments embedded in the provided parameters. This is consistent with the rest of the file, see for example here:
https://github.com/openjdk/jdk/blob/a253e0ff4b88541d01596b0e73ede4b96a258fca/src/jdk.internal.le/share/classes/jdk/internal/org/jline/terminal/impl/ffm/Kernel32.java#L173

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336375](https://bugs.openjdk.org/browse/JDK-8336375): Crash on paste to JShell (**Bug** - P3)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20213/head:pull/20213` \
`$ git checkout pull/20213`

Update a local copy of the PR: \
`$ git checkout pull/20213` \
`$ git pull https://git.openjdk.org/jdk.git pull/20213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20213`

View PR using the GUI difftool: \
`$ git pr show -t 20213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20213.diff">https://git.openjdk.org/jdk/pull/20213.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20213#issuecomment-2232562625)