### PR TITLE
8337676: JFR: Change the label of the throttle setting

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/settings/ThrottleSetting.java
@@ -44,7 +44,7 @@ import jdk.jfr.internal.util.TimespanUnit;
 import jdk.jfr.internal.util.Utils;
 
 @MetadataDefinition
-@Label("Event Emission Throttle")
+@Label("Throttle")
 @Description("Throttles the emission rate for an event")
 @Name(Type.SETTINGS_PREFIX + "Throttle")
 public final class ThrottleSetting extends JDKSettingControl {


### PR DESCRIPTION
Could I have a review of a change that makes the throttle label more consistent with the labels of other settings?

- "Threshold"
- "Period"
- "Stack Trace"
- "Enabled"
- "Cutoff"
- "Level"
- "Event Emission Throttle" -> "Throttle"

Testing: jdk/jdk/jfr

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337676](https://bugs.openjdk.org/browse/JDK-8337676): JFR: Change the label of the throttle setting (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20426/head:pull/20426` \
`$ git checkout pull/20426`

Update a local copy of the PR: \
`$ git checkout pull/20426` \
`$ git pull https://git.openjdk.org/jdk.git pull/20426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20426`

View PR using the GUI difftool: \
`$ git pr show -t 20426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20426.diff">https://git.openjdk.org/jdk/pull/20426.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20426#issuecomment-2264694575)