### PR TITLE
8336661: Parallel: Remove stacks_empty assert in PSScavenge::invoke

### DIFF
--- a/src/hotspot/share/gc/parallel/psScavenge.cpp
+++ b/src/hotspot/share/gc/parallel/psScavenge.cpp
@@ -401,8 +401,6 @@ bool PSScavenge::invoke(bool clear_soft_refs) {
 
     PSPromotionManager::pre_scavenge();
 
-    // We'll use the promotion manager again later.
-    PSPromotionManager* promotion_manager = PSPromotionManager::vm_thread_promotion_manager();
     {
       GCTraceTime(Debug, gc, phases) tm("Scavenge", &_gc_timer);
 
@@ -425,16 +423,11 @@ bool PSScavenge::invoke(bool clear_soft_refs) {
       pt.print_all_references();
     }
 
-    assert(promotion_manager->stacks_empty(),"stacks should be empty at this point");
-
     {
       GCTraceTime(Debug, gc, phases) tm("Weak Processing", &_gc_timer);
       PSAdjustWeakRootsClosure root_closure;
       WeakProcessor::weak_oops_do(&ParallelScavengeHeap::heap()->workers(), &_is_alive_closure, &root_closure, 1);
     }
-
-    // Verify that usage of root_closure didn't copy any objects.
-    assert(promotion_manager->stacks_empty(),"stacks should be empty at this point");
 
     // Finally, flush the promotion_manager's labs, and deallocate its stacks.
     promotion_failure_occurred = PSPromotionManager::post_scavenge(_gc_tracer);


### PR DESCRIPTION
Trivial removing redundant asserts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336661](https://bugs.openjdk.org/browse/JDK-8336661): Parallel: Remove stacks_empty assert in PSScavenge::invoke (**Enhancement** - P4)


### Reviewers
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20218/head:pull/20218` \
`$ git checkout pull/20218`

Update a local copy of the PR: \
`$ git checkout pull/20218` \
`$ git pull https://git.openjdk.org/jdk.git pull/20218/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20218`

View PR using the GUI difftool: \
`$ git pr show -t 20218`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20218.diff">https://git.openjdk.org/jdk/pull/20218.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20218#issuecomment-2233767475)