### PR TITLE
8337810: ProblemList BasicDirectoryModel/LoaderThreadCount.java on Windows

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -640,6 +640,7 @@ javax/sound/sampled/Clip/ClipFlushCrash.java 8308395 linux-x64
 # jdk_swing
 
 javax/swing/plaf/basic/BasicTextUI/8001470/bug8001470.java 8233177 linux-all,windows-all
+javax/swing/plaf/basic/BasicDirectoryModel/LoaderThreadCount.java 8333880 windows-all
 
 javax/swing/JFrame/MaximizeWindowTest.java 8321289 linux-all
 javax/swing/JWindow/ShapedAndTranslucentWindows/ShapedTranslucentPerPixelTranslucentGradient.java 8233582 linux-all


### PR DESCRIPTION
The test BasicDirectoryModel/LoaderThreadCount.java fails rather often in our CI on Windows, exclude it for now.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337810](https://bugs.openjdk.org/browse/JDK-8337810): ProblemList BasicDirectoryModel/LoaderThreadCount.java on Windows (**Sub-task** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20462/head:pull/20462` \
`$ git checkout pull/20462`

Update a local copy of the PR: \
`$ git checkout pull/20462` \
`$ git pull https://git.openjdk.org/jdk.git pull/20462/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20462`

View PR using the GUI difftool: \
`$ git pr show -t 20462`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20462.diff">https://git.openjdk.org/jdk/pull/20462.diff</a>

</details>
