### PR TITLE
8336849: Remove .llvm_addrsig section from JDK/VM static libraries (.a files)

### DIFF
--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -109,9 +109,9 @@ define CreateStaticLibrary
 	      $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
 	      $$($1_LD) $(LDFLAGS_CXX_PARTIAL_LINKING) $$($1_SYSROOT_LDFLAGS) \
 	          -o $$($1_TARGET_RELOCATABLE) $$($1_LD_OBJ_ARG))
-          # Linking with '-Wl,--icf=safe' using objects created by 'ld -r' may not work
-          # and could cause errors like the following:
-          #   ld: --icf=safe conservatively ignores SHT_LLVM_ADDRSIG [...] with sh_link=0 (likely created using objcopy or ld -r)
+          # 'ld -r' might invalidate the .llvm_addrsig section, and this will cause subsequent
+          # calls to lld (with '-Wl,--icf=safe') to fail when linking with this library, so
+          # remove that section.
 	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_objcopy_remove_llvm_addrsig_section, \
 	      $$($1_OBJCOPY) --remove-section=.llvm_addrsig $$($1_TARGET_RELOCATABLE))
         endif

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -109,6 +109,11 @@ define CreateStaticLibrary
 	      $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
 	      $$($1_LD) $(LDFLAGS_CXX_PARTIAL_LINKING) $$($1_SYSROOT_LDFLAGS) \
 	          -o $$($1_TARGET_RELOCATABLE) $$($1_LD_OBJ_ARG))
+          # Linking with '-Wl,--icf=safe' using objects created by 'ld -r' may not work
+          # and could cause errors like the following:
+          #   ld: --icf=safe conservatively ignores SHT_LLVM_ADDRSIG [...] with sh_link=0 (likely created using objcopy or ld -r)
+	  $$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_objcopy_remove_llvm_addrsig_section, \
+	      $$($1_OBJCOPY) --remove-section=.llvm_addrsig $$($1_TARGET_RELOCATABLE))
         endif
 	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_run_ar, \
 	    $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \


### PR DESCRIPTION
Please review this PR that strips the `.llvm_addrsig` section from JDK and hotspot `.a` static libraries when building with clang. Please see https://bugs.openjdk.org/browse/JDK-8336849 description for details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336849](https://bugs.openjdk.org/browse/JDK-8336849): Remove .llvm_addrsig section from JDK/VM static libraries (.a files) (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20265/head:pull/20265` \
`$ git checkout pull/20265`

Update a local copy of the PR: \
`$ git checkout pull/20265` \
`$ git pull https://git.openjdk.org/jdk.git pull/20265/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20265`

View PR using the GUI difftool: \
`$ git pr show -t 20265`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20265.diff">https://git.openjdk.org/jdk/pull/20265.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20265#issuecomment-2240794052)