### PR TITLE
8225209: jdk/jfr/event/compiler/TestCodeSweeper.java fails

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -738,7 +738,6 @@ jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-
 
 # jdk_jfr
 
-jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64


### PR DESCRIPTION
Could I have a review of a PR that prevents intermittent test failures?

The test has been changed to use a RecordingStream instead of a Recording. Before the change, the test failed 4 times out of 800 runs. After the change, no failures have been observed after 5000+ test runs.

One might think the reason the test succeeds is because provokeEvents() is called again if no event arrives in the stream. This is not the case. I have verified this by removing the call to provokeEvents() in the ProvocationEvent handler.

Another possible reason is that a flush happens every second, giving more time for the CodeCacheFull or CompilationFailure events to arrive compared to an immediate call to Recording::stop(). This is also not the case. Events in the stream are sorted by their end time, so CodeCacheFull or CompilationFailure must arrive before ProvocationEvent is committed. Otherwise, the stream would not close, and the test would timeout.

I don't know why it works, but the test seems stable now.

The bug was initially filed for a test timeout, but I have only seen events not arriving in the recording, so I updated the title. 


Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225209](https://bugs.openjdk.org/browse/JDK-8225209): jdk/jfr/event/compiler/TestCodeSweeper.java fails (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20473/head:pull/20473` \
`$ git checkout pull/20473`

Update a local copy of the PR: \
`$ git checkout pull/20473` \
`$ git pull https://git.openjdk.org/jdk.git pull/20473/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20473`

View PR using the GUI difftool: \
`$ git pr show -t 20473`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20473.diff">https://git.openjdk.org/jdk/pull/20473.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20473#issuecomment-2273335458)