### PR TITLE
8336763: Parallel: Merge PCMarkAndPushClosure and PCIterateMarkAndPushClosure

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1188,10 +1188,11 @@ public:
 
     ParCompactionManager* cm = ParCompactionManager::gc_thread_compaction_manager(_worker_id);
 
-    PCMarkAndPushClosure mark_and_push_closure(cm);
-    MarkingNMethodClosure mark_and_push_in_blobs(&mark_and_push_closure, !NMethodToOopClosure::FixRelocations, true /* keepalive nmethods */);
+    MarkingNMethodClosure mark_and_push_in_blobs(&cm->_mark_and_push_closure,
+                                                 !NMethodToOopClosure::FixRelocations,
+                                                 true /* keepalive nmethods */);
 
-    thread->oops_do(&mark_and_push_closure, &mark_and_push_in_blobs);
+    thread->oops_do(&cm->_mark_and_push_closure, &mark_and_push_in_blobs);
 
     // Do the real work
     cm->follow_marking_stacks();
@@ -1232,22 +1233,22 @@ public:
   virtual void work(uint worker_id) {
     ParCompactionManager* cm = ParCompactionManager::gc_thread_compaction_manager(worker_id);
     cm->create_marking_stats_cache();
-    PCMarkAndPushClosure mark_and_push_closure(cm);
-
     {
-      CLDToOopClosure cld_closure(&mark_and_push_closure, ClassLoaderData::_claim_stw_fullgc_mark);
+      CLDToOopClosure cld_closure(&cm->_mark_and_push_closure, ClassLoaderData::_claim_stw_fullgc_mark);
       ClassLoaderDataGraph::always_strong_cld_do(&cld_closure);
 
       // Do the real work
       cm->follow_marking_stacks();
     }
 
-    PCAddThreadRootsMarkingTaskClosure closure(worker_id);
-    Threads::possibly_parallel_threads_do(true /* is_par */, &closure);
+    {
+      PCAddThreadRootsMarkingTaskClosure closure(worker_id);
+      Threads::possibly_parallel_threads_do(_active_workers > 1 /* is_par */, &closure);
+    }
 
     // Mark from OopStorages
     {
-      _oop_storage_set_par_state.oops_do(&mark_and_push_closure);
+      _oop_storage_set_par_state.oops_do(&cm->_mark_and_push_closure);
       // Do the real work
       cm->follow_marking_stacks();
     }
@@ -1269,10 +1270,9 @@ public:
   void work(uint worker_id) override {
     assert(worker_id < _max_workers, "sanity");
     ParCompactionManager* cm = (_tm == RefProcThreadModel::Single) ? ParCompactionManager::get_vmthread_cm() : ParCompactionManager::gc_thread_compaction_manager(worker_id);
-    PCMarkAndPushClosure keep_alive(cm);
     BarrierEnqueueDiscoveredFieldClosure enqueue;
     ParCompactionManager::FollowStackClosure complete_gc(cm, (_tm == RefProcThreadModel::Single) ? nullptr : &_terminator, worker_id);
-    _rp_task->rp_work(worker_id, PSParallelCompact::is_alive_closure(), &keep_alive, &enqueue, &complete_gc);
+    _rp_task->rp_work(worker_id, PSParallelCompact::is_alive_closure(), &cm->_mark_and_push_closure, &enqueue, &complete_gc);
   }
 
   void prepare_run_task_hook() override {


### PR DESCRIPTION
Simple merging two marking closures (w/o ref-processing). Also changed the lifetime of the closure to the same as the per-worker compaction-manager.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336763](https://bugs.openjdk.org/browse/JDK-8336763): Parallel: Merge PCMarkAndPushClosure and PCIterateMarkAndPushClosure (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20240/head:pull/20240` \
`$ git checkout pull/20240`

Update a local copy of the PR: \
`$ git checkout pull/20240` \
`$ git pull https://git.openjdk.org/jdk.git pull/20240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20240`

View PR using the GUI difftool: \
`$ git pr show -t 20240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20240.diff">https://git.openjdk.org/jdk/pull/20240.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20240#issuecomment-2237020046)