### PR TITLE
JDK-8333354: ubsan: frame.inline.hpp:91:25: and src/hotspot/share/runtime/frame.inline.hpp:88:29: runtime error: member call on null pointer of type 'const struct SmallRegisterMap'

### DIFF
--- a/src/hotspot/share/runtime/frame.inline.hpp
+++ b/src/hotspot/share/runtime/frame.inline.hpp
@@ -83,12 +83,12 @@ inline address frame::get_deopt_original_pc() const {
 
 template <typename RegisterMapT>
 inline address frame::oopmapreg_to_location(VMReg reg, const RegisterMapT* reg_map) const {
-  if (reg->is_reg()) {
+  if (reg_map != nullptr && reg->is_reg()) {
     // If it is passed in a register, it got spilled in the stub frame.
     return reg_map->location(reg, sp());
   } else {
     int sp_offset_in_bytes = reg->reg2stack() * VMRegImpl::stack_slot_size;
-    if (reg_map->in_cont()) {
+    if (reg_map != nullptr && reg_map->in_cont()) {
       return (address)((intptr_t)reg_map->as_RegisterMap()->stack_chunk()->relativize_usp_offset(*this, sp_offset_in_bytes));
     }
     address usp = (address)unextended_sp();


### PR DESCRIPTION
When running with ubsan - enabled binaries, some tests trigger the following report :

src/hotspot/share/runtime/frame.inline.hpp:91:25: runtime error: member call on null pointer of type 'const struct SmallRegisterMap'
    #0 0x7fc1df86071e in unsigned char* frame::oopmapreg_to_location<SmallRegisterMap>(VMRegImpl*, SmallRegisterMap const*) const src/hotspot/share/runtime/frame.inline.hpp:91
    #1 0x7fc1df86071e in void OopMapDo<OopClosure, DerivedOopClosure, IncludeAllValues>::iterate_oops_do<SmallRegisterMap>(frame const*, SmallRegisterMap const*, ImmutableOopMap const*) src/hotspot/share/compiler/oopMap.inline.hpp:106
    #2 0x7fc1df8611df in void OopMapDo<OopClosure, DerivedOopClosure, IncludeAllValues>::oops_do<SmallRegisterMap>(frame const*, SmallRegisterMap const*, ImmutableOopMap const*) src/hotspot/share/compiler/oopMap.inline.hpp:157
    #3 0x7fc1df8611df in FrameOopIterator<SmallRegisterMap>::oops_do(OopClosure*) src/hotspot/share/oops/stackChunkOop.cpp:63
    #4 0x7fc1dcfc8745 in BarrierSetStackChunk::encode_gc_mode(stackChunkOopDesc*, OopIterator*) src/hotspot/share/gc/shared/barrierSetStackChunk.cpp:85
    #5 0x7fc1df854080 in bool TransformStackChunkClosure::do_frame<(ChunkFrames)0, SmallRegisterMap>(StackChunkFrameStream<(ChunkFrames)0> const&, SmallRegisterMap const*) src/hotspot/share/oops/stackChunkOop.cpp:319
    #6 0x7fc1df854080 in void stackChunkOopDesc::iterate_stack<(ChunkFrames)0, TransformStackChunkClosure>(TransformStackChunkClosure*) src/hotspot/share/oops/stackChunkOop.inline.hpp:233
    #7 0x7fc1df82f184 in void stackChunkOopDesc::iterate_stack<TransformStackChunkClosure>(TransformStackChunkClosure*) src/hotspot/share/oops/stackChunkOop.inline.hpp:199

Seems in case of (at least) class SmallRegisterMap we miss handling nullptr .
