### PR TITLE
8336787: Examine java.text.Format API for implSpec usage

### DIFF
--- a/src/java.base/share/classes/java/text/Format.java
+++ b/src/java.base/share/classes/java/text/Format.java
@@ -149,12 +149,12 @@ public abstract class Format implements Serializable, Cloneable {
 
     /**
      * Formats an object to produce a string.
-     * This method returns a string that would be equal to the string returned by
+     *
+     * @implSpec This method returns a string that would be equal to the string returned by
      * <blockquote>
      * {@link #format(Object, StringBuffer, FieldPosition) format}<code>(obj,
      *         new StringBuffer(), new FieldPosition(0)).toString();</code>
      * </blockquote>
-     *
      * @param obj    The object to format
      * @return       Formatted string.
      * @throws    IllegalArgumentException if the Format cannot format the given
@@ -207,11 +207,11 @@ public abstract class Format implements Serializable, Cloneable {
      * to define what the legal values are for each attribute in the
      * {@code AttributedCharacterIterator}, but typically the attribute
      * key is also used as the attribute value.
-     * <p>The default implementation creates an
-     * {@code AttributedCharacterIterator} with no attributes. Subclasses
-     * that support fields should override this and create an
-     * {@code AttributedCharacterIterator} with meaningful attributes.
      *
+     * @apiNote Subclasses that support fields should override this and create an
+     * {@code AttributedCharacterIterator} with meaningful attributes.
+     * @implSpec The default implementation creates an
+     * {@code AttributedCharacterIterator} with no attributes.
      * @throws    NullPointerException if obj is null.
      * @throws    IllegalArgumentException when the Format cannot format the
      *            given object.


### PR DESCRIPTION
As discussed in https://bugs.openjdk.org/browse/JDK-8335834, there are occurrences in the java.text.Format API that would benefit from the implSpec (and apiNote) tag. 

This is a doc-only change, and a CSR has also been filed.

I did not think "_Subclasses that support fields should override this and create an ..._" sounded right under the `implSpec` tag, and moved it to an `apiNote` tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8337039](https://bugs.openjdk.org/browse/JDK-8337039) to be approved

### Issues
 * [JDK-8336787](https://bugs.openjdk.org/browse/JDK-8336787): Examine java.text.Format API for implSpec usage (**Bug** - P4)
 * [JDK-8337039](https://bugs.openjdk.org/browse/JDK-8337039): Examine java.text.Format API for implSpec usage (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20303/head:pull/20303` \
`$ git checkout pull/20303`

Update a local copy of the PR: \
`$ git checkout pull/20303` \
`$ git pull https://git.openjdk.org/jdk.git pull/20303/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20303`

View PR using the GUI difftool: \
`$ git pr show -t 20303`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20303.diff">https://git.openjdk.org/jdk/pull/20303.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20303#issuecomment-2245904732)