### PR TITLE
8336816: runtime/PrintingTests/StringPrinting.java fails with release VMs

### DIFF
--- a/test/hotspot/jtreg/runtime/PrintingTests/StringPrinting.java
+++ b/test/hotspot/jtreg/runtime/PrintingTests/StringPrinting.java
@@ -28,7 +28,7 @@
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
- * @run main/othervm -Xbootclasspath/a:. -XX:+WhiteBoxAPI StringPrinting
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI StringPrinting
  */
 
 import jdk.test.whitebox.WhiteBox;


### PR DESCRIPTION
Just add `-XX:+UnlockDiagnosticVMOptions` to fix the failure with release VMs.
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336816](https://bugs.openjdk.org/browse/JDK-8336816): runtime/PrintingTests/StringPrinting.java fails with release VMs (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20249/head:pull/20249` \
`$ git checkout pull/20249`

Update a local copy of the PR: \
`$ git checkout pull/20249` \
`$ git pull https://git.openjdk.org/jdk.git pull/20249/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20249`

View PR using the GUI difftool: \
`$ git pr show -t 20249`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20249.diff">https://git.openjdk.org/jdk/pull/20249.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20249#issuecomment-2238638539)