### PR TITLE
8337839: Make a few fields in MergeCollation static

### DIFF
--- a/src/java.base/share/classes/java/text/MergeCollation.java
+++ b/src/java.base/share/classes/java/text/MergeCollation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -220,9 +220,9 @@ final class MergeCollation {
     // Using BitSet would make this easier, but it's significantly slower.
     //
     private transient byte[] statusArray = new byte[8192];
-    private final byte BITARRAYMASK = (byte)0x1;
-    private final int  BYTEPOWER = 3;
-    private final int  BYTEMASK = (1 << BYTEPOWER) - 1;
+    private static final byte BITARRAYMASK = (byte)0x1;
+    private static final int BYTEPOWER = 3;
+    private static final int BYTEMASK = (1 << BYTEPOWER) - 1;
 
     /*
       If the strength is RESET, then just change the lastEntry to


### PR DESCRIPTION
3 fields in java.text.MergeCollation could be made 'static':
1. BITARRAYMASK
2. BYTEPOWER
3. BYTEMASK

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337839](https://bugs.openjdk.org/browse/JDK-8337839): Make a few fields in MergeCollation static (**Enhancement** - P5)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20323/head:pull/20323` \
`$ git checkout pull/20323`

Update a local copy of the PR: \
`$ git checkout pull/20323` \
`$ git pull https://git.openjdk.org/jdk.git pull/20323/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20323`

View PR using the GUI difftool: \
`$ git pr show -t 20323`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20323.diff">https://git.openjdk.org/jdk/pull/20323.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20323#issuecomment-2269818096)