### PR TITLE
8337334: Test tools/javac/7142086/T7142086.java timeout with fastdebug binary

### DIFF
--- a/test/langtools/TEST.ROOT
+++ b/test/langtools/TEST.ROOT
@@ -42,4 +42,5 @@ requires.extraPropDefns.vmOpts = \
     -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI \
     --add-exports java.base/jdk.internal.foreign=ALL-UNNAMED
 requires.properties= \
-    vm.continuations
+    vm.continuations \
+    vm.debug

--- a/test/langtools/tools/javac/7142086/T7142086.java
+++ b/test/langtools/tools/javac/7142086/T7142086.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,9 +24,17 @@
 /*
  * @test
  * @bug 7142086
+ * @requires vm.debug == false
  * @summary performance problem in Check.checkOverrideClashes(...)
  * @modules jdk.compiler
  * @run main/timeout=10 T7142086
+ */
+
+/*
+ * @test
+ * @requires vm.debug == true
+ * @modules jdk.compiler
+ * @run main/timeout=20 T7142086
  */
 
 import com.sun.source.util.JavacTask;

--- a/test/langtools/tools/javac/7142086/T7142086.java
+++ b/test/langtools/tools/javac/7142086/T7142086.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7142086
+ * @bug 7142086 8337334
  * @requires vm.debug == false
  * @summary performance problem in Check.checkOverrideClashes(...)
  * @modules jdk.compiler


### PR DESCRIPTION
Hi all,
Test `tools/javac/7142086/T7142086.java` run timeouted with fastdebug binary. I think it's necessory set more timeout value  when the tested binary is fastdebug or slowdebug.

The change has been verified, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337334](https://bugs.openjdk.org/browse/JDK-8337334): Test tools/javac/7142086/T7142086.java timeout with fastdebug binary (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20370/head:pull/20370` \
`$ git checkout pull/20370`

Update a local copy of the PR: \
`$ git checkout pull/20370` \
`$ git pull https://git.openjdk.org/jdk.git pull/20370/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20370`

View PR using the GUI difftool: \
`$ git pr show -t 20370`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20370.diff">https://git.openjdk.org/jdk/pull/20370.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20370#issuecomment-2255275385)