### PR TITLE
8337054: JDK 23 RDP2 L10n resource files update

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_de.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_de.properties
@@ -2305,13 +2305,14 @@ compiler.err.this.as.identifier=Ab Release 8 ist "this" nur als Parametername f�
 
 compiler.err.receiver.parameter.not.applicable.constructor.toplevel.class=receiver-Parameter nicht für Konstruktor der obersten Klasse anwendbar
 
-# TODO 308: make a better error message
-# 0: annotation
-compiler.err.cant.type.annotate.scoping.1=Scoping-Konstrukt kann nicht mit type-use-Annotation versehen werden: {0}
+# 0: fragment, 1: symbol, 2: annotated-type
+compiler.err.type.annotation.inadmissible={0} wurde hier nicht erwartet\n(Um einen qualifizierten Typ zu annotieren, schreiben Sie {1}.{2})
 
-# TODO 308: make a better error message
+# 0: annotation
+compiler.misc.type.annotation.1=Typannotation {0} ist
+
 # 0: list of annotation
-compiler.err.cant.type.annotate.scoping=Scoping-Konstrukt kann nicht mit type-use-Annotationen versehen werden: {0}
+compiler.misc.type.annotation=Typannotationen {0} sind
 
 # 0: type, 1: type
 compiler.err.incorrect.receiver.name=Der Empfängername stimmt nicht mit dem einschließenden Klassentyp überein\nErforderlich: {0}\nErmittelt:    {1}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_ja.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_ja.properties
@@ -2305,13 +2305,14 @@ compiler.err.this.as.identifier=リリース8から''this''は受信タイプの
 
 compiler.err.receiver.parameter.not.applicable.constructor.toplevel.class=受取り側パラメータは最上位レベル・クラスのコンストラクタに適用できません
 
-# TODO 308: make a better error message
-# 0: annotation
-compiler.err.cant.type.annotate.scoping.1=スコープ・コンストラクトを型使用注釈で注釈付けすることはできません: {0}
+# 0: fragment, 1: symbol, 2: annotated-type
+compiler.err.type.annotation.inadmissible=ここでは{0}は予期されていません\n(修飾されたタイプに注釈を付けるには、{1}.{2}と記述します)
 
-# TODO 308: make a better error message
+# 0: annotation
+compiler.misc.type.annotation.1=タイプ注釈{0}は
+
 # 0: list of annotation
-compiler.err.cant.type.annotate.scoping=スコープ・コンストラクトを型使用注釈で注釈付けすることはできません: {0}
+compiler.misc.type.annotation=タイプ注釈{0}は
 
 # 0: type, 1: type
 compiler.err.incorrect.receiver.name=受取り側の名前が、包含するクラス・タイプと一致しません\n必須: {0}\n検出:    {1}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_zh_CN.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler_zh_CN.properties
@@ -93,7 +93,7 @@ compiler.err.abstract.cant.be.instantiated={0}是抽象的; 无法实例化
 compiler.err.abstract.meth.cant.have.body=抽象方法不能有主体
 
 # 0: kind name, 1: symbol
-compiler.err.already.annotated={0} {1}已进行注释
+compiler.err.already.annotated={0} {1} 已进行批注
 
 # 0: kind name, 1: symbol, 2: kind name, 3: symbol
 compiler.err.already.defined=已在{2} {3}中定义了{0} {1}
@@ -642,7 +642,7 @@ compiler.err.malformed.fp.lit=浮点文字的格式错误
 
 compiler.err.method.does.not.override.superclass=方法不会覆盖或实现超类型的方法
 
-compiler.err.static.methods.cannot.be.annotated.with.override=不能使用 @Override 注释静态方法
+compiler.err.static.methods.cannot.be.annotated.with.override=不能使用 @Override 对静态方法进行批注
 
 compiler.err.missing.meth.body.or.decl.abstract=缺少方法主体, 或声明抽象
 
@@ -1638,7 +1638,7 @@ compiler.warn.unchecked.varargs.non.reifiable.type=参数化 vararg 类型{0}的
 # 0: symbol
 compiler.warn.varargs.unsafe.use.varargs.param=Varargs 方法可能导致来自不可具体化 varargs 参数 {0} 的堆污染
 
-compiler.warn.missing.deprecated.annotation=未使用 @Deprecated 对已过时的项目进行注释
+compiler.warn.missing.deprecated.annotation=未使用 @Deprecated 对已过时的项目进行批注
 
 # 0: kind name
 compiler.warn.deprecated.annotation.has.no.effect=@Deprecated 批注对此 {0} 声明没有任何效果
@@ -2305,13 +2305,14 @@ compiler.err.this.as.identifier=从发行版 8 开始，''this'' 只能作为接
 
 compiler.err.receiver.parameter.not.applicable.constructor.toplevel.class=接收方参数不适用于顶层类的构造器
 
-# TODO 308: make a better error message
-# 0: annotation
-compiler.err.cant.type.annotate.scoping.1=无法使用 type-use 批注 {0} 来批注确定作用域结构
+# 0: fragment, 1: symbol, 2: annotated-type
+compiler.err.type.annotation.inadmissible={0} 不应出现在此处\n（要对限定类型进行批注，请编写 {1}.{2}）
 
-# TODO 308: make a better error message
+# 0: annotation
+compiler.misc.type.annotation.1=类型批注 {0} 为
+
 # 0: list of annotation
-compiler.err.cant.type.annotate.scoping=无法使用 type-use 批注 {0} 来批注确定作用域结构
+compiler.misc.type.annotation=类型批注 {0} 为
 
 # 0: type, 1: type
 compiler.err.incorrect.receiver.name=接收方名称与封闭类类型不匹配\n需要: {0}\n找到:    {1}

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher_zh_CN.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/launcher_zh_CN.properties
@@ -120,7 +120,7 @@ launcher.err.cant.read.file=读取源文件 {0} 时出错：{1}
 launcher.err.no.value.for.option=没有为选项 {0} 指定值
 
 # 0: string
-launcher.err.invalid.value.for.source=--source 选项的值无效：{0}\n
+launcher.err.invalid.value.for.source=--source 选项的值无效：{0}
 
 launcher.err.unnamed.pkg.not.allowed.named.modules=命名模块中不允许未命名程序包
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_de.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_de.properties
@@ -278,9 +278,9 @@ doclet.record_constructor_doc.param_name=Wert für die Datensatzkomponente {0}
 
 doclet.record_equals_doc.fullbody.head=Gibt an, ob ein anderes Objekt diesem gleich ("equal to") ist. Die Objekte sind gleich, wenn das andere Objekt der gleichen Klasse angehört und alle Datensatzkomponenten gleich sind.
 
-doclet.record_equals_doc.fullbody.tail.both=Referenzkomponenten werden verglichen mit {@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}; primitive Komponenten werden verglichen mit "==".
+doclet.record_equals_doc.fullbody.tail.both=Referenzkomponenten werden verglichen mit {@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}. Primitive Komponenten werden mit der <code>compare</code>-Methode aus den entsprechenden Wrapper-Klassen verglichen.
 
-doclet.record_equals_doc.fullbody.tail.primitive=Alle Komponenten in dieser Datensatzklasse werden verglichen mit "==".
+doclet.record_equals_doc.fullbody.tail.primitive=Alle Komponenten dieser Datensatzklasse werden mit der <code>compare</code>-Methode aus den entsprechenden Wrapper-Klassen verglichen.
 
 doclet.record_equals_doc.fullbody.tail.reference=Alle Komponenten in dieser Datensatzklasse werden verglichen mit {@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}.
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_ja.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_ja.properties
@@ -278,7 +278,7 @@ doclet.record_constructor_doc.param_name={0}レコード・コンポーネント
 
 doclet.record_equals_doc.fullbody.head=他のオブジェクトがこれと"等しい"かどうかを示します。他のオブジェクトが同じクラスであり、すべてのレコード・コンポーネントが等しい場合、オブジェクトは等しくなります。
 
-doclet.record_equals_doc.fullbody.tail.both=参照コンポーネントは{@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}と比較され、プリミティブ・コンポーネントは対応するラッパー・クラスの<code>compare</code>メソッドと比較されます。
+doclet.record_equals_doc.fullbody.tail.both=参照コンポーネントは{@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}と比較され、プリミティブ・コンポーネントは対応するラッパー・クラスの<code>compare</code>メソッドで比較されます。
 
 doclet.record_equals_doc.fullbody.tail.primitive=このレコード・クラスのすべてのコンポーネントは対応するラッパー・クラスの<code>compare</code>メソッドと比較されます。
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_ja.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_ja.properties
@@ -278,9 +278,9 @@ doclet.record_constructor_doc.param_name={0}レコード・コンポーネント
 
 doclet.record_equals_doc.fullbody.head=他のオブジェクトがこれと"等しい"かどうかを示します。他のオブジェクトが同じクラスであり、すべてのレコード・コンポーネントが等しい場合、オブジェクトは等しくなります。
 
-doclet.record_equals_doc.fullbody.tail.both=参照コンポーネントは{@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}と比較され、プリミティブ・コンポーネントは'=='と比較されます。
+doclet.record_equals_doc.fullbody.tail.both=参照コンポーネントは{@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}と比較され、プリミティブ・コンポーネントは対応するラッパー・クラスの<code>compare</code>メソッドと比較されます。
 
-doclet.record_equals_doc.fullbody.tail.primitive=このレコード・クラスのすべてのコンポーネントは'=='と比較されます。
+doclet.record_equals_doc.fullbody.tail.primitive=このレコード・クラスのすべてのコンポーネントは対応するラッパー・クラスの<code>compare</code>メソッドと比較されます。
 
 doclet.record_equals_doc.fullbody.tail.reference=このレコード・クラスのすべてのコンポーネントは{@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}と比較されます。
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_ja.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_ja.properties
@@ -280,7 +280,7 @@ doclet.record_equals_doc.fullbody.head=他のオブジェクトがこれと"等�
 
 doclet.record_equals_doc.fullbody.tail.both=参照コンポーネントは{@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}と比較され、プリミティブ・コンポーネントは対応するラッパー・クラスの<code>compare</code>メソッドで比較されます。
 
-doclet.record_equals_doc.fullbody.tail.primitive=このレコード・クラスのすべてのコンポーネントは対応するラッパー・クラスの<code>compare</code>メソッドと比較されます。
+doclet.record_equals_doc.fullbody.tail.primitive=このレコード・クラスのすべてのコンポーネントは対応するラッパー・クラスの<code>compare</code>メソッドで比較されます。
 
 doclet.record_equals_doc.fullbody.tail.reference=このレコード・クラスのすべてのコンポーネントは{@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)}と比較されます。
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_zh_CN.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/doclets_zh_CN.properties
@@ -278,9 +278,9 @@ doclet.record_constructor_doc.param_name={0} 记录组件的值
 
 doclet.record_equals_doc.fullbody.head=指示某个其他对象是否“等于”此对象。如果两个对象属于同一个类，而且所有记录组件都相等，则这两个对象相等。
 
-doclet.record_equals_doc.fullbody.tail.both=使用 {@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)} 对参考组件进行比较；使用 '==' 对基元组件进行比较
+doclet.record_equals_doc.fullbody.tail.both=使用 {@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)} 对参考组件进行比较；使用 <code>compare</code> 方法从对应的包装类对基元组件进行比较。
 
-doclet.record_equals_doc.fullbody.tail.primitive=此记录类中的所有组件都使用 '==' 进行比较。
+doclet.record_equals_doc.fullbody.tail.primitive=此记录类中的所有组件都使用 <code>compare</code> 方法从对应的包装类进行比较。
 
 doclet.record_equals_doc.fullbody.tail.reference=此记录类中的所有组件都使用 {@link java.util.Objects#equals(Object,Object) Objects::equals(Object,Object)} 进行比较。
 


### PR DESCRIPTION
Localization update for JDK23 RDP2

Please view for enhanced diffs on affected files:
https://cr.openjdk.org/~dnguyen/output/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337054](https://bugs.openjdk.org/browse/JDK-8337054): JDK 23 RDP2 L10n resource files update (**Bug** - P2)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20394/head:pull/20394` \
`$ git checkout pull/20394`

Update a local copy of the PR: \
`$ git checkout pull/20394` \
`$ git pull https://git.openjdk.org/jdk.git pull/20394/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20394`

View PR using the GUI difftool: \
`$ git pr show -t 20394`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20394.diff">https://git.openjdk.org/jdk/pull/20394.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20394#issuecomment-2259143994)