### PR TITLE
8336663: [JVMCI] VM Crash on ZGC due to incompatible handle returned by HotSpotJVMCIRuntime#getJObjectValue

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -710,6 +710,9 @@ C2V_END
 
 C2V_VMENTRY_0(jlong, getJObjectValue, (JNIEnv* env, jobject, jobject constant_jobject))
     requireNotInHotSpot("getJObjectValue", JVMCI_CHECK_0);
+    if (!THREAD->has_last_Java_frame()) {
+        JVMCI_THROW_MSG_0(IllegalStateException, err_msg("Cannot call getJObjectValue without Java frame anchor"));
+    }
     JVMCIObject constant = JVMCIENV->wrap(constant_jobject);
     Handle constant_value = JVMCIENV->asConstant(constant, JVMCI_CHECK_0);
     jobject jni_handle = JNIHandles::make_local(THREAD, constant_value());

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -94,6 +94,12 @@ static void requireInHotSpot(const char* caller, JVMCI_TRAPS) {
   }
 }
 
+static void requireNotInHotSpot(const char* caller, JVMCI_TRAPS) {
+    if (JVMCIENV->is_hotspot()) {
+        JVMCI_THROW_MSG(IllegalStateException, err_msg("Cannot call %s from HotSpot", caller));
+    }
+}
+
 class JVMCITraceMark : public StackObj {
   const char* _msg;
  public:
@@ -700,6 +706,14 @@ C2V_VMENTRY_NULL(jobject, lookupJClass, (JNIEnv* env, jobject, jlong jclass_valu
     JVMCIKlassHandle klass(THREAD, java_lang_Class::as_Klass(obj));
     JVMCIObject result = JVMCIENV->get_jvmci_type(klass, JVMCI_CHECK_NULL);
     return JVMCIENV->get_jobject(result);
+C2V_END
+
+C2V_VMENTRY_0(jlong, getJObjectValue, (JNIEnv* env, jobject, jobject constant_jobject))
+    requireNotInHotSpot("getJObjectValue", JVMCI_CHECK_0);
+    JVMCIObject constant = JVMCIENV->wrap(constant_jobject);
+    Handle constant_value = JVMCIENV->asConstant(constant, JVMCI_CHECK_0);
+    jobject jni_handle = JNIHandles::make_local(THREAD, constant_value());
+    return reinterpret_cast<jlong>(jni_handle);
 C2V_END
 
 C2V_VMENTRY_NULL(jobject, getUncachedStringInPool, (JNIEnv* env, jobject, ARGUMENT_PAIR(cp), jint index))
@@ -3254,6 +3268,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "shouldInlineMethod",                           CC "(" HS_METHOD2 ")Z",                                                               FN_PTR(shouldInlineMethod)},
   {CC "lookupType",                                   CC "(" STRING HS_KLASS2 "IZ)" HS_RESOLVED_TYPE,                                       FN_PTR(lookupType)},
   {CC "lookupJClass",                                 CC "(J)" HS_RESOLVED_TYPE,                                                            FN_PTR(lookupJClass)},
+  {CC "getJObjectValue",                              CC "(" OBJECTCONSTANT ")J",                                                           FN_PTR(getJObjectValue)},
   {CC "getArrayType",                                 CC "(C" HS_KLASS2 ")" HS_KLASS,                                                       FN_PTR(getArrayType)},
   {CC "lookupClass",                                  CC "(" CLASS ")" HS_RESOLVED_TYPE,                                                    FN_PTR(lookupClass)},
   {CC "lookupNameInPool",                             CC "(" HS_CONSTANT_POOL2 "II)" STRING,                                                FN_PTR(lookupNameInPool)},

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -290,6 +290,12 @@ final class CompilerToVM {
     native HotSpotResolvedJavaType lookupJClass(long jclass);
 
     /**
+     * Gets the {@code jobject} value wrapped by {@code peerObject}.
+     * Must not be called if {@link Services#IS_IN_NATIVE_IMAGE} is {@code false}.
+     */
+    native long getJObjectValue(HotSpotObjectConstantImpl peerObject);
+
+    /**
      * Resolves the entry at index {@code cpi} in {@code constantPool} to an interned String object.
      *
      * The behavior of this method is undefined if {@code cpi} does not denote an

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -927,8 +927,10 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
     /**
      * Gets the {@code jobject} value wrapped by {@code peerObject}. The returned value is
      * a JNI local reference whose lifetime is scoped by the nearest Java caller (from
-     * HotSpot's perspective). The current thread's state must be {@code _thread_in_native}.
-     * A call from the JVMCI shared library (e.g. libgraal) is in such a state.
+     * HotSpot's perspective). You can use {@code PushLocalFrame} and {@code PopLocalFrame} to
+     * shorten the lifetime of the reference. The current thread's state must be
+     * {@code _thread_in_native}. A call from the JVMCI shared library (e.g. libgraal) is in such
+     * a state.
      *
      * @param peerObject a reference to an object in the HotSpot heap
      * @return the {@code jobject} value unpacked from {@code peerObject}

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -926,22 +926,16 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
 
     /**
      * Gets the {@code jobject} value wrapped by {@code peerObject}. The returned "naked" value is
-     * only valid as long as {@code peerObject} is valid. Note that the latter may be shorter than
-     * the lifetime of {@code peerObject}. As such, this method should only be used to pass an
-     * object parameter across a JNI call from the JVMCI shared library to HotSpot. This method must
-     * only be called from within the JVMCI shared library.
-     *
+     * a JNI local reference, which is valid for the duration of a JVMCI shared library call. This
+     * method must only be called from within the JVMCI shared library.
      * @param peerObject a reference to an object in the peer runtime
      * @return the {@code jobject} value wrapped by {@code peerObject}
      * @throws IllegalArgumentException if the current runtime is not the JVMCI shared library or
      *             {@code peerObject} is not a peer object reference
+     * @throws IllegalStateException if not called from within the JVMCI shared library
      */
     public long getJObjectValue(HotSpotObjectConstant peerObject) {
-        if (peerObject instanceof IndirectHotSpotObjectConstantImpl) {
-            IndirectHotSpotObjectConstantImpl remote = (IndirectHotSpotObjectConstantImpl) peerObject;
-            return remote.getHandle();
-        }
-        throw new IllegalArgumentException("Cannot get jobject value for " + peerObject + " (" + peerObject.getClass().getName() + ")");
+        return compilerToVm.getJObjectValue((HotSpotObjectConstantImpl)peerObject);
     }
 
     @Override


### PR DESCRIPTION
The `HotSpotJVMCIRuntime#getJObjectValue` method returns a real JNI local handle instead of a JVMCI handle to prevent random crashes on ZGC.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336663](https://bugs.openjdk.org/browse/JDK-8336663): [JVMCI] VM Crash on ZGC due to incompatible handle returned by HotSpotJVMCIRuntime#getJObjectValue (**Bug** - P3)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**) 🔄 Re-review required (review applies to [d10f8184](https://git.openjdk.org/jdk/pull/20219/files/d10f81847f27dfe413ace2521aec2f76647f4071))
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20219/head:pull/20219` \
`$ git checkout pull/20219`

Update a local copy of the PR: \
`$ git checkout pull/20219` \
`$ git pull https://git.openjdk.org/jdk.git pull/20219/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20219`

View PR using the GUI difftool: \
`$ git pr show -t 20219`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20219.diff">https://git.openjdk.org/jdk/pull/20219.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20219#issuecomment-2233802636)