### PR TITLE
8337300: java/lang/Process/WaitForDuration.java leaves child process behind

### DIFF
--- a/test/jdk/java/lang/Process/WaitForDuration.java
+++ b/test/jdk/java/lang/Process/WaitForDuration.java
@@ -55,9 +55,14 @@ public class WaitForDuration {
     @MethodSource("durations")
     void testEdgeDurations(Duration d, int sleepMillis, boolean expected)
             throws IOException, InterruptedException {
-        var pb = ProcessTools.createTestJavaProcessBuilder(
-            WaitForDuration.class.getSimpleName(), Integer.toString(sleepMillis));
-        assertEquals(expected, pb.start().waitFor(d));
+        var child = ProcessTools.createTestJavaProcessBuilder(
+            WaitForDuration.class.getSimpleName(), Integer.toString(sleepMillis))
+                .start();
+        try {
+            assertEquals(expected, child.waitFor(d));
+        } finally {
+            child.destroy();
+        }
     }
 
     @Test


### PR DESCRIPTION
This fix is to address the tier_1 test run on Windows taking much longer time than before. The test case creates child processes that remain behind after the test run has completed, which is problematic on Windows as the make command waits for the process to terminate. Confirmed tier_1/part_1 finishes around 10+min on Windows as before.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337300](https://bugs.openjdk.org/browse/JDK-8337300): java/lang/Process/WaitForDuration.java leaves child process behind (**Bug** - P2)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20379/head:pull/20379` \
`$ git checkout pull/20379`

Update a local copy of the PR: \
`$ git checkout pull/20379` \
`$ git pull https://git.openjdk.org/jdk.git pull/20379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20379`

View PR using the GUI difftool: \
`$ git pr show -t 20379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20379.diff">https://git.openjdk.org/jdk/pull/20379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20379#issuecomment-2256298973)