### PR TITLE
8336915: Shenandoah: Remove unused ShenandoahVerifier::verify_after_evacuation

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -841,18 +841,6 @@ void ShenandoahVerifier::verify_during_evacuation() {
   );
 }
 
-void ShenandoahVerifier::verify_after_evacuation() {
-  verify_at_safepoint(
-          "After Evacuation",
-          _verify_forwarded_allow,     // objects are still forwarded
-          _verify_marked_complete,     // bitmaps might be stale, but alloc-after-mark should be well
-          _verify_cset_forwarded,      // all cset refs are fully forwarded
-          _verify_liveness_disable,    // no reliable liveness data anymore
-          _verify_regions_notrash,     // trash regions have been recycled already
-          _verify_gcstate_forwarded    // evacuation produced some forwarded objects
-  );
-}
-
 void ShenandoahVerifier::verify_before_updaterefs() {
   verify_at_safepoint(
           "Before Updating References",

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -176,7 +176,6 @@ public:
   void verify_after_concmark();
   void verify_before_evacuation();
   void verify_during_evacuation();
-  void verify_after_evacuation();
   void verify_before_updaterefs();
   void verify_after_updaterefs();
   void verify_before_fullgc();


### PR DESCRIPTION
Removing the `verify_after_evacuation()` function, since last use was removed in [JDK-8240868](https://bugs.openjdk.org/browse/JDK-8240868) as directed by [JDK-8336915](https://bugs.openjdk.org/browse/JDK-8336915)

/covered

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336915](https://bugs.openjdk.org/browse/JDK-8336915): Shenandoah: Remove unused ShenandoahVerifier::verify_after_evacuation (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20365/head:pull/20365` \
`$ git checkout pull/20365`

Update a local copy of the PR: \
`$ git checkout pull/20365` \
`$ git pull https://git.openjdk.org/jdk.git pull/20365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20365`

View PR using the GUI difftool: \
`$ git pr show -t 20365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20365.diff">https://git.openjdk.org/jdk/pull/20365.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20365#issuecomment-2290016626)