### PR TITLE
8337239: Fix simple -Wzero-as-null-pointer-constant warnings in classfile code

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -2296,7 +2296,7 @@ Method* ClassFileParser::parse_method(const ClassFileStream* const cfs,
   u2 max_stack = 0;
   u2 max_locals = 0;
   u4 code_length = 0;
-  const u1* code_start = 0;
+  const u1* code_start = nullptr;
   u2 exception_table_length = 0;
   const unsafe_u2* exception_table_start = nullptr; // (potentially unaligned) pointer to array of u2 elements
   Array<int>* exception_handlers = Universe::the_empty_int_array();

--- a/src/hotspot/share/classfile/defaultMethods.cpp
+++ b/src/hotspot/share/classfile/defaultMethods.cpp
@@ -870,7 +870,7 @@ static Method* new_method(
     Symbol* sig, AccessFlags flags, int max_stack, int params,
     ConstMethod::MethodType mt, TRAPS) {
 
-  address code_start = 0;
+  address code_start = nullptr;
   int code_length = 0;
   InlineTableSizes sizes;
 

--- a/src/hotspot/share/classfile/javaAssertions.cpp
+++ b/src/hotspot/share/classfile/javaAssertions.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,12 +38,12 @@
 
 bool                            JavaAssertions::_userDefault = false;
 bool                            JavaAssertions::_sysDefault = false;
-JavaAssertions::OptionList*     JavaAssertions::_classes = 0;
-JavaAssertions::OptionList*     JavaAssertions::_packages = 0;
+JavaAssertions::OptionList*     JavaAssertions::_classes = nullptr;
+JavaAssertions::OptionList*     JavaAssertions::_packages = nullptr;
 
 JavaAssertions::OptionList::OptionList(const char* name, bool enabled,
   OptionList* next) {
-  assert(name != 0, "need a name");
+  assert(name != nullptr, "need a name");
   _name = name;
   _enabled = enabled;
   _next = next;
@@ -51,12 +51,12 @@ JavaAssertions::OptionList::OptionList(const char* name, bool enabled,
 
 int JavaAssertions::OptionList::count(OptionList* p) {
   int rc;
-  for (rc = 0; p != 0; p = p->next(), ++rc) /* empty */;
+  for (rc = 0; p != nullptr; p = p->next(), ++rc) /* empty */;
   return rc;
 }
 
 void JavaAssertions::addOption(const char* name, bool enable) {
-  assert(name != 0, "must have a name");
+  assert(name != nullptr, "must have a name");
 
   // Copy the name.  The storage needs to exist for the lifetime of the vm;
   // it is never freed, so will be leaked (along with other option strings -
@@ -135,7 +135,7 @@ void JavaAssertions::fillJavaArrays(const OptionList* p, int len,
   // matches the order on the command line (the list is in reverse order, since
   // it was created by prepending successive items from the command line).
   int index;
-  for (index = len - 1; p != 0; p = p->next(), --index) {
+  for (index = len - 1; p != nullptr; p = p->next(), --index) {
     assert(index >= 0, "length does not match list");
     TempNewSymbol name = SymbolTable::new_symbol(p->name());
     Handle s = java_lang_String::externalize_classname(name, CHECK);
@@ -147,12 +147,12 @@ void JavaAssertions::fillJavaArrays(const OptionList* p, int len,
 
 inline JavaAssertions::OptionList*
 JavaAssertions::match_class(const char* classname) {
-  for (OptionList* p = _classes; p != 0; p = p->next()) {
+  for (OptionList* p = _classes; p != nullptr; p = p->next()) {
     if (strcmp(p->name(), classname) == 0) {
       return p;
     }
   }
-  return 0;
+  return nullptr;
 }
 
 JavaAssertions::OptionList*
@@ -160,7 +160,7 @@ JavaAssertions::match_package(const char* classname) {
   // Search the package list for any items that apply to classname.  Each
   // sub-package in classname is checked, from most-specific to least, until one
   // is found.
-  if (_packages == 0) return 0;
+  if (_packages == nullptr) return nullptr;
 
   // Find the length of the "most-specific" package in classname.  If classname
   // does not include a package, length will be 0 which will match items for the
@@ -170,7 +170,7 @@ JavaAssertions::match_package(const char* classname) {
 
   do {
     assert(len == 0 || classname[len] == JVM_SIGNATURE_SLASH, "not a package name");
-    for (OptionList* p = _packages; p != 0; p = p->next()) {
+    for (OptionList* p = _packages; p != nullptr; p = p->next()) {
       if (strncmp(p->name(), classname, len) == 0 && p->name()[len] == '\0') {
         return p;
       }
@@ -181,7 +181,7 @@ JavaAssertions::match_package(const char* classname) {
     while (len > 0 && classname[--len] != JVM_SIGNATURE_SLASH) /* empty */;
   } while (len > 0);
 
-  return 0;
+  return nullptr;
 }
 
 inline void JavaAssertions::trace(const char* name,
@@ -193,7 +193,7 @@ const char* typefound, const char* namefound, bool enabled) {
 }
 
 bool JavaAssertions::enabled(const char* classname, bool systemClass) {
-  assert(classname != 0, "must have a classname");
+  assert(classname != nullptr, "must have a classname");
 
   // This will be slow if the number of assertion options on the command line is
   // large--it traverses two lists, one of them multiple times.  Could use a

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -193,7 +193,7 @@ private:
       // We cannot use arena because arena chunks are allocated by the OS. As a result, for example,
       // the archived symbol of "java/lang/Object" may sometimes be lower than "java/lang/String", and
       // sometimes be higher. This would cause non-deterministic contents in the archive.
-      DEBUG_ONLY(static void* last = 0);
+      DEBUG_ONLY(static void* last = nullptr);
       void* p = (void*)MetaspaceShared::symbol_space_alloc(alloc_size);
       assert(p > last, "must increase monotonically");
       DEBUG_ONLY(last = p);


### PR DESCRIPTION
Please review this trivial change that replaces some uses of literal 0 as a
null pointer constant in classfile code to instead use nullptr.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337239](https://bugs.openjdk.org/browse/JDK-8337239): Fix simple -Wzero-as-null-pointer-constant warnings in classfile code (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20340/head:pull/20340` \
`$ git checkout pull/20340`

Update a local copy of the PR: \
`$ git checkout pull/20340` \
`$ git pull https://git.openjdk.org/jdk.git pull/20340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20340`

View PR using the GUI difftool: \
`$ git pr show -t 20340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20340.diff">https://git.openjdk.org/jdk/pull/20340.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20340#issuecomment-2251538522)