### PR TITLE
8337971: Problem list several jvmci tests on linux-riscv64 until JDK-8331704 is fixed

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -63,6 +63,12 @@ compiler/vectorapi/VectorRebracket128Test.java#ZSinglegen 8330538 generic-all
 compiler/vectorapi/VectorRebracket128Test.java#ZGenerational 8330538 generic-all
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/DataPatchTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/MaxOopMapStackOffsetTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/NativeCallTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleDebugInfoTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/SimpleCodeInstallationTest.java 8331704 linux-riscv64
+compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/VirtualObjectDebugInfoTest.java 8331704 linux-riscv64
 
 compiler/floatingpoint/TestSubnormalFloat.java 8317810 generic-i586
 compiler/floatingpoint/TestSubnormalDouble.java 8317810 generic-i586


### PR DESCRIPTION
Hi, As described in the [JDK-8331704](https://bugs.openjdk.org/browse/JDK-8331704) issue, there are some jvmci test cases that fail on linux-riscv64. we put the failed test cases into the Problem list until JDK-8331704 is fixed.

Please take a look and have some reviews. Thanks a lot.

### Testing
- [x] Run hotspot:tier1 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337971](https://bugs.openjdk.org/browse/JDK-8337971): Problem list several jvmci tests on linux-riscv64 until JDK-8331704 is fixed (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20487/head:pull/20487` \
`$ git checkout pull/20487`

Update a local copy of the PR: \
`$ git checkout pull/20487` \
`$ git pull https://git.openjdk.org/jdk.git pull/20487/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20487`

View PR using the GUI difftool: \
`$ git pr show -t 20487`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20487.diff">https://git.openjdk.org/jdk/pull/20487.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20487#issuecomment-2272870931)