### PR TITLE
8337457: Redundant Math.round call in AquaProgressBarUI#getStringPlacement

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaProgressBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -256,7 +256,7 @@ public class AquaProgressBarUI extends ProgressBarUI implements ChangeListener, 
             y = oldX;
         }
 
-        return new Point(x + Math.round(width / 2 - stringWidth / 2), y + ((height + fontSizer.getAscent() - fontSizer.getLeading() - fontSizer.getDescent()) / 2) - 1);
+        return new Point(x + (width / 2 - stringWidth / 2), y + ((height + fontSizer.getAscent() - fontSizer.getLeading() - fontSizer.getDescent()) / 2) - 1);
     }
 
     static Dimension getCircularPreferredSize() {


### PR DESCRIPTION
Since  Math.round with integer argument returns the same value, and also since all arguments and calculations in the AquaProgressBarUI#getStringPlacement are integer arithmetic, Math.round is redundant and can be removed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337457](https://bugs.openjdk.org/browse/JDK-8337457): Redundant Math.round call in AquaProgressBarUI#getStringPlacement (**Bug** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20400/head:pull/20400` \
`$ git checkout pull/20400`

Update a local copy of the PR: \
`$ git checkout pull/20400` \
`$ git pull https://git.openjdk.org/jdk.git pull/20400/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20400`

View PR using the GUI difftool: \
`$ git pr show -t 20400`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20400.diff">https://git.openjdk.org/jdk/pull/20400.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20400#issuecomment-2259837897)