### PR TITLE
8324260: java/foreign/TestStubAllocFailure.java run timeout with -Xcomp

### DIFF
--- a/test/jdk/java/foreign/TestStubAllocFailure.java
+++ b/test/jdk/java/foreign/TestStubAllocFailure.java
@@ -25,6 +25,7 @@
  * @test
  * @library ../ /test/lib
  * @requires jdk.foreign.linker != "FALLBACK"
+ * @requires vm.compMode != "Xcomp"
  * @run testng/othervm/native
  *   --enable-native-access=ALL-UNNAMED
  *   TestStubAllocFailure


### PR DESCRIPTION
This test spawns 2 forked processes, which then try to trigger a code cache OOM in FFM hotspot code. Even without `-Xcomp`, the test is already pretty slow, which increases dramatically with `-Xcomp`, since startup Java code has to be compiled 3 times, once for the main test process, and then 2 more times for forks.

There is seemingly no/very little benefit of running this test with `-Xcomp`, since the test targets hotspot, not Java code. That and the test is sensitive to code cache usage, which is changed by `-Xcomp`.

So, to avoid instabilities, this PR proposes to disable the test when running with  `-Xcomp`. Another option is to not forward the VM flags of the parent process to the forks, but, on the off chance that this is useful for testing some other flags, this PR chooses the approach of disabling the test when running with `-Xcomp` instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324260](https://bugs.openjdk.org/browse/JDK-8324260): java/foreign/TestStubAllocFailure.java run timeout with -Xcomp (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20407/head:pull/20407` \
`$ git checkout pull/20407`

Update a local copy of the PR: \
`$ git checkout pull/20407` \
`$ git pull https://git.openjdk.org/jdk.git pull/20407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20407`

View PR using the GUI difftool: \
`$ git pr show -t 20407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20407.diff">https://git.openjdk.org/jdk/pull/20407.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20407#issuecomment-2260571073)