### PR TITLE
8320561: Inconsistency in monitorinflation logging

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -2074,7 +2074,7 @@ void ObjectSynchronizer::chk_in_use_entry(ObjectMonitor* n, outputStream* out,
 void ObjectSynchronizer::log_in_use_monitor_details(outputStream* out, bool log_all) {
   if (_in_use_list.count() > 0) {
     stringStream ss;
-    out->print_cr("In-use monitor info:");
+    out->print_cr("In-use monitor info%s:", log_all ? "" : " (eliding idle monitors)");
     out->print_cr("(B -> is_busy, H -> has hash code, L -> lock status)");
     out->print_cr("%18s  %s  %18s  %18s",
                   "monitor", "BHL", "object", "object type");


### PR DESCRIPTION
Please review this trivial tweak to the monitorinflation logging output to clarify that some monitors may be elided from the list.

See JBS for more details.

Testing:
 - all tests using monitorlogging
 - tiers 1-3 sanity

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320561](https://bugs.openjdk.org/browse/JDK-8320561): Inconsistency in monitorinflation logging (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20387/head:pull/20387` \
`$ git checkout pull/20387`

Update a local copy of the PR: \
`$ git checkout pull/20387` \
`$ git pull https://git.openjdk.org/jdk.git pull/20387/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20387`

View PR using the GUI difftool: \
`$ git pr show -t 20387`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20387.diff">https://git.openjdk.org/jdk/pull/20387.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20387#issuecomment-2257706985)