### PR TITLE
8337721: G1: Remove unused G1CollectedHeap::young_collection_verify_type

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2336,16 +2336,6 @@ void G1CollectedHeap::start_new_collection_set() {
   _cm->verify_no_collection_set_oops();
 }
 
-G1HeapVerifier::G1VerifyType G1CollectedHeap::young_collection_verify_type() const {
-  if (collector_state()->in_concurrent_start_gc()) {
-    return G1HeapVerifier::G1VerifyConcurrentStart;
-  } else if (collector_state()->in_young_only_phase()) {
-    return G1HeapVerifier::G1VerifyYoungNormal;
-  } else {
-    return G1HeapVerifier::G1VerifyMixed;
-  }
-}
-
 void G1CollectedHeap::verify_before_young_collection(G1HeapVerifier::G1VerifyType type) {
   if (!VerifyBeforeGC) {
     return;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -752,7 +752,6 @@ private:
   // of the incremental collection pause, executed by the vm thread.
   void do_collection_pause_at_safepoint_helper();
 
-  G1HeapVerifier::G1VerifyType young_collection_verify_type() const;
   void verify_before_young_collection(G1HeapVerifier::G1VerifyType type);
   void verify_after_young_collection(G1HeapVerifier::G1VerifyType type);
 


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337721](https://bugs.openjdk.org/browse/JDK-8337721): G1: Remove unused G1CollectedHeap::young_collection_verify_type (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20438/head:pull/20438` \
`$ git checkout pull/20438`

Update a local copy of the PR: \
`$ git checkout pull/20438` \
`$ git pull https://git.openjdk.org/jdk.git pull/20438/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20438`

View PR using the GUI difftool: \
`$ git pr show -t 20438`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20438.diff">https://git.openjdk.org/jdk/pull/20438.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20438#issuecomment-2264688922)