### PR TITLE
8336847: Use pattern match switch in NumberFormat classes

### DIFF
--- a/src/java.base/share/classes/java/text/CompactNumberFormat.java
+++ b/src/java.base/share/classes/java/text/CompactNumberFormat.java
@@ -539,58 +539,42 @@ public final class CompactNumberFormat extends NumberFormat {
     public final StringBuffer format(Object number,
             StringBuffer toAppendTo,
             FieldPosition fieldPosition) {
-
-        if (number == null) {
-            throw new IllegalArgumentException("Cannot format null as a number");
-        }
-
-        if (number instanceof Long || number instanceof Integer
-                || number instanceof Short || number instanceof Byte
-                || number instanceof AtomicInteger
-                || number instanceof AtomicLong
-                || (number instanceof BigInteger
-                && ((BigInteger) number).bitLength() < 64)) {
-            return format(((Number) number).longValue(), toAppendTo,
-                    fieldPosition);
-        } else if (number instanceof BigDecimal) {
-            return format((BigDecimal) number, StringBufFactory.of(toAppendTo), fieldPosition).asStringBuffer();
-        } else if (number instanceof BigInteger) {
-            return format((BigInteger) number, StringBufFactory.of(toAppendTo), fieldPosition).asStringBuffer();
-        } else if (number instanceof Number) {
-            return format(((Number) number).doubleValue(), toAppendTo, fieldPosition);
-        } else {
-            throw new IllegalArgumentException("Cannot format "
-                    + number.getClass().getName() + " as a number");
-        }
+        return switch (number) {
+            case Long l -> format(l.longValue(), toAppendTo, fieldPosition);
+            case Integer i -> format(i.longValue(), toAppendTo, fieldPosition);
+            case Short s -> format(s.longValue(), toAppendTo, fieldPosition);
+            case Byte b -> format(b.longValue(), toAppendTo, fieldPosition);
+            case AtomicInteger ai -> format(ai.longValue(), toAppendTo, fieldPosition);
+            case AtomicLong al -> format(al.longValue(), toAppendTo, fieldPosition);
+            case BigInteger bi when bi.bitLength() < 64 -> format(bi.longValue(), toAppendTo, fieldPosition);
+            case BigDecimal bd -> format(bd, StringBufFactory.of(toAppendTo), fieldPosition).asStringBuffer();
+            case BigInteger bi -> format(bi, StringBufFactory.of(toAppendTo), fieldPosition).asStringBuffer();
+            case Number n -> format(n.doubleValue(), toAppendTo, fieldPosition);
+            case null -> throw new IllegalArgumentException("Cannot format null as a number");
+            default -> throw new IllegalArgumentException(
+                    String.format("Cannot format %s as a number", number.getClass().getName()));
+        };
     }
 
     @Override
     StringBuf format(Object number,
                      StringBuf toAppendTo,
                      FieldPosition fieldPosition) {
-
-        if (number == null) {
-            throw new IllegalArgumentException("Cannot format null as a number");
-        }
-
-        if (number instanceof Long || number instanceof Integer
-                    || number instanceof Short || number instanceof Byte
-                    || number instanceof AtomicInteger
-                    || number instanceof AtomicLong
-                    || (number instanceof BigInteger
-                                && ((BigInteger) number).bitLength() < 64)) {
-            return format(((Number) number).longValue(), toAppendTo,
-                    fieldPosition);
-        } else if (number instanceof BigDecimal) {
-            return format((BigDecimal) number, toAppendTo, fieldPosition);
-        } else if (number instanceof BigInteger) {
-            return format((BigInteger) number, toAppendTo, fieldPosition);
-        } else if (number instanceof Number) {
-            return format(((Number) number).doubleValue(), toAppendTo, fieldPosition);
-        } else {
-            throw new IllegalArgumentException("Cannot format "
-                                                       + number.getClass().getName() + " as a number");
-        }
+        return switch (number) {
+            case Long l -> format(l.longValue(), toAppendTo, fieldPosition);
+            case Integer i -> format(i.longValue(), toAppendTo, fieldPosition);
+            case Short s -> format(s.longValue(), toAppendTo, fieldPosition);
+            case Byte b -> format(b.longValue(), toAppendTo, fieldPosition);
+            case AtomicInteger ai -> format(ai.longValue(), toAppendTo, fieldPosition);
+            case AtomicLong al -> format(al.longValue(), toAppendTo, fieldPosition);
+            case BigInteger bi when bi.bitLength() < 64 -> format(bi.longValue(), toAppendTo, fieldPosition);
+            case BigDecimal bd -> format(bd, toAppendTo, fieldPosition);
+            case BigInteger bi -> format(bi, toAppendTo, fieldPosition);
+            case Number n -> format(n.doubleValue(), toAppendTo, fieldPosition);
+            case null -> throw new IllegalArgumentException("Cannot format null as a number");
+            default -> throw new IllegalArgumentException(
+                    String.format("Cannot format %s as a number", number.getClass().getName()));
+        };
     }
 
     /**
@@ -1182,22 +1166,20 @@ public final class CompactNumberFormat extends NumberFormat {
         CharacterIteratorFieldDelegate delegate
                 = new CharacterIteratorFieldDelegate();
         StringBuf sb = StringBufFactory.of();
-
-        if (obj instanceof Double || obj instanceof Float) {
-            format(((Number) obj).doubleValue(), sb, delegate);
-        } else if (obj instanceof Long || obj instanceof Integer
-                || obj instanceof Short || obj instanceof Byte
-                || obj instanceof AtomicInteger || obj instanceof AtomicLong) {
-            format(((Number) obj).longValue(), sb, delegate);
-        } else if (obj instanceof BigDecimal) {
-            format((BigDecimal) obj, sb, delegate);
-        } else if (obj instanceof BigInteger) {
-            format((BigInteger) obj, sb, delegate, false);
-        } else if (obj == null) {
-            throw new NullPointerException(
+        switch (obj) {
+            case Double d -> format(d.doubleValue(), sb, delegate);
+            case Float f -> format(f.doubleValue(), sb, delegate);
+            case Long l -> format(l.longValue(), sb, delegate);
+            case Integer i -> format(i.longValue(), sb, delegate);
+            case Short s -> format(s.longValue(), sb, delegate);
+            case Byte b -> format(b.longValue(), sb, delegate);
+            case AtomicInteger ai -> format(ai.longValue(), sb, delegate);
+            case AtomicLong al -> format(al.longValue(), sb, delegate);
+            case BigDecimal bd -> format(bd, sb, delegate);
+            case BigInteger bi -> format(bi, sb, delegate, false);
+            case null -> throw new NullPointerException(
                     "formatToCharacterIterator must be passed non-null object");
-        } else {
-            throw new IllegalArgumentException(
+            default -> throw new IllegalArgumentException(
                     "Cannot format given Object as a Number");
         }
         return delegate.getIterator(sb.toString());

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -559,8 +559,7 @@ public class DecimalFormat extends NumberFormat {
             case BigDecimal bd -> format(bd, StringBufFactory.of(toAppendTo), pos).asStringBuffer();
             case BigInteger bi -> format(bi, StringBufFactory.of(toAppendTo), pos).asStringBuffer();
             case Number n -> format(n.doubleValue(), toAppendTo, pos);
-            default ->
-                    throw new IllegalArgumentException("Cannot format given Object as a Number");
+            case null, default -> throw new IllegalArgumentException("Cannot format given Object as a Number");
         };
     }
 
@@ -579,8 +578,7 @@ public class DecimalFormat extends NumberFormat {
             case BigDecimal bd -> format(bd, toAppendTo, pos);
             case BigInteger bi -> format(bi, toAppendTo, pos);
             case Number n -> format(n.doubleValue(), toAppendTo, pos);
-            default ->
-                    throw new IllegalArgumentException("Cannot format given Object as a Number");
+            case null, default -> throw new IllegalArgumentException("Cannot format given Object as a Number");
         };
     }
 

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -1782,11 +1782,14 @@ public class DecimalFormat extends NumberFormat {
     }
 
     /**
-     * Sets the {@code DigitList} used by this {@code DecimalFormat}
+     * Utility method that sets the {@code DigitList} used by this {@code DecimalFormat}
      * instance.
+     *
      * @param number the number to format
      * @param isNegative true, if the number is negative; false otherwise
      * @param maxDigits the max digits
+     * @throws AssertionError if provided a Number subclass that is not supported
+     *         by {@code DigitList}
      */
     void setDigitList(Number number, boolean isNegative, int maxDigits) {
         switch (number) {
@@ -1794,7 +1797,8 @@ public class DecimalFormat extends NumberFormat {
             case BigDecimal bd -> digitList.set(isNegative, bd, maxDigits, true);
             case Long l -> digitList.set(isNegative, l, maxDigits);
             case BigInteger bi -> digitList.set(isNegative, bi, maxDigits);
-            default -> {} // do nothing
+            default -> throw new AssertionError(
+                    String.format("DigitList does not support %s", number.getClass().getName()));
         }
     }
 

--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -548,44 +548,40 @@ public class DecimalFormat extends NumberFormat {
     public final StringBuffer format(Object number,
                                      StringBuffer toAppendTo,
                                      FieldPosition pos) {
-        if (number instanceof Long || number instanceof Integer ||
-                   number instanceof Short || number instanceof Byte ||
-                   number instanceof AtomicInteger ||
-                   number instanceof AtomicLong ||
-                   (number instanceof BigInteger &&
-                    ((BigInteger)number).bitLength () < 64)) {
-            return format(((Number)number).longValue(), toAppendTo, pos);
-        } else if (number instanceof BigDecimal) {
-            return format((BigDecimal)number, StringBufFactory.of(toAppendTo), pos).asStringBuffer();
-        } else if (number instanceof BigInteger) {
-            return format((BigInteger)number, StringBufFactory.of(toAppendTo), pos).asStringBuffer();
-        } else if (number instanceof Number) {
-            return format(((Number)number).doubleValue(), toAppendTo, pos);
-        } else {
-            throw new IllegalArgumentException("Cannot format given Object as a Number");
-        }
+        return switch (number) {
+            case Long l -> format(l.longValue(), toAppendTo, pos);
+            case Integer i -> format(i.longValue(), toAppendTo, pos);
+            case Short s -> format(s.longValue(), toAppendTo, pos);
+            case Byte b -> format(b.longValue(), toAppendTo, pos);
+            case AtomicInteger ai -> format(ai.longValue(), toAppendTo, pos);
+            case AtomicLong al -> format(al.longValue(), toAppendTo, pos);
+            case BigInteger bi when bi.bitLength() < 64 -> format(bi.longValue(), toAppendTo, pos);
+            case BigDecimal bd -> format(bd, StringBufFactory.of(toAppendTo), pos).asStringBuffer();
+            case BigInteger bi -> format(bi, StringBufFactory.of(toAppendTo), pos).asStringBuffer();
+            case Number n -> format(n.doubleValue(), toAppendTo, pos);
+            default ->
+                    throw new IllegalArgumentException("Cannot format given Object as a Number");
+        };
     }
 
     @Override
     final StringBuf format(Object number,
                            StringBuf toAppendTo,
                            FieldPosition pos) {
-        if (number instanceof Long || number instanceof Integer ||
-                    number instanceof Short || number instanceof Byte ||
-                    number instanceof AtomicInteger ||
-                    number instanceof AtomicLong ||
-                    (number instanceof BigInteger &&
-                             ((BigInteger) number).bitLength() < 64)) {
-            return format(((Number) number).longValue(), toAppendTo, pos);
-        } else if (number instanceof BigDecimal) {
-            return format((BigDecimal) number, toAppendTo, pos);
-        } else if (number instanceof BigInteger) {
-            return format((BigInteger) number, toAppendTo, pos);
-        } else if (number instanceof Number) {
-            return format(((Number) number).doubleValue(), toAppendTo, pos);
-        } else {
-            throw new IllegalArgumentException("Cannot format given Object as a Number");
-        }
+        return switch (number) {
+            case Long l -> format(l.longValue(), toAppendTo, pos);
+            case Integer i -> format(i.longValue(), toAppendTo, pos);
+            case Short s -> format(s.longValue(), toAppendTo, pos);
+            case Byte b -> format(b.longValue(), toAppendTo, pos);
+            case AtomicInteger ai -> format(ai.longValue(), toAppendTo, pos);
+            case AtomicLong al -> format(al.longValue(), toAppendTo, pos);
+            case BigInteger bi when bi.bitLength() < 64 -> format(bi.longValue(), toAppendTo, pos);
+            case BigDecimal bd -> format(bd, toAppendTo, pos);
+            case BigInteger bi -> format(bi, toAppendTo, pos);
+            case Number n -> format(n.doubleValue(), toAppendTo, pos);
+            default ->
+                    throw new IllegalArgumentException("Cannot format given Object as a Number");
+        };
     }
 
     /**
@@ -1021,25 +1017,23 @@ public class DecimalFormat extends NumberFormat {
     @Override
     public AttributedCharacterIterator formatToCharacterIterator(Object obj) {
         CharacterIteratorFieldDelegate delegate =
-                         new CharacterIteratorFieldDelegate();
+                new CharacterIteratorFieldDelegate();
         StringBuf sb = StringBufFactory.of();
-
-        if (obj instanceof Double || obj instanceof Float) {
-            format(((Number)obj).doubleValue(), sb, delegate);
-        } else if (obj instanceof Long || obj instanceof Integer ||
-                   obj instanceof Short || obj instanceof Byte ||
-                   obj instanceof AtomicInteger || obj instanceof AtomicLong) {
-            format(((Number)obj).longValue(), sb, delegate);
-        } else if (obj instanceof BigDecimal) {
-            format((BigDecimal)obj, sb, delegate);
-        } else if (obj instanceof BigInteger) {
-            format((BigInteger)obj, sb, delegate, false);
-        } else if (obj == null) {
-            throw new NullPointerException(
-                "formatToCharacterIterator must be passed non-null object");
-        } else {
-            throw new IllegalArgumentException(
-                "Cannot format given Object as a Number");
+        switch (obj) {
+            case Double d -> format(d.doubleValue(), sb, delegate);
+            case Float f -> format(f.doubleValue(), sb, delegate);
+            case Long l -> format(l.longValue(), sb, delegate);
+            case Integer i -> format(i.longValue(), sb, delegate);
+            case Short s -> format(s.longValue(), sb, delegate);
+            case Byte b -> format(b.longValue(), sb, delegate);
+            case AtomicInteger ai -> format(ai.longValue(), sb, delegate);
+            case AtomicLong al -> format(al.longValue(), sb, delegate);
+            case BigDecimal bd -> format(bd, sb, delegate);
+            case BigInteger bi -> format(bi, sb, delegate, false);
+            case null -> throw new NullPointerException(
+                    "formatToCharacterIterator must be passed non-null object");
+            default -> throw new IllegalArgumentException(
+                    "Cannot format given Object as a Number");
         }
         return delegate.getIterator(sb.toString());
     }
@@ -1797,15 +1791,12 @@ public class DecimalFormat extends NumberFormat {
      * @param maxDigits the max digits
      */
     void setDigitList(Number number, boolean isNegative, int maxDigits) {
-
-        if (number instanceof Double) {
-            digitList.set(isNegative, (Double) number, maxDigits, true);
-        } else if (number instanceof BigDecimal) {
-            digitList.set(isNegative, (BigDecimal) number, maxDigits, true);
-        } else if (number instanceof Long) {
-            digitList.set(isNegative, (Long) number, maxDigits);
-        } else if (number instanceof BigInteger) {
-            digitList.set(isNegative, (BigInteger) number, maxDigits);
+        switch (number) {
+            case Double d -> digitList.set(isNegative, d, maxDigits, true);
+            case BigDecimal bd -> digitList.set(isNegative, bd, maxDigits, true);
+            case Long l -> digitList.set(isNegative, l, maxDigits);
+            case BigInteger bi -> digitList.set(isNegative, bi, maxDigits);
+            default -> {} // do nothing
         }
     }
 

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -311,7 +311,7 @@ public abstract class NumberFormat extends Format  {
             case AtomicLong al -> format(al.longValue(), toAppendTo, pos);
             case BigInteger bi when bi.bitLength() < 64 -> format(bi.longValue(), toAppendTo, pos);
             case Number n -> format(n.doubleValue(), toAppendTo, pos);
-            default -> throw new IllegalArgumentException("Cannot format given Object as a Number");
+            case null, default -> throw new IllegalArgumentException("Cannot format given Object as a Number");
         };
     }
 
@@ -328,7 +328,7 @@ public abstract class NumberFormat extends Format  {
             case AtomicLong al -> format(al.longValue(), toAppendTo, pos);
             case BigInteger bi when bi.bitLength() < 64 -> format(bi.longValue(), toAppendTo, pos);
             case Number n -> format(n.doubleValue(), toAppendTo, pos);
-            default -> throw new IllegalArgumentException("Cannot format given Object as a Number");
+            case null, default  -> throw new IllegalArgumentException("Cannot format given Object as a Number");
         };
     }
 

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -328,7 +328,7 @@ public abstract class NumberFormat extends Format  {
             case AtomicLong al -> format(al.longValue(), toAppendTo, pos);
             case BigInteger bi when bi.bitLength() < 64 -> format(bi.longValue(), toAppendTo, pos);
             case Number n -> format(n.doubleValue(), toAppendTo, pos);
-            case null, default  -> throw new IllegalArgumentException("Cannot format given Object as a Number");
+            case null, default -> throw new IllegalArgumentException("Cannot format given Object as a Number");
         };
     }
 

--- a/src/java.base/share/classes/java/text/NumberFormat.java
+++ b/src/java.base/share/classes/java/text/NumberFormat.java
@@ -302,34 +302,34 @@ public abstract class NumberFormat extends Format  {
     public StringBuffer format(Object number,
                                StringBuffer toAppendTo,
                                FieldPosition pos) {
-        if (number instanceof Long || number instanceof Integer ||
-            number instanceof Short || number instanceof Byte ||
-            number instanceof AtomicInteger || number instanceof AtomicLong ||
-            (number instanceof BigInteger &&
-             ((BigInteger)number).bitLength() < 64)) {
-            return format(((Number)number).longValue(), toAppendTo, pos);
-        } else if (number instanceof Number) {
-            return format(((Number)number).doubleValue(), toAppendTo, pos);
-        } else {
-            throw new IllegalArgumentException("Cannot format given Object as a Number");
-        }
+        return switch (number) {
+            case Long l -> format(l.longValue(), toAppendTo, pos);
+            case Integer i -> format(i.longValue(), toAppendTo, pos);
+            case Short s -> format(s.longValue(), toAppendTo, pos);
+            case Byte b -> format(b.longValue(), toAppendTo, pos);
+            case AtomicInteger ai -> format(ai.longValue(), toAppendTo, pos);
+            case AtomicLong al -> format(al.longValue(), toAppendTo, pos);
+            case BigInteger bi when bi.bitLength() < 64 -> format(bi.longValue(), toAppendTo, pos);
+            case Number n -> format(n.doubleValue(), toAppendTo, pos);
+            default -> throw new IllegalArgumentException("Cannot format given Object as a Number");
+        };
     }
 
     @Override
     StringBuf format(Object number,
                      StringBuf toAppendTo,
                      FieldPosition pos) {
-        if (number instanceof Long || number instanceof Integer ||
-                    number instanceof Short || number instanceof Byte ||
-                    number instanceof AtomicInteger || number instanceof AtomicLong ||
-                    (number instanceof BigInteger &&
-                             ((BigInteger) number).bitLength() < 64)) {
-            return format(((Number) number).longValue(), toAppendTo, pos);
-        } else if (number instanceof Number) {
-            return format(((Number) number).doubleValue(), toAppendTo, pos);
-        } else {
-            throw new IllegalArgumentException("Cannot format given Object as a Number");
-        }
+        return switch (number) {
+            case Long l -> format(l.longValue(), toAppendTo, pos);
+            case Integer i -> format(i.longValue(), toAppendTo, pos);
+            case Short s -> format(s.longValue(), toAppendTo, pos);
+            case Byte b -> format(b.longValue(), toAppendTo, pos);
+            case AtomicInteger ai -> format(ai.longValue(), toAppendTo, pos);
+            case AtomicLong al -> format(al.longValue(), toAppendTo, pos);
+            case BigInteger bi when bi.bitLength() < 64 -> format(bi.longValue(), toAppendTo, pos);
+            case Number n -> format(n.doubleValue(), toAppendTo, pos);
+            default -> throw new IllegalArgumentException("Cannot format given Object as a Number");
+        };
     }
 
     /**


### PR DESCRIPTION
As discussed in https://github.com/openjdk/jdk/pull/19513#discussion_r1684957942, there is code within java.text.NumberFormat (and subclasses) that can use the pattern match switch to improve readability.

As this is simply cleanup, there is no regression test added. (Tiers 1-3 and java_text JCK ran to ensure clean migration).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336847](https://bugs.openjdk.org/browse/JDK-8336847): Use pattern match switch in NumberFormat classes (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role) 🔄 Re-review required (review applies to [2efa5d3f](https://git.openjdk.org/jdk/pull/20302/files/2efa5d3f5a14b5cb5c581bebceffec214eda43c6))
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20302/head:pull/20302` \
`$ git checkout pull/20302`

Update a local copy of the PR: \
`$ git checkout pull/20302` \
`$ git pull https://git.openjdk.org/jdk.git pull/20302/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20302`

View PR using the GUI difftool: \
`$ git pr show -t 20302`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20302.diff">https://git.openjdk.org/jdk/pull/20302.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20302#issuecomment-2245838473)