### PR TITLE
8336489: Track scoped accesses in JVMCI compiled code

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
+++ b/src/hotspot/share/jvmci/jvmciCodeInstaller.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -722,6 +722,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
   jint entry_bci = -1;
   JVMCICompileState* compile_state = nullptr;
   bool has_unsafe_access = false;
+  bool has_scoped_access = false;
   jint id = -1;
 
   if (is_nmethod) {
@@ -729,6 +730,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
     entry_bci = is_nmethod ? stream->read_s4("entryBCI") : -1;
     compile_state = (JVMCICompileState*) stream->read_u8("compileState");
     has_unsafe_access = stream->read_bool("hasUnsafeAccess");
+    has_scoped_access = stream->read_bool("hasScopedAccess");
     id = stream->read_s4("id");
   }
   stream->set_code_desc(name, method);
@@ -795,6 +797,7 @@ JVMCI::CodeInstallResult CodeInstaller::install(JVMCICompiler* compiler,
                                         id,
                                         _has_monitors,
                                         has_unsafe_access,
+                                        has_scoped_access,
                                         _has_wide_vector,
                                         compiled_code,
                                         mirror,

--- a/src/hotspot/share/jvmci/jvmciRuntime.cpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.cpp
@@ -2078,6 +2078,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
                                                        int compile_id,
                                                        bool has_monitors,
                                                        bool has_unsafe_access,
+                                                       bool has_scoped_access,
                                                        bool has_wide_vector,
                                                        JVMCIObject compiled_code,
                                                        JVMCIObject nmethod_mirror,
@@ -2183,7 +2184,7 @@ JVMCI::CodeInstallResult JVMCIRuntime::register_method(JVMCIEnv* JVMCIENV,
         nm->set_has_unsafe_access(has_unsafe_access);
         nm->set_has_wide_vectors(has_wide_vector);
         nm->set_has_monitors(has_monitors);
-        nm->set_has_scoped_access(true); // conservative
+        nm->set_has_scoped_access(has_scoped_access);
 
         JVMCINMethodData* data = nm->jvmci_nmethod_data();
         assert(data != nullptr, "must be");

--- a/src/hotspot/share/jvmci/jvmciRuntime.hpp
+++ b/src/hotspot/share/jvmci/jvmciRuntime.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -452,6 +452,7 @@ class JVMCIRuntime: public CHeapObj<mtJVMCI> {
                                            int                       compile_id,
                                            bool                      has_monitors,
                                            bool                      has_unsafe_access,
+                                           bool                      has_scoped_access,
                                            bool                      has_wide_vector,
                                            JVMCIObject               compiled_code,
                                            JVMCIObject               nmethod_mirror,

--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -655,6 +655,7 @@
   declare_constant(ConstMethodFlags::_misc_intrinsic_candidate)           \
   declare_constant(ConstMethodFlags::_misc_reserved_stack_access)         \
   declare_constant(ConstMethodFlags::_misc_changes_current_thread)        \
+  declare_constant(ConstMethodFlags::_misc_is_scoped)                     \
                                                                           \
   declare_constant(CounterData::count_off)                                \
                                                                           \

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotCompiledCodeStream.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotCompiledCodeStream.java
@@ -563,6 +563,7 @@ final class HotSpotCompiledCodeStream implements AutoCloseable {
             writeInt("entryBCI", nmethod.entryBCI);
             writeLong("compileState", nmethod.compileState);
             writeBoolean("hasUnsafeAccess", nmethod.hasUnsafeAccess);
+            writeBoolean("hasScopedAccess", nmethod.hasScopedAccess());
             writeInt("id", nmethod.id);
         }
 

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotCompiledNmethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotCompiledNmethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,4 +100,22 @@ public final class HotSpotCompiledNmethod extends HotSpotCompiledCode {
     public String getInstallationFailureMessage() {
         return installationFailureMessage;
     }
+
+    /**
+     * Determines if {@code methods} contains at least one entry for which {@code HotSpotResolvedJavaMethod.isScoped()} returns true.
+     */
+    public boolean hasScopedAccess() {
+        if (methods == null) {
+            return false;
+        }
+        for (ResolvedJavaMethod method : methods) {
+            if (method instanceof HotSpotResolvedJavaMethod hotSpotMethod) {
+                if (hotSpotMethod.isScoped()) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethod.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,6 +57,13 @@ public interface HotSpotResolvedJavaMethod extends ResolvedJavaMethod {
      * @return true if ReservedStackAccess annotation present, false otherwise
      */
     boolean hasReservedStackAccess();
+
+    /**
+     * Returns true if this method has a {@code Scoped} annotation.
+     *
+     * @return true if Scoped annotation present, false otherwise
+     */
+    boolean isScoped();
 
     /**
      * Sets flags on {@code method} indicating that it should never be inlined or compiled by the

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotResolvedJavaMethodImpl.java
@@ -325,6 +325,16 @@ final class HotSpotResolvedJavaMethodImpl extends HotSpotMethod implements HotSp
     }
 
     /**
+     * Returns true if this method has a {@code Scoped} annotation.
+     *
+     * @return true if Scoped annotation present, false otherwise
+     */
+    @Override
+    public boolean isScoped() {
+        return (getConstMethodFlags() & config().constMethodFlagsIsScoped) != 0;
+    }
+
+    /**
      * Sets flags on {@code method} indicating that it should never be inlined or compiled by the
      * VM.
      */

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotVMConfig.java
@@ -194,6 +194,7 @@ class HotSpotVMConfig extends HotSpotVMConfigAccess {
     final int constMethodFlagsReservedStackAccess = getConstant("ConstMethodFlags::_misc_reserved_stack_access", Integer.class);
     final int constMethodFlagsCallerSensitive = getConstant("ConstMethodFlags::_misc_caller_sensitive", Integer.class);
     final int constMethodFlagsIntrinsicCandidate = getConstant("ConstMethodFlags::_misc_intrinsic_candidate", Integer.class);
+    final int constMethodFlagsIsScoped = getConstant("ConstMethodFlags::_misc_is_scoped", Integer.class);
     final int constMethodHasLineNumberTable = getConstant("ConstMethodFlags::_misc_has_linenumber_table", Integer.class);
     final int constMethodHasLocalVariableTable = getConstant("ConstMethodFlags::_misc_has_localvariable_table", Integer.class);
     final int constMethodHasMethodAnnotations = getConstant("ConstMethodFlags::_misc_has_method_annotations", Integer.class);


### PR DESCRIPTION
This PR adds JVMCI support to scoped access tracking introduced in #20158.

In this PR:
* The `Method::is_scoped` flag is now exposed in JVMCI as `HotSpotResolvedJavaMethod.isScoped()`, and serialized to / deserialized from the JVMCI compiled code stream as a boolean flag.
* To determine whether a compiled method has a scoped access, we simply check `HotSpotResolvedJavaMethod.isScoped()` returns `true` for the root method or any of the methods that were inlined in the compilation.
* The above check is implemented as the method `HotSpotCompiledNMethod.hasScopedAccess()`, instead of as an explicit flag set in a the constructor of `HotSpotCompiledNMethod`. This keeps the change isolated to JVMCI, without requiring coordinated changes to the Graal compiler. No other changes in the compiler are necessary to benefit from the optimization.