### PR TITLE
8337832: Optimize datetime toString

### DIFF
--- a/src/java.base/share/classes/java/time/LocalDateTime.java
+++ b/src/java.base/share/classes/java/time/LocalDateTime.java
@@ -1966,10 +1966,17 @@ public final class LocalDateTime
     @Override
     public String toString() {
         var buf = new StringBuilder(29);
+        formatTo(buf);
+        return buf.toString();
+    }
+
+    /**
+     * Prints the toString result to the given buf, avoiding extra string allocations.
+     */
+    void formatTo(StringBuilder buf) {
         date.formatTo(buf);
         buf.append('T');
         time.formatTo(buf);
-        return buf.toString();
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/OffsetDateTime.java
+++ b/src/java.base/share/classes/java/time/OffsetDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/OffsetDateTime.java
+++ b/src/java.base/share/classes/java/time/OffsetDateTime.java
@@ -1923,7 +1923,10 @@ public final class OffsetDateTime
      */
     @Override
     public String toString() {
-        return dateTime.toString() + offset.toString();
+        String offsetStr = offset.toString();
+        var buf = new StringBuilder(29 + offsetStr.length());
+        dateTime.formatTo(buf);
+        return buf.append(offsetStr).toString();
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/OffsetDateTime.java
+++ b/src/java.base/share/classes/java/time/OffsetDateTime.java
@@ -1923,7 +1923,7 @@ public final class OffsetDateTime
      */
     @Override
     public String toString() {
-        String offsetStr = offset.toString();
+        var offsetStr = offset.toString();
         var buf = new StringBuilder(29 + offsetStr.length());
         dateTime.formatTo(buf);
         return buf.append(offsetStr).toString();

--- a/src/java.base/share/classes/java/time/OffsetTime.java
+++ b/src/java.base/share/classes/java/time/OffsetTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/OffsetTime.java
+++ b/src/java.base/share/classes/java/time/OffsetTime.java
@@ -1398,7 +1398,7 @@ public final class OffsetTime
      */
     @Override
     public String toString() {
-        String offsetStr = offset.toString();
+        var offsetStr = offset.toString();
         var buf = new StringBuilder(18 + offsetStr.length());
         time.formatTo(buf);
         return buf.append(offsetStr).toString();

--- a/src/java.base/share/classes/java/time/OffsetTime.java
+++ b/src/java.base/share/classes/java/time/OffsetTime.java
@@ -1398,7 +1398,10 @@ public final class OffsetTime
      */
     @Override
     public String toString() {
-        return time.toString() + offset.toString();
+        String offsetStr = offset.toString();
+        var buf = new StringBuilder(18 + offsetStr.length());
+        time.formatTo(buf);
+        return buf.append(offsetStr).toString();
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -2219,7 +2219,7 @@ public final class ZonedDateTime
         int length = 29 + offsetStr.length();
         if (offset != zone) {
             zoneStr = zone.toString();
-            length += zoneStr.length();
+            length += zoneStr.length() + 2;
         }
         var buf = new StringBuilder(length);
         dateTime.formatTo(buf);

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -2214,11 +2214,20 @@ public final class ZonedDateTime
      */
     @Override  // override for Javadoc
     public String toString() {
-        String str = dateTime.toString() + offset.toString();
+        String offsetStr = offset.toString();
+        String zoneStr = null;
+        int length = 29 + offsetStr.length();
         if (offset != zone) {
-            str += '[' + zone.toString() + ']';
+            zoneStr = zone.toString();
+            length += zoneStr.length();
         }
-        return str;
+        var buf = new StringBuilder(length);
+        dateTime.formatTo(buf);
+        buf.append(offsetStr);
+        if (zoneStr != null) {
+            buf.append('[').append(zoneStr).append(']');
+        }
+        return buf.toString();
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/ZonedDateTime.java
+++ b/src/java.base/share/classes/java/time/ZonedDateTime.java
@@ -2214,8 +2214,8 @@ public final class ZonedDateTime
      */
     @Override  // override for Javadoc
     public String toString() {
-        String offsetStr = offset.toString();
-        String zoneStr = null;
+        var offsetStr = offset.toString();
+        var zoneStr = (String) null;
         int length = 29 + offsetStr.length();
         if (offset != zone) {
             zoneStr = zone.toString();


### PR DESCRIPTION
Similar to PR #20321, this improves performance by providing a method that passes in a StringBuilder to avoid unnecessary object allocation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8337832](https://bugs.openjdk.org/browse/JDK-8337832): Optimize datetime toString (**Enhancement** - P4)


### Reviewers
 * [Stephen Colebourne](https://openjdk.org/census#scolebourne) (@jodastephen - Author)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20368/head:pull/20368` \
`$ git checkout pull/20368`

Update a local copy of the PR: \
`$ git checkout pull/20368` \
`$ git pull https://git.openjdk.org/jdk.git pull/20368/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20368`

View PR using the GUI difftool: \
`$ git pr show -t 20368`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20368.diff">https://git.openjdk.org/jdk/pull/20368.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20368#issuecomment-2269625309)