### PR TITLE
8337667: sun/tools/jcmd/TestJcmdPIDSubstitution.java is failing on mac and windows

### DIFF
--- a/test/jdk/sun/tools/jcmd/TestJcmdPIDSubstitution.java
+++ b/test/jdk/sun/tools/jcmd/TestJcmdPIDSubstitution.java
@@ -40,6 +40,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import jdk.test.lib.Platform;
+
 public class TestJcmdPIDSubstitution {
 
     private static final String FILENAME = "myfile%p";
@@ -47,8 +49,10 @@ public class TestJcmdPIDSubstitution {
     public static void main(String[] args) throws Exception {
         verifyOutputFilenames("Thread.dump_to_file", FILENAME);
         verifyOutputFilenames("GC.heap_dump", FILENAME);
-        verifyOutputFilenames("Compiler.perfmap", FILENAME);
-        verifyOutputFilenames("System.dump_map", "-F=%s".formatted(FILENAME));
+        if (Platform.isLinux()) {
+            verifyOutputFilenames("Compiler.perfmap", FILENAME);
+            verifyOutputFilenames("System.dump_map", "-F=%s".formatted(FILENAME));
+        }
     }
 
     private static void verifyOutputFilenames(String... args) throws Exception {


### PR DESCRIPTION
Limit testing `Compiler.perfmap` and `System.dump_map` to just linux because they are only supported on linux.

Tested by running just this one test on linux-x64-debug, linux-aarch64-debug, macosx-aarch64, macosx-x64-debug, and windows-x64-debug

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337667](https://bugs.openjdk.org/browse/JDK-8337667): sun/tools/jcmd/TestJcmdPIDSubstitution.java is failing on mac and windows (**Bug** - P2)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20480/head:pull/20480` \
`$ git checkout pull/20480`

Update a local copy of the PR: \
`$ git checkout pull/20480` \
`$ git pull https://git.openjdk.org/jdk.git pull/20480/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20480`

View PR using the GUI difftool: \
`$ git pr show -t 20480`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20480.diff">https://git.openjdk.org/jdk/pull/20480.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20480#issuecomment-2271959537)