### PR TITLE
4265389: JSplitPane does not support ComponentOrientation

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -26,7 +26,7 @@
 package javax.swing;
 
 import java.awt.Component;
-import java.awt.ComponentiOrientation;
+import java.awt.ComponentOrientation;
 import java.awt.Graphics;
 import java.beans.BeanProperty;
 import java.beans.ConstructorProperties;

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -388,7 +388,7 @@ public class JSplitPane extends JComponent implements Accessible
             }
         }
     }
-    
+
     /**
      * {@inheritDoc}
      * @param enabled {@inheritDoc}

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -372,7 +372,7 @@ public class JSplitPane extends JComponent implements Accessible
         super.setComponentOrientation(orientation);
         Component leftComponent = this.getLeftComponent();
         Component rightComponent = this.getRightComponent();
-        if (this.getComponentOrientation().equals(ComponentOrientation.RIGHT_TO_LEFT)) {
+        if (!this.getComponentOrientation().isLeftToRight()) {
             if (rightComponent != null) {
                 setLeftComponent(rightComponent);
             }

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -356,15 +356,19 @@ public class JSplitPane extends JComponent implements Accessible
                                                "or JSplitPane.VERTICAL_SPLIT");
         continuousLayout = newContinuousLayout;
         if (this.getComponentOrientation().equals(ComponentOrientation.LEFT_TO_RIGHT)) {
-            if (newLeftComponent != null)
+            if (newLeftComponent != null) {
                 setLeftComponent(newLeftComponent);
-            if (newRightComponent != null)
+            }
+            if (newRightComponent != null) {
                 setRightComponent(newRightComponent);
+            }
         } else {
-            if (newLeftComponent != null)
+            if (newLeftComponent != null) {
                 setRightComponent(newLeftComponent);
-            if (newRightComponent != null)
+            }
+            if (newRightComponent != null) {
                 setLeftComponent(newRightComponent);
+            }
         }
         updateUI();
 

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -355,21 +355,10 @@ public class JSplitPane extends JComponent implements Accessible
                                                "JSplitPane.HORIZONTAL_SPLIT " +
                                                "or JSplitPane.VERTICAL_SPLIT");
         continuousLayout = newContinuousLayout;
-        if (this.getComponentOrientation().equals(ComponentOrientation.LEFT_TO_RIGHT)) {
-            if (newLeftComponent != null) {
-                setLeftComponent(newLeftComponent);
-            }
-            if (newRightComponent != null) {
-                setRightComponent(newRightComponent);
-            }
-        } else {
-            if (newLeftComponent != null) {
-                setRightComponent(newLeftComponent);
-            }
-            if (newRightComponent != null) {
-                setLeftComponent(newRightComponent);
-            }
-        }
+        if (newLeftComponent != null)
+            setLeftComponent(newLeftComponent);
+        if (newRightComponent != null)
+            setRightComponent(newRightComponent);
         updateUI();
 
     }
@@ -383,6 +372,16 @@ public class JSplitPane extends JComponent implements Accessible
         super.setEnabled(enabled);
         if (this.getUI() instanceof BasicSplitPaneUI) {
             ((BasicSplitPaneUI)(this.getUI())).getDivider().setEnabled(enabled);
+        }
+        if (this.getComponentOrientation().equals(ComponentOrientation.RIGHT_TO_LEFT)) {
+            Component leftComponent = this.getLeftComponent();
+            Component rightComponent = this.getRightComponent();
+            if (rightComponent != null) {
+                setLeftComponent(rightComponent);
+            }
+            if (leftComponent != null) {
+                setRightComponent(leftComponent);
+            }
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -365,6 +365,32 @@ public class JSplitPane extends JComponent implements Accessible
 
     /**
      * {@inheritDoc}
+     * @param orientation {@inheritDoc}
+     */
+    @Override
+    public void setComponentOrientation(ComponentOrientation orientation) {
+        super.setComponentOrientation(orientation);
+        Component leftComponent = this.getLeftComponent();
+        Component rightComponent = this.getRightComponent();
+        if (this.getComponentOrientation().equals(ComponentOrientation.RIGHT_TO_LEFT)) {
+            if (rightComponent != null) {
+                setLeftComponent(rightComponent);
+            }
+            if (leftComponent != null) {
+                setRightComponent(leftComponent);
+            }
+        } else {
+            if (leftComponent != null) {
+                setLeftComponent(leftComponent);
+            }
+            if (rightComponent != null) {
+                setRightComponent(rightComponent);
+            }
+        }
+    }
+    
+    /**
+     * {@inheritDoc}
      * @param enabled {@inheritDoc}
      */
     @Override
@@ -372,16 +398,6 @@ public class JSplitPane extends JComponent implements Accessible
         super.setEnabled(enabled);
         if (this.getUI() instanceof BasicSplitPaneUI) {
             ((BasicSplitPaneUI)(this.getUI())).getDivider().setEnabled(enabled);
-        }
-        if (this.getComponentOrientation().equals(ComponentOrientation.RIGHT_TO_LEFT)) {
-            Component leftComponent = this.getLeftComponent();
-            Component rightComponent = this.getRightComponent();
-            if (rightComponent != null) {
-                setLeftComponent(rightComponent);
-            }
-            if (leftComponent != null) {
-                setRightComponent(leftComponent);
-            }
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/JSplitPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JSplitPane.java
@@ -26,6 +26,7 @@
 package javax.swing;
 
 import java.awt.Component;
+import java.awt.ComponentiOrientation;
 import java.awt.Graphics;
 import java.beans.BeanProperty;
 import java.beans.ConstructorProperties;
@@ -354,10 +355,17 @@ public class JSplitPane extends JComponent implements Accessible
                                                "JSplitPane.HORIZONTAL_SPLIT " +
                                                "or JSplitPane.VERTICAL_SPLIT");
         continuousLayout = newContinuousLayout;
-        if (newLeftComponent != null)
-            setLeftComponent(newLeftComponent);
-        if (newRightComponent != null)
-            setRightComponent(newRightComponent);
+        if (this.getComponentOrientation().equals(ComponentOrientation.LEFT_TO_RIGHT)) {
+            if (newLeftComponent != null)
+                setLeftComponent(newLeftComponent);
+            if (newRightComponent != null)
+                setRightComponent(newRightComponent);
+        } else {
+            if (newLeftComponent != null)
+                setRightComponent(newLeftComponent);
+            if (newRightComponent != null)
+                setLeftComponent(newRightComponent);
+        }
         updateUI();
 
     }

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
@@ -28,6 +28,7 @@
  * @run main TestSplitPaneOrientationTest
  */
 
+import java.awt.ComponentOrientation;
 import javax.swing.JButton;
 import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
@@ -55,6 +56,8 @@ public class TestSplitPaneOrientationTest {
                 setLookAndFeel(laf);
                 JSplitPane jsp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
                                                 new JButton("Left"), new JButton("Right"));
+                jsp.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
+                jsp.setEnabled(true);
                 if (jsp.getRightComponent() instanceof JButton button) {
                     System.out.println(button.getText());
                     if (!button.getText().equals("Left")) {

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4265389
+ * @summary  Verifies JSplitPane support ComponentOrientation
+ * @run main TestSplitPaneOrientationTest
+ */
+
+import javax.swing.JButton;
+import javax.swing.JSplitPane;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+public class TestSplitPaneOrientationTest {
+    private static JButton leftOneTouchButton;
+    private static JButton rightOneTouchButton;
+
+    private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
+        try {
+            UIManager.setLookAndFeel(laf.getClassName());
+        } catch (UnsupportedLookAndFeelException ignored) {
+            System.out.println("Unsupported LAF: " + laf.getClassName());
+        } catch (ClassNotFoundException | InstantiationException
+                 | IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        for (UIManager.LookAndFeelInfo laf : UIManager.getInstalledLookAndFeels()) {
+            System.out.println("Testing LAF : " + laf.getClassName());
+
+            SwingUtilities.invokeAndWait(() -> {
+                setLookAndFeel(laf);
+                JSplitPane jsp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
+                                                new JButton("Left"), new JButton("Right"));
+                jsp.setEnabled(true);
+                if (jsp.getRightComponent() instanceof JButton button) {
+                    System.out.println(button.getText());
+                    if (!button.getText().equals("Left")) {
+                        throw new RuntimeException("JSplitPane did not support ComponentOrientation");
+                    }
+                }
+            });
+        }
+    }
+
+}
+

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
@@ -57,7 +57,6 @@ public class TestSplitPaneOrientationTest {
                 JSplitPane jsp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
                                                 new JButton("Left"), new JButton("Right"));
                 jsp.setComponentOrientation(ComponentOrientation.RIGHT_TO_LEFT);
-                jsp.setEnabled(true);
                 if (jsp.getRightComponent() instanceof JButton button) {
                     System.out.println(button.getText());
                     if (!button.getText().equals("Left")) {

--- a/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
+++ b/test/jdk/javax/swing/JSplitPane/TestSplitPaneOrientationTest.java
@@ -35,8 +35,6 @@ import javax.swing.UIManager;
 import javax.swing.UnsupportedLookAndFeelException;
 
 public class TestSplitPaneOrientationTest {
-    private static JButton leftOneTouchButton;
-    private static JButton rightOneTouchButton;
 
     private static void setLookAndFeel(UIManager.LookAndFeelInfo laf) {
         try {
@@ -57,7 +55,6 @@ public class TestSplitPaneOrientationTest {
                 setLookAndFeel(laf);
                 JSplitPane jsp = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT,
                                                 new JButton("Left"), new JButton("Right"));
-                jsp.setEnabled(true);
                 if (jsp.getRightComponent() instanceof JButton button) {
                     System.out.println(button.getText());
                     if (!button.getText().equals("Left")) {


### PR DESCRIPTION
JSplitPane's support of CompoentOrientation is not present so if orientation is RTL, it still renders left component on left and right component on right instead of other way around..
Fix to make it support RTL orientation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-4265389](https://bugs.openjdk.org/browse/JDK-4265389): JSplitPane does not support ComponentOrientation (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - Committer) 🔄 Re-review required (review applies to [6017c687](https://git.openjdk.org/jdk/pull/20214/files/6017c68796c7a88836e394e51ddc8de24d33045a))
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20214/head:pull/20214` \
`$ git checkout pull/20214`

Update a local copy of the PR: \
`$ git checkout pull/20214` \
`$ git pull https://git.openjdk.org/jdk.git pull/20214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20214`

View PR using the GUI difftool: \
`$ git pr show -t 20214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20214.diff">https://git.openjdk.org/jdk/pull/20214.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20214#issuecomment-2232615826)