### PR TITLE
8334405: java/nio/channels/Selector/SelectWithConsumer.java#id0 failed in testWakeupDuringSelect

### DIFF
--- a/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
+++ b/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -308,11 +308,11 @@ public class SelectWithConsumer {
             Pipe.SinkChannel sink = p.sink();
             source.configureBlocking(false);
             source.register(sel, SelectionKey.OP_READ);
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             int n = sel.select(k -> assertTrue(false), 1000L);
-            long duration = System.currentTimeMillis() - start;
+            long duration = System.nanoTime() - start;
             assertTrue(n == 0);
-            assertTrue(duration > 500, "select took " + duration + " ms");
+            assertTrue(duration > 500000000, "select took " + duration + " ns");
         } finally {
             closePipe(p);
         }
@@ -332,11 +332,11 @@ public class SelectWithConsumer {
         // select(Consumer, timeout)
         try (Selector sel = Selector.open()) {
             sel.wakeup();
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            long duration = System.currentTimeMillis() - start;
+            long duration = System.nanoTime() - start;
             assertTrue(n == 0);
-            assertTrue(duration < 5000, "select took " + duration + " ms");
+            assertTrue(duration < 5000000000L, "select took " + duration + " ns");
         }
     }
 
@@ -354,12 +354,12 @@ public class SelectWithConsumer {
         // select(Consumer, timeout)
         try (Selector sel = Selector.open()) {
             scheduleWakeup(sel, 1, SECONDS);
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            long duration = System.currentTimeMillis() - start;
+            long duration = System.nanoTime() - start;
             assertTrue(n == 0);
-            assertTrue(duration > 500 && duration < 10*1000,
-                    "select took " + duration + " ms");
+            assertTrue(duration > 500000000L && duration < 10*1000000000L,
+                    "select took " + duration + " ns");
         }
     }
 
@@ -381,11 +381,11 @@ public class SelectWithConsumer {
         // select(Consumer, timeout)
         try (Selector sel = Selector.open()) {
             Thread.currentThread().interrupt();
-            long start = System.currentTimeMillis();
+            long start = System.nanoTime();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            long duration = System.currentTimeMillis() - start;
+            long duration = System.nanoTime() - start;
             assertTrue(n == 0);
-            assertTrue(duration < 5000, "select took " + duration + " ms");
+            assertTrue(duration < 5000000000L, "select took " + duration + " ns");
             assertTrue(Thread.currentThread().isInterrupted());
             assertTrue(sel.isOpen());
         } finally {

--- a/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
+++ b/test/jdk/java/nio/channels/Selector/SelectWithConsumer.java
@@ -310,7 +310,7 @@ public class SelectWithConsumer {
             source.register(sel, SelectionKey.OP_READ);
             long start = millisTime();
             int n = sel.select(k -> assertTrue(false), 1000L);
-            expectDuration(start, 501, Long.MAX_VALUE);
+            expectDuration(start, 500, Long.MAX_VALUE);
             assertTrue(n == 0);
         } finally {
             closePipe(p);
@@ -333,7 +333,7 @@ public class SelectWithConsumer {
             sel.wakeup();
             long start = millisTime();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            expectDuration(start, 0, 4999);
+            expectDuration(start, 0, 20_000);
             assertTrue(n == 0);
         }
     }
@@ -354,7 +354,7 @@ public class SelectWithConsumer {
             scheduleWakeup(sel, 1, SECONDS);
             long start = millisTime();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            expectDuration(start, 501, 10*1000 - 1);
+            expectDuration(start, 0, 20_000);
             assertTrue(n == 0);
         }
     }
@@ -379,7 +379,7 @@ public class SelectWithConsumer {
             Thread.currentThread().interrupt();
             long start = millisTime();
             int n = sel.select(k -> assertTrue(false), 60*1000);
-            expectDuration(start, 0, 4999);
+            expectDuration(start, 0, 20_000);
             assertTrue(n == 0);
             assertTrue(Thread.currentThread().isInterrupted());
             assertTrue(sel.isOpen());


### PR DESCRIPTION
Replace differences of milliseconds vs. epoch to differences of nanoseconds per the JVM's high-resolution time source.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334405](https://bugs.openjdk.org/browse/JDK-8334405): java/nio/channels/Selector/SelectWithConsumer.java#id0 failed in testWakeupDuringSelect (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20398/head:pull/20398` \
`$ git checkout pull/20398`

Update a local copy of the PR: \
`$ git checkout pull/20398` \
`$ git pull https://git.openjdk.org/jdk.git pull/20398/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20398`

View PR using the GUI difftool: \
`$ git pr show -t 20398`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20398.diff">https://git.openjdk.org/jdk/pull/20398.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20398#issuecomment-2259387269)