### PR TITLE
8330191: Fix typo in precompiled.hpp

### DIFF
--- a/src/hotspot/share/precompiled/precompiled.hpp
+++ b/src/hotspot/share/precompiled/precompiled.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/precompiled/precompiled.hpp
+++ b/src/hotspot/share/precompiled/precompiled.hpp
@@ -29,7 +29,7 @@
 
 // These header files are included in at least 130 C++ files, as of
 // measurements made in November 2018. This list excludes files named
-// *.include.hpp, since including them decreased build performance.
+// *.inline.hpp, since including them decreased build performance.
 
 #include "classfile/classLoaderData.hpp"
 #include "classfile/javaClasses.hpp"


### PR DESCRIPTION
Hi all,

The file `precompiled.hpp` has a typo in it, which this PR fixes.

Please consider this PR, thank you!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330191](https://bugs.openjdk.org/browse/JDK-8330191): Fix typo in precompiled.hpp (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Sonia Zaldana Calles](https://openjdk.org/census#szaldana) (@SoniaZaldana - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20466/head:pull/20466` \
`$ git checkout pull/20466`

Update a local copy of the PR: \
`$ git checkout pull/20466` \
`$ git pull https://git.openjdk.org/jdk.git pull/20466/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20466`

View PR using the GUI difftool: \
`$ git pr show -t 20466`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20466.diff">https://git.openjdk.org/jdk/pull/20466.diff</a>

</details>
