### PR TITLE
8337222: gc/TestDisableExplicitGC.java fails due to unexpected CodeCache GC

### DIFF
--- a/test/hotspot/jtreg/gc/TestDisableExplicitGC.java
+++ b/test/hotspot/jtreg/gc/TestDisableExplicitGC.java
@@ -26,6 +26,7 @@ package gc;
 /*
  * @test TestDisableExplicitGC
  * @requires vm.opt.DisableExplicitGC == null
+ * @requires vm.compMode != "Xcomp"
  * @summary Verify GC behavior with DisableExplicitGC flag.
  * @library /test/lib
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Hi,

  please review this change that disallows running the `gc/TestDisableExplicitGC.java` test with `-Xcomp` - code compilation can unnecessarily induce code cache gcs which make the test logic fail (expect no gc at all but there is one). There is no gain running this test with `-Xcomp`.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337222](https://bugs.openjdk.org/browse/JDK-8337222): gc/TestDisableExplicitGC.java fails due to unexpected CodeCache GC (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20350/head:pull/20350` \
`$ git checkout pull/20350`

Update a local copy of the PR: \
`$ git checkout pull/20350` \
`$ git pull https://git.openjdk.org/jdk.git pull/20350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20350`

View PR using the GUI difftool: \
`$ git pr show -t 20350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20350.diff">https://git.openjdk.org/jdk/pull/20350.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20350#issuecomment-2252490078)