### PR TITLE
8336755: Remove unused UNALIGNED field from view buffers

### DIFF
--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -56,14 +56,6 @@ class Direct$Type$Buffer$RW$$BO$
 {
 
 #if[rw]
-
-    // Cached unaligned-access capability
-    protected static final boolean UNALIGNED = Bits.unaligned();
-
-    // Base address, used in all indexing calculations
-    // NOTE: moved up to Buffer.java for speed in JNI GetDirectBufferAddress
-    //    protected long address;
-
     // An object attached to this buffer. If this buffer is a view of another
     // buffer then we use this field to keep a reference to that buffer to
     // ensure that its memory isn't freed before we are done with it.
@@ -74,6 +66,8 @@ class Direct$Type$Buffer$RW$$BO$
     }
 
 #if[byte]
+    // Cached unaligned-access capability
+    protected static final boolean UNALIGNED = Bits.unaligned();
 
     private record Deallocator(long address, long size, int capacity) implements Runnable {
         private Deallocator {

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -67,7 +67,7 @@ class Direct$Type$Buffer$RW$$BO$
 
 #if[byte]
     // Cached unaligned-access capability
-    protected static final boolean UNALIGNED = Bits.unaligned();
+    static final boolean UNALIGNED = Bits.unaligned();
 
     private record Deallocator(long address, long size, int capacity) implements Runnable {
         private Deallocator {


### PR DESCRIPTION
Actually it's used only by `DirectByteBuffer` and `DirectByteBufferR` classes.

List of affected classes:
`DirectCharBufferS`, `DirectCharBufferU`,
`DirectDoubleBufferS`, `DirectDoubleBufferU`,
`DirectFloatBufferS`, `DirectFloatBufferU`,
`DirectIntBufferS`, `DirectIntBufferU`,
`DirectLongBufferS`, `DirectLongBufferU`,
`DirectShortBufferS`, `DirectShortBufferU`

Tested `test/jdk/java/nio` on Linux x64 release.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336755](https://bugs.openjdk.org/browse/JDK-8336755): Remove unused UNALIGNED field from view buffers (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20233/head:pull/20233` \
`$ git checkout pull/20233`

Update a local copy of the PR: \
`$ git checkout pull/20233` \
`$ git pull https://git.openjdk.org/jdk.git pull/20233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20233`

View PR using the GUI difftool: \
`$ git pr show -t 20233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20233.diff">https://git.openjdk.org/jdk/pull/20233.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20233#issuecomment-2236908244)