### PR TITLE
8337268: Redundant Math.ceil in StyleSheet.ListPainter#drawShape

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/StyleSheet.java
@@ -2391,7 +2391,7 @@ public class StyleSheet extends StyleContext {
             // Position shape to the middle of the html text.
             int gap = isLeftToRight ? - (bulletgap + size/3) : (aw + bulletgap);
             int x = ax + gap;
-            int y = Math.max(ay, ay + (int)Math.ceil(ah/2));
+            int y = Math.max(ay, ay + ah/2);
 
             if (type == CSS.Value.SQUARE) {
                 g.drawRect(x, y, size/3, size/3);


### PR DESCRIPTION
Math.ceil call with integer argument is redundant as it returns the same value without Math.ceil, so it is removed..
CI testing is green and JDK-8202013 regression testcase for which the code was added, is not affected..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337268](https://bugs.openjdk.org/browse/JDK-8337268): Redundant Math.ceil in StyleSheet.ListPainter#drawShape (**Bug** - P5)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20358/head:pull/20358` \
`$ git checkout pull/20358`

Update a local copy of the PR: \
`$ git checkout pull/20358` \
`$ git pull https://git.openjdk.org/jdk.git pull/20358/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20358`

View PR using the GUI difftool: \
`$ git pr show -t 20358`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20358.diff">https://git.openjdk.org/jdk/pull/20358.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20358#issuecomment-2253132033)