### PR TITLE
8337886: java/awt/Frame/MaximizeUndecoratedTest.java fails in OEL due to a slight color difference

### DIFF
--- a/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
+++ b/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
@@ -50,7 +50,7 @@ import jtreg.SkippedException;
 
 public class MaximizeUndecoratedTest {
     private static final int SIZE = 300;
-    private static final int OFFSET = 2;
+    private static final int OFFSET = 3;
 
     private static Frame frame;
     private static Robot robot;

--- a/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
+++ b/test/jdk/java/awt/Frame/MaximizeUndecoratedTest.java
@@ -50,7 +50,7 @@ import jtreg.SkippedException;
 
 public class MaximizeUndecoratedTest {
     private static final int SIZE = 300;
-    private static final int OFFSET = 3;
+    private static final int OFFSET = 5;
 
     private static Frame frame;
     private static Robot robot;


### PR DESCRIPTION
java/awt/Frame/MaximizeUndecoratedTest.java fails in OEL due to a slight color difference in the background color. This is currently reproduced only for Oracle Linux. 

The Color object I'm getting for each of these Point objects:
new Point(maxBounds.x + OFFSET, maxBounds.y + OFFSET) --> java.awt.Color[r=0,g=255,b=0]
 new Point(maxBounds.width - OFFSET, maxBounds.y + OFFSET) --> java.awt.Color[r=0,g=207,b=0]
 new Point(maxBounds.width - OFFSET, maxBounds.height - OFFSET) --> java.awt.Color[r=0,g=255,b=0]
 new Point(maxBounds.x + OFFSET, maxBounds.height - OFFSET) --> java.awt.Color[r=0,g=255,b=0]
 
So, the issue occurs for the second Point object --> new Point(maxBounds.width - OFFSET, maxBounds.y + OFFSET) - java.awt.Color[r=0,g=207,b=0]


Fix:
When the offset is increased from 2 to 5, it works fine in all the platforms.

This test verifies whether the frame is maximised or not by checking its four border points(by comparing it's colour with GREEN). But in OEL, the top left and top right borders are curved, so there is a possibility of error if we directly compare those points with GREEN colour, that's why an OFFSET is needed. But an OFFSET of 2 is not sufficient for OEL, and for safety I will change it to 5. I don't see this issue in Ubuntu as the borders as rectangular there, but not curved. 

Testing:
Tested using mach5 in all the available platforms and it works fine everywhere(results attached in bug).
Tested manually in OEL 8 and 9(both x64 and aarch64) and it works fine there also.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337886](https://bugs.openjdk.org/browse/JDK-8337886): java/awt/Frame/MaximizeUndecoratedTest.java fails in OEL due to a slight color difference (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20486/head:pull/20486` \
`$ git checkout pull/20486`

Update a local copy of the PR: \
`$ git checkout pull/20486` \
`$ git pull https://git.openjdk.org/jdk.git pull/20486/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20486`

View PR using the GUI difftool: \
`$ git pr show -t 20486`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20486.diff">https://git.openjdk.org/jdk/pull/20486.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20486#issuecomment-2272760807)