### PR TITLE
8332488: Add JVMTI DataDumpRequest to the debug agent

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -995,6 +995,8 @@ parseOptions(char *options)
     gdata->includeVThreads = JNI_FALSE;
     gdata->rememberVThreadsWhenDisconnected = JNI_FALSE;
 
+    gdata->jvmti_data_dump = JNI_FALSE;
+
     /* Options being NULL will end up being an error. */
     if (options == NULL) {
         options = "";
@@ -1158,6 +1160,15 @@ parseOptions(char *options)
             }
             if ( dopause ) {
                 do_pause();
+            }
+        } else if (strcmp(buf, "datadump") == 0) {
+          // Allow enabling of JVMTI DATA_DUMP_REQUEST support.
+          // This is not a documented flag. This feature is only intended to be used
+          // by debug agent developers. It is advised that you launch the debuggee
+          // with -XX:+StartAttachListener. Otherwise the attach listener may fail to
+          // startup due to the Signal Dispatcher thread being suspended due to an event.
+          if ( !get_boolean(&str, &(gdata->jvmti_data_dump)) ) {
+                goto syntax_error;
             }
         } else if (strcmp(buf, "coredump") == 0) {
             if ( !get_boolean(&str, &docoredump) ) {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugInit.c
@@ -1162,11 +1162,9 @@ parseOptions(char *options)
                 do_pause();
             }
         } else if (strcmp(buf, "datadump") == 0) {
-          // Allow enabling of JVMTI DATA_DUMP_REQUEST support.
-          // This is not a documented flag. This feature is only intended to be used
-          // by debug agent developers. It is advised that you launch the debuggee
-          // with -XX:+StartAttachListener. Otherwise the attach listener may fail to
-          // startup due to the Signal Dispatcher thread being suspended due to an event.
+          // Enable JVMTI DATA_DUMP_REQUEST support.
+          // This is not a documented flag. This feature is experimental and is only intended
+          // to be used by debug agent developers. See comment for cbDataDump() for more details.
           if ( !get_boolean(&str, &(gdata->jvmti_data_dump)) ) {
                 goto syntax_error;
             }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1387,9 +1387,7 @@ eventFilterRestricted_deinstall(HandlerNode *node)
     return error1 != JVMTI_ERROR_NONE? error1 : error2;
 }
 
-/***** debugging *****/
-
-#ifdef DEBUG
+/***** APIs for debugging the debug agent *****/
 
 void
 eventFilter_dumpHandlerFilters(HandlerNode *node)
@@ -1476,5 +1474,3 @@ eventFilter_dumpHandlerFilters(HandlerNode *node)
         }
     }
 }
-
-#endif /* DEBUG */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventFilter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,10 +76,8 @@ jvmtiError eventFilter_setPlatformThreadsOnlyFilter(HandlerNode *node, jint inde
 jboolean eventFilter_predictFiltering(HandlerNode *node, jclass clazz, char *classname);
 jboolean isBreakpointSet(jclass clazz, jmethodID method, jlocation location);
 
-/***** debugging *****/
+/***** APIs for debugging the debug agent *****/
 
-#ifdef DEBUG
 void eventFilter_dumpHandlerFilters(HandlerNode *node);
-#endif
 
 #endif /* _EVENT_FILTER_H */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -1335,9 +1335,10 @@ static void JNICALL
 cbDataDump(jvmtiEnv *jvmti_env)
 {
     tty_message("Debug Agent Data Dump");
-    tty_message("=====================");
+    tty_message("=== START DUMP ===");
     threadControl_dumpAllThreads();
     eventHandler_dumpAllHandlers(JNI_TRUE);
+    tty_message("=== END DUMP ===");
 }
 
 /**

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,12 +82,10 @@ jboolean eventHandler_synthesizeUnloadEvent(char *signature, JNIEnv *env);
 
 jclass getMethodClass(jvmtiEnv *jvmti_env, jmethodID method);
 
-/***** debugging *****/
+/***** APIs for debugging the debug agent *****/
 
-#ifdef DEBUG
 void eventHandler_dumpAllHandlers(jboolean dumpPermanent);
 void eventHandler_dumpHandlers(EventIndex ei, jboolean dumpPermanent);
 void eventHandler_dumpHandler(HandlerNode *node);
-#endif
 
 #endif /* _EVENTHANDLER_H */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -137,11 +137,6 @@ typedef struct {
 
 static DeferredEventModeList deferredEventModes;
 
-#ifdef DEBUG
-static void dumpThreadList(ThreadList *list);
-static void dumpThread(ThreadNode *node);
-#endif
-
 /* Get the state of the thread direct from JVMTI */
 static jvmtiError
 threadState(jthread thread, jint *pstate)
@@ -2556,13 +2551,15 @@ threadControl_allVThreads(jint *numVThreads)
     return vthreads;
 }
 
-/***** debugging *****/
+/***** APIs for debugging the debug agent *****/
 
-#ifdef DEBUG
+static void dumpThreadList(ThreadList *list);
+static void dumpThread(ThreadNode *node);
 
 void
 threadControl_dumpAllThreads()
 {
+    tty_message("suspendAllCount: %d", suspendAllCount);
     tty_message("Dumping runningThreads:");
     dumpThreadList(&runningThreads);
     tty_message("\nDumping runningVThreads:");
@@ -2647,5 +2644,3 @@ dumpThread(ThreadNode *node) {
     tty_message("\tobjID: %d", commonRef_refToID(getEnv(), node->thread));
 #endif
 }
-
-#endif /* DEBUG */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.h
@@ -76,11 +76,9 @@ jlong threadControl_getFrameGeneration(jthread thread);
 
 jthread *threadControl_allVThreads(jint *numVThreads);
 
-/***** debugging *****/
+/***** APIs for debugging the debug agent *****/
 
-#ifdef DEBUG
 void threadControl_dumpAllThreads();
 void threadControl_dumpThread(jthread thread);
-#endif
 
 #endif

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -1984,8 +1984,6 @@ eventIndex2jvmti(EventIndex ei)
     return event;
 }
 
-#ifdef DEBUG
-
 char*
 eventIndex2EventName(EventIndex ei)
 {
@@ -2039,8 +2037,6 @@ eventIndex2EventName(EventIndex ei)
             return "Bad EI";
     }
 }
-
-#endif
 
 EventIndex
 jdwp2EventIndex(jdwpEvent eventType)

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.h
@@ -90,6 +90,7 @@ typedef struct {
     jboolean doerrorexit;
     jboolean modifiedUtf8;
     jboolean quiet;
+    jboolean jvmti_data_dump; /* If true, then support JVMTI DATA_DUMP_REQUEST events. */
 
     /* Debug flags (bit mask) */
     int      debugflags;
@@ -389,9 +390,7 @@ void *jvmtiAllocate(jint numBytes);
 void jvmtiDeallocate(void *buffer);
 
 void             eventIndexInit(void);
-#ifdef DEBUG
 char*            eventIndex2EventName(EventIndex ei);
-#endif
 jdwpEvent        eventIndex2jdwp(EventIndex i);
 jvmtiEvent       eventIndex2jvmti(EventIndex i);
 EventIndex       jdwp2EventIndex(jdwpEvent eventType);

--- a/test/jdk/com/sun/jdi/DataDumpTest.java
+++ b/test/jdk/com/sun/jdi/DataDumpTest.java
@@ -48,7 +48,6 @@ import com.sun.jdi.request.ClassPrepareRequest;
  *
  * @library /test/lib
  * @modules jdk.jdi
- * @build DataDumpTest
  * @run driver DataDumpTest
  */
 

--- a/test/jdk/com/sun/jdi/DataDumpTest.java
+++ b/test/jdk/com/sun/jdi/DataDumpTest.java
@@ -49,7 +49,7 @@ import com.sun.jdi.request.ClassPrepareRequest;
  * @library /test/lib
  * @modules jdk.jdi
  * @build DataDumpTest
- * @run main/othervm/timeout=15 DataDumpTest
+ * @run driver DataDumpTest
  */
 
 class DataDumpTestTarg {

--- a/test/jdk/com/sun/jdi/DataDumpTest.java
+++ b/test/jdk/com/sun/jdi/DataDumpTest.java
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import jdk.test.lib.dcmd.PidJcmdExecutor;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import com.sun.jdi.Bootstrap;
+import com.sun.jdi.ClassType;
+import com.sun.jdi.VirtualMachine;
+import com.sun.jdi.VMDisconnectedException;
+import com.sun.jdi.connect.AttachingConnector;
+import com.sun.jdi.connect.Connector;
+import com.sun.jdi.connect.IllegalConnectorArgumentsException;
+import com.sun.jdi.event.ClassPrepareEvent;
+import com.sun.jdi.event.Event;
+import com.sun.jdi.event.EventSet;
+import com.sun.jdi.request.EventRequest;
+import com.sun.jdi.request.ClassPrepareRequest;
+/**
+ * @test
+ * @bug  8332488
+ * @summary Unit test for testing debug agent support for JVMTI.data_dump jcmd.
+ *
+ * @library /test/lib
+ * @modules jdk.jdi
+ * @build DataDumpTest
+ * @run main/othervm/timeout=15 DataDumpTest
+ */
+
+class DataDumpTestTarg {
+    public static void main(String args[]) throws Exception {
+        // Write something that can be read by the driver
+        System.out.println("Debuggee started");
+    }
+}
+
+public class DataDumpTest {
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Test 1: Debuggee start with datadump=y");
+        runTest("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,datadump=y");
+    }
+
+    private static void sleep(long ms) {
+        try {
+            Thread.sleep(ms);
+        } catch (InterruptedException e) {
+        }
+    }
+
+    private static void runTest(String jdwpArg) throws Exception {
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                jdwpArg,
+                // Probably not required by this test, but best to include when using datadump
+                "-XX:+StartAttachListener",
+                "DataDumpTestTarg");
+        Process p = null;
+        OutputAnalyzer out = null;
+        try {
+            p = pb.start();
+            InputStream is = p.getInputStream();
+            out = new OutputAnalyzer(p);
+
+            // Attach a debugger and do the data dump. The data dump output will appear
+            // in the debuggee output.
+            attachAndDump(p.pid());
+
+            out.waitFor(); // Wait for the debuggee to exit
+
+            System.out.println("Deuggee output:");
+            System.out.println(out.getOutput());
+
+            // All these strings are part of the debug agent data dump output.
+            out.shouldHaveExitValue(0);
+            out.shouldContain("Debuggee started");
+            out.shouldContain("Debug Agent Data Dump");
+            out.shouldContain("suspendAllCount: 0");
+            out.shouldContain("ClassMatch: classPattern(DataDumpTestTarg)");
+            out.shouldContain("Handlers for EI_VM_DEATH");
+        } finally {
+            if (p != null) {
+                p.destroyForcibly();
+            }
+        }
+    }
+
+    private static void attachAndDump(long pid) throws IOException,
+            IllegalConnectorArgumentsException {
+        // Get the ProcessAttachingConnector, which can attach using the pid of the debuggee.
+        AttachingConnector ac = Bootstrap.virtualMachineManager().attachingConnectors()
+                .stream()
+                .filter(c -> c.name().equals("com.sun.jdi.ProcessAttach"))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Unable to locate ProcessAttachingConnector"));
+
+        // Set the connector's "pid" argument to the pid of the debuggee.
+        Map<String, Connector.Argument> args = ac.defaultArguments();
+        Connector.StringArgument arg = (Connector.StringArgument)args.get("pid");
+        arg.setValue("" + pid);
+
+        // Attach to the debuggee.
+        System.out.println("Debugger is attaching to: " + pid + " ...");
+        VirtualMachine vm = ac.attach(args);
+
+        // List all threads as a sanity check.
+        System.out.println("Attached! Now listing threads ...");
+        vm.allThreads().stream().forEach(System.out::println);
+
+        // Request VM to trigger ClassPrepareRequest when DataDumpTestTarg class is prepared.
+        ClassPrepareRequest classPrepareRequest = vm.eventRequestManager().createClassPrepareRequest();
+        classPrepareRequest.addClassFilter("DataDumpTestTarg");
+        // Don't use SUSPEND_ALL here. That might prevent the data dump because the
+        // Signal Dispatcher and Attach Listener threads will be suspended, and they
+        // may be needed by the jcmd support.
+        classPrepareRequest.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD);
+        classPrepareRequest.enable();
+
+        try {
+            while (true) { // Exit when we get VMDisconnectedException
+                EventSet eventSet = vm.eventQueue().remove();
+                if (eventSet == null) {
+                    continue;
+                }
+                for (Event event : eventSet) {
+                    System.out.println("Received event: " + event);
+                    if (event instanceof ClassPrepareEvent) {
+                        ClassPrepareEvent evt = (ClassPrepareEvent) event;
+                        ClassType classType = (ClassType) evt.referenceType();
+
+                        // Run JVMTI.data_dump jcmd.
+                        OutputAnalyzer out = new PidJcmdExecutor("" + pid).execute("JVMTI.data_dump");
+                        out.waitFor();
+
+                        // Verify the output of the jcmd. Note the actual dump is in the debuggee
+                        // output, not in the jcmd output, so we don't check it here.
+                        System.out.println("JVMTI.data_dump output:");
+                        System.out.println(out.getOutput());
+                        out.shouldContain("Command executed successfully");
+                        out.shouldHaveExitValue(0);
+                    }
+                }
+                eventSet.resume();
+            }
+        } catch (VMDisconnectedException e) {
+            System.out.println("VM is now disconnected.");
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/jdk/com/sun/jdi/DataDumpTest.java
+++ b/test/jdk/com/sun/jdi/DataDumpTest.java
@@ -41,6 +41,7 @@ import com.sun.jdi.event.Event;
 import com.sun.jdi.event.EventSet;
 import com.sun.jdi.request.EventRequest;
 import com.sun.jdi.request.ClassPrepareRequest;
+
 /**
  * @test
  * @bug  8332488


### PR DESCRIPTION
JVMTI has a somewhat unique event called DataDumpRequest. One way it is triggered is via the JVMTI.data_dump jcmd, which causes JVMTI to send the DataDumpRequest event to all agents that have registered for the event callback. The agent is free to do pretty much what it wants during the callback, but the normal usage is to dump anything that might be useful for debugging the agent. In the case of the debug agent, it could dump internal data like the list of known threads and event handlers. After ranked monitor support is complete, it can also dump the state of all jvmti raw monitors that the debug agent uses.

I decided to not enable this feature by default, and not make public the option to enable it. This should only be used by developers working on the debug agent, or by users when requested to do so (by debug agent developers) to help debug a debug agent problem.

Most of the code executed during the data dump was only available for debug builds, so I've made it available for all builds. Their addition does not affect product builds except for adding a small footprint.

TBD is directing the output to a file. This is useful for some of the debugger tests that don't include the debuggee output in the log. This seems to be the case for most com/sun/jdi tests. I decided not to include it for this first pass since it is rather disruptive and detracts from the main changes being made.

testing tbd: run all tier1, tier2, and. tie5 svc tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332488](https://bugs.openjdk.org/browse/JDK-8332488): Add JVMTI DataDumpRequest to the debug agent (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20367/head:pull/20367` \
`$ git checkout pull/20367`

Update a local copy of the PR: \
`$ git checkout pull/20367` \
`$ git pull https://git.openjdk.org/jdk.git pull/20367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20367`

View PR using the GUI difftool: \
`$ git pr show -t 20367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20367.diff">https://git.openjdk.org/jdk/pull/20367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20367#issuecomment-2253712092)