### PR TITLE
8334085: Test crash: assert(thread->held_monitor_count() == 0) failed: Must be

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2451,7 +2451,7 @@ static inline intptr_t* thaw_internal(JavaThread* thread, const Continuation::th
   assert(is_aligned(sp, frame::frame_alignment), "");
 
   // All the frames have been thawed so we know they don't hold any monitors
-  assert(thread->held_monitor_count() == 0, "Must be");
+  assert(thread->held_monitor_count() - thread->jni_monitor_count() == 0, "Must be");
 
 #ifdef ASSERT
   intptr_t* sp0 = sp;

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2450,8 +2450,8 @@ static inline intptr_t* thaw_internal(JavaThread* thread, const Continuation::th
   intptr_t* const sp = thw.thaw(kind);
   assert(is_aligned(sp, frame::frame_alignment), "");
 
-  // All the frames have been thawed so we know they don't hold any monitors
-  assert(thread->held_monitor_count() - thread->jni_monitor_count() == 0, "Must be");
+  // All or part of the frames have been thawed so we know they don't hold any monitors except JNI monitors.
+  assert(thread->held_monitor_count() == thread->jni_monitor_count(), "Must be");
 
 #ifdef ASSERT
   intptr_t* sp0 = sp;

--- a/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,6 +86,7 @@ public class GetOwnedMonitorInfoTest {
                 System.out.println("Thread doing JNI call: "
                                    + Thread.currentThread().getName());
 
+                Thread.yield();
                 jniMonitorEnterAndLetObjectDie();
             }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
@@ -87,7 +87,7 @@ public class GetOwnedMonitorInfoTest {
                                    + Thread.currentThread().getName());
 
                 // Extra unmount helps to reproduce 8334085.
-                // Two sub-sequential thaws are needed in that sceanrio.
+                // Two sub-sequential thaws are needed in that scenario.
                 Thread.yield();
                 jniMonitorEnterAndLetObjectDie();
             }

--- a/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
@@ -24,7 +24,7 @@
 
 /**
  * @test
- * @bug 8185164 8320515
+ * @bug 8185164 8320515 8334085
  * @summary Checks that a contended monitor does not show up in the list of owned monitors.
  *          8320515 piggy-backs on this test and injects an owned monitor with a dead object,
             and checks that that monitor isn't exposed to GetOwnedMonitorInfo.
@@ -53,7 +53,7 @@ public class GetOwnedMonitorInfoTest {
     private static native boolean hasEventPosted();
 
     private static void jniMonitorEnterAndLetObjectDie() {
-        // The monitor iterator used by GetOwnedMonitorInfo used to
+        // The monitor iterator used by GetOwnedMonitorInfo to
         // assert when an owned monitor with a dead object was found.
         // Inject this situation into this test that performs other
         // GetOwnedMonitorInfo testing.
@@ -86,6 +86,8 @@ public class GetOwnedMonitorInfoTest {
                 System.out.println("Thread doing JNI call: "
                                    + Thread.currentThread().getName());
 
+                // Extra unmount helps to reproduce 8334085.
+                // Two sub-sequential thaws are needed in that sceanrio.
                 Thread.yield();
                 jniMonitorEnterAndLetObjectDie();
             }

--- a/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java
@@ -53,7 +53,7 @@ public class GetOwnedMonitorInfoTest {
     private static native boolean hasEventPosted();
 
     private static void jniMonitorEnterAndLetObjectDie() {
-        // The monitor iterator used by GetOwnedMonitorInfo to
+        // The monitor iterator used by GetOwnedMonitorInfo used to
         // assert when an owned monitor with a dead object was found.
         // Inject this situation into this test that performs other
         // GetOwnedMonitorInfo testing.


### PR DESCRIPTION
The test `serviceability/jvmti/GetOwnedMonitorInfo/GetOwnedMonitorInfoTest.java` is failing with the assert in the `thaw_internal()` function. The assert is not fully correct as it does not account for an unexpected scenario.

Thanks to Patricio for reproducing this failure and identifying the root cause:
> The problem is that we can unmount a virtual thread, then mount it again, thaw a few frames, execute code that acquires a JNI monitor, and then call thaw again without releasing that monitor. In this test this will happen if the vthread is unmounted in System.out.println("Thread doing JNI call: " ...) because of contention with the main thread doing System.out.println("Main waiting for event.").
The issue can be reproduced by adding Thread.yield() before jniMonitorEnterAndLetObjectDie(). 

The fix corrects the assert to account for the `thread->jni_monitor_count()`.
Question: Is the same scenario possible for non-JNI monitors as well?
Also, the fix includes the test tweak described above which makes this failure always reproducible.

Testing:
 - Ran the test `GetOwnedMonitorInfoTest.java` locally
 - Mach5 tiers 1-6 are passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334085](https://bugs.openjdk.org/browse/JDK-8334085): Test crash: assert(thread-&gt;held_monitor_count() == 0) failed: Must be (**Bug** - P3)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) 🔄 Re-review required (review applies to [9c10c555](https://git.openjdk.org/jdk/pull/20294/files/9c10c555ce6613b636ffadb6dd993b502f13e060))
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20294/head:pull/20294` \
`$ git checkout pull/20294`

Update a local copy of the PR: \
`$ git checkout pull/20294` \
`$ git pull https://git.openjdk.org/jdk.git pull/20294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20294`

View PR using the GUI difftool: \
`$ git pr show -t 20294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20294.diff">https://git.openjdk.org/jdk/pull/20294.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20294#issuecomment-2244406251)