### PR TITLE
[JDK-8337331] crash: pinned virtual thread will lead to jvm crash when running with the javaagent option

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.cpp
+++ b/src/hotspot/share/prims/jvmtiExport.cpp
@@ -965,6 +965,9 @@ class JvmtiClassFileLoadHookPoster : public StackObj {
   }
 
   void post() {
+    if (_thread->is_in_any_VTMS_transition()) {
+      return; // no events should be posted if thread is in any VTMS transition
+    }
     post_all_envs();
     copy_modified_data();
   }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTraceWithAgent/TestPinCaseWithTrace.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTraceWithAgent/TestPinCaseWithTrace.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary javaagent+tracePinnedThreads will cause jvm crash/ run into deadlock when the virtual thread is pinned
+ * @library /test/lib
+ * @requires os.family == "linux"
+ * @requires os.arch != "riscv64"
+ * @modules java.base/java.lang:+open
+ * @build TestPinCaseWithTrace
+ * @run driver jdk.test.lib.util.JavaAgentBuilder
+ *      TestPinCaseWithTrace TestPinCaseWithTrace.jar
+ * @run main/othervm/timeout=100 -Djdk.tracePinnedThreads=full TestPinCaseWithTrace
+ * @run main/othervm/timeout=100 -javaagent:TestPinCaseWithTrace.jar TestPinCaseWithTrace
+ * @run main/othervm/timeout=100 -Djdk.tracePinnedThreads=full -javaagent:TestPinCaseWithTrace.jar TestPinCaseWithTrace
+ */
+import java.util.concurrent.*;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.Instrumentation;
+import java.security.ProtectionDomain;
+
+public class TestPinCaseWithTrace {
+
+    public static class TestClassFileTransformer implements ClassFileTransformer {
+        public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] classfileBuffer) throws IllegalClassFormatException {
+            return classfileBuffer;
+        }
+    }
+
+    // Called when agent is loaded at startup
+    public static void premain(String agentArgs, Instrumentation instrumentation) throws Exception {
+        instrumentation.addTransformer(new TestClassFileTransformer());
+    }
+
+    public static void main(String[] args) throws Exception{
+        ExecutorService scheduler = Executors.newFixedThreadPool(1);
+        Thread.Builder builder = TestPinCaseWithTrace.virtualThreadBuilder(scheduler);
+        Thread t1 = builder.name("vthread-1").start(() -> {
+            System.out.println("call native: " + nativeFuncPin(1));
+        });
+    }
+
+    static int native2Java(int b) {
+        try {
+            Thread.sleep(500); // try yield, will pin, javaagent+tracePinnedThreads will crash here (because of the class `PinnedThreadPrinter`)
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return b+1;
+    }
+
+    private static native int nativeFuncPin(int x);
+
+    static {
+        System.loadLibrary("PinJNI");
+    }
+
+    private static Thread.Builder.OfVirtual virtualThreadBuilder(Executor scheduler) {
+        Thread.Builder.OfVirtual builder = Thread.ofVirtual();
+        try {
+            Class<?> clazz = Class.forName("java.lang.ThreadBuilders$VirtualThreadBuilder");
+            Constructor<?> ctor = clazz.getDeclaredConstructor(Executor.class);
+            ctor.setAccessible(true);
+            return (Thread.Builder.OfVirtual) ctor.newInstance(scheduler);
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException re) {
+                throw re;
+            }
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTraceWithAgent/libPinJNI.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/VThreadTraceWithAgent/libPinJNI.c
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+
+JNIEXPORT jint JNICALL
+Java_TestPinCaseWithTrace_nativeFuncPin(JNIEnv* env, jclass klass, jint x) {
+    jmethodID nativeBaz = (*env)->GetStaticMethodID(env, klass, "native2Java", "(I)I");
+    jint r = (*env)->CallStaticIntMethod(env, klass, nativeBaz, x+1);
+    return r + 1;
+}


### PR DESCRIPTION
I add the testcase which can reproduce the crash. I hope that I could get some advise if the codes need changing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20372/head:pull/20372` \
`$ git checkout pull/20372`

Update a local copy of the PR: \
`$ git checkout pull/20372` \
`$ git pull https://git.openjdk.org/jdk.git pull/20372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20372`

View PR using the GUI difftool: \
`$ git pr show -t 20372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20372.diff">https://git.openjdk.org/jdk/pull/20372.diff</a>

</details>
