### PR TITLE
8337972: Problem list jdk/internal/util/ReferencedKeyTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -749,6 +749,8 @@ jdk/jfr/jvm/TestWaste.java                                      8282427 generic-
 
 # jdk_internal
 
+jdk/internal/util/ReferencedKeyTest.java                        8336926 linux-aarch64
+
 ############################################################################
 
 # jdk_jpackage


### PR DESCRIPTION
Problem list until [JDK-8336926](https://bugs.openjdk.org/browse/JDK-8336926) is fixed to reduce the noise in testing.