### PR TITLE
8336635: Add IR test for Reference.refersTo intrinsic

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/gc/ReferenceRefersToTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/gc/ReferenceRefersToTests.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests.gc;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+import jdk.test.whitebox.gc.GC;
+
+import java.lang.ref.*;
+
+/*
+ * @test
+ * @bug 8336635
+ * @summary Test that Reference.refersTo intrinsics are properly handled
+ * @library /test/lib /
+ * @build jdk.test.whitebox.WhiteBox
+ * @requires vm.compiler2.enabled
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI compiler.c2.irTests.gc.ReferenceRefersToTests
+
+ */
+public class ReferenceRefersToTests {
+
+    public static void main(String[] args) {
+        TestFramework framework = new TestFramework();
+
+        // Use PerMethodTrapLimit=0 to compile all branches in the intrinsics.
+
+        int idx = 0;
+        if (GC.isSelectedErgonomically() && GC.Serial.isSupported()) {
+            // Serial does not have any barriers in refersTo.
+            framework.addScenarios(new Scenario(idx++,
+                "-XX:PerMethodTrapLimit=0",
+                "-XX:+UseSerialGC"
+            ));
+        }
+        if (GC.isSelectedErgonomically() && GC.Parallel.isSupported()) {
+            // Parallel does not have any barriers in refersTo.
+            framework.addScenarios(new Scenario(idx++,
+                "-XX:PerMethodTrapLimit=0",
+                "-XX:+UseParallelGC"
+            ));
+        }
+        if (GC.isSelectedErgonomically() && GC.G1.isSupported()) {
+            // G1 nominally needs keep-alive barriers for Reference loads,
+            // but should not have them for refersTo.
+            framework.addScenarios(new Scenario(idx++,
+                "-XX:PerMethodTrapLimit=0",
+                "-XX:+UseG1GC"
+            ));
+        }
+        if (GC.isSelectedErgonomically() && GC.Shenandoah.isSupported()) {
+            // Shenandoah nominally needs keep-alive barriers for Reference loads,
+            // but should not have them for refersTo. We only care to check that
+            // SATB barrier is not emitted. Shenandoah would also emit LRB barrier,
+            // which would false-negative the test.
+            framework.addScenarios(new Scenario(idx++,
+                "-XX:PerMethodTrapLimit=0",
+                "-XX:+UnlockDiagnosticVMOptions",
+                "-XX:ShenandoahGCMode=passive",
+                "-XX:+ShenandoahSATBBarrier",
+                "-XX:+UseShenandoahGC"
+            ));
+        }
+        if (GC.isSelectedErgonomically() && GC.Z.isSupported()) {
+            // ZGC does not emit barriers in IR.
+            framework.addScenarios(new Scenario(idx++,
+                "-XX:PerMethodTrapLimit=0",
+                "-XX:+UseZGC"
+            ));
+        }
+        if (GC.isSelectedErgonomically() && GC.Epsilon.isSupported()) {
+            // Epsilon does not emit barriers at all.
+            framework.addScenarios(new Scenario(idx++,
+                "-XX:PerMethodTrapLimit=0",
+                "-XX:+UnlockExperimentalVMOptions",
+                "-XX:+UseEpsilonGC"
+            ));
+        }
+        framework.start();
+    }
+
+    static final Object REF = new Object();
+
+    static final SoftReference<Object> SR = new SoftReference<>(REF);
+    static final WeakReference<Object> WR = new WeakReference<>(REF);
+    static final PhantomReference<Object> PR = new PhantomReference<>(REF, null);
+
+    // Verify that we are left with a single load of Reference.referent and no stores.
+    // This serves as a signal that no GC barriers are emitted in IR.
+
+    @Test
+    @IR(counts = { IRNode.LOAD, "1" })
+    @IR(failOn = { IRNode.STORE })
+    public boolean soft_null() {
+        return SR.refersTo(null);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOAD, "1" })
+    @IR(failOn = { IRNode.STORE })
+    public boolean soft_ref() {
+        return SR.refersTo(REF);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOAD, "1" })
+    @IR(failOn = { IRNode.STORE })
+    public boolean weak_null() {
+        return WR.refersTo(null);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOAD, "1" })
+    @IR(failOn = { IRNode.STORE })
+    public boolean weak_ref() {
+        return WR.refersTo(REF);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOAD, "1" })
+    @IR(failOn = { IRNode.STORE })
+    public boolean phantom_null() {
+        return PR.refersTo(null);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOAD, "1" })
+    @IR(failOn = { IRNode.STORE })
+    public boolean phantom_ref() {
+        return PR.refersTo(REF);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/gc/ReferenceRefersToTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/gc/ReferenceRefersToTests.java
@@ -30,14 +30,13 @@ import java.lang.ref.*;
 
 /*
  * @test
- * @bug 8336635
+ * @bug 8256999
  * @summary Test that Reference.refersTo intrinsics are properly handled
  * @library /test/lib /
  * @build jdk.test.whitebox.WhiteBox
  * @requires vm.compiler2.enabled
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI compiler.c2.irTests.gc.ReferenceRefersToTests
-
  */
 public class ReferenceRefersToTests {
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/gc/ReferenceRefersToTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/gc/ReferenceRefersToTests.java
@@ -89,14 +89,6 @@ public class ReferenceRefersToTests {
                 "-XX:+UseZGC"
             ));
         }
-        if (GC.isSelectedErgonomically() && GC.Epsilon.isSupported()) {
-            // Epsilon does not emit barriers at all.
-            framework.addScenarios(new Scenario(idx++,
-                "-XX:PerMethodTrapLimit=0",
-                "-XX:+UnlockExperimentalVMOptions",
-                "-XX:+UseEpsilonGC"
-            ));
-        }
         framework.start();
     }
 


### PR DESCRIPTION
As the follow-up for [JDK-8256999](https://bugs.openjdk.org/browse/JDK-8256999), we can directly test for the (absence of) GC barriers in C2 `Reference.refersTo` intrinsic. This would be come less relevant for G1 after Late Barrier expansion lands, but would still be relevant for Shenandoah for a while. It would also be good for backports.

Additional testing:
 - [x] Test fails when I deliberately remove `AS_NO_KEEPALIVE` from the C2 intrinsic
 - [x] Test passes with GC explicitly passed as `TEST_VM_OPTS`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336635](https://bugs.openjdk.org/browse/JDK-8336635): Add IR test for Reference.refersTo intrinsic (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) 🔄 Re-review required (review applies to [ca1ad60e](https://git.openjdk.org/jdk/pull/20215/files/ca1ad60e5c3de3e1a2ae82aff624fe28a0332b39))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20215/head:pull/20215` \
`$ git checkout pull/20215`

Update a local copy of the PR: \
`$ git checkout pull/20215` \
`$ git pull https://git.openjdk.org/jdk.git pull/20215/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20215`

View PR using the GUI difftool: \
`$ git pr show -t 20215`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20215.diff">https://git.openjdk.org/jdk/pull/20215.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20215#issuecomment-2232915332)