### PR TITLE
8336827: compiler/vectorization/TestFloat16VectorConvChain.java  timeouts on ppc64 platforms after JDK-8335860

### DIFF
--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -25,7 +25,7 @@
 * @test
 * @summary Test Float16 vector conversion chain.
 * @library /test/lib /
-* @run driver compiler.vectorization.TestFloat16VectorConvChain
+* @run driver/timeout=1200 compiler.vectorization.TestFloat16VectorConvChain
 */
 
 package compiler.vectorization;

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloat16VectorConvChain.java
@@ -24,8 +24,10 @@
 /**
 * @test
 * @summary Test Float16 vector conversion chain.
+* @requires (vm.cpu.features ~= ".*avx512vl.*" | vm.cpu.features ~= ".*f16c.*") | os.arch == "aarch64"
+*           | (os.arch == "riscv64" & vm.cpu.features ~= ".*zfh.*")
 * @library /test/lib /
-* @run driver/timeout=1200 compiler.vectorization.TestFloat16VectorConvChain
+* @run driver compiler.vectorization.TestFloat16VectorConvChain
 */
 
 package compiler.vectorization;


### PR DESCRIPTION
After [JDK-8335860](https://bugs.openjdk.org/browse/JDK-8335860), we see a lot of timeouts in test compiler/vectorization/TestFloat16VectorConvChain.java
on the ppc64 based platforms.
The timeouts show up especially with the (fast)debug binaries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336827](https://bugs.openjdk.org/browse/JDK-8336827): compiler/vectorization/TestFloat16VectorConvChain.java  timeouts on ppc64 platforms after JDK-8335860 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**) 🔄 Re-review required (review applies to [2c149b77](https://git.openjdk.org/jdk/pull/20276/files/2c149b774c9c9e103b0b1477cbe8714609bf8159))
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) 🔄 Re-review required (review applies to [2c149b77](https://git.openjdk.org/jdk/pull/20276/files/2c149b774c9c9e103b0b1477cbe8714609bf8159))
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20276/head:pull/20276` \
`$ git checkout pull/20276`

Update a local copy of the PR: \
`$ git checkout pull/20276` \
`$ git pull https://git.openjdk.org/jdk.git pull/20276/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20276`

View PR using the GUI difftool: \
`$ git pr show -t 20276`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20276.diff">https://git.openjdk.org/jdk/pull/20276.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20276#issuecomment-2242220497)