### PR TITLE
8337712: Wrong javadoc in java.util.Date#toString(): "61" and right parenthesis

### DIFF
--- a/src/java.base/share/classes/java/util/Date.java
+++ b/src/java.base/share/classes/java/util/Date.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/Date.java
+++ b/src/java.base/share/classes/java/util/Date.java
@@ -1012,7 +1012,7 @@ public class Date
      * <li>{@code mm} is the minute within the hour ({@code 00} through
      *     {@code 59}), as two decimal digits.
      * <li>{@code ss} is the second within the minute ({@code 00} through
-     *     {@code 61}, as two decimal digits.
+     *     {@code 61}), as two decimal digits.
      * <li>{@code zzz} is the time zone (and may reflect daylight saving
      *     time). Standard time zone abbreviations include those
      *     recognized by the method {@code parse}. If time zone


### PR DESCRIPTION
This trivial PR proposes to add a missing parenthesis in `java.util.Date::toString`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337712](https://bugs.openjdk.org/browse/JDK-8337712): Wrong javadoc in java.util.Date#toString(): "61" and right parenthesis (**Bug** - P4)


### Reviewers
 * [Raffaello Giulietti](https://openjdk.org/census#rgiulietti) (@rgiulietti - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20439/head:pull/20439` \
`$ git checkout pull/20439`

Update a local copy of the PR: \
`$ git checkout pull/20439` \
`$ git pull https://git.openjdk.org/jdk.git pull/20439/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20439`

View PR using the GUI difftool: \
`$ git pr show -t 20439`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20439.diff">https://git.openjdk.org/jdk/pull/20439.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20439#issuecomment-2264747537)