### PR TITLE
8337666: AArch64: SHA3 GPR intrinsic

### DIFF
--- a/src/hotspot/cpu/aarch64/globals_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/globals_aarch64.hpp
@@ -97,6 +97,8 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Use simplest and shortest implementation for array equals")  \
   product(bool, UseSIMDForBigIntegerShiftIntrinsics, true,              \
           "Use SIMD instructions for left/right shift of BigInteger")   \
+  product(bool, UseSIMDForSHA3Intrinsic, true,                          \
+          "Use SIMD SHA3 instructions for SHA3 intrinsic")              \
   product(bool, AvoidUnalignedAccesses, false,                          \
           "Avoid generating unaligned memory accesses")                 \
   product(bool, UseLSE, false,                                          \

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -368,7 +368,7 @@ void VM_Version::initialize() {
         FLAG_SET_DEFAULT(UseSHA3Intrinsics, true);
       }
     }
-  } else if (UseSHA3Intrinsics) {
+  } else if (UseSHA3Intrinsics && UseSIMDForSHA3Intrinsic) {
     warning("Intrinsics for SHA3-224, SHA3-256, SHA3-384 and SHA3-512 crypto hash functions not available on this CPU.");
     FLAG_SET_DEFAULT(UseSHA3Intrinsics, false);
   }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3Intrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3Intrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -40,6 +40,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   -Dalgorithm=SHA3-224
  *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -58,6 +59,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   -Dalgorithm=SHA3-256
  *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -76,6 +78,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   -Dalgorithm=SHA3-384
  *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -94,6 +97,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   -Dalgorithm=SHA3-512
  *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
@@ -108,6 +112,128 @@
  * @run main/othervm -DverificationStrategy=VERIFY_INTRINSIC_USAGE
  *                    compiler.testlibrary.intrinsics.Verifier positive_224.log positive_256.log positive_384.log positive_512.log
  *                    negative_224.log negative_256.log negative_384.log negative_512.log
+ */
+
+/**
+ * @test
+ * @bug 8337666
+ * @requires os.arch == "aarch64"
+ * @summary Verify that SHA3-224, SHA3-256, SHA3-384, SHA3-512 intrinsic is actually used.
+ *          -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_224.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   -Dalgorithm=SHA3-224
+ *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_256.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   -Dalgorithm=SHA3-256
+ *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_384.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   -Dalgorithm=SHA3-384
+ *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_512.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   -Dalgorithm=SHA3-512
+ *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
+ * @run main/othervm -DverificationStrategy=VERIFY_INTRINSIC_USAGE
+ *                    compiler.testlibrary.intrinsics.Verifier positive_224.log positive_256.log positive_384.log positive_512.log
+ */
+
+/**
+ * @test
+ * @bug 8337666
+ * @requires os.arch == "aarch64"
+ * @summary Verify that SHA3-224, SHA3-256, SHA3-384, SHA3-512 intrinsic is actually used.
+ *          -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_224.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   -Dalgorithm=SHA3-224
+ *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_256.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   -Dalgorithm=SHA3-256
+ *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_384.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   -Dalgorithm=SHA3-384
+ *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_512.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   -Dalgorithm=SHA3-512
+ *                   compiler.intrinsics.sha.sanity.TestSHA3Intrinsics
+ * @run main/othervm -DverificationStrategy=VERIFY_INTRINSIC_USAGE
+ *                    compiler.testlibrary.intrinsics.Verifier positive_224.log positive_256.log positive_384.log positive_512.log
  */
 
 package compiler.intrinsics.sha.sanity;

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3MultiBlockIntrinsics.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3MultiBlockIntrinsics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -40,6 +40,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
  *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-224
  *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
@@ -50,6 +51,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-224
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
@@ -67,6 +69,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
  *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-256
  *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
@@ -77,6 +80,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-256
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
@@ -94,6 +98,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
  *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-384
  *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
@@ -104,6 +109,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-384
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
@@ -121,6 +127,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
  *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-512
  *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
@@ -131,6 +138,7 @@
  *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
  *                   -XX:CompileOnly=sun.security.provider.SHA3::*
  *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-512
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic
  *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
  * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
  *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
@@ -145,6 +153,226 @@
  *                    positive_384.log positive_512.log positive_224_def.log positive_256_def.log
  *                    positive_384_def.log positive_512_def.log negative_224.log negative_256.log
  *                    negative_384.log negative_512.log
+ */
+
+/**
+ * @test
+ * @bug 8337666
+ * @requires os.arch == "aarch64"
+ * @summary Verify that SHA3-224, SHA3-256, SHA3-384, SHA3-512 multi block intrinsic is actually used.
+ *          -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_224.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
+ *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-224
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_224_def.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-224
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_256.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
+ *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-256
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_256_def.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-256
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_384.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
+ *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-384
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_384_def.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-384
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_512.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
+ *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-512
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_512_def.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-512
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:-PreserveFramePointer
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -DverificationStrategy=VERIFY_INTRINSIC_USAGE
+ *                    compiler.testlibrary.intrinsics.Verifier positive_224.log positive_256.log
+ *                    positive_384.log positive_512.log positive_224_def.log positive_256_def.log
+ *                    positive_384_def.log positive_512_def.log
+ */
+
+/**
+ * @test
+ * @bug 8337666
+ * @requires os.arch == "aarch64"
+ * @summary Verify that SHA3-224, SHA3-256, SHA3-384, SHA3-512 multi block intrinsic is actually used.
+ *          -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *
+ * @library /test/lib /
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ *
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_224.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
+ *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-224
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_224_def.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-224
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_256.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
+ *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-256
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_256_def.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-256
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_384.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
+ *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-384
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_384_def.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-384
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ *
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_512.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -XX:-UseMD5Intrinsics
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   -XX:-UseSHA1Intrinsics -XX:-UseSHA256Intrinsics
+ *                   -XX:-UseSHA512Intrinsics -Dalgorithm=SHA3-512
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI -Xbatch -XX:CompileThreshold=500
+ *                   -XX:Tier4InvocationThreshold=500
+ *                   -XX:+LogCompilation -XX:LogFile=positive_512_def.log
+ *                   -XX:CompileOnly=sun.security.provider.DigestBase::*
+ *                   -XX:CompileOnly=sun.security.provider.SHA3::*
+ *                   -XX:+UseSHA3Intrinsics -Dalgorithm=SHA3-512
+ *                   -XX:+IgnoreUnrecognizedVMOptions
+ *                   -XX:-UseSIMDForSHA3Intrinsic -XX:+PreserveFramePointer
+ *                   compiler.intrinsics.sha.sanity.TestSHA3MultiBlockIntrinsics
+ * @run main/othervm -DverificationStrategy=VERIFY_INTRINSIC_USAGE
+ *                    compiler.testlibrary.intrinsics.Verifier positive_224.log positive_256.log
+ *                    positive_384.log positive_512.log positive_224_def.log positive_256_def.log
+ *                    positive_384_def.log positive_512_def.log
  */
 
 package compiler.intrinsics.sha.sanity;


### PR DESCRIPTION
This is an implementation of SHA3 intrinsics for AArch64 that operates GPRs. It follows the Java implementation algorithm but eagerly uses available registers. For example, FP+R18 are used when it's allowed. On simpler cores like RPi3 or Surface Pro it is 23-53% faster than C2 compiled version; on Graviton 3 it is 8-14% faster than C2 compiled version (which is faster than the current intrinsic); on Apple Silicon it is faster than C2 compiled version but slower than the ARMv8.2-SHA intrinsic. Improvements on a particular CPU depend on the input length. For instance, for Graviton 2:

```
Benchmark (ops/ms)	(digesterName)	(length)	G2
MessageDigests.digest	SHA3-256	64	28.28%
MessageDigests.digest	SHA3-256	16384	53.58%
MessageDigests.digest	SHA3-512	64	27.97%
MessageDigests.digest	SHA3-512	16384	43.90%
MessageDigests.getAndDigest	SHA3-256	64	26.18%
MessageDigests.getAndDigest	SHA3-256	16384	52.82%
MessageDigests.getAndDigest	SHA3-512	64	24.73%
MessageDigests.getAndDigest	SHA3-512	16384	44.31%
```

(results for intermediate input lengths look like steps)

Existing intrinsic implementation is put under a flag `UseSIMDForSHA3Intrinsic` which is on by default where the intrinsic is enabled currently.

Sanity tests were modified to cover new intrinsic variants (`-XX:-UseSIMDForSHA3Intrinsic -XX:+-PreserveFramePointer`) on aarch64 hw. Existing test cases where intrinsic is enabled are executed with `-XX:+IgnoreUnrecognizedVMOptions -XX:+UseSIMDForSHA3Intrinsic`, on platforms where the sha3 extension is missing they still are cut off by isSHA3IntrinsicAvailable() predicate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337666](https://bugs.openjdk.org/browse/JDK-8337666): AArch64: SHA3 GPR intrinsic (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20422/head:pull/20422` \
`$ git checkout pull/20422`

Update a local copy of the PR: \
`$ git checkout pull/20422` \
`$ git pull https://git.openjdk.org/jdk.git pull/20422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20422`

View PR using the GUI difftool: \
`$ git pr show -t 20422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20422.diff">https://git.openjdk.org/jdk/pull/20422.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20422#issuecomment-2317822318)