### PR TITLE
8333391: Test com/sun/jdi/InterruptHangTest.java failed: Thread was never interrupted during sleep

### DIFF
--- a/test/jdk/com/sun/jdi/InterruptHangTest.java
+++ b/test/jdk/com/sun/jdi/InterruptHangTest.java
@@ -101,8 +101,10 @@ class InterruptHangTarg {
         for (int ii = 0; ii < INTERRUPTS_EXPECTED; ii++) {
             boolean wasInterrupted = false;
             try {
-                // Give other thread a chance to interrupt
-                Thread.sleep(100);
+                // Give other thread a chance to interrupt. Normally only a very short
+                // sleep is needed, but we need to account for unexpected delays in
+                // the interrupt due to machine and network hiccups.
+                Thread.sleep(10*1000);
             } catch (InterruptedException ee) {
                 answer++;
                 wasInterrupted = true;


### PR DESCRIPTION
The test sometimes fails because the InterruptException doesn't arrive during the 100ms that the thread sleeps. My suspicion is that the interrupt is being delayed for some external reason, like temporary load on the host. I'm bumping the sleep period to 10s to hopefully avoid such an issue. This won't make the test run any slower when it passes, but will make it slower (by about 10 seconds) when it fails due to waiting longer for the InterruptException to never arrive, assuming it still might fail for this reason.

I tested by running the InterruptHangTest locally. TBD I will run all of con/sun/jdi on all supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333391](https://bugs.openjdk.org/browse/JDK-8333391): Test com/sun/jdi/InterruptHangTest.java failed: Thread was never interrupted during sleep (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20263/head:pull/20263` \
`$ git checkout pull/20263`

Update a local copy of the PR: \
`$ git checkout pull/20263` \
`$ git pull https://git.openjdk.org/jdk.git pull/20263/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20263`

View PR using the GUI difftool: \
`$ git pr show -t 20263`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20263.diff">https://git.openjdk.org/jdk/pull/20263.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20263#issuecomment-2239907162)