### PR TITLE
8337716: ByteBuffer hashCode implementations are inconsistent

### DIFF
--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -29,7 +29,6 @@ package java.nio;
 
 import java.lang.foreign.MemorySegment;
 import java.util.Objects;
-import jdk.internal.util.ArraysSupport;
 
 /**
 #if[rw]
@@ -706,9 +705,6 @@ class Heap$Type$Buffer$RW$
                                                                    addr, segment)));
     }
 
-    public int hashCode() {
-        return ArraysSupport.hashCode(hb, ix(position()), remaining(), 1);
-    }
 
 #end[byte]
 
@@ -737,9 +733,6 @@ class Heap$Type$Buffer$RW$
                                       offset, segment);
     }
 
-    public int hashCode() {
-        return ArraysSupport.hashCode(hb, ix(position()), remaining(), 1);
-    }
 #end[char]
 
 

--- a/test/jdk/java/nio/Buffer/EqualsCompareTest.java
+++ b/test/jdk/java/nio/Buffer/EqualsCompareTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -36,12 +37,20 @@ import java.nio.DoubleBuffer;
 import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
+import java.nio.MappedByteBuffer;
 import java.nio.ShortBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.LongFunction;
 import java.util.stream.IntStream;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /*
  * @test
@@ -711,6 +720,21 @@ public class EqualsCompareTest {
                 return IntStream.of(from, from + 1, from + 2, to / 2 - 1, to / 2, to / 2 + 1, to - 2, to - 1, to)
                         .filter(i -> i >= from && i <= to)
                         .distinct().toArray();
+        }
+    }
+
+    @Test
+    void testHashCode() throws IOException {
+        byte[] bytes = "hello world".getBytes(UTF_8);
+        Path path = Files.createTempFile("", "");
+        Files.write(path, bytes);
+        try (FileChannel fc = FileChannel.open(path, StandardOpenOption.READ,
+            StandardOpenOption.DELETE_ON_CLOSE)) {
+            MappedByteBuffer one =
+                fc.map(FileChannel.MapMode.READ_ONLY, 0, bytes.length);
+            ByteBuffer two = ByteBuffer.wrap(bytes);
+            Assert.assertEquals(one, two);
+            Assert.assertEquals(one.hashCode(), two.hashCode());
         }
     }
 }

--- a/test/jdk/java/nio/Buffer/EqualsCompareTest.java
+++ b/test/jdk/java/nio/Buffer/EqualsCompareTest.java
@@ -42,7 +42,6 @@ import java.nio.ShortBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -51,6 +50,7 @@ import java.util.function.LongFunction;
 import java.util.stream.IntStream;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardOpenOption.*;
 
 /*
  * @test
@@ -728,10 +728,8 @@ public class EqualsCompareTest {
         byte[] bytes = "hello world".getBytes(UTF_8);
         Path path = Files.createTempFile("", "");
         Files.write(path, bytes);
-        try (FileChannel fc = FileChannel.open(path, StandardOpenOption.READ,
-            StandardOpenOption.DELETE_ON_CLOSE)) {
-            MappedByteBuffer one =
-                fc.map(FileChannel.MapMode.READ_ONLY, 0, bytes.length);
+        try (FileChannel fc = FileChannel.open(path, READ, DELETE_ON_CLOSE)) {
+            MappedByteBuffer one = fc.map(FileChannel.MapMode.READ_ONLY, 0, bytes.length);
             ByteBuffer two = ByteBuffer.wrap(bytes);
             Assert.assertEquals(one, two);
             Assert.assertEquals(one.hashCode(), two.hashCode());

--- a/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -922,10 +922,5 @@ public class ByteBuffers {
             r += directByteBuffer.getDouble(i);
         }
         return r;
-    }
-
-    @Benchmark
-    public int testHeapHashCode() {
-        return heapByteBuffer.hashCode();
     }
 }


### PR DESCRIPTION
Revert the changes made in #16992 and add some test coverage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337716](https://bugs.openjdk.org/browse/JDK-8337716): ByteBuffer hashCode implementations are inconsistent (**Bug** - P2)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20451/head:pull/20451` \
`$ git checkout pull/20451`

Update a local copy of the PR: \
`$ git checkout pull/20451` \
`$ git pull https://git.openjdk.org/jdk.git pull/20451/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20451`

View PR using the GUI difftool: \
`$ git pr show -t 20451`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20451.diff">https://git.openjdk.org/jdk/pull/20451.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20451#issuecomment-2267106268)