### PR TITLE
8337102: JITTester: Fix breaks in static initialization blocks

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/conf/default.properties
+++ b/test/hotspot/jtreg/testlibrary/jittester/conf/default.properties
@@ -8,6 +8,6 @@ classes-file=conf/classes.lst
 exclude-methods-file=conf/exclude.methods.lst
 print-complexity=true
 print-hierarchy=true
-disable-static=true
+disable-static=false
 generatorsFactories=jdk.test.lib.jittester.TestGeneratorsFactory
 generators=JavaCode,ByteCode

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/StaticConstructorDefinitionFactory.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/factories/StaticConstructorDefinitionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -63,7 +63,7 @@ class StaticConstructorDefinitionFactory extends Factory<StaticConstructorDefini
                     .setOperatorLimit(operatorLimit)
                     .setLevel(level)
                     .setSubBlock(true)
-                    .setCanHaveBreaks(true)
+                    .setCanHaveBreaks(false)
                     .setCanHaveContinues(false)
                     .setCanHaveReturn(false)
                     .getBlockFactory()


### PR DESCRIPTION
Static initialisation blocks (SIBs) should not have `break`s in their code, as well as their descendants. Currently, StaticConstructorDefinitionFactory allows them, causing non-compilable constructions like this:

```
class Test_0 {
    static {
        if (true) {
            break; // <- compilation error here
        }
    }
}
```

It seems like previously an attempt have been made to resolve this by disabling SIBs whatsoever.

Currently, out of 100 generated tests we have 2-3 compilation errors.
Allowing SIBs raises this to 80 out of 100 tests failing due to erroneous 'break' blocks.
Disabling breaks in StaticConstructorDefinition gives us SIBs, and returns failure rate to the same 2-3%.
Disabling breaks in StaticConstructorDefinition doesn't prevent breaks from happening, as loop factories (`ForFactory`, `WhileFactory`, etc.) explicitly allow for breaks in their descendant trees.

Testing: 
1. 200-300 generations in various setups to get the numbers mentioned above;
2. I checked manually that breaks do not disappear from code,
3. ... and appear in loops' (for, while, do-while) descendants.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337102](https://bugs.openjdk.org/browse/JDK-8337102): JITTester: Fix breaks in static initialization blocks (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20310/head:pull/20310` \
`$ git checkout pull/20310`

Update a local copy of the PR: \
`$ git checkout pull/20310` \
`$ git pull https://git.openjdk.org/jdk.git pull/20310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20310`

View PR using the GUI difftool: \
`$ git pr show -t 20310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20310.diff">https://git.openjdk.org/jdk/pull/20310.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20310#issuecomment-2254208480)