### PR TITLE
8324048: (fc) Make FileKey fields final

### DIFF
--- a/src/java.base/unix/classes/sun/nio/ch/FileKey.java
+++ b/src/java.base/unix/classes/sun/nio/ch/FileKey.java
@@ -64,4 +64,8 @@ public class FileKey {
 
     private static native void init(FileDescriptor fd, long[] finfo)
         throws IOException;
+
+    static {
+        IOUtil.load();
+    }
 }

--- a/src/java.base/unix/classes/sun/nio/ch/FileKey.java
+++ b/src/java.base/unix/classes/sun/nio/ch/FileKey.java
@@ -27,8 +27,6 @@ package sun.nio.ch;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
-import jdk.internal.access.SharedSecrets;
-import jdk.internal.access.JavaIOFileDescriptorAccess;
 
 /*
  * Represents a key to a specific file on Solaris or Linux
@@ -44,11 +42,8 @@ public class FileKey {
     }
 
     public static FileKey create(FileDescriptor fd) throws IOException {
-        JavaIOFileDescriptorAccess access =
-            SharedSecrets.getJavaIOFileDescriptorAccess();
-        int fdVal = access.get(fd);
         long finfo[] = new long[2];
-        init(fdVal, finfo);
+        init(fd, finfo);
         return new FileKey(finfo[0], finfo[1]);
     }
 
@@ -67,6 +62,6 @@ public class FileKey {
                 && (this.st_ino == other.st_ino);
     }
 
-    private static native void init(int fdVal, long[] finfo)
+    private static native void init(FileDescriptor fd, long[] finfo)
         throws IOException;
 }

--- a/src/java.base/unix/classes/sun/nio/ch/FileKey.java
+++ b/src/java.base/unix/classes/sun/nio/ch/FileKey.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,21 +27,29 @@ package sun.nio.ch;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
+import jdk.internal.access.SharedSecrets;
+import jdk.internal.access.JavaIOFileDescriptorAccess;
 
 /*
  * Represents a key to a specific file on Solaris or Linux
  */
 public class FileKey {
 
-    private long st_dev;    // ID of device
-    private long st_ino;    // Inode number
+    private final long st_dev;    // ID of device
+    private final long st_ino;    // Inode number
 
-    private FileKey() { }
+    private FileKey(long st_dev, long st_ino) {
+        this.st_dev = st_dev;
+        this.st_ino = st_ino;
+    }
 
     public static FileKey create(FileDescriptor fd) throws IOException {
-        FileKey fk = new FileKey();
-        fk.init(fd);
-        return fk;
+        JavaIOFileDescriptorAccess access =
+            SharedSecrets.getJavaIOFileDescriptorAccess();
+        int fdVal = access.get(fd);
+        long devIno[] = new long[2];
+        getDevIno(fdVal, devIno);
+        return new FileKey(devIno[0], devIno[1]);
     }
 
     @Override
@@ -59,10 +67,6 @@ public class FileKey {
                 && (this.st_ino == other.st_ino);
     }
 
-    private native void init(FileDescriptor fd) throws IOException;
-    private static native void initIDs();
-
-    static {
-        initIDs();
-    }
+    private static native void getDevIno(int fd, long[] ids)
+        throws IOException;
 }

--- a/src/java.base/unix/classes/sun/nio/ch/FileKey.java
+++ b/src/java.base/unix/classes/sun/nio/ch/FileKey.java
@@ -47,9 +47,9 @@ public class FileKey {
         JavaIOFileDescriptorAccess access =
             SharedSecrets.getJavaIOFileDescriptorAccess();
         int fdVal = access.get(fd);
-        long devIno[] = new long[2];
-        getDevIno(fdVal, devIno);
-        return new FileKey(devIno[0], devIno[1]);
+        long finfo[] = new long[2];
+        init(fdVal, finfo);
+        return new FileKey(finfo[0], finfo[1]);
     }
 
     @Override
@@ -67,6 +67,6 @@ public class FileKey {
                 && (this.st_ino == other.st_ino);
     }
 
-    private static native void getDevIno(int fd, long[] ids)
+    private static native void init(int fdVal, long[] finfo)
         throws IOException;
 }

--- a/src/java.base/unix/native/libnio/ch/FileKey.c
+++ b/src/java.base/unix/native/libnio/ch/FileKey.c
@@ -36,7 +36,7 @@ Java_sun_nio_ch_FileKey_init(JNIEnv* env, jclass clazz, jobject fdo,
 {
     struct stat fbuf;
     int res;
-    long deviceAndInode[2];
+    jlong deviceAndInode[2];
 
     int fd = fdval(env, fdo);
     RESTARTABLE(fstat(fd, &fbuf), res);

--- a/src/java.base/unix/native/libnio/ch/FileKey.c
+++ b/src/java.base/unix/native/libnio/ch/FileKey.c
@@ -30,29 +30,20 @@
 #include "nio_util.h"
 #include "sun_nio_ch_FileKey.h"
 
-static jfieldID key_st_dev;    /* id for FileKey.st_dev */
-static jfieldID key_st_ino;    /* id for FileKey.st_ino */
-
-
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_FileKey_initIDs(JNIEnv *env, jclass clazz)
-{
-    CHECK_NULL(key_st_dev = (*env)->GetFieldID(env, clazz, "st_dev", "J"));
-    CHECK_NULL(key_st_ino = (*env)->GetFieldID(env, clazz, "st_ino", "J"));
-}
-
-
-JNIEXPORT void JNICALL
-Java_sun_nio_ch_FileKey_init(JNIEnv *env, jobject this, jobject fdo)
+Java_sun_nio_ch_FileKey_getDevIno(JNIEnv* env, jclass clazz, jint fdVal,
+    jlongArray devIno)
 {
     struct stat fbuf;
     int res;
+    long deviceAndInode[2];
 
-    RESTARTABLE(fstat(fdval(env, fdo), &fbuf), res);
+    RESTARTABLE(fstat(fdVal, &fbuf), res);
     if (res < 0) {
         JNU_ThrowIOExceptionWithLastError(env, "fstat failed");
     } else {
-        (*env)->SetLongField(env, this, key_st_dev, (jlong)fbuf.st_dev);
-        (*env)->SetLongField(env, this, key_st_ino, (jlong)fbuf.st_ino);
+        deviceAndInode[0] = (jlong)fbuf.st_dev;
+        deviceAndInode[1] = (jlong)fbuf.st_ino;
+        (*env)->SetLongArrayRegion(env, devIno, 0, 2, deviceAndInode);
     }
 }

--- a/src/java.base/unix/native/libnio/ch/FileKey.c
+++ b/src/java.base/unix/native/libnio/ch/FileKey.c
@@ -31,8 +31,8 @@
 #include "sun_nio_ch_FileKey.h"
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_FileKey_getDevIno(JNIEnv* env, jclass clazz, jint fdVal,
-    jlongArray devIno)
+Java_sun_nio_ch_FileKey_init(JNIEnv* env, jclass clazz, jint fdVal,
+    jlongArray finfo)
 {
     struct stat fbuf;
     int res;
@@ -44,6 +44,6 @@ Java_sun_nio_ch_FileKey_getDevIno(JNIEnv* env, jclass clazz, jint fdVal,
     } else {
         deviceAndInode[0] = (jlong)fbuf.st_dev;
         deviceAndInode[1] = (jlong)fbuf.st_ino;
-        (*env)->SetLongArrayRegion(env, devIno, 0, 2, deviceAndInode);
+        (*env)->SetLongArrayRegion(env, finfo, 0, 2, deviceAndInode);
     }
 }

--- a/src/java.base/unix/native/libnio/ch/FileKey.c
+++ b/src/java.base/unix/native/libnio/ch/FileKey.c
@@ -31,14 +31,15 @@
 #include "sun_nio_ch_FileKey.h"
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_FileKey_init(JNIEnv* env, jclass clazz, jint fdVal,
+Java_sun_nio_ch_FileKey_init(JNIEnv* env, jclass clazz, jobject fdo,
     jlongArray finfo)
 {
     struct stat fbuf;
     int res;
     long deviceAndInode[2];
 
-    RESTARTABLE(fstat(fdVal, &fbuf), res);
+    int fd = fdval(env, fdo);
+    RESTARTABLE(fstat(fd, &fbuf), res);
     if (res < 0) {
         JNU_ThrowIOExceptionWithLastError(env, "fstat failed");
     } else {

--- a/src/java.base/windows/classes/sun/nio/ch/FileKey.java
+++ b/src/java.base/windows/classes/sun/nio/ch/FileKey.java
@@ -67,4 +67,8 @@ public class FileKey {
 
     private static native void init(FileDescriptor fd, int[] finfo)
         throws IOException;
+
+    static {
+        IOUtil.load();
+    }
 }

--- a/src/java.base/windows/classes/sun/nio/ch/FileKey.java
+++ b/src/java.base/windows/classes/sun/nio/ch/FileKey.java
@@ -27,8 +27,6 @@ package sun.nio.ch;
 
 import java.io.FileDescriptor;
 import java.io.IOException;
-import jdk.internal.access.SharedSecrets;
-import jdk.internal.access.JavaIOFileDescriptorAccess;
 
 /*
  * Represents a key to a specific file on Windows
@@ -47,11 +45,8 @@ public class FileKey {
     }
 
     public static FileKey create(FileDescriptor fd) throws IOException {
-        JavaIOFileDescriptorAccess access =
-            SharedSecrets.getJavaIOFileDescriptorAccess();
-        long handleVal = access.getHandle(fd);
         int finfo[] = new int[3];
-        init(handleVal, finfo);
+        init(fd, finfo);
         return new FileKey(finfo[0], finfo[1], finfo[2]);
     }
 
@@ -70,6 +65,6 @@ public class FileKey {
                 && this.nFileIndexLow == other.nFileIndexLow;
     }
 
-    private static native void init(long handleVal, int[] finfo)
+    private static native void init(FileDescriptor fd, int[] finfo)
         throws IOException;
 }

--- a/src/java.base/windows/native/libnio/ch/FileKey.c
+++ b/src/java.base/windows/native/libnio/ch/FileKey.c
@@ -31,8 +31,7 @@
 #include "sun_nio_ch_FileKey.h"
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_FileKey_init(JNIEnv *env, jclass clazz, jobject fdo,
-    jintArray finfo)
+Java_sun_nio_ch_FileKey_init(JNIEnv *env, jclass clazz, jobject fdo, jintArray finfo)
 {
     HANDLE fileHandle = (HANDLE)handleval(env, fdo);
     BOOL result;

--- a/src/java.base/windows/native/libnio/ch/FileKey.c
+++ b/src/java.base/windows/native/libnio/ch/FileKey.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,10 +31,10 @@
 #include "sun_nio_ch_FileKey.h"
 
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_FileKey_init(JNIEnv *env, jclass clazz, jlong handleVal,
+Java_sun_nio_ch_FileKey_init(JNIEnv *env, jclass clazz, jobject fdo,
     jintArray finfo)
 {
-    HANDLE fileHandle = (HANDLE)handleVal;
+    HANDLE fileHandle = (HANDLE)handleval(env, fdo);
     BOOL result;
     BY_HANDLE_FILE_INFORMATION fileInfo;
     jint info[3];

--- a/src/java.base/windows/native/libnio/ch/FileKey.c
+++ b/src/java.base/windows/native/libnio/ch/FileKey.c
@@ -30,32 +30,21 @@
 #include "nio_util.h"
 #include "sun_nio_ch_FileKey.h"
 
-static jfieldID key_volumeSN;    /* id for FileKey.dwVolumeSerialNumber */
-static jfieldID key_indexHigh;   /* id for FileKey.nFileIndexHigh */
-static jfieldID key_indexLow;    /* id for FileKey.nFileIndexLow */
-
-
 JNIEXPORT void JNICALL
-Java_sun_nio_ch_FileKey_initIDs(JNIEnv *env, jclass clazz)
+Java_sun_nio_ch_FileKey_init(JNIEnv *env, jclass clazz, jlong handleVal,
+    jintArray finfo)
 {
-    CHECK_NULL(key_volumeSN = (*env)->GetFieldID(env, clazz, "dwVolumeSerialNumber", "I"));
-    CHECK_NULL(key_indexHigh = (*env)->GetFieldID(env, clazz, "nFileIndexHigh", "I"));
-    CHECK_NULL(key_indexLow = (*env)->GetFieldID(env, clazz, "nFileIndexLow", "I"));
-}
-
-
-JNIEXPORT void JNICALL
-Java_sun_nio_ch_FileKey_init(JNIEnv *env, jobject this, jobject fdo)
-{
-    HANDLE fileHandle = (HANDLE)(handleval(env, fdo));
+    HANDLE fileHandle = (HANDLE)handleVal;
     BOOL result;
     BY_HANDLE_FILE_INFORMATION fileInfo;
+    jint info[3];
 
     result = GetFileInformationByHandle(fileHandle, &fileInfo);
     if (result) {
-        (*env)->SetIntField(env, this, key_volumeSN, fileInfo.dwVolumeSerialNumber);
-        (*env)->SetIntField(env, this, key_indexHigh, fileInfo.nFileIndexHigh);
-        (*env)->SetIntField(env, this, key_indexLow, fileInfo.nFileIndexLow);
+        info[0] = (jint)fileInfo.dwVolumeSerialNumber;
+        info[1] = (jint)fileInfo.nFileIndexHigh;
+        info[2] = (jint)fileInfo.nFileIndexLow;
+        (*env)->SetIntArrayRegion(env, finfo, 0, 3, info);
     } else {
         JNU_ThrowIOExceptionWithLastError(env, "GetFileInformationByHandle failed");
     }


### PR DESCRIPTION
Replace use of IDs to set FileKey fields from native with passing down an array, at the expense of an array allocation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324048](https://bugs.openjdk.org/browse/JDK-8324048): (fc) Make FileKey fields final (**Enhancement** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20429/head:pull/20429` \
`$ git checkout pull/20429`

Update a local copy of the PR: \
`$ git checkout pull/20429` \
`$ git pull https://git.openjdk.org/jdk.git pull/20429/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20429`

View PR using the GUI difftool: \
`$ git pr show -t 20429`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20429.diff">https://git.openjdk.org/jdk/pull/20429.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20429#issuecomment-2265899315)