### PR TITLE
8337320: Update ProblemList.txt with tests known to fail on XWayland

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -473,6 +473,12 @@ java/awt/image/multiresolution/MultiResolutionJOptionPaneIconTest.java 8274106 m
 # This test fails on macOS 14
 java/awt/Choice/SelectNewItemTest/SelectNewItemTest.java 8324782 macosx-all
 
+# Wayland related
+
+java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8332158 linux-x64
+java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java 8280991 linux-x64
+java/awt/FullScreen/SetFullScreenTest.java 8332155 linux-x64
+
 ############################################################################
 
 # jdk_beans


### PR DESCRIPTION
Adding tests failing on XWayland.

The `java/awt/Focus/VetoableChangeListenerLoopTest.java` mentioned in the bug description no longer fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337320](https://bugs.openjdk.org/browse/JDK-8337320): Update ProblemList.txt with tests known to fail on XWayland (**Bug** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20384/head:pull/20384` \
`$ git checkout pull/20384`

Update a local copy of the PR: \
`$ git checkout pull/20384` \
`$ git pull https://git.openjdk.org/jdk.git pull/20384/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20384`

View PR using the GUI difftool: \
`$ git pr show -t 20384`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20384.diff">https://git.openjdk.org/jdk/pull/20384.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20384#issuecomment-2257405931)