### PR TITLE
8336833: Endless loop in Javap ClassWriter

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractInstruction.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractInstruction.java
@@ -317,7 +317,7 @@ public abstract sealed class AbstractInstruction
             int pad = ap - (pos + 1);
             int low = code.classReader.readInt(ap + 4);
             int high = code.classReader.readInt(ap + 8);
-            if (high < low || high - low > code.codeLength >> 2) {
+            if (high < low || (long)high - low > code.codeLength >> 2) {
                 throw new IllegalArgumentException("Invalid tableswitch values low: " + low + " high: " + high);
             }
             int cnt = high - low + 1;

--- a/test/jdk/jdk/classfile/LimitsTest.java
+++ b/test/jdk/jdk/classfile/LimitsTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8320360 8330684 8331320 8331655 8331940 8332486 8335820
+ * @bug 8320360 8330684 8331320 8331655 8331940 8332486 8335820 8336833
  * @summary Testing ClassFile limits.
  * @run junit LimitsTest
  */
@@ -165,6 +165,28 @@ class LimitsTest {
                                     b.writeInt(0); //default
                                     b.writeInt(0); //low
                                     b.writeInt(-5); //high to jump back and cause OOME if not checked
+                                    b.writeU2(0);//exception handlers
+                                    b.writeU2(0);//attributes
+                                }})))).methods().get(0).code().get().elementList());
+        assertThrows(IllegalArgumentException.class, () ->
+                ClassFile.of().parse(ClassFile.of().build(ClassDesc.of("TableSwitchClass"), cb -> cb.withMethod(
+                "tableSwitchMethod", MethodTypeDesc.of(ConstantDescs.CD_void), 0, mb ->
+                        ((DirectMethodBuilder)mb).writeAttribute(new UnboundAttribute.AdHocAttribute<CodeAttribute>(Attributes.code()) {
+                                @Override
+                                public void writeBody(BufWriter b) {
+                                    b.writeU2(-1);//max stack
+                                    b.writeU2(-1);//max locals
+                                    b.writeInt(20);
+                                    b.writeU1(Opcode.NOP.bytecode());
+                                    b.writeU1(Opcode.NOP.bytecode());
+                                    b.writeU1(Opcode.NOP.bytecode());
+                                    b.writeU1(Opcode.NOP.bytecode());
+                                    b.writeU1(Opcode.TABLESWITCH.bytecode());
+                                    b.writeU1(0); //padding
+                                    b.writeU2(0); //padding
+                                    b.writeInt(0); //default
+                                    b.writeInt(Integer.MIN_VALUE); //low
+                                    b.writeInt(Integer.MAX_VALUE - 4); //high to jump back and cause infinite loop
                                     b.writeU2(0);//exception handlers
                                     b.writeU2(0);//attributes
                                 }})))).methods().get(0).code().get().elementList());


### PR DESCRIPTION
Artificially corrupted class with overflowing max - min values of `tableswitch` instruction cause infinite loop in `jdk.internal.classfile.impl.CodeImpl::inflateJumpTargets`

This patch fixes the overflow and adds relevant test.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336833](https://bugs.openjdk.org/browse/JDK-8336833): Endless loop in Javap ClassWriter (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20258/head:pull/20258` \
`$ git checkout pull/20258`

Update a local copy of the PR: \
`$ git checkout pull/20258` \
`$ git pull https://git.openjdk.org/jdk.git pull/20258/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20258`

View PR using the GUI difftool: \
`$ git pr show -t 20258`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20258.diff">https://git.openjdk.org/jdk/pull/20258.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20258#issuecomment-2239476771)