### PR TITLE
8337037: compiler internal options are not printing the stacktrace after a compiler crash

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -646,7 +646,14 @@ public class Types {
         public CompilerInternalException(boolean dumpStackTraceOnError) {
             if (dumpStackTraceOnError) {
                 super.fillInStackTrace();
+            } else {
+                fillInStackTrace();
             }
+        }
+
+        @Override
+        public Throwable fillInStackTrace() {
+            return this;
         }
     }
 
@@ -667,11 +674,6 @@ public class Types {
 
         public JCDiagnostic getDiagnostic() {
             return diagnostic;
-        }
-
-        @Override
-        public Throwable fillInStackTrace() {
-            return this;
         }
     }
 
@@ -5137,11 +5139,6 @@ public class Types {
 
             public Type type() {
                 return type;
-            }
-
-            @Override
-            public Throwable fillInStackTrace() {
-                return this;
             }
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -639,24 +639,6 @@ public class Types {
      * wraps a diagnostic that can be used to generate more details error
      * messages.
      */
-    public static class CompilerInternalException extends RuntimeException {
-        private static final long serialVersionUID = 0;
-
-        @SuppressWarnings("this-escape")
-        public CompilerInternalException(boolean dumpStackTraceOnError) {
-            if (dumpStackTraceOnError) {
-                super.fillInStackTrace();
-            } else {
-                fillInStackTrace();
-            }
-        }
-
-        @Override
-        public Throwable fillInStackTrace() {
-            return this;
-        }
-    }
-
     public static class FunctionDescriptorLookupError extends CompilerInternalException {
         private static final long serialVersionUID = 0;
 
@@ -5125,9 +5107,9 @@ public class Types {
 
     // <editor-fold defaultstate="collapsed" desc="Signature Generation">
 
-    public abstract static class SignatureGenerator {
+    public abstract class SignatureGenerator {
 
-        public static class InvalidSignatureException extends CompilerInternalException {
+        public class InvalidSignatureException extends CompilerInternalException {
             private static final long serialVersionUID = 0;
 
             private final transient Type type;
@@ -5142,21 +5124,13 @@ public class Types {
             }
         }
 
-        private final Types types;
-        private final boolean dumpStackTraceOnError;
-
         protected abstract void append(char ch);
         protected abstract void append(byte[] ba);
         protected abstract void append(Name name);
         protected void classReference(ClassSymbol c) { /* by default: no-op */ }
 
-        protected SignatureGenerator(Types types, boolean dumpStackTraceOnError) {
-            this.types = types;
-            this.dumpStackTraceOnError = dumpStackTraceOnError;
-        }
-
         protected void reportIllegalSignature(Type t) {
-            throw new InvalidSignatureException(t, dumpStackTraceOnError);
+            throw new InvalidSignatureException(t, Types.this.dumpStacktraceOnError);
         }
 
         /**
@@ -5272,9 +5246,9 @@ public class Types {
             if (outer.allparams().nonEmpty()) {
                 boolean rawOuter =
                         c.owner.kind == MTH || // either a local class
-                        c.name == types.names.empty; // or anonymous
+                        c.name == Types.this.names.empty; // or anonymous
                 assembleClassSig(rawOuter
-                        ? types.erasure(outer)
+                        ? Types.this.erasure(outer)
                         : outer);
                 append(rawOuter ? '$' : '.');
                 Assert.check(c.flatname.startsWith(c.owner.enclClass().flatname));
@@ -5296,7 +5270,7 @@ public class Types {
             for (List<Type> ts = typarams; ts.nonEmpty(); ts = ts.tail) {
                 Type.TypeVar tvar = (Type.TypeVar) ts.head;
                 append(tvar.tsym.name);
-                List<Type> bounds = types.getBounds(tvar);
+                List<Type> bounds = Types.this.getBounds(tvar);
                 if ((bounds.head.tsym.flags() & INTERFACE) != 0) {
                     append(':');
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -40,7 +40,6 @@ import com.sun.tools.javac.util.List;
 import com.sun.tools.javac.code.*;
 import com.sun.tools.javac.code.Type.*;
 import com.sun.tools.javac.code.Type.UndetVar.InferenceBound;
-import com.sun.tools.javac.code.Types.CompilerInternalException;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.comp.DeferredAttr.AttrMode;
 import com.sun.tools.javac.comp.DeferredAttr.DeferredAttrContext;
@@ -48,6 +47,7 @@ import com.sun.tools.javac.comp.Infer.GraphSolver.InferenceGraph;
 import com.sun.tools.javac.comp.Infer.GraphSolver.InferenceGraph.Node;
 import com.sun.tools.javac.comp.Resolve.InapplicableMethodException;
 import com.sun.tools.javac.comp.Resolve.VerboseResolutionMode;
+import com.sun.tools.javac.util.CompilerInternalException;
 
 import java.io.IOException;
 import java.io.Writer;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Infer.java
@@ -1355,11 +1355,6 @@ public class Infer {
                 super(dumpStacktraceOnError);
                 this.graph = graph;
             }
-
-            @Override
-            public Throwable fillInStackTrace() {
-                return this;
-            }
         }
         /**
          * Pick the next node (leaf) to solve in the graph

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -64,7 +64,6 @@ import static com.sun.tools.javac.comp.LambdaToMethod.LambdaSymbolKind.*;
 import static com.sun.tools.javac.code.Flags.*;
 import static com.sun.tools.javac.code.Kinds.Kind.*;
 import static com.sun.tools.javac.code.TypeTag.*;
-import static com.sun.tools.javac.main.Option.DOE;
 import static com.sun.tools.javac.tree.JCTree.Tag.*;
 
 import javax.lang.model.element.ElementKind;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -121,9 +121,6 @@ public class LambdaToMethod extends TreeTranslator {
     /** deduplicate lambda implementation methods */
     private final boolean deduplicateLambdas;
 
-    /** dump stacktrace on error */
-    private final boolean dumpStacktraceOnError;
-
     /** Flag for alternate metafactories indicating the lambda object is intended to be serializable */
     public static final int FLAG_SERIALIZABLE = 1 << 0;
 
@@ -170,7 +167,6 @@ public class LambdaToMethod extends TreeTranslator {
         debugLinesOrVars = lineDebugInfo || varDebugInfo;
         verboseDeduplication = options.isSet("debug.dumpLambdaToMethodDeduplication");
         deduplicateLambdas = options.getBoolean("deduplicateLambdas", true);
-        dumpStacktraceOnError = options.isSet("dev") || options.isSet(DOE);
     }
     // </editor-fold>
 
@@ -1801,7 +1797,7 @@ public class LambdaToMethod extends TreeTranslator {
         boolean allowIllegalSignatures;
 
         L2MSignatureGenerator(boolean allowIllegalSignatures) {
-            super(types, LambdaToMethod.this.dumpStacktraceOnError);
+            types.super();
             this.allowIllegalSignatures = allowIllegalSignatures;
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -64,6 +64,7 @@ import static com.sun.tools.javac.comp.LambdaToMethod.LambdaSymbolKind.*;
 import static com.sun.tools.javac.code.Flags.*;
 import static com.sun.tools.javac.code.Kinds.Kind.*;
 import static com.sun.tools.javac.code.TypeTag.*;
+import static com.sun.tools.javac.main.Option.DOE;
 import static com.sun.tools.javac.tree.JCTree.Tag.*;
 
 import javax.lang.model.element.ElementKind;
@@ -120,6 +121,9 @@ public class LambdaToMethod extends TreeTranslator {
     /** deduplicate lambda implementation methods */
     private final boolean deduplicateLambdas;
 
+    /** dump stacktrace on error */
+    private final boolean dumpStacktraceOnError;
+
     /** Flag for alternate metafactories indicating the lambda object is intended to be serializable */
     public static final int FLAG_SERIALIZABLE = 1 << 0;
 
@@ -166,6 +170,7 @@ public class LambdaToMethod extends TreeTranslator {
         debugLinesOrVars = lineDebugInfo || varDebugInfo;
         verboseDeduplication = options.isSet("debug.dumpLambdaToMethodDeduplication");
         deduplicateLambdas = options.getBoolean("deduplicateLambdas", true);
+        dumpStacktraceOnError = options.isSet("dev") || options.isSet(DOE);
     }
     // </editor-fold>
 
@@ -1796,7 +1801,7 @@ public class LambdaToMethod extends TreeTranslator {
         boolean allowIllegalSignatures;
 
         L2MSignatureGenerator(boolean allowIllegalSignatures) {
-            super(types);
+            super(types, LambdaToMethod.this.dumpStacktraceOnError);
             this.allowIllegalSignatures = allowIllegalSignatures;
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -109,7 +109,6 @@ public class Lower extends TreeTranslator {
     private final boolean useMatchException;
     private final HashMap<TypePairs, String> typePairToName;
     private int variableIndex = 0;
-    private final boolean dumpStacktraceOnError;
 
     @SuppressWarnings("this-escape")
     protected Lower(Context context) {
@@ -142,7 +141,6 @@ public class Lower extends TreeTranslator {
         useMatchException = Feature.PATTERN_SWITCH.allowedInSource(source) &&
                             (preview.isEnabled() || !preview.isPreview(Feature.PATTERN_SWITCH));
         typePairToName = TypePairs.initialize(syms);
-        dumpStacktraceOnError = options.isSet("dev") || options.isSet(DOE);
     }
 
     /** The currently enclosing class.
@@ -2633,7 +2631,7 @@ public class Lower extends TreeTranslator {
         StringBuilder sb = new StringBuilder();
 
         LowerSignatureGenerator() {
-            super(types, Lower.this.dumpStacktraceOnError);
+            types.super();
         }
 
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -62,6 +62,8 @@ import com.sun.tools.javac.tree.JCTree.JCBreak;
 import com.sun.tools.javac.tree.JCTree.JCCase;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCExpressionStatement;
+
+import static com.sun.tools.javac.main.Option.DOE;
 import static com.sun.tools.javac.tree.JCTree.JCOperatorExpression.OperandPos.LEFT;
 import com.sun.tools.javac.tree.JCTree.JCSwitchExpression;
 
@@ -107,6 +109,7 @@ public class Lower extends TreeTranslator {
     private final boolean useMatchException;
     private final HashMap<TypePairs, String> typePairToName;
     private int variableIndex = 0;
+    private final boolean dumpStacktraceOnError;
 
     @SuppressWarnings("this-escape")
     protected Lower(Context context) {
@@ -139,6 +142,7 @@ public class Lower extends TreeTranslator {
         useMatchException = Feature.PATTERN_SWITCH.allowedInSource(source) &&
                             (preview.isEnabled() || !preview.isPreview(Feature.PATTERN_SWITCH));
         typePairToName = TypePairs.initialize(syms);
+        dumpStacktraceOnError = options.isSet("dev") || options.isSet(DOE);
     }
 
     /** The currently enclosing class.
@@ -2629,7 +2633,7 @@ public class Lower extends TreeTranslator {
         StringBuilder sb = new StringBuilder();
 
         LowerSignatureGenerator() {
-            super(types);
+            super(types, Lower.this.dumpStacktraceOnError);
         }
 
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Lower.java
@@ -63,7 +63,6 @@ import com.sun.tools.javac.tree.JCTree.JCCase;
 import com.sun.tools.javac.tree.JCTree.JCExpression;
 import com.sun.tools.javac.tree.JCTree.JCExpressionStatement;
 
-import static com.sun.tools.javac.main.Option.DOE;
 import static com.sun.tools.javac.tree.JCTree.JCOperatorExpression.OperandPos.LEFT;
 import com.sun.tools.javac.tree.JCTree.JCSwitchExpression;
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -860,7 +860,7 @@ public class Resolve {
             return nilMethodCheck;
         }
 
-        SharedInapplicableMethodException getMethodCheckFailure() {
+        private SharedInapplicableMethodException getMethodCheckFailure() {
             return methodCheckFailure == null ? methodCheckFailure = new SharedInapplicableMethodException() : methodCheckFailure;
         }
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -31,7 +31,6 @@ import com.sun.tools.javac.code.Scope.WriteableScope;
 import com.sun.tools.javac.code.Source.Feature;
 import com.sun.tools.javac.code.Symbol.*;
 import com.sun.tools.javac.code.Type.*;
-import com.sun.tools.javac.code.Types.CompilerInternalException;
 import com.sun.tools.javac.comp.Attr.ResultInfo;
 import com.sun.tools.javac.comp.Check.CheckContext;
 import com.sun.tools.javac.comp.DeferredAttr.AttrMode;
@@ -834,7 +833,7 @@ public class Resolve {
             String key = inferDiag ? diag.inferKey : diag.basicKey;
             throw inferDiag ?
                 infer.error(diags.create(DiagnosticType.FRAGMENT, log.currentSource(), pos, key, args)) :
-                methodCheckFailure.setMessage(diags.create(DiagnosticType.FRAGMENT, log.currentSource(), pos, key, args));
+                getMethodCheckFailure().setMessage(diags.create(DiagnosticType.FRAGMENT, log.currentSource(), pos, key, args));
         }
 
         /**
@@ -855,12 +854,15 @@ public class Resolve {
             }
         }
 
-        SharedInapplicableMethodException methodCheckFailure = new SharedInapplicableMethodException();
+        private SharedInapplicableMethodException methodCheckFailure;
 
         public MethodCheck mostSpecificCheck(List<Type> actuals) {
             return nilMethodCheck;
         }
 
+        SharedInapplicableMethodException getMethodCheckFailure() {
+            return methodCheckFailure == null ? methodCheckFailure = new SharedInapplicableMethodException() : methodCheckFailure;
+        }
     }
 
     /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Resolve.java
@@ -1409,11 +1409,6 @@ public class Resolve {
         public JCDiagnostic getDiagnostic() {
             return diagnostic;
         }
-
-        @Override
-        public Throwable fillInStackTrace() {
-            return this;
-        }
     }
 
 /* ***************************************************************************

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -137,7 +137,6 @@ public class TransPatterns extends TreeTranslator {
     private final Preview preview;
     private TreeMaker make;
     private Env<AttrContext> env;
-    private final boolean dumpStacktraceOnError;
 
     BindingContext bindingContext = new BindingContext() {
         @Override
@@ -199,7 +198,6 @@ public class TransPatterns extends TreeTranslator {
         target = Target.instance(context);
         preview = Preview.instance(context);
         Options options = Options.instance(context);
-        dumpStacktraceOnError = options.isSet("dev") || options.isSet(DOE);
     }
 
     @Override
@@ -792,7 +790,7 @@ public class TransPatterns extends TreeTranslator {
         StringBuilder sb = new StringBuilder();
 
         PrimitiveGenerator() {
-            super(types, TransPatterns.this.dumpStacktraceOnError);
+            types.super();
         }
 
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -110,7 +110,6 @@ import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.List;
-import com.sun.tools.javac.util.Options;
 
 /**
  * This pass translates pattern-matching constructs, such as instanceof <pattern>.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -79,7 +79,6 @@ import com.sun.tools.javac.code.Symbol.RecordComponent;
 import com.sun.tools.javac.code.Type;
 import static com.sun.tools.javac.code.TypeTag.BOT;
 import static com.sun.tools.javac.code.TypeTag.VOID;
-import static com.sun.tools.javac.main.Option.DOE;
 
 import com.sun.tools.javac.jvm.PoolConstant.LoadableConstant;
 import com.sun.tools.javac.jvm.Target;
@@ -197,7 +196,6 @@ public class TransPatterns extends TreeTranslator {
         names = Names.instance(context);
         target = Target.instance(context);
         preview = Preview.instance(context);
-        Options options = Options.instance(context);
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -79,6 +79,8 @@ import com.sun.tools.javac.code.Symbol.RecordComponent;
 import com.sun.tools.javac.code.Type;
 import static com.sun.tools.javac.code.TypeTag.BOT;
 import static com.sun.tools.javac.code.TypeTag.VOID;
+import static com.sun.tools.javac.main.Option.DOE;
+
 import com.sun.tools.javac.jvm.PoolConstant.LoadableConstant;
 import com.sun.tools.javac.jvm.Target;
 import com.sun.tools.javac.tree.JCTree;
@@ -109,6 +111,7 @@ import com.sun.tools.javac.tree.TreeScanner;
 import com.sun.tools.javac.util.Assert;
 import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.List;
+import com.sun.tools.javac.util.Options;
 
 /**
  * This pass translates pattern-matching constructs, such as instanceof <pattern>.
@@ -134,6 +137,7 @@ public class TransPatterns extends TreeTranslator {
     private final Preview preview;
     private TreeMaker make;
     private Env<AttrContext> env;
+    private final boolean dumpStacktraceOnError;
 
     BindingContext bindingContext = new BindingContext() {
         @Override
@@ -194,6 +198,8 @@ public class TransPatterns extends TreeTranslator {
         names = Names.instance(context);
         target = Target.instance(context);
         preview = Preview.instance(context);
+        Options options = Options.instance(context);
+        dumpStacktraceOnError = options.isSet("dev") || options.isSet(DOE);
     }
 
     @Override
@@ -786,7 +792,7 @@ public class TransPatterns extends TreeTranslator {
         StringBuilder sb = new StringBuilder();
 
         PrimitiveGenerator() {
-            super(types);
+            super(types, TransPatterns.this.dumpStacktraceOnError);
         }
 
         @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -100,7 +100,7 @@ public class PoolWriter {
     public PoolWriter(Types types, Names names) {
         this.types = types;
         this.names = names;
-        this.signatureGen = new SharedSignatureGenerator(types);
+        this.signatureGen = new SharedSignatureGenerator();
         this.pool = new WriteablePoolHelper();
     }
 
@@ -278,8 +278,8 @@ public class PoolWriter {
          */
         ByteBuffer sigbuf = new ByteBuffer();
 
-        SharedSignatureGenerator(Types types) {
-            super(types, PoolWriter.this.types.dumpStacktraceOnError);
+        SharedSignatureGenerator() {
+            types.super();
         }
 
         /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/PoolWriter.java
@@ -279,7 +279,7 @@ public class PoolWriter {
         ByteBuffer sigbuf = new ByteBuffer();
 
         SharedSignatureGenerator(Types types) {
-            super(types);
+            super(types, PoolWriter.this.types.dumpStacktraceOnError);
         }
 
         /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/CompilerInternalException.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/CompilerInternalException.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package com.sun.tools.javac.util;
+
+/** The super class of all compiler internal exceptions
+ *
+ *  <p><b>This is NOT part of any supported API.
+ *  If you write code that depends on this, you do so at your own risk.
+ *  This code and its internal interfaces are subject to change or
+ *  deletion without notice.</b>
+ */
+public class CompilerInternalException extends RuntimeException {
+    private static final long serialVersionUID = 0;
+
+    @SuppressWarnings("this-escape")
+    public CompilerInternalException(boolean dumpStackTraceOnError) {
+        /* by default the stacktrace wont be filled, meaning that method CompilerInternalException::fillInStackTrace
+         * will always be invoked, if we do want to dump the stacktrace then we will invoke super::fillInStackTrace
+         * there is a bit of a dance here that could be fixed once flexible constructor bodies exits the preview
+         * state
+         */
+        if (dumpStackTraceOnError) {
+            super.fillInStackTrace();
+        }
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/src/jdk.jshell/share/classes/jdk/jshell/TreeDissector.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/TreeDissector.java
@@ -246,7 +246,7 @@ class TreeDissector {
         StringBuilder sb = new StringBuilder();
 
         TDSignatureGenerator(Types types) {
-            super(types);
+            super(types, types.dumpStacktraceOnError);
         }
 
         @Override

--- a/src/jdk.jshell/share/classes/jdk/jshell/TreeDissector.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/TreeDissector.java
@@ -246,7 +246,7 @@ class TreeDissector {
         StringBuilder sb = new StringBuilder();
 
         TDSignatureGenerator(Types types) {
-            super(types, types.dumpStacktraceOnError);
+            types.super();
         }
 
         @Override


### PR DESCRIPTION
There are two internal javac options: `doe` and `dev` that we use to indicate the compiler to printout the stacktrace of any error issued and or exception thrown. There are a number of internal exceptions for which the stacktrace was not being produced due to performance issues. This patch is restoring the previous compiler behavior, printing out stacktraces if the internal options are passed, while keeping the most performant approach when none of the mentioned internal options is passed,

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8337037: compiler internal options are not printing the stacktrace after a compiler crash`

### Issue
 * [JDK-8337037](https://bugs.openjdk.org/browse/JDK-8337037): compiler internal options are not printing the stacktrace after a compiler crash (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20314/head:pull/20314` \
`$ git checkout pull/20314`

Update a local copy of the PR: \
`$ git checkout pull/20314` \
`$ git pull https://git.openjdk.org/jdk.git pull/20314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20314`

View PR using the GUI difftool: \
`$ git pr show -t 20314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20314.diff">https://git.openjdk.org/jdk/pull/20314.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20314#issuecomment-2248568906)