### PR TITLE
8336999: Verification for resource area allocated data structures in C2

### DIFF
--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -132,7 +132,7 @@ class CompileReplay : public StackObj {
   char* _bufptr;
   char* _buffer;
   int   _buffer_length;
-  ReallocMark _nesting; // assertion check for reallocations
+  ReallocMark _nesting; // Safety checks for arena reallocation
 
   // "compile" data
   ciKlass* _iklass;
@@ -602,9 +602,9 @@ class CompileReplay : public StackObj {
     int buffer_pos = 0;
     while(c != EOF) {
       if (buffer_pos + 1 >= _buffer_length) {
+        _nesting.check(); // Check if a reallocation in the resource arena is safe
         int new_length = _buffer_length * 2;
         // Next call will throw error in case of OOM.
-        _nesting.check();
         _buffer = REALLOC_RESOURCE_ARRAY(char, _buffer, _buffer_length, new_length);
         _buffer_length = new_length;
       }

--- a/src/hotspot/share/ci/ciReplay.cpp
+++ b/src/hotspot/share/ci/ciReplay.cpp
@@ -132,6 +132,7 @@ class CompileReplay : public StackObj {
   char* _bufptr;
   char* _buffer;
   int   _buffer_length;
+  ReallocMark _nesting; // assertion check for reallocations
 
   // "compile" data
   ciKlass* _iklass;
@@ -603,6 +604,7 @@ class CompileReplay : public StackObj {
       if (buffer_pos + 1 >= _buffer_length) {
         int new_length = _buffer_length * 2;
         // Next call will throw error in case of OOM.
+        _nesting.check();
         _buffer = REALLOC_RESOURCE_ARRAY(char, _buffer, _buffer_length, new_length);
         _buffer_length = new_length;
       }

--- a/src/hotspot/share/libadt/vectset.cpp
+++ b/src/hotspot/share/libadt/vectset.cpp
@@ -48,9 +48,9 @@ void VectorSet::init(Arena* arena) {
 
 // Expand the existing set to a bigger size
 void VectorSet::grow(uint new_word_capacity) {
-  _nesting.check(_set_arena);
+  _nesting.check(_set_arena); // Check if a potential reallocation in the arena is safe
   if (new_word_capacity < _size) {
-    return; // no need to grow
+    return; // No need to grow
   }
   assert(new_word_capacity < (1U << 30), "");
   uint x = next_power_of_2(new_word_capacity);

--- a/src/hotspot/share/libadt/vectset.cpp
+++ b/src/hotspot/share/libadt/vectset.cpp
@@ -48,6 +48,10 @@ void VectorSet::init(Arena* arena) {
 
 // Expand the existing set to a bigger size
 void VectorSet::grow(uint new_word_capacity) {
+  _nesting.check(_set_arena);
+  if (new_word_capacity < _size) {
+    return; // no need to grow
+  }
   assert(new_word_capacity < (1U << 30), "");
   uint x = next_power_of_2(new_word_capacity);
   if (x > _data_size) {

--- a/src/hotspot/share/libadt/vectset.hpp
+++ b/src/hotspot/share/libadt/vectset.hpp
@@ -46,8 +46,7 @@ private:
   // Allocated words
   uint       _data_size;
   Arena*     _set_arena;
-
-  ReallocMark _nesting;  // assertion check for reallocations
+  ReallocMark _nesting; // Safety checks for arena reallocation
 
   void init(Arena* arena);
   // Grow vector to required word capacity

--- a/src/hotspot/share/libadt/vectset.hpp
+++ b/src/hotspot/share/libadt/vectset.hpp
@@ -47,6 +47,8 @@ private:
   uint       _data_size;
   Arena*     _set_arena;
 
+  ReallocMark _nesting;  // assertion check for reallocations
+
   void init(Arena* arena);
   // Grow vector to required word capacity
   void grow(uint new_word_capacity);
@@ -77,10 +79,7 @@ public:
   //
   bool test_set(uint elem) {
     uint32_t word = elem >> word_bits;
-    if (word >= _size) {
-      // Then grow
-      grow(word);
-    }
+    grow(word);
     uint32_t mask = 1U << (elem & bit_mask);
     uint32_t data = _data[word];
     _data[word] = data | mask;
@@ -109,9 +108,7 @@ public:
   // Fast inlined set
   void set(uint elem) {
     uint32_t word = elem >> word_bits;
-    if (word >= _size) {
-      grow(word);
-    }
+    grow(word);
     uint32_t mask = 1U << (elem & bit_mask);
     _data[word] |= mask;
   }

--- a/src/hotspot/share/memory/allocation.cpp
+++ b/src/hotspot/share/memory/allocation.cpp
@@ -237,9 +237,10 @@ ReallocMark::ReallocMark() {
 #endif
 }
 
-void ReallocMark::check() {
+void ReallocMark::check(Arena* arena) {
 #ifdef ASSERT
-  if (_nesting != Thread::current()->resource_area()->nesting()) {
+  if ((arena == nullptr || arena == Thread::current()->resource_area()) &&
+      _nesting != Thread::current()->resource_area()->nesting()) {
     fatal("allocation bug: array could grow within nested ResourceMark");
   }
 #endif

--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -556,8 +556,8 @@ protected:
   NOT_PRODUCT(int _nesting;)
 
 public:
-  ReallocMark()   PRODUCT_RETURN;
-  void check()    PRODUCT_RETURN;
+  ReallocMark() PRODUCT_RETURN;
+  void check(Arena* arena = nullptr) PRODUCT_RETURN;
 };
 
 // Uses mmapped memory for all allocations. All allocations are initially

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -39,10 +39,9 @@
 #include "utilities/powerOfTwo.hpp"
 
 void Block_Array::grow( uint i ) {
-  // TODO this triggers
-  // _nesting.check(_arena);
+  _nesting.check(_arena); // Check if a potential reallocation in the arena is safe
   if (i < Max()) {
-    return; // no need to grow
+    return; // No need to grow
   }
   assert(i >= Max(), "must be an overflow");
   debug_only(_limit = i+1);
@@ -379,6 +378,7 @@ void Block::dump(const PhaseCFG* cfg) const {
 PhaseCFG::PhaseCFG(Arena* arena, RootNode* root, Matcher& matcher)
 : Phase(CFG)
 , _root(root)
+, _blocks(arena)
 , _block_arena(arena)
 , _regalloc(nullptr)
 , _scheduling_for_pressure(false)
@@ -1422,7 +1422,7 @@ UnionFind::UnionFind( uint max ) : _cnt(max), _max(max), _indices(NEW_RESOURCE_A
 }
 
 void UnionFind::extend( uint from_idx, uint to_idx ) {
-  _nesting.check();
+  _nesting.check(); // Check if a potential reallocation in the resource arena is safe
   if( from_idx >= _max ) {
     uint size = 16;
     while( size <= from_idx ) size <<=1;

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -43,7 +43,6 @@ void Block_Array::grow( uint i ) {
   if (i < Max()) {
     return; // No need to grow
   }
-  assert(i >= Max(), "must be an overflow");
   debug_only(_limit = i+1);
   if( i < _size )  return;
   if( !_size ) {

--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -39,6 +39,11 @@
 #include "utilities/powerOfTwo.hpp"
 
 void Block_Array::grow( uint i ) {
+  // TODO this triggers
+  // _nesting.check(_arena);
+  if (i < Max()) {
+    return; // no need to grow
+  }
   assert(i >= Max(), "must be an overflow");
   debug_only(_limit = i+1);
   if( i < _size )  return;

--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -51,6 +51,7 @@ class Block_Array : public ArenaObj {
   uint _size;                   // allocated size, as opposed to formal limit
   debug_only(uint _limit;)      // limit to formal domain
   Arena *_arena;                // Arena to allocate in
+  ReallocMark _nesting;         // assertion check for reallocations
 protected:
   Block **_blocks;
   void grow( uint i );          // Grow array node to fit
@@ -68,7 +69,7 @@ public:
   Block *operator[] ( uint i ) const // Lookup, or assert for not mapped
   { assert( i < Max(), "oob" ); return _blocks[i]; }
   // Extend the mapping: index i maps to Block *n.
-  void map( uint i, Block *n ) { if( i>=Max() ) grow(i); _blocks[i] = n; }
+  void map( uint i, Block *n ) { grow(i); _blocks[i] = n; }
   uint Max() const { debug_only(return _limit); return _size; }
 };
 

--- a/src/hotspot/share/opto/block.hpp
+++ b/src/hotspot/share/opto/block.hpp
@@ -51,7 +51,7 @@ class Block_Array : public ArenaObj {
   uint _size;                   // allocated size, as opposed to formal limit
   debug_only(uint _limit;)      // limit to formal domain
   Arena *_arena;                // Arena to allocate in
-  ReallocMark _nesting;         // assertion check for reallocations
+  ReallocMark _nesting;         // Safety checks for arena reallocation
 protected:
   Block **_blocks;
   void grow( uint i );          // Grow array node to fit
@@ -78,7 +78,9 @@ class Block_List : public Block_Array {
   friend class VMStructs;
 public:
   uint _cnt;
-  Block_List() : Block_Array(Thread::current()->resource_area()), _cnt(0) {}
+  Block_List() : Block_List(Thread::current()->resource_area()) { }
+  Block_List(Arena* a) : Block_Array(a), _cnt(0) { }
+
   void push( Block *b ) {  map(_cnt++,b); }
   Block *pop() { return _blocks[--_cnt]; }
   Block *rpop() { Block *b = _blocks[0]; _blocks[0]=_blocks[--_cnt]; return b;}
@@ -656,7 +658,7 @@ class PhaseCFG : public Phase {
 class UnionFind : public ResourceObj {
   uint _cnt, _max;
   uint* _indices;
-  ReallocMark _nesting;  // assertion check for reallocations
+  ReallocMark _nesting; // Safety checks for arena reallocation
 public:
   UnionFind( uint max );
   void reset( uint max );  // Reset to identity map for [0..max]

--- a/src/hotspot/share/opto/domgraph.cpp
+++ b/src/hotspot/share/opto/domgraph.cpp
@@ -61,9 +61,6 @@ struct Tarjan {
 // Compute the dominator tree of the CFG.  The CFG must already have been
 // constructed.  This is the Lengauer & Tarjan O(E-alpha(E,V)) algorithm.
 void PhaseCFG::build_dominator_tree() {
-  // Pre-grow the blocks array, prior to the ResourceMark kicking in
-  _blocks.map(number_of_blocks(), nullptr);
-
   ResourceMark rm;
   // Setup mappings from my Graph to Tarjan's stuff and back
   // Note: Tarjan uses 1-based arrays

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -5248,7 +5248,7 @@ bool IdealLoopTree::verify_tree(IdealLoopTree* loop_verify) const {
 
 //------------------------------set_idom---------------------------------------
 void PhaseIdealLoop::set_idom(Node* d, Node* n, uint dom_depth) {
-  _nesting.check();
+  _nesting.check(); // Check if a potential reallocation in the resource arena is safe
   uint idx = d->_idx;
   if (idx >= _idom_size) {
     uint newsize = next_power_of_2(idx);

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -5248,6 +5248,7 @@ bool IdealLoopTree::verify_tree(IdealLoopTree* loop_verify) const {
 
 //------------------------------set_idom---------------------------------------
 void PhaseIdealLoop::set_idom(Node* d, Node* n, uint dom_depth) {
+  _nesting.check();
   uint idx = d->_idx;
   if (idx >= _idom_size) {
     uint newsize = next_power_of_2(idx);

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -611,7 +611,6 @@ public:
       _head(head), _tail(tail),
       _phase(phase),
       _local_loop_unroll_limit(0), _local_loop_unroll_factor(0),
-      _body(Compile::current()->comp_arena()),
       _nest(0), _irreducible(0), _has_call(0), _has_sfpt(0), _rce_candidate(0),
       _has_range_checks(0), _has_range_checks_computed(0),
       _safepts(nullptr),

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -841,7 +841,7 @@ class PhaseIdealLoop : public PhaseTransform {
   uint *_preorders;
   uint _max_preorder;
 
-  ReallocMark _nesting; // assertion check for reallocations
+  ReallocMark _nesting; // Safety checks for arena reallocation
 
   const PhaseIdealLoop* _verify_me;
   bool _verify_only;
@@ -855,7 +855,7 @@ class PhaseIdealLoop : public PhaseTransform {
 
   // Allocate _preorders[] array
   void reallocate_preorders() {
-    _nesting.check();
+    _nesting.check(); // Check if a potential re-allocation in the resource arena is safe
     if ( _max_preorder < C->unique() ) {
       _preorders = REALLOC_RESOURCE_ARRAY(uint, _preorders, _max_preorder, C->unique());
       _max_preorder = C->unique();
@@ -866,7 +866,7 @@ class PhaseIdealLoop : public PhaseTransform {
   // Check to grow _preorders[] array for the case when build_loop_tree_impl()
   // adds new nodes.
   void check_grow_preorders( ) {
-    _nesting.check();
+    _nesting.check(); // Check if a potential re-allocation in the resource arena is safe
     if ( _max_preorder < C->unique() ) {
       uint newsize = _max_preorder<<1;  // double size of array
       _preorders = REALLOC_RESOURCE_ARRAY(uint, _preorders, _max_preorder, newsize);

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -611,6 +611,7 @@ public:
       _head(head), _tail(tail),
       _phase(phase),
       _local_loop_unroll_limit(0), _local_loop_unroll_factor(0),
+      _body(Compile::current()->comp_arena()),
       _nest(0), _irreducible(0), _has_call(0), _has_sfpt(0), _rce_candidate(0),
       _has_range_checks(0), _has_range_checks_computed(0),
       _safepts(nullptr),
@@ -840,6 +841,8 @@ class PhaseIdealLoop : public PhaseTransform {
   uint *_preorders;
   uint _max_preorder;
 
+  ReallocMark _nesting; // assertion check for reallocations
+
   const PhaseIdealLoop* _verify_me;
   bool _verify_only;
 
@@ -852,6 +855,7 @@ class PhaseIdealLoop : public PhaseTransform {
 
   // Allocate _preorders[] array
   void reallocate_preorders() {
+    _nesting.check();
     if ( _max_preorder < C->unique() ) {
       _preorders = REALLOC_RESOURCE_ARRAY(uint, _preorders, _max_preorder, C->unique());
       _max_preorder = C->unique();
@@ -862,6 +866,7 @@ class PhaseIdealLoop : public PhaseTransform {
   // Check to grow _preorders[] array for the case when build_loop_tree_impl()
   // adds new nodes.
   void check_grow_preorders( ) {
+    _nesting.check();
     if ( _max_preorder < C->unique() ) {
       uint newsize = _max_preorder<<1;  // double size of array
       _preorders = REALLOC_RESOURCE_ARRAY(uint, _preorders, _max_preorder, newsize);

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2766,6 +2766,10 @@ const RegMask &Node::in_RegMask(uint) const {
 }
 
 void Node_Array::grow(uint i) {
+  _nesting.check(_a);
+  if (i < _max) {
+    return;
+  }
   assert(_max > 0, "invariant");
   uint old = _max;
   _max = next_power_of_2(i);
@@ -2973,6 +2977,10 @@ void Unique_Node_List::remove_useless_nodes(VectorSet &useful) {
 
 //=============================================================================
 void Node_Stack::grow() {
+  _nesting.check(_a);
+  if (_inode_top < _inode_max) {
+    return; // No need to grow
+  }
   size_t old_top = pointer_delta(_inode_top,_inodes,sizeof(INode)); // save _top
   size_t old_max = pointer_delta(_inode_max,_inodes,sizeof(INode));
   size_t max = old_max << 1;             // max * 2

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2766,9 +2766,9 @@ const RegMask &Node::in_RegMask(uint) const {
 }
 
 void Node_Array::grow(uint i) {
-  _nesting.check(_a);
+  _nesting.check(_a); // Check if a potential reallocation in the arena is safe
   if (i < _max) {
-    return;
+    return; // No need to grow
   }
   assert(_max > 0, "invariant");
   uint old = _max;
@@ -2977,7 +2977,7 @@ void Unique_Node_List::remove_useless_nodes(VectorSet &useful) {
 
 //=============================================================================
 void Node_Stack::grow() {
-  _nesting.check(_a);
+  _nesting.check(_a); // Check if a potential reallocation in the arena is safe
   if (_inode_top < _inode_max) {
     return; // No need to grow
   }

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1596,6 +1596,9 @@ protected:
   Arena* _a;                    // Arena to allocate in
   uint   _max;
   Node** _nodes;
+
+  ReallocMark _nesting;  // assertion check for reallocations
+
   void   grow( uint i );        // Grow array node to fit
 public:
   Node_Array(Arena* a, uint max = OptoNodeListSize) : _a(a), _max(max) {
@@ -1614,7 +1617,7 @@ public:
   Node* at(uint i) const { assert(i<_max,"oob"); return _nodes[i]; }
   Node** adr() { return _nodes; }
   // Extend the mapping: index i maps to Node *n.
-  void map( uint i, Node *n ) { if( i>=_max ) grow(i); _nodes[i] = n; }
+  void map( uint i, Node *n ) { grow(i); _nodes[i] = n; }
   void insert( uint i, Node *n );
   void remove( uint i );        // Remove, preserving order
   // Clear all entries in _nodes to null but keep storage
@@ -1844,6 +1847,7 @@ protected:
   INode *_inode_max; // End of _inodes == _inodes + _max
   INode *_inodes;    // Array storage for the stack
   Arena *_a;         // Arena to allocate in
+  ReallocMark _nesting; // assertion check for reallocations
   void grow();
 public:
   Node_Stack(int size) {
@@ -1867,7 +1871,7 @@ public:
   }
   void push(Node *n, uint i) {
     ++_inode_top;
-    if (_inode_top >= _inode_max) grow();
+    grow();
     INode *top = _inode_top; // optimization
     top->node = n;
     top->indx = i;

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1596,8 +1596,7 @@ protected:
   Arena* _a;                    // Arena to allocate in
   uint   _max;
   Node** _nodes;
-
-  ReallocMark _nesting;  // assertion check for reallocations
+  ReallocMark _nesting;         // Safety checks for arena reallocation
 
   void   grow( uint i );        // Grow array node to fit
 public:
@@ -1847,7 +1846,7 @@ protected:
   INode *_inode_max; // End of _inodes == _inodes + _max
   INode *_inodes;    // Array storage for the stack
   Arena *_a;         // Arena to allocate in
-  ReallocMark _nesting; // assertion check for reallocations
+  ReallocMark _nesting; // Safety checks for arena reallocation
   void grow();
 public:
   Node_Stack(int size) {

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -2351,6 +2351,7 @@ void Node::replace_by(Node *new_node) {
 //=============================================================================
 //-----------------------------------------------------------------------------
 void Type_Array::grow( uint i ) {
+  assert(_a == Compile::current()->comp_arena(), "Should be allocated in comp_arena");
   if( !_max ) {
     _max = 1;
     _types = (const Type**)_a->Amalloc( _max * sizeof(Type*) );

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -184,7 +184,7 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
   // Process merged VBAs
 
   if (EnableVectorAggressiveReboxing) {
-    Unique_Node_List calls(C->comp_arena());
+    Unique_Node_List calls;
     for (DUIterator_Fast imax, i = vec_box->fast_outs(imax); i < imax; i++) {
       Node* use = vec_box->fast_out(i);
       if (use->is_CallJava()) {
@@ -238,9 +238,9 @@ void PhaseVector::scalarize_vbox_node(VectorBoxNode* vec_box) {
   }
 
   // Process debug uses at safepoints
-  Unique_Node_List safepoints(C->comp_arena());
+  Unique_Node_List safepoints;
 
-  Unique_Node_List worklist(C->comp_arena());
+  Unique_Node_List worklist;
   worklist.push(vec_box);
   while (worklist.size() > 0) {
     Node* n = worklist.pop();


### PR DESCRIPTION
Similar to [GrowableArrayNestingCheck](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/utilities/growableArray.cpp#L60), we should implement a check for C2's resource allocated data structures that verifies that reallocation happens under the same `ResourceMark` as the original allocation. Otherwise, use-after-free bugs like [JDK-8336095](https://bugs.openjdk.org/browse/JDK-8336095) will lead to memory corruption.

This change adds a [ReallocMark](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/memory/allocation.cpp#L233) to all resource allocated data structures used by C2. I slightly modified it such that it checks the arena and skips verification if the data is not allocated in the resource arena. I also modified the grow methods such that we perform verification even if no reallocation is required. In addition, I changed a few `Unique_Node_List` allocations in vector.cpp from `comp_arena` to resource area allocations because they only have a short lifetime.

While testing, I hit the verification code from:
```
V  [libjvm.so+0x5c1ceb]  ReallocMark::check(Arena*)+0x7b  (allocation.cpp:244)
V  [libjvm.so+0x6df2da]  Block_Array::grow(unsigned int)+0x1a  (block.cpp:43)
V  [libjvm.so+0xb88679]  PhaseCFG::do_DFS(Tarjan*, unsigned int)+0x159  (block.hpp:72)
V  [libjvm.so+0xb88b6b]  PhaseCFG::build_dominator_tree()+0xab  (domgraph.cpp:74)
V  [libjvm.so+0xd75791]  PhaseCFG::do_global_code_motion()+0x11  (gcm.cpp:1635)
V  [libjvm.so+0x9f4fd4]  Compile::Code_Gen()+0x2a4  (compile.cpp:2949)
V  [libjvm.so+0x9f5f16]  Compile::Compile(ciEnv*, TypeFunc const* (*)(), unsigned char*, char const*, int, bool, bool, DirectiveSet*)+0xba6  (compile.cpp:991)
```

It's a false positive because the code in `PhaseCFG::build_dominator_tree` pre-grows `PhaseCFG::_blocks` to prevent reallocation before entering the scope of a nested ResourceMark. I think that's bad practice and should be avoided. I changed the code to allocate `_blocks` in a separate arena and removed the pre-growing.

This detects [JDK-8336095](https://bugs.openjdk.org/browse/JDK-8336095) right away, even with `java -Xcomp -version`.

We should revisit the footprint impact of arena allocations in C2 with [JDK-8337015](https://bugs.openjdk.org/browse/JDK-8337015).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336999](https://bugs.openjdk.org/browse/JDK-8336999): Verification for resource area allocated data structures in C2 (**Enhancement** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) 🔄 Re-review required (review applies to [b0f839b8](https://git.openjdk.org/jdk/pull/20311/files/b0f839b898135f660b8c947933c29eb8386ea8d8))
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20311/head:pull/20311` \
`$ git checkout pull/20311`

Update a local copy of the PR: \
`$ git checkout pull/20311` \
`$ git pull https://git.openjdk.org/jdk.git pull/20311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20311`

View PR using the GUI difftool: \
`$ git pr show -t 20311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20311.diff">https://git.openjdk.org/jdk/pull/20311.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20311#issuecomment-2247554554)