### PR TITLE
8336039: Doccheck: HTML warnings, broken links and missing files in java.base documentation

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
@@ -37,7 +37,7 @@ import jdk.internal.javac.PreviewFeature;
  * and calculating max stack size.
  * <p>
  * Sample use:
- * <p>
+ * </p>
  * {@snippet lang=java :
  *     var stackTracker = CodeStackTracker.of();
  *     codeBuilder.transforming(stackTracker, trackedBuilder -> {

--- a/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
+++ b/src/java.base/share/classes/java/lang/classfile/components/CodeStackTracker.java
@@ -37,7 +37,7 @@ import jdk.internal.javac.PreviewFeature;
  * and calculating max stack size.
  * <p>
  * Sample use:
- * </p>
+ *
  * {@snippet lang=java :
  *     var stackTracker = CodeStackTracker.of();
  *     codeBuilder.transforming(stackTracker, trackedBuilder -> {

--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -33,11 +33,11 @@
  * The main class for reading classfiles is {@link java.lang.classfile.ClassModel}; we
  * convert bytes into a {@link java.lang.classfile.ClassModel} with {@link
  * java.lang.classfile.ClassFile#parse(byte[])}:
- * <p>
+ *
  * {@snippet lang=java :
  * ClassModel cm = ClassFile.of().parse(bytes);
  * }
- * <p>
+ *
  * There are several additional overloads of {@code parse} that let you specify
  * various processing options.
  * <p>
@@ -377,7 +377,7 @@
  * <p>
  * Then we can compose {@code fooToBar} and {@code instrumentCalls} with {@link
  * java.lang.classfile.CodeTransform#andThen(java.lang.classfile.CodeTransform)}:
- * <p>
+ *
  * {@snippet lang=java :
  * var cc = ClassFile.of();
  * byte[] newBytes = cc.transform(cc.parse(bytes),
@@ -443,7 +443,7 @@
  * or more, zero or one, exactly one), and a list of components.  The elements
  * of a class are fields, methods, and the attributes that can appear on
  * classes:
- * <p>
+ *
  * {@snippet lang="text" :
  * ClassElement =
  *     FieldModel*(UtfEntry name, Utf8Entry descriptor)
@@ -468,7 +468,7 @@
  *     | PermittedSubclassesAttribute?(List<ClassEntry> permittedSubclasses)
  *     | DeclarationElement*
  * }
- *<p>
+ *
  * where {@code DeclarationElement} are the elements that are common to all declarations
  * (classes,  methods, fields) and so are factored out:
  *

--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -61,7 +61,7 @@ import java.util.function.Consumer;
  * by the garbage collector. The scope of an automatic arena is an automatic scope. As
  * such, the regions of memory backing memory segments allocated with the automatic arena
  * are deallocated at some unspecified time <em>after</em> the automatic arena (and all
- * the segments allocated by it) becomes <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>,
+ * the segments allocated by it) becomes {@linkplain java.lang.ref##reachability unreachable},
  * as shown below:
  * {@snippet lang = java:
  * MemorySegment segment = Arena.ofAuto().allocate(100, 1); // @highlight regex='ofAuto()'

--- a/src/java.base/share/classes/java/lang/foreign/Arena.java
+++ b/src/java.base/share/classes/java/lang/foreign/Arena.java
@@ -61,7 +61,7 @@ import java.util.function.Consumer;
  * by the garbage collector. The scope of an automatic arena is an automatic scope. As
  * such, the regions of memory backing memory segments allocated with the automatic arena
  * are deallocated at some unspecified time <em>after</em> the automatic arena (and all
- * the segments allocated by it) becomes <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>,
+ * the segments allocated by it) becomes <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>,
  * as shown below:
  * {@snippet lang = java:
  * MemorySegment segment = Arena.ofAuto().allocate(100, 1); // @highlight regex='ofAuto()'

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -2662,7 +2662,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * invalidated, either {@link Arena#close() explicitly}, or automatically, by the
      * garbage collector. A segment scope that is invalidated automatically is an
      * <em>automatic scope</em>. An automatic scope is always {@link #isAlive() alive}
-     * as long as it is <a href="../../../java/lang/ref/package-summary.html#reachability">reachable</a>.
+     * as long as it is {@linkplain java.lang.ref##reachability reachable}.
      * Segments associated with an automatic scope are:
      * <ul>
      *     <li>Segments obtained from an {@linkplain Arena#ofAuto() automatic arena};</li>

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -517,7 +517,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *
      * @apiNote When using this method to pass a segment address to some external
      *          operation (e.g. a JNI function), clients must ensure that the segment is
-     *          kept <a href="../../../java/lang/ref/package.html#reachability">reachable</a>
+     *          kept <a href="../../../java/lang/ref/package-summary.html#reachability">reachable</a>
      *          for the entire duration of the operation. A failure to do so might result
      *          in the premature deallocation of the region of memory backing the memory
      *          segment, in case the segment has been allocated with an
@@ -785,7 +785,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *          backing region of memory is no longer available. Furthermore, if the
      *          provided scope is the scope of an {@linkplain Arena#ofAuto() automatic arena},
      *          the cleanup action must not prevent the scope from becoming
-     *          <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
+     *          <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>.
      *          A failure to do so will permanently prevent the regions of memory
      *          allocated by the automatic arena from being deallocated.
      *
@@ -836,7 +836,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *          backing region of memory is no longer available. Furthermore, if the
      *          provided scope is the scope of an {@linkplain Arena#ofAuto() automatic arena},
      *          the cleanup action must not prevent the scope from becoming
-     *          <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
+     *          <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>.
      *          A failure to do so will permanently prevent the regions of memory
      *          allocated by the automatic arena from being deallocated.
      *
@@ -2662,7 +2662,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * invalidated, either {@link Arena#close() explicitly}, or automatically, by the
      * garbage collector. A segment scope that is invalidated automatically is an
      * <em>automatic scope</em>. An automatic scope is always {@link #isAlive() alive}
-     * as long as it is <a href="../../../java/lang/ref/package.html#reachability">reachable</a>.
+     * as long as it is <a href="../../../java/lang/ref/package-summary.html#reachability">reachable</a>.
      * Segments associated with an automatic scope are:
      * <ul>
      *     <li>Segments obtained from an {@linkplain Arena#ofAuto() automatic arena};</li>

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -517,7 +517,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *
      * @apiNote When using this method to pass a segment address to some external
      *          operation (e.g. a JNI function), clients must ensure that the segment is
-     *          kept <a href="../../../java/lang/ref/package-summary.html#reachability">reachable</a>
+     *          kept {@linkplain java.lang.ref##reachability reachable}
      *          for the entire duration of the operation. A failure to do so might result
      *          in the premature deallocation of the region of memory backing the memory
      *          segment, in case the segment has been allocated with an
@@ -785,7 +785,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *          backing region of memory is no longer available. Furthermore, if the
      *          provided scope is the scope of an {@linkplain Arena#ofAuto() automatic arena},
      *          the cleanup action must not prevent the scope from becoming
-     *          <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>.
+     *          {@linkplain java.lang.ref##reachability unreachable}.
      *          A failure to do so will permanently prevent the regions of memory
      *          allocated by the automatic arena from being deallocated.
      *
@@ -836,7 +836,7 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *          backing region of memory is no longer available. Furthermore, if the
      *          provided scope is the scope of an {@linkplain Arena#ofAuto() automatic arena},
      *          the cleanup action must not prevent the scope from becoming
-     *          <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>.
+     *          {@linkplain java.lang.ref##reachability unreachable}.
      *          A failure to do so will permanently prevent the regions of memory
      *          allocated by the automatic arena from being deallocated.
      *

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -219,7 +219,7 @@ public interface SymbolLookup {
      * were loaded after this method returned.
      * <p>
      * Libraries associated with a class loader are unloaded when the class loader becomes
-     * <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>. The
+     * <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>. The
      * symbol lookup returned by this method is associated with an automatic
      * {@linkplain MemorySegment.Scope scope} which keeps the caller's class loader
      * reachable. Therefore, libraries associated with the caller's class loader are

--- a/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
+++ b/src/java.base/share/classes/java/lang/foreign/SymbolLookup.java
@@ -219,7 +219,7 @@ public interface SymbolLookup {
      * were loaded after this method returned.
      * <p>
      * Libraries associated with a class loader are unloaded when the class loader becomes
-     * <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>. The
+     * {@linkplain java.lang.ref##reachability unreachable}. The
      * symbol lookup returned by this method is associated with an automatic
      * {@linkplain MemorySegment.Scope scope} which keeps the caller's class loader
      * reachable. Therefore, libraries associated with the caller's class loader are

--- a/src/java.base/share/classes/java/net/spi/InetAddressResolver.java
+++ b/src/java.base/share/classes/java/net/spi/InetAddressResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/net/spi/InetAddressResolver.java
+++ b/src/java.base/share/classes/java/net/spi/InetAddressResolver.java
@@ -92,7 +92,7 @@ public interface InetAddressResolver {
      * {@linkplain InetAddressResolver#lookupByName(String, LookupPolicy) looking up host addresses}.
      *
      * <p> The default platform-wide lookup policy is constructed by consulting
-     * <a href="doc-files/net-properties.html#Ipv4IPv6">System Properties</a> which affect
+     * <a href="../doc-files/net-properties.html#Ipv4IPv6">System Properties</a> which affect
      * how IPv4 and IPv6 addresses are returned.
      *
      * @since 18

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -371,8 +371,7 @@ import java.util.Objects;
  * The following example demonstrates a general usage of {@code MessageFormat}.
  * In internationalized programs, the message format pattern and other
  * static strings will likely be obtained from resource bundles.
- *
- * <p>
+ * </p>
  * {@snippet lang=java :
  * int planet = 7;
  * String event = "a disturbance in the Force";

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -367,11 +367,11 @@ import java.util.Objects;
  *
  * <h2>Usage Information</h2>
  *
- * <p>
+ *
  * The following example demonstrates a general usage of {@code MessageFormat}.
  * In internationalized programs, the message format pattern and other
  * static strings will likely be obtained from resource bundles.
- * </p>
+ *
  * {@snippet lang=java :
  * int planet = 7;
  * String event = "a disturbance in the Force";

--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -1010,7 +1010,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
          *
          * <p> Construction captures the current thread's {@linkplain ScopedValue scoped
          * value} bindings for inheritance by threads started in the task scope. The
-         * <a href="#TreeStructure">Tree Structure</a> section in the class description
+         * <a href="{@docRoot}/java.base/java/util/concurrent/StructuredTaskScope.html#TreeStructure">Tree Structure</a> section in the class description
          * details how parent-child relations are established implicitly for the purpose
          * of inheritance of scoped value bindings.
          *
@@ -1197,7 +1197,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
          *
          * <p> Construction captures the current thread's {@linkplain ScopedValue scoped
          * value} bindings for inheritance by threads started in the task scope. The
-         * <a href="#TreeStructure">Tree Structure</a> section in the class description
+         * <a href="{@docRoot}/java.base/java/util/concurrent/StructuredTaskScope.html#TreeStructure">Tree Structure</a> section in the class description
          * details how parent-child relations are established implicitly for the purpose
          * of inheritance of scoped value bindings.
          *

--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -1010,7 +1010,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
          *
          * <p> Construction captures the current thread's {@linkplain ScopedValue scoped
          * value} bindings for inheritance by threads started in the task scope. The
-         * <a href="{@docRoot}/java.base/java/util/concurrent/StructuredTaskScope.html#TreeStructure">Tree Structure</a> section in the class description
+         * {@linkplain StructuredTaskScope##TreeStructure Tree Structure} section in the class description
          * details how parent-child relations are established implicitly for the purpose
          * of inheritance of scoped value bindings.
          *
@@ -1197,7 +1197,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
          *
          * <p> Construction captures the current thread's {@linkplain ScopedValue scoped
          * value} bindings for inheritance by threads started in the task scope. The
-         * <a href="{@docRoot}/java.base/java/util/concurrent/StructuredTaskScope.html#TreeStructure">Tree Structure</a> section in the class description
+         * {@linkplain StructuredTaskScope##TreeStructure Tree Structure} section in the class description
          * details how parent-child relations are established implicitly for the purpose
          * of inheritance of scoped value bindings.
          *

--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1010,7 +1010,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
          *
          * <p> Construction captures the current thread's {@linkplain ScopedValue scoped
          * value} bindings for inheritance by threads started in the task scope. The
-         * {@linkplain StructuredTaskScope##TreeStructure Tree Structure} section in the class description
+         * <a href="#TreeStructure">Tree Structure</a> section in the class description
          * details how parent-child relations are established implicitly for the purpose
          * of inheritance of scoped value bindings.
          *
@@ -1197,7 +1197,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
          *
          * <p> Construction captures the current thread's {@linkplain ScopedValue scoped
          * value} bindings for inheritance by threads started in the task scope. The
-         * {@linkplain StructuredTaskScope##TreeStructure Tree Structure} section in the class description
+         * <a href="#TreeStructure">Tree Structure</a> section in the class description
          * details how parent-child relations are established implicitly for the purpose
          * of inheritance of scoped value bindings.
          *

--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -108,8 +108,8 @@ import sun.security.util.ResourcesMgr;
  * and {@code callAs} is similar to {@code doAs} except that the
  * input type and exceptions thrown are slightly different.
  *
- * <p><b><a id="sm-allowed">These methods behave differently depending on
- * whether a security manager is</a>
+ * <p id="sm-allowed"><b>These methods behave differently depending on
+ * whether a security manager is
  * <a href="../../../java/lang/SecurityManager.html#set-security-manager">allowed or disallowed</a></b>:
  * <ul>
  * <li>If a security manager is allowed, which means it is either already set

--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -110,7 +110,7 @@ import sun.security.util.ResourcesMgr;
  *
  * <p id="sm-allowed"><b>These methods behave differently depending on
  * whether a security manager is
- * <a href="../../../java/lang/SecurityManager.html#set-security-manager">allowed or disallowed</a></b>:
+ * {@linkplain SecurityManager##set-security-manager allowed or disallowed}</b>:
  * <ul>
  * <li>If a security manager is allowed, which means it is either already set
  * or allowed to be set dynamically, a {@code Subject} object is associated

--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -109,8 +109,8 @@ import sun.security.util.ResourcesMgr;
  * input type and exceptions thrown are slightly different.
  *
  * <p><b><a id="sm-allowed">These methods behave differently depending on
- * whether a security manager is
- * <a href="../../../java/lang/SecurityManager.html#set-security-manager">allowed or disallowed</a></a></b>:
+ * whether a security manager is</a>
+ * <a href="../../../java/lang/SecurityManager.html#set-security-manager">allowed or disallowed</a></b>:
  * <ul>
  * <li>If a security manager is allowed, which means it is either already set
  * or allowed to be set dynamically, a {@code Subject} object is associated


### PR DESCRIPTION
Can I get a review for this change that fixes some broken links in javadoc comments? The new docs are hosted [here](https://cr.openjdk.org/~nbenalla/GeneratedDocs/8336039-warnings-links/).

It's mostly fixing some relative links.
If using `{@docroot}` isn't ideal I can change it.

Here is the result of running `diff -r docs-master docs` on the docs from master vs and after these changes 

```
diff -r docs-master/api/java.base/java/lang/classfile/components/CodeStackTracker.html docs/api/java.base/java/lang/classfile/components/CodeStackTracker.html
106c106
<  <p>
---
>  </p>
diff -r docs-master/api/java.base/java/lang/classfile/package-summary.html docs/api/java.base/java/lang/classfile/package-summary.html
99c99
<  <p>
---
> 
106c106
<  <p>
---
> 
618c618
<  <p>
---
> 
755c755
<  <p>
---
> 
783c783
< <p>
---
> 
diff -r docs-master/api/java.base/java/lang/foreign/Arena.html docs/api/java.base/java/lang/foreign/Arena.html
142c142
<  the segments allocated by it) becomes <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>,
---
>  the segments allocated by it) becomes <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>,
diff -r docs-master/api/java.base/java/lang/foreign/MemorySegment.Scope.html docs/api/java.base/java/lang/foreign/MemorySegment.Scope.html
120c120
<  as long as it is <a href="../../../java/lang/ref/package.html#reachability">reachable</a>.
---
>  as long as it is <a href="../../../java/lang/ref/package-summary.html#reachability">reachable</a>.
diff -r docs-master/api/java.base/java/lang/foreign/MemorySegment.html docs/api/java.base/java/lang/foreign/MemorySegment.html
1420c1420
<           kept <a href="../../../java/lang/ref/package.html#reachability">reachable</a>
---
>           kept <a href="../../../java/lang/ref/package-summary.html#reachability">reachable</a>
1833c1833
<           <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
---
>           <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>.
1899c1899
<           <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>.
---
>           <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>.
diff -r docs-master/api/java.base/java/lang/foreign/SymbolLookup.html docs/api/java.base/java/lang/foreign/SymbolLookup.html
395c395
<  <a href="../../../java/lang/ref/package.html#reachability">unreachable</a>. The
---
>  <a href="../../../java/lang/ref/package-summary.html#reachability">unreachable</a>. The
diff -r docs-master/api/java.base/java/net/spi/InetAddressResolver.LookupPolicy.html docs/api/java.base/java/net/spi/InetAddressResolver.LookupPolicy.html
117c117
<  <a href="doc-files/net-properties.html#Ipv4IPv6">System Properties</a> which affect
---
>  <a href="../doc-files/net-properties.html#Ipv4IPv6">System Properties</a> which affect
diff -r docs-master/api/java.base/java/text/MessageFormat.html docs/api/java.base/java/text/MessageFormat.html
433,434c433
< 
<  <p>
---
>  </p>
diff -r docs-master/api/java.base/java/util/concurrent/StructuredTaskScope.ShutdownOnFailure.html docs/api/java.base/java/util/concurrent/StructuredTaskScope.ShutdownOnFailure.html
245c245
<  <a href="#TreeStructure">Tree Structure</a> section in the class description
---
>  <a href="../../../../java.base/java/util/concurrent/StructuredTaskScope.html#TreeStructure">Tree Structure</a> section in the class description
diff -r docs-master/api/java.base/java/util/concurrent/StructuredTaskScope.ShutdownOnSuccess.html docs/api/java.base/java/util/concurrent/StructuredTaskScope.ShutdownOnSuccess.html
242c242
<  <a href="#TreeStructure">Tree Structure</a> section in the class description
---
>  <a href="../../../../java.base/java/util/concurrent/StructuredTaskScope.html#TreeStructure">Tree Structure</a> section in the class description
diff -r docs-master/api/java.base/javax/security/auth/Subject.html docs/api/java.base/javax/security/auth/Subject.html
207,208c207,208
<  whether a security manager is
<  <a href="../../../java/lang/SecurityManager.html#set-security-manager">allowed or disallowed</a></a></b>:
---
>  whether a security manager is</a>
>  <a href="../../../java/lang/SecurityManager.html#set-security-manager">allowed or disallowed</a></b>:
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8336039](https://bugs.openjdk.org/browse/JDK-8336039): Doccheck: HTML warnings, broken links and missing files in java.base documentation (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20251/head:pull/20251` \
`$ git checkout pull/20251`

Update a local copy of the PR: \
`$ git checkout pull/20251` \
`$ git pull https://git.openjdk.org/jdk.git pull/20251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20251`

View PR using the GUI difftool: \
`$ git pr show -t 20251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20251.diff">https://git.openjdk.org/jdk/pull/20251.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20251#issuecomment-2238971913)