### PR TITLE
8336879: Always true condition 'img != null' in GTKPainter.paintPopupMenuBackground

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
@@ -610,7 +610,7 @@ class GTKPainter extends SynthPainter {
                 x + insets.left, y + insets.top, w - insets.left - insets.right,
                 h - insets.top - insets.bottom);
             BufferedImage img = ENGINE.finishPainting();
-            if(!isHW) {
+            if(!isHW && img != null) {
                 int border = img.getRGB(0, h / 2);
                 if (border == img.getRGB(w / 2, h / 2)) {
                     // fix no menu borders in Adwaita theme

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
@@ -610,10 +610,10 @@ class GTKPainter extends SynthPainter {
                 x + insets.left, y + insets.top, w - insets.left - insets.right,
                 h - insets.top - insets.bottom);
             BufferedImage img = ENGINE.finishPainting();
-            if(!isHW && img != null) {
+            if (!isHW && img != null) {
                 int border = img.getRGB(0, h / 2);
                 if (border == img.getRGB(w / 2, h / 2)) {
-                    // fix no menu borders in Adwaita theme
+                    // fix no menu borders
                     Graphics g2 = img.getGraphics();
                     Color c = new Color(border);
                     g2.setColor(new Color(Math.max((int) (c.getRed() * 0.8), 0),

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
@@ -612,7 +612,7 @@ class GTKPainter extends SynthPainter {
             BufferedImage img = ENGINE.finishPainting();
             if(!isHW) {
                 int border = img.getRGB(0, h / 2);
-                if (img != null && border == img.getRGB(w / 2, h / 2)) {
+                if (border == img.getRGB(w / 2, h / 2)) {
                     // fix no menu borders in Adwaita theme
                     Graphics g2 = img.getGraphics();
                     Color c = new Color(border);


### PR DESCRIPTION
In GTKPainter.paintPopupMenuBackground method, `img != null` condition will always be true, because it's only checked after `img.getRGB` method is called and that means img can't be `null`.  So, the null check condition is removed. CI testing is ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336879](https://bugs.openjdk.org/browse/JDK-8336879): Always true condition 'img != null' in GTKPainter.paintPopupMenuBackground (**Bug** - P5)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20308/head:pull/20308` \
`$ git checkout pull/20308`

Update a local copy of the PR: \
`$ git checkout pull/20308` \
`$ git pull https://git.openjdk.org/jdk.git pull/20308/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20308`

View PR using the GUI difftool: \
`$ git pr show -t 20308`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20308.diff">https://git.openjdk.org/jdk/pull/20308.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20308#issuecomment-2246918161)