### PR TITLE
8336944: Shenandoah: Should only relativize stack chunks for successful evacuations

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1178,12 +1178,11 @@ oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
 
   // Try to install the new forwarding pointer.
   oop copy_val = cast_to_oop(copy);
-  ContinuationGCSupport::relativize_stack_chunk(copy_val);
-
   oop result = ShenandoahForwarding::try_update_forwardee(p, copy_val);
   if (result == copy_val) {
     // Successfully evacuated. Our copy is now the public one!
     shenandoah_assert_correct(nullptr, copy_val);
+    ContinuationGCSupport::relativize_stack_chunk(copy_val);
     return copy_val;
   }  else {
     // Failed to evacuate. We need to deal with the object that is left behind. Since this

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1181,8 +1181,8 @@ oop ShenandoahHeap::evacuate_object(oop p, Thread* thread) {
   oop result = ShenandoahForwarding::try_update_forwardee(p, copy_val);
   if (result == copy_val) {
     // Successfully evacuated. Our copy is now the public one!
-    shenandoah_assert_correct(nullptr, copy_val);
     ContinuationGCSupport::relativize_stack_chunk(copy_val);
+    shenandoah_assert_correct(nullptr, copy_val);
     return copy_val;
   }  else {
     // Failed to evacuate. We need to deal with the object that is left behind. Since this


### PR DESCRIPTION
In some cases, different threads may race to evacuate an object. The race is won by "CAS"ing in the forwarding pointer. The threads that lose this race must "back out" their allocation. The work to relativize stack chunks should only happen for the thread that wins the evacuation race.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336944](https://bugs.openjdk.org/browse/JDK-8336944): Shenandoah: Should only relativize stack chunks for successful evacuations (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) 🔄 Re-review required (review applies to [ad832e7e](https://git.openjdk.org/jdk/pull/20288/files/ad832e7e7733a35646f6b7b4cca45593684c3be1))
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20288/head:pull/20288` \
`$ git checkout pull/20288`

Update a local copy of the PR: \
`$ git checkout pull/20288` \
`$ git pull https://git.openjdk.org/jdk.git pull/20288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20288`

View PR using the GUI difftool: \
`$ git pr show -t 20288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20288.diff">https://git.openjdk.org/jdk/pull/20288.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20288#issuecomment-2244025812)