### PR TITLE
8337968: Problem list compiler/vectorapi/VectorRebracket128Test.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -59,6 +59,8 @@ compiler/codecache/CheckLargePages.java 8332654 linux-x64
 
 compiler/vectorapi/reshape/TestVectorReinterpret.java 8320897 aix-ppc64,linux-ppc64le
 compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x64
+compiler/vectorapi/VectorRebracket128Test.java#ZSinglegen 8330538 generic-all
+compiler/vectorapi/VectorRebracket128Test.java#ZGenerational 8330538 generic-all
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 


### PR DESCRIPTION
Problem list until [JDK-8330538](https://bugs.openjdk.org/browse/JDK-8330538) is fixed to reduce the noise in testing.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337968](https://bugs.openjdk.org/browse/JDK-8337968): Problem list compiler/vectorapi/VectorRebracket128Test.java (**Sub-task** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20485/head:pull/20485` \
`$ git checkout pull/20485`

Update a local copy of the PR: \
`$ git checkout pull/20485` \
`$ git pull https://git.openjdk.org/jdk.git pull/20485/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20485`

View PR using the GUI difftool: \
`$ git pr show -t 20485`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20485.diff">https://git.openjdk.org/jdk/pull/20485.diff</a>

</details>
