### PR TITLE
8336742: test

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -205,9 +205,7 @@ void ShenandoahConcurrentMark::concurrent_mark() {
 
   ShenandoahSATBMarkQueueSet& qset = ShenandoahBarrierSet::satb_mark_queue_set();
   ShenandoahFlushSATBHandshakeClosure flush_satb(qset);
-  double handshake_total_time = 0;
-  uint flushes;
-  for (flushes = 0; flushes < ShenandoahMaxSATBBufferFlushes; flushes++) {
+  for (uint flushes = 0; flushes < ShenandoahMaxSATBBufferFlushes; flushes++) {
     TaskTerminator terminator(nworkers, task_queues());
     ShenandoahConcurrentMarkingTask<NON_GEN> task(this, &terminator);
     workers->run_task(&task);
@@ -229,7 +227,6 @@ void ShenandoahConcurrentMark::concurrent_mark() {
       break;
     }
   }
-
   assert(task_queues()->is_empty() || heap->cancelled_gc(), "Should be empty when not cancelled");
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -137,17 +137,21 @@ bool ShenandoahPhaseTimings::is_root_work_phase(Phase phase) {
   }
 }
 
-void ShenandoahPhaseTimings::set_cycle_data(Phase phase, double time) {
-#ifdef ASSERT
-  double d = _cycle_data[phase];
-  assert(d == uninitialized(), "Should not be set yet: %s, current value: %lf", phase_name(phase), d);
-#endif
-  _cycle_data[phase] = time;
+void ShenandoahPhaseTimings::set_cycle_data(Phase phase, double time, bool should_aggregate_cycles) {
+  if (should_aggregate_cycles) {
+    _cycle_data[phase] = _cycle_data[phase] <= 0 ? time :  _cycle_data[phase] + time;
+  } else {
+    #ifdef ASSERT
+    double d = _cycle_data[phase];
+    assert(d == uninitialized(), "Should not be set yet: %s, current value: %lf", phase_name(phase), d);
+    #endif
+    _cycle_data[phase] = time;
+  }
 }
 
-void ShenandoahPhaseTimings::record_phase_time(Phase phase, double time) {
+void ShenandoahPhaseTimings::record_phase_time(Phase phase, double time, bool should_aggregate_cycles) {
   if (!_policy->is_at_shutdown()) {
-    set_cycle_data(phase, time);
+    set_cycle_data(phase, time, should_aggregate_cycles);
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -57,6 +57,7 @@ class outputStream;
   f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
   SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "  CMR: ", f)                      \
   f(conc_mark,                                      "Concurrent Marking")              \
+  f(conc_mark_satb_flush_rendezvous,                "  SATB Flush Rendezvous") \
                                                                                        \
   f(final_mark_gross,                               "Pause Final Mark (G)")            \
   f(final_mark,                                     "Pause Final Mark (N)")            \

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -57,7 +57,7 @@ class outputStream;
   f(conc_mark_roots,                                "Concurrent Mark Roots ")          \
   SHENANDOAH_PAR_PHASE_DO(conc_mark_roots,          "  CMR: ", f)                      \
   f(conc_mark,                                      "Concurrent Marking")              \
-  f(conc_mark_satb_flush_rendezvous,                "  SATB Flush Rendezvous") \
+  f(conc_mark_satb_flush_rendezvous,                "  SATB Flush Rendezvous")         \
                                                                                        \
   f(final_mark_gross,                               "Pause Final Mark (G)")            \
   f(final_mark,                                     "Pause Final Mark (N)")            \
@@ -217,13 +217,13 @@ private:
   ShenandoahWorkerData* worker_data(Phase phase, ParPhase par_phase);
   Phase worker_par_phase(Phase phase, ParPhase par_phase);
 
-  void set_cycle_data(Phase phase, double time);
+  void set_cycle_data(Phase phase, double time, bool should_aggregate=false);
   static double uninitialized() { return -1; }
 
 public:
   ShenandoahPhaseTimings(uint max_workers);
 
-  void record_phase_time(Phase phase, double time);
+  void record_phase_time(Phase phase, double time, bool should_aggregate=false);
 
   void record_workers_start(Phase phase);
   void record_workers_end(Phase phase);
@@ -234,6 +234,14 @@ public:
   static const char* phase_name(Phase phase) {
     assert(phase >= 0 && phase < _num_phases, "Out of bound");
     return _phase_names[phase];
+  }
+
+  static const char* phase_name_without_leading_whitespace(Phase phase) {
+    const char* current_phase_name = phase_name(phase);
+    while (*current_phase_name == ' ') {
+      current_phase_name++;
+    }
+    return current_phase_name;
   }
 
   void print_cycle_on(outputStream* out) const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.hpp
@@ -217,13 +217,13 @@ private:
   ShenandoahWorkerData* worker_data(Phase phase, ParPhase par_phase);
   Phase worker_par_phase(Phase phase, ParPhase par_phase);
 
-  void set_cycle_data(Phase phase, double time, bool should_aggregate=false);
+  void set_cycle_data(Phase phase, double time, bool should_aggregate_cycles=false);
   static double uninitialized() { return -1; }
 
 public:
   ShenandoahPhaseTimings(uint max_workers);
 
-  void record_phase_time(Phase phase, double time, bool should_aggregate=false);
+  void record_phase_time(Phase phase, double time, bool should_aggregate_cycles=false);
 
   void record_workers_start(Phase phase);
   void record_workers_end(Phase phase);
@@ -237,11 +237,11 @@ public:
   }
 
   static const char* phase_name_without_leading_whitespace(Phase phase) {
-    const char* current_phase_name = phase_name(phase);
-    while (*current_phase_name == ' ') {
-      current_phase_name++;
+    const char* trimmed_phase_name = phase_name(phase);
+    while (*trimmed_phase_name == ' ') {
+      trimmed_phase_name++;
     }
-    return current_phase_name;
+    return trimmed_phase_name;
   }
 
   void print_cycle_on(outputStream* out) const;

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -112,16 +112,26 @@ ShenandoahConcurrentPhase::~ShenandoahConcurrentPhase() {
 }
 
 ShenandoahTimingsTracker::ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase) :
+  ShenandoahTimingsTracker(phase, false) {
+
+  }
+
+ShenandoahTimingsTracker::ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate_cycles) :
   _timings(ShenandoahHeap::heap()->phase_timings()), _phase(phase) {
   assert(Thread::current()->is_VM_thread() || Thread::current()->is_ConcurrentGC_thread(),
           "Must be set by these threads");
   _parent_phase = _current_phase;
   _current_phase = phase;
   _start = os::elapsedTime();
+  _should_aggregate_cycles = should_aggregate_cycles;
+  log_info(gc, phases, start) ("Started phase : %s", ShenandoahPhaseTimings::phase_name_without_leading_whitespace(_phase));
 }
 
 ShenandoahTimingsTracker::~ShenandoahTimingsTracker() {
-  _timings->record_phase_time(_phase, os::elapsedTime() - _start);
+  double end_time = os::elapsedTime();
+  double phase_elapsed_time = end_time - _start;
+  _timings->record_phase_time(_phase, phase_elapsed_time, _should_aggregate_cycles);
+    log_info(gc, phases) ("Ended phase : %s. Elapsed time %f ms", ShenandoahPhaseTimings::phase_name_without_leading_whitespace(_phase), phase_elapsed_time * MILLIUNITS);
   _current_phase = _parent_phase;
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.cpp
@@ -111,11 +111,6 @@ ShenandoahConcurrentPhase::~ShenandoahConcurrentPhase() {
   _timer->register_gc_concurrent_end();
 }
 
-ShenandoahTimingsTracker::ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase) :
-  ShenandoahTimingsTracker(phase, false) {
-
-  }
-
 ShenandoahTimingsTracker::ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate_cycles) :
   _timings(ShenandoahHeap::heap()->phase_timings()), _phase(phase) {
   assert(Thread::current()->is_VM_thread() || Thread::current()->is_ConcurrentGC_thread(),
@@ -131,8 +126,8 @@ ShenandoahTimingsTracker::~ShenandoahTimingsTracker() {
   double end_time = os::elapsedTime();
   double phase_elapsed_time = end_time - _start;
   _timings->record_phase_time(_phase, phase_elapsed_time, _should_aggregate_cycles);
-    log_info(gc, phases) ("Ended phase : %s. Elapsed time %f ms", ShenandoahPhaseTimings::phase_name_without_leading_whitespace(_phase), phase_elapsed_time * MILLIUNITS);
   _current_phase = _parent_phase;
+  log_info(gc, phases) ("Ended phase : %s. Elapsed time %f ms", ShenandoahPhaseTimings::phase_name_without_leading_whitespace(_phase), phase_elapsed_time * MILLIUNITS);
 }
 
 bool ShenandoahTimingsTracker::is_current_phase_valid() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -66,9 +66,11 @@ private:
   const ShenandoahPhaseTimings::Phase   _phase;
   ShenandoahPhaseTimings::Phase         _parent_phase;
   double _start;
+  bool _should_aggregate_cycles;
 
 public:
   ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase);
+  ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate_cycles);
   ~ShenandoahTimingsTracker();
 
   static ShenandoahPhaseTimings::Phase current_phase() { return _current_phase; }

--- a/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUtils.hpp
@@ -69,8 +69,7 @@ private:
   bool _should_aggregate_cycles;
 
 public:
-  ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase);
-  ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate_cycles);
+  ShenandoahTimingsTracker(ShenandoahPhaseTimings::Phase phase, bool should_aggregate_cycles=false);
   ~ShenandoahTimingsTracker();
 
   static ShenandoahPhaseTimings::Phase current_phase() { return _current_phase; }


### PR DESCRIPTION
* Not to be reviewed * 

**GC stats**
```
11.078s][info][gc,stats       ] Concurrent Reset                  55119 us
[11.078s][info][gc,stats       ] Pause Init Mark (G)              124205 us
[11.078s][info][gc,stats       ] Pause Init Mark (N)              119850 us
[11.078s][info][gc,stats       ]   Update Region States              244 us
[11.078s][info][gc,stats       ] Concurrent Mark Roots              9838 us, parallelism: 11.44x
[11.078s][info][gc,stats       ]   CMR: <total>                   112503 us
[11.078s][info][gc,stats       ]   CMR: Thread Roots              111175 us, workers (us): 9484, 9272, 9549, 9305, 9458, 9094, 9453, 9309, 8511, 9321, 9270, 9149, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.078s][info][gc,stats       ]   CMR: VM Strong Roots              449 us, workers (us):  60,  61,  48,  44,  38,  35,  38,  30,  27,  25,  22,  21, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.078s][info][gc,stats       ]   CMR: CLDG Roots                   880 us, workers (us): ---, ---, ---, ---, ---,   4, ---,   4, 860,   3,   4,   4, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.078s][info][gc,stats       ] Concurrent Marking                 5432 us
[11.078s][info][gc,stats       ]   SATB Flush Rendezvous            1971 us
[11.078s][info][gc,stats       ] Pause Final Mark (G)              31392 us
[11.078s][info][gc,stats       ] Pause Final Mark (N)              31105 us
[11.078s][info][gc,stats       ]   Finish Mark                       357 us
[11.078s][info][gc,stats       ]   Update Region States              118 us
[11.078s][info][gc,stats       ]   Choose Collection Set           30416 us
[11.078s][info][gc,stats       ]   Rebuild Free Set                   75 us
[11.078s][info][gc,stats       ] Concurrent Weak References          160 us, parallelism: 0.11x
[11.078s][info][gc,stats       ]   CWRF: <total>                      18 us
[11.079s][info][gc,stats       ]   CWRF: Weak References              18 us, workers (us):  14,   2,   0,   0,   0,   0,   0,   1,   0,   0,   0,   0, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.079s][info][gc,stats       ] Concurrent Weak Roots              1570 us
[11.079s][info][gc,stats       ]   Roots                             499 us, parallelism: 4.40x
[11.079s][info][gc,stats       ]     CWR: <total>                   2195 us
[11.079s][info][gc,stats       ]     CWR: Code Cache Roots          1240 us, workers (us):   0,  90, 177,   1,   1, 180, 212,   1, 169, 243,   1, 165, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.079s][info][gc,stats       ]     CWR: VM Weak Roots              862 us, workers (us): 127, 106, 105,  86,  73,  71,  71,  54,  52,  59,  36,  23, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.079s][info][gc,stats       ]     CWR: CLDG Roots                  93 us, workers (us):  14,   8, ---,  11,  22, ---, ---,  22, ---, ---,  16, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.079s][info][gc,stats       ]   Rendezvous                        987 us
```

**Logging**
```
[10.257s][info][gc,phases,start] GC(1) Started phase : SATB Flush Rendezvous
[10.258s][info][gc,phases      ] GC(1) Ended phase : SATB Flush Rendezvous. Elapsed time 1.581811 ms
[10.258s][info][gc,phases,start] GC(1) Started phase : SATB Flush Rendezvous
[10.259s][info][gc,phases      ] GC(1) Ended phase : SATB Flush Rendezvous. Elapsed time 0.389443 ms
```

```
[11.077s][info][gc,phases,start] GC(1) Started phase : Rendezvous
[11.078s][info][gc,phases      ] GC(1) Ended phase : Rendezvous. Elapsed time 0.869589 ms
[11.078s][info][gc,phases,start] GC(1) Started phase : Purge Unlinked
[11.078s][info][gc,phases,start] GC(1) Started phase : Code Roots
[11.078s][info][gc,phases      ] GC(1) Ended phase : Code Roots. Elapsed time 0.025291 ms
[11.078s][info][gc,phases,start] GC(1) Started phase : CLDG
[11.078s][info][gc,phases      ] GC(1) Ended phase : CLDG. Elapsed time 0.012031 ms
[11.078s][info][gc,phases,start] GC(1) Started phase : Exception Caches
[11.078s][info][gc,phases      ] GC(1) Ended phase : Exception Caches. Elapsed time 0.003750 ms
[11.078s][info][gc,phases      ] GC(1) Ended phase : Purge Unlinked. Elapsed time 0.067904 ms
```

**GC Statistics**
```
[11.078s][info][gc,stats       ] Concurrent Reset                  55119 us
[11.078s][info][gc,stats       ] Pause Init Mark (G)              124205 us
[11.078s][info][gc,stats       ] Pause Init Mark (N)              119850 us
[11.078s][info][gc,stats       ]   Update Region States              244 us
[11.078s][info][gc,stats       ] Concurrent Mark Roots              9838 us, parallelism: 11.44x
[11.078s][info][gc,stats       ]   CMR: <total>                   112503 us
[11.078s][info][gc,stats       ]   CMR: Thread Roots              111175 us, workers (us): 9484, 9272, 9549, 9305, 9458, 9094, 9453, 9309, 8511, 9321, 9270, 9149, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.078s][info][gc,stats       ]   CMR: VM Strong Roots              449 us, workers (us):  60,  61,  48,  44,  38,  35,  38,  30,  27,  25,  22,  21, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.078s][info][gc,stats       ]   CMR: CLDG Roots                   880 us, workers (us): ---, ---, ---, ---, ---,   4, ---,   4, 860,   3,   4,   4, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.078s][info][gc,stats       ] Concurrent Marking                 5432 us
[11.078s][info][gc,stats       ]   SATB Flush Rendezvous            1971 us
[11.078s][info][gc,stats       ] Pause Final Mark (G)              31392 us
[11.078s][info][gc,stats       ] Pause Final Mark (N)              31105 us
[11.078s][info][gc,stats       ]   Finish Mark                       357 us
[11.078s][info][gc,stats       ]   Update Region States              118 us
[11.078s][info][gc,stats       ]   Choose Collection Set           30416 us
[11.078s][info][gc,stats       ]   Rebuild Free Set                   75 us
[11.078s][info][gc,stats       ] Concurrent Weak References          160 us, parallelism: 0.11x
[11.078s][info][gc,stats       ]   CWRF: <total>                      18 us
[11.079s][info][gc,stats       ]   CWRF: Weak References              18 us, workers (us):  14,   2,   0,   0,   0,   0,   0,   1,   0,   0,   0,   0, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.079s][info][gc,stats       ] Concurrent Weak Roots              1570 us
[11.079s][info][gc,stats       ]   Roots                             499 us, parallelism: 4.40x
[11.079s][info][gc,stats       ]     CWR: <total>                   2195 us
[11.079s][info][gc,stats       ]     CWR: Code Cache Roots          1240 us, workers (us):   0,  90, 177,   1,   1, 180, 212,   1, 169, 243,   1, 165, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.079s][info][gc,stats       ]     CWR: VM Weak Roots              862 us, workers (us): 127, 106, 105,  86,  73,  71,  71,  54,  52,  59,  36,  23, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.079s][info][gc,stats       ]     CWR: CLDG Roots                  93 us, workers (us):  14,   8, ---,  11,  22, ---, ---,  22, ---, ---,  16, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, ---, 
[11.079s][info][gc,stats       ]   Rendezvous                        987 us
[11.079s][info][gc,stats       ] 
[11.079s][info][gc,stats       ] Allocation pacing accrued:
[11.079s][info][gc,stats       ]      11 of  1758 ms (  0.6%): main
[11.079s][info][gc,stats       ]      11 of  1758 ms (  0.6%): <total>
[11.079s][info][gc,stats       ]       0 of  1758 ms (  0.0%): <average total>
[11.079s][info][gc,stats       ]      11 of  1758 ms (  0.6%): <average non-zero>
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8336742](https://bugs.openjdk.org/browse/JDK-8336742)

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8336742: test`

### Issue
 * [JDK-8336742](https://bugs.openjdk.org/browse/JDK-8336742): Shenandoah: Add more verbose logging/stats for mark termination attempts (**Enhancement** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20433/head:pull/20433` \
`$ git checkout pull/20433`

Update a local copy of the PR: \
`$ git checkout pull/20433` \
`$ git pull https://git.openjdk.org/jdk.git pull/20433/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20433`

View PR using the GUI difftool: \
`$ git pr show -t 20433`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20433.diff">https://git.openjdk.org/jdk/pull/20433.diff</a>

</details>
