### PR TITLE
8336873: BasicSplitPaneDivider:oneTouchExpandableChanged() should mention that implementation depends on SplitPane.supportsOneTouchButtons property

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -396,7 +396,7 @@ public class BasicSplitPaneDivider extends Container
      * Messaged when the oneTouchExpandable value of the JSplitPane the
      * divider is contained in changes.
      * If a particular L&amp;F supports SplitPane.supportsOneTocuhButtons property
-     * it Will create the
+     * it will create the
      * <code>leftButton</code> and <code>rightButton</code> if they are null
      * and corresponding JSplitPane supports oneTouchExpandable property.
      * Invalidates the corresponding JSplitPane as well.

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -394,7 +394,9 @@ public class BasicSplitPaneDivider extends Container
 
     /**
      * Messaged when the oneTouchExpandable value of the JSplitPane the
-     * divider is contained in changes. Will create the
+     * divider is contained in changes.
+     * If a particular L&F supports SplitPane.supportsOneTocuhButtons property
+     * it Will create the
      * <code>leftButton</code> and <code>rightButton</code> if they are null
      * and corresponding JSplitPane supports oneTouchExpandable property.
      * Invalidates the corresponding JSplitPane as well.

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -395,7 +395,8 @@ public class BasicSplitPaneDivider extends Container
     /**
      * Messaged when the oneTouchExpandable value of the JSplitPane the
      * divider is contained in changes.
-     * If a particular L&amp;F supports SplitPane.supportsOneTouchButtons property
+     * If a particular L&amp;F supports this Swing
+     * "SplitPane.supportsOneTouchButtons" property
      * it will create the
      * <code>leftButton</code> and <code>rightButton</code> if they are null
      * and corresponding JSplitPane supports oneTouchExpandable property.

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -395,7 +395,7 @@ public class BasicSplitPaneDivider extends Container
     /**
      * Messaged when the oneTouchExpandable value of the JSplitPane the
      * divider is contained in changes.
-     * If a particular L&amp;F supports SplitPane.supportsOneTocuhButtons property
+     * If a particular L&amp;F supports SplitPane.supportsOneTouchButtons property
      * it will create the
      * <code>leftButton</code> and <code>rightButton</code> if they are null
      * and corresponding JSplitPane supports oneTouchExpandable property.

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicSplitPaneDivider.java
@@ -395,7 +395,7 @@ public class BasicSplitPaneDivider extends Container
     /**
      * Messaged when the oneTouchExpandable value of the JSplitPane the
      * divider is contained in changes.
-     * If a particular L&F supports SplitPane.supportsOneTocuhButtons property
+     * If a particular L&amp;F supports SplitPane.supportsOneTocuhButtons property
      * it Will create the
      * <code>leftButton</code> and <code>rightButton</code> if they are null
      * and corresponding JSplitPane supports oneTouchExpandable property.


### PR DESCRIPTION
BasicSplitPaneDivider:oneTouchExpandableChanged() spec doesn't mention that it will create left/right button only if L&F supports SplitPane.supportsOneTouchButtons which is now added in javadoc..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8336947](https://bugs.openjdk.org/browse/JDK-8336947) to be approved

### Issues
 * [JDK-8336873](https://bugs.openjdk.org/browse/JDK-8336873): BasicSplitPaneDivider:oneTouchExpandableChanged() should mention that implementation depends on SplitPane.supportsOneTouchButtons property (**Bug** - P3)
 * [JDK-8336947](https://bugs.openjdk.org/browse/JDK-8336947): BasicSplitPaneDivider:oneTouchExpandableChanged() should mention that implementation depends on SplitPane.supportsOneTouchButtons property (**CSR**)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**) Review applies to [359dded8](https://git.openjdk.org/jdk/pull/20289/files/359dded8f63c75497ff357817a731b820c4ae389)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20289/head:pull/20289` \
`$ git checkout pull/20289`

Update a local copy of the PR: \
`$ git checkout pull/20289` \
`$ git pull https://git.openjdk.org/jdk.git pull/20289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20289`

View PR using the GUI difftool: \
`$ git pr show -t 20289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20289.diff">https://git.openjdk.org/jdk/pull/20289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20289#issuecomment-2244215879)