### PR TITLE
8334482: Shenandoah: Deadlock when safepoint is pending during nmethods iteration

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
@@ -95,19 +95,16 @@ public:
 
 class ShenandoahDisarmNMethodsTask : public WorkerTask {
 private:
+  size_t                              _expected_workers;
   ShenandoahDisarmNMethodClosure      _cl;
   ShenandoahConcurrentNMethodIterator _iterator;
 
 public:
   ShenandoahDisarmNMethodsTask() :
     WorkerTask("Shenandoah Disarm NMethods"),
-    _iterator(ShenandoahCodeRoots::table()) {
+    _expected_workers(ShenandoahHeap::heap()->workers()->active_workers()),
+    _iterator(ShenandoahCodeRoots::table(), _expected_workers) {
     assert(SafepointSynchronize::is_at_safepoint(), "Only at a safepoint");
-    _iterator.nmethods_do_begin();
-  }
-
-  ~ShenandoahDisarmNMethodsTask() {
-    _iterator.nmethods_do_end();
   }
 
   virtual void work(uint worker_id) {
@@ -175,12 +172,7 @@ public:
   ShenandoahUnlinkTask(bool unloading_occurred) :
     WorkerTask("Shenandoah Unlink NMethods"),
     _cl(unloading_occurred),
-    _iterator(ShenandoahCodeRoots::table()) {
-    _iterator.nmethods_do_begin();
-  }
-
-  ~ShenandoahUnlinkTask() {
-    _iterator.nmethods_do_end();
+    _iterator(ShenandoahCodeRoots::table(), ShenandoahHeap::heap()->workers()->active_workers()) {
   }
 
   virtual void work(uint worker_id) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
@@ -95,15 +95,13 @@ public:
 
 class ShenandoahDisarmNMethodsTask : public WorkerTask {
 private:
-  size_t                              _expected_workers;
   ShenandoahDisarmNMethodClosure      _cl;
   ShenandoahConcurrentNMethodIterator _iterator;
 
 public:
   ShenandoahDisarmNMethodsTask() :
     WorkerTask("Shenandoah Disarm NMethods"),
-    _expected_workers(ShenandoahHeap::heap()->workers()->active_workers()),
-    _iterator(ShenandoahCodeRoots::table(), _expected_workers) {
+    _iterator(ShenandoahCodeRoots::table(), ShenandoahHeap::heap()->workers()->active_workers()) {
     assert(SafepointSynchronize::is_at_safepoint(), "Only at a safepoint");
   }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahCodeRoots.cpp
@@ -101,7 +101,7 @@ private:
 public:
   ShenandoahDisarmNMethodsTask() :
     WorkerTask("Shenandoah Disarm NMethods"),
-    _iterator(ShenandoahCodeRoots::table(), ShenandoahHeap::heap()->workers()->active_workers()) {
+    _iterator(ShenandoahCodeRoots::table()) {
     assert(SafepointSynchronize::is_at_safepoint(), "Only at a safepoint");
   }
 
@@ -170,8 +170,7 @@ public:
   ShenandoahUnlinkTask(bool unloading_occurred) :
     WorkerTask("Shenandoah Unlink NMethods"),
     _cl(unloading_occurred),
-    _iterator(ShenandoahCodeRoots::table(), ShenandoahHeap::heap()->workers()->active_workers()) {
-  }
+    _iterator(ShenandoahCodeRoots::table()) {}
 
   virtual void work(uint worker_id) {
     _iterator.nmethods_do(&_cl);

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -753,7 +753,6 @@ public:
 // dead weak roots.
 class ShenandoahConcurrentWeakRootsEvacUpdateTask : public WorkerTask {
 private:
-  uint                                 const _expected_workers;
   ShenandoahVMWeakRoots<true /*concurrent*/> _vm_roots;
 
   // Roots related to concurrent class unloading
@@ -765,12 +764,10 @@ private:
 public:
   ShenandoahConcurrentWeakRootsEvacUpdateTask(ShenandoahPhaseTimings::Phase phase) :
     WorkerTask("Shenandoah Evacuate/Update Concurrent Weak Roots"),
-    _expected_workers(ShenandoahHeap::heap()->workers()->active_workers()),
     _vm_roots(phase),
-    _cld_roots(phase, _expected_workers, false /*heap iteration*/),
-    _nmethod_itr(ShenandoahCodeRoots::table(), _expected_workers),
-    _phase(phase) {
-  }
+    _cld_roots(phase, ShenandoahHeap::heap()->workers()->active_workers(), false /*heap iteration*/),
+    _nmethod_itr(ShenandoahCodeRoots::table()),
+    _phase(phase) {}
 
   ~ShenandoahConcurrentWeakRootsEvacUpdateTask() {
     // Notify runtime data structures of potentially dead oops
@@ -862,7 +859,6 @@ public:
 
 class ShenandoahConcurrentRootsEvacUpdateTask : public WorkerTask {
 private:
-  uint                                    const _expected_workers;
   ShenandoahPhaseTimings::Phase                 _phase;
   ShenandoahVMRoots<true /*concurrent*/>        _vm_roots;
   ShenandoahClassLoaderDataRoots<true /*concurrent*/>
@@ -872,12 +868,10 @@ private:
 public:
   ShenandoahConcurrentRootsEvacUpdateTask(ShenandoahPhaseTimings::Phase phase) :
     WorkerTask("Shenandoah Evacuate/Update Concurrent Strong Roots"),
-    _expected_workers(ShenandoahHeap::heap()->workers()->active_workers()),
     _phase(phase),
     _vm_roots(phase),
-    _cld_roots(phase, _expected_workers, false /*heap iteration*/),
-    _nmethod_itr(ShenandoahCodeRoots::table(), _expected_workers) {
-  }
+    _cld_roots(phase, ShenandoahHeap::heap()->workers()->active_workers(), false /*heap iteration*/),
+    _nmethod_itr(ShenandoahCodeRoots::table()) {}
 
   void work(uint worker_id) {
     ShenandoahConcurrentWorkerSession worker_session(worker_id);

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -47,7 +47,6 @@
 #include "gc/shenandoah/shenandoahWorkerPolicy.hpp"
 #include "memory/allocation.hpp"
 #include "prims/jvmtiTagMap.hpp"
-#include "runtime/safepointVerifiers.hpp"
 #include "runtime/vmThread.hpp"
 #include "utilities/events.hpp"
 
@@ -754,7 +753,7 @@ public:
 // dead weak roots.
 class ShenandoahConcurrentWeakRootsEvacUpdateTask : public WorkerTask {
 private:
-  size_t                                     _expected_workers;
+  uint                                 const _expected_workers;
   ShenandoahVMWeakRoots<true /*concurrent*/> _vm_roots;
 
   // Roots related to concurrent class unloading
@@ -863,7 +862,7 @@ public:
 
 class ShenandoahConcurrentRootsEvacUpdateTask : public WorkerTask {
 private:
-  size_t                                        _expected_workers;
+  uint                                    const _expected_workers;
   ShenandoahPhaseTimings::Phase                 _phase;
   ShenandoahVMRoots<true /*concurrent*/>        _vm_roots;
   ShenandoahClassLoaderDataRoots<true /*concurrent*/>
@@ -902,7 +901,6 @@ public:
     if (!ShenandoahHeap::heap()->unload_classes()) {
       ShenandoahWorkerTimingsTracker timer(_phase, ShenandoahPhaseTimings::CodeCacheRoots, worker_id);
       ShenandoahEvacUpdateCodeCacheClosure cl;
-
       _nmethod_itr.nmethods_do(&cl);
     }
   }

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
@@ -181,13 +181,14 @@ class ShenandoahConcurrentNMethodIterator {
 private:
   ShenandoahNMethodTable*         const _table;
   ShenandoahNMethodTableSnapshot*       _table_snapshot;
+  size_t                                _workers_expected;
+  size_t                                _workers_started;
+  size_t                                _workers_finished;
 
 public:
-  ShenandoahConcurrentNMethodIterator(ShenandoahNMethodTable* table);
+  ShenandoahConcurrentNMethodIterator(ShenandoahNMethodTable* table, size_t expected_workers);
 
-  void nmethods_do_begin();
   void nmethods_do(NMethodClosure* cl);
-  void nmethods_do_end();
 };
 
 #endif // SHARE_GC_SHENANDOAH_SHENANDOAHNMETHOD_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
@@ -181,12 +181,12 @@ class ShenandoahConcurrentNMethodIterator {
 private:
   ShenandoahNMethodTable*         const _table;
   ShenandoahNMethodTableSnapshot*       _table_snapshot;
-  size_t                                _workers_expected;
-  size_t                                _workers_started;
-  size_t                                _workers_finished;
+  uint                            const _expected_workers;
+  uint                                  _started_workers;
+  uint                                  _finished_workers;
 
 public:
-  ShenandoahConcurrentNMethodIterator(ShenandoahNMethodTable* table, size_t expected_workers);
+  ShenandoahConcurrentNMethodIterator(ShenandoahNMethodTable* table, uint expected_workers);
 
   void nmethods_do(NMethodClosure* cl);
 };

--- a/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahNMethod.hpp
@@ -181,12 +181,11 @@ class ShenandoahConcurrentNMethodIterator {
 private:
   ShenandoahNMethodTable*         const _table;
   ShenandoahNMethodTableSnapshot*       _table_snapshot;
-  uint                            const _expected_workers;
   uint                                  _started_workers;
   uint                                  _finished_workers;
 
 public:
-  ShenandoahConcurrentNMethodIterator(ShenandoahNMethodTable* table, uint expected_workers);
+  ShenandoahConcurrentNMethodIterator(ShenandoahNMethodTable* table);
 
   void nmethods_do(NMethodClosure* cl);
 };


### PR DESCRIPTION
There is a problem in interaction between STS taken in `ShenandoahConcurrentWeakRootsEvacUpdateTask::work` and nmethod list iteration. If we start the nmethod iteration in `ShCWREUT` constructor, proceed to STS and block, any waiter that waits for the end of iteration would block until safepoint is over. If that waiter waits without a safepoint check, like anyone waiting on `CodeCache_lock`, e.g. Sweeper (not really in mainline, but we seen a case in JDK 17), or a JIT compiler patching code, then we would have a deadlock.

A solution is to initialize iteration only immediately before the use of iterator. This will pass any pending STSes that we have seen could deadlock. As long as nothing in nmethod handling safepoints, the deadlock is resolved. I think `NoSafepointVerifier` would give us a warning if something safepoints while iteration is on.

Unfortunately, it is really hard to reproduce in mainline, since the absence of Sweeper makes this deadlock exceedingly rare.

Additional testing:
 - [x] Reproducer on JDK 17u with this patch applied now does not deadlock
 - [x] Linux AArch64 server fastdebug, `all` with `-XX:+UseShenandoahGC`
 - [x] Linux x86_64 server fastdebug, `all` with `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334482](https://bugs.openjdk.org/browse/JDK-8334482): Shenandoah: Deadlock when safepoint is pending during nmethods iteration (**Bug** - P3)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Xiaolong Peng](https://openjdk.org/census#xpeng) (@pengxiaolong - Author)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20309/head:pull/20309` \
`$ git checkout pull/20309`

Update a local copy of the PR: \
`$ git checkout pull/20309` \
`$ git pull https://git.openjdk.org/jdk.git pull/20309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20309`

View PR using the GUI difftool: \
`$ git pr show -t 20309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20309.diff">https://git.openjdk.org/jdk/pull/20309.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20309#issuecomment-2248804081)