### PR TITLE
8337205: Typo in Stack vs Deque Method table in Deque specification

### DIFF
--- a/src/java.base/share/classes/java/util/Deque.java
+++ b/src/java.base/share/classes/java/util/Deque.java
@@ -163,7 +163,7 @@ package java.util;
  *  </tr>
  *  <tr>
  *    <th scope="row">{@link #peek() peek()}</th>
- *    <td>{@link #getFirst() getFirst()}</td>
+ *    <td>{@link #peekFirst() peekFirst()}</td>
  *  </tr>
  *  </tbody>
  * </table>


### PR DESCRIPTION
This PR fixes `java.util.Deque`'s specification to name `peekFirst()` as an equivalent to Stack's `peek()` method since both of them don't throw when a collection is empty. This is not the case with the current `getFirst()` method.

Please let me know if I have to fix something in the PR. Will appreciate your guidance since this is my first PR to JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337205](https://bugs.openjdk.org/browse/JDK-8337205): Typo in Stack vs Deque Method table in Deque specification (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20363/head:pull/20363` \
`$ git checkout pull/20363`

Update a local copy of the PR: \
`$ git checkout pull/20363` \
`$ git pull https://git.openjdk.org/jdk.git pull/20363/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20363`

View PR using the GUI difftool: \
`$ git pr show -t 20363`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20363.diff">https://git.openjdk.org/jdk/pull/20363.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20363#issuecomment-2271396169)