### PR TITLE
8336844: ZipConstants64 defines duplicate constants EXTID_ZIP64 and ZIP64_EXTID

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipConstants64.java
+++ b/src/java.base/share/classes/java/util/zip/ZipConstants64.java
@@ -40,7 +40,6 @@ class ZipConstants64 {
     static final int  ZIP64_ENDHDR = 56;           // ZIP64 end header size
     static final int  ZIP64_LOCHDR = 20;           // ZIP64 end loc header size
     static final int  ZIP64_EXTHDR = 24;           // EXT header size
-    static final int  ZIP64_EXTID  = 0x0001;       // Extra field Zip64 header ID
 
     static final int  ZIP64_MAGICCOUNT = 0xFFFF;
     static final long ZIP64_MAGICVAL = 0xFFFFFFFFL;

--- a/src/java.base/share/classes/java/util/zip/ZipConstants64.java
+++ b/src/java.base/share/classes/java/util/zip/ZipConstants64.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1324,7 +1324,7 @@ public class ZipFile implements ZipConstants, Closeable {
                             tag, cenPos));
                 }
 
-                if (tag == ZIP64_EXTID) {
+                if (tag == EXTID_ZIP64) {
                     // Get the compressed size;
                     long csize = CENSIZ(cen, cenPos);
                     // Get the uncompressed size;
@@ -1360,7 +1360,7 @@ public class ZipFile implements ZipConstants, Closeable {
                                                 long size, long locoff, int diskNo)
                 throws ZipException {
             byte[] cen = this.cen;
-            // if ZIP64_EXTID blocksize == 0, which may occur with some older
+            // if EXTID_ZIP64 blocksize == 0, which may occur with some older
             // versions of Apache Ant and Commons Compress, validate csize and size
             // to make sure neither field == ZIP64_MAGICVAL
             if (blockSize == 0) {
@@ -1368,7 +1368,7 @@ public class ZipFile implements ZipConstants, Closeable {
                         locoff == ZIP64_MAGICVAL || diskNo == ZIP64_MAGICCOUNT) {
                     zerror("Invalid CEN header (invalid zip64 extra data field size)");
                 }
-                // Only validate the ZIP64_EXTID data if the block size > 0
+                // Only validate the EXTID_ZIP64 data if the block size > 0
                 return;
             }
             // Validate the Zip64 Extended Information Extra Field (0x0001)

--- a/src/java.base/share/classes/java/util/zip/ZipInputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipInputStream.java
@@ -679,7 +679,7 @@ public class ZipInputStream extends InflaterInputStream implements ZipConstants 
                 if (i + headerSize + dsize > extra.length) {
                     return false; // Invalid size
                 }
-                if (id == ZIP64_EXTID) {
+                if (id == EXTID_ZIP64) {
                     return true;
                 }
                 i += headerSize + dsize;

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -485,7 +485,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
         writeShort(elen);
         writeBytes(nameBytes, 0, nameBytes.length);
         if (hasZip64) {
-            writeShort(ZIP64_EXTID);
+            writeShort(EXTID_ZIP64);
             writeShort(16);
             writeLong(e.size);
             writeLong(e.csize);
@@ -643,7 +643,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
 
         // take care of EXTID_ZIP64 and EXTID_EXTT
         if (hasZip64) {
-            writeShort(ZIP64_EXTID);// Zip64 extra
+            writeShort(EXTID_ZIP64);// Zip64 extra
             writeShort(elenZIP64);
             if (size == ZIP64_MAGICVAL)
                 writeLong(e.size);

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipConstants.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipConstants.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipConstants.java
@@ -130,7 +130,6 @@ class ZipConstants {
     static final int  ZIP64_ENDHDR = 56;           // ZIP64 end header size
     static final int  ZIP64_LOCHDR = 20;           // ZIP64 end loc header size
     static final int  ZIP64_EXTHDR = 24;           // EXT header size
-    static final int  ZIP64_EXTID  = 0x0001;       // Extra field Zip64 header ID
 
     static final int  ZIP64_MINVAL32 = 0xFFFF;
     static final long ZIP64_MINVAL = 0xFFFFFFFFL;

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -1710,7 +1710,7 @@ class ZipFileSystem extends FileSystem {
     private void checkZip64ExtraFieldValues(byte[] cen, int off, int blockSize, long csize,
                                             long size, long locoff, int diskNo)
             throws ZipException {
-        // if ZIP64_EXTID blocksize == 0, which may occur with some older
+        // if EXTID_ZIP64 blocksize == 0, which may occur with some older
         // versions of Apache Ant and Commons Compress, validate csize and size
         // to make sure neither field == ZIP64_MAGICVAL
         if (blockSize == 0) {
@@ -1718,7 +1718,7 @@ class ZipFileSystem extends FileSystem {
                     locoff == ZIP64_MINVAL || diskNo == ZIP64_MINVAL32) {
                 zerror("Invalid CEN header (invalid zip64 extra data field size)");
             }
-            // Only validate the ZIP64_EXTID data if the block size > 0
+            // Only validate the EXTID_ZIP64 data if the block size > 0
             return;
         }
         // Validate the Zip64 Extended Information Extra Field (0x0001)


### PR DESCRIPTION
This change deduplicates constants in ZipConstants64 for the Zip64 Extended Information Extra Field Header ID (see APPNOTE.TXT 4.5.3).

I think there are arguments for consolidating on either `EXTID_ZIP64` or `ZIP64_EXTID`. The PR currently consolidates on `EXTID_ZIP64`, `ZIP64_EXTID` is also an option if there's a preference for that.

I noticed this while working on a zip64 bug in [JDK-8328995](https://bugs.openjdk.org/browse/JDK-8328995), I was reviewing places that handled zip64 extra fields and initially missed some because I was only looking at one of the constants.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336844](https://bugs.openjdk.org/browse/JDK-8336844): ZipConstants64 defines duplicate constants EXTID_ZIP64 and ZIP64_EXTID (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20264/head:pull/20264` \
`$ git checkout pull/20264`

Update a local copy of the PR: \
`$ git checkout pull/20264` \
`$ git pull https://git.openjdk.org/jdk.git pull/20264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20264`

View PR using the GUI difftool: \
`$ git pr show -t 20264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20264.diff">https://git.openjdk.org/jdk/pull/20264.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20264#issuecomment-2240004687)