### PR TITLE
8328553: Get rid of JApplet in test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java

### DIFF
--- a/test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java
+++ b/test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java
@@ -31,7 +31,6 @@ import java.net.URL;
 import javax.swing.BoxLayout;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
-import javax.swing.JApplet;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.UIManager;

--- a/test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java
+++ b/test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java
@@ -214,3 +214,4 @@ public class DemoModule extends JPanel {
 
     void updateDragEnabled(boolean dragEnabled) {}
 }
+

--- a/test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java
+++ b/test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,10 +42,8 @@ import javax.swing.border.SoftBevelBorder;
 
 /**
  * A generic SwingSet2 demo module
- *
- * @author Jeff Dinkins
  */
-public class DemoModule extends JApplet {
+public class DemoModule extends JPanel {
 
     // The preferred size of the demo
     private int PREFERRED_WIDTH = 680;
@@ -212,11 +210,6 @@ public class DemoModule extends JApplet {
     public static void main(String[] args) {
         DemoModule demo = new DemoModule(null);
         demo.mainImpl();
-    }
-
-    public void init() {
-        getContentPane().setLayout(new BorderLayout());
-        getContentPane().add(getDemoPanel(), BorderLayout.CENTER);
     }
 
     void updateDragEnabled(boolean dragEnabled) {}


### PR DESCRIPTION
1) Replaced JApplet with JPanel 
2) Tests passed before and after fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328553](https://bugs.openjdk.org/browse/JDK-8328553): Get rid of JApplet in test/jdk/sanity/client/lib/SwingSet2/src/DemoModule.java (**Bug** - P3)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20450/head:pull/20450` \
`$ git checkout pull/20450`

Update a local copy of the PR: \
`$ git checkout pull/20450` \
`$ git pull https://git.openjdk.org/jdk.git pull/20450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20450`

View PR using the GUI difftool: \
`$ git pr show -t 20450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20450.diff">https://git.openjdk.org/jdk/pull/20450.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20450#issuecomment-2267091350)