### PR TITLE
8337283: configure.log is truncated when build dir is on different filesystem

### DIFF
--- a/make/autoconf/configure.ac
+++ b/make/autoconf/configure.ac
@@ -313,9 +313,11 @@ AC_OUTPUT
 
 # After AC_OUTPUT, we need to do final work
 CUSTOM_CONFIG_OUTPUT_GENERATED_HOOK
-BASIC_POST_CONFIG_OUTPUT
 
 # Finally output some useful information to the user
 HELP_PRINT_SUMMARY_AND_WARNINGS
 CUSTOM_SUMMARY_AND_WARNINGS_HOOK
 HELP_REPEAT_WARNINGS
+
+# All output is done. Do the post-config output management.
+BASIC_POST_CONFIG_OUTPUT


### PR DESCRIPTION
I noticed that `build/$confname/configure.log` was truncated on some of my build nodes. Turns out, we are moving configure.log from tree root to that place a bit prematurely.

We move `configure.log` here:
https://github.com/openjdk/jdk/blob/4f194f10a1481cdc9df4e6338f6cabd07a34c84c/make/autoconf/basic.m4#L594-L618

...and that is called here:
https://github.com/openjdk/jdk/blob/4bcb8f04ed3623da7c84dda28017f473cbc97e53/make/autoconf/configure.ac#L314-L321

Or, before we print configuration summary.

Now, this works most of the time by accident: when root dir and build dir are on the same filesystem, the file move does not interfere with inodes/FDs, and we are still able to write to the same file _after_ we moved. But if build dir is on _another_ filesystem, then we miss writing the configuration summary when file moves away.

Apparently, my systems fall into that trap, since build dir is on RAM disk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337283](https://bugs.openjdk.org/browse/JDK-8337283): configure.log is truncated when build dir is on different filesystem (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20356/head:pull/20356` \
`$ git checkout pull/20356`

Update a local copy of the PR: \
`$ git checkout pull/20356` \
`$ git pull https://git.openjdk.org/jdk.git pull/20356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20356`

View PR using the GUI difftool: \
`$ git pr show -t 20356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20356.diff">https://git.openjdk.org/jdk/pull/20356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20356#issuecomment-2253096989)