### PR TITLE
8337124: (fs) sun.nio.fs.WindowsSecurity.enablePrivilege should pin when continuations supported

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsSecurity.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,8 @@
 
 package sun.nio.fs;
 
-import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.vm.Continuation;
+import jdk.internal.vm.ContinuationSupport;
 
 import static sun.nio.fs.WindowsNativeDispatcher.*;
 import static sun.nio.fs.WindowsConstants.*;
@@ -106,7 +106,7 @@ class WindowsSecurity {
         final boolean needToRevert = elevated;
 
         // prevent yielding with privileges
-        if (PreviewFeatures.isEnabled())
+        if (ContinuationSupport.isSupported())
             Continuation.pin();
 
         return () -> {
@@ -126,7 +126,7 @@ class WindowsSecurity {
                 }
             } finally {
                 LocalFree(pLuid);
-                if (PreviewFeatures.isEnabled())
+                if (ContinuationSupport.isSupported())
                     Continuation.unpin();
             }
         };


### PR DESCRIPTION
In `sun.nio.fs.WindowsSecurity.enablePrivilege`, change `PreviewFeatures.isEnabled` to `ContinuationSupport.isSupported`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337124](https://bugs.openjdk.org/browse/JDK-8337124): (fs) sun.nio.fs.WindowsSecurity.enablePrivilege should pin when continuations supported (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20319/head:pull/20319` \
`$ git checkout pull/20319`

Update a local copy of the PR: \
`$ git checkout pull/20319` \
`$ git pull https://git.openjdk.org/jdk.git pull/20319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20319`

View PR using the GUI difftool: \
`$ git pr show -t 20319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20319.diff">https://git.openjdk.org/jdk/pull/20319.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20319#issuecomment-2249080699)