### PR TITLE
8337603: Change in behavior with -Djava.locale.useOldISOCodes=true

### DIFF
--- a/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/LocaleResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +62,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import jdk.internal.util.StaticProperty;
 import sun.security.action.GetPropertyAction;
 import sun.util.resources.LocaleData;
 import sun.util.resources.OpenListResourceBundle;
@@ -289,6 +290,16 @@ public class LocaleResources {
     }
 
     public String getLocaleName(String key) {
+        // Get names for old ISO codes with new ISO code resources
+        if (StaticProperty.javaLocaleUseOldISOCodes().equalsIgnoreCase("true")) {
+            key = switch (key) {
+                case "iw" -> "he";
+                case "in" -> "id";
+                case "ji" -> "yi";
+                default -> key;
+            };
+        }
+
         Object localeName = null;
         String cacheKey = LOCALE_NAMES + key;
 

--- a/test/jdk/java/util/Locale/LocaleTest.java
+++ b/test/jdk/java/util/Locale/LocaleTest.java
@@ -20,12 +20,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-/**
+/*
  * @test
  * @bug 4052404 4052440 4084688 4092475 4101316 4105828 4107014 4107953 4110613
  * 4118587 4118595 4122371 4126371 4126880 4135316 4135752 4139504 4139940 4143951
  * 4147315 4147317 4147552 4335196 4778440 4940539 5010672 6475525 6544471 6627549
  * 6786276 7066203 7085757 8008577 8030696 8170840 8174269 8255086 8263202 8287868
+ * 8337603
  * @summary test Locales
  * @modules jdk.localedata
  * @run junit LocaleTest
@@ -84,9 +85,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.MissingResourceException;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
-
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
 public class LocaleTest {
@@ -732,6 +737,32 @@ test commented out pending API-change approval
             }
         }
 
+    }
+
+    /**
+     * @bug 8337603
+     */
+    static Stream<Arguments> changedISOCodes() {
+        var hebrew = "\u05e2\u05d1\u05e8\u05d9\u05ea";
+        var yiddish = "\u05d9\u05d9\u05b4\u05d3\u05d9\u05e9";
+        var indonesian = "Indonesia";
+
+        return Stream.of(
+            Arguments.of("he", hebrew),
+            Arguments.of("iw", hebrew),
+            Arguments.of("yi", yiddish),
+            Arguments.of("ji", yiddish),
+            Arguments.of("id", indonesian),
+            Arguments.of("in", indonesian)
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("changedISOCodes")
+    public void TestOldISOCodeLanguageName(String code, String expected) {
+        var loc = Locale.of(code);
+        assertEquals(expected,
+            loc.getDisplayName(loc),
+            "java.locale.useOldISOCodes=" + System.getProperty("java.locale.useOldISOCodes"));
     }
 
     /**


### PR DESCRIPTION
Fixing a regression caused by the removal of the legacy locale data. Legacy locale data happened to have resource bundle for "he" language (new ISO code) with the launguage name for "iw" (old ISO code). CLDR does not have it, thus the name fell back to English.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337603](https://bugs.openjdk.org/browse/JDK-8337603): Change in behavior with -Djava.locale.useOldISOCodes=true (**Bug** - P3)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20474/head:pull/20474` \
`$ git checkout pull/20474`

Update a local copy of the PR: \
`$ git checkout pull/20474` \
`$ git pull https://git.openjdk.org/jdk.git pull/20474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20474`

View PR using the GUI difftool: \
`$ git pr show -t 20474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20474.diff">https://git.openjdk.org/jdk/pull/20474.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20474#issuecomment-2270166701)