### PR TITLE
8337245: Fix wrong comment of StringConcatHelper

### DIFF
--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -184,7 +184,7 @@ final class StringConcatHelper {
      * @param indexCoder final char index in the buffer, along with coder packed
      *                   into higher bits.
      * @param buf        buffer to append to
-     * @param value      boolean value to encode
+     * @param value      char value to encode
      * @param prefix     a constant to prepend before value
      * @return           updated index (coder value retained)
      */
@@ -210,7 +210,7 @@ final class StringConcatHelper {
      * @param indexCoder final char index in the buffer, along with coder packed
      *                   into higher bits.
      * @param buf        buffer to append to
-     * @param value      boolean value to encode
+     * @param value      int value to encode
      * @param prefix     a constant to prepend before value
      * @return           updated index (coder value retained)
      */
@@ -236,7 +236,7 @@ final class StringConcatHelper {
      * @param indexCoder final char index in the buffer, along with coder packed
      *                   into higher bits.
      * @param buf        buffer to append to
-     * @param value      boolean value to encode
+     * @param value      long value to encode
      * @param prefix     a constant to prepend before value
      * @return           updated index (coder value retained)
      */


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337245](https://bugs.openjdk.org/browse/JDK-8337245): Fix wrong comment of StringConcatHelper (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20344/head:pull/20344` \
`$ git checkout pull/20344`

Update a local copy of the PR: \
`$ git checkout pull/20344` \
`$ git pull https://git.openjdk.org/jdk.git pull/20344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20344`

View PR using the GUI difftool: \
`$ git pr show -t 20344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20344.diff">https://git.openjdk.org/jdk/pull/20344.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20344#issuecomment-2251627962)