### PR TITLE
Optimize StringConcat

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2987,7 +2987,7 @@ public final class String
         if (str.isEmpty()) {
             return this;
         }
-        return StringConcatHelper.simpleConcat(this, str);
+        return StringConcatHelper.doConcat(this, str);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2987,7 +2987,10 @@ public final class String
         if (str.isEmpty()) {
             return this;
         }
-        return StringConcatHelper.doConcat(this, str == null ? "null" : str);
+        if (isEmpty()) {
+            return str;
+        }
+        return StringConcatHelper.doConcat(this, str);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3588,9 +3588,9 @@ public final class String
     @ForceInline
     static String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
         int icoder = prefix.coder() | suffix.coder();
-        long len = (long) prefix.length() + suffix.length();
+        int len = prefix.length() + suffix.length();
         if (size > 1) { // when there are more than one element, size - 1 delimiters will be emitted
-            len += (long) (size - 1) * delimiter.length();
+            len += (size - 1) * delimiter.length();
             icoder |= delimiter.coder();
         }
         // assert len > 0L; // max: (long) Integer.MAX_VALUE << 32
@@ -3603,10 +3603,10 @@ public final class String
         }
         byte coder = (byte) icoder;
         // long len overflow check, char -> byte length, int len overflow check
-        if (len < 0L || (len <<= coder) != (int) len) {
+        if (len < 0L) {
             throw new OutOfMemoryError("Requested string length exceeds VM limit");
         }
-        byte[] value = StringConcatHelper.newArray(len);
+        byte[] value = StringConcatHelper.newArray(len << coder);
 
         int off = 0;
         prefix.getBytes(value, off, coder); off += prefix.length();

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -2987,7 +2987,7 @@ public final class String
         if (str.isEmpty()) {
             return this;
         }
-        return StringConcatHelper.doConcat(this, str);
+        return StringConcatHelper.doConcat(this, str == null ? "null" : str);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -368,16 +368,12 @@ final class StringConcatHelper {
             // newly created string required, see JLS 15.18.1
             return new String(s1);
         }
-        // start "mixing" in length and coder or arguments, order is not
-        // important
-        long indexCoder = mix(initialCoder(), s1);
-        indexCoder = mix(indexCoder, s2);
-        byte[] buf = newArray(indexCoder);
-        // prepend each argument in reverse order, since we prepending
-        // from the end of the byte array
-        indexCoder = prepend(indexCoder, buf, s2);
-        indexCoder = prepend(indexCoder, buf, s1);
-        return newString(buf, indexCoder);
+        byte coder = (byte) (s1.coder() | s2.coder());
+        int len = s1.length() + s2.length();
+        byte[] buf = (byte[]) UNSAFE.allocateUninitializedArray(byte.class, len << coder);
+        s1.getBytes(buf, 0, coder);
+        s2.getBytes(buf, s1.length(), coder);
+        return new String(buf, coder);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -368,6 +368,11 @@ final class StringConcatHelper {
             // newly created string required, see JLS 15.18.1
             return new String(s1);
         }
+        return doConcat(s1, s2);
+    }
+
+    @ForceInline
+    static String doConcat(String s1, String s2) {
         byte coder = (byte) (s1.coder() | s2.coder());
         int newLength = (s1.length() + s2.length()) << coder;
         byte[] buf = newArray(newLength);

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -371,6 +371,13 @@ final class StringConcatHelper {
         return doConcat(s1, s2);
     }
 
+    /**
+     * Perform a simple concatenation between two non-empty strings.
+     *
+     * @param s1         first argument
+     * @param s2         second argument
+     * @return String    resulting string
+     */
     @ForceInline
     static String doConcat(String s1, String s2) {
         byte coder = (byte) (s1.coder() | s2.coder());

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2611,20 +2611,8 @@ public final class System {
                 return StringConcatHelper.lookupStatic(name, methodType);
             }
 
-            public long stringConcatHelperPrepend(long indexCoder, byte[] buf, String value) {
-                return StringConcatHelper.prepend(indexCoder, buf, value);
-            }
-
-            public long stringConcatInitialCoder() {
+            public byte stringConcatInitialCoder() {
                 return StringConcatHelper.initialCoder();
-            }
-
-            public long stringConcatMix(long lengthCoder, String constant) {
-                return StringConcatHelper.mix(lengthCoder, constant);
-            }
-
-            public long stringConcatMix(long lengthCoder, char value) {
-                return StringConcatHelper.mix(lengthCoder, value);
             }
 
             public int stringSize(long i) {
@@ -2641,6 +2629,10 @@ public final class System {
 
             public String join(String prefix, String suffix, String delimiter, String[] elements, int size) {
                 return String.join(prefix, suffix, delimiter, elements, size);
+            }
+
+            public byte stringCoder(String str) {
+                return str.coder();
             }
 
             public Object classData(Class<?> c) {

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -433,25 +433,9 @@ public interface JavaLangAccess {
     MethodHandle stringConcatHelper(String name, MethodType methodType);
 
     /**
-     * Prepends constant and the stringly representation of value into buffer,
-     * given the coder and final index. Index is measured in chars, not in bytes!
-     */
-    long stringConcatHelperPrepend(long indexCoder, byte[] buf, String value);
-
-    /**
      * Get the string concat initial coder
      */
-    long stringConcatInitialCoder();
-
-    /**
-     * Update lengthCoder for constant
-     */
-    long stringConcatMix(long lengthCoder, String constant);
-
-    /**
-     * Mix value length and coder into current length and coder.
-     */
-    long stringConcatMix(long lengthCoder, char value);
+    byte stringConcatInitialCoder();
 
     /**
      * Join strings
@@ -470,6 +454,8 @@ public interface JavaLangAccess {
     int getCharsLatin1(long i, int index, byte[] buf);
 
     int getCharsUTF16(long i, int index, byte[] buf);
+
+    byte stringCoder(String str);
 
     long findNative(ClassLoader loader, String entry);
 


### PR DESCRIPTION
The current implementation of StringConcat is to mix the coder and length into a long. This operation will have some overhead for int/long/boolean types. We can separate the calculation of the coder from the calculation of the length, which can improve the performance in the scenario of concat int/long/boolean.

This idea comes from the suggestion of @l4es in the discussion of PR https://github.com/openjdk/jdk/pull/20253#issuecomment-2240412866

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20272/head:pull/20272` \
`$ git checkout pull/20272`

Update a local copy of the PR: \
`$ git checkout pull/20272` \
`$ git pull https://git.openjdk.org/jdk.git pull/20272/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20272`

View PR using the GUI difftool: \
`$ git pr show -t 20272`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20272.diff">https://git.openjdk.org/jdk/pull/20272.diff</a>

</details>
