### PR TITLE
8336462: ConcurrentSkipListSet Javadoc incorrectly warns about size method complexity

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
@@ -189,14 +189,9 @@ public class ConcurrentSkipListSet<E>
      * contains more than {@code Integer.MAX_VALUE} elements, it
      * returns {@code Integer.MAX_VALUE}.
      *
-     * <p>Beware that, unlike in most collections, this method is
-     * <em>NOT</em> a constant-time operation. Because of the
-     * asynchronous nature of these sets, determining the current
-     * number of elements requires traversing them all to count them.
-     * Additionally, it is possible for the size to change during
-     * execution of this method, in which case the returned result
-     * will be inaccurate. Thus, this method is typically not very
-     * useful in concurrent applications.
+     * It is possible for the size to change during execution of this method,
+     * in which case the returned result will be inaccurate.
+     * Thus, this method is typically not very useful in concurrent applications.
      *
      * @return the number of elements in this set
      */

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListSet.java
@@ -189,7 +189,7 @@ public class ConcurrentSkipListSet<E>
      * contains more than {@code Integer.MAX_VALUE} elements, it
      * returns {@code Integer.MAX_VALUE}.
      *
-     * It is possible for the size to change during execution of this method,
+     * <p>It is possible for the size to change during execution of this method,
      * in which case the returned result will be inaccurate.
      * Thus, this method is typically not very useful in concurrent applications.
      *


### PR DESCRIPTION
Removes some of the old wording around the algorithmic complexity of ConcurrentSkipListSet::size() while still retaining the warning around the accuracy of the returned result.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336462](https://bugs.openjdk.org/browse/JDK-8336462): ConcurrentSkipListSet Javadoc incorrectly warns about size method complexity (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20388/head:pull/20388` \
`$ git checkout pull/20388`

Update a local copy of the PR: \
`$ git checkout pull/20388` \
`$ git pull https://git.openjdk.org/jdk.git pull/20388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20388`

View PR using the GUI difftool: \
`$ git pr show -t 20388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20388.diff">https://git.openjdk.org/jdk/pull/20388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20388#issuecomment-2257900233)