### PR TITLE
8336588: Ensure Transform downstream receives upstream start items only after downstream started

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/TransformImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/TransformImpl.java
@@ -111,7 +111,7 @@ public final class TransformImpl {
             ResolvedTransform<ClassElement> upstream = TransformImpl.resolve(t, chainedBuilder);
             return new ResolvedTransform<>(upstream.consumer(),
                                           chainRunnable(upstream.endHandler(), downstream.endHandler()),
-                                          chainRunnable(upstream.startHandler(), downstream.startHandler()));
+                                          chainRunnable(downstream.startHandler(), upstream.startHandler()));
         }
     }
 
@@ -198,7 +198,7 @@ public final class TransformImpl {
             ResolvedTransform<MethodElement> upstream = TransformImpl.resolve(t, chainedBuilder);
             return new ResolvedTransform<>(upstream.consumer(),
                                            chainRunnable(upstream.endHandler(), downstream.endHandler()),
-                                           chainRunnable(upstream.startHandler(), downstream.startHandler()));
+                                           chainRunnable(downstream.startHandler(), upstream.startHandler()));
         }
     }
 
@@ -261,7 +261,7 @@ public final class TransformImpl {
             ResolvedTransform<FieldElement> upstream = TransformImpl.resolve(t, chainedBuilder);
             return new ResolvedTransform<>(upstream.consumer(),
                                            chainRunnable(upstream.endHandler(), downstream.endHandler()),
-                                           chainRunnable(upstream.startHandler(), downstream.startHandler()));
+                                           chainRunnable(downstream.startHandler(), upstream.startHandler()));
         }
     }
 
@@ -301,7 +301,7 @@ public final class TransformImpl {
             ResolvedTransform<CodeElement> upstream = TransformImpl.resolve(t, chainedBuilder);
             return new ResolvedTransform<>(upstream.consumer(),
                                          chainRunnable(upstream.endHandler(), downstream.endHandler()),
-                                         chainRunnable(upstream.startHandler(), downstream.startHandler()));
+                                         chainRunnable(downstream.startHandler(), upstream.startHandler()));
         }
     }
 


### PR DESCRIPTION
There's another bug in ClassFile transform composition where the downstream transform receives items from upstream transform's chained builders before the downstream transform itself starts. This is a simple fix, and a test case against `ClassTransform` is added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336588](https://bugs.openjdk.org/browse/JDK-8336588): Ensure Transform downstream receives upstream start items only after downstream started (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20227/head:pull/20227` \
`$ git checkout pull/20227`

Update a local copy of the PR: \
`$ git checkout pull/20227` \
`$ git pull https://git.openjdk.org/jdk.git pull/20227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20227`

View PR using the GUI difftool: \
`$ git pr show -t 20227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20227.diff">https://git.openjdk.org/jdk/pull/20227.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20227#issuecomment-2234364740)