### PR TITLE
8337282: Speed ​​up StringConcat with more simpleConcat

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/StringConcat.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringConcat.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,20 +49,27 @@ public class StringConcat {
 
     @Param("4711")
     public int intValue;
-
+    public Integer integerValue = intValue + 1;
+    public float floatValue = 156456.36435637F + intValue;
     public String stringValue = String.valueOf(intValue);
-
     public Object objectValue = Long.valueOf(intValue);
-
     public boolean boolValue = true;
-
     public byte byteValue = (byte)-128;
-
     public String emptyString = "";
 
     @Benchmark
     public String concatConstInt() {
         return "string" + intValue;
+    }
+
+    @Benchmark
+    public String concatConstInteger() {
+        return "string" + integerValue;
+    }
+
+    @Benchmark
+    public String concatConstFloat() {
+        return "string" + floatValue;
     }
 
     @Benchmark
@@ -95,6 +103,26 @@ public class StringConcat {
     }
 
     @Benchmark
+    public String concatConstIntString() {
+        return "string" + intValue + stringValue;
+    }
+
+    @Benchmark
+    public String concatConstIntegerString() {
+        return "string" + integerValue + stringValue;
+    }
+
+    @Benchmark
+    public String concatConstFloatString() {
+        return "string" + floatValue + stringValue;
+    }
+
+    @Benchmark
+    public String concatConstBooleanString() {
+        return "string" + boolValue + stringValue;
+    }
+
+    @Benchmark
     public String concatConstIntConstInt() {
         return "string" + intValue + "string" + intValue;
     }
@@ -112,6 +140,21 @@ public class StringConcat {
         String s3 = stringValue + stringValue + "string" + stringValue + "string" + stringValue + "string";
         String s4 = "string" + stringValue + "string" + stringValue + "string" + stringValue + "string" + stringValue + "string";
         return s1 + s2 + s3 + s4;
+    }
+
+    @Benchmark
+    public String concat3String() {
+        return stringValue + stringValue + stringValue;
+    }
+
+    @Benchmark
+    public String concatStringIntString() {
+        return stringValue + intValue + stringValue;
+    }
+
+    @Benchmark
+    public String concatStringIntegerString() {
+        return stringValue + integerValue + stringValue;
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/StringConcatStartup.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringConcatStartup.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +28,7 @@ import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.State;
 
@@ -44,13 +46,31 @@ import java.util.concurrent.TimeUnit;
 public class StringConcatStartup {
 
     public static void main(String... args) {
-        String[] selection = new String[] { "StringLarge", "MixedSmall", "StringSingle", "MixedLarge" };
+        String[] selection = {
+                "StringLarge",
+                "MixedSmall",
+                "StringSingle",
+                "StringThree",
+                "MixedLarge"
+        };
         if (args.length > 0) {
             selection = args;
         }
         for (String select : selection) {
             switch (select) {
-                case "StringSingle" -> new StringSingle().run();
+                case "StringSingle" -> {
+                    new StringSingle().constInt();
+                    new StringSingle().constFloat();
+                    new StringSingle().constString();
+                    new StringSingle().const2String();
+                    new StringSingle().constIntString();
+                    new StringSingle().constFloatString();
+                    new StringSingle().constBooleanString();
+                }
+                case "StringThree" -> {
+                    new StringThree().stringIntString();
+                    new StringThree().stringIntegerString();
+                }
                 case "MixedSmall" -> new MixedSmall().run();
                 case "StringLarge" -> new StringLarge().run();
                 case "MixedLarge" -> new MixedLarge().run();
@@ -64,14 +84,79 @@ public class StringConcatStartup {
     @Fork(value = 40, warmups = 2)
     public static class StringSingle {
 
-        public String s = "foo";
+        @Param("4711")
+        public int intValue;
+        public Integer integerValue = intValue;
+        public float floatValue = 156456.36435637F + intValue;
+        public String stringValue = String.valueOf(intValue);
+        public boolean boolValue = true;
 
         @Benchmark
-        public String run() {
-            return "" + s;
+        public String constInt() {
+            return "string" + intValue;
+        }
+
+        @Benchmark
+        public String constInteger() {
+            return "string" + integerValue;
+        }
+
+        @Benchmark
+        public String constFloat() {
+            return "string" + floatValue;
+        }
+
+        @Benchmark
+        public String constString() {
+            return "string" + stringValue;
+        }
+
+        public String const2String() {
+            return "string" + stringValue + stringValue;
+        }
+
+        @Benchmark
+        public String constIntString() {
+            return "string" + intValue + stringValue;
+        }
+
+        @Benchmark
+        public String constIntegerString() {
+            return "string" + integerValue + stringValue;
+        }
+
+        @Benchmark
+        public String constFloatString() {
+            return "string" + floatValue + stringValue;
+        }
+
+        @Benchmark
+        public String constBooleanString() {
+            return "string" + boolValue + stringValue;
         }
     }
 
+    @BenchmarkMode(Mode.SingleShotTime)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @State(Scope.Thread)
+    @Fork(value = 40, warmups = 2)
+    public static class StringThree {
+
+        @Param("4711")
+        public int intValue;
+        public Integer integerValue = intValue;
+        public String stringValue = String.valueOf(intValue);
+
+        @Benchmark
+        public String stringIntString() {
+            return stringValue + intValue + stringValue;
+        }
+
+        @Benchmark
+        public String stringIntegerString() {
+            return stringValue + integerValue + stringValue;
+        }
+    }
 
     @BenchmarkMode(Mode.SingleShotTime)
     @OutputTimeUnit(TimeUnit.MILLISECONDS)


### PR DESCRIPTION
StringConcatFactory improves startup speed and running performance through simpleConcat, but simpleConcat is currently given priority and only supports the following scenarios:
```java
// x instanceof Object
prefix + x
x = subfix

// x instanceof Object && z instanceof Object
x + y
```

This PR improves startup and running performance by supporting more scenarios including
```java
// x instanceof byte/short/int/char/boolean/float/double
prefix + x
x + suffix

// x instanceof byte/short/int/char/boolean/float/double/Integer/Long/Object
prefix + suffix

// x instanceof Object
x + y + suffix

// x instanceof Object
x + y + suffix
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337282](https://bugs.openjdk.org/browse/JDK-8337282): Speed ​​up StringConcat with more simpleConcat (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20355/head:pull/20355` \
`$ git checkout pull/20355`

Update a local copy of the PR: \
`$ git checkout pull/20355` \
`$ git pull https://git.openjdk.org/jdk.git pull/20355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20355`

View PR using the GUI difftool: \
`$ git pr show -t 20355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20355.diff">https://git.openjdk.org/jdk/pull/20355.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20355#issuecomment-2253063243)