### PR TITLE
8337683: Fix -Wconversion problem with arrayOop.hpp

### DIFF
--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -68,10 +68,10 @@ private:
   // The header is considered the oop part of this type plus the length.
   // This is not equivalent to sizeof(arrayOopDesc) which should not appear in the code.
   static int header_size_in_bytes() {
-    size_t hs = length_offset_in_bytes() + sizeof(int);
+    int hs = length_offset_in_bytes() + (int)sizeof(int);
 #ifdef ASSERT
     // make sure it isn't called before UseCompressedOops is initialized.
-    static size_t arrayoopdesc_hs = 0;
+    static int arrayoopdesc_hs = 0;
     if (arrayoopdesc_hs == 0) arrayoopdesc_hs = hs;
     assert(arrayoopdesc_hs == hs, "header size can't change");
 #endif // ASSERT
@@ -83,13 +83,13 @@ private:
   // it occupies the second half of the _klass field in oopDesc.
   static int length_offset_in_bytes() {
     return UseCompressedClassPointers ? klass_gap_offset_in_bytes() :
-                               sizeof(arrayOopDesc);
+                               (int)sizeof(arrayOopDesc);
   }
 
   // Returns the offset of the first element.
   static int base_offset_in_bytes(BasicType type) {
-    size_t hs = header_size_in_bytes();
-    return (int)(element_type_should_be_aligned(type) ? align_up(hs, BytesPerLong) : hs);
+    int hs = header_size_in_bytes();
+    return element_type_should_be_aligned(type) ? align_up(hs, BytesPerLong) : hs;
   }
 
   // Returns the address of the first element. The elements in the array will not
@@ -139,9 +139,9 @@ private:
     int hdr_size_in_words = align_up(hdr_size_in_bytes, HeapWordSize) / HeapWordSize;
 
     const size_t max_element_words_per_size_t =
-      align_down((SIZE_MAX/HeapWordSize - hdr_size_in_words), MinObjAlignment);
+      align_down((SIZE_MAX/HeapWordSize - (size_t)hdr_size_in_words), MinObjAlignment);
     const size_t max_elements_per_size_t =
-      HeapWordSize * max_element_words_per_size_t / type2aelembytes(type);
+      HeapWordSize * max_element_words_per_size_t / (size_t)type2aelembytes(type);
     if ((size_t)max_jint < max_elements_per_size_t) {
       // It should be ok to return max_jint here, but parts of the code
       // (CollectedHeap, Klass::oop_oop_iterate(), and more) uses an int for

--- a/src/hotspot/share/oops/arrayOop.hpp
+++ b/src/hotspot/share/oops/arrayOop.hpp
@@ -134,9 +134,9 @@ private:
     assert(type < T_CONFLICT, "wrong type");
     assert(type2aelembytes(type) != 0, "wrong type");
 
-    size_t hdr_size_in_bytes = base_offset_in_bytes(type);
+    int hdr_size_in_bytes = base_offset_in_bytes(type);
     // This is rounded-up and may overlap with the first array elements.
-    size_t hdr_size_in_words = align_up(hdr_size_in_bytes, HeapWordSize) / HeapWordSize;
+    int hdr_size_in_words = align_up(hdr_size_in_bytes, HeapWordSize) / HeapWordSize;
 
     const size_t max_element_words_per_size_t =
       align_down((SIZE_MAX/HeapWordSize - hdr_size_in_words), MinObjAlignment);

--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1118,7 +1118,7 @@ inline T Atomic::CmpxchgByteUsingInt::operator()(T volatile* dest,
   uint8_t canon_compare_value = compare_value;
   volatile uint32_t* aligned_dest
     = reinterpret_cast<volatile uint32_t*>(align_down(dest, sizeof(uint32_t)));
-  size_t offset = pointer_delta(dest, aligned_dest, 1);
+  uint32_t offset = checked_cast<uint32_t>(pointer_delta(dest, aligned_dest, 1));
 
   uint32_t idx = (Endian::NATIVE == Endian::BIG)
                    ? (sizeof(uint32_t) - 1 - offset)

--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -31,8 +31,8 @@
 #include "runtime/orderAccess.hpp"
 #include "utilities/align.hpp"
 #include "utilities/bytes.hpp"
+#include "utilities/checkedCast.hpp"
 #include "utilities/macros.hpp"
-#include "utilities/globalDefinitions.hpp"
 
 #include <type_traits>
 
@@ -1119,7 +1119,7 @@ inline T Atomic::CmpxchgByteUsingInt::operator()(T volatile* dest,
   uint8_t canon_compare_value = compare_value;
   volatile uint32_t* aligned_dest
     = reinterpret_cast<volatile uint32_t*>(align_down(dest, sizeof(uint32_t)));
-  uint32_t offset = pointer_delta_as_int(dest, aligned_dest);
+  uint32_t offset = checked_cast<uint32_t>(pointer_delta(dest, aligned_dest, 1));
 
   uint32_t idx = (Endian::NATIVE == Endian::BIG)
                    ? (sizeof(uint32_t) - 1 - offset)

--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -32,6 +32,7 @@
 #include "utilities/align.hpp"
 #include "utilities/bytes.hpp"
 #include "utilities/macros.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 #include <type_traits>
 

--- a/src/hotspot/share/runtime/atomic.hpp
+++ b/src/hotspot/share/runtime/atomic.hpp
@@ -1118,7 +1118,7 @@ inline T Atomic::CmpxchgByteUsingInt::operator()(T volatile* dest,
   uint8_t canon_compare_value = compare_value;
   volatile uint32_t* aligned_dest
     = reinterpret_cast<volatile uint32_t*>(align_down(dest, sizeof(uint32_t)));
-  uint32_t offset = checked_cast<uint32_t>(pointer_delta(dest, aligned_dest, 1));
+  uint32_t offset = pointer_delta_as_int(dest, aligned_dest);
 
   uint32_t idx = (Endian::NATIVE == Endian::BIG)
                    ? (sizeof(uint32_t) - 1 - offset)

--- a/src/hotspot/share/utilities/byteswap.hpp
+++ b/src/hotspot/share/utilities/byteswap.hpp
@@ -26,6 +26,7 @@
 #define SHARE_UTILITIES_BYTESWAP_HPP
 
 #include "metaprogramming/enableIf.hpp"
+#include "utilities/checkedCast.hpp"
 #include "utilities/globalDefinitions.hpp"
 
 #include <cstddef>

--- a/src/hotspot/share/utilities/byteswap.hpp
+++ b/src/hotspot/share/utilities/byteswap.hpp
@@ -63,7 +63,7 @@ struct ByteswapFallbackImpl;
 template <typename T>
 struct ByteswapFallbackImpl<T, 2> {
   inline constexpr uint16_t operator()(uint16_t x) const {
-    return (((x & UINT16_C(0x00ff)) << 8) | ((x & UINT16_C(0xff00)) >> 8));
+    return checked_cast<uint16_t>(((x & UINT16_C(0x00ff)) << 8) | ((x & UINT16_C(0xff00)) >> 8));
   }
 };
 


### PR DESCRIPTION
Since base_offset_in_bytes and HeapWordSize are int, there's no loss of conversion in making these variables int.  This seems trivial.
Tested with tier1 on linux and windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337683](https://bugs.openjdk.org/browse/JDK-8337683): Fix -Wconversion problem with arrayOop.hpp (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20431/head:pull/20431` \
`$ git checkout pull/20431`

Update a local copy of the PR: \
`$ git checkout pull/20431` \
`$ git pull https://git.openjdk.org/jdk.git pull/20431/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20431`

View PR using the GUI difftool: \
`$ git pr show -t 20431`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20431.diff">https://git.openjdk.org/jdk/pull/20431.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20431#issuecomment-2263753601)