### PR TITLE
8336479: Provide Process.waitFor(Duration)

### DIFF
--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -498,7 +498,7 @@ public abstract class Process {
 
         if (hasExited())
             return true;
-        if (duration.isZero() || duration.isNegative())
+        if (!duration.isPositive())
             return false;
 
         return waitForNanos(TimeUnit.NANOSECONDS.convert(duration));
@@ -618,8 +618,8 @@ public abstract class Process {
 
     /**
      * This is called from the default implementation of
-     * {@code waitFor(long, TimeUnit)}, which is specified to poll
-     * {@code exitValue()}.
+     * {@code waitFor(long, TimeUnit)} and {@code waitFor(Duration)},
+     * which are specified to poll {@code exitValue()}.
      */
     private boolean hasExited() {
         try {

--- a/src/java.base/share/classes/java/lang/Process.java
+++ b/src/java.base/share/classes/java/lang/Process.java
@@ -460,7 +460,6 @@ public abstract class Process {
         throws InterruptedException
     {
         long remainingNanos = unit.toNanos(timeout); // throw NPE before other conditions
-
         if (hasExited())
             return true;
         if (timeout <= 0)

--- a/test/jdk/java/lang/Process/WaitForDuration.java
+++ b/test/jdk/java/lang/Process/WaitForDuration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8336479
+ * @summary Tests for Process.waitFor(Duration)
+ * @run junit WaitForDuration
+ */
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class WaitForDuration {
+    static Stream<Arguments> durations() {
+        return Stream.of(
+            Arguments.of(Duration.ZERO, false),
+            Arguments.of(Duration.ofSeconds(-100), false),
+            Arguments.of(Duration.ofSeconds(100), true),
+            Arguments.of(Duration.ofSeconds(Long.MAX_VALUE), true), // nano overflow
+            Arguments.of(Duration.ofSeconds(Long.MIN_VALUE), false) // nano underflow
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("durations")
+    void testEdgeDurations(Duration d, boolean expected)
+            throws IOException, InterruptedException {
+        assertEquals(expected,
+            new ProcessBuilder("sleep", "3").start().waitFor(d));
+    }
+
+    @Test
+    void testNullDuration() throws IOException, InterruptedException {
+        assertThrows(NullPointerException.class, () ->
+            new ProcessBuilder("sleep", "3").start().waitFor(null));
+    }
+}

--- a/test/lib/jdk/test/lib/process/ProcessTools.java
+++ b/test/lib/jdk/test/lib/process/ProcessTools.java
@@ -42,6 +42,7 @@ import java.nio.file.Paths;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -959,6 +960,15 @@ public final class ProcessTools {
         @Override
         public boolean waitFor(long timeout, TimeUnit unit) throws InterruptedException {
             boolean rslt = p.waitFor(timeout, unit);
+            if (rslt) {
+                waitForStreams();
+            }
+            return rslt;
+        }
+
+        @Override
+        public boolean waitFor(Duration duration) throws InterruptedException {
+            boolean rslt = p.waitFor(duration);
             if (rslt) {
                 waitForStreams();
             }


### PR DESCRIPTION
Proposing a new overload method for `Process#waitFor()` which takes a `Duration` for the timeout value. This will reduce the possibility for making mistakes with the `TimeUnit` in the other overload method. A corresponding CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8336494](https://bugs.openjdk.org/browse/JDK-8336494) to be approved

### Issues
 * [JDK-8336479](https://bugs.openjdk.org/browse/JDK-8336479): Provide Process.waitFor(Duration) (**Enhancement** - P4)
 * [JDK-8336494](https://bugs.openjdk.org/browse/JDK-8336494): Provide Process.waitFor(Duration) (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20220/head:pull/20220` \
`$ git checkout pull/20220`

Update a local copy of the PR: \
`$ git checkout pull/20220` \
`$ git pull https://git.openjdk.org/jdk.git pull/20220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20220`

View PR using the GUI difftool: \
`$ git pr show -t 20220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20220.diff">https://git.openjdk.org/jdk/pull/20220.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20220#issuecomment-2233936317)