### PR TITLE
8337720: Test com/sun/jndi/dns/ConfigTests/Timeout.java fails with C1 mode by fastdebug binary

### DIFF
--- a/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
+++ b/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
+++ b/test/jdk/com/sun/jndi/dns/ConfigTests/Timeout.java
@@ -40,6 +40,7 @@ import jdk.test.lib.net.URIBuilder;
  *          number of retries.
  * @library ../lib/ /test/lib
  * @modules java.base/sun.security.util
+ * @requires vm.debug != true & vm.compiler2.enabled
  * @run main Timeout
  */
 
@@ -113,7 +114,7 @@ public class Timeout extends DNSTestBase {
             }
             throw new RuntimeException(
                     "Failed: timeout in " + elapsedTime.toMillis()
-                            + " ms, expected" + expectedTime.toMillis() + "ms");
+                            + "ms, expected " + expectedTime.toMillis() + "ms");
         }
 
         return super.handleException(e);


### PR DESCRIPTION
Hi all,
The test `com/sun/jndi/dns/ConfigTests/Timeout.java` fails with `-Xcomp -XX:TieredStopAtLevel=1` jvm options by fastdebug binary. In C1 mode and with debug binary, the JIT comple time longger than -Xmixed  and release binary is accatable. So this should not report fails with `-Xcomp -XX:TieredStopAtLevel=1` jvm options by fastdebug binary.
Thus, this test should be skip when run with `-Xcomp -XX:TieredStopAtLevel=1` jvm options by fastdebug binary.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Issue
 * [JDK-8337720](https://bugs.openjdk.org/browse/JDK-8337720): Test com/sun/jndi/dns/ConfigTests/Timeout.java fails with C1 mode by fastdebug binary (**Bug** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20440/head:pull/20440` \
`$ git checkout pull/20440`

Update a local copy of the PR: \
`$ git checkout pull/20440` \
`$ git pull https://git.openjdk.org/jdk.git pull/20440/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20440`

View PR using the GUI difftool: \
`$ git pr show -t 20440`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20440.diff">https://git.openjdk.org/jdk/pull/20440.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20440#issuecomment-2264850453)
</details>
