### PR TITLE
8336855: Duplicate protected declaration and comment in interp_masm_aarch64.hpp

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2015, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -35,8 +35,6 @@
 typedef ByteSize (*OffsetFunction)(uint);
 
 class InterpreterMacroAssembler: public MacroAssembler {
- protected:
-
  protected:
   // Interpreter specific version of call_VM_base
   using MacroAssembler::call_VM_leaf_base;
@@ -113,8 +111,6 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void get_dispatch();
 
   // Helpers for runtime call arguments/results
-
-  // Helpers for runtime call arguments/results
   void get_method(Register reg) {
     ldr(reg, Address(rfp, frame::interpreter_frame_method_offset * wordSize));
   }
@@ -181,7 +177,7 @@ class InterpreterMacroAssembler: public MacroAssembler {
   void load_ptr(int n, Register val);
   void store_ptr(int n, Register val);
 
-// Load float value from 'address'. The value is loaded onto the FPU register v0.
+  // Load float value from 'address'. The value is loaded onto the FPU register v0.
   void load_float(Address src);
   void load_double(Address src);
 


### PR DESCRIPTION
Hi all,
In `src/hotspot/cpu/aarch64/interp_masm_aarch64.hpp` file, there is duplicate protected declaration and comment. I think it's can be deleted safetied.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336855](https://bugs.openjdk.org/browse/JDK-8336855): Duplicate protected declaration and comment in interp_masm_aarch64.hpp (**Bug** - P5)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20271/head:pull/20271` \
`$ git checkout pull/20271`

Update a local copy of the PR: \
`$ git checkout pull/20271` \
`$ git pull https://git.openjdk.org/jdk.git pull/20271/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20271`

View PR using the GUI difftool: \
`$ git pr show -t 20271`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20271.diff">https://git.openjdk.org/jdk/pull/20271.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20271#issuecomment-2241552027)