### PR TITLE
8337838: Remove unused methods from ChronoLocalDateImpl

### DIFF
--- a/src/java.base/share/classes/java/time/chrono/ChronoLocalDateImpl.java
+++ b/src/java.base/share/classes/java/time/chrono/ChronoLocalDateImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -259,25 +259,6 @@ abstract class ChronoLocalDateImpl<D extends ChronoLocalDate>
     abstract D plusMonths(long monthsToAdd);
 
     /**
-     * Returns a copy of this date with the specified number of weeks added.
-     * <p>
-     * This adds the specified period in weeks to the date.
-     * In some cases, adding weeks can cause the resulting date to become invalid.
-     * If this occurs, then other fields will be adjusted to ensure that the result is valid.
-     * <p>
-     * The default implementation uses {@link #plusDays(long)} using a 7 day week.
-     * <p>
-     * This instance is immutable and unaffected by this method call.
-     *
-     * @param weeksToAdd  the weeks to add, may be negative
-     * @return a date based on this one with the weeks added, not null
-     * @throws DateTimeException if the result exceeds the supported date range
-     */
-    D plusWeeks(long weeksToAdd) {
-        return plusDays(Math.multiplyExact(weeksToAdd, 7));
-    }
-
-    /**
      * Returns a copy of this date with the specified number of days added.
      * <p>
      * This adds the specified period in days to the date.
@@ -291,85 +272,6 @@ abstract class ChronoLocalDateImpl<D extends ChronoLocalDate>
     abstract D plusDays(long daysToAdd);
 
     //-----------------------------------------------------------------------
-    /**
-     * Returns a copy of this date with the specified number of years subtracted.
-     * <p>
-     * This subtracts the specified period in years to the date.
-     * In some cases, subtracting years can cause the resulting date to become invalid.
-     * If this occurs, then other fields, typically the day-of-month, will be adjusted to ensure
-     * that the result is valid. Typically this will select the last valid day of the month.
-     * <p>
-     * The default implementation uses {@link #plusYears(long)}.
-     * <p>
-     * This instance is immutable and unaffected by this method call.
-     *
-     * @param yearsToSubtract  the years to subtract, may be negative
-     * @return a date based on this one with the years subtracted, not null
-     * @throws DateTimeException if the result exceeds the supported date range
-     */
-    @SuppressWarnings("unchecked")
-    D minusYears(long yearsToSubtract) {
-        return (yearsToSubtract == Long.MIN_VALUE ? ((ChronoLocalDateImpl<D>)plusYears(Long.MAX_VALUE)).plusYears(1) : plusYears(-yearsToSubtract));
-    }
-
-    /**
-     * Returns a copy of this date with the specified number of months subtracted.
-     * <p>
-     * This subtracts the specified period in months to the date.
-     * In some cases, subtracting months can cause the resulting date to become invalid.
-     * If this occurs, then other fields, typically the day-of-month, will be adjusted to ensure
-     * that the result is valid. Typically this will select the last valid day of the month.
-     * <p>
-     * The default implementation uses {@link #plusMonths(long)}.
-     * <p>
-     * This instance is immutable and unaffected by this method call.
-     *
-     * @param monthsToSubtract  the months to subtract, may be negative
-     * @return a date based on this one with the months subtracted, not null
-     * @throws DateTimeException if the result exceeds the supported date range
-     */
-    @SuppressWarnings("unchecked")
-    D minusMonths(long monthsToSubtract) {
-        return (monthsToSubtract == Long.MIN_VALUE ? ((ChronoLocalDateImpl<D>)plusMonths(Long.MAX_VALUE)).plusMonths(1) : plusMonths(-monthsToSubtract));
-    }
-
-    /**
-     * Returns a copy of this date with the specified number of weeks subtracted.
-     * <p>
-     * This subtracts the specified period in weeks to the date.
-     * In some cases, subtracting weeks can cause the resulting date to become invalid.
-     * If this occurs, then other fields will be adjusted to ensure that the result is valid.
-     * <p>
-     * The default implementation uses {@link #plusWeeks(long)}.
-     * <p>
-     * This instance is immutable and unaffected by this method call.
-     *
-     * @param weeksToSubtract  the weeks to subtract, may be negative
-     * @return a date based on this one with the weeks subtracted, not null
-     * @throws DateTimeException if the result exceeds the supported date range
-     */
-    @SuppressWarnings("unchecked")
-    D minusWeeks(long weeksToSubtract) {
-        return (weeksToSubtract == Long.MIN_VALUE ? ((ChronoLocalDateImpl<D>)plusWeeks(Long.MAX_VALUE)).plusWeeks(1) : plusWeeks(-weeksToSubtract));
-    }
-
-    /**
-     * Returns a copy of this date with the specified number of days subtracted.
-     * <p>
-     * This subtracts the specified period in days to the date.
-     * <p>
-     * The default implementation uses {@link #plusDays(long)}.
-     * <p>
-     * This instance is immutable and unaffected by this method call.
-     *
-     * @param daysToSubtract  the days to subtract, may be negative
-     * @return a date based on this one with the days subtracted, not null
-     * @throws DateTimeException if the result exceeds the supported date range
-     */
-    @SuppressWarnings("unchecked")
-    D minusDays(long daysToSubtract) {
-        return (daysToSubtract == Long.MIN_VALUE ? ((ChronoLocalDateImpl<D>)plusDays(Long.MAX_VALUE)).plusDays(1) : plusDays(-daysToSubtract));
-    }
 
     //-----------------------------------------------------------------------
     @Override

--- a/src/java.base/share/classes/java/time/chrono/HijrahDate.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -545,11 +545,6 @@ public final class HijrahDate
     }
 
     @Override
-    HijrahDate plusWeeks(long weeksToAdd) {
-        return super.plusWeeks(weeksToAdd);
-    }
-
-    @Override
     HijrahDate plusDays(long days) {
         return new HijrahDate(chrono, toEpochDay() + days);
     }
@@ -562,26 +557,6 @@ public final class HijrahDate
     @Override
     public HijrahDate minus(long amountToSubtract, TemporalUnit unit) {
         return super.minus(amountToSubtract, unit);
-    }
-
-    @Override
-    HijrahDate minusYears(long yearsToSubtract) {
-        return super.minusYears(yearsToSubtract);
-    }
-
-    @Override
-    HijrahDate minusMonths(long monthsToSubtract) {
-        return super.minusMonths(monthsToSubtract);
-    }
-
-    @Override
-    HijrahDate minusWeeks(long weeksToSubtract) {
-        return super.minusWeeks(weeksToSubtract);
-    }
-
-    @Override
-    HijrahDate minusDays(long daysToSubtract) {
-        return super.minusDays(daysToSubtract);
     }
 
     @Override        // for javadoc and covariant return type

--- a/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
+++ b/src/java.base/share/classes/java/time/chrono/JapaneseDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -617,11 +617,6 @@ public final class JapaneseDate
     }
 
     @Override
-    JapaneseDate plusWeeks(long weeksToAdd) {
-        return with(isoDate.plusWeeks(weeksToAdd));
-    }
-
-    @Override
     JapaneseDate plusDays(long days) {
         return with(isoDate.plusDays(days));
     }
@@ -634,26 +629,6 @@ public final class JapaneseDate
     @Override
     public JapaneseDate minus(long amountToSubtract, TemporalUnit unit) {
         return super.minus(amountToSubtract, unit);
-    }
-
-    @Override
-    JapaneseDate minusYears(long yearsToSubtract) {
-        return super.minusYears(yearsToSubtract);
-    }
-
-    @Override
-    JapaneseDate minusMonths(long monthsToSubtract) {
-        return super.minusMonths(monthsToSubtract);
-    }
-
-    @Override
-    JapaneseDate minusWeeks(long weeksToSubtract) {
-        return super.minusWeeks(weeksToSubtract);
-    }
-
-    @Override
-    JapaneseDate minusDays(long daysToSubtract) {
-        return super.minusDays(daysToSubtract);
     }
 
     private JapaneseDate with(LocalDate newDate) {

--- a/src/java.base/share/classes/java/time/chrono/MinguoDate.java
+++ b/src/java.base/share/classes/java/time/chrono/MinguoDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -378,11 +378,6 @@ public final class MinguoDate
     }
 
     @Override
-    MinguoDate plusWeeks(long weeksToAdd) {
-        return super.plusWeeks(weeksToAdd);
-    }
-
-    @Override
     MinguoDate plusDays(long days) {
         return with(isoDate.plusDays(days));
     }
@@ -395,26 +390,6 @@ public final class MinguoDate
     @Override
     public MinguoDate minus(long amountToSubtract, TemporalUnit unit) {
         return super.minus(amountToSubtract, unit);
-    }
-
-    @Override
-    MinguoDate minusYears(long yearsToSubtract) {
-        return super.minusYears(yearsToSubtract);
-    }
-
-    @Override
-    MinguoDate minusMonths(long monthsToSubtract) {
-        return super.minusMonths(monthsToSubtract);
-    }
-
-    @Override
-    MinguoDate minusWeeks(long weeksToSubtract) {
-        return super.minusWeeks(weeksToSubtract);
-    }
-
-    @Override
-    MinguoDate minusDays(long daysToSubtract) {
-        return super.minusDays(daysToSubtract);
     }
 
     private MinguoDate with(LocalDate newDate) {

--- a/src/java.base/share/classes/java/time/chrono/ThaiBuddhistDate.java
+++ b/src/java.base/share/classes/java/time/chrono/ThaiBuddhistDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -380,11 +380,6 @@ public final class ThaiBuddhistDate
     }
 
     @Override
-    ThaiBuddhistDate plusWeeks(long weeksToAdd) {
-        return super.plusWeeks(weeksToAdd);
-    }
-
-    @Override
     ThaiBuddhistDate plusDays(long days) {
         return with(isoDate.plusDays(days));
     }
@@ -397,26 +392,6 @@ public final class ThaiBuddhistDate
     @Override
     public ThaiBuddhistDate minus(long amountToSubtract, TemporalUnit unit) {
         return super.minus(amountToSubtract, unit);
-    }
-
-    @Override
-    ThaiBuddhistDate minusYears(long yearsToSubtract) {
-        return super.minusYears(yearsToSubtract);
-    }
-
-    @Override
-    ThaiBuddhistDate minusMonths(long monthsToSubtract) {
-        return super.minusMonths(monthsToSubtract);
-    }
-
-    @Override
-    ThaiBuddhistDate minusWeeks(long weeksToSubtract) {
-        return super.minusWeeks(weeksToSubtract);
-    }
-
-    @Override
-    ThaiBuddhistDate minusDays(long daysToSubtract) {
-        return super.minusDays(daysToSubtract);
     }
 
     private ThaiBuddhistDate with(LocalDate newDate) {


### PR DESCRIPTION
A few methods in `java.time.chrono.ChronoLocalDateImpl` are unused and could be removed:
1. plusWeeks(long)
2. minusYears(long)
3. minusMonths(long)
4. minusWeeks(long)
5. minusDays(long)

Tested `test/jdk/java/time` on Linux x64 release

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337838](https://bugs.openjdk.org/browse/JDK-8337838): Remove unused methods from ChronoLocalDateImpl (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20250/head:pull/20250` \
`$ git checkout pull/20250`

Update a local copy of the PR: \
`$ git checkout pull/20250` \
`$ git pull https://git.openjdk.org/jdk.git pull/20250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20250`

View PR using the GUI difftool: \
`$ git pr show -t 20250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20250.diff">https://git.openjdk.org/jdk/pull/20250.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20250#issuecomment-2269812356)