### PR TITLE
8336706: Optimize LocalDate.toString with StringBuilder.repeat

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDate.java
+++ b/src/java.base/share/classes/java/time/LocalDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2154,10 +2154,10 @@ public final class LocalDate
         StringBuilder buf = new StringBuilder(10);
         if (absYear < 1000) {
             if (yearValue < 0) {
-                buf.append(yearValue - 10000).deleteCharAt(1);
-            } else {
-                buf.append(yearValue + 10000).deleteCharAt(0);
+                buf.append('-');
             }
+            buf.repeat('0', absYear < 10 ? 3 : absYear < 100 ? 2 : 1);
+            buf.append(absYear);
         } else {
             if (yearValue > 9999) {
                 buf.append('+');


### PR DESCRIPTION
```java
class LocalDate {
    public String toString() {
        if (absYear < 1000) {
            if (yearValue < 0) {
                buf.append(yearValue - 10000).deleteCharAt(1);
            } else {
                buf.append(yearValue + 10000).deleteCharAt(0);
            }
       // ...
    }
}
```
Currently, LocalDate.toString causes an extra memory copy when processing years < 1000. This can be replaced by using StringBuilder.repeat, which is more concise and has better performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8336706](https://bugs.openjdk.org/browse/JDK-8336706): Optimize LocalDate.toString with StringBuilder.repeat (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20229/head:pull/20229` \
`$ git checkout pull/20229`

Update a local copy of the PR: \
`$ git checkout pull/20229` \
`$ git pull https://git.openjdk.org/jdk.git pull/20229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20229`

View PR using the GUI difftool: \
`$ git pr show -t 20229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20229.diff">https://git.openjdk.org/jdk/pull/20229.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20229#issuecomment-2235442306)