### PR TITLE
8332850: javac crashes if container for repeatable annotation is not found

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Annotate.java
@@ -945,7 +945,13 @@ public class Annotate {
         boolean fatalError = false;
 
         // Validate that there is a (and only 1) value method
-        Scope scope = targetContainerType.tsym.members();
+        Scope scope = null;
+        try {
+            scope = targetContainerType.tsym.members();
+        } catch (CompletionFailure ex) {
+            chk.completionError(pos, ex);
+            return null;
+        }
         int nr_value_elems = 0;
         boolean error = false;
         for(Symbol elm : scope.getSymbolsByName(names.value)) {

--- a/test/langtools/tools/javac/annotations/repeatingAnnotations/CompletionErrorOnRepeatingAnnosTest.java
+++ b/test/langtools/tools/javac/annotations/repeatingAnnotations/CompletionErrorOnRepeatingAnnosTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8332850
+ * @summary javac crashes if container for repeatable annotation is not found
+ * @library /tools/javac/lib /tools/lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ */
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.List;
+
+import toolbox.*;
+import toolbox.Task.*;
+
+public class CompletionErrorOnRepeatingAnnosTest {
+    ToolBox tb = new ToolBox();
+
+    public static void main(String... args) throws Exception {
+        CompletionErrorOnRepeatingAnnosTest t = new CompletionErrorOnRepeatingAnnosTest();
+        t.testMissingContainerAnno();
+    }
+
+    void testMissingContainerAnno() throws Exception {
+        Path base = Paths.get(".");
+        Path src = base.resolve("src");
+        tb.createDirectories(src);
+        tb.writeJavaFiles(src,
+                """
+                import java.lang.annotation.Repeatable;
+                @Repeatable(As.class)
+                @interface A {}
+                @interface As {
+                    A[] value();
+                }
+                """);
+        Path out = base.resolve("out");
+        tb.createDirectories(out);
+        new JavacTask(tb)
+                .outdir(out)
+                .files(tb.findJavaFiles(src))
+                .run();
+        // let's now compile T.java which uses repeated annotations, we want to load the anno classes from the CP
+        tb.deleteFiles(src.resolve("A.java"));
+        tb.writeJavaFiles(src, "@A @A class T {}");
+        new JavacTask(tb)
+                .outdir(out)
+                .classpath(out)
+                .files(tb.findJavaFiles(src))
+                .run();
+        // now if we remove As.class there will be an error but javac should not crash
+        tb.deleteFiles(out.resolve("As.class"));
+        List<String> log = new JavacTask(tb)
+                .outdir(out)
+                .classpath(out)
+                .options("-XDrawDiagnostics")
+                .files(tb.findJavaFiles(src))
+                .run(Expect.FAIL)
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+        List<String> expectedOut = Arrays.asList(
+                "T.java:1:1: compiler.err.cant.access: As, (compiler.misc.class.file.not.found: As)",
+                "T.java:1:4: compiler.err.invalid.repeatable.annotation.no.value: As",
+                "2 errors"
+        );
+        if (!expectedOut.equals(log))
+            throw new Exception("expected output not found: " + log);
+    }
+}


### PR DESCRIPTION
javac is crashing if it can't find the container for repeatable annotations in the classpath, this is due to a `CompletionFailure` exception that is not being caught. The current fix is catching the exception and producing an error message which is what we do for similar cases,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8332850: javac crashes if container for repeatable annotation is not found`

### Issue
 * [JDK-8332850](https://bugs.openjdk.org/browse/JDK-8332850): javac crashes if container for repeatable annotation is not found (**Bug** - P3)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20260/head:pull/20260` \
`$ git checkout pull/20260`

Update a local copy of the PR: \
`$ git checkout pull/20260` \
`$ git pull https://git.openjdk.org/jdk.git pull/20260/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20260`

View PR using the GUI difftool: \
`$ git pr show -t 20260`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20260.diff">https://git.openjdk.org/jdk/pull/20260.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20260#issuecomment-2239697516)