### PR TITLE
8337031: Improvements to CompilationMemoryStatistic

### DIFF
--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -194,7 +194,7 @@ class MemStatEntry : public CHeapObj<mtInternal> {
   // peak usage, bytes, over all arenas
   size_t _total;
   // usage per arena tag when total peaked
-  ArenaTagsCounter _peak_by_tag;
+  ArenaCountersByTag _peak_by_tag;
   // number of nodes (c2 only) when total peaked
   unsigned _live_nodes_at_peak;
   const char* _result;
@@ -216,7 +216,7 @@ public:
   void inc_recompilation() { _num_recomp++; }
 
   void set_total(size_t n) { _total = n; }
-  void set_peak_by_tag(ArenaTagsCounter peak_by_tag) { _peak_by_tag = peak_by_tag; }
+  void set_peak_by_tag(ArenaCountersByTag peak_by_tag) { _peak_by_tag = peak_by_tag; }
   void set_live_nodes_at_peak(unsigned n) { _live_nodes_at_peak = n; }
 
   void set_result(const char* s) { _result = s; }
@@ -352,7 +352,7 @@ class MemStatTable :
 public:
 
   void add(const FullMethodName& fmn, CompilerType comptype,
-           size_t total, ArenaTagsCounter peak_by_tag,
+           size_t total, ArenaCountersByTag peak_by_tag,
            unsigned live_nodes_at_peak, size_t limit, const char* result) {
     assert_lock_strong(NMTCompilationCostHistory_lock);
     MemStatTableKey key(fmn, comptype);

--- a/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.cpp
@@ -51,29 +51,36 @@
 #include "utilities/quickSort.hpp"
 #include "utilities/resourceHash.hpp"
 
-ArenaStatCounter::ArenaStatCounter() :
-  _current(0), _start(0), _peak(0),
-  _na(0), _ra(0),
-  _limit(0), _hit_limit(false), _limit_in_process(false),
-  _na_at_peak(0), _ra_at_peak(0), _live_nodes_at_peak(0)
-{}
+ArenaStatCounter::ArenaStatCounter() {
+  init();
+}
 
-size_t ArenaStatCounter::peak_since_start() const {
-  return _peak > _start ? _peak - _start : 0;
+void ArenaStatCounter::init() {
+  _current = 0;
+  _peak = 0;
+  memset(_tags_size, 0, sizeof(_tags_size));
+  memset(_tags_size_at_peak, 0, sizeof(_tags_size_at_peak));
+  _limit = 0;
+  _hit_limit = false;
+  _limit_in_process = false;
+  _live_nodes_at_peak = 0;
+  _active = false;
 }
 
 void ArenaStatCounter::start(size_t limit) {
-  _peak = _start = _current;
+  init();
+  _active = true;
   _limit = limit;
-  _hit_limit = false;
 }
 
-void ArenaStatCounter::end(){
+void ArenaStatCounter::end() {
   _limit = 0;
   _hit_limit = false;
+  _active = false;
 }
 
 void ArenaStatCounter::update_c2_node_count() {
+  assert(_active, "compilaton has not yet started");
 #ifdef COMPILER2
   CompilerThread* const th = Thread::current()->as_Compiler_thread();
   const CompileTask* const task = th->task();
@@ -90,33 +97,34 @@ void ArenaStatCounter::update_c2_node_count() {
 
 // Account an arena allocation or de-allocation.
 bool ArenaStatCounter::account(ssize_t delta, int tag) {
+  assert(_active, "compilaton has not yet started");
   bool rc = false;
 #ifdef ASSERT
   // Note: if this fires, we free more arena memory under the scope of the
   // CompilationMemoryHistoryMark than we allocate. This cannot be since we
   // assume arena allocations in CompilerThread to be stack bound and symmetric.
   assert(delta >= 0 || ((ssize_t)_current + delta) >= 0,
-         "Negative overflow (d=%zd %zu %zu %zu)", delta, _current, _start, _peak);
+         "Negative overflow (d=%zd %zu %zu)", delta, _current, _peak);
 #endif
   // Update totals
   _current += delta;
-  // Update detail counter
-  switch ((Arena::Tag)tag) {
-    case Arena::Tag::tag_ra: _ra += delta; break;
-    case Arena::Tag::tag_node: _na += delta; break;
-    default: // ignore
-      break;
-  };
+  _tags_size[tag] += delta;
+  size_t total = 0;
+  for (int tag = 0; tag < Arena::tag_count(); tag++) {
+    total += _tags_size[tag];
+  }
+  if (total != _current) {
+    log_info(compilation, alloc)("WARNING!!! Total does not match current");
+  }
   // Did we reach a peak?
   if (_current > _peak) {
     _peak = _current;
-    assert(delta > 0, "Sanity (%zu %zu %zu)", _current, _start, _peak);
-    _na_at_peak = _na;
-    _ra_at_peak = _ra;
+    assert(delta > 0, "Sanity (%zu %zu)", _current, _peak);
     update_c2_node_count();
+    memcpy(_tags_size_at_peak, _tags_size, sizeof(_tags_size));
     rc = true;
     // Did we hit the memory limit?
-    if (!_hit_limit && _limit > 0 && peak_since_start() > _limit) {
+    if (!_hit_limit && _limit > 0 && _peak > _limit) {
       _hit_limit = true;
     }
   }
@@ -124,9 +132,15 @@ bool ArenaStatCounter::account(ssize_t delta, int tag) {
 }
 
 void ArenaStatCounter::print_on(outputStream* st) const {
-  st->print("%zu [na %zu ra %zu]", peak_since_start(), _na_at_peak, _ra_at_peak);
+  st->print("%zu [", _peak);
+  for (int tag = 0; tag < Arena::tag_count(); tag++) {
+    if (_tags_size_at_peak[tag] > 0) {
+      st->print("%s %zu ", Arena::tag_name[tag], _tags_size_at_peak[tag]);
+    }
+  }
+  st->print("]");
 #ifdef ASSERT
-  st->print(" (%zu->%zu->%zu)", _start, _peak, _current);
+  st->print(" (%zu->%zu)", _peak, _current);
 #endif
 }
 
@@ -186,10 +200,8 @@ class MemStatEntry : public CHeapObj<mtInternal> {
 
   // peak usage, bytes, over all arenas
   size_t _total;
-  // usage in node arena when total peaked
-  size_t _na_at_peak;
-  // usage in resource area when total peaked
-  size_t _ra_at_peak;
+  // usage per arena tag when total peaked
+  size_t _tags_size_at_peak[Arena::tag_count()];
   // number of nodes (c2 only) when total peaked
   unsigned _live_nodes_at_peak;
   const char* _result;
@@ -199,8 +211,9 @@ public:
   MemStatEntry(FullMethodName method)
     : _method(method), _comptype(compiler_c1),
       _time(0), _num_recomp(0), _thread(nullptr), _limit(0),
-      _total(0), _na_at_peak(0), _ra_at_peak(0), _live_nodes_at_peak(0),
+      _total(0), _live_nodes_at_peak(0),
       _result(nullptr) {
+    memset(_tags_size_at_peak, 0, sizeof(_tags_size_at_peak));
   }
 
   void set_comptype(CompilerType comptype) { _comptype = comptype; }
@@ -210,8 +223,10 @@ public:
   void inc_recompilation() { _num_recomp++; }
 
   void set_total(size_t n) { _total = n; }
-  void set_na_at_peak(size_t n) { _na_at_peak = n; }
-  void set_ra_at_peak(size_t n) { _ra_at_peak = n; }
+  void set_tags_size_at_peak(size_t* tags_size_at_peak, int nelements) {
+    assert(nelements*sizeof(size_t) <= sizeof(_tags_size_at_peak), "overflow check");
+    memcpy(_tags_size_at_peak, tags_size_at_peak, nelements*sizeof(size_t));
+  }
   void set_live_nodes_at_peak(unsigned n) { _live_nodes_at_peak = n; }
 
   void set_result(const char* s) { _result = s; }
@@ -219,21 +234,34 @@ public:
   size_t total() const { return _total; }
 
   static void print_legend(outputStream* st) {
+#define LEGEND_KEY_FMT "%11s"
     st->print_cr("Legend:");
-    st->print_cr("  total  : memory allocated via arenas while compiling");
-    st->print_cr("  NA     : ...how much in node arenas (if c2)");
-    st->print_cr("  RA     : ...how much in resource areas");
-    st->print_cr("  result : Result: 'ok' finished successfully, 'oom' hit memory limit, 'err' compilation failed");
-    st->print_cr("  #nodes : ...how many nodes (c2 only)");
-    st->print_cr("  limit  : memory limit, if set");
-    st->print_cr("  time   : time of last compilation (sec)");
-    st->print_cr("  type   : compiler type");
-    st->print_cr("  #rc    : how often recompiled");
-    st->print_cr("  thread : compiler thread");
+    st->print_cr("  " LEGEND_KEY_FMT ": %s", "total", "memory allocated via arenas while compiling");
+    for (int tag = 0; tag < Arena::tag_count(); tag++) {
+      st->print_cr("  " LEGEND_KEY_FMT ": %s", Arena::tag_name[tag], Arena::tag_desc[tag]);
+    }
+    st->print_cr("  " LEGEND_KEY_FMT ": %s", "result", "Result: 'ok' finished successfully, 'oom' hit memory limit, 'err' compilation failed");
+    st->print_cr("  " LEGEND_KEY_FMT ": %s", "#nodes", "...how many nodes (c2 only)");
+    st->print_cr("  " LEGEND_KEY_FMT ": %s", "limit", "memory limit, if set");
+    st->print_cr("  " LEGEND_KEY_FMT ": %s", "time", "time taken for last compilation (sec)");
+    st->print_cr("  " LEGEND_KEY_FMT ": %s", "type", "compiler type");
+    st->print_cr("  " LEGEND_KEY_FMT ": %s", "#rc", "how often recompiled");
+    st->print_cr("  " LEGEND_KEY_FMT ": %s", "thread", "compiler thread");
+#undef LEGEND_KEY_FMT
   }
 
   static void print_header(outputStream* st) {
-    st->print_cr("total     NA        RA        result  #nodes  limit   time    type  #rc thread              method");
+#define SIZE_FMT "%-10s"
+    st->print(SIZE_FMT, "total");
+    for (int tag = 0; tag < Arena::tag_count(); tag++) {
+      st->print(SIZE_FMT, Arena::tag_name[tag]);
+    }
+#define HDR_FMT1 "%-8s%-8s%-8s%-8s"
+#define HDR_FMT2 "%-6s%-4s%-19s%s"
+
+    st->print(HDR_FMT1, "result", "#nodes", "limit", "time");
+    st->print(HDR_FMT2, "type", "#rc", "thread", "method");
+    st->print_cr("");
   }
 
   void print_on(outputStream* st, bool human_readable) const {
@@ -247,21 +275,14 @@ public:
     }
     col += 10; st->fill_to(col);
 
-    // NA
-    if (human_readable) {
-      st->print(PROPERFMT " ", PROPERFMTARGS(_na_at_peak));
-    } else {
-      st->print("%zu ", _na_at_peak);
+    for (int tag = 0; tag < Arena::tag_count(); tag++) {
+      if (human_readable) {
+        st->print(PROPERFMT " ", PROPERFMTARGS(_tags_size_at_peak[tag]));
+      } else {
+        st->print("%zu ", _tags_size_at_peak[tag]);
+      }
+      col += 10; st->fill_to(col);
     }
-    col += 10; st->fill_to(col);
-
-    // RA
-    if (human_readable) {
-      st->print(PROPERFMT " ", PROPERFMTARGS(_ra_at_peak));
-    } else {
-      st->print("%zu ", _ra_at_peak);
-    }
-    col += 10; st->fill_to(col);
 
     // result?
     st->print("%s ", _result ? _result : "");
@@ -296,7 +317,7 @@ public:
     col += 4; st->fill_to(col);
 
     // Thread
-    st->print(PTR_FORMAT "  ", p2i(_thread));
+    st->print(PTR_FORMAT " ", p2i(_thread));
 
     // MethodName
     char buf[1024];
@@ -341,7 +362,7 @@ class MemStatTable :
 public:
 
   void add(const FullMethodName& fmn, CompilerType comptype,
-           size_t total, size_t na_at_peak, size_t ra_at_peak,
+           size_t total, size_t* tags_size_at_peak, int nelements,
            unsigned live_nodes_at_peak, size_t limit, const char* result) {
     assert_lock_strong(NMTCompilationCostHistory_lock);
     MemStatTableKey key(fmn, comptype);
@@ -360,8 +381,7 @@ public:
     e->set_comptype(comptype);
     e->inc_recompilation();
     e->set_total(total);
-    e->set_na_at_peak(na_at_peak);
-    e->set_ra_at_peak(ra_at_peak);
+    e->set_tags_size_at_peak(tags_size_at_peak, nelements);
     e->set_live_nodes_at_peak(live_nodes_at_peak);
     e->set_limit(limit);
     e->set_result(result);
@@ -427,7 +447,7 @@ void CompilationMemoryStatistic::on_end_compilation() {
   const bool print = directive->should_print_memstat();
 
   // Store memory used in task, for later processing by JFR
-  task->set_arena_bytes(arena_stat->peak_since_start());
+  task->set_arena_bytes(arena_stat->peak());
 
   // Store result
   // For this to work, we must call on_end_compilation() at a point where
@@ -447,9 +467,9 @@ void CompilationMemoryStatistic::on_end_compilation() {
     assert(_the_table != nullptr, "not initialized");
 
     _the_table->add(fmn, ct,
-                    arena_stat->peak_since_start(), // total
-                    arena_stat->na_at_peak(),
-                    arena_stat->ra_at_peak(),
+                    arena_stat->peak(), // total
+                    (size_t *)arena_stat->tags_size_at_peak(),
+                    Arena::tag_count(),
                     arena_stat->live_nodes_at_peak(),
                     arena_stat->limit(),
                     result);
@@ -511,7 +531,7 @@ void CompilationMemoryStatistic::on_arena_change(ssize_t diff, const Arena* aren
 
   bool hit_limit_before = arena_stat->hit_limit();
 
-  if (arena_stat->account(diff, (int)arena->get_tag())) { // new peak?
+  if (arena_stat->is_active() && arena_stat->account(diff, (int)arena->get_tag())) { // new peak?
 
     // Limit handling
     if (arena_stat->hit_limit()) {
@@ -545,7 +565,7 @@ void CompilationMemoryStatistic::on_arena_change(ssize_t diff, const Arena* aren
         }
         ss.print("Hit MemLimit %s(limit: %zu now: %zu)",
                  (hit_limit_before ? "again " : ""),
-                 arena_stat->limit(), arena_stat->peak_since_start());
+                 arena_stat->limit(), arena_stat->peak());
       }
 
       // log if needed

--- a/src/hotspot/share/compiler/compilationMemoryStatistic.hpp
+++ b/src/hotspot/share/compiler/compilationMemoryStatistic.hpp
@@ -37,7 +37,7 @@ class Symbol;
 class DirectiveSet;
 
 // Helper class to wrap the array of arena tags for easier processing
-class ArenaTagsCounter {
+class ArenaCountersByTag {
 private:
   size_t _counter[Arena::tag_count()];
 
@@ -67,9 +67,9 @@ class ArenaStatCounter : public CHeapObj<mtCompiler> {
   // bytes at last peak, total
   size_t _peak;
   // Current bytes used by arenas per tag
-  ArenaTagsCounter _current_by_tag;
+  ArenaCountersByTag _current_by_tag;
   // Peak composition:
-  ArenaTagsCounter _peak_by_tag;
+  ArenaCountersByTag _peak_by_tag;
   // MemLimit handling
   size_t _limit;
   bool _hit_limit;
@@ -92,7 +92,7 @@ public:
   size_t peak() const { return _peak; }
 
   // Peak details
-  ArenaTagsCounter peak_by_tag() const { return _peak_by_tag; }
+  ArenaCountersByTag peak_by_tag() const { return _peak_by_tag; }
   unsigned live_nodes_at_peak() const { return _live_nodes_at_peak; }
 
   // Mark the start and end of a compilation.

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -44,6 +44,26 @@ STATIC_ASSERT(is_aligned((int)Chunk::init_size, ARENA_AMALLOC_ALIGNMENT));
 STATIC_ASSERT(is_aligned((int)Chunk::medium_size, ARENA_AMALLOC_ALIGNMENT));
 STATIC_ASSERT(is_aligned((int)Chunk::size, ARENA_AMALLOC_ALIGNMENT));
 
+#define ARENA_TAG_STRING_(str) #str
+#define ARENA_TAG_STRING(name, str, desc) ARENA_TAG_STRING_(str),
+
+const char* Arena::tag_name[] = {
+  DO_ARENA_TAG(ARENA_TAG_STRING)
+};
+
+#undef ARENA_TAG_STRING
+#undef ARENA_TAG_STRING_
+
+#define ARENA_TAG_DESC_(desc) #desc
+#define ARENA_TAG_DESC(name, str, desc) ARENA_TAG_DESC_(desc),
+
+const char* Arena::tag_desc[] = {
+  DO_ARENA_TAG(ARENA_TAG_DESC)
+};
+
+#undef ARENA_TAG_DESC
+#undef ARENA_TAG_DESC_
+
 // MT-safe pool of same-sized chunks to reduce malloc/free thrashing
 // NB: not using Mutex because pools are used before Threads are initialized
 class ChunkPool {

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -44,25 +44,18 @@ STATIC_ASSERT(is_aligned((int)Chunk::init_size, ARENA_AMALLOC_ALIGNMENT));
 STATIC_ASSERT(is_aligned((int)Chunk::medium_size, ARENA_AMALLOC_ALIGNMENT));
 STATIC_ASSERT(is_aligned((int)Chunk::size, ARENA_AMALLOC_ALIGNMENT));
 
-#define ARENA_TAG_STRING_(str) #str
-#define ARENA_TAG_STRING(name, str, desc) ARENA_TAG_STRING_(str),
 
 const char* Arena::tag_name[] = {
+#define ARENA_TAG_STRING(name, str, desc) XSTR(name),
   DO_ARENA_TAG(ARENA_TAG_STRING)
-};
-
 #undef ARENA_TAG_STRING
-#undef ARENA_TAG_STRING_
-
-#define ARENA_TAG_DESC_(desc) #desc
-#define ARENA_TAG_DESC(name, str, desc) ARENA_TAG_DESC_(desc),
+};
 
 const char* Arena::tag_desc[] = {
+#define ARENA_TAG_DESC(name, str, desc) XSTR(desc),
   DO_ARENA_TAG(ARENA_TAG_DESC)
-};
-
 #undef ARENA_TAG_DESC
-#undef ARENA_TAG_DESC_
+};
 
 // MT-safe pool of same-sized chunks to reduce malloc/free thrashing
 // NB: not using Mutex because pools are used before Threads are initialized

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -83,16 +83,33 @@ public:
   bool contains(char* p) const  { return bottom() <= p && p <= top(); }
 };
 
+#define DO_ARENA_TAG(template) \
+  template(other, Others, Other arenas) \
+  template(ra, RA, Resource areas) \
+  template(ha, HA, Handle area) \
+  template(node, NA, Node arena) \
+
 // Fast allocation of memory
 class Arena : public CHeapObjBase {
 public:
 
-  enum class Tag : uint8_t {
-    tag_other = 0,
-    tag_ra,   // resource area
-    tag_ha,   // handle area
-    tag_node  // C2 Node arena
+#define ARENA_TAG_ENUM_(name) tag_##name
+#define ARENA_TAG_ENUM(name, str, desc) ARENA_TAG_ENUM_(name),
+
+  enum class Tag: uint8_t {
+    DO_ARENA_TAG(ARENA_TAG_ENUM)
+    tag_count
   };
+
+#undef ARENA_TAG_ENUM
+#undef ARENA_TAG_ENUM_
+
+  constexpr static int tag_count() {
+    return static_cast<int>(Tag::tag_count);
+  }
+
+  static const char* tag_name[static_cast<int>(Arena::Tag::tag_count)];
+  static const char* tag_desc[static_cast<int>(Arena::Tag::tag_count)];
 
 private:
   const MEMFLAGS _flags;        // Memory tracking flags

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -83,26 +83,21 @@ public:
   bool contains(char* p) const  { return bottom() <= p && p <= top(); }
 };
 
-#define DO_ARENA_TAG(template) \
-  template(other, Others, Other arenas) \
-  template(ra, RA, Resource areas) \
-  template(ha, HA, Handle area) \
-  template(node, NA, Node arena) \
+#define DO_ARENA_TAG(FN) \
+  FN(other, Others, Other arenas) \
+  FN(ra, RA, Resource areas) \
+  FN(ha, HA, Handle area) \
+  FN(node, NA, Node arena) \
 
 // Fast allocation of memory
 class Arena : public CHeapObjBase {
 public:
-
-#define ARENA_TAG_ENUM_(name) tag_##name
-#define ARENA_TAG_ENUM(name, str, desc) ARENA_TAG_ENUM_(name),
-
   enum class Tag: uint8_t {
+#define ARENA_TAG_ENUM(name, str, desc) tag_##name,
     DO_ARENA_TAG(ARENA_TAG_ENUM)
+#undef ARENA_TAG_ENUM
     tag_count
   };
-
-#undef ARENA_TAG_ENUM
-#undef ARENA_TAG_ENUM_
 
   constexpr static int tag_count() {
     return static_cast<int>(Tag::tag_count);

--- a/test/hotspot/jtreg/compiler/print/CompileCommandPrintMemStat.java
+++ b/test/hotspot/jtreg/compiler/print/CompileCommandPrintMemStat.java
@@ -77,10 +77,10 @@ public class CompileCommandPrintMemStat {
 
         // Should see final report
         // Looks like this:
-        // total     NA        RA        result  #nodes  limit   time    type  #rc thread              method
-        // 2149912   0         1986272   ok      -       -       0.101   c1    1   0x000000015180a600  jdk/internal/org/objectweb/asm/Frame::execute((IILjdk/internal/org/objectweb/asm/Symbol;Ljdk/internal/org/objectweb/asm/SymbolTable;)V)
+        // total     Others    RA        HA        NA        result  #nodes  limit   time    type  #rc thread             method
+        // 523648    32728     490920    0         0         ok      -       -       0.250   c1    1   0x00007f4ec00d4ac0 java/lang/Class::descriptorString(()Ljava/lang/String;)
         // or
-        // 537784    98184     208536    ok      267     -       0.096   c2    1   0x0000000153019c00  jdk/internal/classfile/impl/BufWriterImpl::writeU1((I)V)
+        // 1898600   853176    750872    0         294552    ok      934     -       1.501   c2    1   0x00007f4ec00d3330 java/lang/String::replace((CC)Ljava/lang/String;)
         oa.shouldMatch("total.*method");
         oa.shouldMatch("\\d+ +(\\d+ +){4}ok +(\\d+|-) +.*" + expectedNameIncl + ".*");
 

--- a/test/hotspot/jtreg/compiler/print/CompileCommandPrintMemStat.java
+++ b/test/hotspot/jtreg/compiler/print/CompileCommandPrintMemStat.java
@@ -78,15 +78,16 @@ public class CompileCommandPrintMemStat {
         // Should see final report
         // Looks like this:
         // total     NA        RA        result  #nodes  limit   time    type  #rc thread              method
-        // 2149912   0         1986272   ok      -       -       0.101   c1    1   0x000000015180a600  jdk/internal/org/objectweb/asm/Frame::execute((IILjdk/internal/org/objectweb/asm/Symbol;Ljdk/internal/org/objectweb/asm/SymbolTable;)V)        oa.shouldMatch("total.*method");
+        // 2149912   0         1986272   ok      -       -       0.101   c1    1   0x000000015180a600  jdk/internal/org/objectweb/asm/Frame::execute((IILjdk/internal/org/objectweb/asm/Symbol;Ljdk/internal/org/objectweb/asm/SymbolTable;)V)
         // or
-        // 537784    98184     208536    ok      267     -       0.096   c2    1   0x0000000153019c00  jdk/internal/classfile/impl/BufWriterImpl::writeU1((I)V) 4521912   0         1986272   ok      -       -       0.101   c1    1   0x000000015180a600  jdk/internal/org/objectweb/asm/Frame::execute((IILjdk/internal/org/objectweb/asm/Symbol;Ljdk/internal/org/objectweb/asm/SymbolTable;)V)        oa.shouldMatch("total.*method");
-        oa.shouldMatch("\\d+ +\\d+ +\\d+ +ok +(\\d+|-) +.*" + expectedNameIncl + ".*");
+        // 537784    98184     208536    ok      267     -       0.096   c2    1   0x0000000153019c00  jdk/internal/classfile/impl/BufWriterImpl::writeU1((I)V)
+        oa.shouldMatch("total.*method");
+        oa.shouldMatch("\\d+ +(\\d+ +){4}ok +(\\d+|-) +.*" + expectedNameIncl + ".*");
 
         // In debug builds, we have a default memory limit enabled. That implies MemStat. Therefore we
         // expect to see all methods, not just the one we specified on the command line.
         if (Platform.isDebugBuild()) {
-            oa.shouldMatch("\\d+ +\\d+ +\\d+ +ok +(\\d+|-) +.*" + expectedNameExcl + ".*");
+            oa.shouldMatch("\\d+ +(\\d+ +){4}ok +(\\d+|-) +.*" + expectedNameExcl + ".*");
         } else {
             oa.shouldNotMatch(".*" + expectedNameExcl + ".*");
         }

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CompilerMemoryStatisticTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CompilerMemoryStatisticTest.java
@@ -47,8 +47,8 @@ public class CompilerMemoryStatisticTest {
         out.shouldHaveExitValue(0);
 
         // Looks like this:
-        // total     NA        RA        result  #nodes  time    type  #rc thread              method
-        // 211488    66440     77624     ok      13      0.057   c2    2   0x00007fb49428db70  compiler/print/CompileCommandPrintMemStat$TestMain::method1(()V)
+        // total     Others    RA        HA        NA        result  #nodes  limit   time    type  #rc thread             method
+        // 1898600   853176    750872    0         294552    ok      934     -       1.501   c2    1   0x00007f4ec00d3330 java/lang/String::replace((CC)Ljava/lang/String;)
         out.shouldMatch("total.*method");
         out.shouldMatch("\\d+ +(\\d+ +){4}\\S+ +\\d+.*java.*\\(.*\\)");
     }

--- a/test/hotspot/jtreg/serviceability/dcmd/compiler/CompilerMemoryStatisticTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/compiler/CompilerMemoryStatisticTest.java
@@ -50,6 +50,6 @@ public class CompilerMemoryStatisticTest {
         // total     NA        RA        result  #nodes  time    type  #rc thread              method
         // 211488    66440     77624     ok      13      0.057   c2    2   0x00007fb49428db70  compiler/print/CompileCommandPrintMemStat$TestMain::method1(()V)
         out.shouldMatch("total.*method");
-        out.shouldMatch("\\d+ +\\d+ +\\d+ +\\S+ +\\d+.*java.*\\(.*\\)");
+        out.shouldMatch("\\d+ +(\\d+ +){4}\\S+ +\\d+.*java.*\\(.*\\)");
     }
 }


### PR DESCRIPTION
Some minor improvements to CompilationMemoryStatistic. More details are in [JDK-8337031](https://bugs.openjdk.org/browse/JDK-8337031)

Testing:
  test/hotspot/jtreg/compiler/print/CompileCommandPrintMemStat.java
  test/hotspot/jtreg/serviceability/dcmd/compiler/CompilerMemoryStatisticTest.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337031](https://bugs.openjdk.org/browse/JDK-8337031): Improvements to CompilationMemoryStatistic (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) 🔄 Re-review required (review applies to [008ac6b9](https://git.openjdk.org/jdk/pull/20304/files/008ac6b93d32c32825532d45914434ecb5c4d524))
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20304/head:pull/20304` \
`$ git checkout pull/20304`

Update a local copy of the PR: \
`$ git checkout pull/20304` \
`$ git pull https://git.openjdk.org/jdk.git pull/20304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20304`

View PR using the GUI difftool: \
`$ git pr show -t 20304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20304.diff">https://git.openjdk.org/jdk/pull/20304.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20304#issuecomment-2246376684)