### PR TITLE
8337546: Remove unused GCCause::_adaptive_size_policy

### DIFF
--- a/src/hotspot/share/gc/shared/gcCause.cpp
+++ b/src/hotspot/share/gc/shared/gcCause.cpp
@@ -78,9 +78,6 @@ const char* GCCause::to_string(GCCause::Cause cause) {
     case _metadata_GC_clear_soft_refs:
       return "Metadata GC Clear Soft References";
 
-    case _adaptive_size_policy:
-      return "Ergonomics";
-
     case _g1_inc_collection_pause:
       return "G1 Evacuation Pause";
 

--- a/src/hotspot/share/gc/shared/gcCause.hpp
+++ b/src/hotspot/share/gc/shared/gcCause.hpp
@@ -66,8 +66,6 @@ class GCCause : public AllStatic {
     _metadata_GC_threshold,
     _metadata_GC_clear_soft_refs,
 
-    _adaptive_size_policy,
-
     _g1_inc_collection_pause,
     _g1_compaction_pause,
     _g1_humongous_allocation,
@@ -110,20 +108,16 @@ class GCCause : public AllStatic {
 
   // Causes for collection of the tenured gernation
   inline static bool is_tenured_allocation_failure_gc(GCCause::Cause cause) {
-    // _adaptive_size_policy for a full collection after a young GC
     // _allocation_failure is the generic cause a collection which could result
     // in the collection of the tenured generation if there is not enough space
     // in the tenured generation to support a young GC.
-    return (cause == GCCause::_adaptive_size_policy ||
-            cause == GCCause::_allocation_failure);
+    return cause == GCCause::_allocation_failure;
   }
 
   // Causes for collection of the young generation
   inline static bool is_allocation_failure_gc(GCCause::Cause cause) {
     // _allocation_failure is the generic cause a collection for allocation failure
-    // _adaptive_size_policy is for a collection done before a full GC
     return (cause == GCCause::_allocation_failure ||
-            cause == GCCause::_adaptive_size_policy ||
             cause == GCCause::_shenandoah_allocation_failure_evac);
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/gc/shared/GCCause.java
@@ -48,8 +48,6 @@ public enum GCCause {
   _metadata_GC_threshold ("Metadata GC Threshold"),
   _metadata_GC_clear_soft_refs ("Metadata GC Clear Soft References"),
 
-  _adaptive_size_policy ("Ergonomics"),
-
   _g1_inc_collection_pause ("G1 Evacuation Pause"),
   _g1_compaction_pause ("G1 Compaction Pause"),
   _g1_humongous_allocation ("G1 Humongous Allocation"),

--- a/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithParallelOld.java
+++ b/test/jdk/jdk/jfr/event/gc/collection/TestGCCauseWithParallelOld.java
@@ -39,7 +39,7 @@ public class TestGCCauseWithParallelOld {
         String testID = "ParallelOld";
         String[] vmFlags = {"-XX:+UseParallelGC"};
         String[] gcNames = {GCHelper.gcParallelScavenge, GCHelper.gcParallelOld};
-        String[] gcCauses = {"Allocation Failure", "Ergonomics", "System.gc()", "GCLocker Initiated GC"};
+        String[] gcCauses = {"Allocation Failure", "System.gc()", "GCLocker Initiated GC"};
         GCGarbageCollectionUtil.test(testID, vmFlags, gcNames, gcCauses);
     }
 }


### PR DESCRIPTION
Trivial removing an unused gc-cause; it was previously used by Parallel only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337546](https://bugs.openjdk.org/browse/JDK-8337546): Remove unused GCCause::_adaptive_size_policy (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20403/head:pull/20403` \
`$ git checkout pull/20403`

Update a local copy of the PR: \
`$ git checkout pull/20403` \
`$ git pull https://git.openjdk.org/jdk.git pull/20403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20403`

View PR using the GUI difftool: \
`$ git pr show -t 20403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20403.diff">https://git.openjdk.org/jdk/pull/20403.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20403#issuecomment-2260305436)