### PR TITLE
8337966: (fs) Files.readAttributes fails with Operation not permitted on older docker releases

### DIFF
--- a/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
+++ b/src/java.base/linux/native/libnio/ch/FileDispatcherImpl.c
@@ -71,6 +71,8 @@ Java_sun_nio_ch_FileDispatcherImpl_transferFrom0(JNIEnv *env, jobject this,
         if (errno == EINTR) {
             return IOS_INTERRUPTED;
         }
+        if (errno == EPERM)
+            return IOS_UNSUPPORTED;
         JNU_ThrowIOExceptionWithLastError(env, "Transfer failed");
         return IOS_THROWN;
     }
@@ -103,6 +105,7 @@ Java_sun_nio_ch_FileDispatcherImpl_transferTo0(JNIEnv *env, jobject this,
                 case EINVAL:
                 case ENOSYS:
                 case EXDEV:
+                case EPERM:
                     // ignore and try sendfile()
                     break;
                 default:

--- a/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
+++ b/src/java.base/linux/native/libnio/fs/LinuxNativeDispatcher.c
@@ -193,6 +193,7 @@ Java_sun_nio_fs_LinuxNativeDispatcher_directCopy0
                     case EINVAL:
                     case ENOSYS:
                     case EXDEV:
+                    case EPERM:
                         // ignore and try sendfile()
                         break;
                     default:

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -400,7 +400,14 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
 #if defined(__linux__)
     my_statx_func = (statx_func*) dlsym(RTLD_DEFAULT, "statx");
     if (my_statx_func != NULL) {
-        capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_BIRTHTIME;
+        /* Verify if statx call is permitted */
+        struct my_statx statx_buf;
+        int err = statx_wrapper(-1, "", AT_EMPTY_PATH, 0, &statx_buf);
+        if (err == -1 && errno == EPERM) {
+            my_statx_func = NULL;
+        } else {
+            capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_BIRTHTIME;
+        }
     }
 #endif
 


### PR DESCRIPTION
Please review the fix for regression on the old docker versions (before v18.04)

Suggest to verify if statx is permitted during initialization

statx(-1, "", AT_EMPTY_PATH, 0, &statx_buf) return EPERM if statx syscall not permitted and EBADF otherwise

Fallback to stat() if statx() not permitted

Related  jtreg tests passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337966](https://bugs.openjdk.org/browse/JDK-8337966): (fs) Files.readAttributes fails with Operation not permitted on older docker releases (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20484/head:pull/20484` \
`$ git checkout pull/20484`

Update a local copy of the PR: \
`$ git checkout pull/20484` \
`$ git pull https://git.openjdk.org/jdk.git pull/20484/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20484`

View PR using the GUI difftool: \
`$ git pr show -t 20484`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20484.diff">https://git.openjdk.org/jdk/pull/20484.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20484#issuecomment-2272591536)