### PR TITLE
8336846: assert(state->get_thread() == jt) failed: handshake unsafe conditions

### DIFF
--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -982,17 +982,17 @@ JvmtiEventControllerPrivate::change_field_watch(jvmtiEvent event_type, bool adde
             added? "add" : "remove",
             *count_addr));
 
+  JvmtiVTMSTransitionDisabler disabler;
+
   if (added) {
     (*count_addr)++;
     if (*count_addr == 1) {
-      JvmtiVTMSTransitionDisabler disabler;
       recompute_enabled();
     }
   } else {
     if (*count_addr > 0) {
       (*count_addr)--;
       if (*count_addr == 0) {
-        JvmtiVTMSTransitionDisabler disabler;
         recompute_enabled();
       }
     } else {

--- a/src/hotspot/share/prims/jvmtiEventController.cpp
+++ b/src/hotspot/share/prims/jvmtiEventController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -985,12 +985,14 @@ JvmtiEventControllerPrivate::change_field_watch(jvmtiEvent event_type, bool adde
   if (added) {
     (*count_addr)++;
     if (*count_addr == 1) {
+      JvmtiVTMSTransitionDisabler disabler;
       recompute_enabled();
     }
   } else {
     if (*count_addr > 0) {
       (*count_addr)--;
       if (*count_addr == 0) {
+        JvmtiVTMSTransitionDisabler disabler;
         recompute_enabled();
       }
     } else {

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -274,7 +274,7 @@ void mutex_init() {
 
   MUTEX_DEFN(JvmtiThreadState_lock           , PaddedMutex  , safepoint);   // Used by JvmtiThreadState/JvmtiEventController
   MUTEX_DEFN(EscapeBarrier_lock              , PaddedMonitor, nosafepoint); // Used to synchronize object reallocation/relocking triggered by JVMTI
-  MUTEX_DEFN(JvmtiVTMSTransition_lock        , PaddedMonitor, safepoint);   // used for Virtual Thread Mount State transition management
+  MUTEX_DEFN(JvmtiVTMSTransition_lock        , PaddedMonitor, safepoint-1); // used for Virtual Thread Mount State transition management
   MUTEX_DEFN(Management_lock                 , PaddedMutex  , safepoint);   // used for JVM management
 
   MUTEX_DEFN(ConcurrentGCBreakpoints_lock    , PaddedMonitor, safepoint, true);

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -274,7 +274,6 @@ void mutex_init() {
 
   MUTEX_DEFN(JvmtiThreadState_lock           , PaddedMutex  , safepoint);   // Used by JvmtiThreadState/JvmtiEventController
   MUTEX_DEFN(EscapeBarrier_lock              , PaddedMonitor, nosafepoint); // Used to synchronize object reallocation/relocking triggered by JVMTI
-  MUTEX_DEFN(JvmtiVTMSTransition_lock        , PaddedMonitor, safepoint-1); // used for Virtual Thread Mount State transition management
   MUTEX_DEFN(Management_lock                 , PaddedMutex  , safepoint);   // used for JVM management
 
   MUTEX_DEFN(ConcurrentGCBreakpoints_lock    , PaddedMonitor, safepoint, true);
@@ -360,6 +359,7 @@ void mutex_init() {
   // JVMCIRuntime_lock must be acquired before JVMCI_lock to avoid deadlock
   MUTEX_DEFL(JVMCI_lock                     , PaddedMonitor, JVMCIRuntime_lock);
 #endif
+  MUTEX_DEFL(JvmtiVTMSTransition_lock        , PaddedMonitor, JvmtiThreadState_lock); // used for Virtual Thread Mount State transition management
 
   // Allocate RecursiveMutex
   MultiArray_lock = new RecursiveMutex();


### PR DESCRIPTION
The JVMTI Watch Field functions do not disable VTMS transitions with the `JvmtiVTMSTransitionDisabler`:
- `SetFieldAccessWatch()`
- `ClearFieldAccessWatch()`
- `SetFieldModificationWatch()`
- `ClearFieldModificationWatch()`
 so in the `recompute_enabled()` we could see that a vthread is mounted, but in the `EnterInterpOnlyModeClosure` handshake the thread could have been unmounted already. This is a root cause of failures with this assert.
 
The fix is to disable transitions in the `JvmtiEventControllerPrivate::change_field_watch()` function.

Testing:
- TBD: submit mach5 tiers 1-6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336846](https://bugs.openjdk.org/browse/JDK-8336846): assert(state-&gt;get_thread() == jt) failed: handshake unsafe conditions (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) 🔄 Re-review required (review applies to [bb94448c](https://git.openjdk.org/jdk/pull/20413/files/bb94448ca6730b10623a21bbbbeee27f9aa9a2cc))
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) 🔄 Re-review required (review applies to [3d166446](https://git.openjdk.org/jdk/pull/20413/files/3d1664463948acaec640e60d364f03736c80e1cf))
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) 🔄 Re-review required (review applies to [bb94448c](https://git.openjdk.org/jdk/pull/20413/files/bb94448ca6730b10623a21bbbbeee27f9aa9a2cc))
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20413/head:pull/20413` \
`$ git checkout pull/20413`

Update a local copy of the PR: \
`$ git checkout pull/20413` \
`$ git pull https://git.openjdk.org/jdk.git pull/20413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20413`

View PR using the GUI difftool: \
`$ git pr show -t 20413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20413.diff">https://git.openjdk.org/jdk/pull/20413.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20413#issuecomment-2261972014)