### PR TITLE
8337657: AArch64: No need for acquire fence in safepoint poll during JNI calls

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1903,16 +1903,8 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // Check for safepoint operation in progress and/or pending suspend requests.
   {
-    // We need an acquire here to ensure that any subsequent load of the
-    // global SafepointSynchronize::_state flag is ordered after this load
-    // of the thread-local polling word.  We don't want this poll to
-    // return false (i.e. not safepointing) and a later poll of the global
-    // SafepointSynchronize::_state spuriously to return true.
-    //
-    // This is to avoid a race when we're in a native->Java transition
-    // racing the code which wakes up from a safepoint.
-
-    __ safepoint_poll(safepoint_in_progress, true /* at_return */, true /* acquire */, false /* in_nmethod */);
+    // No need for acquire as Java threads always disarm themselves.
+    __ safepoint_poll(safepoint_in_progress, true /* at_return */, false /* acquire */, false /* in_nmethod */);
     __ ldrw(rscratch1, Address(rthread, JavaThread::suspend_flags_offset()));
     __ cbnzw(rscratch1, safepoint_in_progress);
     __ bind(safepoint_in_progress_done);

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1413,15 +1413,8 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   {
     Label L, Continue;
 
-    // We need an acquire here to ensure that any subsequent load of the
-    // global SafepointSynchronize::_state flag is ordered after this load
-    // of the thread-local polling word.  We don't want this poll to
-    // return false (i.e. not safepointing) and a later poll of the global
-    // SafepointSynchronize::_state spuriously to return true.
-    //
-    // This is to avoid a race when we're in a native->Java transition
-    // racing the code which wakes up from a safepoint.
-    __ safepoint_poll(L, true /* at_return */, true /* acquire */, false /* in_nmethod */);
+    // No need for acquire as Java threads always disarm themselves.
+    __ safepoint_poll(L, true /* at_return */, false /* acquire */, false /* in_nmethod */);
     __ ldrw(rscratch2, Address(rthread, JavaThread::suspend_flags_offset()));
     __ cbz(rscratch2, Continue);
     __ bind(L);

--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *


### PR DESCRIPTION
This is a tiny change to improve JNI calls performance on AArch64.  In SharedRuntime::generate_native_wrapper() and TemplateInterpreterGenerator::generate_native_entry()  safepoint_poll is made with acquire=true. It comes from the aarch64 implementation of Thread-local handshakes [0], [1]. Presently, it is no longer required [2].

Turning LDAR into regular load has significant performance effect. For instance, NativeCall benchmarks [3] by @simonis on Graviton 2 show following improvements:

-XX:-UseSystemMemoryBarrier (current default)

```
NativeCall.callingEmptyNative				8.04%
NativeCall.callingJniCriticalArray			1.01%
NativeCall.callingJniCriticalEmpty			6.73%
NativeCall.callingStaticEmpty				10.47%
NativeCall.methodCallingNativeWithArgs			10.73%
NativeCall.methodCallingNativeWithManyArgs		9.41%
NativeCall.staticMethodCallingStaticNativeIntStub	3.68%
NativeCall.staticMethodCallingStaticNativeNoTiered	9.86%
NativeCall.staticMethodCallingStaticNativeWithManyArgs	4.81%
```

-XX:+UseSystemMemoryBarrier

```
NativeCall.callingEmptyNative				33.70%
NativeCall.callingJniCriticalArray			3.64%
NativeCall.callingJniCriticalEmpty			34.15%
NativeCall.callingStaticArray				3.02%
NativeCall.callingStaticEmpty				34.25%
NativeCall.methodCallingNativeWithArgs			35.98%
NativeCall.methodCallingNativeWithManyArgs		34.42%
NativeCall.staticMethodCallingStaticNativeIntStub	15.66%
NativeCall.staticMethodCallingStaticNativeNoTiered	35.27%
NativeCall.staticMethodCallingStaticNativeWithManyArgs	32.99%
```

Similar improvements are observed on different CPUs.

It is especially interesting that -XX:+UseSystemMemoryBarrier variant began to show improvements in cases where there was parity.

Testing: tier1-3 on linux-aarch64.

[0] https://bugs.openjdk.org/browse/JDK-8189596
[1] https://mail.openjdk.org/pipermail/hotspot-dev/2017-November/029264.html
[2] https://mail.openjdk.org/pipermail/hotspot-compiler-dev/2024-July/078715.html
[3] https://github.com/simonis/Java2Native/tree/main/examples/jmh/java2native

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337657](https://bugs.openjdk.org/browse/JDK-8337657): AArch64: No need for acquire fence in safepoint poll during JNI calls (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20420/head:pull/20420` \
`$ git checkout pull/20420`

Update a local copy of the PR: \
`$ git checkout pull/20420` \
`$ git pull https://git.openjdk.org/jdk.git pull/20420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20420`

View PR using the GUI difftool: \
`$ git pr show -t 20420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20420.diff">https://git.openjdk.org/jdk/pull/20420.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20420#issuecomment-2263087575)