### PR TITLE
8339017: Make a couple of fields in DoubleByte static

### DIFF
--- a/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
+++ b/src/java.base/share/classes/sun/nio/cs/DoubleByte.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -402,7 +402,7 @@ public class DoubleByte {
                         else
                             currentState = SBCS;
                     } else {
-                        char c = UNMAPPABLE_DECODING;
+                        char c;
                         if (currentState == SBCS) {
                             c = b2cSB[b1];
                             if (c == UNMAPPABLE_DECODING)
@@ -452,7 +452,7 @@ public class DoubleByte {
                     else
                         currentState = SBCS;
                 } else {
-                    char c =  UNMAPPABLE_DECODING;
+                    char c;
                     if (currentState == SBCS) {
                         c = b2cSB[b1];
                         if (c == UNMAPPABLE_DECODING)
@@ -503,8 +503,8 @@ public class DoubleByte {
     // The only thing we need to "override" is to check SS2/SS3 and
     // return "malformed" if found
     public static class Decoder_EUC_SIM extends Decoder {
-        private final int SS2 =  0x8E;
-        private final int SS3 =  0x8F;
+        private static final int SS2 = 0x8E;
+        private static final int SS3 = 0x8F;
 
         public Decoder_EUC_SIM(Charset cs,
                                char[][] b2c, char[] b2cSB, int b2Min, int b2Max,
@@ -556,7 +556,7 @@ public class DoubleByte {
     public static class Encoder extends CharsetEncoder
                                 implements ArrayEncoder
     {
-        protected final int MAX_SINGLEBYTE = 0xff;
+        protected static final int MAX_SINGLEBYTE = 0xff;
         private final char[] c2b;
         private final char[] c2bIndex;
         protected Surrogate.Parser sgp;
@@ -659,7 +659,7 @@ public class DoubleByte {
                         dst.put((byte)(bb));
                     } else {
                         if (dst.remaining() < 1)
-                        return CoderResult.OVERFLOW;
+                            return CoderResult.OVERFLOW;
                         dst.put((byte)bb);
                     }
                     mark++;


### PR DESCRIPTION
3 fields in `sun.nio.cs.DoubleByte.{Encoder,Decoder}` could be made 'static':
1. SS2
2. SS3
3. MAX_SINGLEBYTE

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8339017](https://bugs.openjdk.org/browse/JDK-8339017): Make a couple of fields in DoubleByte static (**Enhancement** - P5)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20329/head:pull/20329` \
`$ git checkout pull/20329`

Update a local copy of the PR: \
`$ git checkout pull/20329` \
`$ git pull https://git.openjdk.org/jdk.git pull/20329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20329`

View PR using the GUI difftool: \
`$ git pr show -t 20329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20329.diff">https://git.openjdk.org/jdk/pull/20329.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20329#issuecomment-2310989579)