### PR TITLE
8337876: [IR Framework] Add support for IR tests with @Stable

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -157,7 +157,16 @@ The framework allows the use of additional compiler control annotations for help
 - [@ForceCompile](./ForceCompile.java)
 - [@ForceCompileClassInitializer](./ForceCompileClassInitializer.java)
 
-### 2.5 Framework Debug and Stress Flags
+### 2.5 IR Tests with `@Stable` annotation
+To run tests with `@Stable` annotations, one need to add the test classes to the boot classpath. This can easily be achieved by calling `TestFramework.addTestClassesToBootClassPath()` on the test framework object:
+```
+TestFramework testFramework = new TestFramework();
+testFramework
+        .addTestClassesToBootClassPath()
+        .start();
+```
+
+### 2.6 Framework Debug and Stress Flags
 The framework provides various stress and debug flags. They should mainly be used as JTreg VM and/or Javaoptions (apart from `VerifyIR`). The following (property) flags are supported:
 
 - `-DVerifyIR=false`: Explicitly disable IR verification. This is useful, for example, if some scenarios use VM flags that let `@IR` annotation rules fail and the user does not want to provide separate IR rules or add flag preconditions to the already existing IR rules.

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/README.md
@@ -157,8 +157,8 @@ The framework allows the use of additional compiler control annotations for help
 - [@ForceCompile](./ForceCompile.java)
 - [@ForceCompileClassInitializer](./ForceCompileClassInitializer.java)
 
-### 2.5 IR Tests with `@Stable` annotation
-To run tests with `@Stable` annotations, one need to add the test classes to the boot classpath. This can easily be achieved by calling `TestFramework.addTestClassesToBootClassPath()` on the test framework object:
+### 2.5 IR Tests with Privileged Classes
+To run tests in a privileged mode (e.g. when using `@Stable`, `@Contended`, `@ReservedStackAccess` etc.), one need to add the test classes to the boot classpath. This can easily be achieved by calling `TestFramework.addTestClassesToBootClassPath()` on the test framework object:
 ```
 TestFramework testFramework = new TestFramework();
 testFramework

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -326,7 +326,7 @@ public class TestFramework {
 
     /**
      * Add test classes to boot classpath. This adds all classes found on path {@link jdk.test.lib.Utils#TEST_CLASSES}
-     * to the boot classpath with "-Xbootclasspath/a". This is useful when trying to run tests with @Stable annotations.
+     * to the boot classpath with "-Xbootclasspath/a". This is useful when trying to run tests in a privileged mode.
      */
     public TestFramework addTestClassesToBootClassPath() {
         this.testClassesOnBootClassPath = true;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/TestFramework.java
@@ -172,6 +172,7 @@ public class TestFramework {
     private Set<Integer> scenarioIndices;
     private List<String> flags;
     private int defaultWarmup = -1;
+    private boolean testClassesOnBootClassPath;
 
     /*
      * Public interface methods
@@ -320,6 +321,15 @@ public class TestFramework {
             this.scenarios.add(scenario);
         }
         TestFormat.throwIfAnyFailures();
+        return this;
+    }
+
+    /**
+     * Add test classes to boot classpath. This adds all classes found on path {@link jdk.test.lib.Utils#TEST_CLASSES}
+     * to the boot classpath with "-Xbootclasspath/a". This is useful when trying to run tests with @Stable annotations.
+     */
+    public TestFramework addTestClassesToBootClassPath() {
+        this.testClassesOnBootClassPath = true;
         return this;
     }
 
@@ -744,7 +754,8 @@ public class TestFramework {
     }
 
     private void runTestVM(List<String> additionalFlags) {
-        TestVMProcess testVMProcess = new TestVMProcess(additionalFlags, testClass, helperClasses, defaultWarmup);
+        TestVMProcess testVMProcess = new TestVMProcess(additionalFlags, testClass, helperClasses, defaultWarmup,
+                                                        testClassesOnBootClassPath);
         if (shouldVerifyIR) {
             try {
                 TestClassParser testClassParser = new TestClassParser(testClass);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -37,6 +37,7 @@ import jdk.test.lib.process.ProcessTools;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * This class prepares, creates, and runs the "test" VM with verification of proper termination. The class also stores
@@ -97,14 +98,14 @@ public class TestVMProcess {
         // Need White Box access in test VM.
         String bootClassPath = "-Xbootclasspath/a:.";
         if (testClassesOnBootClassPath) {
-            // Add test classes themselves to boot classpath. This is required, for example, for IR tests with @Stable.
+            // Add test classes themselves to boot classpath to make them privileged.
             bootClassPath += ":" + Utils.TEST_CLASSES;
         }
         cmds.add(bootClassPath);
         cmds.add("-XX:+UnlockDiagnosticVMOptions");
         cmds.add("-XX:+WhiteBoxAPI");
-        // Ignore CompileThreshold and CompileCommand flags which have an impact on the profiling information.
-        List<String> jtregVMFlags = Arrays.stream(Utils.getTestJavaOpts()).filter(s -> !s.contains("CompileThreshold")).toList();
+        // Ignore CompileCommand flags which have an impact on the profiling information.
+        List<String> jtregVMFlags = Arrays.stream(Utils.getTestJavaOpts()).filter(s -> !s.contains("CompileThreshold")).collect(Collectors.toList());
         if (!PREFER_COMMAND_LINE_FLAGS) {
             cmds.addAll(jtregVMFlags);
         }

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -34,6 +34,7 @@ import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 
+import java.io.File;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -99,7 +100,7 @@ public class TestVMProcess {
         String bootClassPath = "-Xbootclasspath/a:.";
         if (testClassesOnBootClassPath) {
             // Add test classes themselves to boot classpath to make them privileged.
-            bootClassPath += ":" + Utils.TEST_CLASSES;
+            bootClassPath += File.pathSeparator + Utils.TEST_CLASSES;
         }
         cmds.add(bootClassPath);
         cmds.add("-XX:+UnlockDiagnosticVMOptions");

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPhaseIRMatching.java
@@ -66,7 +66,7 @@ public class TestPhaseIRMatching {
         List<String> noAdditionalFlags = new ArrayList<>();
         FlagVMProcess flagVMProcess = new FlagVMProcess(testClass, noAdditionalFlags);
         List<String> testVMFlags = flagVMProcess.getTestVMFlags();
-        TestVMProcess testVMProcess = new TestVMProcess(testVMFlags, testClass, null, -1);
+        TestVMProcess testVMProcess = new TestVMProcess(testVMFlags, testClass, null, -1, false);
         TestClassParser testClassParser = new TestClassParser(testClass);
         Matchable testClassMatchable = testClassParser.parse(testVMProcess.getHotspotPidFileName(),
                                                              testVMProcess.getIrEncoding());

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package ir_framework.tests;
+
+import compiler.lib.ir_framework.*;
+import compiler.lib.ir_framework.driver.irmatching.IRViolationException;
+
+import jdk.internal.vm.annotation.Stable;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @requires vm.flagless
+ * @summary Test that IR framework successfully adds test class to boot classpath in order to run in privileged mode.
+ * @modules java.base/jdk.internal.vm.annotation
+ * @library /test/lib /
+ * @run driver ir_framework.tests.TestPrivilegedMode
+ */
+
+public class TestPrivilegedMode {
+    static @Stable int iFld; // Treated as constant after first being set.
+
+    public static void main(String[] args) {
+        try {
+            TestFramework.run();
+            Asserts.fail("should not reach");
+        } catch (IRViolationException e) {
+            // Without adding test class to boot classpath, we fail to replace the field load by a constant.
+            Asserts.assertTrue(e.getExceptionInfo().contains("Matched forbidden node"));
+            Asserts.assertTrue(e.getExceptionInfo().contains("LoadI"));
+        }
+
+        // When adding the test class to the boot classpath, we can replace the field load by a constant.
+        new TestFramework().addTestClassesToBootClassPath().start();
+    }
+
+    @Test
+    @Arguments(setup = "setup")
+    @IR(failOn = IRNode.LOAD_I)
+    public int test() {
+        return iFld;
+    }
+
+    @Setup
+    public void setup() {
+        iFld = 34;
+    }
+}


### PR DESCRIPTION
It is currently not possible to write IR tests with `@Stable` annotations because one need to somehow add the IR test classes to the boot classpath. This patch provides support to write such IR tests. I've added a section to the README to provide guidance on how this can be done.

This is motivated by https://github.com/openjdk/jdk/pull/19635.

I've tested this patch by taking the current patch of https://github.com/openjdk/jdk/pull/19635, dropping the `RestrictStable` flag and modifying the tests to work with the new IR framework feature:
```
TestFramework testFramework = new TestFramework();
testFramework
        .addFlags("-XX:-TieredCompilation",
                  "-XX:+UseParallelGC")
        .addTestClassesToBootClassPath()
        .start();
```

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337876](https://bugs.openjdk.org/browse/JDK-8337876): [IR Framework] Add support for IR tests with @<!---->Stable (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20477/head:pull/20477` \
`$ git checkout pull/20477`

Update a local copy of the PR: \
`$ git checkout pull/20477` \
`$ git pull https://git.openjdk.org/jdk.git pull/20477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20477`

View PR using the GUI difftool: \
`$ git pr show -t 20477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20477.diff">https://git.openjdk.org/jdk/pull/20477.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20477#issuecomment-2271105119)