### PR TITLE
8336830: C2: assert(get_loop(lca)->_nest < n_loop->_nest || lca->in(0)->is_NeverBranch()) failed: must not be moved into inner loop

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1069,7 +1069,7 @@ void PhaseIdealLoop::try_move_store_after_loop(Node* n) {
 #endif
             lca = place_outside_loop(lca, n_loop);
             assert(!n_loop->is_member(get_loop(lca)), "control must not be back in the loop");
-            assert(get_loop(lca)->_nest < n_loop->_nest || lca->in(0)->is_NeverBranch(), "must not be moved into inner loop");
+            assert(get_loop(lca)->_nest < n_loop->_nest || get_loop(lca)->_head->as_Loop()->is_in_infinite_subgraph(), "must not be moved into inner loop");
 
             // Move store out of the loop
             _igvn.replace_node(hook, n->in(MemNode::Memory));
@@ -1272,9 +1272,7 @@ Node* PhaseIdealLoop::place_outside_loop(Node* useblock, IdealLoopTree* loop) co
   // Pick control right outside the loop
   for (;;) {
     Node* dom = idom(useblock);
-    if (loop->is_member(get_loop(dom)) ||
-        // NeverBranch nodes are not assigned to the loop when constructed
-        (dom->is_NeverBranch() && loop->is_member(get_loop(dom->in(0))))) {
+    if (loop->is_member(get_loop(dom))) {
       break;
     }
     useblock = dom;

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1272,7 +1272,9 @@ Node* PhaseIdealLoop::place_outside_loop(Node* useblock, IdealLoopTree* loop) co
   // Pick control right outside the loop
   for (;;) {
     Node* dom = idom(useblock);
-    if (loop->is_member(get_loop(dom))) {
+    if (loop->is_member(get_loop(dom)) ||
+        // NeverBranch nodes are not assigned to the loop when constructed
+        (dom->is_NeverBranch() && loop->is_member(get_loop(dom->in(0))))) {
       break;
     }
     useblock = dom;

--- a/test/hotspot/jtreg/compiler/loopopts/TestSunkNodeInInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestSunkNodeInInfiniteLoop.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8336830
+ * @summary C2: assert(get_loop(lca)->_nest < n_loop->_nest || lca->in(0)->is_NeverBranch()) failed: must not be moved into inner loop
+ * @library /test/lib
+ * @run main/othervm -XX:CompileCommand=compileonly,TestSunkNodeInInfiniteLoop::* -Xcomp TestSunkNodeInInfiniteLoop
+ *
+ */
+
+import jdk.test.lib.Utils;
+
+public class TestSunkNodeInInfiniteLoop {
+    public static void main(String[] args) throws InterruptedException {
+        byte[] a = new byte[1];
+        Thread thread = new Thread(() -> test(a));
+        thread.setDaemon(true);
+        thread.start();
+        Thread.sleep(Utils.adjustTimeout(4000));
+    }
+
+    static void test(byte[] a) {
+        // L0:
+        while(true) {
+            int i1 = a.length;
+            // L3:
+            while(true) {
+                int i2 = 0;
+                if ((i1--) <= 0) { break; /* ifle L0 */}
+                a[i2++] = -1;
+                // goto L3
+            }
+        }
+    }
+}


### PR DESCRIPTION
A store is sunk from a counted loop into an enclosing infinite
loop. The assert fires because:

```
get_loop(lca)->_nest < n_loop->_nest
```

is false. That happens because the outer loop was found to be infinite
in the current loop opts pass. When that happens, it's not properly
attached to the loop tree. The second part of the assert was added to
cover a similar case:

```
lca->in(0)->is_NeverBranch()
```

but it doesn't work in this case bcause lca is not a projection of the
`NeverBranch`. It's the exit projection of the counted loop. The fix I
propose changes that part of the assert to test that lca is, indeed,
in an infinite loop in a way that's robust.

I also removed some code that I believe to be useless following
8335709.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336830](https://bugs.openjdk.org/browse/JDK-8336830): C2: assert(get_loop(lca)-&gt;_nest &lt; n_loop-&gt;_nest || lca-&gt;in(0)-&gt;is_NeverBranch()) failed: must not be moved into inner loop (**Bug** - P3)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**) Review applies to [420873b7](https://git.openjdk.org/jdk/pull/20334/files/420873b76b858fce02b6151f6e170b8532e8d79a)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Contributors
 * Emanuel Peter `<epeter@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20334/head:pull/20334` \
`$ git checkout pull/20334`

Update a local copy of the PR: \
`$ git checkout pull/20334` \
`$ git pull https://git.openjdk.org/jdk.git pull/20334/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20334`

View PR using the GUI difftool: \
`$ git pr show -t 20334`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20334.diff">https://git.openjdk.org/jdk/pull/20334.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20334#issuecomment-2250681282)