### PR TITLE
8337410: The makefiles should set problemlist and adjust timeout basing on the given VM flags

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -841,15 +841,15 @@ define SetupRunJtregTestBody
   JTREG_AUTO_TIMEOUT_FACTOR := 4
 
   ifneq ($$(findstring -Xcomp, $$(JTREG_ALL_OPTIONS)), )
-    JTREG_AUTO_PROBLEM_LISTS := $$(JTREG_AUTO_PROBLEM_LISTS) ProblemList-Xcomp.txt
-    JTREG_AUTO_TIMEOUT_FACTOR ?= 10
+    JTREG_AUTO_PROBLEM_LISTS += ProblemList-Xcomp.txt
+    JTREG_AUTO_TIMEOUT_FACTOR := 10
   endif
 
   ifneq ($$(findstring -XX:+UseZGC, $$(JTREG_ALL_OPTIONS)), )
     ifneq ($$(findstring -XX:-ZGenerational, $$(JTREG_ALL_OPTIONS)), )
-      JTREG_AUTO_PROBLEM_LISTS := $$(JTREG_AUTO_PROBLEM_LISTS) ProblemList-zgc.txt
+      JTREG_AUTO_PROBLEM_LISTS += ProblemList-zgc.txt
     else
-      JTREG_AUTO_PROBLEM_LISTS := $$(JTREG_AUTO_PROBLEM_LISTS) ProblemList-generational-zgc.txt
+      JTREG_AUTO_PROBLEM_LISTS += ProblemList-generational-zgc.txt
     endif
   endif
 

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -748,8 +748,6 @@ define SetupRunJtregTestBody
   # we may end up with a lot of JVM's
   $1_JTREG_MAX_RAM_PERCENTAGE := $$(shell $(AWK) 'BEGIN { print 25 / $$($1_JTREG_JOBS); }')
 
-  JTREG_TIMEOUT_FACTOR ?= 4
-
   JTREG_VERBOSE ?= fail,error,summary
   JTREG_RETAIN ?= fail,error
   JTREG_TEST_THREAD_FACTORY ?=
@@ -837,6 +835,24 @@ define SetupRunJtregTestBody
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$($1_JTREG_PROBLEM_LIST))
   endif
 
+  JTREG_ALL_OPTIONS := $$(JTREG_JAVA_OPTIONS) $$(JTREG_VM_OPTIONS)
+
+  JTREG_AUTO_PROBLEM_LISTS :=
+  JTREG_AUTO_TIMEOUT_FACTOR := 4
+
+  ifneq ($$(findstring -Xcomp, $$(JTREG_ALL_OPTIONS)), )
+    JTREG_AUTO_PROBLEM_LISTS := $$(JTREG_AUTO_PROBLEM_LISTS) ProblemList-Xcomp.txt
+    JTREG_AUTO_TIMEOUT_FACTOR ?= 10
+  endif
+
+  ifneq ($$(findstring -XX:+UseZGC, $$(JTREG_ALL_OPTIONS)), )
+    ifneq ($$(findstring -XX:-ZGenerational, $$(JTREG_ALL_OPTIONS)), )
+      JTREG_AUTO_PROBLEM_LISTS := $$(JTREG_AUTO_PROBLEM_LISTS) ProblemList-zgc.txt
+    else
+      JTREG_AUTO_PROBLEM_LISTS := $$(JTREG_AUTO_PROBLEM_LISTS) ProblemList-generational-zgc.txt
+    endif
+  endif
+
   ifneq ($$(JTREG_EXTRA_PROBLEM_LISTS), )
     # Accept both absolute paths as well as relative to the current test root.
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \
@@ -867,6 +883,18 @@ define SetupRunJtregTestBody
   endif
 
   $$(eval $$(call SetupRunJtregTestCustom, $1))
+
+  # SetupRunJtregTestCustom might also adjust JTREG_AUTO_ variables
+  # so set the final results after setting values from custom setup
+  ifneq ($$(JTREG_AUTO_PROBLEM_LISTS), )
+    # Accept both absolute paths as well as relative to the current test root.
+    $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \
+        $$(JTREG_AUTO_PROBLEM_LISTS) \
+        $$(addprefix $$($1_TEST_ROOT)/, $$(JTREG_AUTO_PROBLEM_LISTS)) \
+    ))
+  endif
+
+  JTREG_TIMEOUT_FACTOR ?= $$(JTREG_AUTO_TIMEOUT_FACTOR)
 
   clean-outputdirs-$1:
 	$$(RM) -r $$($1_TEST_SUPPORT_DIR)


### PR DESCRIPTION
There jtreg tests have several additional problemlists 
ProblemList-Xcomp.txt
ProblemList-generational-zgc.txt
ProblemList-zgc.txt
Each of them is bound to corresponding execution mode (Xcomp/ZGC) and it makes sense to treat them like standard problemlist when tests are executed with -Xcomp or ZGC enabled.
Currently, it is needed to set them manually and it is often forgotten. So engineers waste time analyzing known failures.

Additionally, the **default** timeoutFactor is increased when Xcomp is enabled because of slowness of this mode. 

The jtreg allows to add the same problemlist twice so it is not needed to update any execution system that set problemlists.

Later it might makes sens to set 'JTREG_ALL_OPTIONS' by asking java about actually set mode. So it is possible to adjust  options for fastdebug/slowdebug/product modes and/or different options that are set during compilation (saying different default GC).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337410](https://bugs.openjdk.org/browse/JDK-8337410): The makefiles should set problemlist and adjust timeout basing on the given VM flags (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20430/head:pull/20430` \
`$ git checkout pull/20430`

Update a local copy of the PR: \
`$ git checkout pull/20430` \
`$ git pull https://git.openjdk.org/jdk.git pull/20430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20430`

View PR using the GUI difftool: \
`$ git pr show -t 20430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20430.diff">https://git.openjdk.org/jdk/pull/20430.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20430#issuecomment-2263708838)