### PR TITLE
8333812: ClassFile.verify() can throw exceptions instead of returning VerifyErrors

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -285,7 +285,11 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         public BoundLocalVariableTableAttribute(AttributedElement enclosing, ClassReader cf, AttributeMapper<LocalVariableTableAttribute> mapper, int pos) {
             super(cf, mapper, pos);
-            codeAttribute = (CodeImpl) enclosing;
+            if (enclosing instanceof CodeImpl ci) {
+                this.codeAttribute = ci;
+            } else {
+                throw new IllegalArgumentException("Invalid LocalVariableTable attribute location");
+            }
         }
 
         @Override
@@ -312,7 +316,11 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
 
         public BoundLocalVariableTypeTableAttribute(AttributedElement enclosing, ClassReader cf, AttributeMapper<LocalVariableTypeTableAttribute> mapper, int pos) {
             super(cf, mapper, pos);
-            this.codeAttribute = (CodeImpl) enclosing;
+            if (enclosing instanceof CodeImpl ci) {
+                this.codeAttribute = ci;
+            } else {
+                throw new IllegalArgumentException("Invalid LocalVariableTypeTable attribute location");
+            }
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
@@ -132,7 +132,11 @@ public record ClassFileImpl(StackMapsOption stackMapsOption,
 
     @Override
     public List<VerifyError> verify(ClassModel model) {
-        return VerifierImpl.verify(model, classHierarchyResolverOption().classHierarchyResolver(), null);
+        try {
+            return VerifierImpl.verify(model, classHierarchyResolverOption().classHierarchyResolver(), null);
+        } catch (IllegalArgumentException verifierInitializationError) {
+            return List.of(new VerifyError(verifierInitializationError.getMessage()));
+        }
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
@@ -114,9 +114,10 @@ public final class VerifierImpl {
     }
 
     public static List<VerifyError> verify(ClassModel classModel, ClassHierarchyResolver classHierarchyResolver, Consumer<String> logger) {
-        var klass = new VerificationWrapper(classModel);
-        log_info(logger, "Start class verification for: %s", klass.thisClassName());
+        String clsName = classModel.thisClass().asInternalName();
+        log_info(logger, "Start class verification for: %s", clsName);
         try {
+            var klass = new VerificationWrapper(classModel);
             var errors = new ArrayList<VerifyError>();
             errors.addAll(new ParserVerifier(classModel).verify());
             if (is_eligible_for_verification(klass)) {
@@ -134,7 +135,7 @@ public final class VerifierImpl {
             }
             return errors;
         } finally {
-            log_info(logger, "End class verification for: %s", klass.thisClassName());
+            log_info(logger, "End class verification for: %s", clsName);
         }
     }
 

--- a/test/jdk/jdk/classfile/VerifierSelfTest.java
+++ b/test/jdk/jdk/classfile/VerifierSelfTest.java
@@ -24,6 +24,7 @@
 /*
  * @test
  * @summary Testing ClassFile Verifier.
+ * @bug 8333812
  * @enablePreview
  * @run junit VerifierSelfTest
  */
@@ -46,8 +47,10 @@ import java.lang.classfile.*;
 import java.lang.classfile.attribute.*;
 import java.lang.classfile.components.ClassPrinter;
 import java.lang.constant.ModuleDesc;
+import jdk.internal.classfile.impl.DirectClassBuilder;
+import jdk.internal.classfile.impl.UnboundAttribute;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.*;
 
 class VerifierSelfTest {
 
@@ -92,6 +95,19 @@ class VerifierSelfTest {
         if (ClassFile.of().verify(brokenClassBytes).isEmpty()) {
             throw new AssertionError("expected verification failure");
         }
+    }
+
+    @Test
+    void testInvalidAttrLocation() {
+        var cc = ClassFile.of();
+        var bytes = cc.build(ClassDesc.of("InvalidAttrLocationClass"), cb ->
+            ((DirectClassBuilder)cb).writeAttribute(new UnboundAttribute.AdHocAttribute<LocalVariableTableAttribute>(Attributes.localVariableTable()) {
+                @Override
+                public void writeBody(BufWriter b) {
+                    b.writeU2(0);
+                }
+            }));
+        assertTrue(cc.verify(bytes).stream().anyMatch(e -> e.getMessage().contains("Invalid LocalVariableTable attribute location")));
     }
 
     @Test

--- a/test/jdk/jdk/classfile/VerifierSelfTest.java
+++ b/test/jdk/jdk/classfile/VerifierSelfTest.java
@@ -111,6 +111,14 @@ class VerifierSelfTest {
     }
 
     @Test
+    void testInvalidClassNameEntry() {
+        var cc = ClassFile.of();
+        var bytes = ClassFile.of().parse(new byte[]{(byte)0xCA, (byte)0xFE, (byte)0xBA, (byte)0xBE,
+            0, 0, 0, 0, 0, 2, ClassFile.TAG_INTEGER, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+        assertTrue(cc.verify(bytes).stream().anyMatch(e -> e.getMessage().contains("expected ClassEntry")));
+    }
+
+    @Test
     void testParserVerification() {
         var cc = ClassFile.of();
         var cd_test = ClassDesc.of("ParserVerificationTestClass");

--- a/test/jdk/jdk/classfile/VerifierSelfTest.java
+++ b/test/jdk/jdk/classfile/VerifierSelfTest.java
@@ -113,7 +113,7 @@ class VerifierSelfTest {
     @Test
     void testInvalidClassNameEntry() {
         var cc = ClassFile.of();
-        var bytes = ClassFile.of().parse(new byte[]{(byte)0xCA, (byte)0xFE, (byte)0xBA, (byte)0xBE,
+        var bytes = cc.parse(new byte[]{(byte)0xCA, (byte)0xFE, (byte)0xBA, (byte)0xBE,
             0, 0, 0, 0, 0, 2, ClassFile.TAG_INTEGER, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
         assertTrue(cc.verify(bytes).stream().anyMatch(e -> e.getMessage().contains("expected ClassEntry")));
     }


### PR DESCRIPTION
`ClassFile.verify()` should always return list of verification errors and never throw an exception, even for corrupted classes.
`BoundAttribute` initializations of `LocalVariableTable` and `LocalVariableTypeTable` attributes do not expect invalid possible locations and cause `ClassCastException`.

This patch fixes `BoundAttribute` to throw `IllegalArgumentException` for invalid `LocalVariableTable` and `LocalVariableTypeTable` attributes locations. And makes `VerifierImpl` a bit more resilient to exceptions thrown from the verifier initialization.

Relevant test is added.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333812](https://bugs.openjdk.org/browse/JDK-8333812): ClassFile.verify() can throw exceptions instead of returning VerifyErrors (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20241/head:pull/20241` \
`$ git checkout pull/20241`

Update a local copy of the PR: \
`$ git checkout pull/20241` \
`$ git pull https://git.openjdk.org/jdk.git pull/20241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20241`

View PR using the GUI difftool: \
`$ git pr show -t 20241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20241.diff">https://git.openjdk.org/jdk/pull/20241.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20241#issuecomment-2237034666)