### PR TITLE
8337641: G1: Remove unused G1CollectedHeap::alloc_highest_free_region

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2941,20 +2941,6 @@ void G1CollectedHeap::retire_gc_alloc_region(G1HeapRegion* alloc_region,
   G1HeapRegionPrinter::retire(alloc_region);
 }
 
-G1HeapRegion* G1CollectedHeap::alloc_highest_free_region() {
-  bool expanded = false;
-  uint index = _hrm.find_highest_free(&expanded);
-
-  if (index != G1_NO_HRM_INDEX) {
-    if (expanded) {
-      log_debug(gc, ergo, heap)("Attempt heap expansion (requested address range outside heap bounds). region size: " SIZE_FORMAT "B",
-                                G1HeapRegion::GrainWords * HeapWordSize);
-    }
-    return _hrm.allocate_free_regions_starting_at(index, 1);
-  }
-  return nullptr;
-}
-
 void G1CollectedHeap::mark_evac_failure_object(uint worker_id, const oop obj, size_t obj_size) const {
   assert(!_cm->is_marked_in_bitmap(obj), "must be");
 

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -669,10 +669,6 @@ public:
   // Allocates a new heap region instance.
   G1HeapRegion* new_heap_region(uint hrs_index, MemRegion mr);
 
-  // Allocate the highest free region in the reserved heap. This will commit
-  // regions as necessary.
-  G1HeapRegion* alloc_highest_free_region();
-
   // Frees a region by resetting its metadata and adding it to the free list
   // passed as a parameter (this is usually a local list which will be appended
   // to the master free list later or null if free list management is handled

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.cpp
@@ -529,28 +529,6 @@ void G1HeapRegionManager::iterate(G1HeapRegionIndexClosure* blk) const {
   }
 }
 
-uint G1HeapRegionManager::find_highest_free(bool* expanded) {
-  // Loop downwards from the highest region index, looking for an
-  // entry which is either free or not yet committed.  If not yet
-  // committed, expand at that index.
-  for (uint curr = reserved_length(); curr-- > 0;) {
-    G1HeapRegion* hr = _regions.get_by_index(curr);
-    if (hr == nullptr || !is_available(curr)) {
-      // Found uncommitted and free region, expand to make it available for use.
-      expand_exact(curr, 1, nullptr);
-      assert(at(curr)->is_free(), "Region (%u) must be available and free after expand", curr);
-
-      *expanded = true;
-      return curr;
-    }
-    if (hr->is_free()) {
-      *expanded = false;
-      return curr;
-    }
-  }
-  return G1_NO_HRM_INDEX;
-}
-
 bool G1HeapRegionManager::allocate_containing_regions(MemRegion range, size_t* commit_count, WorkerThreads* pretouch_workers) {
   size_t commits = 0;
   uint start_index = (uint)_regions.get_index_by_address(range.start());

--- a/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionManager.hpp
@@ -256,11 +256,6 @@ public:
 
   G1HeapRegion* next_region_in_heap(const G1HeapRegion* r) const;
 
-  // Find the highest free or uncommitted region in the reserved heap,
-  // and if uncommitted, commit it. If none are available, return G1_NO_HRM_INDEX.
-  // Set the 'expanded' boolean true if a new region was committed.
-  uint find_highest_free(bool* expanded);
-
   // Allocate the regions that contain the address range specified, committing the
   // regions if necessary. Return false if any of the regions is already committed
   // and not free, and return the number of regions newly committed in commit_count.


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337641](https://bugs.openjdk.org/browse/JDK-8337641): G1: Remove unused G1CollectedHeap::alloc_highest_free_region (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20415/head:pull/20415` \
`$ git checkout pull/20415`

Update a local copy of the PR: \
`$ git checkout pull/20415` \
`$ git pull https://git.openjdk.org/jdk.git pull/20415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20415`

View PR using the GUI difftool: \
`$ git pr show -t 20415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20415.diff">https://git.openjdk.org/jdk/pull/20415.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20415#issuecomment-2262271844)