### PR TITLE
8248609: [Graal] vmTestbase/nsk/jdi/VoidValue/toString/tostring001/TestDescription.java failed with Unexpected com.sun.jdi.ObjectCollectedException

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/toString/tostring001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/VoidValue/toString/tostring001.java
@@ -140,6 +140,10 @@ public class tostring001 {
 
         try {
             testedObject = testedClass.newInstance(thread, ctor, params, 0);
+            // Disable collection on testedObject. invokeMethod() will essentially do a
+            // vm.resume(), which gives GC a chance to run, which might result in this
+            // object being collected.
+            testedObject.disableCollection();
         } catch (Exception e) {
             throw new Failure("unexpected " + e + " when invoking debuggee's constructor");
         }
@@ -178,6 +182,7 @@ public class tostring001 {
         }
 
         display("Checking of debuggee's void value methods completed!");
+        testedObject.enableCollection();
         debuggee.resume();
     }
 


### PR DESCRIPTION
The test is failing with an ObjectCollectedException.  The test hits a SUSPEND_ALL breakpoint. It then uses JDI to allocate an Object on the debuggee side:

            testedObject = testedClass.newInstance(thread, ctor, params, 0);

Since we are under a SUSPEND_ALL, the object is not initially at risk of getting GC'd. However, the test then calls invokeMethod() in a loop:

                if (method.isStatic()) {
                    voidValue = (VoidValue) testedClass.invokeMethod(thread, method, params, 0);
                } else {
                    voidValue = (VoidValue) testedObject.invokeMethod(thread, method, params, 0);
                }

On the first iteration of the loop, invokeMethod() will do a resumeAll() so it can execute the method on the specified thread. During this time a GC can happen, and that GC is likely to collect the object that testedObject is mirroring since it is only weakly kept alive. Then on a subsequent iteration of the loop, testedObject.invokeMethod() is called again, but this time you get the ObjectCollectedException because the object that testedObject is mirroring has been collected. The test needs to add a call to testedObject.disableCollection() to prevent it from being collected.

I'm not able to reproduce this failure, but the bug is pretty clear. Testing is in progress. I'll run tier1 CI and also tier2 and tier5 test tasks that run this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8248609](https://bugs.openjdk.org/browse/JDK-8248609): [Graal] vmTestbase/nsk/jdi/VoidValue/toString/tostring001/TestDescription.java failed with Unexpected com.sun.jdi.ObjectCollectedException (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20242/head:pull/20242` \
`$ git checkout pull/20242`

Update a local copy of the PR: \
`$ git checkout pull/20242` \
`$ git pull https://git.openjdk.org/jdk.git pull/20242/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20242`

View PR using the GUI difftool: \
`$ git pr show -t 20242`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20242.diff">https://git.openjdk.org/jdk/pull/20242.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20242#issuecomment-2237325586)