### PR TITLE
8336753: Don't run serviceability/sa/ClhsdbDumpheap.java with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
@@ -40,6 +40,7 @@ import jtreg.SkippedException;
  * @bug 8240989
  * @summary Test clhsdb dumpheap command
  * @requires vm.hasSA
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib
  * @run main/othervm/timeout=240 ClhsdbDumpheap
  */

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
@@ -37,10 +37,13 @@ import jtreg.SkippedException;
 
 /**
  * @test
- * @bug 8240989
+ * @bug 8240989 8336753
  * @summary Test clhsdb dumpheap command
  * @requires vm.hasSA
  * @requires vm.compMode != "Xcomp"
+ * @comment Running this test with -Xcomp is slow and therefore tends to cause
+ *          timeouts. As there is no known direct benefit from running the test
+ *          with -Xcomp, we disable such testing.
  * @library /test/lib
  * @run main/othervm/timeout=240 ClhsdbDumpheap
  */

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbDumpheap.java
@@ -37,7 +37,7 @@ import jtreg.SkippedException;
 
 /**
  * @test
- * @bug 8240989 8336753
+ * @bug 8240989
  * @summary Test clhsdb dumpheap command
  * @requires vm.hasSA
  * @requires vm.compMode != "Xcomp"


### PR DESCRIPTION
### Issue Summary

We are seeing quite a few timeouts for `serviceability/sa/ClhsdbDumpheap.java` running with -Xcomp in testing, possibly related to [JDK-8324241](https://bugs.openjdk.org/browse/JDK-8324241). We should disable running `ClhsdbDumpheap.java` with -Xcomp, at least for now.

### Changeset

- Add `@requires vm.compMode != "Xcomp"` to `ClhsdbDumpheap.java`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336753](https://bugs.openjdk.org/browse/JDK-8336753): Don't run serviceability/sa/ClhsdbDumpheap.java with -Xcomp (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) 🔄 Re-review required (review applies to [05eddeb1](https://git.openjdk.org/jdk/pull/20237/files/05eddeb1352e24a82d458fc9b9390e6effa44ff6))
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) 🔄 Re-review required (review applies to [05eddeb1](https://git.openjdk.org/jdk/pull/20237/files/05eddeb1352e24a82d458fc9b9390e6effa44ff6))
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20237/head:pull/20237` \
`$ git checkout pull/20237`

Update a local copy of the PR: \
`$ git checkout pull/20237` \
`$ git pull https://git.openjdk.org/jdk.git pull/20237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20237`

View PR using the GUI difftool: \
`$ git pr show -t 20237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20237.diff">https://git.openjdk.org/jdk/pull/20237.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20237#issuecomment-2236813199)