### PR TITLE
8337027: Parallel: Obsolete BaseFootPrintEstimate

### DIFF
--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.cpp
@@ -205,8 +205,6 @@ void PSAdaptiveSizePolicy::compute_eden_space_size(
                                            bool   is_full_gc) {
 
   // Update statistics
-  // Time statistics are updated as we go, update footprint stats here
-  _avg_base_footprint->sample(BaseFootPrintEstimate);
   avg_young_live()->sample(young_live);
   avg_eden_live()->sample(eden_live);
 
@@ -363,8 +361,7 @@ void PSAdaptiveSizePolicy::compute_eden_space_size(
   log_debug(gc, ergo)("Live_space: " SIZE_FORMAT " free_space: " SIZE_FORMAT,
                       live_space(), free_space());
 
-  log_trace(gc, ergo)("Base_footprint: " SIZE_FORMAT " avg_young_live: " SIZE_FORMAT " avg_old_live: " SIZE_FORMAT,
-                      (size_t)_avg_base_footprint->average(),
+  log_trace(gc, ergo)("avg_young_live: " SIZE_FORMAT " avg_old_live: " SIZE_FORMAT,
                       (size_t)avg_young_live()->average(),
                       (size_t)avg_old_live()->average());
 
@@ -535,8 +532,7 @@ void PSAdaptiveSizePolicy::compute_old_gen_free_space(
   log_debug(gc, ergo)("Live_space: " SIZE_FORMAT " free_space: " SIZE_FORMAT,
                       live_space(), free_space());
 
-  log_trace(gc, ergo)("Base_footprint: " SIZE_FORMAT " avg_young_live: " SIZE_FORMAT " avg_old_live: " SIZE_FORMAT,
-                      (size_t)_avg_base_footprint->average(),
+  log_trace(gc, ergo)("avg_young_live: " SIZE_FORMAT " avg_old_live: " SIZE_FORMAT,
                       (size_t)avg_young_live()->average(),
                       (size_t)avg_old_live()->average());
 

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
+++ b/src/hotspot/share/gc/parallel/psAdaptiveSizePolicy.hpp
@@ -145,8 +145,7 @@ class PSAdaptiveSizePolicy : public AdaptiveSizePolicy {
 
   // Footprint accessors
   size_t live_space() const {
-    return (size_t)(avg_base_footprint()->average() +
-                    avg_young_live()->average() +
+    return (size_t)(avg_young_live()->average() +
                     avg_old_live()->average());
   }
   size_t free_space() const {

--- a/src/hotspot/share/gc/parallel/psGCAdaptivePolicyCounters.cpp
+++ b/src/hotspot/share/gc/parallel/psGCAdaptivePolicyCounters.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/psGCAdaptivePolicyCounters.cpp
+++ b/src/hotspot/share/gc/parallel/psGCAdaptivePolicyCounters.cpp
@@ -107,10 +107,6 @@ PSGCAdaptivePolicyCounters::PSGCAdaptivePolicyCounters(const char* name_arg,
     _free_space = PerfDataManager::create_variable(SUN_GC, cname,
       PerfData::U_Bytes, ps_size_policy()->free_space(), CHECK);
 
-    cname = PerfDataManager::counter_name(name_space(), "avgBaseFootprint");
-    _avg_base_footprint = PerfDataManager::create_variable(SUN_GC, cname,
-      PerfData::U_Bytes, (jlong) ps_size_policy()->avg_base_footprint()->average(), CHECK);
-
     cname = PerfDataManager::counter_name(name_space(), "liveAtLastFullGc");
     _live_at_last_full_gc_counter =
       PerfDataManager::create_variable(SUN_GC, cname,
@@ -157,7 +153,6 @@ void PSGCAdaptivePolicyCounters::update_counters_from_policy() {
     update_decrement_tenuring_threshold_for_survivor_limit();
     update_live_space();
     update_free_space();
-    update_avg_base_footprint();
 
     update_change_old_gen_for_maj_pauses();
     update_change_young_gen_for_maj_pauses();

--- a/src/hotspot/share/gc/parallel/psGCAdaptivePolicyCounters.hpp
+++ b/src/hotspot/share/gc/parallel/psGCAdaptivePolicyCounters.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/parallel/psGCAdaptivePolicyCounters.hpp
+++ b/src/hotspot/share/gc/parallel/psGCAdaptivePolicyCounters.hpp
@@ -50,7 +50,6 @@ class PSGCAdaptivePolicyCounters : public GCAdaptivePolicyCounters {
   PerfVariable* _avg_major_interval;
   PerfVariable* _live_space;
   PerfVariable* _free_space;
-  PerfVariable* _avg_base_footprint;
   PerfVariable* _live_at_last_full_gc_counter;
   PerfVariable* _old_capacity;
 
@@ -142,11 +141,6 @@ class PSGCAdaptivePolicyCounters : public GCAdaptivePolicyCounters {
     _free_space->set_value(ps_size_policy()->free_space());
   }
 
-  inline void update_avg_base_footprint() {
-    _avg_base_footprint->set_value(
-      (jlong)(ps_size_policy()->avg_base_footprint()->average())
-    );
-  }
   inline void update_avg_old_live() {
     _avg_old_live_counter->set_value(
       (jlong)(ps_size_policy()->avg_old_live()->average())

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -422,10 +422,6 @@
           "Initial ratio of young generation/survivor space size")          \
           range(0, max_uintx)                                               \
                                                                             \
-  product(size_t, BaseFootPrintEstimate, 256*M,                             \
-          "Estimate of footprint other than Java Heap")                     \
-          range(0, max_uintx)                                               \
-                                                                            \
   product(bool, UseGCOverheadLimit, true,                                   \
           "Use policy to limit of proportion of time spent in GC "          \
           "before an OutOfMemory error is thrown")                          \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -521,6 +521,8 @@ static SpecialFlag const special_jvm_flags[] = {
   { "RTMRetryCount",                JDK_Version::jdk(23), JDK_Version::jdk(24), JDK_Version::jdk(25) },
 #endif // X86
 
+
+  { "BaseFootPrintEstimate",           JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "HeapFirstMaximumCompactionCount", JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(25) },
   { "UseVtableBasedCHA",               JDK_Version::undefined(), JDK_Version::jdk(24), JDK_Version::jdk(25) },
 #ifdef ASSERT

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1653,9 +1653,6 @@ jint Arguments::set_aggressive_heap_flags() {
 #endif
 
   // Increase some data structure sizes for efficiency
-  if (FLAG_SET_CMDLINE(BaseFootPrintEstimate, MaxHeapSize) != JVMFlag::SUCCESS) {
-    return JNI_EINVAL;
-  }
   if (FLAG_SET_CMDLINE(ResizeTLAB, false) != JVMFlag::SUCCESS) {
     return JNI_EINVAL;
   }

--- a/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/resources/aliasmap
+++ b/src/jdk.internal.jvmstat/share/classes/sun/jvmstat/perfdata/resources/aliasmap
@@ -404,8 +404,6 @@ alias sun.gc.lastCause                            // 1.5.0 b39
         hotspot.gc.last_cause                     // 1.4.2_02
 
 // sun.gc.policy
-alias sun.gc.policy.avgBaseFootprint              // 1.5.0 b39
-	hotspot.gc.policy.avg_base_footprint      // 1.5.0 b21
 alias sun.gc.policy.avgMajorIntervalTime          // 1.5.0 b39
 	hotspot.gc.policy.avg_major_interval      // 1.5.0 b21
 alias sun.gc.policy.avgMajorPauseTime             // 1.5.0 b39


### PR DESCRIPTION
Simple obsoleting a Parallel GC product flag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8337028](https://bugs.openjdk.org/browse/JDK-8337028) to be approved

### Issues
 * [JDK-8337027](https://bugs.openjdk.org/browse/JDK-8337027): Parallel: Obsolete BaseFootPrintEstimate (**Enhancement** - P4)
 * [JDK-8337028](https://bugs.openjdk.org/browse/JDK-8337028): Parallel: Obsolete BaseFootPrintEstimate (**CSR**)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) 🔄 Re-review required (review applies to [10720a6d](https://git.openjdk.org/jdk/pull/20299/files/10720a6d114b56573407a310f7c9b5082d608895))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20299/head:pull/20299` \
`$ git checkout pull/20299`

Update a local copy of the PR: \
`$ git checkout pull/20299` \
`$ git pull https://git.openjdk.org/jdk.git pull/20299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20299`

View PR using the GUI difftool: \
`$ git pr show -t 20299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20299.diff">https://git.openjdk.org/jdk/pull/20299.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20299#issuecomment-2245387817)