### PR TITLE
8335267: [XWayland] move screencast tokens from .awt to .java folder

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
+++ b/src/java.desktop/unix/classes/sun/awt/screencast/TokenStorage.java
@@ -75,23 +75,16 @@ final class TokenStorage {
 
     @SuppressWarnings("removal")
     private static void doPrivilegedRunnable(Runnable runnable) {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            @Override
-            public Void run() {
-                runnable.run();
-                return null;
-            }
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            runnable.run();
+            return null;
         });
     }
 
     static {
         @SuppressWarnings("removal")
-        Path propsPath = AccessController.doPrivileged(new PrivilegedAction<Path>() {
-            @Override
-            public Path run() {
-                return setupPath();
-            }
-        });
+        Path propsPath = AccessController
+                .doPrivileged((PrivilegedAction<Path>) () -> setupPath());
 
         PROPS_PATH = propsPath;
 


### PR DESCRIPTION
Trivial fix to move the screencast token storage file from `~/.awt/robot/screencast-tokens.properties` to `~/.java/robot/screencast-tokens.properties`, where it should be.
Old location is still valid and will only be used if there is a file in the old location and the new location does not have it.

Along with the fix  `@SuppressWarnings("removal")` is moved to individual items as it was done in [JFX](https://github.com/openjdk/jfx/pull/1490).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335267](https://bugs.openjdk.org/browse/JDK-8335267): [XWayland] move screencast tokens from .awt to .java folder (**Bug** - P4)


### Reviewers
 * [Alexey Ushakov](https://openjdk.org/census#avu) (@avu - Committer) 🔄 Re-review required (review applies to [3aabdb77](https://git.openjdk.org/jdk/pull/20234/files/3aabdb77d4bf984589e1a129b8d8952f58aa41c1))
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20234/head:pull/20234` \
`$ git checkout pull/20234`

Update a local copy of the PR: \
`$ git checkout pull/20234` \
`$ git pull https://git.openjdk.org/jdk.git pull/20234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20234`

View PR using the GUI difftool: \
`$ git pr show -t 20234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20234.diff">https://git.openjdk.org/jdk/pull/20234.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20234#issuecomment-2236649287)