### PR TITLE
8336742: Shenandoah: Add more verbose logging/stats for mark termination attempts

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -217,7 +217,7 @@ void ShenandoahConcurrentMark::concurrent_mark() {
 
     size_t before = qset.completed_buffers_num();
     {
-      ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_mark_satb_flush_rendezvous, true);
+      ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_mark_satb_flush, true);
       Handshake::execute(&flush_satb);
     }
     size_t after = qset.completed_buffers_num();

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -205,9 +205,7 @@ void ShenandoahConcurrentMark::concurrent_mark() {
 
   ShenandoahSATBMarkQueueSet& qset = ShenandoahBarrierSet::satb_mark_queue_set();
   ShenandoahFlushSATBHandshakeClosure flush_satb(qset);
-  double handshake_total_time = 0;
-  uint flushes;
-  for (flushes = 0; flushes < ShenandoahMaxSATBBufferFlushes; flushes++) {
+  for (uint flushes = 0; flushes < ShenandoahMaxSATBBufferFlushes; flushes++) {
     TaskTerminator terminator(nworkers, task_queues());
     ShenandoahConcurrentMarkingTask<NON_GEN> task(this, &terminator);
     workers->run_task(&task);
@@ -218,9 +216,10 @@ void ShenandoahConcurrentMark::concurrent_mark() {
     }
 
     size_t before = qset.completed_buffers_num();
-    double handshake_start_time = os::elapsedTime();
-    Handshake::execute(&flush_satb);
-    handshake_total_time += os::elapsedTime() - handshake_start_time;
+    {
+      ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_mark_satb_flush_rendezvous, true);
+      Handshake::execute(&flush_satb);
+    }
     size_t after = qset.completed_buffers_num();
 
     if (before == after) {
@@ -228,10 +227,6 @@ void ShenandoahConcurrentMark::concurrent_mark() {
       break;
     }
   }
-  ShenandoahPhaseTimings* const timings = heap->phase_timings();
-  timings->record_phase_time(ShenandoahPhaseTimings::conc_mark_satb_flush_rendezvous, handshake_total_time);
-
-  log_info(gc, phases) ("Total SATB flush attempts : %d", (flushes + 1));
   assert(task_queues()->is_empty() || heap->cancelled_gc(), "Should be empty when not cancelled");
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -140,7 +140,7 @@ bool ShenandoahPhaseTimings::is_root_work_phase(Phase phase) {
 void ShenandoahPhaseTimings::set_cycle_data(Phase phase, double time, bool should_aggregate) {
   const double cycle_data = _cycle_data[phase];
   if (should_aggregate) {
-    _cycle_data[phase] = (cycle_data == uninitialized()) ? time :  cycle_data + time;
+    _cycle_data[phase] = (cycle_data == uninitialized()) ? time :  (cycle_data + time);
   } else {
 #ifdef ASSERT
     assert(cycle_data == uninitialized(), "Should not be set yet: %s, current value: %lf", phase_name(phase), cycle_data);

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -137,21 +137,21 @@ bool ShenandoahPhaseTimings::is_root_work_phase(Phase phase) {
   }
 }
 
-void ShenandoahPhaseTimings::set_cycle_data(Phase phase, double time, bool should_aggregate_cycles) {
-  if (should_aggregate_cycles) {
-    _cycle_data[phase] = _cycle_data[phase] <= 0 ? time :  _cycle_data[phase] + time;
+void ShenandoahPhaseTimings::set_cycle_data(Phase phase, double time, bool should_aggregate) {
+  const double cycle_data = _cycle_data[phase];
+  if (should_aggregate) {
+    _cycle_data[phase] = (cycle_data == uninitialized()) ? time :  cycle_data + time;
   } else {
 #ifdef ASSERT
-    double d = _cycle_data[phase];
-    assert(d == uninitialized(), "Should not be set yet: %s, current value: %lf", phase_name(phase), d);
+    assert(cycle_data == uninitialized(), "Should not be set yet: %s, current value: %lf", phase_name(phase), cycle_data);
 #endif
     _cycle_data[phase] = time;
   }
 }
 
-void ShenandoahPhaseTimings::record_phase_time(Phase phase, double time, bool should_aggregate_cycles) {
+void ShenandoahPhaseTimings::record_phase_time(Phase phase, double time, bool should_aggregate) {
   if (!_policy->is_at_shutdown()) {
-    set_cycle_data(phase, time, should_aggregate_cycles);
+    set_cycle_data(phase, time, should_aggregate);
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -137,17 +137,21 @@ bool ShenandoahPhaseTimings::is_root_work_phase(Phase phase) {
   }
 }
 
-void ShenandoahPhaseTimings::set_cycle_data(Phase phase, double time) {
+void ShenandoahPhaseTimings::set_cycle_data(Phase phase, double time, bool should_aggregate_cycles) {
+  if (should_aggregate_cycles) {
+    _cycle_data[phase] = _cycle_data[phase] <= 0 ? time :  _cycle_data[phase] + time;
+  } else {
 #ifdef ASSERT
-  double d = _cycle_data[phase];
-  assert(d == uninitialized(), "Should not be set yet: %s, current value: %lf", phase_name(phase), d);
+    double d = _cycle_data[phase];
+    assert(d == uninitialized(), "Should not be set yet: %s, current value: %lf", phase_name(phase), d);
 #endif
-  _cycle_data[phase] = time;
+    _cycle_data[phase] = time;
+  }
 }
 
-void ShenandoahPhaseTimings::record_phase_time(Phase phase, double time) {
+void ShenandoahPhaseTimings::record_phase_time(Phase phase, double time, bool should_aggregate_cycles) {
   if (!_policy->is_at_shutdown()) {
-    set_cycle_data(phase, time);
+    set_cycle_data(phase, time, should_aggregate_cycles);
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -57,6 +57,7 @@ class outputStream;
   f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
   SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "  CMR: ", f)                      \
   f(conc_mark,                                      "Concurrent Marking")              \
+  f(conc_mark_satb_flush_rendezvous,                "  SATB Flush Rendezvous") \
                                                                                        \
   f(final_mark_gross,                               "Pause Final Mark (G)")            \
   f(final_mark,                                     "Pause Final Mark (N)")            \

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -217,13 +217,13 @@ private:
   ShenandoahWorkerData* worker_data(Phase phase, ParPhase par_phase);
   Phase worker_par_phase(Phase phase, ParPhase par_phase);
 
-  void set_cycle_data(Phase phase, double time, bool should_aggregate_cycles=false);
+  void set_cycle_data(Phase phase, double time, bool should_aggregate = false);
   static double uninitialized() { return -1; }
 
 public:
   ShenandoahPhaseTimings(uint max_workers);
 
-  void record_phase_time(Phase phase, double time, bool should_aggregate_cycles=false);
+  void record_phase_time(Phase phase, double time, bool should_aggregate = false);
 
   void record_workers_start(Phase phase);
   void record_workers_end(Phase phase);

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -57,7 +57,7 @@ class outputStream;
   f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
   SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "  CMR: ", f)                      \
   f(conc_mark,                                      "Concurrent Marking")              \
-  f(conc_mark_satb_flush_rendezvous,                "  Flush SATB")                    \
+  f(conc_mark_satb_flush,                           "  Flush SATB")                    \
                                                                                        \
   f(final_mark_gross,                               "Pause Final Mark (G)")            \
   f(final_mark,                                     "Pause Final Mark (N)")            \

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -57,7 +57,7 @@ class outputStream;
   f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
   SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "  CMR: ", f)                      \
   f(conc_mark,                                      "Concurrent Marking")              \
-  f(conc_mark_satb_flush_rendezvous,                "  SATB Flush Rendezvous") \
+  f(conc_mark_satb_flush_rendezvous,                "  SATB Flush Rendezvous")         \
                                                                                        \
   f(final_mark_gross,                               "Pause Final Mark (G)")            \
   f(final_mark,                                     "Pause Final Mark (N)")            \
@@ -217,13 +217,13 @@ private:
   ShenandoahWorkerData* worker_data(Phase phase, ParPhase par_phase);
   Phase worker_par_phase(Phase phase, ParPhase par_phase);
 
-  void set_cycle_data(Phase phase, double time);
+  void set_cycle_data(Phase phase, double time, bool should_aggregate_cycles=false);
   static double uninitialized() { return -1; }
 
 public:
   ShenandoahPhaseTimings(uint max_workers);
 
-  void record_phase_time(Phase phase, double time);
+  void record_phase_time(Phase phase, double time, bool should_aggregate_cycles=false);
 
   void record_workers_start(Phase phase);
   void record_workers_end(Phase phase);

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -57,7 +57,7 @@ class outputStream;
   f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
   SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "  CMR: ", f)                      \
   f(conc_mark,                                      "Concurrent Marking")              \
-  f(conc_mark_satb_flush_rendezvous,                "  SATB Flush Rendezvous")         \
+  f(conc_mark_satb_flush_rendezvous,                "  Flush SATB")                    \
                                                                                        \
   f(final_mark_gross,                               "Pause Final Mark (G)")            \
   f(final_mark,                                     "Pause Final Mark (N)")            \

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -111,20 +111,18 @@ ShenandoahConcurrentPhase::~ShenandoahConcurrentPhase() {
   _timer->register_gc_concurrent_end();
 }
 
-ShenandoahTimingsTracker::ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate_cycles) :
+ShenandoahTimingsTracker::ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate) :
   _timings(ShenandoahHeap::heap()->phase_timings()), _phase(phase) {
   assert(Thread::current()->is_VM_thread() || Thread::current()->is_ConcurrentGC_thread(),
           "Must be set by these threads");
   _parent_phase = _current_phase;
   _current_phase = phase;
   _start = os::elapsedTime();
-  _should_aggregate_cycles = should_aggregate_cycles;
+  _should_aggregate = should_aggregate;
 }
 
 ShenandoahTimingsTracker::~ShenandoahTimingsTracker() {
-  const double end_time = os::elapsedTime();
-  const double phase_elapsed_time = end_time - _start;
-  _timings->record_phase_time(_phase, phase_elapsed_time, _should_aggregate_cycles);
+  _timings->record_phase_time(_phase, os::elapsedTime() - _start, _should_aggregate);
   _current_phase = _parent_phase;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -112,13 +112,12 @@ ShenandoahConcurrentPhase::~ShenandoahConcurrentPhase() {
 }
 
 ShenandoahTimingsTracker::ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate) :
-  _timings(ShenandoahHeap::heap()->phase_timings()), _phase(phase) {
+  _timings(ShenandoahHeap::heap()->phase_timings()), _phase(phase), _should_aggregate(should_aggregate) {
   assert(Thread::current()->is_VM_thread() || Thread::current()->is_ConcurrentGC_thread(),
           "Must be set by these threads");
   _parent_phase = _current_phase;
   _current_phase = phase;
   _start = os::elapsedTime();
-  _should_aggregate = should_aggregate;
 }
 
 ShenandoahTimingsTracker::~ShenandoahTimingsTracker() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -111,17 +111,20 @@ ShenandoahConcurrentPhase::~ShenandoahConcurrentPhase() {
   _timer->register_gc_concurrent_end();
 }
 
-ShenandoahTimingsTracker::ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase) :
+ShenandoahTimingsTracker::ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate_cycles) :
   _timings(ShenandoahHeap::heap()->phase_timings()), _phase(phase) {
   assert(Thread::current()->is_VM_thread() || Thread::current()->is_ConcurrentGC_thread(),
           "Must be set by these threads");
   _parent_phase = _current_phase;
   _current_phase = phase;
   _start = os::elapsedTime();
+  _should_aggregate_cycles = should_aggregate_cycles;
 }
 
 ShenandoahTimingsTracker::~ShenandoahTimingsTracker() {
-  _timings->record_phase_time(_phase, os::elapsedTime() - _start);
+  const double end_time = os::elapsedTime();
+  const double phase_elapsed_time = end_time - _start;
+  _timings->record_phase_time(_phase, phase_elapsed_time, _should_aggregate_cycles);
   _current_phase = _parent_phase;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -64,9 +64,9 @@ private:
 
   ShenandoahPhaseTimings* const         _timings;
   const ShenandoahPhaseTimings::Phase   _phase;
+  const bool _should_aggregate;
   ShenandoahPhaseTimings::Phase         _parent_phase;
   double _start;
-  bool _should_aggregate;
 
 public:
   ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate = false);

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -64,7 +64,7 @@ private:
 
   ShenandoahPhaseTimings* const         _timings;
   const ShenandoahPhaseTimings::Phase   _phase;
-  const bool _should_aggregate;
+  const bool                            _should_aggregate;
   ShenandoahPhaseTimings::Phase         _parent_phase;
   double _start;
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -66,9 +66,10 @@ private:
   const ShenandoahPhaseTimings::Phase   _phase;
   ShenandoahPhaseTimings::Phase         _parent_phase;
   double _start;
+  bool _should_aggregate_cycles;
 
 public:
-  ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase);
+  ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate_cycles=false);
   ~ShenandoahTimingsTracker();
 
   static ShenandoahPhaseTimings::Phase current_phase() { return _current_phase; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -66,10 +66,10 @@ private:
   const ShenandoahPhaseTimings::Phase   _phase;
   ShenandoahPhaseTimings::Phase         _parent_phase;
   double _start;
-  bool _should_aggregate_cycles;
+  bool _should_aggregate;
 
 public:
-  ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate_cycles=false);
+  ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate = false);
   ~ShenandoahTimingsTracker();
 
   static ShenandoahPhaseTimings::Phase current_phase() { return _current_phase; }


### PR DESCRIPTION
**Revision 2 Notes** 
1. Added time spent on handshaking all threads requesting them to flush their SATB buffers as part of GC stats.
2. As mentioned in PR feedback, will raise separate PR to adding logging in ShenandoahTimingsTracker.

**Revision 1 Notes**
This PR adds the following
1.  info logging on number of SATB flush attempts
3. total time spend on handshaking all threads requesting them to flush their SATB buffers.

As suggested by William in [JDK-8336742 ](https://bugs.openjdk.org/browse/JDK-83367420), we can use handshake logging to get time spend and other stats for each handshake.
```
[4.515s][info][handshake   ] Handshake "Shenandoah Flush SATB Handshake", Targeted threads: 1036, Executed by requesting thread: 1035, Total completion time: 597004 ns
[4.517s][info][handshake   ] Handshake "Shenandoah Flush SATB Handshake", Targeted threads: 1036, Executed by requesting thread: 1033, Total completion time: 207402 ns
```

**Testing**
1. tier1, tier2 and hotspot_gc_shenandoah tests.
2. **-Xlog:gc+stats=info**

```
[4.911s][info][gc,stats]   CMR: VM Strong Roots              539 us, workers (us): 102,  89,  89,  79,  46,  40,  40,  25,  24,   1,   2,   2, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[4.911s][info][gc,stats]   CMR: CLDG Roots                   461 us, workers (us): 429,   5,  12,  11,   4, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[4.911s][info][gc,stats] Concurrent Marking                 4392 us
[4.911s][info][gc,stats]   Flush SATB                       1035 us
[4.911s][info][gc,stats] Pause Final Mark (G)               2615 us
[4.912s][info][gc,stats] Pause Final Mark (N)               2339 us
[4.912s][info][gc,stats]   Finish Mark                       780 us
[4.912s][info][gc,stats]   Update Region States              109 us
[4.912s][info][gc,stats]   Choose Collection Set            1336 us
[4.912s][info][gc,stats]   Rebuild Free Set                   23 us
```

on app termination

```
4.924s][info][gc,stats] Concurrent Reset               =    0.042 s (a =     1846 us) (n =    23) (lvls, us =     1113,     1660,     1895,     2031,     2674)
[4.924s][info][gc,stats] Pause Init Mark (G)            =    0.073 s (a =     3163 us) (n =    23) (lvls, us =     2812,     2949,     3047,     3281,     3790)
[4.924s][info][gc,stats] Pause Init Mark (N)            =    0.065 s (a =     2810 us) (n =    23) (lvls, us =     2578,     2676,     2793,     2793,     3260)
[4.924s][info][gc,stats]   Update Region States         =    0.003 s (a =      112 us) (n =    23) (lvls, us =       92,      100,      109,      115,      147)
[4.924s][info][gc,stats] Concurrent Mark Roots          =    0.227 s (a =     9877 us) (n =    23) (lvls, us =     8320,     8965,     9258,    10156,    13403)
[4.924s][info][gc,stats]   CMR: <total>                 =    2.606 s (a =   113310 us) (n =    23) (lvls, us =    95703,   103516,   105469,   115234,   153738)
[4.924s][info][gc,stats]   CMR: Thread Roots            =    2.578 s (a =   112083 us) (n =    23) (lvls, us =    94922,   101562,   103516,   115234,   147708)
[4.924s][info][gc,stats]   CMR: VM Strong Roots         =    0.015 s (a =      641 us) (n =    23) (lvls, us =      395,      436,      477,      557,     3791)
[4.924s][info][gc,stats]   CMR: CLDG Roots              =    0.013 s (a =      587 us) (n =    23) (lvls, us =      328,      414,      434,      693,     2238)
[4.924s][info][gc,stats] Concurrent Marking             =    0.099 s (a =     4302 us) (n =    23) (lvls, us =     3809,     3965,     4219,     4414,     5623)
[4.924s][info][gc,stats]   Flush SATB                   =    0.021 s (a =      927 us) (n =    23) (lvls, us =      633,      861,      912,      996,     1104)
[4.924s][info][gc,stats] Pause Final Mark (G)           =    0.051 s (a =     2231 us) (n =    23) (lvls, us =     1445,     1699,     2285,     2461,     3002)
[4.924s][info][gc,stats] Pause Final Mark (N)           =    0.046 s (a =     1995 us) (n =    23) (lvls, us =     1270,     1465,     2051,     2168,     2643)
[4.924s][info][gc,stats]   Finish Mark                  =    0.015 s (a =      648 us) (n =    23) (lvls, us =      426,      594,      629,      693,      893)
[4.924s][info][gc,stats]   Update Region States         =    0.002 s (a =      105 us) (n =    23) (lvls, us =       91,       97,      100,      107,      135)
[4.924s][info][gc,stats]   Choose Collection Set        =    0.026 s (a =     1137 us) (n =    23) (lvls, us =      578,      672,     1191,     1250,     1837)
[4.924s][info][gc,stats]   Rebuild Free Set             =    0.001 s (a =       24 us) (n =    23) (lvls, us =       22,       23,       23,       24,       35)
[4.924s][info][gc,stats] Concurrent Weak References     =    0.002 s (a =       76 us) (n =    23) (lvls, us =       54,       62,       70,       81,      144)
[4.924s][info][gc,stats]   CWRF: <total>                =    0.001 s (a =       60 us) (n =    23) (lvls, us =       15,       19,       38,       76,      330)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336742](https://bugs.openjdk.org/browse/JDK-8336742): Shenandoah: Add more verbose logging/stats for mark termination attempts (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20318/head:pull/20318` \
`$ git checkout pull/20318`

Update a local copy of the PR: \
`$ git checkout pull/20318` \
`$ git pull https://git.openjdk.org/jdk.git pull/20318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20318`

View PR using the GUI difftool: \
`$ git pr show -t 20318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20318.diff">https://git.openjdk.org/jdk/pull/20318.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20318#issuecomment-2248914971)