### PR TITLE
8311990: Two JDI tests may interfere with each other

### DIFF
--- a/test/jdk/com/sun/jdi/JdwpListenTest.java
+++ b/test/jdk/com/sun/jdi/JdwpListenTest.java
@@ -51,7 +51,7 @@ public class JdwpListenTest {
     // Set to true to allow testing of attach from wrong address (expected to fail).
     // It's off by default as it causes test time increase and test interference (see JDK-8231915).
     private static boolean allowNegativeTesting =
-        "true".equalsIgnoreCase(System.getProperty("JDI_ALLOW_NEGATIVE_TESTING"));
+        "true".equalsIgnoreCase(System.getProperty("jdk.jdi.allowNegativeTesting"));
 
     public static void main(String[] args) throws Exception {
         List<InetAddress> addresses = Utils.getAddressesWithSymbolicAndNumericScopes();

--- a/test/jdk/com/sun/jdi/JdwpListenTest.java
+++ b/test/jdk/com/sun/jdi/JdwpListenTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,8 @@ public class JdwpListenTest {
 
     // Set to true to allow testing of attach from wrong address (expected to fail).
     // It's off by default as it causes test time increase and test interference (see JDK-8231915).
-    private static boolean allowNegativeTesting = false;
+    private static boolean allowNegativeTesting =
+        "true".equalsIgnoreCase(System.getProperty("JDI_ALLOW_NEGATIVE_TESTING"));
 
     public static void main(String[] args) throws Exception {
         List<InetAddress> addresses = Utils.getAddressesWithSymbolicAndNumericScopes();

--- a/test/jdk/com/sun/jdi/JdwpNetProps.java
+++ b/test/jdk/com/sun/jdi/JdwpNetProps.java
@@ -51,7 +51,8 @@ public class JdwpNetProps {
 
     // Set to true to allow testing of attach from wrong address (expected to fail).
     // It's off by default as it causes test interference (see JDK-8311990).
-    private static boolean allowNegativeAttachTesting = false;
+    private static boolean allowNegativeAttachTesting =
+        "true".equalsIgnoreCase(System.getProperty("JDI_ALLOW_NEGATIVE_TESTING"));
 
     public static void main(String[] args) throws Exception {
         InetAddress addrs[] = InetAddress.getAllByName("localhost");

--- a/test/jdk/com/sun/jdi/JdwpNetProps.java
+++ b/test/jdk/com/sun/jdi/JdwpNetProps.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,10 @@ import java.util.Objects;
  * @run main/othervm -Djava.net.preferIPv6Addresses=system JdwpNetProps
  */
 public class JdwpNetProps {
+
+    // Set to true to allow testing of attach from wrong address (expected to fail).
+    // It's off by default as it causes test interference (see JDK-8311990).
+    private static boolean allowNegativeAttachTesting = false;
 
     public static void main(String[] args) throws Exception {
         InetAddress addrs[] = InetAddress.getAllByName("localhost");
@@ -171,6 +175,14 @@ public class JdwpNetProps {
         }
 
         public void run(TestResult expectedResult) throws Exception {
+            log("\nTest: listen at " + listenAddress + ", attaching to " + connectAddress
+                + ", preferIPv4Stack = " + preferIPv4Stack
+                + ", preferIPv6Addresses = " + preferIPv6Addresses
+                + ", expectedResult = " + expectedResult);
+            if (expectedResult == TestResult.AttachFailed && !allowNegativeAttachTesting) {
+                log("SKIPPED: negative attach testing is disabled");
+                return;
+            }
             List<String> options = new LinkedList<>();
             if (preferIPv4Stack != null) {
                 options.add("-Djava.net.preferIPv4Stack=" + preferIPv4Stack.toString());

--- a/test/jdk/com/sun/jdi/JdwpNetProps.java
+++ b/test/jdk/com/sun/jdi/JdwpNetProps.java
@@ -52,7 +52,7 @@ public class JdwpNetProps {
     // Set to true to allow testing of attach from wrong address (expected to fail).
     // It's off by default as it causes test interference (see JDK-8311990).
     private static boolean allowNegativeAttachTesting =
-        "true".equalsIgnoreCase(System.getProperty("JDI_ALLOW_NEGATIVE_TESTING"));
+        "true".equalsIgnoreCase(System.getProperty("jdk.jdi.allowNegativeTesting"));
 
     public static void main(String[] args) throws Exception {
         InetAddress addrs[] = InetAddress.getAllByName("localhost");


### PR DESCRIPTION
"Attach fails" scenarios (debuggee starts listening and debugger is expected to fail trying to attach) sometimes interfere with other JDI tests (so JdwpNetProps.java test or other JDI test or both fail).
The fix disables the scenarios to remove noise in the CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311990](https://bugs.openjdk.org/browse/JDK-8311990): Two JDI tests may interfere with each other (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) 🔄 Re-review required (review applies to [0378fc48](https://git.openjdk.org/jdk/pull/20362/files/0378fc4855700a4a56cdc6b12c26b9a2ee5ca7d4))
 * @abdelhak-zaaim (no known openjdk.org user name / role) 🔄 Re-review required (review applies to [737b0869](https://git.openjdk.org/jdk/pull/20362/files/737b08698747929220dd4630872fda23c4d36dee))
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20362/head:pull/20362` \
`$ git checkout pull/20362`

Update a local copy of the PR: \
`$ git checkout pull/20362` \
`$ git pull https://git.openjdk.org/jdk.git pull/20362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20362`

View PR using the GUI difftool: \
`$ git pr show -t 20362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20362.diff">https://git.openjdk.org/jdk/pull/20362.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20362#issuecomment-2253508412)