### PR TITLE
8337779: test/jdk/jdk/jfr/jvm/TestHiddenWait.java is a bit fragile

### DIFF
--- a/test/jdk/jdk/jfr/jvm/TestHiddenWait.java
+++ b/test/jdk/jdk/jfr/jvm/TestHiddenWait.java
@@ -77,6 +77,15 @@ public class TestHiddenWait {
                 s.start();
             }
             List<RecordedEvent> events = Events.fromRecording(r);
+            // Only keep events from the test thread and the JFR threads
+            String testThread = Thread.currentThread().getName();
+            events.removeIf(event -> {
+               String threadName = event.getThread().getJavaName();
+               if (threadName.equals(testThread) || threadName.contains("JFR")) {
+                   return false;
+               }
+               return true;
+            });
             for (RecordedEvent event : events) {
                 if (!event.getEventType().getName().equals(PERIODIC_EVENT_NAME)) {
                     System.out.println(event);


### PR DESCRIPTION
Could I have a review of a test fix that allows for other threads than the test or JFR threads to emit events during the test, i.e. events from the "Common-Cleaner" thread.

Testing: jdk/jdk/jfr/jvm/TestHiddenWait.java

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337779](https://bugs.openjdk.org/browse/JDK-8337779): test/jdk/jdk/jfr/jvm/TestHiddenWait.java is a bit fragile (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20459/head:pull/20459` \
`$ git checkout pull/20459`

Update a local copy of the PR: \
`$ git checkout pull/20459` \
`$ git pull https://git.openjdk.org/jdk.git pull/20459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20459`

View PR using the GUI difftool: \
`$ git pr show -t 20459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20459.diff">https://git.openjdk.org/jdk/pull/20459.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20459#issuecomment-2267516365)