### PR TITLE
8337421: RISC-V: client VM build failure after JDK-8335191

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5970,7 +5970,6 @@ static const int64_t right_3_bits = right_n_bits(3);
       StubRoutines::_bigIntegerLeftShiftWorker = generate_bigIntegerLeftShift();
       StubRoutines::_bigIntegerRightShiftWorker = generate_bigIntegerRightShift();
     }
-#endif // COMPILER2
 
     if (UseSHA256Intrinsics) {
       Sha2Generator sha2(_masm, this);
@@ -5983,10 +5982,6 @@ static const int64_t right_3_bits = right_n_bits(3);
       StubRoutines::_sha512_implCompress   = sha2.generate_sha512_implCompress(false);
       StubRoutines::_sha512_implCompressMB = sha2.generate_sha512_implCompress(true);
     }
-
-    generate_compare_long_strings();
-
-    generate_string_indexof_stubs();
 
     if (UseMD5Intrinsics) {
       StubRoutines::_md5_implCompress   = generate_md5_implCompress(false, "md5_implCompress");
@@ -6005,6 +6000,11 @@ static const int64_t right_3_bits = right_n_bits(3);
     if (UseAdler32Intrinsics) {
       StubRoutines::_updateBytesAdler32 = generate_updateBytesAdler32();
     }
+#endif // COMPILER2
+
+    generate_compare_long_strings();
+
+    generate_string_indexof_stubs();
 
 #endif // COMPILER2_OR_JVMCI
   }


### PR DESCRIPTION
Hi, please help review this patch that fix the client VM build failed for riscv.

Error log for client VM build to see: [JDK-8337421](https://bugs.openjdk.org/browse/JDK-8337421)

The root cause is that MaxVectorSize is defined in COMPILER2 or JVMCI, which is not included in client mode. In addition to this, I have adjusted the functions related to initialization using UseSHA256Intrinsics, UseSHA512Intrinsics, UseMD5Intrinsics, UseChaCha20Intrinsics, UseSHA1Intrinsics, UseAdler32Intrinsics to be under the control of the COMPILER2 macro.  And made related adjustments in VM_Version::c2_initialize().

### Testing
- [x] linux-riscv client VM fastdebug native build