### PR TITLE
8337788: RISC-V: Cleanup code in MacroAssembler::reserved_stack_check

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -4130,29 +4130,25 @@ void MacroAssembler::remove_frame(int framesize) {
 }
 
 void MacroAssembler::reserved_stack_check() {
-    // testing if reserved zone needs to be enabled
-    Label no_reserved_zone_enabling;
+  // testing if reserved zone needs to be enabled
+  Label no_reserved_zone_enabling;
 
-    ld(t0, Address(xthread, JavaThread::reserved_stack_activation_offset()));
-    bltu(sp, t0, no_reserved_zone_enabling);
+  ld(t0, Address(xthread, JavaThread::reserved_stack_activation_offset()));
+  bltu(sp, t0, no_reserved_zone_enabling);
 
-    enter();   // RA and FP are live.
-    mv(c_rarg0, xthread);
-    rt_call(CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone));
-    leave();
+  enter();   // RA and FP are live.
+  mv(c_rarg0, xthread);
+  rt_call(CAST_FROM_FN_PTR(address, SharedRuntime::enable_stack_reserved_zone));
+  leave();
 
-    // We have already removed our own frame.
-    // throw_delayed_StackOverflowError will think that it's been
-    // called by our caller.
-    RuntimeAddress target(StubRoutines::throw_delayed_StackOverflowError_entry());
-    relocate(target.rspec(), [&] {
-      int32_t offset;
-      movptr(t0, target.target(), offset);
-      jr(t0, offset);
-    });
-    should_not_reach_here();
+  // We have already removed our own frame.
+  // throw_delayed_StackOverflowError will think that it's been
+  // called by our caller.
+  la(t0, RuntimeAddress(StubRoutines::throw_delayed_StackOverflowError_entry()));
+  jr(t0);
+  should_not_reach_here();
 
-    bind(no_reserved_zone_enabling);
+  bind(no_reserved_zone_enabling);
 }
 
 // Move the address of the polling page into dest.


### PR DESCRIPTION
Hi, 
In the MacroAssembler::reserved_stack_check() function:
```
    RuntimeAddress target(StubRoutines::throw_delayed_StackOverflowError_entry());
    relocate(target.rspec(), [&] {
      int32_t offset;
      movptr(t0, target.target(), offset);
      jr(t0, offset);
    });
```
can be simplified to:
```
  la(t0, RuntimeAddress(StubRoutines::throw_delayed_StackOverflowError_entry()));
  jr(t0);
```

In addition, the code formatting has been modified to remove the extra spaces before the code.

Please take a look and have some reviews. Thanks a lot.

### Testing
- [x] Run tier1-3 tests on SOPHON SG2042 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337788](https://bugs.openjdk.org/browse/JDK-8337788): RISC-V: Cleanup code in MacroAssembler::reserved_stack_check (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20458/head:pull/20458` \
`$ git checkout pull/20458`

Update a local copy of the PR: \
`$ git checkout pull/20458` \
`$ git pull https://git.openjdk.org/jdk.git pull/20458/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20458`

View PR using the GUI difftool: \
`$ git pr show -t 20458`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20458.diff">https://git.openjdk.org/jdk/pull/20458.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20458#issuecomment-2267264007)