### PR TITLE
8337416: Fix -Wzero-as-null-pointer-constant warnings in misc. runtime code 

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -370,7 +370,7 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
 
   // Split the option string to its colon separated components.
   char* str = copy;
-  char* substrings[4] = {0};
+  char* substrings[4] = {};
   for (int i = 0 ; i < 4; i++) {
     substrings[i] = str;
 

--- a/src/hotspot/share/memory/metaspace/metachunk.cpp
+++ b/src/hotspot/share/memory/metaspace/metachunk.cpp
@@ -253,7 +253,7 @@ void Metachunk::verify_neighborhood() const {
   }
 }
 
-volatile MetaWord dummy = 0;
+volatile MetaWord dummy = nullptr;
 
 void Metachunk::verify() const {
   // Note. This should be called under CLD lock protection.

--- a/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
+++ b/src/hotspot/share/memory/metaspace/rootChunkArea.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -59,7 +59,7 @@ RootChunkArea::~RootChunkArea() {
 // root chunk header. It will be partly initialized.
 // Note: this just allocates a memory-less header; memory itself is allocated inside VirtualSpaceNode.
 Metachunk* RootChunkArea::alloc_root_chunk_header(VirtualSpaceNode* node) {
-  assert(_first_chunk == 0, "already have a root");
+  assert(_first_chunk == nullptr, "already have a root");
   Metachunk* c = ChunkHeaderPool::pool()->allocate_chunk_header();
   c->initialize(node, const_cast<MetaWord*>(_base), chunklevel::ROOT_CHUNK_LEVEL);
   _first_chunk = c;

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -159,7 +159,7 @@ static char* reserve_memory(char* requested_address, const size_t size,
   // If the memory was requested at a particular address, use
   // os::attempt_reserve_memory_at() to avoid mapping over something
   // important.  If the reservation fails, return null.
-  if (requested_address != 0) {
+  if (requested_address != nullptr) {
     assert(is_aligned(requested_address, alignment),
            "Requested address " PTR_FORMAT " must be aligned to " SIZE_FORMAT,
            p2i(requested_address), alignment);

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -2065,7 +2065,7 @@ static void print_cpool_bytes(jint cnt, u1 *bytes) {
     size  += ent_size;
   }
   printf("Cpool size: %d\n", size);
-  fflush(0);
+  fflush(nullptr);
   return;
 } /* end print_cpool_bytes */
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2779,9 +2779,9 @@ void InstanceKlass::release_C_heap_structures(bool release_sub_metadata) {
 
 #if INCLUDE_JVMTI
   // Deallocate breakpoint records
-  if (breakpoints() != 0x0) {
+  if (breakpoints() != nullptr) {
     methods_do(clear_all_breakpoints);
-    assert(breakpoints() == 0x0, "should have cleared breakpoints");
+    assert(breakpoints() == nullptr, "should have cleared breakpoints");
   }
 
   // deallocate the cached class file

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -322,7 +322,7 @@ void Method::mask_for(const methodHandle& this_mh, int bci, InterpreterOopMap* m
 }
 
 int Method::bci_from(address bcp) const {
-  if (is_native() && bcp == 0) {
+  if (is_native() && bcp == nullptr) {
     return 0;
   }
   // Do not have a ResourceMark here because AsyncGetCallTrace stack walking code
@@ -345,7 +345,7 @@ int Method::validate_bci(int bci) const {
 int Method::validate_bci_from_bcp(address bcp) const {
   // keep bci as -1 if not a valid bci
   int bci = -1;
-  if (bcp == 0 || bcp == code_base()) {
+  if (bcp == nullptr || bcp == code_base()) {
     // code_size() may return 0 and we allow 0 here
     // the method may be native
     bci = 0;

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -102,7 +102,7 @@ size_t Arguments::_default_SharedBaseAddress    = SharedBaseAddress;
 
 bool   Arguments::_enable_preview               = false;
 
-LegacyGCLogging Arguments::_legacyGCLogging     = { 0, 0 };
+LegacyGCLogging Arguments::_legacyGCLogging     = { nullptr, 0 };
 
 // These are not set by the JDK's built-in launchers, but they can be set by
 // programs that embed the JVM using JNI_CreateJavaVM. See comments around
@@ -1850,11 +1850,11 @@ bool Arguments::is_bad_option(const JavaVMOption* option, jboolean ignore,
 }
 
 static const char* user_assertion_options[] = {
-  "-da", "-ea", "-disableassertions", "-enableassertions", 0
+  "-da", "-ea", "-disableassertions", "-enableassertions", nullptr
 };
 
 static const char* system_assertion_options[] = {
-  "-dsa", "-esa", "-disablesystemassertions", "-enablesystemassertions", 0
+  "-dsa", "-esa", "-disablesystemassertions", "-enablesystemassertions", nullptr
 };
 
 bool Arguments::parse_uint(const char* value,

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -470,8 +470,8 @@ JavaThread::JavaThread(MEMFLAGS flags) :
 #endif // INCLUDE_JVMCI
 
   _exception_oop(oop()),
-  _exception_pc(0),
-  _exception_handler_pc(0),
+  _exception_pc(nullptr),
+  _exception_handler_pc(nullptr),
   _is_method_handle_return(0),
 
   _jni_active_critical(0),
@@ -483,7 +483,7 @@ JavaThread::JavaThread(MEMFLAGS flags) :
   _frames_to_pop_failed_realloc(0),
 
   _cont_entry(nullptr),
-  _cont_fastpath(0),
+  _cont_fastpath(nullptr),
   _cont_fastpath_thread_state(1),
   _held_monitor_count(0),
   _jni_monitor_count(0),

--- a/src/hotspot/share/runtime/vframeArray.cpp
+++ b/src/hotspot/share/runtime/vframeArray.cpp
@@ -321,7 +321,7 @@ void vframeArrayElement::unpack_on_stack(int caller_actual_parameters,
            "should be held, after move_to");
   }
   if (ProfileInterpreter) {
-    iframe()->interpreter_frame_set_mdp(0); // clear out the mdp.
+    iframe()->interpreter_frame_set_mdp(nullptr); // clear out the mdp.
   }
   iframe()->interpreter_frame_set_bcp(bcp);
   if (ProfileInterpreter) {


### PR DESCRIPTION
Please review this (perhaps trivial?) change that removes some uses of literal
0 as a null pointer constant in misc. runtime code.  Most are changed to use
nullptr. 

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337416](https://bugs.openjdk.org/browse/JDK-8337416): Fix -Wzero-as-null-pointer-constant warnings in misc. runtime code (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20383/head:pull/20383` \
`$ git checkout pull/20383`

Update a local copy of the PR: \
`$ git checkout pull/20383` \
`$ git pull https://git.openjdk.org/jdk.git pull/20383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20383`

View PR using the GUI difftool: \
`$ git pr show -t 20383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20383.diff">https://git.openjdk.org/jdk/pull/20383.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20383#issuecomment-2257395378)