### PR TITLE
8334145: <pid> missing from vm_memory_map_<pid>.txt in System.dump_map help text

### DIFF
--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -878,7 +878,7 @@ The following \f[I]options\f[R] must be specified using either
 \f[V]-H\f[R]: (Optional) Human readable format (BOOLEAN, false)
 .IP \[bu] 2
 \f[V]-F\f[R]: (Optional) File path (STRING,
-\[dq]vm_memory_map_.txt\[dq])
+\[dq]vm_memory_map_<pid>.txt\[dq])
 .RE
 .TP
 \f[V]System.map\f[R] [\f[I]options\f[R]] (Linux only)


### PR DESCRIPTION
Fix issue with `<pid>` argument.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334145](https://bugs.openjdk.org/browse/JDK-8334145): &lt;pid&gt; missing from vm_memory_map_&lt;pid&gt;.txt in System.dump_map help text (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20246/head:pull/20246` \
`$ git checkout pull/20246`

Update a local copy of the PR: \
`$ git checkout pull/20246` \
`$ git pull https://git.openjdk.org/jdk.git pull/20246/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20246`

View PR using the GUI difftool: \
`$ git pr show -t 20246`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20246.diff">https://git.openjdk.org/jdk/pull/20246.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20246#issuecomment-2237865190)