### PR TITLE
8337067: Test runtime/classFileParserBug/Bad_NCDFE_Msg.java won't compile

### DIFF
--- a/test/hotspot/jtreg/runtime/classFileParserBug/Bad_NCDFE_Msg.java
+++ b/test/hotspot/jtreg/runtime/classFileParserBug/Bad_NCDFE_Msg.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@
  *          java.management
  * @compile C.java
  * @run driver Bad_NCDFE_Msg
+ */
 
 import java.io.File;
 import jdk.test.lib.process.ProcessTools;


### PR DESCRIPTION
Trivial fix to a test to restore a comment block terminator that was deleted in a bad merge two years ago.

Testing: ran the test 10x on each of our main platforms

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337067](https://bugs.openjdk.org/browse/JDK-8337067): Test runtime/classFileParserBug/Bad_NCDFE_Msg.java won't compile (**Bug** - P4)


### Reviewers
 * [Lois Foltan](https://openjdk.org/census#lfoltan) (@lfoltan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20307/head:pull/20307` \
`$ git checkout pull/20307`

Update a local copy of the PR: \
`$ git checkout pull/20307` \
`$ git pull https://git.openjdk.org/jdk.git pull/20307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20307`

View PR using the GUI difftool: \
`$ git pr show -t 20307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20307.diff">https://git.openjdk.org/jdk/pull/20307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20307#issuecomment-2246903795)