### PR TITLE
8336935: Test sun/security/krb5/auto/RealmSpecificValues.java fails: java.lang.RuntimeException: Should not reach here

### DIFF
--- a/test/jdk/sun/security/krb5/auto/RealmSpecificValues.java
+++ b/test/jdk/sun/security/krb5/auto/RealmSpecificValues.java
@@ -35,6 +35,7 @@ import sun.security.krb5.Config;
  * @bug 8333772
  * @summary check krb5.conf reading on default and realm-specific values
  * @library /test/lib
+ * @run main/othervm RealmSpecificValues
  */
 public class RealmSpecificValues {
 


### PR DESCRIPTION
The test sets system properties. Should run in `othervm`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336935](https://bugs.openjdk.org/browse/JDK-8336935): Test sun/security/krb5/auto/RealmSpecificValues.java fails: java.lang.RuntimeException: Should not reach here (**Bug** - P4)


### Reviewers
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20284/head:pull/20284` \
`$ git checkout pull/20284`

Update a local copy of the PR: \
`$ git checkout pull/20284` \
`$ git pull https://git.openjdk.org/jdk.git pull/20284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20284`

View PR using the GUI difftool: \
`$ git pr show -t 20284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20284.diff">https://git.openjdk.org/jdk/pull/20284.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20284#issuecomment-2243866953)