### PR TITLE
8337274: Remove repeated 'the' in StyleSheet.create{Small,Large}AttributeSet

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -724,7 +724,7 @@ public class StyleSheet extends StyleContext {
      * to return an AttributeSet that provides some sort of
      * attribute conversion.
      *
-     * @param a The set of attributes to be represented in the
+     * @param a The set of attributes to be represented in
      *  the compact form.
      */
     protected SmallAttributeSet createSmallAttributeSet(AttributeSet a) {
@@ -740,7 +740,7 @@ public class StyleSheet extends StyleContext {
      * to return a MutableAttributeSet that provides some sort of
      * attribute conversion.
      *
-     * @param a The set of attributes to be represented in the
+     * @param a The set of attributes to be represented in
      *  the larger form.
      */
     protected MutableAttributeSet createLargeAttributeSet(AttributeSet a) {
@@ -2173,7 +2173,7 @@ public class StyleSheet extends StyleContext {
         /**
          * Returns a string that represents the value
          * of the HTML.Attribute.TYPE attribute.
-         * If this attributes is not defined, then
+         * If this attributes is not defined,
          * then the type defaults to "disc" unless
          * the tag is on Ordered list.  In the case
          * of the latter, the default type is "decimal".


### PR DESCRIPTION
A trivial fix which removes the repeated word ‘the’ from the parameter description for `StyleSheet.create{Small,Large}AttributeSet` methods. These methods are public API.

Additionally, I dropped repeated ‘then’ from the description of a private method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337274](https://bugs.openjdk.org/browse/JDK-8337274): Remove repeated 'the' in StyleSheet.create{Small,Large}AttributeSet (**Bug** - P4)


### Reviewers
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20352/head:pull/20352` \
`$ git checkout pull/20352`

Update a local copy of the PR: \
`$ git checkout pull/20352` \
`$ git pull https://git.openjdk.org/jdk.git pull/20352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20352`

View PR using the GUI difftool: \
`$ git pr show -t 20352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20352.diff">https://git.openjdk.org/jdk/pull/20352.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20352#issuecomment-2252870240)