### PR TITLE
8337826: Improve logging in OCSPTimeout and SimpleOCSPResponder to help diagnose JDK-8309754

### DIFF
--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
@@ -29,7 +29,7 @@
 
 /**
  * @test
- * @bug 8179502 8337826
+ * @bug 8179502
  * @summary Enhance OCSP, CRL and Certificate Fetch Timeouts
  * @modules java.base/sun.security.x509
  *          java.base/sun.security.provider.certpath

--- a/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
+++ b/test/jdk/java/security/cert/CertPathValidator/OCSP/OCSPTimeout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,24 +29,24 @@
 
 /**
  * @test
- * @bug 8179502
+ * @bug 8179502 8337826
  * @summary Enhance OCSP, CRL and Certificate Fetch Timeouts
  * @modules java.base/sun.security.x509
  *          java.base/sun.security.provider.certpath
  *          java.base/sun.security.util
  * @library ../../../../../java/security/testlibrary
  * @build CertificateBuilder SimpleOCSPServer
- * @run main/othervm OCSPTimeout 1000 true
- * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=5
- *      OCSPTimeout 1000 true
- * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=1
- *      OCSPTimeout 5000 false
- * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=1s
- *      OCSPTimeout 5000 false
- * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=1500ms
- *      OCSPTimeout 5000 false
- * @run main/othervm -Dcom.sun.security.ocsp.readtimeout=4500ms
- *      OCSPTimeout 1000 true
+ * @run main/othervm -Djava.security.debug=certpath OCSPTimeout 1000 true
+ * @run main/othervm -Djava.security.debug=certpath
+ *      -Dcom.sun.security.ocsp.readtimeout=5 OCSPTimeout 1000 true
+ * @run main/othervm -Djava.security.debug=certpath
+ *      -Dcom.sun.security.ocsp.readtimeout=1 OCSPTimeout 5000 false
+ * @run main/othervm -Djava.security.debug=certpath
+ *      -Dcom.sun.security.ocsp.readtimeout=1s OCSPTimeout 5000 false
+ * @run main/othervm -Djava.security.debug=certpath
+ *      -Dcom.sun.security.ocsp.readtimeout=1500ms OCSPTimeout 5000 false
+ * @run main/othervm -Djava.security.debug=certpath
+ *      -Dcom.sun.security.ocsp.readtimeout=4500ms OCSPTimeout 1000 true
  */
 
 import java.io.*;
@@ -82,62 +82,72 @@ public class OCSPTimeout {
     static SimpleOCSPServer rootOcsp;       // Root CA OCSP Responder
     static int rootOcspPort;                // Port number for root OCSP
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         int ocspTimeout = 15000;
         boolean expected = false;
 
         createPKI();
 
-        if (args[0] != null) {
-            ocspTimeout = Integer.parseInt(args[0]);
-        }
-        rootOcsp.setDelay(ocspTimeout);
-
-        expected = (args[1] != null && Boolean.parseBoolean(args[1]));
-        log("Test case expects to " + (expected ? "pass" : "fail"));
-
-        // validate chain
-        CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
-        PKIXRevocationChecker prc =
-                (PKIXRevocationChecker) cpv.getRevocationChecker();
-        prc.setOptions(EnumSet.of(NO_FALLBACK, SOFT_FAIL));
-        PKIXParameters params =
-                new PKIXParameters(Set.of(new TrustAnchor(rootCert, null)));
-        params.addCertPathChecker(prc);
-        CertificateFactory cf = CertificateFactory.getInstance("X.509");
-        CertPath cp = cf.generateCertPath(List.of(eeCert));
-        cpv.validate(cp, params);
-
-        // unwrap soft fail exceptions and check for SocketTimeoutException
-        List<CertPathValidatorException> softExc = prc.getSoftFailExceptions();
-        if (expected) {
-            if (softExc.size() > 0) {
-                throw new RuntimeException("Expected to pass, found " +
-                        softExc.size() + " soft fail exceptions");
+        try {
+            if (args[0] != null) {
+                ocspTimeout = Integer.parseInt(args[0]);
             }
-        } else {
-            // If we expect to fail the validation then there should be a
-            // SocketTimeoutException
-            boolean found = false;
-            for (CertPathValidatorException softFail : softExc) {
-                log("CPVE: " + softFail);
-                Throwable cause = softFail.getCause();
-                log("Cause: " + cause);
-                while (cause != null) {
-                    if (cause instanceof SocketTimeoutException) {
-                        found = true;
+            rootOcsp.setDelay(ocspTimeout);
+
+            expected = (args[1] != null && Boolean.parseBoolean(args[1]));
+            log("Test case expects to " + (expected ? "pass" : "fail"));
+
+            // validate chain
+            CertPathValidator cpv = CertPathValidator.getInstance("PKIX");
+            PKIXRevocationChecker prc =
+                    (PKIXRevocationChecker) cpv.getRevocationChecker();
+            prc.setOptions(EnumSet.of(NO_FALLBACK, SOFT_FAIL));
+            PKIXParameters params =
+                    new PKIXParameters(Set.of(new TrustAnchor(rootCert, null)));
+            params.addCertPathChecker(prc);
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            CertPath cp = cf.generateCertPath(List.of(eeCert));
+            cpv.validate(cp, params);
+
+            // unwrap soft fail exceptions and check for SocketTimeoutException
+            List<CertPathValidatorException> softExc = prc.getSoftFailExceptions();
+            if (expected) {
+                if (!softExc.isEmpty()) {
+                    log("Expected to pass, found " + softExc.size() +
+                            " soft fail exceptions");
+                    for (CertPathValidatorException cpve : softExc) {
+                        log("Exception: " + cpve);
+                    }
+                    throw new RuntimeException("Expected to pass, found " +
+                            softExc.size() + " soft fail exceptions");
+                }
+            } else {
+                // If we expect to fail the validation then there should be a
+                // SocketTimeoutException
+                boolean found = false;
+                for (CertPathValidatorException softFail : softExc) {
+                    log("CPVE: " + softFail);
+                    Throwable cause = softFail.getCause();
+                    log("Cause: " + cause);
+                    while (cause != null) {
+                        if (cause instanceof SocketTimeoutException) {
+                            found = true;
+                            break;
+                        }
+                        cause = cause.getCause();
+                    }
+                    if (found) {
                         break;
                     }
-                    cause = cause.getCause();
                 }
-                if (found) {
-                    break;
-                }
-            }
 
-            if (!found) {
-                throw new RuntimeException("SocketTimeoutException not thrown");
+                if (!found) {
+                    throw new RuntimeException("SocketTimeoutException not thrown");
+                }
             }
+        } finally {
+            rootOcsp.stop();
+            rootOcsp.shutdownNow();
         }
     }
 

--- a/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
+++ b/test/jdk/java/security/testlibrary/SimpleOCSPServer.java
@@ -572,8 +572,8 @@ public class SimpleOCSPServer {
      */
     private synchronized void log(String message) {
         if (logEnabled || debug != null) {
-            System.out.println("[" + Thread.currentThread().getName() + "]: " +
-                    message);
+            System.out.println("[" + Thread.currentThread().getName() + "][" +
+                    System.currentTimeMillis() + "]: " + message);
         }
     }
 
@@ -727,6 +727,7 @@ public class SimpleOCSPServer {
             // wait out the delay here before any other processing.
             try {
                 if (delayMsec > 0) {
+                    log("Delaying response for " + delayMsec + " milliseconds.");
                     Thread.sleep(delayMsec);
                 }
             } catch (InterruptedException ie) {
@@ -908,6 +909,13 @@ public class SimpleOCSPServer {
          */
         private LocalOcspRequest parseHttpOcspGet(String[] headerTokens,
                 InputStream inStream) throws IOException, CertificateException {
+            // Display the whole request
+            StringBuilder sb = new StringBuilder("OCSP GET REQUEST\n");
+            for (String hTok : headerTokens) {
+                sb.append(hTok).append("\n");
+            }
+            log(sb.toString());
+
             // Before we process the remainder of the GET URL, we should drain
             // the InputStream of any other header data.  We (for now) won't
             // use it, but will display the contents if logging is enabled.
@@ -999,6 +1007,10 @@ public class SimpleOCSPServer {
         private LocalOcspRequest(byte[] requestBytes) throws IOException,
                 CertificateException {
             Objects.requireNonNull(requestBytes, "Received null input");
+
+            // Display the DER encoding before parsing
+            log("Local OCSP Request Constructor, parsing bytes:\n" +
+                    dumpHexBytes(requestBytes));
 
             DerInputStream dis = new DerInputStream(requestBytes);
 


### PR DESCRIPTION
This proposed enhancement adds logging to the OCSPTimeout test, which is intermittently failing and difficult to reproduce.  The hope is that with extra logging enabled that additional clues as to the cause of these rare failures will become apparent.

JBS: https://bugs.openjdk.org/browse/JDK-8337826

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337826](https://bugs.openjdk.org/browse/JDK-8337826): Improve logging in OCSPTimeout and SimpleOCSPResponder to help diagnose JDK-8309754 (**Enhancement** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20471/head:pull/20471` \
`$ git checkout pull/20471`

Update a local copy of the PR: \
`$ git checkout pull/20471` \
`$ git pull https://git.openjdk.org/jdk.git pull/20471/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20471`

View PR using the GUI difftool: \
`$ git pr show -t 20471`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20471.diff">https://git.openjdk.org/jdk/pull/20471.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20471#issuecomment-2269726709)