### PR TITLE
8316882: Do not close ZipFileSystem on interrupt

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -301,7 +301,8 @@ module java.base {
         java.management,
         jdk.crypto.cryptoki,
         jdk.net,
-        jdk.sctp;
+        jdk.sctp,
+        jdk.zipfs;
     exports sun.nio.cs to
         jdk.charsets;
     exports sun.nio.fs to

--- a/src/java.base/share/lib/security/default.policy
+++ b/src/java.base/share/lib/security/default.policy
@@ -203,6 +203,7 @@ grant codeBase "jrt:/jdk.zipfs" {
     permission java.util.PropertyPermission "os.name", "read";
     permission java.util.PropertyPermission "user.dir", "read";
     permission java.util.PropertyPermission "user.name", "read";
+    permission java.lang.RuntimePermission "accessClassInPackage.sun.nio.ch";
 };
 
 // permissions needed by applications using java.desktop module

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -63,6 +63,8 @@ import java.util.zip.Inflater;
 import java.util.zip.InflaterInputStream;
 import java.util.zip.ZipException;
 
+import sun.nio.ch.FileChannelImpl;
+
 import static java.lang.Boolean.TRUE;
 import static java.nio.file.StandardCopyOption.COPY_ATTRIBUTES;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
@@ -175,6 +177,8 @@ class ZipFileSystem extends FileSystem {
         this.zc = ZipCoder.get(nameEncoding);
         this.rootdir = new ZipPath(this, new byte[]{'/'});
         this.ch = Files.newByteChannel(zfpath, READ);
+        if (this.ch instanceof FileChannelImpl fci)
+            fci.setUninterruptible();
         try {
             this.cen = initCEN();
         } catch (IOException x) {

--- a/test/jdk/jdk/nio/zipfs/CallWithInterruptSet.java
+++ b/test/jdk/jdk/nio/zipfs/CallWithInterruptSet.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8316882
+ * @run testng CallWithInterruptSet
+ * @summary Test invoking ZipFS methods with the interrupt status set
+ */
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+public class CallWithInterruptSet {
+
+    @Test
+    public void testReadAllBytes() throws Exception {
+        Path file = Files.createTempFile(Path.of("."), "tmp", ".zip");
+        try (var zout = new ZipOutputStream(Files.newOutputStream(file))) {
+            zout.putNextEntry(new ZipEntry("entry"));
+            zout.write("HEHE".getBytes(StandardCharsets.UTF_8), 0, 4);
+            zout.closeEntry();
+        }
+        try (var zipfs = FileSystems.newFileSystem(file)) {
+            var zippath = zipfs.getPath("entry");
+            Thread.currentThread().interrupt();
+            assertEquals(
+                    Files.readAllBytes(zippath),
+                    "HEHE".getBytes(StandardCharsets.UTF_8));
+        }
+        assertTrue(Thread.interrupted()); // clear interrupt
+    }
+
+}
+


### PR DESCRIPTION
Hi,

Here is a fix for https://bugs.openjdk.org/browse/JDK-8316882, following the `FileChannelImpl#setUninterruptible` pattern used in `Files.readAllBytes` for example.

There has been some discussion on nio-dev about more broadly rethinking the interrupt handling for `FileChannels`, for example by adding a new open option. This PR is just meant to fix the ZipFS issue in the meanwhile. (Maybe I will tackle the more general issue?). [1] [2]

[1]: https://mail.openjdk.org/pipermail/nio-dev/2018-February/004756.html
[2]: https://mail.openjdk.org/pipermail/nio-dev/2024-April/016147.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8316882](https://bugs.openjdk.org/browse/JDK-8316882)

### Issue
 * [JDK-8316882](https://bugs.openjdk.org/browse/JDK-8316882): (zipfs) ZipFileSystem closed by interrupt is unexpected (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20274/head:pull/20274` \
`$ git checkout pull/20274`

Update a local copy of the PR: \
`$ git checkout pull/20274` \
`$ git pull https://git.openjdk.org/jdk.git pull/20274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20274`

View PR using the GUI difftool: \
`$ git pr show -t 20274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20274.diff">https://git.openjdk.org/jdk/pull/20274.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20274#issuecomment-2241613526)