### PR TITLE
8332120: Potential compilation failure in istream.cpp:205 - loss of data on conversion

### DIFF
--- a/src/hotspot/share/utilities/istream.hpp
+++ b/src/hotspot/share/utilities/istream.hpp
@@ -96,7 +96,6 @@ class inputStream : public CHeapObjBase {
 
   Input* _input;   // where the input comes from or else nullptr
   IState _input_state;  // one of {NTR,EOF,ERR}_STATE
-  char   _line_ending;  // one of {0,1,2} for "", "\n", "\r\n"
   char*  _buffer;       // scratch buffer holding at least the current line
   size_t _buffer_size;  // allocated size of buffer
   size_t _content_end;  // offset to end of valid contents of buffer
@@ -225,7 +224,6 @@ class inputStream : public CHeapObjBase {
   inputStream() :
     _input(nullptr),
     _input_state(IState::NTR_STATE),
-    _line_ending(0),
     _buffer(&_small_buffer[0]),
     _buffer_size(sizeof(_small_buffer)),
     _content_end(0),


### PR DESCRIPTION
This field _line_ending isn't used, and I'm not sure how this even works.  So I deleted it.
Tested with tier1 on many Oracle supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332120](https://bugs.openjdk.org/browse/JDK-8332120): Potential compilation failure in istream.cpp:205 - loss of data on conversion (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20427/head:pull/20427` \
`$ git checkout pull/20427`

Update a local copy of the PR: \
`$ git checkout pull/20427` \
`$ git pull https://git.openjdk.org/jdk.git pull/20427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20427`

View PR using the GUI difftool: \
`$ git pr show -t 20427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20427.diff">https://git.openjdk.org/jdk/pull/20427.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20427#issuecomment-2263536064)