### PR TITLE
8337415: Remove inappropriate Atomic access in FreeListAllocator

### DIFF
--- a/src/hotspot/share/gc/shared/freeListAllocator.cpp
+++ b/src/hotspot/share/gc/shared/freeListAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ void FreeListAllocator::delete_list(FreeNode* list) {
 FreeListAllocator::~FreeListAllocator() {
   uint index = Atomic::load(&_active_pending_list);
   NodeList pending_list = _pending_lists[index].take_all();
-  delete_list(Atomic::load(&pending_list._head));
+  delete_list(pending_list._head);
   delete_list(_free_list.pop_all());
 }
 
@@ -106,7 +106,7 @@ size_t FreeListAllocator::free_count() const {
 
 size_t FreeListAllocator::pending_count() const {
   uint index = Atomic::load(&_active_pending_list);
-  return _pending_lists[index].count();;
+  return _pending_lists[index].count();
 }
 
 // To solve the ABA problem, popping a node from the _free_list is performed within


### PR DESCRIPTION
Please review this change to ~FreeListAllocator to replace an inappropriate
use of Atomic::load with a plain access.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337415](https://bugs.openjdk.org/browse/JDK-8337415): Remove inappropriate Atomic access in FreeListAllocator (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20382/head:pull/20382` \
`$ git checkout pull/20382`

Update a local copy of the PR: \
`$ git checkout pull/20382` \
`$ git pull https://git.openjdk.org/jdk.git pull/20382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20382`

View PR using the GUI difftool: \
`$ git pr show -t 20382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20382.diff">https://git.openjdk.org/jdk/pull/20382.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20382#issuecomment-2257386313)