### PR TITLE
8337473: Remove sun/management/jdp tests from ProblemList on Linux-aarch64, MacOSX

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -515,9 +515,9 @@ java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all
 java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8247426 generic-all
 
-sun/management/jdp/JdpDefaultsTest.java                         8241865,8308807 linux-aarch64,macosx-all,aix-ppc64
-sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865,8308807 macosx-all,aix-ppc64
-sun/management/jdp/JdpSpecificAddressTest.java                  8241865,8308807 macosx-all,aix-ppc64
+sun/management/jdp/JdpDefaultsTest.java                         8308807 aix-ppc64
+sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8308807 aix-ppc64
+sun/management/jdp/JdpSpecificAddressTest.java                  8308807 aix-ppc64
 sun/management/jdp/JdpOffTest.java                              8308807 aix-ppc64
 
 ############################################################################


### PR DESCRIPTION
Problemlist update only, should be trivial:

Remove problemlist entries for sun/management/jdp tests on MacOS and Linux.

8241865 was a failure last seen July 2022.
Was related to
8241530 com/sun/jdi tests fail due to network issues on OSX 10.15
Originally logged for macOS failures but Linux failures also seen.

The tests all pass 20 times in a row on the affected platforms.
 
They remain problemlisted for JDK-8308807 on AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337473](https://bugs.openjdk.org/browse/JDK-8337473): Remove sun/management/jdp tests from ProblemList on Linux-aarch64, MacOSX (**Sub-task** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20402/head:pull/20402` \
`$ git checkout pull/20402`

Update a local copy of the PR: \
`$ git checkout pull/20402` \
`$ git pull https://git.openjdk.org/jdk.git pull/20402/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20402`

View PR using the GUI difftool: \
`$ git pr show -t 20402`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20402.diff">https://git.openjdk.org/jdk/pull/20402.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20402#issuecomment-2260342635)