### PR TITLE
8336912: G1: Undefined behavior for G1ConfidencePercent=0

### DIFF
--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -112,7 +112,7 @@
                                                                             \
   product(uint, G1ConfidencePercent, 50,                                    \
           "Confidence level for MMU/pause predictions")                     \
-          range(0, 100)                                                     \
+          range(1, 100)                                                     \
                                                                             \
   product(uintx, G1SummarizeRSetStatsPeriod, 0, DIAGNOSTIC,                 \
           "The period (in number of GCs) at which we will generate "        \

--- a/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1PercentageOptions.java
@@ -51,14 +51,14 @@ public class TestG1PercentageOptions {
         }
     }
 
-    private static final String[] defaultValid = new String[] {
-        "0", "1", "50", "95", "100" };
-    private static final String[] defaultInvalid = new String[] {
-        "-10", "110", "bad" };
+    private static final String[] rangeOneToHundredValid = new String[] {
+        "1", "50", "95", "100" };
+    private static final String[] rangeOneToHundredInvalid = new String[] {
+        "0", "-10", "110", "bad" };
 
     // All of the G1 product arguments that are percentages.
     private static final OptionDescription[] percentOptions = new OptionDescription[] {
-        new OptionDescription("G1ConfidencePercent", defaultValid, defaultInvalid)
+        new OptionDescription("G1ConfidencePercent", rangeOneToHundredValid, rangeOneToHundredInvalid)
         // Other percentage options are not yet validated by argument processing.
     };
 


### PR DESCRIPTION
Hello,

  please review this change to workaround an unintentional division by zero found by ubsan.

The global option `G1ConfidencePercent` allowed zero as confidence for predictions which this change simply disallows: not sure what the response of the VM would be if the user told it that it should have absolutely no confidence (i.e. confidence is zero) in the predictions (not "very low" confidence).

Testing: after this change, the ubsan failure goes away.

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8337340](https://bugs.openjdk.org/browse/JDK-8337340) to be approved

### Issues
 * [JDK-8336912](https://bugs.openjdk.org/browse/JDK-8336912): G1: Undefined behavior for G1ConfidencePercent=0 (**Bug** - P4)
 * [JDK-8337340](https://bugs.openjdk.org/browse/JDK-8337340): G1: Disallow a value of zero for G1ConfidencePercent (**CSR**)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20371/head:pull/20371` \
`$ git checkout pull/20371`

Update a local copy of the PR: \
`$ git checkout pull/20371` \
`$ git pull https://git.openjdk.org/jdk.git pull/20371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20371`

View PR using the GUI difftool: \
`$ git pr show -t 20371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20371.diff">https://git.openjdk.org/jdk/pull/20371.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20371#issuecomment-2255646708)