### PR TITLE
8337060: Test java/foreign/TestConcurrentClose.java failed: IllegalStateException: SegmentAccessor::doAccess method not being compiled

### DIFF
--- a/test/jdk/java/foreign/TestConcurrentClose.java
+++ b/test/jdk/java/foreign/TestConcurrentClose.java
@@ -36,6 +36,7 @@
  *   -XX:+UnlockDiagnosticVMOptions
  *   -XX:+WhiteBoxAPI
  *   -XX:CompileCommand=dontinline,TestConcurrentClose$SegmentAccessor::doAccess
+ *   -Xbatch
  *   TestConcurrentClose
  */
 
@@ -71,7 +72,7 @@ public class TestConcurrentClose {
 
     static final int ITERATIONS = 5;
     static final int SEGMENT_SIZE = 10_000;
-    static final int MAX_EXECUTOR_WAIT_SECONDS = 20;
+    static final int MAX_EXECUTOR_WAIT_SECONDS = 60;
     static final int NUM_ACCESSORS = 50;
 
     static final AtomicLong start = new AtomicLong();
@@ -176,13 +177,8 @@ public class TestConcurrentClose {
     }
 
     private static void awaitCompilation() throws InterruptedException {
-        int retries = 0;
         while (WB.getMethodCompilationLevel(DO_ACCESS_METHOD, false) != C2_COMPILED_LEVEL) {
-            if (retries > 20) {
-                throw new IllegalStateException("SegmentAccessor::doAccess method not being compiled");
-            }
             Thread.sleep(1000);
-            retries++;
         }
     }
 }


### PR DESCRIPTION
We are seeing some failures of this test in our CI, particularly on Windows machines, which are known to starve out certain threads.

To make sure the compiler threads get a chance to work, I've added `-Xbatch` to the flags with which the test runs (this was missed in the original PR). I've also removed the timeout from the `awaitCompilation` method. The intent is to instead rely on the overall test's timeout, which can also be adjusted with a timeout factor for slower machines, rather than putting an absolute time limit on the compilation.

Finally, Alan asked me to increase the timeout for the executor shutdown, since there have also been some timeouts there. The current timeout is borrowed from `test/jdk/java/foreign/TestHandshake`, but that test uses a lot less threads, so it can probably get await with waiting just 20 seconds.

Testing: I ran this test 200 time in Oracle CI, half of the runs were with `-Duse.JTREG_TEST_THREAD_FACTORY=Virtual -XX:-VerifyContinuations` (which is one of the failing configurations).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337060](https://bugs.openjdk.org/browse/JDK-8337060): Test java/foreign/TestConcurrentClose.java failed: IllegalStateException: SegmentAccessor::doAccess method not being compiled (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20325/head:pull/20325` \
`$ git checkout pull/20325`

Update a local copy of the PR: \
`$ git checkout pull/20325` \
`$ git pull https://git.openjdk.org/jdk.git pull/20325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20325`

View PR using the GUI difftool: \
`$ git pr show -t 20325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20325.diff">https://git.openjdk.org/jdk/pull/20325.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20325#issuecomment-2250060130)