### PR TITLE
8321140: Add comment to note difference in Metal's JButton margins

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
@@ -727,9 +727,8 @@ public abstract class BasicLookAndFeel extends LookAndFeel implements Serializab
             "Button.highlight", controlLtHighlight,
             "Button.border", buttonBorder,
             "Button.margin", new InsetsUIResource(2, 14, 2, 14),
-            // margin is (2, 14, 2, 14) which is vastly larger in horizontal
-            // values when compared to other default LookAndFeels that do not
-            // rely on these values
+            // The above margin has vastly larger horizontal values when
+            // compared to other look and feels that don't rely on these values
             "Button.textIconGap", 4,
             "Button.textShiftOffset", zero,
             "Button.focusInputMap", new UIDefaults.LazyInputMap(new Object[] {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLookAndFeel.java
@@ -727,6 +727,9 @@ public abstract class BasicLookAndFeel extends LookAndFeel implements Serializab
             "Button.highlight", controlLtHighlight,
             "Button.border", buttonBorder,
             "Button.margin", new InsetsUIResource(2, 14, 2, 14),
+            // margin is (2, 14, 2, 14) which is vastly larger in horizontal
+            // values when compared to other default LookAndFeels that do not
+            // rely on these values
             "Button.textIconGap", 4,
             "Button.textShiftOffset", zero,
             "Button.focusInputMap", new UIDefaults.LazyInputMap(new Object[] {

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,52 +25,27 @@
 
 package javax.swing.plaf.metal;
 
-import java.awt.Color;
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.Frame;
-import java.awt.Insets;
-import java.awt.Toolkit;
-import java.awt.Window;
+import java.awt.*;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.lang.ref.ReferenceQueue;
-import java.lang.ref.WeakReference;
-import java.security.AccessController;
-
-import javax.swing.ButtonModel;
-import javax.swing.DefaultButtonModel;
-import javax.swing.Icon;
-import javax.swing.ImageIcon;
-import javax.swing.JComponent;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.JRootPane;
-import javax.swing.JTextField;
-import javax.swing.JToggleButton;
-import javax.swing.LayoutStyle;
-import javax.swing.LookAndFeel;
-import javax.swing.SwingConstants;
-import javax.swing.SwingUtilities;
-import javax.swing.UIDefaults;
-import javax.swing.UIManager;
-import javax.swing.plaf.BorderUIResource;
-import javax.swing.plaf.ColorUIResource;
-import javax.swing.plaf.FontUIResource;
-import javax.swing.plaf.InsetsUIResource;
-import javax.swing.plaf.UIResource;
-import javax.swing.plaf.basic.BasicLookAndFeel;
+import javax.swing.plaf.*;
+import javax.swing.*;
+import javax.swing.plaf.basic.*;
 import javax.swing.text.DefaultEditorKit;
 
-import sun.awt.AppContext;
-import sun.awt.OSInfo;
-import sun.awt.SunToolkit;
+import java.awt.Color;
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+
+import java.security.AccessController;
+
+import sun.awt.*;
 import sun.security.action.GetPropertyAction;
 import sun.swing.DefaultLayoutStyle;
+import static javax.swing.UIDefaults.LazyValue;
+
 import sun.swing.SwingAccessor;
 import sun.swing.SwingUtilities2;
-
-import static javax.swing.UIDefaults.LazyValue;
 
 /**
  * The Java Look and Feel, otherwise known as Metal.
@@ -807,8 +782,6 @@ public class MetalLookAndFeel extends BasicLookAndFeel
                           "SPACE", "pressed",
                  "released SPACE", "released"
               }),
-            // margin is (2, 14, 2, 14) which is vastly larger in horizontal
-            // values when compared to other LookAndFeels
 
             "CheckBox.disabledText", inactiveControlTextColor,
             "Checkbox.select", controlShadow,

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,27 +25,52 @@
 
 package javax.swing.plaf.metal;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Toolkit;
+import java.awt.Window;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import javax.swing.plaf.*;
-import javax.swing.*;
-import javax.swing.plaf.basic.*;
-import javax.swing.text.DefaultEditorKit;
-
-import java.awt.Color;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-
 import java.security.AccessController;
 
-import sun.awt.*;
+import javax.swing.ButtonModel;
+import javax.swing.DefaultButtonModel;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JRootPane;
+import javax.swing.JTextField;
+import javax.swing.JToggleButton;
+import javax.swing.LayoutStyle;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.plaf.BorderUIResource;
+import javax.swing.plaf.ColorUIResource;
+import javax.swing.plaf.FontUIResource;
+import javax.swing.plaf.InsetsUIResource;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.basic.BasicLookAndFeel;
+import javax.swing.text.DefaultEditorKit;
+
+import sun.awt.AppContext;
+import sun.awt.OSInfo;
+import sun.awt.SunToolkit;
 import sun.security.action.GetPropertyAction;
 import sun.swing.DefaultLayoutStyle;
-import static javax.swing.UIDefaults.LazyValue;
-
 import sun.swing.SwingAccessor;
 import sun.swing.SwingUtilities2;
+
+import static javax.swing.UIDefaults.LazyValue;
 
 /**
  * The Java Look and Feel, otherwise known as Metal.
@@ -782,6 +807,8 @@ public class MetalLookAndFeel extends BasicLookAndFeel
                           "SPACE", "pressed",
                  "released SPACE", "released"
               }),
+            // margin is (2, 14, 2, 14) which is vastly larger in horizontal
+            // values when compared to other LookAndFeels
 
             "CheckBox.disabledText", inactiveControlTextColor,
             "Checkbox.select", controlShadow,

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -25,27 +25,52 @@
 
 package javax.swing.plaf.metal;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Frame;
+import java.awt.Insets;
+import java.awt.Toolkit;
+import java.awt.Window;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import javax.swing.plaf.*;
-import javax.swing.*;
-import javax.swing.plaf.basic.*;
-import javax.swing.text.DefaultEditorKit;
-
-import java.awt.Color;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-
 import java.security.AccessController;
 
-import sun.awt.*;
+import javax.swing.ButtonModel;
+import javax.swing.DefaultButtonModel;
+import javax.swing.Icon;
+import javax.swing.ImageIcon;
+import javax.swing.JComponent;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+import javax.swing.JRootPane;
+import javax.swing.JTextField;
+import javax.swing.JToggleButton;
+import javax.swing.LayoutStyle;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingConstants;
+import javax.swing.SwingUtilities;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.plaf.BorderUIResource;
+import javax.swing.plaf.ColorUIResource;
+import javax.swing.plaf.FontUIResource;
+import javax.swing.plaf.InsetsUIResource;
+import javax.swing.plaf.UIResource;
+import javax.swing.plaf.basic.BasicLookAndFeel;
+import javax.swing.text.DefaultEditorKit;
+
+import sun.awt.AppContext;
+import sun.awt.OSInfo;
+import sun.awt.SunToolkit;
 import sun.security.action.GetPropertyAction;
 import sun.swing.DefaultLayoutStyle;
-import static javax.swing.UIDefaults.LazyValue;
-
 import sun.swing.SwingAccessor;
 import sun.swing.SwingUtilities2;
+
+import static javax.swing.UIDefaults.LazyValue;
 
 /**
  * The Java Look and Feel, otherwise known as Metal.
@@ -782,6 +807,8 @@ public class MetalLookAndFeel extends BasicLookAndFeel
                           "SPACE", "pressed",
                  "released SPACE", "released"
               }),
+            // Button default margin is (2, 14, 2, 14), defined in
+            // BasicLookAndFeel via "Button.margin" UI property.
 
             "CheckBox.disabledText", inactiveControlTextColor,
             "Checkbox.select", controlShadow,


### PR DESCRIPTION
Previously in [JDK-8282772](https://bugs.openjdk.org/browse/JDK-8282772), there was a fix for JButtons with HTML content alignment for non-MacOS L&Fs. This fix was to make other L&Fs in line with the Aqua fix found in [JDK-8015854](https://bugs.openjdk.org/browse/JDK-8015854).

However, the non-MacOS L&F fix caused a regression and the details and original discussion can be found in [JDK-8318590](https://bugs.openjdk.org/browse/JDK-8318590). This non-MacOS L&F fix was backed out and the current behavior for JButtons with HTML content for these L&Fs was deemed to be correct as is.

Through discussion, a note about Metal's different margin values should be added somewhere for future reference. Metal's horizontal margins are 14 where other L&Fs are zero or some small value. This discrepancy is what caused the original issue to be filed. This change is to add a comment to `MetalLookAndFeel.java` since there is no exact spot where these values are set for the margin. It's been added where other Metal components (CheckBox, RadioButton, etc.) have comments on margins as well.

Here are some L&F values for reference/comparison:
```
Metal's margins: [top=2,left=14,bottom=2,right=14]
Aqua's margins: [top=0,left=2,bottom=0,right=2]
Motif's margins: [top=2,left=4,bottom=2,right=4]
Nimbus's margins: [top=0,left=0,bottom=0,right=0]
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321140](https://bugs.openjdk.org/browse/JDK-8321140): Add comment to note difference in Metal's JButton margins (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) 🔄 Re-review required (review applies to [a16b29be](https://git.openjdk.org/jdk/pull/20482/files/a16b29be54a4a53fc3fbe9ddd92e5fedc41e33f3))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20482/head:pull/20482` \
`$ git checkout pull/20482`

Update a local copy of the PR: \
`$ git checkout pull/20482` \
`$ git pull https://git.openjdk.org/jdk.git pull/20482/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20482`

View PR using the GUI difftool: \
`$ git pr show -t 20482`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20482.diff">https://git.openjdk.org/jdk/pull/20482.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20482#issuecomment-2272319269)