### PR TITLE
8329398: Links in InetAddress class description show "#format"

### DIFF
--- a/src/java.base/share/classes/java/net/InetAddress.java
+++ b/src/java.base/share/classes/java/net/InetAddress.java
@@ -142,12 +142,12 @@ import static java.net.spi.InetAddressResolver.LookupPolicy.IPV6_FIRST;
  *
  * <p>
  *
- * For IPv4 address format, please refer to <A
- * HREF="Inet4Address.html#format">Inet4Address#format</A>; For IPv6
- * address format, please refer to <A
- * HREF="Inet6Address.html#format">Inet6Address#format</A>.
+ * For IPv4 address format, please refer to the supported
+ * {@linkplain Inet4Address##format IPv4 address textual representations};
+ * For IPv6 address format, please refer to the supported
+ * {@linkplain Inet6Address##format IPv6 address textual representations}.
  *
- * <p> There is a <a href="doc-files/net-properties.html#Ipv4IPv6">couple of
+ * <p> There are a <a href="doc-files/net-properties.html#Ipv4IPv6">couple of
  * System Properties</a> affecting how IPv4 and IPv6 addresses are used.
  *
  * <h2 id="host-name-resolution"> Host Name Resolution </h2>


### PR DESCRIPTION
This PR modifies links in the `InetAddress` class-level javadoc showed as `"#format"`.
In addition, it changes one grammatical error in the adjacent paragraph.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329398](https://bugs.openjdk.org/browse/JDK-8329398): Links in InetAddress class description show "#format" (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20252/head:pull/20252` \
`$ git checkout pull/20252`

Update a local copy of the PR: \
`$ git checkout pull/20252` \
`$ git pull https://git.openjdk.org/jdk.git pull/20252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20252`

View PR using the GUI difftool: \
`$ git pr show -t 20252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20252.diff">https://git.openjdk.org/jdk/pull/20252.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20252#issuecomment-2238981819)