### PR TITLE
8336854: CAInterop.java#actalisauthenticationrootca conflicted with /manual and /timeout

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -25,14 +25,16 @@
  * @test id=actalisauthenticationrootca
  * @bug 8189131
  * @summary Interoperability tests with Actalis CA
+ * Before this test set to manual, the original timeout
+ * value if 180
  * @library /test/lib
  * @build jtreg.SkippedException ValidatePathWithURL CAInterop
  * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
  *  CAInterop actalisauthenticationrootca OCSP
- * @run main/othervm/manual/timeout=180 -Djava.security.debug=certpath,ocsp
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
  *  -Dcom.sun.security.ocsp.useget=false
  *  CAInterop actalisauthenticationrootca OCSP
- * @run main/othervm/manual/timeout=180 -Djava.security.debug=certpath,ocsp
+ * @run main/othervm/manual -Djava.security.debug=certpath,ocsp
  *  CAInterop actalisauthenticationrootca CRL
  */
 


### PR DESCRIPTION
Hi all,
The testcase `test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java#actalisauthenticationrootca` run Error, because the `@run` set conflicted with `/manual` and `/timeout`. I think the `/timeout` not needed for manual test.

Only this testcase has this issue, the search shell command is:
```shell
for i in `grep "@run" test -rnl` ; do grep "/manual" $i | grep -q "/timeout" && echo $i ; done
```

Only change the testcase, the change has been verified, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336854](https://bugs.openjdk.org/browse/JDK-8336854): CAInterop.java#actalisauthenticationrootca conflicted with /manual and /timeout (**Bug** - P4)


### Reviewers
 * [Rajan Halade](https://openjdk.org/census#rhalade) (@rhalade - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20270/head:pull/20270` \
`$ git checkout pull/20270`

Update a local copy of the PR: \
`$ git checkout pull/20270` \
`$ git pull https://git.openjdk.org/jdk.git pull/20270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20270`

View PR using the GUI difftool: \
`$ git pr show -t 20270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20270.diff">https://git.openjdk.org/jdk/pull/20270.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20270#issuecomment-2241187133)