### PR TITLE
8336895: BufferedReader doesn't read full \r\n line ending when it doesn't fit in buffer

### DIFF
--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -50,6 +50,12 @@ import jdk.internal.util.ArraysSupport;
  * reread before new bytes are  taken from
  * the contained input stream.
  *
+ * <p> In general, different {@code BufferedInputStream}s should not be used
+ * to read from the same {@code InputStream}. There is no way for a
+ * {@code BufferedInputStream} to know what another {@code BufferedInputStream}
+ * has read from the underlying {@code InputStream}, nor dues it have access
+ * to the other {@code BufferedInputStream}'s internal buffer.
+ *
  * @author  Arthur van Hoff
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -50,11 +50,11 @@ import jdk.internal.util.ArraysSupport;
  * reread before new bytes are  taken from
  * the contained input stream.
  *
- * <p> In general, different {@code BufferedInputStream}s should not be used
- * to read from the same {@code InputStream}. There is no way for a
- * {@code BufferedInputStream} to know what another {@code BufferedInputStream}
- * has read from the underlying {@code InputStream}, nor does it have access
- * to the other {@code BufferedInputStream}'s internal buffer.
+ * <p> More than one instance of {@code BufferedInputStream} should not be
+ * used with the same underlying {@code InputStream} instance.  Doing
+ * so can cause the {@code BufferedInputStream} instances to return an
+ * incorrect result since each instance of {@code BufferedInputStream}
+ * maintains its own state.
  *
  * @author  Arthur van Hoff
  * @since   1.0

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -53,7 +53,7 @@ import jdk.internal.util.ArraysSupport;
  * <p> In general, different {@code BufferedInputStream}s should not be used
  * to read from the same {@code InputStream}. There is no way for a
  * {@code BufferedInputStream} to know what another {@code BufferedInputStream}
- * has read from the underlying {@code InputStream}, nor dues it have access
+ * has read from the underlying {@code InputStream}, nor does it have access
  * to the other {@code BufferedInputStream}'s internal buffer.
  *
  * @author  Arthur van Hoff

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -51,7 +51,7 @@ import jdk.internal.util.ArraysSupport;
  * the contained input stream.
  *
  * <p> More than one instance of {@code BufferedInputStream} should not be
- * used with the same underlying {@code InputStream} instance.  Doing
+ * used with the same underlying {@code InputStream} instance. Doing
  * so can cause the {@code BufferedInputStream} instances to return an
  * incorrect result since each instance of {@code BufferedInputStream}
  * maintains its own state.

--- a/src/java.base/share/classes/java/io/BufferedInputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedInputStream.java
@@ -50,11 +50,10 @@ import jdk.internal.util.ArraysSupport;
  * reread before new bytes are  taken from
  * the contained input stream.
  *
- * <p> More than one instance of {@code BufferedInputStream} should not be
- * used with the same underlying {@code InputStream} instance. Doing
- * so can cause the {@code BufferedInputStream} instances to return an
- * incorrect result since each instance of {@code BufferedInputStream}
- * maintains its own state.
+ * @apiNote
+ * Once wrapped in a {@code BufferedInputStream}, the underlying
+ * {@code InputStream} should not be used directly nor wrapped with
+ * another stream.
  *
  * @author  Arthur van Hoff
  * @since   1.0

--- a/src/java.base/share/classes/java/io/BufferedOutputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,6 +34,11 @@ import jdk.internal.misc.VM;
  * an output stream, an application can write bytes to the underlying
  * output stream without necessarily causing a call to the underlying
  * system for each byte written.
+ *
+ * <p> More than one instance of {@code BufferedOutputStream} should not be
+ * used with the same underlying {@code OutputStream} instance.  Doing so can
+ * cause unpredictable results as each {@code BufferedOutputStream} maintains
+ * its own state and flushes its internal buffer according to that state.
  *
  * @author  Arthur van Hoff
  * @since   1.0

--- a/src/java.base/share/classes/java/io/BufferedOutputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedOutputStream.java
@@ -36,7 +36,7 @@ import jdk.internal.misc.VM;
  * system for each byte written.
  *
  * <p> More than one instance of {@code BufferedOutputStream} should not be
- * used with the same underlying {@code OutputStream} instance.  Doing so can
+ * used with the same underlying {@code OutputStream} instance. Doing so can
  * cause unpredictable results as each {@code BufferedOutputStream} maintains
  * its own state and flushes its internal buffer according to that state.
  *

--- a/src/java.base/share/classes/java/io/BufferedOutputStream.java
+++ b/src/java.base/share/classes/java/io/BufferedOutputStream.java
@@ -35,10 +35,10 @@ import jdk.internal.misc.VM;
  * output stream without necessarily causing a call to the underlying
  * system for each byte written.
  *
- * <p> More than one instance of {@code BufferedOutputStream} should not be
- * used with the same underlying {@code OutputStream} instance. Doing so can
- * cause unpredictable results as each {@code BufferedOutputStream} maintains
- * its own state and flushes its internal buffer according to that state.
+ * @apiNote
+ * Once wrapped in a {@code BufferedOutputStream}, the underlying
+ * {@code OutputStream} should not be used directly nor wrapped with
+ * another stream.
  *
  * @author  Arthur van Hoff
  * @since   1.0

--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -59,10 +59,10 @@ import jdk.internal.misc.InternalLock;
  * <p> Programs that use DataInputStreams for textual input can be localized by
  * replacing each DataInputStream with an appropriate BufferedReader.
  *
- * <p> In general, different BufferedReaders should not be used to read from
- * the same Reader. There is no way for a BufferedReader to know what another
- * BufferedReader has read from the underlying Reader, nor does it have access
- * to the other BufferedReader's internal buffer.
+ * <p> More than one instance of BufferedReader should not be used with the
+ * same underlying Reader instance.  Doing so can cause the BufferedReader
+ * instances to return an incorrect result since each instance of
+ * BufferedReader maintains its own state.
  *
  * @see FileReader
  * @see InputStreamReader

--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -61,7 +61,7 @@ import jdk.internal.misc.InternalLock;
  *
  * <p> In general, different BufferedReaders should not be used to read from
  * the same Reader. There is no way for a BufferedReader to know what another
- * BufferedReader has read from the underlying Reader, nor dues it have access
+ * BufferedReader has read from the underlying Reader, nor does it have access
  * to the other BufferedReader's internal buffer.
  *
  * @see FileReader

--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,11 @@ import jdk.internal.misc.InternalLock;
  *
  * <p> Programs that use DataInputStreams for textual input can be localized by
  * replacing each DataInputStream with an appropriate BufferedReader.
+ *
+ * <p> In general, different BufferedReaders should not be used to read from
+ * the same Reader. There is no way for a BufferedReader to know what another
+ * BufferedReader has read from the underlying Reader, nor dues it have access
+ * to the other BufferedReader's internal buffer.
  *
  * @see FileReader
  * @see InputStreamReader

--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -43,8 +43,9 @@ import jdk.internal.misc.InternalLock;
  *
  * <p> In general, each read request made of a Reader causes a corresponding
  * read request to be made of the underlying character or byte stream.  It is
- * therefore advisable to wrap a BufferedReader around any Reader whose read()
- * operations may be costly, such as FileReaders and InputStreamReaders.  For
+ * therefore advisable to wrap a {@code BufferedReader} around any
+ * {@code Reader} whose {@code read()} operations may be costly, such as
+ * {@code FileReader}s and {@code InputStreamReader}s.  For
  * example,
  *
  * {@snippet lang=java :
@@ -52,17 +53,18 @@ import jdk.internal.misc.InternalLock;
  * }
  *
  * will buffer the input from the specified file.  Without buffering, each
- * invocation of read() or readLine() could cause bytes to be read from the
- * file, converted into characters, and then returned, which can be very
- * inefficient.
+ * invocation of {@code read()} or {@code readLine()} could cause bytes to be
+ * read from the file, converted into characters, and then returned, which can
+ * be very inefficient.
  *
- * <p> Programs that use DataInputStreams for textual input can be localized by
- * replacing each DataInputStream with an appropriate BufferedReader.
+ * <p> Programs that use {@code DataInputStream}s for textual input can be
+ * localized by replacing each {@code DataInputStream} with an appropriate
+ * {@code BufferedReader}.
  *
- * <p> More than one instance of BufferedReader should not be used with the
- * same underlying Reader instance.  Doing so can cause the BufferedReader
- * instances to return an incorrect result since each instance of
- * BufferedReader maintains its own state.
+ * <p> More than one instance of {@code BufferedReader} should not be used
+ * with the same underlying Reader instance. Doing so can cause the
+ * {@code BufferedReader} instances to return an incorrect result since each
+ * instance of {@code BufferedReader} maintains its own state.
  *
  * @see FileReader
  * @see InputStreamReader

--- a/src/java.base/share/classes/java/io/BufferedReader.java
+++ b/src/java.base/share/classes/java/io/BufferedReader.java
@@ -61,10 +61,10 @@ import jdk.internal.misc.InternalLock;
  * localized by replacing each {@code DataInputStream} with an appropriate
  * {@code BufferedReader}.
  *
- * <p> More than one instance of {@code BufferedReader} should not be used
- * with the same underlying Reader instance. Doing so can cause the
- * {@code BufferedReader} instances to return an incorrect result since each
- * instance of {@code BufferedReader} maintains its own state.
+ * @apiNote
+ * Once wrapped in a {@code BufferedReader}, the underlying
+ * {@code Reader} should not be used directly nor wrapped with
+ * another reader.
  *
  * @see FileReader
  * @see InputStreamReader

--- a/src/java.base/share/classes/java/io/BufferedWriter.java
+++ b/src/java.base/share/classes/java/io/BufferedWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,6 +56,11 @@ import jdk.internal.misc.VM;
  * invocation of a print() method would cause characters to be converted into
  * bytes that would then be written immediately to the file, which can be very
  * inefficient.
+ *
+ * <p> More than one instance of BufferedWriter should not be used with the
+ * same underlying Writer instance.  Doing so can cause unpredictable results
+ * as each BufferedWriter maintains its own state and flushes its internal
+ * buffer according to that state.
  *
  * @see PrintWriter
  * @see FileWriter

--- a/src/java.base/share/classes/java/io/BufferedWriter.java
+++ b/src/java.base/share/classes/java/io/BufferedWriter.java
@@ -58,10 +58,10 @@ import jdk.internal.misc.VM;
  * converted into bytes that would then be written immediately to the file,
  * which can be very inefficient.
  *
- * <p> More than one instance of {@code BufferedWriter} should not be used with
- * the same underlying {@code Writer} instance. Doing so can cause unpredictable
- * results as each {@code BufferedWriter} maintains its own state and flushes
- * its internal buffer according to that state.
+ * @apiNote
+ * Once wrapped in a {@code BufferedWriter}, the underlying
+ * {@code Writer} should not be used directly nor wrapped with
+ * another writer.
  *
  * @see PrintWriter
  * @see FileWriter

--- a/src/java.base/share/classes/java/io/BufferedWriter.java
+++ b/src/java.base/share/classes/java/io/BufferedWriter.java
@@ -37,30 +37,31 @@ import jdk.internal.misc.VM;
  * <p> The buffer size may be specified, or the default size may be accepted.
  * The default is large enough for most purposes.
  *
- * <p> A newLine() method is provided, which uses the platform's own notion of
- * line separator as defined by the system property {@code line.separator}.
- * Not all platforms use the newline character ('\n') to terminate lines.
- * Calling this method to terminate each output line is therefore preferred to
- * writing a newline character directly.
+ * <p> A {@code newLine()} method is provided, which uses the platform's own
+ * notion of line separator as defined by the system property
+ * {@linkplain System#lineSeparator() line.separator}. Not all platforms use the newline character ('\n')
+ * to terminate lines. Calling this method to terminate each output line is
+ * therefore preferred to writing a newline character directly.
  *
- * <p> In general, a Writer sends its output immediately to the underlying
- * character or byte stream.  Unless prompt output is required, it is advisable
- * to wrap a BufferedWriter around any Writer whose write() operations may be
- * costly, such as FileWriters and OutputStreamWriters.  For example,
+ * <p> In general, a {@code Writer} sends its output immediately to the
+ * underlying character or byte stream.  Unless prompt output is required, it
+ * is advisable to wrap a {@code BufferedWriter} around any {@code Writer} whose
+ * {@code write()} operations may be costly, such as {@code FileWriter}s and
+ * {@code OutputStreamWriter}s.  For example,
  *
  * {@snippet lang=java :
  *     PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter("foo.out")));
  * }
  *
- * will buffer the PrintWriter's output to the file.  Without buffering, each
- * invocation of a print() method would cause characters to be converted into
- * bytes that would then be written immediately to the file, which can be very
- * inefficient.
+ * will buffer the {@code PrintWriter}'s output to the file.  Without buffering,
+ * each invocation of a {@code print()} method would cause characters to be
+ * converted into bytes that would then be written immediately to the file,
+ * which can be very inefficient.
  *
- * <p> More than one instance of BufferedWriter should not be used with the
- * same underlying Writer instance.  Doing so can cause unpredictable results
- * as each BufferedWriter maintains its own state and flushes its internal
- * buffer according to that state.
+ * <p> More than one instance of {@code BufferedWriter} should not be used with
+ * the same underlying {@code Writer} instance. Doing so can cause unpredictable
+ * results as each {@code BufferedWriter} maintains its own state and flushes
+ * its internal buffer according to that state.
  *
  * @see PrintWriter
  * @see FileWriter


### PR DESCRIPTION
Add some verbiage stating that two buffered readers or input streams should not be used to read from the same reader or input stream, respectively.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8339189](https://bugs.openjdk.org/browse/JDK-8339189) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8336895](https://bugs.openjdk.org/browse/JDK-8336895): BufferedReader doesn't read full \r\n line ending when it doesn't fit in buffer (**Bug** - P4)
 * [JDK-8339189](https://bugs.openjdk.org/browse/JDK-8339189): BufferedReader doesn't read full \r\n line ending when it doesn't fit in buffer (**CSR**)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20320/head:pull/20320` \
`$ git checkout pull/20320`

Update a local copy of the PR: \
`$ git checkout pull/20320` \
`$ git pull https://git.openjdk.org/jdk.git pull/20320/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20320`

View PR using the GUI difftool: \
`$ git pr show -t 20320`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20320.diff">https://git.openjdk.org/jdk/pull/20320.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20320#issuecomment-2249113594)