### PR TITLE
8327054: DiagnosticCommand Compiler.perfmap does not log on output()

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1801,7 +1801,7 @@ void CodeCache::write_perf_map(const char* filename, outputStream* st) {
 
   fileStream fs(filename, "w");
   if (!fs.is_open()) {
-    st->print_cr("Failed to create %s for perf map", filename);
+    st->print_cr("Warning: Failed to create %s for perf map", filename);
     return;
   }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1788,7 +1788,7 @@ void CodeCache::log_state(outputStream* st) {
 }
 
 #ifdef LINUX
-void CodeCache::write_perf_map(const char* filename) {
+void CodeCache::write_perf_map(const char* filename, outputStream* st) {
   MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
 
   // Perf expects to find the map file at /tmp/perf-<pid>.map
@@ -1801,7 +1801,7 @@ void CodeCache::write_perf_map(const char* filename) {
 
   fileStream fs(filename, "w");
   if (!fs.is_open()) {
-    log_warning(codecache)("Failed to create %s for perf map", filename);
+    st->print_cr("Failed to create %s for perf map", filename);
     return;
   }
 

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -223,7 +223,7 @@ class CodeCache : AllStatic {
   static void print_trace(const char* event, CodeBlob* cb, uint size = 0) PRODUCT_RETURN;
   static void print_summary(outputStream* st, bool detailed = true); // Prints a summary of the code cache usage
   static void log_state(outputStream* st);
-  LINUX_ONLY(static void write_perf_map(const char* filename = nullptr);)
+  LINUX_ONLY(static void write_perf_map(const char* filename, outputStream* st);)
   static const char* get_code_heap_name(CodeBlobType code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
   static void report_codemem_full(CodeBlobType code_blob_type, bool print);
 

--- a/src/hotspot/share/code/codeCache.hpp
+++ b/src/hotspot/share/code/codeCache.hpp
@@ -223,7 +223,7 @@ class CodeCache : AllStatic {
   static void print_trace(const char* event, CodeBlob* cb, uint size = 0) PRODUCT_RETURN;
   static void print_summary(outputStream* st, bool detailed = true); // Prints a summary of the code cache usage
   static void log_state(outputStream* st);
-  LINUX_ONLY(static void write_perf_map(const char* filename, outputStream* st);)
+  LINUX_ONLY(static void write_perf_map(const char* filename, outputStream* st);) // Prints warnings and error messages to outputStream
   static const char* get_code_heap_name(CodeBlobType code_blob_type)  { return (heap_available(code_blob_type) ? get_code_heap(code_blob_type)->name() : "Unused"); }
   static void report_codemem_full(CodeBlobType code_blob_type, bool print);
 

--- a/src/hotspot/share/runtime/java.cpp
+++ b/src/hotspot/share/runtime/java.cpp
@@ -484,7 +484,7 @@ void before_exit(JavaThread* thread, bool halt) {
 
 #ifdef LINUX
   if (DumpPerfMapAtExit) {
-    CodeCache::write_perf_map();
+    CodeCache::write_perf_map(nullptr, tty);
   }
   if (PrintMemoryMapAtExit) {
     MemMapPrinter::print_all_mappings(tty);

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -865,7 +865,7 @@ void PerfMapDCmd::execute(DCmdSource source, TRAPS) {
   // The check for _filename.is_set() is because we don't want to use
   // DEFAULT_PERFMAP_FILENAME, since it is meant as a description
   // of the default, not the actual default.
-  CodeCache::write_perf_map(_filename.is_set() ? _filename.value() : nullptr);
+  CodeCache::write_perf_map(_filename.is_set() ? _filename.value() : nullptr, output());
 }
 #endif // LINUX
 

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2023, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -111,6 +111,16 @@ public class PerfMapTest {
         String test_dir = System.getProperty("test.dir", ".");
         Path path = Paths.get("/tmp/perf-<pid>.map");
         run(new JMXExecutor(), "Compiler.perfmap " + path.toString(), path);
+        Files.deleteIfExists(path);
+    }
+
+    @Test
+    public void logErrorsDcmdOutputStream() throws IOException {
+        String test_dir = System.getProperty("test.dir", ".");
+        Path path = Paths.get("nonexistent", test_dir);
+        OutputAnalyzer output = new JMXExecutor().execute("Compiler.perfmap %s".formatted(path));
+        output.shouldContain("Failed to create nonexistent/%s for perf map".formatted(test_dir));
+        output.shouldNotHaveExitValue(0);
         Files.deleteIfExists(path);
     }
 }

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
@@ -120,8 +120,7 @@ public class PerfMapTest {
         Path path = Paths.get("nonexistent", test_dir);
         try {
             OutputAnalyzer output = new JMXExecutor().execute("Compiler.perfmap %s".formatted(path));
-            output.shouldContain("Failed to create nonexistent/%s for perf map".formatted(test_dir));
-            output.shouldNotHaveExitValue(0);
+            output.shouldContain("Warning: Failed to create nonexistent/%s for perf map".formatted(test_dir));
         } finally {
             Files.deleteIfExists(path);
         }

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java
@@ -118,9 +118,12 @@ public class PerfMapTest {
     public void logErrorsDcmdOutputStream() throws IOException {
         String test_dir = System.getProperty("test.dir", ".");
         Path path = Paths.get("nonexistent", test_dir);
-        OutputAnalyzer output = new JMXExecutor().execute("Compiler.perfmap %s".formatted(path));
-        output.shouldContain("Failed to create nonexistent/%s for perf map".formatted(test_dir));
-        output.shouldNotHaveExitValue(0);
-        Files.deleteIfExists(path);
+        try {
+            OutputAnalyzer output = new JMXExecutor().execute("Compiler.perfmap %s".formatted(path));
+            output.shouldContain("Failed to create nonexistent/%s for perf map".formatted(test_dir));
+            output.shouldNotHaveExitValue(0);
+        } finally {
+            Files.deleteIfExists(path);
+        }
     }
 }


### PR DESCRIPTION
Hi all, 

This is a small patch to address [8327054](https://bugs.openjdk.org/browse/JDK-8327054) making `CodeCache::write_perf_map` aware of which output stream errors and warning message should be going to.

Testing: 
- [x] Added test case passes. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327054](https://bugs.openjdk.org/browse/JDK-8327054): DiagnosticCommand Compiler.perfmap does not log on output() (**Bug** - P5)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) 🔄 Re-review required (review applies to [6129d87c](https://git.openjdk.org/jdk/pull/20257/files/6129d87c4bec1e1d7af3edf559f0974b2042e961))
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20257/head:pull/20257` \
`$ git checkout pull/20257`

Update a local copy of the PR: \
`$ git checkout pull/20257` \
`$ git pull https://git.openjdk.org/jdk.git pull/20257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20257`

View PR using the GUI difftool: \
`$ git pr show -t 20257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20257.diff">https://git.openjdk.org/jdk/pull/20257.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20257#issuecomment-2239925075)