### PR TITLE
8335836: serviceability/jvmti/StartPhase/AllowedFunctions/AllowedFunctions.java fails with unexpected exit code: 112

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/StartPhase/AllowedFunctions/libAllowedFunctions.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/StartPhase/AllowedFunctions/libAllowedFunctions.c
@@ -356,7 +356,7 @@ ClassPrepare(jvmtiEnv *jvmti, JNIEnv *env, jthread thread, jclass klass) {
     jvmtiError err;
 
     // Block VMDeath event and other ClassPrepare events while this callback is executed.
-    // Sync with VMDeath event guards against JVMTI_ERROR WRONG_PHASE.
+    // Sync with VMDeath event and check for is_vm_dead guard against JVMTI_ERROR WRONG_PHASE.
     err = (*jvmti)->RawMonitorEnter(jvmti, event_mon);
     check_jvmti_error(jvmti, "ClassPrepare event: Failed in RawMonitorEnter", err);
 

--- a/test/hotspot/jtreg/serviceability/jvmti/StartPhase/AllowedFunctions/libAllowedFunctions.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/StartPhase/AllowedFunctions/libAllowedFunctions.c
@@ -360,7 +360,7 @@ ClassPrepare(jvmtiEnv *jvmti, JNIEnv *env, jthread thread, jclass klass) {
     err = (*jvmti)->RawMonitorEnter(jvmti, event_mon);
     check_jvmti_error(jvmti, "ClassPrepare event: Failed in RawMonitorEnter", err);
 
-    if (is_vm_dead == JNI_TRUE) {
+    if (is_vm_dead) {
         printf("\nIgnoring ClassPrepare event during the dead phase\n");
         err = (*jvmti)->RawMonitorExit(jvmti, event_mon);
         check_jvmti_error(jvmti, "ClassPrepare event: Failed in RawMonitorExit", err);

--- a/test/hotspot/jtreg/serviceability/jvmti/StartPhase/AllowedFunctions/libAllowedFunctions.c
+++ b/test/hotspot/jtreg/serviceability/jvmti/StartPhase/AllowedFunctions/libAllowedFunctions.c
@@ -354,7 +354,7 @@ ClassPrepare(jvmtiEnv *jvmti, JNIEnv *env, jthread thread, jclass klass) {
     jvmtiError err;
 
     // Block VMDeath event and other ClassPrepare events while this callback is executed.
-    // Sync with VMDeath event guards agains JVMTI_ERROR WRONG_PHASE.
+    // Sync with VMDeath event guards against JVMTI_ERROR WRONG_PHASE.
     err = (*jvmti)->RawMonitorEnter(jvmti, event_mon);
     check_jvmti_error(jvmti, "ClassPrepare event: Failed in RawMonitorEnter", err);
 


### PR DESCRIPTION
The test has been fixed to:
 - add a guard against JVMTI_ERROR_WRONG_PHASE
 - replace `exit(err)` with `abort()` in the `check_jvmti_error()`
 
The JVMTI `VMDeath` event is enabled and a `RawMonitor` is introduced to serialize `ClassPrepare` and `VMDeath` events, and so, to prevent JVMTI_ERROR_WRONG_PHASE in the `ClassPrepare` events.

Testing:
 - run the test AllowedFunctions.java locally
 - TBD: submit a mach5 run for fixed test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335836](https://bugs.openjdk.org/browse/JDK-8335836): serviceability/jvmti/StartPhase/AllowedFunctions/AllowedFunctions.java fails with unexpected exit code: 112 (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20397/head:pull/20397` \
`$ git checkout pull/20397`

Update a local copy of the PR: \
`$ git checkout pull/20397` \
`$ git pull https://git.openjdk.org/jdk.git pull/20397/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20397`

View PR using the GUI difftool: \
`$ git pr show -t 20397`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20397.diff">https://git.openjdk.org/jdk/pull/20397.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20397#issuecomment-2259355847)