### PR TITLE
8339972: Make a few fields in SortingFocusTraversalPolicy static

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/SortingFocusTraversalPolicy.java
+++ b/src/java.desktop/share/classes/javax/swing/SortingFocusTraversalPolicy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,8 +87,8 @@ public class SortingFocusTraversalPolicy
     private static final SwingContainerOrderFocusTraversalPolicy
         fitnessTestPolicy = new SwingContainerOrderFocusTraversalPolicy();
 
-    private final int FORWARD_TRAVERSAL = 0;
-    private final int BACKWARD_TRAVERSAL = 1;
+    private static final int FORWARD_TRAVERSAL = 0;
+    private static final int BACKWARD_TRAVERSAL = 1;
 
     /*
      * When true (by default), the legacy merge-sort algo is used to sort an FTP cycle.


### PR DESCRIPTION
2 fields in javax.swing.SortingFocusTraversalPolicy could be made 'static':
1. FORWARD_TRAVERSAL = 0
2. BACKWARD_TRAVERSAL = 1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339972](https://bugs.openjdk.org/browse/JDK-8339972): Make a few fields in SortingFocusTraversalPolicy static (**Enhancement** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20327/head:pull/20327` \
`$ git checkout pull/20327`

Update a local copy of the PR: \
`$ git checkout pull/20327` \
`$ git pull https://git.openjdk.org/jdk.git pull/20327/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20327`

View PR using the GUI difftool: \
`$ git pr show -t 20327`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20327.diff">https://git.openjdk.org/jdk/pull/20327.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20327#issuecomment-2344587887)