### PR TITLE
Optimize Integer and Long toString with allocateUninitializedArray

### DIFF
--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import static java.lang.Character.digit;
 import static java.lang.String.COMPACT_STRINGS;
 import static java.lang.String.LATIN1;
 import static java.lang.String.UTF16;
+import static java.lang.StringConcatHelper.newArray;
 
 /**
  * The {@code Integer} class wraps a value of the primitive type
@@ -366,11 +367,11 @@ public final class Integer extends Number
         int mag = Integer.SIZE - Integer.numberOfLeadingZeros(val);
         int chars = Math.max(((mag + (shift - 1)) / shift), 1);
         if (COMPACT_STRINGS) {
-            byte[] buf = new byte[chars];
+            byte[] buf = newArray(chars);
             formatUnsignedInt(val, shift, buf, chars);
             return new String(buf, LATIN1);
         } else {
-            byte[] buf = new byte[chars * 2];
+            byte[] buf = newArray(chars << 1);
             formatUnsignedIntUTF16(val, shift, buf, chars);
             return new String(buf, UTF16);
         }
@@ -430,11 +431,11 @@ public final class Integer extends Number
     public static String toString(int i) {
         int size = DecimalDigits.stringSize(i);
         if (COMPACT_STRINGS) {
-            byte[] buf = new byte[size];
+            byte[] buf = newArray(size);
             StringLatin1.getChars(i, size, buf);
             return new String(buf, LATIN1);
         } else {
-            byte[] buf = new byte[size * 2];
+            byte[] buf = newArray(size << 1);
             StringUTF16.getChars(i, size, buf);
             return new String(buf, UTF16);
         }

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,7 @@ import static java.lang.Character.digit;
 import static java.lang.String.COMPACT_STRINGS;
 import static java.lang.String.LATIN1;
 import static java.lang.String.UTF16;
+import static java.lang.StringConcatHelper.newArray;
 
 /**
  * The {@code Long} class wraps a value of the primitive type {@code
@@ -395,11 +396,11 @@ public final class Long extends Number
         int mag = Long.SIZE - Long.numberOfLeadingZeros(val);
         int chars = Math.max(((mag + (shift - 1)) / shift), 1);
         if (COMPACT_STRINGS) {
-            byte[] buf = new byte[chars];
+            byte[] buf = newArray(chars);
             formatUnsignedLong0(val, shift, buf, 0, chars);
             return new String(buf, LATIN1);
         } else {
-            byte[] buf = new byte[chars * 2];
+            byte[] buf = newArray(chars << 1);
             formatUnsignedLong0UTF16(val, shift, buf, 0, chars);
             return new String(buf, UTF16);
         }
@@ -460,11 +461,11 @@ public final class Long extends Number
     public static String toString(long i) {
         int size = DecimalDigits.stringSize(i);
         if (COMPACT_STRINGS) {
-            byte[] buf = new byte[size];
+            byte[] buf = newArray(size);
             StringLatin1.getChars(i, size, buf);
             return new String(buf, LATIN1);
         } else {
-            byte[] buf = new byte[size * 2];
+            byte[] buf = newArray(size << 1);
             StringUTF16.getChars(i, size, buf);
             return new String(buf, UTF16);
         }

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,6 +111,27 @@ public class Integers {
     public void toStringBig(Blackhole bh) {
         for (int i : intsBig) {
             bh.consume(Integer.toString(i));
+        }
+    }
+
+    @Benchmark
+    public void toHexStringTiny(Blackhole bh) {
+        for (int i : intsTiny) {
+            bh.consume(Integer.toHexString(i));
+        }
+    }
+
+    @Benchmark
+    public void toHexStringSmall(Blackhole bh) {
+        for (int i : intsSmall) {
+            bh.consume(Integer.toHexString(i));
+        }
+    }
+
+    @Benchmark
+    public void toHexStringBig(Blackhole bh) {
+        for (int i : intsBig) {
+            bh.consume(Integer.toHexString(i));
         }
     }
 

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,6 +78,14 @@ public class Longs {
         }
     }
 
+    /** Performs toHexString on small values, just a couple of digits. */
+    @Benchmark
+    public void toHexStringSmall(Blackhole bh) {
+        for (long value : longArraySmall) {
+            bh.consume(Long.toHexString(value));
+        }
+    }
+
     @Benchmark
     public void decode(Blackhole bh) {
         for (String s : strings) {
@@ -90,6 +98,14 @@ public class Longs {
     public void toStringBig(Blackhole bh) {
         for (long value : longArrayBig) {
             bh.consume(Long.toString(value));
+        }
+    }
+
+    /** Performs toHexString on large values */
+    @Benchmark
+    public void toHexStringBig(Blackhole bh) {
+        for (long value : longArrayBig) {
+            bh.consume(Long.toHexString(value));
         }
     }
 


### PR DESCRIPTION
The .toString/toHexString methods of Integer and Long allocate buf that is fully initialized, so you can use the StringConcatHelper.newArray method to allocate it to improve performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20369/head:pull/20369` \
`$ git checkout pull/20369`

Update a local copy of the PR: \
`$ git checkout pull/20369` \
`$ git pull https://git.openjdk.org/jdk.git pull/20369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20369`

View PR using the GUI difftool: \
`$ git pr show -t 20369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20369.diff">https://git.openjdk.org/jdk/pull/20369.diff</a>

</details>
