### PR TITLE
8325984: 4 jcstress tests are failing in Tier6 4 times each

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -119,11 +119,6 @@ runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
 
-applications/jcstress/accessAtomic.java 8325984 generic-all
-applications/jcstress/acqrel.java 8325984 generic-all
-applications/jcstress/atomicity.java 8325984 generic-all
-applications/jcstress/coherence.java 8325984 generic-all
-
 applications/jcstress/copy.java 8229852 linux-all
 
 containers/cgroup/PlainRead.java 8333967,8261242 linux-all


### PR DESCRIPTION
Hi all,

This pull request contains a backport of commit [ee82346b](https://github.com/openjdk/jdk/commit/ee82346bd5ecf3024d6dc7b7529598099483a42c) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Jorn Vernee on 7 Jun 2024 and was reviewed by Aleksey Shipilev.

This is a `P2` test-only change, which is allowed without extra approval under the release process in RDP2: https://openjdk.org/jeps/3#Quick-reference

Testing: running the 4 affected tests on `linux-x64-debug`.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325984](https://bugs.openjdk.org/browse/JDK-8325984): 4 jcstress tests are failing in Tier6 4 times each (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20239/head:pull/20239` \
`$ git checkout pull/20239`

Update a local copy of the PR: \
`$ git checkout pull/20239` \
`$ git pull https://git.openjdk.org/jdk.git pull/20239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20239`

View PR using the GUI difftool: \
`$ git pr show -t 20239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20239.diff">https://git.openjdk.org/jdk/pull/20239.diff</a>

</details>
