### PR TITLE
8337243: Fix more -Wzero-as-null-pointer-constant warnings in compiler code

### DIFF
--- a/src/hotspot/share/c1/c1_LIRGenerator.cpp
+++ b/src/hotspot/share/c1/c1_LIRGenerator.cpp
@@ -1300,7 +1300,7 @@ void LIRGenerator::do_isPrimitive(Intrinsic* x) {
   }
 
   __ move(new LIR_Address(rcvr.result(), java_lang_Class::klass_offset(), T_ADDRESS), temp, info);
-  __ cmp(lir_cond_notEqual, temp, LIR_OprFact::metadataConst(0));
+  __ cmp(lir_cond_notEqual, temp, LIR_OprFact::metadataConst(nullptr));
   __ cmove(lir_cond_notEqual, LIR_OprFact::intConst(0), LIR_OprFact::intConst(1), result, T_BOOLEAN);
 }
 
@@ -1333,7 +1333,7 @@ void LIRGenerator::do_getModifiers(Intrinsic* x) {
 
   // Check if this is a Java mirror of primitive type, and select the appropriate klass.
   LIR_Opr klass = new_register(T_METADATA);
-  __ cmp(lir_cond_equal, recv_klass, LIR_OprFact::metadataConst(0));
+  __ cmp(lir_cond_equal, recv_klass, LIR_OprFact::metadataConst(nullptr));
   __ cmove(lir_cond_equal, prim_klass, recv_klass, klass, T_ADDRESS);
 
   // Get the answer.

--- a/src/hotspot/share/ci/ciConstantPoolCache.cpp
+++ b/src/hotspot/share/ci/ciConstantPoolCache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,7 +37,7 @@
 ciConstantPoolCache::ciConstantPoolCache(Arena* arena,
                                  int expected_size) {
   _elements =
-    new (arena) GrowableArray<void*>(arena, expected_size, 0, 0);
+    new (arena) GrowableArray<void*>(arena, expected_size, 0, nullptr);
   _keys = new (arena) GrowableArray<int>(arena, expected_size, 0, 0);
 }
 

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -135,7 +135,7 @@ Bytecodes::Code ciBytecodeStream::next_wide_or_table(Bytecodes::Code bc) {
 // ------------------------------------------------------------------
 // ciBytecodeStream::reset_to_bci
 void ciBytecodeStream::reset_to_bci( int bci ) {
-  _bc_start=_was_wide=0;
+  _bc_start = _was_wide = nullptr;
   _pc = _start+bci;
 }
 

--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -165,8 +165,8 @@ class CodeBlob_sizes {
 // Iterate over all CodeBlobs (cb) on the given CodeHeap
 #define FOR_ALL_BLOBS(cb, heap) for (CodeBlob* cb = first_blob(heap); cb != nullptr; cb = next_blob(heap, cb))
 
-address CodeCache::_low_bound = 0;
-address CodeCache::_high_bound = 0;
+address CodeCache::_low_bound = nullptr;
+address CodeCache::_high_bound = nullptr;
 volatile int CodeCache::_number_of_nmethods_with_dependencies = 0;
 ExceptionCache* volatile CodeCache::_exception_cache_purge_list = nullptr;
 

--- a/src/hotspot/share/code/dependencies.cpp
+++ b/src/hotspot/share/code/dependencies.cpp
@@ -72,7 +72,7 @@ void Dependencies::initialize(ciEnv* env) {
 #endif
   DEBUG_ONLY(_deps[end_marker] = nullptr);
   for (int i = (int)FIRST_TYPE; i < (int)TYPE_LIMIT; i++) {
-    _deps[i] = new(arena) GrowableArray<ciBaseObject*>(arena, 10, 0, 0);
+    _deps[i] = new(arena) GrowableArray<ciBaseObject*>(arena, 10, 0, nullptr);
   }
   _content_bytes = nullptr;
   _size_in_bytes = (size_t)-1;

--- a/src/hotspot/share/code/nmethod.cpp
+++ b/src/hotspot/share/code/nmethod.cpp
@@ -3270,7 +3270,7 @@ void nmethod::print_recorded_oop(int log_n, int i) {
   if (value == Universe::non_oop_word()) {
     tty->print("non-oop word");
   } else {
-    if (value == 0) {
+    if (value == nullptr) {
       tty->print("nullptr-oop");
     } else {
       oop_at(i)->print_value_on(tty);

--- a/src/hotspot/share/code/oopRecorder.cpp
+++ b/src/hotspot/share/code/oopRecorder.cpp
@@ -68,10 +68,10 @@ template <class T> void ValueRecorder<T>::copy_values_to(nmethod* nm) {
 template <class T> void ValueRecorder<T>::maybe_initialize() {
   if (_handles == nullptr) {
     if (_arena != nullptr) {
-      _handles  = new(_arena) GrowableArray<T>(_arena, 10, 0, 0);
+      _handles  = new(_arena) GrowableArray<T>(_arena, 10, 0, T{});
       _no_finds = new(_arena) GrowableArray<int>(    _arena, 10, 0, 0);
     } else {
-      _handles  = new GrowableArray<T>(10, 0, 0);
+      _handles  = new GrowableArray<T>(10, 0, T{});
       _no_finds = new GrowableArray<int>(    10, 0, 0);
     }
   }

--- a/src/hotspot/share/code/oopRecorder.cpp
+++ b/src/hotspot/share/code/oopRecorder.cpp
@@ -69,10 +69,10 @@ template <class T> void ValueRecorder<T>::maybe_initialize() {
   if (_handles == nullptr) {
     if (_arena != nullptr) {
       _handles  = new(_arena) GrowableArray<T>(_arena, 10, 0, T{});
-      _no_finds = new(_arena) GrowableArray<int>(    _arena, 10, 0, 0);
+      _no_finds = new(_arena) GrowableArray<int>(_arena, 10, 0, 0);
     } else {
       _handles  = new GrowableArray<T>(10, 0, T{});
-      _no_finds = new GrowableArray<int>(    10, 0, 0);
+      _no_finds = new GrowableArray<int>(10, 0, 0);
     }
   }
 }


### PR DESCRIPTION
Please review this (perhaps trivial?) change that removes some uses of literal
0 as a null pointer constant in compiler code. Most are changed to use nullptr.
There are a couple where the better approach is to use a value-initialized
object of the appropriate template parameter type.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337243](https://bugs.openjdk.org/browse/JDK-8337243): Fix more -Wzero-as-null-pointer-constant warnings in compiler code (**Enhancement** - P4)


### Reviewers
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20343/head:pull/20343` \
`$ git checkout pull/20343`

Update a local copy of the PR: \
`$ git checkout pull/20343` \
`$ git pull https://git.openjdk.org/jdk.git pull/20343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20343`

View PR using the GUI difftool: \
`$ git pr show -t 20343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20343.diff">https://git.openjdk.org/jdk/pull/20343.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20343#issuecomment-2251602726)