### PR TITLE
8336032: Enforce immutability of Lists used by ClassFile API

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/AttributedElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/AttributedElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@
 package java.lang.classfile;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -83,6 +84,6 @@ public sealed interface AttributedElement extends ClassFileElement
                 list.add(t);
             }
         }
-        return list;
+        return Collections.unmodifiableList(list);
     }
 }

--- a/src/java.base/share/classes/java/lang/classfile/ClassSignature.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassSignature.java
@@ -76,7 +76,7 @@ public sealed interface ClassSignature
                                     Signature.ClassTypeSig superclassSignature,
                                     Signature.ClassTypeSig... superinterfaceSignatures) {
         return new SignaturesImpl.ClassSignatureImpl(
-                requireNonNull(typeParameters),
+                List.copyOf(requireNonNull(typeParameters)),
                 requireNonNull(superclassSignature),
                 List.of(superinterfaceSignatures));
     }

--- a/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
+++ b/src/java.base/share/classes/java/lang/classfile/CompoundElement.java
@@ -25,6 +25,7 @@
 package java.lang.classfile;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Spliterator;
@@ -90,7 +91,7 @@ public sealed interface CompoundElement<E extends ClassFileElement>
                 list.add(e);
             }
         });
-        return list;
+        return Collections.unmodifiableList(list);
     }
 
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractUnboundModel.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractUnboundModel.java
@@ -24,6 +24,7 @@
  */
 package jdk.internal.classfile.impl;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -37,11 +38,11 @@ public abstract sealed class AbstractUnboundModel<E extends ClassFileElement>
         extends AbstractElement
         implements CompoundElement<E>, AttributedElement, Util.Writable
         permits BufferedCodeBuilder.Model, BufferedFieldBuilder.Model, BufferedMethodBuilder.Model {
-    private final List<E> elements;
+    final List<E> elements;
     private List<Attribute<?>> attributes;
 
     public AbstractUnboundModel(List<E> elements) {
-        this.elements = elements;
+        this.elements = Collections.unmodifiableList(elements);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -39,6 +39,7 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 
@@ -134,7 +135,6 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
         var filled = new ArrayList<Attribute<?>>(size);
         int p = pos + 2;
         int cfLen = reader.classfileLength();
-        var apo = ((ClassReaderImpl)reader).context().attributesProcessingOption();
         for (int i = 0; i < size; ++i) {
             Utf8Entry name = reader.readEntry(p, Utf8Entry.class);
             int len = reader.readInt(p + 2);
@@ -148,7 +148,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 mapper = customAttributes.apply(name);
             }
             if (mapper != null) {
-                filled.add((Attribute)mapper.readAttribute(enclosing, reader, p));
+                filled.add((Attribute<?>) Objects.requireNonNull(mapper.readAttribute(enclosing, reader, p)));
             } else {
                 AttributeMapper<UnknownAttribute> fakeMapper = new AttributeMapper<>() {
                     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedCodeBuilder.java
@@ -156,7 +156,7 @@ public final class BufferedCodeBuilder
             implements CodeModel {
 
         private Model() {
-            super(elements);
+            super(BufferedCodeBuilder.this.elements);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedFieldBuilder.java
@@ -78,7 +78,7 @@ public final class BufferedFieldBuilder
             extends AbstractUnboundModel<FieldElement>
             implements FieldModel {
         public Model() {
-            super(elements);
+            super(BufferedFieldBuilder.this.elements);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedMethodBuilder.java
@@ -156,7 +156,7 @@ public final class BufferedMethodBuilder
             extends AbstractUnboundModel<MethodElement>
             implements MethodModel, MethodInfo {
         public Model() {
-            super(elements);
+            super(BufferedMethodBuilder.this.elements);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
@@ -285,5 +285,9 @@ public class StackMapDecoder {
                                            List<VerificationTypeInfo> locals,
                                            List<VerificationTypeInfo> stack)
             implements StackMapFrameInfo {
+        public StackMapFrameImpl {
+            locals = List.copyOf(locals);
+            stack = List.copyOf(stack);
+        }
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/UnboundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/UnboundAttribute.java
@@ -92,6 +92,8 @@ import java.lang.classfile.constantpool.NameAndTypeEntry;
 import java.lang.classfile.constantpool.PackageEntry;
 import java.lang.classfile.constantpool.Utf8Entry;
 
+import jdk.internal.access.SharedSecrets;
+
 public abstract sealed class UnboundAttribute<T extends Attribute<T>>
         extends AbstractElement
         implements Attribute<T>, Util.Writable {
@@ -627,7 +629,13 @@ public abstract sealed class UnboundAttribute<T extends Attribute<T>>
 
         public UnboundRuntimeInvisibleParameterAnnotationsAttribute(List<List<Annotation>> elements) {
             super(Attributes.runtimeInvisibleParameterAnnotations());
-            this.elements = List.copyOf(elements);
+            // deep copy
+            var array = elements.toArray().clone();
+            for (int i = 0; i < array.length; i++) {
+                array[i] = List.copyOf((List<?>) array[i]);
+            }
+
+            this.elements = SharedSecrets.getJavaUtilCollectionAccess().listFromTrustedArray(array);
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/VerifierImpl.java
@@ -26,6 +26,7 @@ package jdk.internal.classfile.impl.verifier;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.lang.classfile.ClassHierarchyResolver;
@@ -133,7 +134,7 @@ public final class VerifierImpl {
                     errors.addAll(inference_verify(klass));
                 }
             }
-            return errors;
+            return Collections.unmodifiableList(errors);
         } finally {
             log_info(logger, "End class verification for: %s", clsName);
         }


### PR DESCRIPTION
In #20241, it's noted that `ClassFile.verify` can return a mix-and-match of mutable and immutable lists.

Though the mutability of the list returned by `verify` has no particular importance, as the mutable list is constructed on every call and does not mutate the models, there are a few scenarios that they matter. Since ClassFile API is designed with immutability in mind, we should change all lists in ClassFile API to be immutable.

Change summary:
- Critical scenarios where ClassFile API stores mutable objects:
  - `ClassSignature.typeParameters` - keeps user mutable list
  - `CompoundElement.elementList` - buffered models expose the underlying mutable list
  - `RuntimeInvisibleParameterAnnotationsAttribute`(and Visible) - keeps users' nest mutable lists in an immutable list
  - `StackMapFrameInfo.locals/stack` - keeps user mutable lists
- Optional scenarios to return immutable for good practice
  - `ClassFile.verify` - mutable for full verified results
  - `CompoundElement.elementList` - safe mutable for bound models
- Fail fast on user null `Attribute`s in `BoundAttribute.readAttributes` to prevent unmodifiable list containing null

I have also checked if we should stick with null-hostile `List.of` lists instead of `Collections.unmodifiableList` lists; we are using `unmodifiableList` (extensively in Signature parsing, for example) or other ad-hoc immutable lists, so it is somewhat impractical and not meaningful to enforce null-hostility. (See the list in JBS)

These use sites are too sporadic so I made no unit tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336032](https://bugs.openjdk.org/browse/JDK-8336032): Enforce immutability of Lists used by ClassFile API (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20380/head:pull/20380` \
`$ git checkout pull/20380`

Update a local copy of the PR: \
`$ git checkout pull/20380` \
`$ git pull https://git.openjdk.org/jdk.git pull/20380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20380`

View PR using the GUI difftool: \
`$ git pr show -t 20380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20380.diff">https://git.openjdk.org/jdk/pull/20380.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20380#issuecomment-2256760878)