### PR TITLE
8337787: Fix -Wzero-as-null-pointer-constant warnings when JVMTI feature is disabled

### DIFF
--- a/src/hotspot/share/prims/jvmtiExport.hpp
+++ b/src/hotspot/share/prims/jvmtiExport.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -287,10 +287,10 @@ class JvmtiExport : public AllStatic {
   }
 
   // field access management
-  static address  get_field_access_count_addr() NOT_JVMTI_RETURN_(0);
+  static address  get_field_access_count_addr() NOT_JVMTI_RETURN_(nullptr);
 
   // field modification management
-  static address  get_field_modification_count_addr() NOT_JVMTI_RETURN_(0);
+  static address  get_field_modification_count_addr() NOT_JVMTI_RETURN_(nullptr);
 
   // -----------------
 


### PR DESCRIPTION
Please review this trivial change that replaces some uses of literal 0 as a
null pointer constant when JVMTI is disabled to instead use nullptr.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337787](https://bugs.openjdk.org/browse/JDK-8337787): Fix -Wzero-as-null-pointer-constant warnings when JVMTI feature is disabled (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20455/head:pull/20455` \
`$ git checkout pull/20455`

Update a local copy of the PR: \
`$ git checkout pull/20455` \
`$ git pull https://git.openjdk.org/jdk.git pull/20455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20455`

View PR using the GUI difftool: \
`$ git pr show -t 20455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20455.diff">https://git.openjdk.org/jdk/pull/20455.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20455#issuecomment-2267200322)