### PR TITLE
8325280: Update troff manpages in JDK 23 before RC

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVA" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JAVA" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -1195,7 +1195,7 @@ or directories.
 \f[V]--source\f[R] \f[I]version\f[R]
 Sets the version of the source in source-file mode.
 .TP
-\f[V]--sun-misc-unsafe-memory-acces=\f[R] \f[I]value\f[R]
+\f[V]--sun-misc-unsafe-memory-access=\f[R] \f[I]value\f[R]
 Allow or deny usage of unsupported API \f[V]sun.misc.Unsafe\f[R].
 \f[I]value\f[R] is one of:
 .RS
@@ -3491,16 +3491,6 @@ By default, this option is disabled.
 Enables printing of information about adaptive-generation sizing.
 By default, this option is disabled.
 .TP
-\f[V]-XX:+ScavengeBeforeFullGC\f[R]
-Enables GC of the young generation before each full GC.
-This option is enabled by default.
-It is recommended that you \f[I]don\[aq]t\f[R] disable it, because
-scavenging the young generation before a full GC can reduce the number
-of objects reachable from the old generation space into the young
-generation space.
-To disable GC of the young generation before each full GC, specify the
-option \f[V]-XX:-ScavengeBeforeFullGC\f[R].
-.TP
 \f[V]-XX:SoftRefLRUPolicyMSPerMB=\f[R]\f[I]time\f[R]
 Sets the amount of time (in milliseconds) a softly reachable object is
 kept active on the heap after the last time it was referenced.
@@ -3755,45 +3745,6 @@ Enables the use of Java Flight Recorder (JFR) during the runtime of the
 application.
 Since JDK 8u40 this option has not been required to use JFR.
 .TP
-\f[V]-XX:InitialRAMFraction=\f[R]\f[I]ratio\f[R]
-Sets the initial amount of memory that the JVM may use for the Java heap
-before applying ergonomics heuristics as a ratio of the maximum amount
-determined as described in the \f[V]-XX:MaxRAM\f[R] option.
-The default value is 64.
-.RS
-.PP
-Use the option \f[V]-XX:InitialRAMPercentage\f[R] instead.
-.RE
-.TP
-\f[V]-XX:MaxRAMFraction=\f[R]\f[I]ratio\f[R]
-Sets the maximum amount of memory that the JVM may use for the Java heap
-before applying ergonomics heuristics as a fraction of the maximum
-amount determined as described in the \f[V]-XX:MaxRAM\f[R] option.
-The default value is 4.
-.RS
-.PP
-Specifying this option disables automatic use of compressed oops if the
-combined result of this and other options influencing the maximum amount
-of memory is larger than the range of memory addressable by compressed
-oops.
-See \f[V]-XX:UseCompressedOops\f[R] for further information about
-compressed oops.
-.PP
-Use the option \f[V]-XX:MaxRAMPercentage\f[R] instead.
-.RE
-.TP
-\f[V]-XX:MinRAMFraction=\f[R]\f[I]ratio\f[R]
-Sets the maximum amount of memory that the JVM may use for the Java heap
-before applying ergonomics heuristics as a fraction of the maximum
-amount determined as described in the \f[V]-XX:MaxRAM\f[R] option for
-small heaps.
-A small heap is a heap of approximately 125 MB.
-The default value is 2.
-.RS
-.PP
-Use the option \f[V]-XX:MinRAMPercentage\f[R] instead.
-.RE
-.TP
 \f[V]-XX:RTMAbortRatio=\f[R]\f[I]abort_ratio\f[R]
 Specifies the RTM abort ratio is specified as a percentage (%) of all
 executed RTM transactions.
@@ -3882,6 +3833,55 @@ Controlled \f[I]relaxed strong encapsulation\f[R], as defined in
 This option was deprecated in JDK 16 by \f[B]JEP 396\f[R]
 [https://openjdk.org/jeps/396] and made obsolete in JDK 17 by \f[B]JEP
 403\f[R] [https://openjdk.org/jeps/403].
+.TP
+\f[V]-XX:+ScavengeBeforeFullGC\f[R]
+Enables GC of the young generation before each full GC.
+This option is enabled by default.
+It is recommended that you \f[I]don\[aq]t\f[R] disable it, because
+scavenging the young generation before a full GC can reduce the number
+of objects reachable from the old generation space into the young
+generation space.
+To disable GC of the young generation before each full GC, specify the
+option \f[V]-XX:-ScavengeBeforeFullGC\f[R].
+.TP
+\f[V]-XX:InitialRAMFraction=\f[R]\f[I]ratio\f[R]
+Sets the initial amount of memory that the JVM may use for the Java heap
+before applying ergonomics heuristics as a ratio of the maximum amount
+determined as described in the \f[V]-XX:MaxRAM\f[R] option.
+The default value is 64.
+.RS
+.PP
+Use the option \f[V]-XX:InitialRAMPercentage\f[R] instead.
+.RE
+.TP
+\f[V]-XX:MaxRAMFraction=\f[R]\f[I]ratio\f[R]
+Sets the maximum amount of memory that the JVM may use for the Java heap
+before applying ergonomics heuristics as a fraction of the maximum
+amount determined as described in the \f[V]-XX:MaxRAM\f[R] option.
+The default value is 4.
+.RS
+.PP
+Specifying this option disables automatic use of compressed oops if the
+combined result of this and other options influencing the maximum amount
+of memory is larger than the range of memory addressable by compressed
+oops.
+See \f[V]-XX:UseCompressedOops\f[R] for further information about
+compressed oops.
+.PP
+Use the option \f[V]-XX:MaxRAMPercentage\f[R] instead.
+.RE
+.TP
+\f[V]-XX:MinRAMFraction=\f[R]\f[I]ratio\f[R]
+Sets the maximum amount of memory that the JVM may use for the Java heap
+before applying ergonomics heuristics as a fraction of the maximum
+amount determined as described in the \f[V]-XX:MaxRAM\f[R] option for
+small heaps.
+A small heap is a heap of approximately 125 MB.
+The default value is 2.
+.RS
+.PP
+Use the option \f[V]-XX:MinRAMPercentage\f[R] instead.
+.RE
 .SH REMOVED JAVA OPTIONS
 .PP
 These \f[V]java\f[R] options have been removed in JDK 23 and using them

--- a/src/java.base/share/man/keytool.1
+++ b/src/java.base/share/man/keytool.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "KEYTOOL" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "KEYTOOL" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -1747,7 +1747,7 @@ risk.
 The \f[V]keytool\f[R] command supports these named extensions.
 The names aren\[aq]t case-sensitive.
 .TP
-\f[V]BC\f[R] or \f[V]BasicContraints\f[R]
+\f[V]BC\f[R] or \f[V]BasicConstraints\f[R]
 Values:
 .RS
 .PP

--- a/src/java.rmi/share/man/rmiregistry.1
+++ b/src/java.rmi/share/man/rmiregistry.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "RMIREGISTRY" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "RMIREGISTRY" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/java.scripting/share/man/jrunscript.1
+++ b/src/java.scripting/share/man/jrunscript.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JRUNSCRIPT" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JRUNSCRIPT" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.compiler/share/man/javac.1
+++ b/src/jdk.compiler/share/man/javac.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAC" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JAVAC" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.compiler/share/man/serialver.1
+++ b/src/jdk.compiler/share/man/serialver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "SERIALVER" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "SERIALVER" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.hotspot.agent/share/man/jhsdb.1
+++ b/src/jdk.hotspot.agent/share/man/jhsdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JHSDB" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JHSDB" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.httpserver/share/man/jwebserver.1
+++ b/src/jdk.httpserver/share/man/jwebserver.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JWEBSERVER" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JWEBSERVER" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAR" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JAR" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jartool/share/man/jarsigner.1
+++ b/src/jdk.jartool/share/man/jarsigner.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JARSIGNER" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JARSIGNER" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.javadoc/share/man/javadoc.1
+++ b/src/jdk.javadoc/share/man/javadoc.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVADOC" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JAVADOC" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP
@@ -218,7 +218,7 @@ summary is required.
 For more explicit control in any individual documentation comment,
 enclose the contents of the first sentence in a
 \f[V]{\[at]summary ...}\f[R] tag, or when applicable, in a
-\[ga]{\[at]return ...} tag.
+\f[V]{\[at]return ...}\f[R] tag.
 .RE
 .TP
 \f[V]-doclet\f[R] \f[I]class\f[R]
@@ -522,7 +522,8 @@ Allow JavaScript in documentation comments, and options whose value is
 \f[I]html-code\f[R].
 .TP
 \f[V]-author\f[R]
-Includes the \f[V]\[at]author\f[R] text in the generated docs.
+Includes the text of any \f[V]author\f[R] tags in the generated
+documentation.
 .TP
 \f[V]-bottom\f[R] \f[I]html-code\f[R]
 Specifies the text to be placed at the bottom of each generated page.
@@ -986,8 +987,8 @@ is used.
 .RE
 .TP
 \f[V]-nosince\f[R]
-Omits from the generated documents the \f[V]Since\f[R] sections
-associated with the \f[V]\[at]since\f[R] tags.
+Omits from the generated documentation the \f[V]Since\f[R] sections
+derived from any \f[V]since\f[R] tags.
 .TP
 \f[V]-notimestamp\f[R]
 Suppresses the time stamp, which is hidden in an HTML comment in the
@@ -1020,9 +1021,6 @@ to the current working directory.
 .PP
 The file may be an HTML file, with a filename ending in \f[V].html\f[R],
 or a Markdown file, with a filename ending in \f[V].md\f[R].
-.PD 0
-.P
-.PD
 If the file is an HTML file, the content for the overview documentation
 is taken from the \f[V]<main>\f[R] element in the file, if one is
 present, or from the \f[V]<body>\f[R] element is there is no
@@ -1213,10 +1211,11 @@ To access the generated Use page, go to the class or package and click
 the \f[B]USE\f[R] link in the navigation bar.
 .TP
 \f[V]-version\f[R]
-Includes the version text in the generated docs.
+Includes the text of any \f[V]version\f[R] tags in the generated
+documentation.
 This text is omitted by default.
-To find out what version of the \f[V]javadoc\f[R] tool you are using,
-use the \f[V]--version\f[R] option (with two hyphens).
+Note: To find out what version of the \f[V]javadoc\f[R] tool you are
+using, use the \f[V]--version\f[R] option (with two hyphens).
 .TP
 \f[V]-windowtitle\f[R] \f[I]title\f[R]
 Specifies the title to be placed in the HTML \f[V]<title>\f[R] tag.

--- a/src/jdk.jcmd/share/man/jcmd.1
+++ b/src/jdk.jcmd/share/man/jcmd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCMD" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JCMD" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jinfo.1
+++ b/src/jdk.jcmd/share/man/jinfo.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JINFO" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JINFO" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jmap.1
+++ b/src/jdk.jcmd/share/man/jmap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMAP" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JMAP" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jps.1
+++ b/src/jdk.jcmd/share/man/jps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPS" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JPS" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstack.1
+++ b/src/jdk.jcmd/share/man/jstack.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTACK" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JSTACK" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jcmd/share/man/jstat.1
+++ b/src/jdk.jcmd/share/man/jstat.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTAT" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JSTAT" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jconsole/share/man/jconsole.1
+++ b/src/jdk.jconsole/share/man/jconsole.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JCONSOLE" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JCONSOLE" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/javap.1
+++ b/src/jdk.jdeps/share/man/javap.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JAVAP" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JAVAP" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeprscan.1
+++ b/src/jdk.jdeps/share/man/jdeprscan.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPRSCAN" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JDEPRSCAN" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdeps/share/man/jdeps.1
+++ b/src/jdk.jdeps/share/man/jdeps.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDEPS" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JDEPS" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jdi/share/man/jdb.1
+++ b/src/jdk.jdi/share/man/jdb.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JDB" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JDB" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jfr/share/man/jfr.1
+++ b/src/jdk.jfr/share/man/jfr.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JFR" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JFR" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jlink/share/man/jlink.1
+++ b/src/jdk.jlink/share/man/jlink.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JLINK" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JLINK" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jlink/share/man/jmod.1
+++ b/src/jdk.jlink/share/man/jmod.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JMOD" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JMOD" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jpackage/share/man/jpackage.1
+++ b/src/jdk.jpackage/share/man/jpackage.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JPACKAGE" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JPACKAGE" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jshell/share/man/jshell.1
+++ b/src/jdk.jshell/share/man/jshell.1
@@ -36,7 +36,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSHELL" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JSHELL" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP

--- a/src/jdk.jstatd/share/man/jstatd.1
+++ b/src/jdk.jstatd/share/man/jstatd.1
@@ -35,7 +35,7 @@
 . ftr VB CB
 . ftr VBI CBI
 .\}
-.TH "JSTATD" "1" "2024" "JDK 23-ea" "JDK Commands"
+.TH "JSTATD" "1" "2024" "JDK 23" "JDK Commands"
 .hy
 .SH NAME
 .PP


### PR DESCRIPTION
Before RC we need to update the man pages in the repo from their Markdown sources. All pages at a minimum have 23-ea replaced with 23, and publication year set to 2024 if needed.

This also picks up the unpublished changes to java.1 from:

- [JDK-8324836](https://bugs.openjdk.org/browse/JDK-8324836): Update Manpage for obsoletion of RAMFraction flags
- [JDK-8330807](https://bugs.openjdk.org/browse/JDK-8330807): Update Manpage for obsoletion of ScavengeBeforeFullGC

And a typo crept in to java.1 from:
- [JDK-8331670](https://bugs.openjdk.org/browse/JDK-8331670): Deprecate the Memory-Access Methods in sun.misc.Unsafe for Removal

This also picks up the unpublished change to keytool.1 from:

- [JDK-8284500](https://bugs.openjdk.org/browse/JDK-8284500): Typo in Supported Named Extensions - BasicContraints

This also picks up the unpublished change to javadoc.1 from:

- [JDK-8324342](https://bugs.openjdk.org/browse/JDK-8324342): Doclet should default @since for a nested class to that of its enclosing class

and some formatting changes (unclear why - perhaps pandoc version) from the combined changeset for:

- [JDK-8298405](https://bugs.openjdk.org/browse/JDK-8298405): Implement JEP 467: Markdown Documentation Comments
- [JDK-8329296](https://bugs.openjdk.org/browse/JDK-8329296): Update Elements for '///' documentation comments

The javac.1 file has its copyright year reverted to match what is in the source file (which should have been updated but wasn't).

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325280](https://bugs.openjdk.org/browse/JDK-8325280): Update troff manpages in JDK 23 before RC (**Task** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20248/head:pull/20248` \
`$ git checkout pull/20248`

Update a local copy of the PR: \
`$ git checkout pull/20248` \
`$ git pull https://git.openjdk.org/jdk.git pull/20248/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20248`

View PR using the GUI difftool: \
`$ git pr show -t 20248`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20248.diff">https://git.openjdk.org/jdk/pull/20248.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20248#issuecomment-2238251974)