### PR TITLE
8336692: Redo fix for JDK-8284620

### DIFF
--- a/src/hotspot/share/asm/codeBuffer.cpp
+++ b/src/hotspot/share/asm/codeBuffer.cpp
@@ -135,10 +135,11 @@ CodeBuffer::~CodeBuffer() {
     // Previous incarnations of this buffer are held live, so that internal
     // addresses constructed before expansions will not be confused.
     cb->free_blob();
-    // free any overflow storage
-    delete cb->_overflow_arena;
   }
-
+  if (_overflow_arena != nullptr) {
+    // free any overflow storage
+    delete _overflow_arena;
+  }
   if (_shared_trampoline_requests != nullptr) {
     delete _shared_trampoline_requests;
   }
@@ -973,8 +974,6 @@ void CodeBuffer::take_over_code_from(CodeBuffer* cb) {
     CodeSection* this_sect = code_section(n);
     this_sect->take_over_code_from(cb_sect);
   }
-  _overflow_arena = cb->_overflow_arena;
-  cb->_overflow_arena = nullptr;
   // Make sure the old cb won't try to use it or free it.
   DEBUG_ONLY(cb->_blob = (BufferBlob*)badAddress);
 }


### PR DESCRIPTION
[JDK-8284620](https://bugs.openjdk.org/browse/JDK-8284620) tried to fix memory leak for `CodeBuffer::_overflow_arena` but I think the fix was incorrect. It created an issue when CodeBuffer expanded and we try to use information in `CodeBuffer::_overflow_arena` but it will be nulled.

CodeBuffer expansion affect only data (addresses and descriptors) associated with code and data in CodeCache where we create new CodeBlob with bigger space for code. CodeBuffer's data allocated in C heap is not affected and should not be updated.

The original code in [CodeBuffer::take_over_code_from()](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/asm/codeBuffer.cpp#L976) incorrectly copied `_overflow_arena` from [new CodeBuffer `cb`](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/asm/codeBuffer.cpp#L937) where it is NULL and as result we lost pointer to allocated space. Which was the reason for memory leak.

The fix is to remove that old line in `CodeBuffer::take_over_code_from()` and undo JDK-8284620) fix.

Tested tier1-3,stress,xcomp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336692](https://bugs.openjdk.org/browse/JDK-8336692): Redo fix for JDK-8284620 (**Bug** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20236/head:pull/20236` \
`$ git checkout pull/20236`

Update a local copy of the PR: \
`$ git checkout pull/20236` \
`$ git pull https://git.openjdk.org/jdk.git pull/20236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20236`

View PR using the GUI difftool: \
`$ git pr show -t 20236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20236.diff">https://git.openjdk.org/jdk/pull/20236.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20236#issuecomment-2236764252)