### PR TITLE
8336860: x86: Change integer src operand for CMoveL of 0 and 1 to long

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -6388,7 +6388,7 @@ instruct cmovP_regUCF2_eq(cmpOpUCF2 cop, rFlagsRegUCF cr, rRegP dst, rRegP src) 
   ins_pipe(pipe_cmov_reg);
 %}
 
-instruct cmovL_imm_01(rRegL dst, immI_1 src, rFlagsReg cr, cmpOp cop)
+instruct cmovL_imm_01(rRegL dst, immL1 src, rFlagsReg cr, cmpOp cop)
 %{
   predicate(n->in(2)->in(2)->is_Con() && n->in(2)->in(2)->get_long() == 0);
   match(Set dst (CMoveL (Binary cop cr) (Binary src dst)));
@@ -6426,7 +6426,7 @@ instruct cmovL_mem(cmpOp cop, rFlagsReg cr, rRegL dst, memory src)
   ins_pipe(pipe_cmov_mem);  // XXX
 %}
 
-instruct cmovL_imm_01U(rRegL dst, immI_1 src, rFlagsRegU cr, cmpOpU cop)
+instruct cmovL_imm_01U(rRegL dst, immL1 src, rFlagsRegU cr, cmpOpU cop)
 %{
   predicate(n->in(2)->in(2)->is_Con() && n->in(2)->in(2)->get_long() == 0);
   match(Set dst (CMoveL (Binary cop cr) (Binary src dst)));
@@ -6452,7 +6452,7 @@ instruct cmovL_regU(cmpOpU cop, rFlagsRegU cr, rRegL dst, rRegL src)
   ins_pipe(pipe_cmov_reg); // XXX
 %}
 
-instruct cmovL_imm_01UCF(rRegL dst, immI_1 src, rFlagsRegUCF cr, cmpOpUCF cop)
+instruct cmovL_imm_01UCF(rRegL dst, immL1 src, rFlagsRegUCF cr, cmpOpUCF cop)
 %{
   predicate(n->in(2)->in(2)->is_Con() && n->in(2)->in(2)->get_long() == 0);
   match(Set dst (CMoveL (Binary cop cr) (Binary src dst)));

--- a/test/hotspot/jtreg/compiler/c2/irTests/CMoveLConstants.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/CMoveLConstants.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2.irTests;
+
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * bug 8336860
+ * @summary Verify codegen for CMoveL with constants 0 and 1
+ * @requires os.simpleArch == "x64"
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.CMoveLConstants
+ */
+public class CMoveLConstants {
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @IR(counts = {IRNode.X86_CMOVEL_IMM01, "1"}, phase = CompilePhase.FINAL_CODE)
+    public static long testSigned(int a, int b) {
+        return a > b ? 1L : 0L;
+    }
+
+    @Test
+    @IR(counts = {IRNode.X86_CMOVEL_IMM01U, "1"}, phase = CompilePhase.FINAL_CODE)
+    public static long testUnsigned(int a, int b) {
+        return Integer.compareUnsigned(a, b) > 0 ? 1L : 0L;
+    }
+
+    @Test
+    @IR(counts = {IRNode.X86_CMOVEL_IMM01UCF, "1"}, phase = CompilePhase.FINAL_CODE)
+    public static long testFloat(float a, float b) {
+        return a > b ? 1L : 0L;
+    }
+
+    @DontCompile
+    public void assertResults(int a, int b) {
+        Asserts.assertEQ(a > b ? 1L : 0L, testSigned(a, b));
+        Asserts.assertEQ(Integer.compareUnsigned(a, b) > 0 ? 1L : 0L, testUnsigned(a, b));
+        Asserts.assertEQ((float) a > (float) b ? 1L : 0L, testFloat(a, b));
+    }
+
+    @Run(test = {"testSigned", "testUnsigned", "testFloat"})
+    public void runMethod() {
+        assertResults(10, 20);
+        assertResults(20, 10);
+    }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/CMoveLConstants.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/CMoveLConstants.java
@@ -30,7 +30,6 @@ import compiler.lib.ir_framework.*;
  * @test
  * bug 8336860
  * @summary Verify codegen for CMoveL with constants 0 and 1
- * @requires os.simpleArch == "x64"
  * @library /test/lib /
  * @run driver compiler.c2.irTests.CMoveLConstants
  */
@@ -40,19 +39,19 @@ public class CMoveLConstants {
     }
 
     @Test
-    @IR(counts = {IRNode.X86_CMOVEL_IMM01, "1"}, phase = CompilePhase.FINAL_CODE)
+    @IR(applyIfPlatform = {"x64", "true"}, counts = {IRNode.X86_CMOVEL_IMM01, "1"}, phase = CompilePhase.FINAL_CODE)
     public static long testSigned(int a, int b) {
         return a > b ? 1L : 0L;
     }
 
     @Test
-    @IR(counts = {IRNode.X86_CMOVEL_IMM01U, "1"}, phase = CompilePhase.FINAL_CODE)
+    @IR(applyIfPlatform = {"x64", "true"}, counts = {IRNode.X86_CMOVEL_IMM01U, "1"}, phase = CompilePhase.FINAL_CODE)
     public static long testUnsigned(int a, int b) {
         return Integer.compareUnsigned(a, b) > 0 ? 1L : 0L;
     }
 
     @Test
-    @IR(counts = {IRNode.X86_CMOVEL_IMM01UCF, "1"}, phase = CompilePhase.FINAL_CODE)
+    @IR(applyIfPlatform = {"x64", "true"}, counts = {IRNode.X86_CMOVEL_IMM01UCF, "1"}, phase = CompilePhase.FINAL_CODE)
     public static long testFloat(float a, float b) {
         return a > b ? 1L : 0L;
     }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -2233,6 +2233,21 @@ public class IRNode {
         machOnlyNameRegex(X86_TESTL_REG, "testL_reg");
     }
 
+    public static final String X86_CMOVEL_IMM01 = PREFIX + "X86_CMOVEL_IMM01" + POSTFIX;
+    static {
+        machOnlyNameRegex(X86_CMOVEL_IMM01, "cmovL_imm_01");
+    }
+
+    public static final String X86_CMOVEL_IMM01U = PREFIX + "X86_CMOVEL_IMM01U" + POSTFIX;
+    static {
+        machOnlyNameRegex(X86_CMOVEL_IMM01U, "cmovL_imm_01U");
+    }
+
+    public static final String X86_CMOVEL_IMM01UCF = PREFIX + "X86_CMOVEL_IMM01UCF" + POSTFIX;
+    static {
+        machOnlyNameRegex(X86_CMOVEL_IMM01UCF, "cmovL_imm_01UCF");
+    }
+
     /*
      * Utility methods to set up IR_NODE_MAPPINGS.
      */

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,14 +173,6 @@ public class Longs {
     public void reverse() {
         for (int i = 0; i < size; i++) {
             res[i] = Long.reverse(longArraySmall[i]);
-        }
-    }
-
-    @Benchmark
-    public void cmovConstant01(Blackhole bh) {
-        for (int i = 0; i < size; i++) {
-            long r = longArraySmall[i] > bound ? 1L : 0L;
-            bh.consume(r);
         }
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -173,6 +173,14 @@ public class Longs {
     public void reverse() {
         for (int i = 0; i < size; i++) {
             res[i] = Long.reverse(longArraySmall[i]);
+        }
+    }
+
+    @Benchmark
+    public void cmovConstant01(Blackhole bh) {
+        for (int i = 0; i < size; i++) {
+            long r = longArraySmall[i] > bound ? 1L : 0L;
+            bh.consume(r);
         }
     }
 }

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
+import java.util.Random;
+
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
@@ -37,6 +39,16 @@ public class BasicRules {
     static final long[] LONG_ARRAY = new long[1024];
     static final int INT_IMM = 100;
     static final long LONG_IMM = 100;
+
+    @Setup(Level.Iteration)
+    public void setup() {
+        Random random = new Random(1000);
+
+        for (int i = 0; i < 1024; i++) {
+            INT_ARRAY[i] = random.nextInt();
+            LONG_ARRAY[i] = random.nextLong();
+        }
+    }
 
     @Benchmark
     public void andL_rReg_imm255(Blackhole bh) {
@@ -123,6 +135,13 @@ public class BasicRules {
     public void subL_rReg_imm(Blackhole bh) {
         for (int i = 0; i < LONG_ARRAY.length; i++) {
             bh.consume(LONG_ARRAY[i] - LONG_IMM);
+        }
+    }
+
+    @Benchmark
+    public void cmovL_imm_01(Blackhole bh) {
+        for (int i = 0; i < INT_ARRAY.length; i++) {
+            bh.consume(INT_ARRAY[i] > 0 ? 1L : 0L);
         }
     }
 }


### PR DESCRIPTION
Hi all,
This patch fixes `cmovL_imm_01*` instructions matching against an integer immediate 1 instead of a long immediate 1. I noticed while looking at the backend implementation of CMove that the rules specify `immI_1` instead of `immL1`, which means that the instructions can't be matched and instead falls through to the base case. I added a small benchmark and got these results:
```c
                                        Baseline                     Patch           Improvement
Benchmark                Mode  Cnt    Score   Error  Units      Score   Error  Units
BasicRules.cmovL_imm_01  avgt   15  259.073 ± 5.806  ns/op    231.108 ± 2.730  ns/op  (+ 11.41%)
```
Thoughts and reviews would be appreciated!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336860](https://bugs.openjdk.org/browse/JDK-8336860): x86: Change integer src operand for CMoveL of 0 and 1 to long (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [586d7703](https://git.openjdk.org/jdk/pull/20275/files/586d770367a42a7387a09957ab0cc89b5c9dd5d5)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer) Review applies to [02f8d0f7](https://git.openjdk.org/jdk/pull/20275/files/02f8d0f7fb8c51415b5d96f5092b36f1cbac4b49)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**) Review applies to [1b926ecf](https://git.openjdk.org/jdk/pull/20275/files/1b926ecf1dbc3b1bc905a186b0ed3082a5c4211b)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20275/head:pull/20275` \
`$ git checkout pull/20275`

Update a local copy of the PR: \
`$ git checkout pull/20275` \
`$ git pull https://git.openjdk.org/jdk.git pull/20275/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20275`

View PR using the GUI difftool: \
`$ git pr show -t 20275`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20275.diff">https://git.openjdk.org/jdk/pull/20275.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20275#issuecomment-2241979689)