### PR TITLE
8336299: Improve GCLocker stall diagnostics

### DIFF
--- a/src/hotspot/share/gc/shared/gcLocker.cpp
+++ b/src/hotspot/share/gc/shared/gcLocker.cpp
@@ -33,7 +33,7 @@
 #include "runtime/javaThread.inline.hpp"
 #include "runtime/safepoint.hpp"
 #include "runtime/threadSMR.hpp"
-#include "runtime/timer.hpp"
+#include "utilities/ticks.hpp"
 
 volatile jint GCLocker::_jni_lock_count = 0;
 volatile bool GCLocker::_needs_gc       = false;

--- a/src/hotspot/share/gc/shared/gcLocker.hpp
+++ b/src/hotspot/share/gc/shared/gcLocker.hpp
@@ -29,7 +29,7 @@
 #include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
-#include "runtime/timer.hpp"
+#include "utilities/ticks.hpp"
 
 class JavaThread;
 

--- a/src/hotspot/share/gc/shared/gcLocker.hpp
+++ b/src/hotspot/share/gc/shared/gcLocker.hpp
@@ -67,7 +67,6 @@ class GCLocker: public AllStatic {
   }
 
   static void log_debug_jni(const char* msg);
-  static void log_debug_jni(const char* msg, const elapsedTimer elapsed_timer);
 
   static bool is_at_safepoint();
 
@@ -152,3 +151,16 @@ class GCLocker: public AllStatic {
 };
 
 #endif // SHARE_GC_SHARED_GCLOCKER_HPP
+
+/*
+ * GCLockerTimingDebugLogger tracks specific timing information for GC lock waits.
+ */
+class GCLockerTimingDebugLogger : public StackObj {
+private:
+  const char*  _log_message;
+  Ticks _start;
+
+public:
+  GCLockerTimingDebugLogger(const char* log_message);
+  ~GCLockerTimingDebugLogger();
+};

--- a/src/hotspot/share/gc/shared/gcLocker.hpp
+++ b/src/hotspot/share/gc/shared/gcLocker.hpp
@@ -29,7 +29,6 @@
 #include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/ticks.hpp"
 
 class JavaThread;
 
@@ -151,16 +150,3 @@ class GCLocker: public AllStatic {
 };
 
 #endif // SHARE_GC_SHARED_GCLOCKER_HPP
-
-/*
- * GCLockerTimingDebugLogger tracks specific timing information for GC lock waits.
- */
-class GCLockerTimingDebugLogger : public StackObj {
-private:
-  const char*  _log_message;
-  Ticks _start;
-
-public:
-  GCLockerTimingDebugLogger(const char* log_message);
-  ~GCLockerTimingDebugLogger();
-};

--- a/src/hotspot/share/gc/shared/gcLocker.hpp
+++ b/src/hotspot/share/gc/shared/gcLocker.hpp
@@ -29,6 +29,7 @@
 #include "memory/allStatic.hpp"
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/macros.hpp"
+#include "runtime/timer.hpp"
 
 class JavaThread;
 
@@ -66,6 +67,7 @@ class GCLocker: public AllStatic {
   }
 
   static void log_debug_jni(const char* msg);
+  static void log_debug_jni(const char* msg, const elapsedTimer elapsed_timer);
 
   static bool is_at_safepoint();
 


### PR DESCRIPTION
**Notes**
Adding logs to get more visibility into how fast a thread resumes from allocation stall. 

**Testing**
* tier 1, tier 2, hotspot_gc tests.

Example log messages
```
1. Last thread exiting. Performing GC after exiting critical section. Thread "main" 0 locked.

2. Thread exiting critical region. Thread "main" 0 locked.

3. Thread stalled by JNI critical section. Resumed after 1294ms. Thread "Thread-0".

4. Thread blocked to enter critical region. Resumed after 1280ms. Thread "SIGINT handler".
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336299](https://bugs.openjdk.org/browse/JDK-8336299): Improve GCLocker stall diagnostics (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) Review applies to [77fd9d55](https://git.openjdk.org/jdk/pull/20277/files/77fd9d553c955da37062a72c161b49b8b247db26)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20277/head:pull/20277` \
`$ git checkout pull/20277`

Update a local copy of the PR: \
`$ git checkout pull/20277` \
`$ git pull https://git.openjdk.org/jdk.git pull/20277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20277`

View PR using the GUI difftool: \
`$ git pr show -t 20277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20277.diff">https://git.openjdk.org/jdk/pull/20277.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20277#issuecomment-2245254340)