### PR TITLE
8336786: VerifyError with lambda capture and enclosing instance references

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1291,6 +1291,7 @@ public class LambdaToMethod extends TreeTranslator {
          * in nested scopes (which do not need to undergo capture).
          */
         private JCTree capturedDecl(int depth, Symbol sym) {
+            Assert.check(sym.kind != TYP);
             int currentDepth = frameStack.size() - 1;
             for (Frame block : frameStack) {
                 switch (block.tree.getTag()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1297,7 +1297,7 @@ public class LambdaToMethod extends TreeTranslator {
                 switch (block.tree.getTag()) {
                     case CLASSDEF:
                         ClassSymbol clazz = ((JCClassDecl)block.tree).sym;
-                        if (sym.isMemberOf(clazz, types)) {
+                        if (clazz.isSubClass(sym.enclClass(), types)) {
                             return currentDepth > depth ? null : block.tree;
                         }
                         break;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -1297,7 +1297,7 @@ public class LambdaToMethod extends TreeTranslator {
                 switch (block.tree.getTag()) {
                     case CLASSDEF:
                         ClassSymbol clazz = ((JCClassDecl)block.tree).sym;
-                        if (clazz.isSubClass(sym, types) || sym.isMemberOf(clazz, types)) {
+                        if (sym.isMemberOf(clazz, types)) {
                             return currentDepth > depth ? null : block.tree;
                         }
                         break;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -1828,11 +1828,10 @@ public class Lower extends TreeTranslator {
      *                       due to protection?
      */
     JCExpression makeOwnerThis(DiagnosticPosition pos, Symbol sym, boolean preciseMatch) {
-        Symbol c = sym.owner;
         if (preciseMatch ? sym.isMemberOf(currentClass, types)
                          : currentClass.isSubClass(sym.owner, types)) {
             // in this case, `this' works fine
-            return make.at(pos).This(c.erasure(types));
+            return make.at(pos).This(currentClass.erasure(types));
         } else {
             // need to go via this$n
             return makeOwnerThisN(pos, sym, preciseMatch);

--- a/test/langtools/tools/javac/lambda/SuperClassThisCapture/SuperClassThisCapture.java
+++ b/test/langtools/tools/javac/lambda/SuperClassThisCapture/SuperClassThisCapture.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2024, Alphabet LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8336786
+ * @summary VerifyError with lambda capture and enclosing instance references
+ * @compile a/A.java SuperClassThisCapture.java
+ * @run main SuperClassThisCapture
+ */
+
+public class SuperClassThisCapture extends a.A {
+
+  public static void main(String[] args) {
+    new SuperClassThisCapture().f(42);
+    new SuperClassThisCapture().g();
+  }
+
+  public void f(int x) {
+    Runnable r = () -> {
+      System.err.println(x);
+      new I();
+    };
+    r.run();
+  }
+
+  public void g() {
+    Runnable r = () -> new I();
+    r.run();
+  }
+}

--- a/test/langtools/tools/javac/lambda/SuperClassThisCapture/a/A.java
+++ b/test/langtools/tools/javac/lambda/SuperClassThisCapture/a/A.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Alphabet LLC. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package a;
+
+public class A {
+  public class I {}
+}


### PR DESCRIPTION
Hi, please consider this fix for [JDK-8336786](https://bugs.openjdk.org/browse/JDK-8336786). After [JDK-8334037](https://bugs.openjdk.org/browse/JDK-8334037) the handling of capturing `this` in lambdas does not handle synthetic `this` variables declared in supertypes in different packages. This change adjusts the lowering of `this` references to be owned by the enclosing class, instead of the superclass, so they are handle correctly be the capture logic in `capturedDecl` in `LambdaToMethod`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336786](https://bugs.openjdk.org/browse/JDK-8336786): VerifyError with lambda capture and enclosing instance references (**Bug** - P2)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20259/head:pull/20259` \
`$ git checkout pull/20259`

Update a local copy of the PR: \
`$ git checkout pull/20259` \
`$ git pull https://git.openjdk.org/jdk.git pull/20259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20259`

View PR using the GUI difftool: \
`$ git pr show -t 20259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20259.diff">https://git.openjdk.org/jdk/pull/20259.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20259#issuecomment-2239540392)