### PR TITLE
8337674: ZGC: Remove leading underscore from private static constants

### DIFF
--- a/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/z/c2/zBarrierSetC2.cpp
@@ -46,7 +46,7 @@
 #include "utilities/growableArray.hpp"
 #include "utilities/macros.hpp"
 
-template<typename K, typename V, size_t _table_size>
+template<typename K, typename V, size_t TableSize>
 class ZArenaHashtable : public ResourceObj {
   class ZArenaHashtableEntry : public ResourceObj {
   public:
@@ -55,10 +55,10 @@ class ZArenaHashtable : public ResourceObj {
     V _value;
   };
 
-  static const size_t _table_mask = _table_size - 1;
+  static const size_t TableMask = TableSize - 1;
 
   Arena* _arena;
-  ZArenaHashtableEntry* _table[_table_size];
+  ZArenaHashtableEntry* _table[TableSize];
 
 public:
   class Iterator {
@@ -84,7 +84,7 @@ public:
       if (_current_entry != nullptr) {
         _current_entry = _current_entry->_next;
       }
-      while (_current_entry == nullptr && ++_current_index < _table_size) {
+      while (_current_entry == nullptr && ++_current_index < TableSize) {
         _current_entry = _table->_table[_current_index];
       }
     }
@@ -100,12 +100,12 @@ public:
     ZArenaHashtableEntry* entry = new (_arena) ZArenaHashtableEntry();
     entry->_key = key;
     entry->_value = value;
-    entry->_next = _table[key & _table_mask];
-    _table[key & _table_mask] = entry;
+    entry->_next = _table[key & TableMask];
+    _table[key & TableMask] = entry;
   }
 
   V* get(K key) const {
-    for (ZArenaHashtableEntry* e = _table[key & _table_mask]; e != nullptr; e = e->_next) {
+    for (ZArenaHashtableEntry* e = _table[key & TableMask]; e != nullptr; e = e->_next) {
       if (e->_key == key) {
         return &(e->_value);
       }

--- a/src/hotspot/share/gc/z/zStat.cpp
+++ b/src/hotspot/share/gc/z/zStat.cpp
@@ -1098,11 +1098,11 @@ void ZStat::terminate() {
 //
 class ZStatTablePrinter {
 private:
-  static const size_t _buffer_size = 256;
+  static const size_t BufferSize = 256;
 
   const size_t _column0_width;
   const size_t _columnN_width;
-  char         _buffer[_buffer_size];
+  char         _buffer[BufferSize];
 
 public:
   class ZColumn {
@@ -1119,7 +1119,7 @@ public:
     }
 
     size_t print(size_t position, const char* fmt, va_list va) {
-      const int res = jio_vsnprintf(_buffer + position, _buffer_size - position, fmt, va);
+      const int res = jio_vsnprintf(_buffer + position, BufferSize - position, fmt, va);
       if (res < 0) {
         return 0;
       }

--- a/src/hotspot/share/gc/z/zStoreBarrierBuffer.cpp
+++ b/src/hotspot/share/gc/z/zStoreBarrierBuffer.cpp
@@ -55,7 +55,7 @@ ZStoreBarrierBuffer::ZStoreBarrierBuffer()
     _last_installed_color(),
     _base_pointer_lock(),
     _base_pointers(),
-    _current(ZBufferStoreBarriers ? _buffer_size_bytes : 0) {}
+    _current(ZBufferStoreBarriers ? BufferSizeBytes : 0) {}
 
 void ZStoreBarrierBuffer::initialize() {
   _last_processed_color = ZPointerStoreGoodMask;
@@ -63,11 +63,11 @@ void ZStoreBarrierBuffer::initialize() {
 }
 
 void ZStoreBarrierBuffer::clear() {
-  _current = _buffer_size_bytes;
+  _current = BufferSizeBytes;
 }
 
 bool ZStoreBarrierBuffer::is_empty() const {
-  return _current == _buffer_size_bytes;
+  return _current == BufferSizeBytes;
 }
 
 void ZStoreBarrierBuffer::install_base_pointers_inner() {
@@ -79,7 +79,7 @@ void ZStoreBarrierBuffer::install_base_pointers_inner() {
          (ZPointer::remap_bits(_last_processed_color) & ZPointerRemappedOldMask) == 0,
          "Should not have double bit errors");
 
-  for (size_t i = current(); i < _buffer_length; ++i) {
+  for (size_t i = current(); i < BufferLength; ++i) {
     const ZStoreBarrierEntry& entry = _buffer[i];
     volatile zpointer* const p = entry._p;
     const zaddress_unsafe p_unsafe = to_zaddress_unsafe((uintptr_t)p);
@@ -229,7 +229,7 @@ void ZStoreBarrierBuffer::on_new_phase() {
   // Install all base pointers for relocation
   install_base_pointers();
 
-  for (size_t i = current(); i < _buffer_length; ++i) {
+  for (size_t i = current(); i < BufferLength; ++i) {
     on_new_phase_relocate(i);
     on_new_phase_remember(i);
     on_new_phase_mark(i);
@@ -259,7 +259,7 @@ void ZStoreBarrierBuffer::on_error(outputStream* st) {
   st->print_cr(" _last_processed_color: " PTR_FORMAT, _last_processed_color);
   st->print_cr(" _last_installed_color: " PTR_FORMAT, _last_installed_color);
 
-  for (size_t i = current(); i < _buffer_length; ++i) {
+  for (size_t i = current(); i < BufferLength; ++i) {
     st->print_cr(" [%2zu]: base: " PTR_FORMAT " p: " PTR_FORMAT " prev: " PTR_FORMAT,
         i,
         untype(_base_pointers[i]),
@@ -276,7 +276,7 @@ void ZStoreBarrierBuffer::flush() {
   OnError on_error(this);
   VMErrorCallbackMark mark(&on_error);
 
-  for (size_t i = current(); i < _buffer_length; ++i) {
+  for (size_t i = current(); i < BufferLength; ++i) {
     const ZStoreBarrierEntry& entry = _buffer[i];
     const zaddress addr = ZBarrier::make_load_good(entry._prev);
     ZBarrier::mark_and_remember(entry._p, addr);
@@ -296,7 +296,7 @@ bool ZStoreBarrierBuffer::is_in(volatile zpointer* p) {
     const uintptr_t  last_remap_bits = ZPointer::remap_bits(buffer->_last_processed_color) & ZPointerRemappedMask;
     const bool needs_remap = last_remap_bits != ZPointerRemapped;
 
-    for (size_t i = buffer->current(); i < _buffer_length; ++i) {
+    for (size_t i = buffer->current(); i < BufferLength; ++i) {
       const ZStoreBarrierEntry& entry = buffer->_buffer[i];
       volatile zpointer* entry_p = entry._p;
 

--- a/src/hotspot/share/gc/z/zStoreBarrierBuffer.hpp
+++ b/src/hotspot/share/gc/z/zStoreBarrierBuffer.hpp
@@ -42,10 +42,10 @@ class ZStoreBarrierBuffer : public CHeapObj<mtGC> {
   friend class ZVerify;
 
 private:
-  static const size_t _buffer_length     = 32;
-  static const size_t _buffer_size_bytes = _buffer_length * sizeof(ZStoreBarrierEntry);
+  static const size_t BufferLength     = 32;
+  static const size_t BufferSizeBytes = BufferLength * sizeof(ZStoreBarrierEntry);
 
-  ZStoreBarrierEntry _buffer[_buffer_length];
+  ZStoreBarrierEntry _buffer[BufferLength];
 
   // Color from previous phase this buffer was processed
   uintptr_t          _last_processed_color;
@@ -54,7 +54,7 @@ private:
   uintptr_t          _last_installed_color;
 
   ZLock              _base_pointer_lock;
-  zaddress_unsafe    _base_pointers[_buffer_length];
+  zaddress_unsafe    _base_pointers[BufferLength];
 
   // sizeof(ZStoreBarrierEntry) scaled index growing downwards
   size_t             _current;

--- a/src/hotspot/share/gc/z/zVerify.cpp
+++ b/src/hotspot/share/gc/z/zVerify.cpp
@@ -589,7 +589,7 @@ void ZVerify::on_color_flip() {
   for (JavaThreadIteratorWithHandle jtiwh; JavaThread* const jt = jtiwh.next(); ) {
     const ZStoreBarrierBuffer* const buffer = ZThreadLocalData::store_barrier_buffer(jt);
 
-    for (size_t i = buffer->current(); i < ZStoreBarrierBuffer::_buffer_length; ++i) {
+    for (size_t i = buffer->current(); i < ZStoreBarrierBuffer::BufferLength; ++i) {
       volatile zpointer* const p = buffer->_buffer[i]._p;
       bool created = false;
       z_verify_store_barrier_buffer_table->put_if_absent(p, true, &created);


### PR DESCRIPTION
Some private static constants in ZGC code have leading underscore in their name, making it confusing whether they are associated with the class instance or the class itself. The leading underscore should be removed to clarify the code.

The variables with misleading names were found using the following command:
`rg "static const .* _" src/hotspot/share/gc/z`

Tested with tiers 1-3 on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337674](https://bugs.openjdk.org/browse/JDK-8337674): ZGC: Remove leading underscore from private static constants (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20423/head:pull/20423` \
`$ git checkout pull/20423`

Update a local copy of the PR: \
`$ git checkout pull/20423` \
`$ git pull https://git.openjdk.org/jdk.git pull/20423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20423`

View PR using the GUI difftool: \
`$ git pr show -t 20423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20423.diff">https://git.openjdk.org/jdk/pull/20423.diff</a>

</details>
