### PR TITLE
8337344: Redundant javadoc at RasterPrinterJob.isCancelled

### DIFF
--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -2474,12 +2474,6 @@ public abstract class RasterPrinterJob extends PrinterJob {
         }
     }
 
-    /**
-     * Returns true if a print job is ongoing and user
-     * has cancelled the printjob and will
-     * be cancelled at the next opportunity. false is
-     * returned otherwise.
-     */
     public boolean isCancelled() {
 
         boolean cancelled = false;

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -2475,8 +2475,9 @@ public abstract class RasterPrinterJob extends PrinterJob {
     }
 
     /**
-     * Returns true is a print job is ongoing but will
-     * be cancelled and the next opportunity. false is
+     * Returns true if a print job is ongoing and user
+     * has cancelled the printjob and will
+     * be cancelled at the next opportunity. false is
      * returned otherwise.
      */
     public boolean isCancelled() {

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -2474,6 +2474,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
         }
     }
 
+    @Override
     public boolean isCancelled() {
 
         boolean cancelled = false;


### PR DESCRIPTION
RasterPrinterJob.isCancelled cites
`is a print job is ongoing but will be cancelled and the next opportunity`

"and" -> "at" is fixed and more clarification added..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337344](https://bugs.openjdk.org/browse/JDK-8337344): Redundant javadoc at RasterPrinterJob.isCancelled (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20375/head:pull/20375` \
`$ git checkout pull/20375`

Update a local copy of the PR: \
`$ git checkout pull/20375` \
`$ git pull https://git.openjdk.org/jdk.git pull/20375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20375`

View PR using the GUI difftool: \
`$ git pr show -t 20375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20375.diff">https://git.openjdk.org/jdk/pull/20375.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20375#issuecomment-2255852342)