### PR TITLE
8336691: Test LongArgTest.java intermittent fails java.lang.NoClassDefFoundError: jdk/test/lib/Utils

### DIFF
--- a/test/hotspot/jtreg/serviceability/attach/LongArgTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/LongArgTest.java
@@ -27,6 +27,7 @@
  * @bug 8334168
  * @library /test/lib
  * @modules jdk.attach/sun.tools.attach
+ * @build jdk.test.lib.Utils jdk.test.lib.apps.LingeredApp LongArgTest
  * @run main LongArgTest
  */
 

--- a/test/hotspot/jtreg/serviceability/attach/LongArgTest.java
+++ b/test/hotspot/jtreg/serviceability/attach/LongArgTest.java
@@ -27,7 +27,7 @@
  * @bug 8334168
  * @library /test/lib
  * @modules jdk.attach/sun.tools.attach
- * @build jdk.test.lib.Utils jdk.test.lib.apps.LingeredApp LongArgTest
+ * @build jdk.test.lib.Utils jdk.test.lib.apps.LingeredApp
  * @run main LongArgTest
  */
 


### PR DESCRIPTION
Hi all,
The testcase `serviceability/attach/LongArgTest.java` intermittent fails `java.lang.NoClassDefFoundError: jdk/test/lib/Utils`. Jtreg doesn't automatically compile `jdk/test/lib/Utils.class` and `jdk/test/lib/apps/LingeredApp.class` etc.. Maybe it's a jtreg  framework bug.
I think it's necessory to compile `jdk.test.lib.Utils` and `jdk.test.lib.apps.LingeredApp` explicitly.
Only change the testcase, the change has been verified, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336691](https://bugs.openjdk.org/browse/JDK-8336691): Test LongArgTest.java intermittent fails java.lang.NoClassDefFoundError: jdk/test/lib/Utils (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20228/head:pull/20228` \
`$ git checkout pull/20228`

Update a local copy of the PR: \
`$ git checkout pull/20228` \
`$ git pull https://git.openjdk.org/jdk.git pull/20228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20228`

View PR using the GUI difftool: \
`$ git pr show -t 20228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20228.diff">https://git.openjdk.org/jdk/pull/20228.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20228#issuecomment-2235126303)
</details>
