### PR TITLE
8334466: Ambiguous method call with generics may cause FunctionDescriptorLookupError

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1221,6 +1221,7 @@ public class Resolve {
                     tDescNoCapture = types.findDescriptorType(t);
                     sDesc = types.findDescriptorType(s);
                 } catch (Types.FunctionDescriptorLookupError ex) {
+                    // don't report, a more meaningful error should be reported upstream
                     return false;
                 }
                 final List<Type> tTypeParams = tDesc.getTypeArguments();

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1213,9 +1213,16 @@ public class Resolve {
 
             /** Parameters {@code t} and {@code s} are unrelated functional interface types. */
             private boolean functionalInterfaceMostSpecific(Type t, Type s, JCTree tree) {
-                Type tDesc = types.findDescriptorType(types.capture(t));
-                Type tDescNoCapture = types.findDescriptorType(t);
-                Type sDesc = types.findDescriptorType(s);
+                Type tDesc;
+                Type tDescNoCapture;
+                Type sDesc;
+                try {
+                    tDesc = types.findDescriptorType(types.capture(t));
+                    tDescNoCapture = types.findDescriptorType(t);
+                    sDesc = types.findDescriptorType(s);
+                } catch (Types.FunctionDescriptorLookupError ex) {
+                    return false;
+                }
                 final List<Type> tTypeParams = tDesc.getTypeArguments();
                 final List<Type> tTypeParamsNoCapture = tDescNoCapture.getTypeArguments();
                 final List<Type> sTypeParams = sDesc.getTypeArguments();

--- a/test/langtools/tools/javac/lambda/CrashWithFunctionDescriptorLookupErrorTest.java
+++ b/test/langtools/tools/javac/lambda/CrashWithFunctionDescriptorLookupErrorTest.java
@@ -1,0 +1,25 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8334466
+ * @summary Ambiguous method call with generics may cause FunctionDescriptorLookupError
+ * @compile/fail/ref=CrashWithFunctionDescriptorLookupErrorTest.out -XDrawDiagnostics CrashWithFunctionDescriptorLookupErrorTest.java
+ */
+
+import java.util.List;
+
+class CrashWithFunctionDescriptorLookupErrorTest {
+    void m() {
+        List<X> list = List.of(new X());
+        test(list.get(0));
+    }
+
+    void test(A<?> a) { }
+    void test(B<?> b) { }
+
+    interface A<T extends A<T>> { T a(); }
+    interface B<T extends B<T>> { T b(); }
+    class X implements A<X>, B<X> {
+        public X a() { return null; }
+        public X b() { return null; }
+    }
+}

--- a/test/langtools/tools/javac/lambda/CrashWithFunctionDescriptorLookupErrorTest.out
+++ b/test/langtools/tools/javac/lambda/CrashWithFunctionDescriptorLookupErrorTest.out
@@ -1,0 +1,2 @@
+CrashWithFunctionDescriptorLookupErrorTest.java:13:9: compiler.err.ref.ambiguous: test, kindname.method, test(CrashWithFunctionDescriptorLookupErrorTest.A<?>), CrashWithFunctionDescriptorLookupErrorTest, kindname.method, test(CrashWithFunctionDescriptorLookupErrorTest.B<?>), CrashWithFunctionDescriptorLookupErrorTest
+1 error


### PR DESCRIPTION
javac is crashing while compiling code like:

```
import java.util.List;

class Test {
    void m() {
        List<X> list = List.of(new X());
        test(list.get(0));
    }

    void test(A<?> a) { }
    void test(B<?> b) { }

    interface A<T extends A<T>> { T a(); }
    interface B<T extends B<T>> { T b(); }
    class X implements A<X>, B<X> {
        public X a() { return null; }
        public X b() { return null; }
    }
}
```
this is because method Types::findDescriptorType, which is invoked in this particular case, throws `FunctionDescriptorLookupError` which is an internal exception that is supposed to be captured by the client. The client then should interpret the exception depending on the context. This was not happening in the code path stressed by this test case. This PR is fixing this issue

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334466](https://bugs.openjdk.org/browse/JDK-8334466): Ambiguous method call with generics may cause FunctionDescriptorLookupError (**Bug** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20300/head:pull/20300` \
`$ git checkout pull/20300`

Update a local copy of the PR: \
`$ git checkout pull/20300` \
`$ git pull https://git.openjdk.org/jdk.git pull/20300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20300`

View PR using the GUI difftool: \
`$ git pr show -t 20300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20300.diff">https://git.openjdk.org/jdk/pull/20300.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20300#issuecomment-2245390199)