### PR TITLE
8337213: Shenandoah: Add verification for class mirrors

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -250,6 +250,25 @@ void ShenandoahAsserts::assert_correct(void* interior_loc, oop obj, const char* 
                     file, line);
     }
   }
+
+  // Do additional checks for special objects: their fields can hold metadata as well.
+  // We want to check class loading/unloading did not corrupt them.
+
+  if (java_lang_Class::is_instance(obj)) {
+    Metadata* klass = obj->metadata_field(java_lang_Class::klass_offset());
+    if (klass != nullptr && !Metaspace::contains(klass)) {
+      print_failure(_safe_all, obj, interior_loc, nullptr, "Shenandoah assert_correct failed",
+                    "Instance class mirror should point to Metaspace",
+                    file, line);
+    }
+
+    Metadata* array_klass = obj->metadata_field(java_lang_Class::array_klass_offset());
+    if (array_klass != nullptr && !Metaspace::contains(array_klass)) {
+      print_failure(_safe_all, obj, interior_loc, nullptr, "Shenandoah assert_correct failed",
+                    "Array class mirror should point to Metaspace",
+                    file, line);
+    }
+  }
 }
 
 void ShenandoahAsserts::assert_in_correct_region(void* interior_loc, oop obj, const char* file, int line) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -212,6 +212,21 @@ private:
       fwd_reg = obj_reg;
     }
 
+    // Do additional checks for special objects: their fields can hold metadata as well.
+    // We want to check class loading/unloading did not corrupt them.
+
+    if (java_lang_Class::is_instance(obj)) {
+      Metadata* klass = obj->metadata_field(java_lang_Class::klass_offset());
+      check(ShenandoahAsserts::_safe_oop, obj,
+            klass == nullptr || Metaspace::contains(klass),
+            "Instance class mirror should point to Metaspace");
+
+      Metadata* array_klass = obj->metadata_field(java_lang_Class::array_klass_offset());
+      check(ShenandoahAsserts::_safe_oop, obj,
+            array_klass == nullptr || Metaspace::contains(array_klass),
+            "Array class mirror should point to Metaspace");
+    }
+
     // ------------ obj and fwd are safe at this point --------------
 
     switch (_options._verify_marked) {


### PR DESCRIPTION
When working in Leyden, I noticed some oddities when loading Class mirrors from the CDS archive. These are not caught by Shenandoah asserts or verifier, since the problem is due to wrong metadata. We can amend verification to test these. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `all` with `-XX:+UseShenandoahGC`
 - [x] Linux x86_64 server fastdebug, `all` with `-XX:+UseShenandoahGC -XX:+ShenandoahVerify`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337213](https://bugs.openjdk.org/browse/JDK-8337213): Shenandoah: Add verification for class mirrors (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20332/head:pull/20332` \
`$ git checkout pull/20332`

Update a local copy of the PR: \
`$ git checkout pull/20332` \
`$ git pull https://git.openjdk.org/jdk.git pull/20332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20332`

View PR using the GUI difftool: \
`$ git pr show -t 20332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20332.diff">https://git.openjdk.org/jdk/pull/20332.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20332#issuecomment-2250501976)