### PR TITLE
8337798: JFR: Remove jdk/jfr/api/consumer/recordingstream/TestOnEvent.java from ProblemList.txt

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -743,7 +743,6 @@ jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc6
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
-jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64,linux-aarch64
 
 ############################################################################
 


### PR DESCRIPTION
Could I have a review of a change that removes a test from ProblemList.txt? We want to determine if the issue still exists, in which case more time needs to be spent fixing it.

The theory is that the EventProducer used in the test may provoke a chunk rotation under stress, which could lead to the parser getting stuck due to timing issues, fixed by JDK-8304732 / JDK-8334886:

Testing: I can't reproduce the failure after running the test more than 800 times on Linux (50% on aarch64 and 50% x86_64).

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337798](https://bugs.openjdk.org/browse/JDK-8337798): JFR: Remove jdk/jfr/api/consumer/recordingstream/TestOnEvent.java from ProblemList.txt (**Sub-task** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20463/head:pull/20463` \
`$ git checkout pull/20463`

Update a local copy of the PR: \
`$ git checkout pull/20463` \
`$ git pull https://git.openjdk.org/jdk.git pull/20463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20463`

View PR using the GUI difftool: \
`$ git pr show -t 20463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20463.diff">https://git.openjdk.org/jdk/pull/20463.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20463#issuecomment-2268826189)