### PR TITLE
8336638: Parallel: Remove redundant mangle in PSScavenge::invoke

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -344,6 +344,9 @@ bool PSScavenge::invoke(bool clear_soft_refs) {
   PSOldGen* old_gen = heap->old_gen();
   PSAdaptiveSizePolicy* size_policy = heap->size_policy();
 
+  assert(young_gen->to_space()->is_empty(),
+         "Attempt to scavenge with live objects in to_space");
+
   heap->increment_total_collections();
 
   if (AdaptiveSizePolicy::should_update_eden_stats(gc_cause)) {
@@ -378,10 +381,6 @@ bool PSScavenge::invoke(bool clear_soft_refs) {
 
     // Let the size policy know we're starting
     size_policy->minor_collection_begin();
-
-    assert(young_gen->to_space()->is_empty(),
-           "Attempt to scavenge with live objects in to_space");
-    young_gen->to_space()->clear(SpaceDecorator::Mangle);
 
 #if COMPILER2_OR_JVMCI
     DerivedPointerTable::clear();


### PR DESCRIPTION
Trivial removing unnecessary clear at start of young-gc. Also move a precondition to the start, as early as possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336638](https://bugs.openjdk.org/browse/JDK-8336638): Parallel: Remove redundant mangle in PSScavenge::invoke (**Enhancement** - P4)


### Reviewers
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20216/head:pull/20216` \
`$ git checkout pull/20216`

Update a local copy of the PR: \
`$ git checkout pull/20216` \
`$ git pull https://git.openjdk.org/jdk.git pull/20216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20216`

View PR using the GUI difftool: \
`$ git pr show -t 20216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20216.diff">https://git.openjdk.org/jdk/pull/20216.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20216#issuecomment-2232933691)