### PR TITLE
8335843: C2 hits assert(_print_inlining_stream->size() > 0) failed: missing inlining msg

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -432,6 +432,10 @@ bool LateInlineMHCallGenerator::do_late_inline_check(Compile* C, JVMState* jvms)
   assert(!input_not_const, "sanity"); // shouldn't have been scheduled for inlining in the first place
 
   if (cg != nullptr) {
+    if (!allow_inline && (C->print_inlining() || C->print_intrinsics())) {
+      C->print_inlining(cg->method(), jvms->depth()-1, call_node()->jvms()->bci(), InliningResult::FAILURE,
+                        "late method handle call resolution");
+    }
     assert(!cg->is_late_inline() || cg->is_mh_late_inline() || AlwaysIncrementalInline || StressIncrementalInlining, "we're doing late inlining");
     _inline_cg = cg;
     C->dec_number_of_mh_late_inlines();
@@ -555,7 +559,7 @@ bool LateInlineVirtualCallGenerator::do_late_inline_check(Compile* C, JVMState* 
 
   if (cg != nullptr) {
     if (!allow_inline && (C->print_inlining() || C->print_intrinsics())) {
-      C->print_inlining(method(), jvms->depth()-1, call_node()->jvms()->bci(), InliningResult::FAILURE,
+      C->print_inlining(cg->method(), jvms->depth()-1, call_node()->jvms()->bci(), InliningResult::FAILURE,
                         "late call devirtualization");
     }
     assert(!cg->is_late_inline() || cg->is_mh_late_inline() || AlwaysIncrementalInline || StressIncrementalInlining, "we're doing late inlining");


### PR DESCRIPTION
This is similar to 8327741 but for method handle calls. When a method
handle call can be resolved late so it can't be inlined but the target
of the call is changed, no new inlining message is produced. The fix I
propose is similar to the fix for 8327741. I also made a small change
to the fix for 8327741 so `PrintInlining` now reports the resolved
method. With:

```
    static class A {
        void m() {

        }
    }

    static class B extends A {
        void m() {

        }
    }
```

If the virtual call to `A.m()` is resolved to a call to
`B.m()`. Before this change, the `PrintInlining` output reports a call
to `A.m()` and now it reports the actual target `B.m()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335843](https://bugs.openjdk.org/browse/JDK-8335843): C2 hits assert(_print_inlining_stream-&gt;size() &gt; 0) failed: missing inlining msg (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20230/head:pull/20230` \
`$ git checkout pull/20230`

Update a local copy of the PR: \
`$ git checkout pull/20230` \
`$ git pull https://git.openjdk.org/jdk.git pull/20230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20230`

View PR using the GUI difftool: \
`$ git pr show -t 20230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20230.diff">https://git.openjdk.org/jdk/pull/20230.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20230#issuecomment-2235913986)