### PR TITLE
8336966: Alpine Linux x86_64 compilation error: sendfile64

### DIFF
--- a/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
@@ -114,7 +114,7 @@ Java_sun_nio_ch_FileDispatcherImpl_transferTo0(JNIEnv *env, jobject this,
             return n;
     }
 
-    n = sendfile64(dstFD, srcFD, &offset, (size_t)count);
+    n = sendfile(dstFD, srcFD, &offset, (size_t)count);
     if (n < 0) {
         if (errno == EAGAIN)
             return IOS_UNAVAILABLE;

--- a/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
+++ b/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
@@ -211,7 +211,7 @@ Java_sun_nio_fs_LinuxNativeDispatcher_directCopy0
     }
 
     do {
-        RESTARTABLE(sendfile64(dst, src, NULL, count), bytes_sent);
+        RESTARTABLE(sendfile(dst, src, NULL, count), bytes_sent);
         if (bytes_sent < 0) {
             if (errno == EAGAIN)
                 return IOS_UNAVAILABLE;


### PR DESCRIPTION
Alpine Linux 3.20 x86_64 compilation error:

```
.../src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c: In function 'Java_sun_nio_ch_FileDispatcherImpl_transferTo0':
.../src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c:117:9: error: implicit declaration of function 'sendfile64'; did you mean 'sendfile'? [-Werror=implicit-function-declaration]
  117 | n = sendfile64(dstFD, srcFD, &offset, (size_t)count);
      | ^~~~~~~~~~
      | sendfile
cc1: all warnings being treated as errors
* For target support_native_java.base_libnio_LinuxNativeDispatcher.o:
In file included from .../src/java.base/share/native/libjava/jni_util.h:30,
                 from .../src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c:27:
.../src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c: In function 'Java_sun_nio_fs_LinuxNativeDispatcher_directCopy0':
.../src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c:214:21: error: implicit declaration of function 'sendfile64'; did you mean 'sendfile'? [-Werror=implicit-function-declaration]
  214 | RESTARTABLE(sendfile64(dst, src, NULL, count), bytes_sent);
      | ^~~~~~~~~~
.../src/java.base/unix/native/libjava/jni_util_md.h:31:15: note: in definition of macro 'RESTARTABLE'
   31 | _result = _cmd; \
      | ^~~~
cc1: all warnings being treated as errors
```
`make/autoconf/flags-cflags.m4`
```
  if test "x$OPENJDK_TARGET_OS" = xlinux; then
    CFLAGS_OS_DEF_JVM="-DLINUX -D_FILE_OFFSET_BITS=64"
    CFLAGS_OS_DEF_JDK="-D_GNU_SOURCE -D_REENTRANT -D_FILE_OFFSET_BITS=64"
```
`sendfile64` were introduced by: #10154 and inherited from https://github.com/openjdk/jdk/commit/a449cd08d7475215fe50218312a5d858068c694c

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336966](https://bugs.openjdk.org/browse/JDK-8336966): Alpine Linux x86_64 compilation error: sendfile64 (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20295/head:pull/20295` \
`$ git checkout pull/20295`

Update a local copy of the PR: \
`$ git checkout pull/20295` \
`$ git pull https://git.openjdk.org/jdk.git pull/20295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20295`

View PR using the GUI difftool: \
`$ git pr show -t 20295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20295.diff">https://git.openjdk.org/jdk/pull/20295.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20295#issuecomment-2244707983)