### PR TITLE
8337396: Cleanup usage of ExternalAddess

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -736,7 +736,7 @@ void MacroAssembler::reserved_stack_check() {
     br(Assembler::LO, no_reserved_zone_enabling);
 
     enter();   // LR and FP are live.
-    lea(rscratch1, CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone));
+    lea(rscratch1, RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone)));
     mov(c_rarg0, rthread);
     blr(rscratch1);
     leave();
@@ -6454,7 +6454,7 @@ void MacroAssembler::verify_cross_modify_fence_not_required() {
     Label fence_not_required;
     cbz(rscratch1, fence_not_required);
     // If it does then fail.
-    lea(rscratch1, CAST_FROM_FN_PTR(address, JavaThread::verify_cross_modify_fence_failure));
+    lea(rscratch1, RuntimeAddress(CAST_FROM_FN_PTR(address, JavaThread::verify_cross_modify_fence_failure)));
     mov(c_rarg0, rthread);
     blr(rscratch1);
     bind(fence_not_required);

--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1879,7 +1879,7 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
   movptr(rscratch1, (uintptr_t)(address)b);
 
   // call indirectly to solve generation ordering problem
-  lea(rscratch2, ExternalAddress(StubRoutines::verify_oop_subroutine_entry_address()));
+  lea(rscratch2, RuntimeAddress(StubRoutines::verify_oop_subroutine_entry_address()));
   ldr(rscratch2, Address(rscratch2));
   blr(rscratch2);
 
@@ -1918,7 +1918,7 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
   movptr(rscratch1, (uintptr_t)(address)b);
 
   // call indirectly to solve generation ordering problem
-  lea(rscratch2, ExternalAddress(StubRoutines::verify_oop_subroutine_entry_address()));
+  lea(rscratch2, RuntimeAddress(StubRoutines::verify_oop_subroutine_entry_address()));
   ldr(rscratch2, Address(rscratch2));
   blr(rscratch2);
 

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -7045,7 +7045,7 @@ class StubGenerator: public StubCodeGenerator {
     Label thaw_success;
     // rscratch2 contains the size of the frames to thaw, 0 if overflow or no more frames
     __ cbnz(rscratch2, thaw_success);
-    __ lea(rscratch1, ExternalAddress(StubRoutines::throw_StackOverflowError_entry()));
+    __ lea(rscratch1, RuntimeAddress(StubRoutines::throw_StackOverflowError_entry()));
     __ br(rscratch1);
     __ bind(thaw_success);
 

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -1337,8 +1337,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   {
     Label L;
     __ ldr(r10, Address(rmethod, Method::native_function_offset()));
-    address unsatisfied = (SharedRuntime::native_method_throw_unsatisfied_link_error_entry());
-    __ mov(rscratch2, unsatisfied);
+    ExternalAddress unsatisfied(SharedRuntime::native_method_throw_unsatisfied_link_error_entry());
+    __ lea(rscratch2, unsatisfied);
     __ ldr(rscratch2, rscratch2);
     __ cmp(r10, rscratch2);
     __ br(Assembler::NE, L);
@@ -1432,7 +1432,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
     // hand.
     //
     __ mov(c_rarg0, rthread);
-    __ mov(rscratch2, CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans));
+    __ lea(rscratch2, RuntimeAddress(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans)));
     __ blr(rscratch2);
     __ get_method(rmethod);
     __ reinit_heapbase();
@@ -1482,7 +1482,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
 
     __ push_call_clobbered_registers();
     __ mov(c_rarg0, rthread);
-    __ mov(rscratch2, CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages));
+    __ lea(rscratch2, RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::reguard_yellow_pages)));
     __ blr(rscratch2);
     __ pop_call_clobbered_registers();
 
@@ -2085,7 +2085,7 @@ void TemplateInterpreterGenerator::trace_bytecode(Template* t) {
 
   assert(Interpreter::trace_code(t->tos_in()) != nullptr,
          "entry must have been generated");
-  __ bl(Interpreter::trace_code(t->tos_in()));
+  __ bl(RuntimeAddress(Interpreter::trace_code(t->tos_in())));
   __ reinit_heapbase();
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -547,7 +547,7 @@ void MacroAssembler::_verify_oop(Register reg, const char* s, const char* file, 
   }
 
   // call indirectly to solve generation ordering problem
-  ExternalAddress target(StubRoutines::verify_oop_subroutine_entry_address());
+  RuntimeAddress target(StubRoutines::verify_oop_subroutine_entry_address());
   relocate(target.rspec(), [&] {
     int32_t offset;
     la(t1, target.target(), offset);
@@ -592,7 +592,7 @@ void MacroAssembler::_verify_oop_addr(Address addr, const char* s, const char* f
   }
 
   // call indirectly to solve generation ordering problem
-  ExternalAddress target(StubRoutines::verify_oop_subroutine_entry_address());
+  RuntimeAddress target(StubRoutines::verify_oop_subroutine_entry_address());
   relocate(target.rspec(), [&] {
     int32_t offset;
     la(t1, target.target(), offset);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3774,7 +3774,7 @@ class StubGenerator: public StubCodeGenerator {
     Label thaw_success;
     // t1 contains the size of the frames to thaw, 0 if overflow or no more frames
     __ bnez(t1, thaw_success);
-    __ la(t0, ExternalAddress(StubRoutines::throw_StackOverflowError_entry()));
+    __ la(t0, RuntimeAddress(StubRoutines::throw_StackOverflowError_entry()));
     __ jr(t0);
     __ bind(thaw_success);
 

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1111,8 +1111,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   {
     Label L;
     __ ld(x28, Address(xmethod, Method::native_function_offset()));
-    address unsatisfied = (SharedRuntime::native_method_throw_unsatisfied_link_error_entry());
-    __ mv(t, unsatisfied);
+    ExternalAddress unsatisfied(SharedRuntime::native_method_throw_unsatisfied_link_error_entry());
+    __ la(t, unsatisfied);
     __ load_long_misaligned(t1, Address(t, 0), t0, 2); // 2 bytes aligned, but not 4 or 8
 
     __ bne(x28, t1, L);
@@ -1815,7 +1815,7 @@ void TemplateInterpreterGenerator::trace_bytecode(Template* t) {
   // the tosca in-state for the given template.
 
   assert(Interpreter::trace_code(t->tos_in()) != nullptr, "entry must have been generated");
-  __ call(Interpreter::trace_code(t->tos_in()));
+  __ rt_call(Interpreter::trace_code(t->tos_in()));
   __ reinit_heapbase();
 }
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -3702,7 +3702,7 @@ address StubGenerator::generate_cont_thaw(const char* label, Continuation::thaw_
   Label L_thaw_success;
   __ testptr(rbx, rbx);
   __ jccb(Assembler::notZero, L_thaw_success);
-  __ jump(ExternalAddress(StubRoutines::throw_StackOverflowError_entry()));
+  __ jump(RuntimeAddress(StubRoutines::throw_StackOverflowError_entry()));
   __ bind(L_thaw_success);
 
   // Make room for the thawed frames and align the stack.

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -178,7 +178,7 @@ address TemplateInterpreterGenerator::generate_exception_handler_common(
                rarg, rarg2);
   }
   // throw exception
-  __ jump(ExternalAddress(Interpreter::throw_exception_entry()));
+  __ jump(RuntimeAddress(Interpreter::throw_exception_entry()));
   return entry;
 }
 
@@ -546,7 +546,7 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
   // Note: the restored frame is not necessarily interpreted.
   // Use the shared runtime version of the StackOverflowError.
   assert(StubRoutines::throw_StackOverflowError_entry() != nullptr, "stub not yet generated");
-  __ jump(ExternalAddress(StubRoutines::throw_StackOverflowError_entry()));
+  __ jump(RuntimeAddress(StubRoutines::throw_StackOverflowError_entry()));
   // all done with frame size check
   __ bind(after_frame_check_pop);
   NOT_LP64(__ pop(rsi));

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/x86/templateTable_x86.cpp
+++ b/src/hotspot/cpu/x86/templateTable_x86.cpp
@@ -774,7 +774,7 @@ void TemplateTable::index_check_without_pop(Register array, Register index) {
   __ jccb(Assembler::below, skip);
   // Pass array to create more detailed exceptions.
   __ mov(NOT_LP64(rax) LP64_ONLY(c_rarg1), array);
-  __ jump(ExternalAddress(Interpreter::_throw_ArrayIndexOutOfBoundsException_entry));
+  __ jump(RuntimeAddress(Interpreter::_throw_ArrayIndexOutOfBoundsException_entry));
   __ bind(skip);
 }
 
@@ -1152,7 +1152,7 @@ void TemplateTable::aastore() {
 
   // Come here on failure
   // object is at TOS
-  __ jump(ExternalAddress(Interpreter::_throw_ArrayStoreException_entry));
+  __ jump(RuntimeAddress(Interpreter::_throw_ArrayStoreException_entry));
 
   // Come here on success
   __ bind(ok_is_subtype);
@@ -1432,7 +1432,7 @@ void TemplateTable::ldiv() {
   // generate explicit div0 check
   __ testq(rcx, rcx);
   __ jump_cc(Assembler::zero,
-             ExternalAddress(Interpreter::_throw_ArithmeticException_entry));
+             RuntimeAddress(Interpreter::_throw_ArithmeticException_entry));
   // Note: could xor rax and rcx and compare with (-1 ^ min_int). If
   //       they are not equal, one could do a normal division (no correction
   //       needed), which may speed up this implementation for the common case.
@@ -1445,7 +1445,7 @@ void TemplateTable::ldiv() {
   // check if y = 0
   __ orl(rax, rdx);
   __ jump_cc(Assembler::zero,
-             ExternalAddress(Interpreter::_throw_ArithmeticException_entry));
+             RuntimeAddress(Interpreter::_throw_ArithmeticException_entry));
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::ldiv));
   __ addptr(rsp, 4 * wordSize);  // take off temporaries
 #endif
@@ -1458,7 +1458,7 @@ void TemplateTable::lrem() {
   __ pop_l(rax);
   __ testq(rcx, rcx);
   __ jump_cc(Assembler::zero,
-             ExternalAddress(Interpreter::_throw_ArithmeticException_entry));
+             RuntimeAddress(Interpreter::_throw_ArithmeticException_entry));
   // Note: could xor rax and rcx and compare with (-1 ^ min_int). If
   //       they are not equal, one could do a normal division (no correction
   //       needed), which may speed up this implementation for the common case.
@@ -1472,7 +1472,7 @@ void TemplateTable::lrem() {
   // check if y = 0
   __ orl(rax, rdx);
   __ jump_cc(Assembler::zero,
-             ExternalAddress(Interpreter::_throw_ArithmeticException_entry));
+             RuntimeAddress(Interpreter::_throw_ArithmeticException_entry));
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, SharedRuntime::lrem));
   __ addptr(rsp, 4 * wordSize);
 #endif
@@ -4222,7 +4222,7 @@ void TemplateTable::checkcast() {
   // Come here on failure
   __ push_ptr(rdx);
   // object is at TOS
-  __ jump(ExternalAddress(Interpreter::_throw_ClassCastException_entry));
+  __ jump(RuntimeAddress(Interpreter::_throw_ClassCastException_entry));
 
   // Come here on success
   __ bind(ok_is_subtype);
@@ -4340,7 +4340,7 @@ void TemplateTable::_breakpoint() {
 void TemplateTable::athrow() {
   transition(atos, vtos);
   __ null_check(rax);
-  __ jump(ExternalAddress(Interpreter::throw_exception_entry()));
+  __ jump(RuntimeAddress(Interpreter::throw_exception_entry()));
 }
 
 //-----------------------------------------------------------------------------

--- a/src/hotspot/share/code/oopRecorder.cpp
+++ b/src/hotspot/share/code/oopRecorder.cpp
@@ -32,6 +32,7 @@
 #include "oops/oop.inline.hpp"
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "runtime/os.hpp"
 #include "utilities/copy.hpp"
 
 #ifdef ASSERT
@@ -220,6 +221,11 @@ ExternalsRecorder* ExternalsRecorder::_recorder = nullptr;
 
 ExternalsRecorder::ExternalsRecorder(): _arena(mtCode), _externals(&_arena) {}
 
+#ifndef PRODUCT
+static int total_access_count = 0;
+static GrowableArray<int>* extern_hist = nullptr;
+#endif
+
 void ExternalsRecorder_init() {
   ExternalsRecorder::initialize();
 }
@@ -228,30 +234,107 @@ void ExternalsRecorder::initialize() {
   // After Mutex and before CodeCache are initialized
   assert(_recorder == nullptr, "should initialize only once");
   _recorder = new ExternalsRecorder();
+#ifndef PRODUCT
+  if (PrintNMethodStatistics) {
+    Arena* arena = &_recorder->_arena;
+    extern_hist = new(arena) GrowableArray<int>(arena, 512, 512, 0);
+  }
+#endif
 }
 
 int ExternalsRecorder::find_index(address adr) {
-  MutexLocker ml(ExternalsRecorder_lock, Mutex::_no_safepoint_check_flag);
   assert(_recorder != nullptr, "sanity");
-  return _recorder->_externals.find_index(adr);
+  MutexLocker ml(ExternalsRecorder_lock, Mutex::_no_safepoint_check_flag);
+  int index = _recorder->_externals.find_index(adr);
+#ifndef PRODUCT
+  total_access_count++;
+  if (PrintNMethodStatistics) {
+    int n = extern_hist->at_grow(index, 0);
+    extern_hist->at_put(index, (n + 1));
+  }
+#endif
+  return index;
 }
 
 address ExternalsRecorder::at(int index) {
+  assert(_recorder != nullptr, "sanity");
   // find_index() may resize array by reallocating it and freeing old,
   // we need loock here to make sure we not accessing to old freed array.
   MutexLocker ml(ExternalsRecorder_lock, Mutex::_no_safepoint_check_flag);
-  assert(_recorder != nullptr, "sanity");
   return _recorder->_externals.at(index);
 }
 
 int ExternalsRecorder::count() {
-  MutexLocker ml(ExternalsRecorder_lock, Mutex::_no_safepoint_check_flag);
   assert(_recorder != nullptr, "sanity");
+  MutexLocker ml(ExternalsRecorder_lock, Mutex::_no_safepoint_check_flag);
   return _recorder->_externals.count();
 }
 
 #ifndef PRODUCT
+extern "C" {
+  // Order from large to small values
+  static int count_cmp(const void *i, const void *j) {
+    int a = *(int*)i;
+    int b = *(int*)j;
+    return a < b ? 1 : a > b ? -1 : 0;
+  }
+}
+
 void ExternalsRecorder::print_statistics() {
-  tty->print_cr("External addresses table: %d entries", count());
+  int cnt = count();
+  tty->print_cr("External addresses table: %d entries, %d accesses", cnt, total_access_count);
+  if (PrintNMethodStatistics) {
+    // Order entries by access count
+    int* array = NEW_C_HEAP_ARRAY(int, (2 * cnt), mtCode);
+    for (int i = 0; i < cnt; i++) {
+      array[(2 * i) + 0] = extern_hist->at(i);
+      array[(2 * i) + 1] = i;
+    }
+    // Reverse sort to have "hottest" addresses first.
+    qsort(array, cnt, 2*sizeof(int), count_cmp);
+    // Print all entries with Verbose flag otherwise only top 5.
+    int limit = (Verbose || cnt <= 5) ? cnt : 5;
+    int j = 0;
+    for (int i = 0; i < limit; i++) {
+      int index = array[(2 * i) + 1];
+      int n = extern_hist->at(index);
+      if (n > 0) {
+        address addr = at(index);
+        tty->print("%d: %8d " INTPTR_FORMAT " :", j++, n, p2i(addr));
+        if (addr != nullptr) {
+          if (StubRoutines::contains(addr)) {
+            StubCodeDesc* desc = StubCodeDesc::desc_for(addr);
+            if (desc == nullptr) {
+              desc = StubCodeDesc::desc_for(addr + frame::pc_return_offset);
+            }
+            const char* stub_name = (desc != nullptr) ? desc->name() : "<unknown>";
+            tty->print(" stub: %s", stub_name);
+          } else {
+            ResourceMark rm;
+            const int buflen = 1024;
+            char* buf = NEW_RESOURCE_ARRAY(char, buflen);
+            int offset = 0;
+            if (os::dll_address_to_function_name(addr, buf, buflen, &offset)) {
+              tty->print(" extn: %s", buf);
+              if (offset != 0) {
+                tty->print("+%d", offset);
+              }
+            } else {
+              if (CodeCache::contains((void*)addr)) {
+                // Something in CodeCache
+                tty->print(" in CodeCache");
+              } else {
+                // It could be string
+                memcpy(buf, (char*)addr, 80);
+                buf[80] = '\0';
+                tty->print(" '%s'", buf);
+              }
+            }
+          }
+        }
+        tty->cr();
+      }
+    }
+  }
 }
 #endif

--- a/src/hotspot/share/code/oopRecorder.cpp
+++ b/src/hotspot/share/code/oopRecorder.cpp
@@ -247,8 +247,8 @@ int ExternalsRecorder::find_index(address adr) {
   MutexLocker ml(ExternalsRecorder_lock, Mutex::_no_safepoint_check_flag);
   int index = _recorder->_externals.find_index(adr);
 #ifndef PRODUCT
-  total_access_count++;
   if (PrintNMethodStatistics) {
+    total_access_count++;
     int n = extern_hist->at_grow(index, 0);
     extern_hist->at_put(index, (n + 1));
   }
@@ -283,8 +283,7 @@ extern "C" {
 void ExternalsRecorder::print_statistics() {
   int cnt = count();
   tty->print_cr("External addresses table: %d entries, %d accesses", cnt, total_access_count);
-  if (PrintNMethodStatistics) {
-    // Order entries by access count
+  { // Print most accessed entries in the table.
     int* array = NEW_C_HEAP_ARRAY(int, (2 * cnt), mtCode);
     for (int i = 0; i < cnt; i++) {
       array[(2 * i) + 0] = extern_hist->at(i);


### PR DESCRIPTION
`ExternalAddess` should be used only for data load. For calls (and jump) instructions we should use `RuntimeAddress` which uses `runtime_call_Relocation`.

I found few places where `ExternalAddess` is used incorrectly and fixed them.

I also added code to print "hottest" (most referenced) `ExternalAddess` addresses in global table to move them into static global tables which will be introduced by [JDK-8334691](https://bugs.openjdk.org/browse/JDK-8334691) and [JDK-8337519](https://bugs.openjdk.org/browse/JDK-8337519).

Here is current output from debug VM on MacBook M1 (Aarch64):
```
External addresses table: 6 entries, 324 accesses
0:      158 0x00000001082de0f0 : extn: vmClasses::_klasses+480
1:       84 0x00000001082ddf20 : extn: vmClasses::_klasses+16
2:       40 0x00000001082c4790 : extn: SharedRuntime::_partial_subtype_ctr
3:       24 0x00000001082bdb04 : extn: JvmtiExport::_should_notify_object_alloc
4:       18 0x0000000118384080 : stub: forward exception
```

on MacOS-x64:
```
External addresses table: 143 entries, 44405 accesses
0:    11766 0x00000001047922a0 : extn: CompressedOops::_narrow_oop
1:    11002 0x0000000104474384 : 'should not reach here'
2:     9672 0x0000000104581a90 : extn: ClassLoader::file_name_for_class_name(char const*, int)::class_suffix+882068
3:     2447 0x0000000104508005 : extn: ClassLoader::file_name_for_class_name(char const*, int)::class_suffix+383753
4:     1916 0x000000010458188e : extn: ClassLoader::file_name_for_class_name(char const*, int)::class_suffix+881554
```

and on linux-x64:
```
External addresses table: 143 entries, 77297 accesses
0:    22334 0x00007f35d5b9c000 : ''
1:    19789 0x00007f35d55eea1f : 'should not reach here'
2:    18366 0x00007f35d5747bb8 : 'MacroAssembler::decode_heap_oop: heap base corrupted?'
3:     5036 0x00007f35d56e4d40 : 'uncommon trap returned which should never happen'
4:     3643 0x00007f35d57479f8 : 'MacroAssembler::encode_heap_oop: heap base corrupted?'
```

Few points about difference in output:
1. aarch64 does not use `ExternalAddess` or any relocation for messages (strings).
2. `stub: forward exception` corresponds to `StubRoutines::forward_exception_entry()` for which C2 generates tail-call from [C2's stubs](https://github.com/openjdk/jdk/blob/master/src/hotspot/share/opto/generateOptoStub.cpp#L258C48-L258C87). It is difficult to convert it to `RuntimeAddress` because how relocation for constants in C2 are handled.
3. linux-x64 implementation of `dlladdr()`, I used to print C++ symbol name, only works for functions:
    `0x00007f35d5b9c000` points to `CompressedOops::_narrow_oop._base` from code in [MacroAssembler::verify_heapbase()](https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/x86/macroAssembler_x86.cpp#L5760) and on aarch64 [verify_heapbase()](https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp#L2959) is empty (guarded by `#if 0`).
4. I think `ClassLoader::file_name_for_class_name()+...` on MacOSX-x64 corresponds to strings on linux-x64.

Additionally I moved asserts before locks in `ExternalsRecorder` methods.

Tested: tier1-3, xcomp, stress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337396](https://bugs.openjdk.org/browse/JDK-8337396): Cleanup usage of ExternalAddess (**Sub-task** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**) 🔄 Re-review required (review applies to [9bb7867f](https://git.openjdk.org/jdk/pull/20412/files/9bb7867f9ad6569f400cef4f3c622e656e71b56e))
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Contributors
 * Fei Yang `<fyang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20412/head:pull/20412` \
`$ git checkout pull/20412`

Update a local copy of the PR: \
`$ git checkout pull/20412` \
`$ git pull https://git.openjdk.org/jdk.git pull/20412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20412`

View PR using the GUI difftool: \
`$ git pr show -t 20412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20412.diff">https://git.openjdk.org/jdk/pull/20412.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20412#issuecomment-2261669655)