### PR TITLE
8336781: Erroneous exhaustivity check with boolean switch

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -787,7 +787,7 @@ public class Flow {
         private boolean exhausts(JCExpression selector, List<JCCase> cases) {
             Set<PatternDescription> patternSet = new HashSet<>();
             Map<Symbol, Set<Symbol>> enum2Constants = new HashMap<>();
-            Set<Object> booleanLiterals = new HashSet<>();
+            Set<Object> booleanLiterals = new HashSet<>(Set.of(0, 1));
             for (JCCase c : cases) {
                 if (!TreeInfo.unguardedCase(c))
                     continue;
@@ -800,7 +800,7 @@ public class Flow {
                     } else if (l instanceof JCConstantCaseLabel constantLabel) {
                         if (types.unboxedTypeOrType(selector.type).hasTag(TypeTag.BOOLEAN)) {
                             Object value = ((JCLiteral) constantLabel.expr).value;
-                            booleanLiterals.add(value);
+                            booleanLiterals.remove(value);
                         } else {
                             Symbol s = TreeInfo.symbol(constantLabel.expr);
                             if (s != null && s.isEnum()) {
@@ -817,7 +817,7 @@ public class Flow {
                 }
             }
 
-            if (types.unboxedTypeOrType(selector.type).hasTag(TypeTag.BOOLEAN) && booleanLiterals.size() == 2) {
+            if (types.unboxedTypeOrType(selector.type).hasTag(TypeTag.BOOLEAN) && booleanLiterals.isEmpty()) {
                 return true;
             }
 

--- a/test/langtools/tools/javac/patterns/T8336781.java
+++ b/test/langtools/tools/javac/patterns/T8336781.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8336781
+ * @summary Erroneous exhaustivity check with boolean switch
+ * @enablePreview
+ * @compile -XDshould-stop.at=FLOW T8336781.java
+ */
+public class T8336781 {
+    public static void test() {
+        Boolean bool = null;
+        var _ = switch (bool) {
+            case null -> "nothing";
+            case true -> "something true";
+            case false -> "something false";
+        };
+    }
+}


### PR DESCRIPTION
In the case of a `Boolean` switch with 3 values true, false and `null` there was a miscalculation on what consists an exhaustive switch. This PR addresses this bug by removing the values true and false (instead of adding and comparing with 2 expected values).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336781](https://bugs.openjdk.org/browse/JDK-8336781): Erroneous exhaustivity check with boolean switch (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20243/head:pull/20243` \
`$ git checkout pull/20243`

Update a local copy of the PR: \
`$ git checkout pull/20243` \
`$ git pull https://git.openjdk.org/jdk.git pull/20243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20243`

View PR using the GUI difftool: \
`$ git pr show -t 20243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20243.diff">https://git.openjdk.org/jdk/pull/20243.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20243#issuecomment-2237510448)