### PR TITLE
8336491: Unnecessary boxing conversions in void-returning lambdas

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -3330,7 +3330,8 @@ public class Lower extends TreeTranslator {
     /** Expand a boxing or unboxing conversion if needed. */
     @SuppressWarnings("unchecked") // XXX unchecked
     <T extends JCExpression> T boxIfNeeded(T tree, Type type) {
-        if (type.hasTag(VOID))
+        Assert.check(!type.hasTag(VOID));
+        if (type.hasTag(NONE))
             return tree;
         boolean havePrimitive = tree.type.isPrimitive();
         if (havePrimitive == type.isPrimitive())
@@ -3848,6 +3849,9 @@ public class Lower extends TreeTranslator {
         Type prevRestype = currentRestype;
         try {
             currentRestype = types.erasure(tree.getDescriptorType(types)).getReturnType();
+            // represent void results as NO_TYPE, to avoid unnecessary boxing in boxIfNeeded
+            if (currentRestype.hasTag(VOID))
+                currentRestype = Type.noType;
             tree.body = tree.getBodyKind() == BodyKind.EXPRESSION ?
                     translate((JCExpression) tree.body, currentRestype) :
                     translate(tree.body);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -3330,6 +3330,7 @@ public class Lower extends TreeTranslator {
     /** Expand a boxing or unboxing conversion if needed. */
     @SuppressWarnings("unchecked") // XXX unchecked
     <T extends JCExpression> T boxIfNeeded(T tree, Type type) {
+        Assert.check(!type.hasTag(VOID));
         boolean havePrimitive = tree.type.isPrimitive();
         if (havePrimitive == type.isPrimitive())
             return tree;
@@ -3846,7 +3847,7 @@ public class Lower extends TreeTranslator {
         Type prevRestype = currentRestype;
         try {
             currentRestype = types.erasure(tree.getDescriptorType(types)).getReturnType();
-            tree.body = tree.getBodyKind() == BodyKind.EXPRESSION ?
+            tree.body = !currentRestype.hasTag(VOID) && tree.getBodyKind() == BodyKind.EXPRESSION ?
                     translate((JCExpression) tree.body, currentRestype) :
                     translate(tree.body);
         } finally {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -3330,7 +3330,8 @@ public class Lower extends TreeTranslator {
     /** Expand a boxing or unboxing conversion if needed. */
     @SuppressWarnings("unchecked") // XXX unchecked
     <T extends JCExpression> T boxIfNeeded(T tree, Type type) {
-        Assert.check(!type.hasTag(VOID));
+        if (type.hasTag(VOID))
+            return tree;
         boolean havePrimitive = tree.type.isPrimitive();
         if (havePrimitive == type.isPrimitive())
             return tree;
@@ -3847,7 +3848,7 @@ public class Lower extends TreeTranslator {
         Type prevRestype = currentRestype;
         try {
             currentRestype = types.erasure(tree.getDescriptorType(types)).getReturnType();
-            tree.body = !currentRestype.hasTag(VOID) && tree.getBodyKind() == BodyKind.EXPRESSION ?
+            tree.body = tree.getBodyKind() == BodyKind.EXPRESSION ?
                     translate((JCExpression) tree.body, currentRestype) :
                     translate(tree.body);
         } finally {

--- a/test/langtools/tools/javac/lambda/VoidReturnBoxing.java
+++ b/test/langtools/tools/javac/lambda/VoidReturnBoxing.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Alphabet LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8336491
+ * @summary Verify that void returning expression lambdas don't box their result
+ * @modules jdk.compiler
+ *          jdk.jdeps/com.sun.tools.javap
+ */
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.file.Path;
+
+public class VoidReturnBoxing {
+
+    public static void main(String[] args) {
+        new VoidReturnBoxing().run();
+    }
+
+    void run() {
+        Path path = Path.of(System.getProperty("test.classes"), "T.class");
+        StringWriter s;
+        String out;
+        try (PrintWriter pw = new PrintWriter(s = new StringWriter())) {
+            com.sun.tools.javap.Main.run(new String[] {"-p", "-c", path.toString()}, pw);
+            out = s.toString();
+        }
+        if (out.contains("java/lang/Integer.valueOf")) {
+            throw new AssertionError(
+                    "Unnecessary boxing of void returning expression lambda result:\n\n" + out);
+        }
+    }
+}
+
+class T {
+    int g() {
+        return 0;
+    }
+
+    Runnable r = () -> g();
+}


### PR DESCRIPTION
Please consider this possible fix for [JDK-8336491](https://bugs.openjdk.org/browse/JDK-8336491), which avoids generating an unnecessary boxing conversion for the result of void-returning expression lambdas.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336491](https://bugs.openjdk.org/browse/JDK-8336491): Unnecessary boxing conversions in void-returning lambdas (**Bug** - P2)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20222/head:pull/20222` \
`$ git checkout pull/20222`

Update a local copy of the PR: \
`$ git checkout pull/20222` \
`$ git pull https://git.openjdk.org/jdk.git pull/20222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20222`

View PR using the GUI difftool: \
`$ git pr show -t 20222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20222.diff">https://git.openjdk.org/jdk/pull/20222.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20222#issuecomment-2234060726)