### PR TITLE
8337716: ByteBuffer hashCode implementations are inconsistent

### DIFF
--- a/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Heap-X-Buffer.java.template
@@ -29,7 +29,6 @@ package java.nio;
 
 import java.lang.foreign.MemorySegment;
 import java.util.Objects;
-import jdk.internal.util.ArraysSupport;
 
 /**
 #if[rw]
@@ -706,9 +705,6 @@ class Heap$Type$Buffer$RW$
                                                                    addr, segment)));
     }
 
-    public int hashCode() {
-        return ArraysSupport.hashCode(hb, ix(position()), remaining(), 1);
-    }
 
 #end[byte]
 
@@ -737,9 +733,6 @@ class Heap$Type$Buffer$RW$
                                       offset, segment);
     }
 
-    public int hashCode() {
-        return ArraysSupport.hashCode(hb, ix(position()), remaining(), 1);
-    }
 #end[char]
 
 

--- a/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
+++ b/test/micro/org/openjdk/bench/java/nio/ByteBuffers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -922,10 +922,5 @@ public class ByteBuffers {
             r += directByteBuffer.getDouble(i);
         }
         return r;
-    }
-
-    @Benchmark
-    public int testHeapHashCode() {
-        return heapByteBuffer.hashCode();
     }
 }


### PR DESCRIPTION
Backport to JDK 23 of JDK 24 ```8337716: ByteBuffer hashCode implementations are inconsistent```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337716](https://bugs.openjdk.org/browse/JDK-8337716): ByteBuffer hashCode implementations are inconsistent (**Bug** - P2)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20461/head:pull/20461` \
`$ git checkout pull/20461`

Update a local copy of the PR: \
`$ git checkout pull/20461` \
`$ git pull https://git.openjdk.org/jdk.git pull/20461/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20461`

View PR using the GUI difftool: \
`$ git pr show -t 20461`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20461.diff">https://git.openjdk.org/jdk/pull/20461.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20461#issuecomment-2268331683)