### PR TITLE
8337265: [Graal] Add basic libgraal GitHub Actions job

### DIFF
--- a/.github/actions/get-bundles/action.yml
+++ b/.github/actions/get-bundles/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,10 @@ inputs:
     required: true
   debug-suffix:
     description: 'File name suffix denoting debug level, possibly empty'
+    required: false
+  include-static-libs:
+    description: 'Should static-libs be part of installed JDK bundle?'
+    default: false
     required: false
 outputs:
   jdk-path:
@@ -73,6 +77,13 @@ runs:
           echo 'Unpacking jdk bundle...'
           mkdir -p bundles/jdk
           tar -xf bundles/jdk-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz -C bundles/jdk
+        fi
+
+        if [[ '${{ inputs.include-static-libs }}' == 'true' ]]; then
+          if [[ -d bundles/jdk && -e bundles/static-libs-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz ]]; then
+            echo 'Unpacking static-libs bundle...'
+            tar -xf bundles/static-libs-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz -C bundles/jdk
+          fi
         fi
 
         if [[ -e bundles/symbols-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz ]]; then

--- a/.github/actions/get-graal/action.yml
+++ b/.github/actions/get-graal/action.yml
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+name: 'Get Graal'
+description: 'Clone Graal from GitHub'
+outputs:
+  path:
+    description: 'Path to cloned Graal repo'
+    value: ${{ steps.path-name.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: 'Checkout graal repo'
+      uses: actions/checkout@v4
+      with:
+        repository: graalvm/graal
+        ref: refs/heads/galahad
+        path: graal
+        fetch-depth: 1
+
+    - name: 'Export path to where graal is cloned'
+      id: path-name
+      run: |
+        # Export the path
+        echo 'path=graal' >> $GITHUB_OUTPUT
+      shell: bash

--- a/.github/actions/upload-bundles/action.yml
+++ b/.github/actions/upload-bundles/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -45,6 +45,7 @@ runs:
         jdk_bundle_tar_gz="$(ls build/*/bundles/jdk-*_bin${{ inputs.debug-suffix }}.tar.gz 2> /dev/null || true)"
         symbols_bundle="$(ls build/*/bundles/jdk-*_bin${{ inputs.debug-suffix }}-symbols.tar.gz 2> /dev/null || true)"
         tests_bundle="$(ls build/*/bundles/jdk-*_bin-tests${{ inputs.debug-suffix }}.tar.gz 2> /dev/null || true)"
+        static_libs_bundle="$(ls build/*/bundles/jdk-*_bin-static-libs${{ inputs.debug-suffix }}.tar.gz 2> /dev/null || true)"
 
         mkdir bundles
 
@@ -60,8 +61,11 @@ runs:
         if [[ "$tests_bundle" != "" ]]; then
           mv "$tests_bundle" "bundles/tests-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz"
         fi
+        if [[ "$static_libs_bundle" != "" ]]; then
+          mv "$static_libs_bundle" "bundles/static-libs-${{ inputs.platform }}${{ inputs.debug-suffix }}.tar.gz"
+        fi
 
-        if [[ "$jdk_bundle_zip$jdk_bundle_tar_gz$symbols_bundle$tests_bundle" != "" ]]; then
+        if [[ "$jdk_bundle_zip$jdk_bundle_tar_gz$symbols_bundle$tests_bundle$static_libs_bundle" != "" ]]; then
           echo 'bundles-found=true' >> $GITHUB_OUTPUT
         else
           echo 'bundles-found=false' >> $GITHUB_OUTPUT

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -133,8 +133,12 @@ jobs:
       - name: 'Build'
         id: build
         uses: ./.github/actions/do-build
+        env:
+          # Only build static-libs-bundles for release builds.
+          # For debug builds, building static-libs often exceeds disk space.
+          STATIC_LIBS: ${{ matrix.debug-level == 'release' && 'static-libs-bundles' }}
         with:
-          make-target: '${{ inputs.make-target }} ${{ inputs.make-arguments }}'
+          make-target: '${{ inputs.make-target }} ${STATIC_LIBS} ${{ inputs.make-arguments }}'
           platform: ${{ inputs.platform }}
           debug-suffix: '${{ matrix.suffix }}'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -364,6 +364,16 @@ jobs:
       bootjdk-platform: windows-x64
       runs-on: windows-2019
 
+  test-libgraal-linux-x64:
+    name: linux-x64
+    needs:
+      - build-linux-x64
+    uses: ./.github/workflows/test-libgraal.yml
+    with:
+      platform: linux-x64
+      bootjdk-platform: linux-x64
+      runs-on: ubuntu-22.04
+
   # Remove bundles so they are not misconstrued as binary distributions from the JDK project
   remove-bundles:
     name: 'Remove bundle artifacts'

--- a/.github/workflows/test-libgraal.yml
+++ b/.github/workflows/test-libgraal.yml
@@ -1,0 +1,194 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+name: 'Build and test libgraal'
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+      bootjdk-platform:
+        required: true
+        type: string
+      runs-on:
+        required: true
+        type: string
+
+jobs:
+  # This job builds and tests libgraal using a JDK bundle built by a PR.
+  # Due to use of continue-on-error, the job always has a success status.
+  # If any of the libgraal-related build and test steps fail, a comment
+  # is posted (to head commit of the pull request) that will notify the
+  # Graal team of the failure.
+  test-libgraal:
+    runs-on: ${{ inputs.runs-on }}
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+
+    env:
+      JAVA_HOME: ${{ github.workspace }}/jdk
+      MX_PATH: ${{ github.workspace }}/mx
+
+    steps:
+      - name: 'Checkout the JDK source'
+        uses: actions/checkout@v4
+
+      - name: 'Clone Graal'
+        id: clone-graal
+        continue-on-error: true
+        uses: ./.github/actions/get-graal
+
+      - name: 'Get bundles'
+        id: get-bundles
+        continue-on-error: true
+        uses: ./.github/actions/get-bundles
+        with:
+          platform: ${{ inputs.platform }}
+          include-static-libs: true
+
+      - name: Get mx and python version
+        id: get-versions
+        continue-on-error: true
+        run: |
+          mx_python=$(grep MX_PYTHON ${{ steps.clone-graal.outputs.path }}/ci/common.jsonnet | sed 's:.*"\(python.*\)".*:\1:g')
+          echo "MX_PYTHON=${mx_python}" >> ${GITHUB_ENV}
+          echo "mx_version=$(jq -r '.mx_version' ${{ steps.clone-graal.outputs.path }}/common.json)" >> $GITHUB_OUTPUT
+          echo "python_version=${mx_python/python/}" >> $GITHUB_OUTPUT
+
+      - name: Checkout graalvm/mx
+        id: checkout-mx
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          repository: graalvm/mx.git
+          ref: ${{ steps.get-versions.outputs.mx_version }}
+          fetch-depth: 1
+          path: ${{ env.MX_PATH }}
+
+      - name: Set up Python
+        id: setup-python
+        continue-on-error: true
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ steps.get-versions.outputs.python_version }}
+
+      - name: Update mx cache
+        id: update-mx-cache
+        continue-on-error: true
+        uses: actions/cache@v4
+        with:
+          path: ~/.mx
+          key: ${{ runner.os }}-mx-${{ hashFiles('**/suite.py') }}
+          restore-keys: ${{ runner.os }}-mx-
+
+      - name: Build libgraal
+        id: build-libgraal
+        continue-on-error: true
+        run: |
+          ${MX_PATH}/mx \
+            --primary-suite-path ${{ steps.clone-graal.outputs.path }}/vm \
+            --java-home=${{ steps.get-bundles.outputs.jdk-path }} \
+            --env libgraal build
+
+      - name: Libgraal gate
+        id: libgraal-gate
+        continue-on-error: true
+        run: |
+          ${MX_PATH}/mx \
+            --primary-suite-path ${{ steps.clone-graal.outputs.path }}/vm \
+            --java-home=${{ steps.get-bundles.outputs.jdk-path }} \
+            --env libgraal gate --task 'LibGraal Compiler'
+
+      - name: Libgraal notify failure
+        continue-on-error: true
+        # Only need to test the libgraal-gate step for failure
+        # as it will also fail if an earlier step fails.
+        if: steps.libgraal-gate.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STEPS_CONTEXT: ${{ toJson(steps) }}
+        run: |
+          headers=(-H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28")
+          commit="/repos/${{ github.repository }}/commits/${{ github.sha }}"
+
+          # Get info for first associated pull request
+          pr_url=$(gh api "${headers[@]}" ${commit}/pulls | jq -r '.[0].html_url')
+
+          # Get job URL. Need to use pagination as there can be a lot of jobs.
+          # Initialize job URL to run URL in case a job URL is not found
+          job_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          page=1
+          while true; do
+            jobs=$(gh api "${headers[@]}" "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}" | jq -r '.jobs[]')
+            if [[ "${jobs}" == "" ]]; then
+              break
+            fi            
+            url=$(gh api "${headers[@]}" "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs?per_page=100&page=${page}" | jq -r '.jobs | .[] | select(.name | endswith("test-libgraal")) | .html_url')
+            if [[ "${url}" != "null" ]]; then
+              job_url="${url}"
+              break
+            fi
+            page=$((page + 1))
+          done
+
+          # Get the failed steps
+          failed_steps=$(echo "${STEPS_CONTEXT}" | jq -r 'with_entries(select(.value | .outcome == "failure")) | keys | join(", ")')
+
+          if [[ "$pr_url" != "null" ]]; then
+            # The @graalvm/compiler mention in the comment will notify
+            # the members of https://github.com/orgs/graalvm/teams/compiler
+            body="A [PR containing this commit](${pr_url}) or the JDK version on which the PR is based appears to include a change that breaks the Graal compiler integration.
+            
+          CC'ing @graalvm/compiler to notify the Graal team. No further action is needed.
+            
+          Relevant CI job: ${job_url}
+          Failed steps: ${failed_steps}"
+            
+            # Search for existing comment to avoid posting it more than once
+            readarray -t bodies < <(gh api "${headers[@]}" ${commit}/comments | jq '.[] | .body')
+            for b in "${bodies[@]}"; do
+              if [[ "$b" == "\"$body\"" ]]; then
+                body=""
+                break
+              fi
+            done
+            if [[ "$body" != "" ]]; then
+              # Post comment to commit
+              gh api "${headers[@]}" --method POST ${commit}/comments -f "body=${body}" | tee response
+              comment_url=$(jq -r '.html_url' <response)
+              echo
+              echo "Posted comment: ${comment_url}"
+            else
+              echo "Commit ${{ github.sha }} already has this comment: ${body}"
+            fi
+          else
+            echo "No PR found for commit ${{ github.sha }}"
+          fi


### PR DESCRIPTION
Since libgraal is built with SVM and SVM is closely tied to OpenJDK internals, it's easy enough for an OpenJDK change to break building libgraal.
This PR adds a GitHub Actions job that does a basic build and test of libgraal by pulling sources from the graal repo.
The job always exits with success but if libgraal building or testing fails, a comment is added to head commit of the PR that triggers a notification to be sent to [the Graal compiler team](https://github.com/orgs/graalvm/teams/compiler).
The comment makes it clear that no further action is needed by the PR author.

Example comment: https://github.com/dougxc/jdk/commit/b567ab93a7177464c3460cf1f60cfda29eddaa1b#commitcomment-144869332

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8337265](https://bugs.openjdk.org/browse/JDK-8337265)

### Warnings
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Issue
 * [JDK-8337265](https://bugs.openjdk.org/browse/JDK-8337265): Test static-libs build in GitHub Actions (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20347/head:pull/20347` \
`$ git checkout pull/20347`

Update a local copy of the PR: \
`$ git checkout pull/20347` \
`$ git pull https://git.openjdk.org/jdk.git pull/20347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20347`

View PR using the GUI difftool: \
`$ git pr show -t 20347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20347.diff">https://git.openjdk.org/jdk/pull/20347.diff</a>

</details>
