### PR TITLE
8336928: GHA: Bundle artifacts removal broken

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -367,7 +367,7 @@ jobs:
         run: |
           # Find and remove all bundle artifacts
           # See: https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28
-          ALL_ARTIFACT_IDS="$(curl -L \
+          ALL_ARTIFACT_IDS="$(curl -sL \
               -H 'Accept: application/vnd.github+json' \
               -H 'Authorization: Bearer ${{ github.token }}' \
               -H 'X-GitHub-Api-Version: 2022-11-28' \
@@ -375,7 +375,7 @@ jobs:
           BUNDLE_ARTIFACT_IDS="$(echo "$ALL_ARTIFACT_IDS" | jq -r -c '.artifacts | map(select(.name|startswith("bundles-"))) | .[].id')"
           for id in $BUNDLE_ARTIFACT_IDS; do
             echo "Removing $id"
-            curl -L \
+            curl -sL \
                 -X DELETE \
                 -H 'Accept: application/vnd.github+json' \
                 -H 'Authorization: Bearer ${{ github.token }}' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -363,26 +363,23 @@ jobs:
       - test-windows-x64
 
     steps:
-        # Hack to get hold of the api environment variables that are only defined for actions
-      - name: 'Get API configuration'
-        id: api
-        uses: actions/github-script@v7
-        with:
-          script: 'return { url: process.env["ACTIONS_RUNTIME_URL"], token: process.env["ACTIONS_RUNTIME_TOKEN"] }'
-
       - name: 'Remove bundle artifacts'
         run: |
           # Find and remove all bundle artifacts
-          ALL_ARTIFACT_URLS="$(curl -s \
-              -H 'Accept: application/json;api-version=6.0-preview' \
-              -H 'Authorization: Bearer ${{ fromJson(steps.api.outputs.result).token }}' \
-              '${{ fromJson(steps.api.outputs.result).url }}_apis/pipelines/workflows/${{ github.run_id }}/artifacts?api-version=6.0-preview')"
-          BUNDLE_ARTIFACT_URLS="$(echo "$ALL_ARTIFACT_URLS" | jq -r -c '.value | map(select(.name|startswith("bundles-"))) | .[].url')"
-          for url in $BUNDLE_ARTIFACT_URLS; do
-            echo "Removing $url"
-            curl -s \
-                -H 'Accept: application/json;api-version=6.0-preview' \
-                -H 'Authorization: Bearer ${{ fromJson(steps.api.outputs.result).token }}' \
-                -X DELETE "$url" \
+          # See: https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28
+          ALL_ARTIFACT_IDS="$(curl -L \
+              -H 'Accept: application/vnd.github+json' \
+              -H 'Authorization: Bearer ${{ github.token }}' \
+              -H 'X-GitHub-Api-Version: 2022-11-28' \
+              '${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts')"
+          BUNDLE_ARTIFACT_IDS="$(echo "$ALL_ARTIFACT_IDS" | jq -r -c '.artifacts | map(select(.name|startswith("bundles-"))) | .[].id')"
+          for id in $BUNDLE_ARTIFACT_IDS; do
+            echo "Removing $id"
+            curl -L \
+                -X DELETE \
+                -H 'Accept: application/vnd.github+json' \
+                -H 'Authorization: Bearer ${{ github.token }}' \
+                -H 'X-GitHub-Api-Version: 2022-11-28' \
+                "${{ github.api_url }}/repos/${{ github.repository }}/actions/artifacts/$id" \
             || echo "Failed to remove bundle"
           done


### PR DESCRIPTION
GHA code, which tries to remove bundle artifacts no longer works. It probably broke after [JDK-8324723](https://bugs.openjdk.org/browse/JDK-8324723) (GHA: Upgrade some actions to avoid deprecated Node 16).

**Details:**
Seems like there were some backend architecture changes in [artifact actions in v4](https://github.com/actions/upload-artifact?tab=readme-ov-file#v4---whats-new). As result old code to remove artifacts no longer works. However there is [REST API](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28) available, which works.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336928](https://bugs.openjdk.org/browse/JDK-8336928): GHA: Bundle artifacts removal broken (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20281/head:pull/20281` \
`$ git checkout pull/20281`

Update a local copy of the PR: \
`$ git checkout pull/20281` \
`$ git pull https://git.openjdk.org/jdk.git pull/20281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20281`

View PR using the GUI difftool: \
`$ git pr show -t 20281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20281.diff">https://git.openjdk.org/jdk/pull/20281.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20281#issuecomment-2243765457)