### PR TITLE
8204582: Extra spaces in jlink documentation make it incorrect.

### DIFF
--- a/src/jdk.jlink/share/man/jlink.1
+++ b/src/jdk.jlink/share/man/jlink.1
@@ -110,7 +110,7 @@ Specifies the launcher command name for the module or the command name
 for the module and main class (the module and the main class names are
 separated by a slash (\f[V]/\f[R])).
 .TP
-\f[V]--limit-modules\f[R] \f[I]mod\f[R] [\f[V],\f[R] \f[I]mod\f[R]...]
+\f[V]--limit-modules\f[R] \f[I]mod\f[R][\f[V],\f[R]\f[I]mod\f[R]...]
 Limits the universe of observable modules to those in the transitive
 closure of the named modules, \f[V]mod\f[R], plus the main module, if
 any, plus any further modules specified in the \f[V]--add-modules\f[R]

--- a/src/jdk.jlink/share/man/jlink.1
+++ b/src/jdk.jlink/share/man/jlink.1
@@ -44,8 +44,8 @@ into a custom runtime image
 .SH SYNOPSIS
 .PP
 \f[V]jlink\f[R] [\f[I]options\f[R]] \f[V]--module-path\f[R]
-\f[I]modulepath\f[R] \f[V]--add-modules\f[R] \f[I]module\f[R] [,
-\f[I]module\f[R]...]
+\f[I]modulepath\f[R] \f[V]--add-modules\f[R]
+\f[I]module\f[R][,\f[I]module\f[R]...]
 .TP
 \f[I]options\f[R]
 Command-line options separated by spaces.
@@ -69,7 +69,7 @@ transitive dependences, to create a custom runtime image.
 Developers are responsible for updating their custom runtime images.
 .SH JLINK OPTIONS
 .TP
-\f[V]--add-modules\f[R] \f[I]mod\f[R] [\f[V],\f[R] \f[I]mod\f[R]...]
+\f[V]--add-modules\f[R] \f[I]mod\f[R][\f[V],\f[R]\f[I]mod\f[R]...]
 Adds the named modules, \f[I]mod\f[R], to the default set of root
 modules.
 The default set of root modules is empty.


### PR DESCRIPTION
removed extra whitespaces

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8204582: Extra spaces in jlink documentation make it incorrect.`

### Issue
 * [JDK-8204582](https://bugs.openjdk.org/browse/JDK-8204582): Extra spaces in jlink documentation make it incorrect. (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20292/head:pull/20292` \
`$ git checkout pull/20292`

Update a local copy of the PR: \
`$ git checkout pull/20292` \
`$ git pull https://git.openjdk.org/jdk.git pull/20292/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20292`

View PR using the GUI difftool: \
`$ git pr show -t 20292`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20292.diff">https://git.openjdk.org/jdk/pull/20292.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20292#issuecomment-2244256646)