### PR TITLE
8327538: The SSLExtension class specifies incorrect values for heartbeat per RFC 6520 and post_handshake_auth per RFC 8446

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLExtension.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLExtension.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,7 +181,7 @@ enum SSLExtension implements SSLStringizer {
     USE_SRTP                (0x000E, "use_srtp"),
 
     // Extensions defined in RFC 6520 (TLS and DTLS Heartbeat Extension)
-    HEARTBEAT               (0x000E, "heartbeat"),
+    HEARTBEAT               (0x000F, "heartbeat"),
 
     // Extensions defined in RFC 7301 (TLS Application-Layer Protocol Negotiation Extension)
     CH_ALPN                 (0x0010, "application_layer_protocol_negotiation",
@@ -406,7 +406,7 @@ enum SSLExtension implements SSLStringizer {
                                 CertificateAuthoritiesExtension.ssStringizer),
 
     OID_FILTERS             (0x0030, "oid_filters"),
-    POST_HANDSHAKE_AUTH     (0x0030, "post_handshake_auth"),
+    POST_HANDSHAKE_AUTH     (0x0031, "post_handshake_auth"),
 
     CH_SIGNATURE_ALGORITHMS_CERT (0x0032, "signature_algorithms_cert",
                                 SSLHandshake.CLIENT_HELLO,


### PR DESCRIPTION
8327538: The SSLExtension class specifies incorrect values for heartbeat per RFC 6520 and post_handshake_auth per RFC 8446

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8327538](https://bugs.openjdk.org/browse/JDK-8327538): The SSLExtension class specifies incorrect values for heartbeat per RFC 6520 and post_handshake_auth per RFC 8446 (**Bug** - P4)


### Reviewers
 * [Bradford Wetmore](https://openjdk.org/census#wetmore) (@bradfordwetmore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20261/head:pull/20261` \
`$ git checkout pull/20261`

Update a local copy of the PR: \
`$ git checkout pull/20261` \
`$ git pull https://git.openjdk.org/jdk.git pull/20261/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20261`

View PR using the GUI difftool: \
`$ git pr show -t 20261`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20261.diff">https://git.openjdk.org/jdk/pull/20261.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20261#issuecomment-2239727414)