### PR TITLE
8235404: [macos] JOptionPane blocks drawing string on another component

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -882,8 +882,11 @@ public class JOptionPane extends JComponent implements Accessible
         dialog.dispose();
 
         Object        selectedValue = pane.getValue();
-        parentComponent.revalidate();
-        parentComponent.repaint();
+
+        if (parentComponent != null) {
+            parentComponent.revalidate();
+            parentComponent.repaint();
+        }
 
         if(selectedValue == null)
             return CLOSED_OPTION;

--- a/src/java.desktop/share/classes/javax/swing/JOptionPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JOptionPane.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -882,6 +882,8 @@ public class JOptionPane extends JComponent implements Accessible
         dialog.dispose();
 
         Object        selectedValue = pane.getValue();
+        parentComponent.revalidate();
+        parentComponent.repaint();
 
         if(selectedValue == null)
             return CLOSED_OPTION;

--- a/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
+++ b/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
@@ -4,9 +4,7 @@
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
- * published by the Free Software Foundation.  Oracle designates this
- * particular file as subject to the "Classpath" exception as provided
- * by Oracle in the LICENSE file that accompanied this code.
+ * published by the Free Software Foundation.
  *
  * This code is distributed in the hope that it will be useful, but WITHOUT
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or

--- a/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
+++ b/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
@@ -38,10 +38,10 @@ import javax.swing.UnsupportedLookAndFeelException;
 /*
  * @test
  * @bug 8235404
- * @summary temp
+ * @summary Checks that JOptionPane doesn't block drawing strings on another component
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
- * @run main OptionPaneInput
+ * @run main/manual OptionPaneInput
  */
 public class OptionPaneInput {
     private static JFrame f;
@@ -55,8 +55,6 @@ public class OptionPaneInput {
             """;
 
     public static void main(String[] args) throws Exception {
-//        UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
-
         PassFailJFrame testFrame = new PassFailJFrame(instructions);
 
         SwingUtilities.invokeAndWait(() -> createGUI());
@@ -68,9 +66,6 @@ public class OptionPaneInput {
         c = new Canvas();
         t = new JTextField();
         f.add(c);
-
-//        RepaintManager.currentManager(f).setDoubleBufferingEnabled(false);
-//        RepaintManager.currentManager(c).setDoubleBufferingEnabled(false);
 
         t.addActionListener(e->{
             String text = t.getText();
@@ -87,16 +82,5 @@ public class OptionPaneInput {
         f.setVisible(true);
 
         JOptionPane.showMessageDialog(null, t);
-
-//        JDialog d = new JDialog(f, true);
-//        d.add(t);
-//        d.setLocationRelativeTo(f);
-//        d.pack();
-//        d.show();
-
-//        Graphics2D g2 = (Graphics2D)(c.getGraphics());
-//        g2.setColor(Color.BLACK);
-//        g2.drawString("Dialog Closed", 10, 25);
-//        g2.dispose();
     }
 }

--- a/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
+++ b/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import javax.swing.JTextField;
+import javax.swing.RepaintManager;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+
+/*
+ * @test
+ * @bug 8235404
+ * @summary temp
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main OptionPaneInput
+ */
+public class OptionPaneInput {
+    private static JFrame f;
+    private static Canvas c;
+    private static JTextField t;
+    private static final String instructions = """
+            1. Type "test" into the message dialog.
+            2. Press enter key.
+            3. Press OK button.
+            4. If the OptionPaneInput frame has test drawn on it, pass. Otherwise fail.
+            """;
+
+    public static void main(String[] args) throws Exception {
+//        UIManager.setLookAndFeel("com.sun.java.swing.plaf.motif.MotifLookAndFeel");
+
+        PassFailJFrame testFrame = new PassFailJFrame(instructions);
+
+        SwingUtilities.invokeAndWait(() -> createGUI());
+        testFrame.awaitAndCheck();
+    }
+
+    public static void createGUI() {
+        f = new JFrame("OptionPaneInput");
+        c = new Canvas();
+        t = new JTextField();
+        f.add(c);
+
+//        RepaintManager.currentManager(f).setDoubleBufferingEnabled(false);
+//        RepaintManager.currentManager(c).setDoubleBufferingEnabled(false);
+
+        t.addActionListener(e->{
+            String text = t.getText();
+            Graphics2D g2 = (Graphics2D)(c.getGraphics());
+            g2.setColor(Color.BLACK);
+            g2.drawString(text, 10, 10);
+            System.out.println("drawing "+text);
+            g2.dispose();
+        });
+
+        f.setSize(300,100);
+        PassFailJFrame.addTestWindow(f);
+        PassFailJFrame.positionTestWindow(f, PassFailJFrame.Position.HORIZONTAL);
+        f.setVisible(true);
+
+        JOptionPane.showMessageDialog(null, t);
+
+//        JDialog d = new JDialog(f, true);
+//        d.add(t);
+//        d.setLocationRelativeTo(f);
+//        d.pack();
+//        d.show();
+
+//        Graphics2D g2 = (Graphics2D)(c.getGraphics());
+//        g2.setColor(Color.BLACK);
+//        g2.drawString("Dialog Closed", 10, 25);
+//        g2.dispose();
+    }
+}

--- a/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
+++ b/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
@@ -72,7 +72,7 @@ public class OptionPaneInput {
             g2.dispose();
         });
 
-        f.setSize(300,100);
+        f.setSize(300, 100);
         PassFailJFrame.addTestWindow(f);
         PassFailJFrame.positionTestWindow(f, PassFailJFrame.Position.HORIZONTAL);
         f.setVisible(true);

--- a/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
+++ b/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
@@ -26,14 +26,10 @@
 import java.awt.Canvas;
 import java.awt.Color;
 import java.awt.Graphics2D;
-import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JTextField;
-import javax.swing.RepaintManager;
 import javax.swing.SwingUtilities;
-import javax.swing.UIManager;
-import javax.swing.UnsupportedLookAndFeelException;
 
 /*
  * @test
@@ -81,6 +77,6 @@ public class OptionPaneInput {
         PassFailJFrame.positionTestWindow(f, PassFailJFrame.Position.HORIZONTAL);
         f.setVisible(true);
 
-        JOptionPane.showMessageDialog(null, t);
+        JOptionPane.showMessageDialog(f, t);
     }
 }

--- a/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
+++ b/test/jdk/javax/swing/JOptionPane/OptionPaneInput.java
@@ -63,7 +63,7 @@ public class OptionPaneInput {
         t = new JTextField();
         f.add(c);
 
-        t.addActionListener(e->{
+        t.addActionListener(e -> {
             String text = t.getText();
             Graphics2D g2 = (Graphics2D)(c.getGraphics());
             g2.setColor(Color.BLACK);


### PR DESCRIPTION
Currently if you try to use graphics to draw a string on a frame using JOptionPane + JTextField with a listener as a prompt, the string will not draw. Adding a repaint after dialog.dispose in JOptionPane will cause the text to show after the dialog is closed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8235404](https://bugs.openjdk.org/browse/JDK-8235404): [macos] JOptionPane blocks drawing string on another component (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer) 🔄 Re-review required (review applies to [84d62d5e](https://git.openjdk.org/jdk/pull/20359/files/84d62d5ebe26350eda7381ee208afa109e441f3e))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20359/head:pull/20359` \
`$ git checkout pull/20359`

Update a local copy of the PR: \
`$ git checkout pull/20359` \
`$ git pull https://git.openjdk.org/jdk.git pull/20359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20359`

View PR using the GUI difftool: \
`$ git pr show -t 20359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20359.diff">https://git.openjdk.org/jdk/pull/20359.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20359#issuecomment-2264232986)