### PR TITLE
8336667: IAE in DerInputStream.toByteArray

### DIFF
--- a/src/java.base/share/classes/sun/security/util/DerInputStream.java
+++ b/src/java.base/share/classes/sun/security/util/DerInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,7 +114,7 @@ public class DerInputStream {
             // to the end of return value by DerIndefLenConverter::convertBytes
             // and stay inside result.buffer.
             int unused = result.buffer.length - result.end;
-            this.pos = this.data.length - unused;
+            this.pos = this.end - unused;
         } else {
             this.pos = result.end;
         }

--- a/test/jdk/sun/security/util/DerInputBuffer/B8336667/PoC.java
+++ b/test/jdk/sun/security/util/DerInputBuffer/B8336667/PoC.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8336667
+ * @summary Ensure the unused bytes are calculated correctly when converting
+ *          indefinite length BER to DER
+ * @modules java.base/sun.security.util
+ * @library /test/lib
+ */
+import jdk.test.lib.Asserts;
+import sun.security.util.DerInputStream;
+
+import java.util.HexFormat;
+
+public class PoC {
+    public static void main(String[] args) throws Exception {
+        // A BER indefinite encoding with some unused bytes at the end
+        var data = HexFormat.of().parseHex("""
+                2480 0401AA 0401BB 0000 -- 2 byte string
+                010100 -- boolean false
+                12345678 -- 4 unused bytes"""
+                .replaceAll("(\\s|--.*)", ""));
+        var dis = new DerInputStream(data, 0, data.length - 4, true);
+        Asserts.assertEQ(dis.getDerValue().getOctetString().length, 2);
+        Asserts.assertFalse(dis.getDerValue().getBoolean());
+        dis.atEnd();
+    }
+}

--- a/test/jdk/sun/security/util/DerInputBuffer/B8336667/Reproducer.java
+++ b/test/jdk/sun/security/util/DerInputBuffer/B8336667/Reproducer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8336667
+ * @summary Ensure the unused bytes are calculated correctly when converting
+ *          indefinite length BER to DER
+ */
+import java.io.ByteArrayInputStream;
+import java.security.cert.CRLException;
+import java.security.cert.CertificateException;
+import java.util.Base64;
+
+public class Reproducer {
+    private static final String INPUT = """
+            MIIBljCCAVMwgAaB/////////yb////////////////////9////AgDv////////////////////
+            /////2RjPWNvbf////8k/////////yb///////////////////9vbf////8k/////////yb/////
+            ////////////////////AgD/////////////b23/////JP////////8m/////yf/////////////
+            /////wIA//////////////////////////////////////8AAABl//////8m/////////y1CRUdJ
+            TiA9Y290cnVlVlZWVlZWVlZWVjEAAAAAAAAArQdVUwNVBAsTA0RvRDEaMBhAA1UAAAAAAAAAAAAA
+            AAAAAAAAAAAAAAAAAAEXDTAzMDcxNTE2MjAwNFqgHzAdMA8GA1UdHAEB/wQFMAPyAf8wCgYDVR0P
+            BAMCAQIwCwYHKoZIzjgEAwUAAzBkARkTA2NvbTEYMBYGCgmSJomT8ixkARkTCG15VGVzdENBMBIC
+            AQHyAjZG+RfHdO4=""";
+
+    Reproducer(byte[] data) {
+        try {
+            java.security.cert.CertificateFactory.
+                    getInstance("X.509").generateCRLs(new ByteArrayInputStream(data));
+        } catch (CertificateException | CRLException e) {
+            if (System.getProperty("dbg", "false").equals("true")) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    public static void main(String[] a) throws Exception {
+        byte[] decodedBytes = Base64.getMimeDecoder().decode(INPUT);
+        new Reproducer(decodedBytes);
+    }
+}


### PR DESCRIPTION
When reading an indefinite BER `DerValue` from a `DerInputStream`, the current position of the stream must be placed right after the BER. There is a bug in the calculation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336667](https://bugs.openjdk.org/browse/JDK-8336667): IAE in DerInputStream.toByteArray (**Bug** - P3)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20283/head:pull/20283` \
`$ git checkout pull/20283`

Update a local copy of the PR: \
`$ git checkout pull/20283` \
`$ git pull https://git.openjdk.org/jdk.git pull/20283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20283`

View PR using the GUI difftool: \
`$ git pr show -t 20283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20283.diff">https://git.openjdk.org/jdk/pull/20283.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20283#issuecomment-2243868346)