### PR TITLE
Optimize DateTimeFormatter format & parse

### DIFF
--- a/src/java.base/share/classes/java/time/chrono/HijrahDate.java
+++ b/src/java.base/share/classes/java/time/chrono/HijrahDate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -488,7 +488,7 @@ public final class HijrahDate
      *
      * @return the day-of-year
      */
-    private int getDayOfYear() {
+    public int getDayOfYear() {
         return chrono.getDayOfYear(prolepticYear, monthOfYear) + dayOfMonth;
     }
 

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -2002,15 +2002,7 @@ public final class DateTimeFormatter {
      * @throws DateTimeParseException if unable to parse the requested result
      */
     public <T> T parse(CharSequence text, TemporalQuery<T> query) {
-        Objects.requireNonNull(text, "text");
-        Objects.requireNonNull(query, "query");
-        try {
-            return parseResolved0(text, null).query(query);
-        } catch (DateTimeParseException ex) {
-            throw ex;
-        } catch (RuntimeException ex) {
-            throw createError(text, ex);
-        }
+        return printerParser.parse(text, this, query);
     }
 
     /**
@@ -2067,7 +2059,7 @@ public final class DateTimeFormatter {
         }
     }
 
-    private DateTimeParseException createError(CharSequence text, RuntimeException ex) {
+    DateTimeParseException createError(CharSequence text, RuntimeException ex) {
         String abbr;
         if (text.length() > 64) {
             abbr = text.subSequence(0, 64).toString() + "...";
@@ -2091,7 +2083,7 @@ public final class DateTimeFormatter {
      * @throws DateTimeException if an error occurs while resolving the date or time
      * @throws IndexOutOfBoundsException if the position is invalid
      */
-    private TemporalAccessor parseResolved0(final CharSequence text, final ParsePosition position) {
+    TemporalAccessor parseResolved0(final CharSequence text, final ParsePosition position) {
         ParsePosition pos = (position != null ? position : new ParsePosition(0));
         DateTimeParseContext context = parseUnresolved0(text, pos);
         if (context == null || pos.getErrorIndex() >= 0 || (position == null && pos.getIndex() < text.length())) {

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatter.java
@@ -1875,9 +1875,7 @@ public final class DateTimeFormatter {
      * @throws DateTimeException if an error occurs during formatting
      */
     public String format(TemporalAccessor temporal) {
-        StringBuilder buf = new StringBuilder(32);
-        formatTo(temporal, buf);
-        return buf.toString();
+        return printerParser.format(temporal, this);
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2541,7 +2541,7 @@ public final class DateTimeFormatterBuilder {
         final boolean optional;
 
         static CompositePrinterParser of(DateTimePrinterParser[] printerParsers, boolean optional) {
-            if (COMPILE) {
+            if (COMPILE && !optional) {
                 return PrinterParserFactory.generate(printerParsers, optional);
             }
             // Use subclasses with printerParsers.length of 1 to 15 so that C2 can do TypeProfile optimization

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -3294,6 +3294,10 @@ public final class DateTimeFormatterBuilder {
             return true;
         }
 
+        public void format(StringBuilder buf, DecimalStyle decimalStyle, int value) {
+            format(buf, decimalStyle, (long) value);
+        }
+
         public void format(StringBuilder buf, DecimalStyle decimalStyle, long value) {
             int size = DecimalDigits.stringSize(value);
             if (value < 0) {
@@ -3533,8 +3537,12 @@ public final class DateTimeFormatterBuilder {
             }
             @Override
             public void format(StringBuilder buf, DecimalStyle decimalStyle, long value) {
+                format(buf, decimalStyle, (int) value);
+            }
+            @Override
+            public void format(StringBuilder buf, DecimalStyle decimalStyle, int value) {
                 char zeroDigit = decimalStyle.getZeroDigit();
-                int val = (int) value;
+                int val = value;
                 if (val >= 10) {
                     buf.append((char) (zeroDigit + val / 10));
                 }
@@ -3548,10 +3556,13 @@ public final class DateTimeFormatterBuilder {
             }
             @Override
             public void format(StringBuilder buf, DecimalStyle decimalStyle, long value) {
-                int val = (int) value;
+                format(buf, decimalStyle, (int) value);
+            }
+            @Override
+            public void format(StringBuilder buf, DecimalStyle decimalStyle, int value) {
                 char zeroDigit = decimalStyle.getZeroDigit();
-                buf.append((char) (zeroDigit + val / 10))
-                   .append((char) (zeroDigit + val % 10));
+                buf.append((char) (zeroDigit + value / 10))
+                   .append((char) (zeroDigit + value % 10));
             }
         }
 
@@ -3561,13 +3572,15 @@ public final class DateTimeFormatterBuilder {
             }
             @Override
             public void format(StringBuilder buf, DecimalStyle decimalStyle, long value) {
-                int val = (int) value;
-                int c0  = val % 10;
-                val = val / 10;
+                format(buf, decimalStyle, (int) value);
+            }
+            @Override
+            public void format(StringBuilder buf, DecimalStyle decimalStyle, int value) {
+                int div = value / 10;
                 char zeroDigit = decimalStyle.getZeroDigit();
-                buf.append((char) (zeroDigit + c0))
-                   .append((char) (zeroDigit + val / 10))
-                   .append((char) (zeroDigit + val % 10));
+                buf.append((char) (zeroDigit + div / 10))
+                   .append((char) (zeroDigit + div % 10))
+                   .append((char) (zeroDigit + value % 10));
             }
         }
 
@@ -3887,6 +3900,10 @@ public final class DateTimeFormatterBuilder {
         @Override
         public void format(StringBuilder buf, DecimalStyle decimalStyle, long value) {
             int val = field.range().checkValidIntValue(value, field);
+            format(buf, decimalStyle, val);
+        }
+        @Override
+        public void format(StringBuilder buf, DecimalStyle decimalStyle, int val) {
             int stringSize = DecimalDigits.stringSize(val);
             char zero = decimalStyle.getZeroDigit();
             if (val == 0 || stringSize < 10 - maxWidth) {
@@ -3980,15 +3997,14 @@ public final class DateTimeFormatterBuilder {
             private FixWidth3() {
                 super(3, 3, false, 0);
             }
-
             @Override
-            public void format(StringBuilder buf, DecimalStyle decimalStyle, long value) {
-                int val = ((int) value) / 1_000_000;
-                int div  = val / 10;
+            public void format(StringBuilder buf, DecimalStyle decimalStyle, int value) {
+                int nano3 = value / 1_000_000;
+                int nano2  = nano3 / 10;
                 char zeroDigit = decimalStyle.getZeroDigit();
-                buf.append((char) (zeroDigit + div / 10))
-                   .append((char) (zeroDigit + div % 10))
-                   .append((char) (zeroDigit + val % 10));
+                buf.append((char) (zeroDigit + nano2 / 10))
+                   .append((char) (zeroDigit + nano2 % 10))
+                   .append((char) (zeroDigit + nano3 % 10));
             }
         }
     }
@@ -6166,6 +6182,7 @@ public final class DateTimeFormatterBuilder {
         static final ClassDesc CD_NanosPrinterParser          = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$NanosPrinterParser;");
         static final ClassDesc CD_NanosPrinterParserFixWidth3 = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$NanosPrinterParser$FixWidth3;");
         static final ClassDesc CD_NumberPrinterParser         = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$NumberPrinterParser;");
+        static final ClassDesc CD_TemporalAccessor            = ClassDesc.ofDescriptor("Ljava/time/temporal/TemporalAccessor;");
         static final ClassDesc CD_Width1NotNegative           = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$NumberPrinterParser$Width1NotNegative;");
         static final ClassDesc CD_Width2NotNegative           = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$NumberPrinterParser$Width2NotNegative;");
         static final ClassDesc CD_FixWidth2NotNegative        = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$NumberPrinterParser$FixWidth2NotNegative;");
@@ -6173,13 +6190,18 @@ public final class DateTimeFormatterBuilder {
         static final ClassDesc CD_Width4ExceedsPad            = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$NumberPrinterParser$Width4ExceedsPad;");
         static final ClassDesc CD_FixWidth4NotNegative        = ClassDesc.ofDescriptor("Ljava/time/format/DateTimeFormatterBuilder$NumberPrinterParser$FixWidth4NotNegative;");
 
-        static final MethodTypeDesc MTD_StringBuilder_char = MethodTypeDesc.of(CD_StringBuilder, CD_char);
-        static final MethodTypeDesc MTD_void_int           = MethodTypeDesc.of(CD_void, CD_int);
-        static final MethodTypeDesc MTD_int                = MethodTypeDesc.of(CD_int);
-        static final MethodTypeDesc MTD_long               = MethodTypeDesc.of(CD_long);
-        static final MethodTypeDesc MTD_DecimalStyle       = MethodTypeDesc.of(CD_DecimalStyle);
-        static final MethodTypeDesc MTD_Long_TemporalField = MethodTypeDesc.of(CD_Long, CD_TemporalField);
+        static final MethodTypeDesc MTD_StringBuilder_char    = MethodTypeDesc.of(CD_StringBuilder, CD_char);
+        static final MethodTypeDesc MTD_void_int              = MethodTypeDesc.of(CD_void, CD_int);
+        static final MethodTypeDesc MTD_boolean               = MethodTypeDesc.of(CD_boolean);
+        static final MethodTypeDesc MTD_int                   = MethodTypeDesc.of(CD_int);
+        static final MethodTypeDesc MTD_long                  = MethodTypeDesc.of(CD_long);
+        static final MethodTypeDesc MTD_DecimalStyle          = MethodTypeDesc.of(CD_DecimalStyle);
+        static final MethodTypeDesc MTD_Long_TemporalField    = MethodTypeDesc.of(CD_Long, CD_TemporalField);
+        static final MethodTypeDesc MTD_long_TemporalField    = MethodTypeDesc.of(CD_long, CD_TemporalField);
+        static final MethodTypeDesc MTD_boolean_TemporalField = MethodTypeDesc.of(CD_boolean, CD_TemporalField);
+        static final MethodTypeDesc MTD_TemporalAccessor      = MethodTypeDesc.of(CD_TemporalAccessor);
 
+        static final MethodTypeDesc MTD_void_StringBuilder_DecimalStyle_int        = MethodTypeDesc.of(CD_void, CD_StringBuilder, CD_DecimalStyle, CD_int);
         static final MethodTypeDesc MTD_void_StringBuilder_DecimalStyle_long       = MethodTypeDesc.of(CD_void, CD_StringBuilder, CD_DecimalStyle, CD_long);
         static final MethodTypeDesc MTD_void_DateTimePrintParserArray_boolean      = MethodTypeDesc.of(CD_void, CD_DateTimePrinterParser_array, CD_boolean);
         static final MethodTypeDesc MTD_int_DateTimeParserContext_CharSequence_int = MethodTypeDesc.of(CD_int, CD_DateTimeParseContext, CD_CharSequence, CD_int);
@@ -6259,26 +6281,26 @@ public final class DateTimeFormatterBuilder {
             };
         }
 
-        private static ClassDesc paramType(DateTimePrinterParser p) {
-            if (p instanceof NanosPrinterParser.FixWidth3) {
+        private static ClassDesc paramType(DateTimePrinterParser pp) {
+            if (pp instanceof NanosPrinterParser.FixWidth3) {
                 return CD_NanosPrinterParserFixWidth3;
-            } else if (p instanceof NanosPrinterParser) {
+            } else if (pp instanceof NanosPrinterParser) {
                 return CD_NanosPrinterParser;
-            } else if (p instanceof NumberPrinterParser.Width1NotNegative) {
+            } else if (pp instanceof NumberPrinterParser.Width1NotNegative) {
                 return CD_Width1NotNegative;
-            } else if (p instanceof NumberPrinterParser.Width2NotNegative) {
+            } else if (pp instanceof NumberPrinterParser.Width2NotNegative) {
                 return CD_Width2NotNegative;
-            } else if (p instanceof NumberPrinterParser.FixWidth2NotNegative) {
+            } else if (pp instanceof NumberPrinterParser.FixWidth2NotNegative) {
                 return CD_FixWidth2NotNegative;
-            } else if (p instanceof NumberPrinterParser.FixWidth3NotNegative) {
+            } else if (pp instanceof NumberPrinterParser.FixWidth3NotNegative) {
                 return CD_FixWidth3NotNegative;
-            } else if (p instanceof NumberPrinterParser.Width4ExceedsPad) {
+            } else if (pp instanceof NumberPrinterParser.Width4ExceedsPad) {
                 return CD_Width4ExceedsPad;
-            } else if (p instanceof NumberPrinterParser.FixWidth4NotNegative) {
+            } else if (pp instanceof NumberPrinterParser.FixWidth4NotNegative) {
                 return CD_FixWidth4NotNegative;
-            } else if (p instanceof NumberPrinterParser) {
+            } else if (pp instanceof NumberPrinterParser) {
                 return CD_NumberPrinterParser;
-            } else if (p instanceof CharLiteralPrinterParser) {
+            } else if (pp instanceof CharLiteralPrinterParser) {
                 return CD_CharLiteralPrinterParser;
             } else {
                 return CD_DateTimePrinterParser;
@@ -6295,7 +6317,8 @@ public final class DateTimeFormatterBuilder {
                       bufSlot          = 2,
                       lengthSlot       = 3,
                       valueLongSlot    = 4,
-                      decimalStyleSlot = 5;
+                      decimalStyleSlot = 5,
+                      temporalSlot     = 6;
 
             return new Consumer<CodeBuilder>() {
                 @Override
@@ -6307,6 +6330,13 @@ public final class DateTimeFormatterBuilder {
                         cb.aload(contextSlot)
                           .invokevirtual(CD_DateTimePrintContext, "startOptional", MTD_void);
                     }
+
+                    /*
+                     * TemporalAccessor temporal = context.temporal;
+                     */
+                    cb.aload(contextSlot)
+                      .invokevirtual(CD_DateTimePrintContext, "getTemporal", MTD_TemporalAccessor)
+                      .astore(temporalSlot);
 
                     /*
                      * int length = buf.length();
@@ -6364,42 +6394,69 @@ public final class DateTimeFormatterBuilder {
                       .ireturn();
                 }
 
-                private void appendNumber(CodeBuilder cb, NumberPrinterParser parser, int index, Label unableLabel) {
-                    var L0 = cb.newLabel();
+                private void appendNumber(CodeBuilder cb, NumberPrinterParser pp, int index, Label unableLabel) {
+                    Label L0 = cb.newLabel(), L1 = cb.newLabel(), L2 = cb.newLabel();
 
                     /*
-                     * Long valueLong = context.getValue(field);
-                     * if (valueLong == null) {
+                     * if (context.isOptional() && temporal.isSupported(field)) {
                      *     return false;
                      * }
                      */
-                    cb.aload(contextSlot);
-                    if (parser.field instanceof ChronoField chronoField) {
-                        cb.getstatic(CD_ChronoField, chronoField.name(), CD_ChronoField);
-                    } else {
-                        cb.aload(thisSlot)
-                          .getfield(classDesc, "printerParser" + index, paramType(parser))
-                          .getfield(CD_NumberPrinterParser, "field", CD_TemporalField);
-                    }
-                    cb.invokevirtual(CD_DateTimePrintContext, "getValue", MTD_Long_TemporalField)
-                      .dup()
-                      .astore(valueLongSlot)
-                      .ifnonnull(L0)
+                    cb.aload(contextSlot)
+                      .invokevirtual(CD_DateTimePrintContext, "isOptional", MTD_boolean)
+                      .ifgt(L0)
+                      .aload(temporalSlot);
+                    getfield(cb, pp, index);
+                    cb.invokeinterface(CD_TemporalAccessor, "isSupported", MTD_boolean_TemporalField)
+                      .ifeq(L0)
+                      .goto_(L1)
+                      .labelBinding(L0)
                       .iconst_0()
                       .ireturn()
-                      .labelBinding(L0);
+                      .labelBinding(L1);
 
                     /*
-                     * printerParserN.format(buf, context.getDecimalStyle(), longValue.longValue());
+                     * printerParserN.format(buf, context.getDecimalStyle(), temporal.getLong(field));
                      */
                     cb.aload(thisSlot)
-                      .getfield(classDesc, "printerParser" + index, paramType(parser))
+                      .getfield(classDesc, "printerParser" + index, paramType(pp))
                       .aload(bufSlot)
                       .aload(contextSlot)
                       .invokevirtual(CD_DateTimePrintContext, "getDecimalStyle", MTD_DecimalStyle)
-                      .aload(valueLongSlot)
-                      .invokevirtual(CD_Long, "longValue", MTD_long)
-                      .invokevirtual(CD_NumberPrinterParser, "format", MTD_void_StringBuilder_DecimalStyle_long);
+                      .aload(temporalSlot);
+
+                    if (pp.field instanceof ChronoField chronoField) {
+                        String methodName = switch (chronoField) {
+                            case YEAR             -> "getYear";
+                            case MONTH_OF_YEAR    -> "getMonthValue";
+                            case DAY_OF_YEAR      -> "getDayOfYear";
+                            case DAY_OF_MONTH     -> "getDayOfMonth";
+                            case HOUR_OF_DAY      -> "getHour";
+                            case MINUTE_OF_HOUR   -> "getMinute";
+                            case SECOND_OF_MINUTE -> "getSecond";
+                            case NANO_OF_SECOND   -> "getNano";
+                            default               -> null;
+                        };
+                        if (methodName != null) {
+                            cb.invokeinterface(CD_TemporalAccessor, methodName, MTD_int)
+                              .invokevirtual(CD_NumberPrinterParser, "format", MTD_void_StringBuilder_DecimalStyle_int);
+                            return;
+                        }
+                    }
+
+                    getfield(cb, pp, index);
+                    cb.invokeinterface(CD_TemporalAccessor, "getLong", MTD_long_TemporalField);
+                    cb.invokevirtual(CD_NumberPrinterParser, "format", MTD_void_StringBuilder_DecimalStyle_long);
+                }
+
+                private void getfield(CodeBuilder cb, NumberPrinterParser pp, int index) {
+                    if (pp.field instanceof ChronoField chronoField) {
+                        cb.getstatic(CD_ChronoField, chronoField.name(), CD_ChronoField);
+                    } else {
+                        cb.aload(thisSlot)
+                          .getfield(classDesc, "printerParser" + index, paramType(pp))
+                          .getfield(CD_NumberPrinterParser, "field", CD_TemporalField);
+                    }
                 }
 
                 private void appendLiteral(CodeBuilder cb, CharLiteralPrinterParser parser) {

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -196,7 +196,7 @@ public final class DateTimeFormatterBuilder {
         COMPILE = property == null || property.isEmpty() || "true".equalsIgnoreCase(property);
 
         property = VM.getSavedProperty("java.time.format.DateTimeFormatter.monolithic");
-        MONOLITHIC = property != null && (property.isEmpty() || "true".equalsIgnoreCase(property));
+        MONOLITHIC = property == null || property.isEmpty() || "true".equalsIgnoreCase(property);
     }
 
     private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
@@ -3448,7 +3448,7 @@ public final class DateTimeFormatterBuilder {
                 pos = litteral(text, pos, literal);
 
                 valuePos = printerParserDayOfMonth.parse(text, pos);
-                pos = position(text, valuePos);
+                position(text, valuePos);
                 int dayOfMonth = (int) (valuePos >> 32);
 
                 return query.queryFrom(
@@ -3592,7 +3592,7 @@ public final class DateTimeFormatterBuilder {
                 pos = litteral(text, pos, literal7);
 
                 valuePos = printerParserSecond.parse(text, pos);
-                pos = position(text, valuePos);
+                position(text, valuePos);
                 int second = (int) (valuePos >> 32);
 
                 return query.queryFrom(
@@ -3673,7 +3673,7 @@ public final class DateTimeFormatterBuilder {
                 pos = litteral(text, pos, literal11);
 
                 valuePos = printerParserNano.parse(text, pos);
-                pos = position(text, valuePos);
+                position(text, valuePos);
                 int nano = (int) (valuePos >> 32);
 
                 return query.queryFrom(

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -6395,7 +6395,7 @@ public final class DateTimeFormatterBuilder {
                 }
 
                 private void appendNumber(CodeBuilder cb, NumberPrinterParser pp, int index, Label unableLabel) {
-                    Label L0 = cb.newLabel(), L1 = cb.newLabel(), L2 = cb.newLabel();
+                    var L0 = cb.newLabel();
 
                     /*
                      * if (context.isOptional() && !temporal.isSupported(field)) {
@@ -6404,11 +6404,12 @@ public final class DateTimeFormatterBuilder {
                      */
                     cb.aload(contextSlot)
                       .invokevirtual(CD_DateTimePrintContext, "isOptional", MTD_boolean)
-                      .ifeq(unableLabel)
+                      .ifne(L0)
                       .aload(temporalSlot);
                     getfield(cb, pp, index);
                     cb.invokeinterface(CD_TemporalAccessor, "isSupported", MTD_boolean_TemporalField)
-                      .ifeq(unableLabel);
+                      .ifeq(unableLabel)
+                      .labelBinding(L0);
 
                     /*
                      * printerParserN.format(buf, context.getDecimalStyle(), temporal.getLong(field));

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2609,28 +2609,32 @@ public final class DateTimeFormatterBuilder {
         }
 
         @Override
-        public int parse(DateTimeParseContext context, CharSequence text, int position) {
+        public final int parse(DateTimeParseContext context, CharSequence text, int position) {
             if (optional) {
                 context.startOptional();
-                int pos = position;
-                for (DateTimePrinterParser pp : printerParsers) {
-                    pos = pp.parse(context, text, pos);
-                    if (pos < 0) {
-                        context.endOptional(false);
-                        return position;  // return original position
-                    }
-                }
-                context.endOptional(true);
-                return pos;
-            } else {
-                for (DateTimePrinterParser pp : printerParsers) {
-                    position = pp.parse(context, text, position);
-                    if (position < 0) {
-                        break;
-                    }
-                }
-                return position;
             }
+            int pos = parse0(context, text, position);
+            if (pos < 0) {
+                if (optional) {
+                    context.endOptional(false);
+                    return position;  // return original position
+                }
+            }
+            if (optional) {
+                context.endOptional(true);
+            }
+            return pos;
+        }
+
+        int parse0(DateTimeParseContext context, CharSequence text, int position) {
+            int pos = position;
+            for (DateTimePrinterParser pp : printerParsers) {
+                pos = pp.parse(context, text, pos);
+                if (pos < 0) {
+                    return pos;
+                }
+            }
+            return pos;
         }
 
         @Override
@@ -2669,8 +2673,12 @@ public final class DateTimeFormatterBuilder {
                 }
                 return true;
             }
-            public boolean format0(DateTimePrintContext context, StringBuilder buf) {
+            boolean format0(DateTimePrintContext context, StringBuilder buf) {
                 return p0.format(context, buf);
+            }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                return p0.parse(context, text, position);
             }
         }
 
@@ -2680,9 +2688,18 @@ public final class DateTimeFormatterBuilder {
                 super(printerParsers, optional);
                 p1 = printerParsers[1];
             }
-            public boolean format0(DateTimePrintContext context, StringBuilder buf) {
+            @Override
+            boolean format0(DateTimePrintContext context, StringBuilder buf) {
                 return p0.format(context, buf)
                     && p1.format(context, buf);
+            }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0) {
+                    return pos;
+                }
+                return p1.parse(context, text, pos);
             }
         }
 
@@ -2696,6 +2713,16 @@ public final class DateTimeFormatterBuilder {
                 return p0.format(context, buf)
                     && p1.format(context, buf)
                     && p2.format(context, buf);
+            }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p2.parse(context, text, pos);
             }
         }
 
@@ -2711,6 +2738,17 @@ public final class DateTimeFormatterBuilder {
                     && p2.format(context, buf)
                     && p3.format(context, buf);
             }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p3.parse(context, text, pos);
+            }
         }
 
         static class N5 extends N4 {
@@ -2725,6 +2763,18 @@ public final class DateTimeFormatterBuilder {
                     && p2.format(context, buf)
                     && p3.format(context, buf)
                     && p4.format(context, buf);
+            }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p4.parse(context, text, pos);
             }
         }
 
@@ -2742,6 +2792,19 @@ public final class DateTimeFormatterBuilder {
                     && p4.format(context, buf)
                     && p5.format(context, buf);
             }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p5.parse(context, text, pos);
+            }
         }
 
         static class N7 extends N6 {
@@ -2758,6 +2821,20 @@ public final class DateTimeFormatterBuilder {
                     && p4.format(context, buf)
                     && p5.format(context, buf)
                     && p6.format(context, buf);
+            }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                 || (pos = p5.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p6.parse(context, text, pos);
             }
         }
 
@@ -2777,6 +2854,21 @@ public final class DateTimeFormatterBuilder {
                     && p6.format(context, buf)
                     && p7.format(context, buf);
             }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                 || (pos = p5.parse(context, text, pos)) < 0
+                 || (pos = p6.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p7.parse(context, text, pos);
+            }
         }
 
         static class N9 extends N8 {
@@ -2795,6 +2887,22 @@ public final class DateTimeFormatterBuilder {
                     && p6.format(context, buf)
                     && p7.format(context, buf)
                     && p8.format(context, buf);
+            }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                 || (pos = p5.parse(context, text, pos)) < 0
+                 || (pos = p6.parse(context, text, pos)) < 0
+                 || (pos = p7.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p8.parse(context, text, pos);
             }
         }
 
@@ -2818,6 +2926,23 @@ public final class DateTimeFormatterBuilder {
                     && p8.format(context, buf)
                     && p9.format(context, buf);
             }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                 || (pos = p5.parse(context, text, pos)) < 0
+                 || (pos = p6.parse(context, text, pos)) < 0
+                 || (pos = p7.parse(context, text, pos)) < 0
+                 || (pos = p8.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p9.parse(context, text, pos);
+            }
         }
 
         static class N11 extends N10 {
@@ -2838,6 +2963,24 @@ public final class DateTimeFormatterBuilder {
                     && p8.format(context, buf)
                     && p9.format(context, buf)
                     && p10.format(context, buf);
+            }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                 || (pos = p5.parse(context, text, pos)) < 0
+                 || (pos = p6.parse(context, text, pos)) < 0
+                 || (pos = p7.parse(context, text, pos)) < 0
+                 || (pos = p8.parse(context, text, pos)) < 0
+                 || (pos = p9.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p10.parse(context, text, pos);
             }
         }
 
@@ -2861,6 +3004,25 @@ public final class DateTimeFormatterBuilder {
                     && p10.format(context, buf)
                     && p11.format(context, buf);
             }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                 || (pos = p5.parse(context, text, pos)) < 0
+                 || (pos = p6.parse(context, text, pos)) < 0
+                 || (pos = p7.parse(context, text, pos)) < 0
+                 || (pos = p8.parse(context, text, pos)) < 0
+                 || (pos = p9.parse(context, text, pos)) < 0
+                 || (pos = p10.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p11.parse(context, text, pos);
+            }
         }
 
         static class N13 extends N12 {
@@ -2883,6 +3045,26 @@ public final class DateTimeFormatterBuilder {
                     && p10.format(context, buf)
                     && p11.format(context, buf)
                     && p12.format(context, buf);
+            }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                 || (pos = p5.parse(context, text, pos)) < 0
+                 || (pos = p6.parse(context, text, pos)) < 0
+                 || (pos = p7.parse(context, text, pos)) < 0
+                 || (pos = p8.parse(context, text, pos)) < 0
+                 || (pos = p9.parse(context, text, pos)) < 0
+                 || (pos = p10.parse(context, text, pos)) < 0
+                 || (pos = p11.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p12.parse(context, text, pos);
             }
         }
 
@@ -2908,6 +3090,27 @@ public final class DateTimeFormatterBuilder {
                     && p12.format(context, buf)
                     && p13.format(context, buf);
             }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                 || (pos = p5.parse(context, text, pos)) < 0
+                 || (pos = p6.parse(context, text, pos)) < 0
+                 || (pos = p7.parse(context, text, pos)) < 0
+                 || (pos = p8.parse(context, text, pos)) < 0
+                 || (pos = p9.parse(context, text, pos)) < 0
+                 || (pos = p10.parse(context, text, pos)) < 0
+                 || (pos = p11.parse(context, text, pos)) < 0
+                 || (pos = p12.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p13.parse(context, text, pos);
+            }
         }
 
         static final class N15 extends N14 {
@@ -2932,6 +3135,28 @@ public final class DateTimeFormatterBuilder {
                     && p12.format(context, buf)
                     && p13.format(context, buf)
                     && p14.format(context, buf);
+            }
+            @Override
+            int parse0(DateTimeParseContext context, CharSequence text, int position) {
+                int pos  = position;
+                if ((pos = p0.parse(context, text, pos)) < 0
+                 || (pos = p1.parse(context, text, pos)) < 0
+                 || (pos = p2.parse(context, text, pos)) < 0
+                 || (pos = p3.parse(context, text, pos)) < 0
+                 || (pos = p4.parse(context, text, pos)) < 0
+                 || (pos = p5.parse(context, text, pos)) < 0
+                 || (pos = p6.parse(context, text, pos)) < 0
+                 || (pos = p7.parse(context, text, pos)) < 0
+                 || (pos = p8.parse(context, text, pos)) < 0
+                 || (pos = p9.parse(context, text, pos)) < 0
+                 || (pos = p10.parse(context, text, pos)) < 0
+                 || (pos = p11.parse(context, text, pos)) < 0
+                 || (pos = p12.parse(context, text, pos)) < 0
+                 || (pos = p13.parse(context, text, pos)) < 0
+                ) {
+                    return pos;
+                }
+                return p14.parse(context, text, pos);
             }
         }
     }

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -2541,7 +2541,7 @@ public final class DateTimeFormatterBuilder {
         final boolean optional;
 
         static CompositePrinterParser of(DateTimePrinterParser[] printerParsers, boolean optional) {
-            if (COMPILE && !optional) {
+            if (COMPILE) {
                 return PrinterParserFactory.generate(printerParsers, optional);
             }
             // Use subclasses with printerParsers.length of 1 to 15 so that C2 can do TypeProfile optimization
@@ -6398,22 +6398,17 @@ public final class DateTimeFormatterBuilder {
                     Label L0 = cb.newLabel(), L1 = cb.newLabel(), L2 = cb.newLabel();
 
                     /*
-                     * if (context.isOptional() && temporal.isSupported(field)) {
-                     *     return false;
+                     * if (context.isOptional() && !temporal.isSupported(field)) {
+                     *     break;
                      * }
                      */
                     cb.aload(contextSlot)
                       .invokevirtual(CD_DateTimePrintContext, "isOptional", MTD_boolean)
-                      .ifgt(L0)
+                      .ifeq(unableLabel)
                       .aload(temporalSlot);
                     getfield(cb, pp, index);
                     cb.invokeinterface(CD_TemporalAccessor, "isSupported", MTD_boolean_TemporalField)
-                      .ifeq(L0)
-                      .goto_(L1)
-                      .labelBinding(L0)
-                      .iconst_0()
-                      .ireturn()
-                      .labelBinding(L1);
+                      .ifeq(unableLabel);
 
                     /*
                      * printerParserN.format(buf, context.getDecimalStyle(), temporal.getLong(field));

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -3280,6 +3280,9 @@ public final class DateTimeFormatterBuilder {
             }
         }
 
+        /**
+         * Optimized implementation of Pattern `HH:mm:ss.SSS`
+         */
         static final class HMS extends N5 {
             final NumberPrinterParser.FixWidth2NotNegative printerParserHour;
             final NumberPrinterParser.FixWidth2NotNegative printerParserMinute;
@@ -3364,6 +3367,9 @@ public final class DateTimeFormatterBuilder {
             }
         }
 
+        /**
+         * Optimized implementation of Pattern `yyyy-MM-dd`
+         */
         static final class YMD extends N5 {
             final NumberPrinterParser.Width4ExceedsPad printerParserYear;
             final NumberPrinterParser.FixWidth2NotNegative printerParserMonth;
@@ -3456,6 +3462,9 @@ public final class DateTimeFormatterBuilder {
             }
         }
 
+        /**
+         * Optimized implementation of Pattern `yyyy-MM-ddTHH:mm:ss.SSS`
+         */
         static final class YMDHMS extends N11 {
             final NumberPrinterParser.Width4ExceedsPad     printerParserYear;
             final NumberPrinterParser.FixWidth2NotNegative printerParserMonth;
@@ -3600,6 +3609,9 @@ public final class DateTimeFormatterBuilder {
             }
         }
 
+        /**
+         * Optimized implementation of Pattern `yyyy-MM-ddTHH:mm:ss.SSS`
+         */
         static final class YMDHMSS extends N13 {
             final char literal1;
             final char literal5;

--- a/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
+++ b/src/java.base/share/classes/java/time/format/DateTimeFormatterBuilder.java
@@ -6394,22 +6394,16 @@ public final class DateTimeFormatterBuilder {
                       .ireturn();
                 }
 
-                private void appendNumber(CodeBuilder cb, NumberPrinterParser pp, int index, Label unableLabel) {
-                    var L0 = cb.newLabel();
-
+                private void appendNumber(CodeBuilder cb, NumberPrinterParser pp, int index, Label LReturn) {
                     /*
-                     * if (context.isOptional() && !temporal.isSupported(field)) {
+                     * if (context.isSupported(field)) {
                      *     break;
                      * }
                      */
-                    cb.aload(contextSlot)
-                      .invokevirtual(CD_DateTimePrintContext, "isOptional", MTD_boolean)
-                      .ifne(L0)
-                      .aload(temporalSlot);
+                    cb.aload(contextSlot);
                     getfield(cb, pp, index);
-                    cb.invokeinterface(CD_TemporalAccessor, "isSupported", MTD_boolean_TemporalField)
-                      .ifeq(unableLabel)
-                      .labelBinding(L0);
+                    cb.invokevirtual(CD_DateTimePrintContext, "isSupported", MTD_boolean_TemporalField)
+                      .ifeq(LReturn);
 
                     /*
                      * printerParserN.format(buf, context.getDecimalStyle(), temporal.getLong(field));

--- a/src/java.base/share/classes/java/time/format/DateTimePrintContext.java
+++ b/src/java.base/share/classes/java/time/format/DateTimePrintContext.java
@@ -285,6 +285,13 @@ final class DateTimePrintContext {
     }
 
     /**
+     * isOption segment of the input.
+     */
+    boolean isOptional() {
+        return optional > 0;
+    }
+
+    /**
      * Gets a value using a query.
      *
      * @param query  the query to use, not null

--- a/src/java.base/share/classes/java/time/format/DateTimePrintContext.java
+++ b/src/java.base/share/classes/java/time/format/DateTimePrintContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -152,9 +152,7 @@ final class DateTimePrintContext {
             // block changing zone on OffsetTime, and similar problem cases
             if (overrideZone.normalized() instanceof ZoneOffset && temporal.isSupported(OFFSET_SECONDS) &&
                     temporal.get(OFFSET_SECONDS) != overrideZone.getRules().getOffset(Instant.EPOCH).getTotalSeconds()) {
-                throw new DateTimeException("Unable to apply override zone '" + overrideZone +
-                        "' because the temporal object being formatted has a different offset but" +
-                        " does not represent an instant: " + temporal);
+                throw overrideZoneError(temporal, overrideZone);
             }
         }
         final ZoneId effectiveZone = (overrideZone != null ? overrideZone : temporalZone);
@@ -167,9 +165,7 @@ final class DateTimePrintContext {
                 if (!(overrideChrono == IsoChronology.INSTANCE && temporalChrono == null)) {
                     for (ChronoField f : ChronoField.values()) {
                         if (f.isDateBased() && temporal.isSupported(f)) {
-                            throw new DateTimeException("Unable to apply override chronology '" + overrideChrono +
-                                    "' because the temporal object being formatted contains date fields but" +
-                                    " does not represent a whole date: " + temporal);
+                            throw overrideChronoError(temporal, overrideChrono);
                         }
                     }
                 }
@@ -226,6 +222,18 @@ final class DateTimePrintContext {
                         (effectiveZone != null ? " with zone " + effectiveZone : "");
             }
         };
+    }
+
+    private static DateTimeException overrideZoneError(TemporalAccessor temporal, ZoneId overrideZone) {
+        return new DateTimeException("Unable to apply override zone '" + overrideZone +
+                "' because the temporal object being formatted has a different offset but" +
+                " does not represent an instant: " + temporal);
+    }
+
+    private static DateTimeException overrideChronoError(TemporalAccessor temporal, Chronology overrideChrono) {
+        return new DateTimeException("Unable to apply override chronology '" + overrideChrono +
+                "' because the temporal object being formatted contains date fields but" +
+                " does not represent a whole date: " + temporal);
     }
 
     //-----------------------------------------------------------------------

--- a/src/java.base/share/classes/java/time/format/DateTimePrintContext.java
+++ b/src/java.base/share/classes/java/time/format/DateTimePrintContext.java
@@ -287,8 +287,8 @@ final class DateTimePrintContext {
     /**
      * isOption segment of the input.
      */
-    boolean isOptional() {
-        return optional > 0;
+    boolean isSupported(TemporalField field) {
+        return optional == 0 || temporal.isSupported(field);
     }
 
     /**

--- a/src/java.base/share/classes/java/time/temporal/TemporalAccessor.java
+++ b/src/java.base/share/classes/java/time/temporal/TemporalAccessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -314,4 +314,85 @@ public interface TemporalAccessor {
         return query.queryFrom(this);
     }
 
+    /**
+     * Gets the year field.
+     * <p>
+     * This method returns the primitive {@code int} value for the year.
+     * <p>
+     * The year returned by this method is proleptic as per {@code get(YEAR)}.
+     * To obtain the year-of-era, use {@code get(YEAR_OF_ERA)}.
+     *
+     * @return the year, from MIN_YEAR to MAX_YEAR
+     */
+    default int getYear() {
+        return get(ChronoField.YEAR);
+    }
+
+    /**
+     * Gets the month-of-year field using the {@code Month} enum.
+     *
+     * @return the month-of-year, not null
+     * @see #getMonthValue()
+     */
+    default int getMonthValue() {
+        return get(ChronoField.MONTH_OF_YEAR);
+    }
+
+    /**
+     * Gets the day-of-year field.
+     * <p>
+     * This method returns the primitive {@code int} value for the day-of-year.
+     *
+     * @return the day-of-year, from 1 to 365, or 366 in a leap year
+     */
+    default int getDayOfYear() {
+        return get(ChronoField.DAY_OF_YEAR);
+    }
+
+    /**
+     * Gets the day-of-month field.
+     * <p>
+     * This method returns the primitive {@code int} value for the day-of-month.
+     *
+     * @return the day-of-month, from 1 to 31
+     */
+    default int getDayOfMonth() {
+        return get(ChronoField.DAY_OF_MONTH);
+    }
+
+    /**
+     * Gets the hour-of-day field.
+     *
+     * @return the hour-of-day, from 0 to 23
+     */
+    default int getHour() {
+        return get(ChronoField.HOUR_OF_DAY);
+    }
+
+    /**
+     * Gets the minute-of-hour field.
+     *
+     * @return the minute-of-hour, from 0 to 59
+     */
+    default int getMinute() {
+        return get(ChronoField.MINUTE_OF_HOUR);
+    }
+
+    /**
+     * Gets the second-of-minute field.
+     *
+     * @return the second-of-minute, from 0 to 59
+     */
+    default int getSecond() {
+        return get(ChronoField.SECOND_OF_MINUTE);
+    }
+
+    /**
+     * Gets the nano-of-second field.
+     *
+     * @return the nano-of-second, from 0 to 999,999,999
+     */
+    default int getNano() {
+        return get(ChronoField.NANO_OF_SECOND);
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -136,4 +136,11 @@ public final class DecimalDigits {
         }
         return 19 + d;
     }
+
+    public static int putPairLatin1(byte[] buf, int charPos, int value) {
+        short pair = DIGITS[value];
+        buf[charPos    ] = (byte)(pair);
+        buf[charPos + 1] = (byte)(pair >> 8);
+        return charPos + 2;
+    }
 }

--- a/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterParse.java
+++ b/test/micro/org/openjdk/bench/java/time/format/DateTimeFormatterParse.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.time.format;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoUnit;
+
+import java.util.Locale;
+import java.util.Random;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@Fork(3)
+@State(Scope.Thread)
+public class DateTimeFormatterParse {
+    private static final DateTimeFormatter formatter10 = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd")
+            .toFormatter();
+
+
+    private static final DateTimeFormatter formatter19 = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss")
+            .toFormatter();
+
+    private static final DateTimeFormatter formatter23 = new DateTimeFormatterBuilder()
+            .appendPattern("yyyy-MM-dd'T'HH:mm:ss.SSS")
+            .toFormatter();
+
+    private static final String TEXT_10 = "2024-08-01";
+    private static final String TEXT_19 = "2024-08-01T21:11:48";
+    private static final String TEXT_23 = "2024-08-01T21:11:48.456";
+
+    @Benchmark
+    public LocalDate parse10() {
+        return LocalDate.parse(TEXT_10, formatter10);
+    }
+
+    @Benchmark
+    public LocalDateTime parse19() {
+        return LocalDateTime.parse(TEXT_19, formatter19);
+    }
+
+    @Benchmark
+    public LocalDateTime parse23() {
+        return LocalDateTime.parse(TEXT_23, formatter23);
+    }
+}


### PR DESCRIPTION
This PR optimizes the performance of DateTimeFormatter.format. The optimization work includes the following:

## 1. Reduce method size to be inlined by C2
Refactor the NumberPrinterParser.format method. Currently, the codeSize of NumberPrinterParser.format is > 325 and cannot be inlined by the C2 optimizer.

```
java.time.format.DateTimeFormatterBuilder$NumberPrinterParser::format (395 bytes)
```

The exception handling code can be extracted into a separate method to reduce the codeSize of the method, as follows:

```java
        final void maxWidthError(long value) {
            throw new DateTimeException("Field " + field +
                    " cannot be printed as the value " + value +
                    " exceeds the maximum print width of " + maxWidth);
        }

        final void negateFieldError(long value) {
            throw new DateTimeException("Field " + field +
                    " cannot be printed as the value " + value +
                    " cannot be negative according to the SignStyle");
        }

```

## 2. Provide targeted optimization implementation for common scenarios

Provides optimized NumberPrinterParser subclasses for common field patterns, covering common patterns, including:
```
M
MM
d
dd
Y
YYYY
W
w
H
HH
h
hh
m
mm
s
ss
SSS
```

```java
    static class NumberPrinterParser implements DateTimePrinterParser {
        static NumberPrinterParser of(TemporalField field, int minWidth, int maxWidth, SignStyle signStyle, int subsequentWidth) {
            // Subclasses optimized for specific scenarios
            var range = field.range();
            long minimum    = range.getMinimum(),
                 maximum    = range.getMaximum();
            int maximumSize = DecimalDigits.stringSize(maximum),
                minimumSize = DecimalDigits.stringSize(Math.abs(minimum));
            if (signStyle == SignStyle.NOT_NEGATIVE) {
                if (minWidth == 1 && maxWidth == 1 && minimum >= 0 && maximumSize == 1) {
                    return new Width1NotNegative(field, subsequentWidth);
                }
                if (maxWidth == 2 && minimum >= 0) {
                    if (minimum >= 0 && maximumSize <= 2) {
                        if (minWidth == 1) {
                            return new Width2NotNegative(field, subsequentWidth);
                        }
                        if (minWidth == 2) {
                            return new FixWidth2NotNegative(field, subsequentWidth);
                        }
                    }
                }
                if (minWidth == 3 && maxWidth == 3 && minimum >= 0 && maximumSize <= 3) {
                    return new FixWidth3NotNegative(field, subsequentWidth);
                }
                if (minWidth == 4 && maxWidth == 4) {
                    // nedd range check
                    return new FixWidth4NotNegative(field, subsequentWidth);
                }
            }
            if (minWidth == 4) {
                if (signStyle == SignStyle.EXCEEDS_PAD) {
                    if (minimumSize <= maxWidth && maximumSize <= maxWidth) {
                        return new Width4ExceedsPad(field, maxWidth);
                    }
                }
            }
            return new NumberPrinterParser(field, minWidth, maxWidth, signStyle, subsequentWidth);
        }

        static final class FixWidth2NotNegative extends NumberPrinterParser {
            private FixWidth2NotNegative(TemporalField field, int subsequentWidth) {
                super(field, 2, 2, SignStyle.NOT_NEGATIVE, subsequentWidth);
            }
            @Override
            public void format(StringBuilder buf, DecimalStyle decimalStyle, long value) {
                int val = (int) value;
                char zeroDigit = decimalStyle.getZeroDigit();
                buf.append((char) (zeroDigit + val / 10))
                   .append((char) (zeroDigit + val % 10));
            }
        }
    }

```

## 3. Convert printerParsers of CompositePrinterParser to concrete fields so that they can be optimized by TypeProfile in C2
Use subclasses with printerParsers.length of 1 to 15 so that C2 can do TypeProfile optimization

``` java
	static class CompositePrinterParser implements DateTimePrinterParser {
        static CompositePrinterParser of(DateTimePrinterParser[] printerParsers, boolean optional) {
            // Use subclasses with printerParsers.length of 1 to 15 so that C2 can do TypeProfile optimization
            return switch (printerParsers.length) {
                case 1 -> new N1(printerParsers, optional);
                case 2 -> new N2(printerParsers, optional);
                case 3 -> new N3(printerParsers, optional);
                case 4 -> new N4(printerParsers, optional);
                case 5 -> new N5(printerParsers, optional);
                case 6 -> new N6(printerParsers, optional);
                case 7 -> new N7(printerParsers, optional);
                case 8 -> new N8(printerParsers, optional);
                case 9 -> new N9(printerParsers, optional);
                case 10 -> new N10(printerParsers, optional);
                case 11 -> new N11(printerParsers, optional);
                case 12 -> new N12(printerParsers, optional);
                case 13 -> new N13(printerParsers, optional);
                case 14 -> new N14(printerParsers, optional);
                case 15 -> new N15(printerParsers, optional);
                default -> new CompositePrinterParser(printerParsers, optional);
            };
        }

        static class N1 extends CompositePrinterParser {
            final DateTimePrinterParser p0;
        }

        static class N2 extends N1 {
            final DateTimePrinterParser p1;
            protected N2(DateTimePrinterParser[] printerParsers, boolean optional) {
                super(printerParsers, optional);
                p1 = printerParsers[1];
            }

            public boolean format0(DateTimePrintContext context, StringBuilder buf) {
                return p0.format(context, buf)
                    && p1.format(context, buf);
            }
        }

        static class N2 extends N1 {
            final DateTimePrinterParser p1;
            protected N2(DateTimePrinterParser[] printerParsers, boolean optional) {
                super(printerParsers, optional);
                p1 = printerParsers[1];
            }
            public boolean format0(DateTimePrintContext context, StringBuilder buf) {
                return p0.format(context, buf)
                    && p1.format(context, buf);
            }
        }

        // ...

        static class N15 extends N14 {
            final DateTimePrinterParser p14;
            protected N15(DateTimePrinterParser[] printerParsers, boolean optional) {
                super(printerParsers, optional);
                p14 = printerParsers[14];
            }
            public boolean format0(DateTimePrintContext context, StringBuilder buf) {
                return p0.format(context, buf)
                    && p1.format(context, buf)
                    && p2.format(context, buf)
                    && p3.format(context, buf)
                    && p4.format(context, buf)
                    && p5.format(context, buf)
                    && p6.format(context, buf)
                    && p7.format(context, buf)
                    && p8.format(context, buf)
                    && p9.format(context, buf)
                    && p10.format(context, buf)
                    && p11.format(context, buf)
                    && p12.format(context, buf)
                    && p13.format(context, buf)
                    && p14.format(context, buf);
            }
        }
	}

```

We can see that TypeProfile works

```
 @ 6   java.time.format.DateTimeFormatterBuilder$NumberPrinterParser::format (35 bytes)   inline (hot)
  \-> TypeProfile (15360/15360 counts) = java/time/format/DateTimeFormatterBuilder$NumberPrinterParser$Width4ExceedsPad

 @118   java.time.format.DateTimeFormatterBuilder$NumberPrinterParser::format (35 bytes)   inline (hot)
  \-> TypeProfile (15360/15360 counts) = java/time/format/DateTimeFormatterBuilder$NumberPrinterParser$FixWidth2NotNegative
```

## 4. Special optimization for commonly used patterns
Provides a monolithic NumberPrinterParser implementation for commonly used patterns, similar to InstantPrinterParser, instead of using CompositePrinterParser.
```
HH:mm:ss
HH:mm:ss.SSS
yyyy-MM-dd'T'HH:mm:ss
yyyy-MM-dd'T'HH:mm:ss.SSS这些
```

```java
public final class DateTimeFormatterBuilder {
	static class CompositePrinterParser implements DateTimePrinterParser {
	
	    /*
	     * yyyy-MM-dd
	     */
		static final class YMD extends N5 {
			final NumberPrinterParser.Width4ExceedsPad printerParserYear;
            final NumberPrinterParser.FixWidth2NotNegative printerParserMonth;
            final NumberPrinterParser.FixWidth2NotNegative printerParserDayOfMonth;

            ...

            @Override
            public boolean format(DateTimePrintContext context, StringBuilder buf) {
                var temporal = context.getTemporal();
                int year       = temporal.getYear();
                int month      = temporal.getMonthValue();
                int dayOfMonth = temporal.getDayOfMonth();

                if (printerParserYear.field == ChronoField.YEAR_OF_ERA) {
                    year = (year >= 1 ? year : 1 - year);
                }

                printerParserYear.format(buf, context.getDecimalStyle(), year);
                var zeroDigit = context.getDecimalStyle().getZeroDigit();
                buf.append(literal)
                   .append((char) (zeroDigit + month / 10))
                   .append((char) (zeroDigit + month % 10))
                   .append(literal)
                   .append((char) (zeroDigit + dayOfMonth / 10))
                   .append((char) (zeroDigit + dayOfMonth % 10));
                return true;
            }

            public String format(TemporalAccessor temporal, DateTimeFormatter formatter) {
                char zeroDigit = formatter.getDecimalStyle().getZeroDigit();
                if (zeroDigit != '0'
                        && (literal >>> 8 == 0) // StringLatin1.canEncode
                ) {
                    StringBuilder buf = new StringBuilder(15);
                    format(new DateTimePrintContext(temporal, formatter), buf);
                    return buf.toString();
                }

                int year       = temporal.getYear();
                int month      = temporal.getMonthValue();
                int dayOfMonth = temporal.getDayOfMonth();

                int size   = printerParserYear.size(year) + 6;
                byte[] buf = new byte[size];
                int index  = printerParserYear.formatTo(buf, 0, year);
                buf[index] = (byte) literal;
                index      = DecimalDigits.putPairLatin1(buf, index + 1, month);
                buf[index] = (byte) literal;
                index      = DecimalDigits.putPairLatin1(buf, index + 1, dayOfMonth);
                try {
                    return JLA.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
                } catch (CharacterCodingException cce) {
                    throw new AssertionError(cce);
                }
            }

            public <T> T parse(CharSequence text, DateTimeFormatter formatter, TemporalQuery<T> query) {
                char zeroDigit = formatter.getDecimalStyle().getZeroDigit();
                if (zeroDigit != '0') {
                    return super.parse(text, formatter, query);
                }

                long valuePos = printerParserYear.parse(text, 0);
                int pos = position(text, valuePos);
                int year = (int) (valuePos >> 32);

                pos = litteral(text, pos, literal);

                valuePos = printerParserMonth.parse(text, pos);
                pos = position(text, valuePos);
                int month = (int) (valuePos >> 32);

                pos = litteral(text, pos, literal);

                valuePos = printerParserDayOfMonth.parse(text, pos);
                position(text, valuePos);
                int dayOfMonth = (int) (valuePos >> 32);

                return query.queryFrom(
                        LocalDate.of(year, month, dayOfMonth));
            }
            ...
		}
	}
}
```
This optimization reduces many intermediate steps, such as the very time-consuming DateTimeParseContext, thereby further improving performance.


## 5. Provide a version based on latin1 encoding byte[]
```java
	static class CompositePrinterParser implements DateTimePrinterParser {	
		static final class Width4ExceedsPad extends NumberPrinterParser {
            public int size(int value) {
                if (value > -1000 && value < 10000) {
                    return 4;
                }

                int size = 0;
                if (value >= 0) {
                    if (value > 9999) {
                        size = 1;
                    }
                } else {
                    value = -value;
                    size = 1;
                }
                return size + DecimalDigits.stringSize(value);
            }

            public int formatTo(byte[] buf, int index, int value) {
                if (value >= 0) {
                    if (value > 9999) {
                        buf[index++] = '+';
                    }
                } else {
                    value = -value;
                    buf[index++] = '-';
                }
                if (value < 10000) {
                    int div = value / 100;
                    int rem = value % 100;
                    index = DecimalDigits.putPairLatin1(buf, index, div);
                    index = DecimalDigits.putPairLatin1(buf, index, rem);
                } else {
                    index += DecimalDigits.stringSize(value);
                    JLA.getCharsLatin1(value, index, buf);
                }
                return index;
            }
		}

		static final class YMDHMS extends N11 {
			final NumberPrinterParser.Width4ExceedsPad     printerParserYear;

            public String format(TemporalAccessor temporal, DateTimeFormatter formatter) {
                var zeroDigit = formatter.getDecimalStyle().getZeroDigit();
                if (zeroDigit != '0'
                        && (literal1 >>> 8 == 0) // StringLatin1.canEncode
                        && (literal5 >>> 8 == 0) // StringLatin1.canEncode
                        && (literal7 >>> 8 == 0) // StringLatin1.canEncode
                ) {
                    StringBuilder buf = new StringBuilder(32);
                    format(new DateTimePrintContext(temporal, formatter), buf);
                    return buf.toString();
                }

                int year       = temporal.getYear();
                int month      = temporal.getMonthValue();
                int dayOfMonth = temporal.getDayOfMonth();
                int hour       = temporal.getHour();
                int minute     = temporal.getMinute();
                int second     = temporal.getSecond();

                int size = printerParserYear.size(year) + 15;
                byte[] buf = new byte[size];
                int index  = printerParserYear.formatTo(buf, 0, year);
                buf[index] = (byte) literal1;
                index      = DecimalDigits.putPairLatin1(buf, index + 1, month);
                buf[index] = (byte) literal1;
                index      = DecimalDigits.putPairLatin1(buf, index + 1, dayOfMonth);
                buf[index] = (byte) literal5;
                index      = DecimalDigits.putPairLatin1(buf, index + 1, hour);
                buf[index] = (byte) literal7;
                index      = DecimalDigits.putPairLatin1(buf, index + 1, minute);
                buf[index] = (byte) literal7;
                index      = DecimalDigits.putPairLatin1(buf, index + 1, second);
                try {
                    return JLA.newStringNoRepl(buf, StandardCharsets.ISO_8859_1);
                } catch (CharacterCodingException cce) {
                    throw new AssertionError(cce);
                }
            }
        }
    }
```

## 6. Summary

This PR uses a lot of optimizations and has a significant performance improvement, but there are too many changes and it will not be submitted as a formal PR. We can discuss it here and finally split it into multiple small PRs.

3. The same optimization applies to parse

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20391/head:pull/20391` \
`$ git checkout pull/20391`

Update a local copy of the PR: \
`$ git checkout pull/20391` \
`$ git pull https://git.openjdk.org/jdk.git pull/20391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20391`

View PR using the GUI difftool: \
`$ git pr show -t 20391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20391.diff">https://git.openjdk.org/jdk/pull/20391.diff</a>

</details>
