### PR TITLE
8329756: [macos] "javax/swing/JTable/KeyBoardNavigation.java" fail because most combinations of navigational keys with the Ctrl key do not work

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaKeyBindings.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaKeyBindings.java
@@ -388,7 +388,9 @@ public class AquaKeyBindings {
             "alt shift TAB", "focusHeader",
             "F8", "focusHeader",
             "ctrl shift UP", "selectFirstRowExtendSelection",
-            "ctrl shift DOWN", "selectLastRowExtendSelection"
+            "ctrl shift DOWN", "selectLastRowExtendSelection",
+            "ctrl shift RIGHT", "selectLastColumnExtendSelection",
+            "ctrl shift LEFT", "selectFirstColumnExtendSelection"
         }));
     }
 

--- a/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
+++ b/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
@@ -39,7 +39,7 @@ import javax.swing.table.TableModel;
 /*
  * @test
  * @key headful
- * @bug 4112270 8264102
+ * @bug 4112270 8264102 8329756
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Test Keyboard Navigation in JTable.
@@ -270,7 +270,7 @@ public class KeyBoardNavigation {
                                 up/down
                 Left/Right Arrow - Deselect current selection;
                                    move focus one cell left/right
-                FN+Up Arrow/FN+Down Arrow - Deselect current selection;
+                fn+Up/Down Arrow - Deselect current selection;
                                    scroll up/down one JViewport view;
                                    first visible cell in current column gets focus
                 fn - Allows editing in a cell containing information without

--- a/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
+++ b/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
@@ -273,21 +273,16 @@ public class KeyBoardNavigation {
                 FN+Up Arrow/FN+Down Arrow - Deselect current selection;
                                    scroll up/down one JViewport view;
                                    first visible cell in current column gets focus
-                Control-FN+Up Arrow/FN+Down Arrow - Deselect current selection;
-                                                    move focus and view to
-                                                    first/last cell in current row
-                F2 - Allows editing in a cell containing information without
+                fn - Allows editing in a cell containing information without
                      overwriting the information
                 Esc -  Resets the cell content back to the state it was in
                        before editing started
-                Ctrl+A, Ctrl+/ - Select All
-                Ctrl+\\ - Deselect all
+                Cmd+A - Select All
                 Shift-Up/Down Arrow -  Extend selection up/down one row
                 Shift-Left/Right Arrow - Extend selection left/right one column
-                FN-Shift Up/Down Arrow -  Extend selection to top/bottom of column
-                Shift-PageUp/PageDown - Extend selection up/down one view and scroll
-                                        table
-                                """;
+                Ctrl-Shift Up/Down Arrow -  Extend selection to top/bottom of row
+                Ctrl-Shift Left/Right Arrow -  Extend selection to first/last of column
+                """;
         String osName = System.getProperty("os.name").toLowerCase();
         if (osName.startsWith("mac")) {
             return MAC_SPECIFIC;

--- a/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
+++ b/test/jdk/javax/swing/JTable/KeyBoardNavigation.java
@@ -178,7 +178,7 @@ public class KeyBoardNavigation {
                 1. Refer the below keyboard navigation specs
                  (referenced from bug report 4112270).
                 2. Check all combinations of navigational keys mentioned below
-                 and verifying each key combinations against the spec defined.
+                 and verify each key combination against the spec defined.
                  If it does, press "pass", otherwise press "fail".
 
                 """;


### PR DESCRIPTION
Mismatch in key combinations, I have taken native macos Numbers application as reference to verify. Have added `Ctrl-Shift Left/Right` action keys similar to `Ctrl-Shift UP/DOWN` which would be expected functionality. I've removed those test instructions which are not applicable/implemented/not working in Macos keyboard navigation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8329756](https://bugs.openjdk.org/browse/JDK-8329756): [macos] "javax/swing/JTable/KeyBoardNavigation.java" fail because most combinations of navigational keys with the Ctrl key do not work (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20331/head:pull/20331` \
`$ git checkout pull/20331`

Update a local copy of the PR: \
`$ git checkout pull/20331` \
`$ git pull https://git.openjdk.org/jdk.git pull/20331/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20331`

View PR using the GUI difftool: \
`$ git pr show -t 20331`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20331.diff">https://git.openjdk.org/jdk/pull/20331.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20331#issuecomment-2250867838)