### PR TITLE
8337501: JFR: Use TimespanUnit

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/ArgumentParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/ArgumentParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
 import jdk.jfr.internal.util.SpellChecker;
+import jdk.jfr.internal.util.TimespanUnit;
 
 final class ArgumentParser {
     private final Map<String, Object> options = new HashMap<>();
@@ -302,16 +303,11 @@ final class ArgumentParser {
             }
             throw new IllegalArgumentException("Integer parsing error nanotime value: unit required");
         }
-        return switch(unit) {
-            case "ns" -> time;
-            case "us" -> time * 1000;
-            case "ms" -> time * 1000 * 1000;
-            case "s" -> time * 1000 * 1000 * 1000;
-            case "m" -> time * 60 * 1000 * 1000 * 1000;
-            case "h" -> time * 60 * 60* 1000 * 1000 * 1000;
-            case "d" -> time * 24 * 60 * 60 * 1000 * 1000 * 1000;
-            default -> throw new IllegalArgumentException("Integer parsing error nanotime value: illegal unit");
-        };
+        TimespanUnit tu = TimespanUnit.fromText(unit);
+        if (tu == null) {
+            throw new IllegalArgumentException("Integer parsing error nanotime value: illegal unit");
+        }
+        return tu.toNanos(time);
     }
 
     int indexOfUnit(String text) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/Utilities.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/Utilities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,9 @@
 package jdk.jfr.internal.jfc.model;
 
 import java.util.StringJoiner;
+import jdk.jfr.internal.util.TimespanUnit;
 
 public final class Utilities {
-    private static final String[] UNITS = new String[] {
-        "ns", "us", "ns", "ms", "s", "m", "h", "d" // order matters
-    };
 
     static XmlElement instantiate(Class<? extends XmlElement> type) {
         try {
@@ -104,9 +102,9 @@ public final class Utilities {
     static String parseTimespan(String s) {
         StringBuilder sb = new StringBuilder();
         try {
-            for (String unit : UNITS) {
-                if (s.endsWith(unit)) {
-                    return parseForUnit(s, unit);
+            for (TimespanUnit timespan : TimespanUnit.values()) {
+                if (s.endsWith(timespan.text)) {
+                    return parseForUnit(s, timespan.text);
                 }
             }
             Long.parseLong(s);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/TimespanUnit.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/TimespanUnit.java
@@ -24,21 +24,29 @@
  */
 package jdk.jfr.internal.util;
 
+import java.util.concurrent.TimeUnit;
+
 public enum TimespanUnit {
-    NANOSECONDS ("ns",                           1L, 1000),
-    MICROSECONDS("us",                        1000L, 1000),
-    MILLISECONDS("ms",                   1_000_000L, 1000),
-    SECONDS     ("s",                1_000_000_000L,   60),
-    MINUTES     ("m",           60 * 1_000_000_000L,   60),
-    HOURS       ("h",      60 * 60 * 1_000_000_000L,   24),
-    DAYS        ("d", 24 * 60 * 60 * 1_000_000_000L,    7);
+    NANOSECONDS ("ns",  TimeUnit.NANOSECONDS, 1000),
+    MICROSECONDS("us", TimeUnit.MICROSECONDS, 1000),
+    MILLISECONDS("ms", TimeUnit.MILLISECONDS, 1000),
+    SECONDS     ("s",       TimeUnit.SECONDS,   60),
+    MINUTES     ("m",       TimeUnit.MINUTES,   60),
+    HOURS       ("h",         TimeUnit.HOURS,   24),
+    DAYS        ("d",          TimeUnit.DAYS,    7);
     public final String text;
     public final long nanos;
     public final int size;
-    TimespanUnit(String text, long nanos, int size) {
+    private final TimeUnit timeUnit;
+    TimespanUnit(String text, TimeUnit tu, int size) {
         this.text = text;
-        this.nanos = nanos;
         this.size = size;
+        this.nanos = tu.toNanos(1);
+        this.timeUnit = tu;
+    }
+
+    public long toNanos(long value) {
+        return timeUnit.toNanos(value);
     }
 
     public static TimespanUnit fromText(String text) {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/TimespanUnit.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/TimespanUnit.java
@@ -40,8 +40,8 @@ public enum TimespanUnit {
     private final TimeUnit timeUnit;
     TimespanUnit(String text, TimeUnit tu, int size) {
         this.text = text;
-        this.size = size;
         this.nanos = tu.toNanos(1);
+        this.size = size;
         this.timeUnit = tu;
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/util/ValueParser.java
@@ -51,26 +51,12 @@ public final class ValueParser {
     }
 
     public static long parseTimespan(String s) {
-        if (s.endsWith("ns")) {
-            return Long.parseLong(s.substring(0, s.length() - 2).trim());
-        }
-        if (s.endsWith("us")) {
-            return MICROSECONDS.toNanos(Long.parseLong(s.substring(0, s.length() - 2).trim()));
-        }
-        if (s.endsWith("ms")) {
-            return MILLISECONDS.toNanos(Long.parseLong(s.substring(0, s.length() - 2).trim()));
-        }
-        if (s.endsWith("s")) {
-            return SECONDS.toNanos(Long.parseLong(s.substring(0, s.length() - 1).trim()));
-        }
-        if (s.endsWith("m")) {
-            return MINUTES.toNanos(Long.parseLong(s.substring(0, s.length() - 1).trim()));
-        }
-        if (s.endsWith("h")) {
-            return HOURS.toNanos(Long.parseLong(s.substring(0, s.length() - 1).trim()));
-        }
-        if (s.endsWith("d")) {
-            return DAYS.toNanos(Long.parseLong(s.substring(0, s.length() - 1).trim()));
+        for (TimespanUnit unit : TimespanUnit.values()) {
+            String text = unit.text;
+            if (s.endsWith(text)) {
+                long value = Long.parseLong(s.substring(0, s.length() - text.length()).strip());
+                return unit.toNanos(value);
+            }
         }
 
         try {


### PR DESCRIPTION
Could I have a review of change that updates the JFR code to use the newly introduced TimespanUnit enum. The enum is updated to use j.u.c.TimeUnit enum so the method TimeUnit::toNanos can be leveraged. It can handle over- and underflow properly.  

Path forward is to introduce a Timespan class, similar to the Rate class, that will prevent negative values, parse "infinity" and provide means to compare values. This will consolidate code further.


Testing: test/jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337501](https://bugs.openjdk.org/browse/JDK-8337501): JFR: Use TimespanUnit (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20392/head:pull/20392` \
`$ git checkout pull/20392`

Update a local copy of the PR: \
`$ git checkout pull/20392` \
`$ git pull https://git.openjdk.org/jdk.git pull/20392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20392`

View PR using the GUI difftool: \
`$ git pr show -t 20392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20392.diff">https://git.openjdk.org/jdk/pull/20392.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20392#issuecomment-2259045474)