### PR TITLE
8336410

### DIFF
--- a/test/hotspot/jtreg/runtime/NMT/TotalMallocMmapDiffTest.java
+++ b/test/hotspot/jtreg/runtime/NMT/TotalMallocMmapDiffTest.java
@@ -43,7 +43,7 @@ import jdk.test.whitebox.WhiteBox;
 public class TotalMallocMmapDiffTest {
     private static final WhiteBox wb = WhiteBox.getWhiteBox();
     private static final long ALLOCATE_SIZE = 250 * 1024 * 1024; // 250MB
-    private static final double FUDGE_FACTOR = 0.2;
+    private static final double FUDGE_FACTOR = 0.3;
     private static final double UPPER_BOUND = ALLOCATE_SIZE * (1 + FUDGE_FACTOR);
     private static final double LOWER_BOUND = ALLOCATE_SIZE * (1 - FUDGE_FACTOR);
 


### PR DESCRIPTION
Hi,

We've seen intermittent failures in this test because of the change being out of the pre-defined range. The largest "out of bounds" we've observed is 1.5MiB, so increasing the fudge factor to allow for 25MiBs more/less should be sufficient for us to not see this error for a while. This kind of adjustment is an unfortunate necessity when developing these kinds of tests.