### PR TITLE
8337550: Add documentation to TestOutOfMemoryDuringInit.java

### DIFF
--- a/test/hotspot/jtreg/runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java
+++ b/test/hotspot/jtreg/runtime/ClassInitErrors/TestOutOfMemoryDuringInit.java
@@ -44,6 +44,10 @@ public class TestOutOfMemoryDuringInit {
         static void forceInit() { }
         static {
             while (theList != null) {
+                // Use the minimal allocation size to push heap occupation to
+                // the limit, ensuring there is not enough memory to create the
+                // ExceptionInInitializerError that the VM tries to create when
+                // the clinit throws the OOM.
                 theList.add(new Object());
             }
         }


### PR DESCRIPTION
Comment-only patch to make the intention of the test explicit.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337550](https://bugs.openjdk.org/browse/JDK-8337550): Add documentation to TestOutOfMemoryDuringInit.java (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20405/head:pull/20405` \
`$ git checkout pull/20405`

Update a local copy of the PR: \
`$ git checkout pull/20405` \
`$ git pull https://git.openjdk.org/jdk.git pull/20405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20405`

View PR using the GUI difftool: \
`$ git pr show -t 20405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20405.diff">https://git.openjdk.org/jdk/pull/20405.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20405#issuecomment-2260469295)