### PR TITLE
8337667: sun/tools/jcmd/TestJcmdPIDSubstitution.java is failing on mac and windows

### DIFF
--- a/test/jdk/sun/tools/jcmd/TestJcmdPIDSubstitution.java
+++ b/test/jdk/sun/tools/jcmd/TestJcmdPIDSubstitution.java
@@ -47,7 +47,6 @@ public class TestJcmdPIDSubstitution {
     public static void main(String[] args) throws Exception {
         verifyOutputFilenames("Thread.dump_to_file", FILENAME);
         verifyOutputFilenames("GC.heap_dump", FILENAME);
-        verifyOutputFilenames("Compiler.perfmap", FILENAME);
         verifyOutputFilenames("System.dump_map", "-F=%s".formatted(FILENAME));
     }
 


### PR DESCRIPTION
Hi all, 

This PR addresses [8337667](https://bugs.openjdk.org/browse/JDK-8337667) . 

The `Compiler.perfmap` test case is failing on mac and windows as it is only enabled in linux. I am removing this test case and noting that this use case is already tested in [test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java](https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/serviceability/dcmd/compiler/PerfMapTest.java#L88) which is linux specific.

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337667](https://bugs.openjdk.org/browse/JDK-8337667): sun/tools/jcmd/TestJcmdPIDSubstitution.java is failing on mac and windows (**Bug** - P2) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20421/head:pull/20421` \
`$ git checkout pull/20421`

Update a local copy of the PR: \
`$ git checkout pull/20421` \
`$ git pull https://git.openjdk.org/jdk.git pull/20421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20421`

View PR using the GUI difftool: \
`$ git pr show -t 20421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20421.diff">https://git.openjdk.org/jdk/pull/20421.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20421#issuecomment-2263573979)