### PR TITLE
JDK-8337974 - ChannelInputStream::skip can use splice (linux)

### DIFF
--- a/src/java.base/linux/classes/sun/nio/ch/PipeDispatcherImpl.java
+++ b/src/java.base/linux/classes/sun/nio/ch/PipeDispatcherImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.ch;
+
+import java.io.FileDescriptor;
+
+class PipeDispatcherImpl extends FileDispatcherImpl {
+    PipeDispatcherImpl() {
+        super();
+    }
+
+    /**
+     * Skip at most n bytes
+     * @return the number of bytes skipped or IOS_INTERRUPTED
+     */
+    long skip(FileDescriptor fd, long n) {
+        return skip0(fd, n);
+    }
+
+    // -- Native methods --
+
+    static native void init0();
+
+    static {
+        init0();
+    }
+
+    private static native long skip0(FileDescriptor fd, long n);
+}

--- a/src/java.base/linux/native/libnio/ch/PipeDispatcherImpl.c
+++ b/src/java.base/linux/native/libnio/ch/PipeDispatcherImpl.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+#include "nio.h"
+#include "nio_util.h"
+#include "sun_nio_ch_PipeDispatcherImpl.h"
+
+static int devnull;
+
+JNIEXPORT void JNICALL
+Java_sun_nio_ch_PipeDispatcherImpl_init0(JNIEnv *env, jclass klass)
+{
+    devnull = open("/dev/null", O_WRONLY);
+    if (devnull < 0)
+        JNU_ThrowIOExceptionWithLastError(env, "open /dev/null failed");
+}
+
+JNIEXPORT jlong JNICALL
+Java_sun_nio_ch_PipeDispatcherImpl_skip0(JNIEnv *env, jclass cl, jobject fdo, jlong n)
+{
+    if (n < 1)
+        return 0;
+
+    const jint fd = fdval(env, fdo);
+
+    jlong tn = 0;
+
+    for (;;) {
+        const jlong remaining = n - tn;
+        const ssize_t count = remaining < SSIZE_MAX ? (ssize_t) remaining : SSIZE_MAX;
+        const ssize_t nr = splice(fd, NULL, devnull, NULL, count, SPLICE_F_MOVE | SPLICE_F_NONBLOCK);
+        if (nr < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return tn;
+            } else if (errno == EINTR) {
+                return IOS_INTERRUPTED;
+            } else {
+                JNU_ThrowIOExceptionWithLastError(env, "splice");
+                return IOS_THROWN;
+            }
+        }
+        if (nr > 0)
+            tn += nr;
+        if (nr == SSIZE_MAX)
+            continue;
+        return tn;
+    }
+}

--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -875,8 +875,9 @@ public class Socket implements java.io.Closeable {
      *
      * <p> If this socket has an associated channel then the resulting input
      * stream delegates all of its operations to the channel.  If the channel
-     * is in non-blocking mode then the input stream's {@code read} operations
-     * will throw an {@link java.nio.channels.IllegalBlockingModeException}.
+     * is in non-blocking mode then the input stream's {@code read} and
+     * {@code skip} operations will throw an
+     * {@link java.nio.channels.IllegalBlockingModeException}.
      *
      * <p> Reading from the input stream is {@linkplain Thread#interrupt()
      * interruptible} in the following circumstances:
@@ -884,9 +885,9 @@ public class Socket implements java.io.Closeable {
      *   <li> The socket is {@linkplain SocketChannel#socket() associated} with
      *        a {@link SocketChannel SocketChannel}.
      *        In that case, interrupting a thread reading from the input stream
-     *        will close the underlying channel and cause the read method to
-     *        throw {@link ClosedByInterruptException} with the interrupt
-     *        status set.
+     *        will close the underlying channel and cause the read and skip
+     *        methods to throw {@link ClosedByInterruptException} with the
+     *        interrupt status set.
      *   <li> The socket uses the system-default socket implementation and a
      *        {@linkplain Thread#isVirtual() virtual thread} is reading from the
      *        input stream. In that case, interrupting the virtual thread will
@@ -1274,6 +1275,9 @@ public class Socket implements java.io.Closeable {
      *  Socket is still valid. A timeout of zero is interpreted as an infinite timeout.
      *  The option <B>must</B> be enabled prior to entering the blocking operation
      *  to have effect.
+     *
+     * <p> Behavior of any other method call on the InputStream associated with
+     * this Socket is implementation specific.
      *
      * @param timeout the specified timeout, in milliseconds.
      * @throws SocketException if there is an error in the underlying protocol,

--- a/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
+++ b/src/java.base/share/classes/sun/nio/ch/ChannelInputStream.java
@@ -238,6 +238,15 @@ class ChannelInputStream extends InputStream {
             sbc.position(newPos);
             return newPos - pos;
         }
+
+        // special case where the channel is to a pipe
+        if (ch instanceof SourceChannelImpl sci)
+            return sci.skip(n);
+
+        // special case where the channel is to a socket
+        if (ch instanceof SocketChannelImpl sci)
+            return sci.skip(n);
+
         return super.skip(n);
     }
 

--- a/src/java.base/share/classes/sun/nio/ch/IOUtil.java
+++ b/src/java.base/share/classes/sun/nio/ch/IOUtil.java
@@ -475,6 +475,14 @@ public final class IOUtil {
         }
     }
 
+    /**
+     * Skip at most n bytes
+     * @return the number of bytes skipped or IOS_INTERRUPTED
+     */
+    static long skip(FileDescriptor fd, long n, NativeDispatcher nd) throws IOException {
+        return nd.skip(fd, n);
+    }
+
     private static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     static void acquireScope(ByteBuffer bb, boolean async) {

--- a/src/java.base/share/classes/sun/nio/ch/NativeDispatcher.java
+++ b/src/java.base/share/classes/sun/nio/ch/NativeDispatcher.java
@@ -86,4 +86,12 @@ abstract class NativeDispatcher {
     void dup(FileDescriptor fd1, FileDescriptor fd2) throws IOException {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * Skip at most n bytes
+     * @return the number of bytes skipped or IOS_INTERRUPTED
+     */
+    long skip(FileDescriptor fd, long n) throws IOException {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/java.base/unix/classes/sun/nio/ch/PipeDispatcherImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/PipeDispatcherImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ package sun.nio.ch;
+
+ import java.io.FileDescriptor;
+ 
+ class PipeDispatcherImpl extends FileDispatcherImpl {
+     PipeDispatcherImpl() {
+         super();
+     }
+ }
+ 

--- a/src/java.base/unix/classes/sun/nio/ch/PipeDispatcherImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/PipeDispatcherImpl.java
@@ -23,13 +23,13 @@
  * questions.
  */
 
- package sun.nio.ch;
+package sun.nio.ch;
 
- import java.io.FileDescriptor;
- 
- class PipeDispatcherImpl extends FileDispatcherImpl {
-     PipeDispatcherImpl() {
-         super();
-     }
- }
- 
+import java.io.FileDescriptor;
+
+class PipeDispatcherImpl extends FileDispatcherImpl {
+    PipeDispatcherImpl() {
+        super();
+    }
+}
+

--- a/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
@@ -42,7 +42,7 @@ class SinkChannelImpl
     implements SelChImpl
 {
     // Used to make native read and write calls
-    private static final NativeDispatcher nd = new FileDispatcherImpl();
+    private static final NativeDispatcher nd = new PipeDispatcherImpl();
 
     // The file descriptor associated with this channel
     private final FileDescriptor fd;

--- a/src/java.base/unix/classes/sun/nio/ch/SocketDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SocketDispatcher.java
@@ -74,6 +74,10 @@ class SocketDispatcher extends UnixDispatcher {
         preClose0(fd);
     }
 
+    long skip(FileDescriptor fd, long n) throws IOException {
+        return skip0(fd, n);
+    }
+
     // -- Native methods --
 
     private static native int read0(FileDescriptor fd, long address, int len)
@@ -86,6 +90,9 @@ class SocketDispatcher extends UnixDispatcher {
         throws IOException;
 
     static native long writev0(FileDescriptor fd, long address, int len)
+        throws IOException;
+
+    private static native long skip0(FileDescriptor fd, long n)
         throws IOException;
 
     static {

--- a/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
@@ -42,7 +42,7 @@ class SourceChannelImpl
     implements SelChImpl
 {
     // Used to make native read and write calls
-    private static final NativeDispatcher nd = new FileDispatcherImpl();
+    private static final NativeDispatcher nd = new PipeDispatcherImpl();
 
     // The file descriptor associated with this channel
     private final FileDescriptor fd;
@@ -364,5 +364,54 @@ class SourceChannelImpl
     @Override
     public long read(ByteBuffer[] dsts) throws IOException {
         return read(dsts, 0, dsts.length);
+    }
+
+    /**
+     * Skips over and discards {@code n} bytes of data from this source
+     * channel. The {@code skip} method may, for a variety of reasons, end
+     * up skipping over some smaller number of bytes, possibly {@code 0}.
+     * This may result from any of a number of conditions; reaching end of file
+     * before {@code n} bytes have been skipped is only one possibility.
+     * The actual number of bytes skipped is returned. If {@code n} is
+     * negative, the {@code skip} method for class {@code SourceChannelImpl} always
+     * returns 0, and no bytes are skipped. Subclasses may handle the negative
+     * value differently.
+     *
+     * @implSpec
+     * The {@code skip} method implementation of this class creates an off-heap
+     * byte array and then repeatedly reads into it until {@code n} bytes
+     * have been read or the end of the stream has been reached. Subclasses are
+     * encouraged to provide a more efficient implementation of this method.
+     * For instance, the implementation may depend on the ability to seek.
+     *
+     * @param      n   the number of bytes to be skipped.
+     * @return     the actual number of bytes skipped which might be zero.
+     * @throws     IOException  if an I/O error occurs.
+     */
+    public long skip(long n) throws IOException {
+        if (n < 1)
+            return 0;
+
+        readLock.lock();
+        try {
+            boolean blocking = isBlocking();
+            long ns = 0;
+            try {
+                beginRead(blocking);
+                configureSocketNonBlockingIfVirtualThread();
+                ns = IOUtil.skip(fd, n, nd);
+                if (blocking)
+                    while (IOStatus.okayToRetry(ns) && isOpen()) {
+                        park(Net.POLLIN);
+                        ns = IOUtil.skip(fd, n, nd);
+                    }
+            } finally {
+                endRead(blocking, ns > 0);
+                assert IOStatus.check(ns);
+            }
+            return IOStatus.normalize(ns);
+        } finally {
+            readLock.unlock();
+        }
     }
 }

--- a/src/java.base/unix/classes/sun/nio/ch/UnixFileDispatcherImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/UnixFileDispatcherImpl.java
@@ -173,6 +173,14 @@ class UnixFileDispatcherImpl extends FileDispatcher {
         return result;
     }
 
+    /**
+     * Skip at most n bytes
+     * @return the number of bytes skipped or IOS_INTERRUPTED
+     */
+    long skip(FileDescriptor fd, long n) {
+        return skip0(fd, n);
+    }
+
     // -- Native methods --
 
     static native int read0(FileDescriptor fd, long address, int len)
@@ -225,4 +233,6 @@ class UnixFileDispatcherImpl extends FileDispatcher {
     static native int unmap0(long address, long length);
 
     static native int setDirect0(FileDescriptor fd) throws IOException;
+
+    private static native long skip0(FileDescriptor fd, long n);
 }

--- a/src/java.base/unix/native/libnio/ch/UnixFileDispatcherImpl.c
+++ b/src/java.base/unix/native/libnio/ch/UnixFileDispatcherImpl.c
@@ -52,6 +52,10 @@
   #define fstatvfs fstatvfs64
 #endif
 
+// MAX_SKIP_BUFFER_SIZE is used to determine the maximum buffer size to
+// use when skipping.
+static const ssize_t MAX_SKIP_BUFFER_SIZE = 4096;
+
 JNIEXPORT jint JNICALL
 Java_sun_nio_ch_UnixFileDispatcherImpl_read0(JNIEnv *env, jclass clazz,
                              jobject fdo, jlong address, jint len)
@@ -444,4 +448,38 @@ Java_sun_nio_ch_UnixFileDispatcherImpl_setDirect0(JNIEnv *env, jclass clazz,
     result = -1;
 #endif
     return result;
+}
+
+JNIEXPORT jlong JNICALL
+Java_sun_nio_ch_UnixFileDispatcherImpl_skip0(JNIEnv *env, jclass cl, jobject fdo, jlong n)
+{
+    if (n < 1)
+        return 0;
+
+    const jint fd = fdval(env, fdo);
+
+    const long bs = n < MAX_SKIP_BUFFER_SIZE ? (long) n : MAX_SKIP_BUFFER_SIZE;
+    char buf[bs];
+    jlong tn = 0;
+
+    for (;;) {
+        const jlong remaining = n - tn;
+        const ssize_t count = remaining < bs ? (ssize_t) remaining : bs;
+        const ssize_t nr = read(fd, buf, count);
+        if (nr < 0) {
+            if (errno == EAGAIN || errno == EWOULDBLOCK) {
+                return tn;
+            } else if (errno == EINTR) {
+                return IOS_INTERRUPTED;
+            } else {
+                JNU_ThrowIOExceptionWithLastError(env, "read");
+                return IOS_THROWN;
+            }
+        }
+        if (nr > 0)
+            tn += nr;
+        if (nr == bs)
+            continue;
+        return tn;
+    }
 }

--- a/src/java.base/windows/classes/sun/nio/ch/SocketDispatcher.java
+++ b/src/java.base/windows/classes/sun/nio/ch/SocketDispatcher.java
@@ -66,6 +66,10 @@ class SocketDispatcher extends NativeDispatcher {
         invalidateAndClose(fd);
     }
 
+    long skip(FileDescriptor fd, long n) throws IOException {
+        return skip0(fd, n);
+    }
+
     static void invalidateAndClose(FileDescriptor fd) throws IOException {
         assert fd.valid();
         int fdVal = fdAccess.get(fd);
@@ -88,6 +92,9 @@ class SocketDispatcher extends NativeDispatcher {
         throws IOException;
 
     private static native void close0(int fdVal) throws IOException;
+
+    private static native long skip0(FileDescriptor fd, long n)
+        throws IOException;
 
     static {
         IOUtil.load();

--- a/src/java.base/windows/classes/sun/nio/ch/SourceChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/SourceChannelImpl.java
@@ -139,4 +139,37 @@ class SourceChannelImpl
         }
     }
 
+    /**
+     * Skips over and discards {@code n} bytes of data from this source
+     * channel. The {@code skip} method may, for a variety of reasons, end
+     * up skipping over some smaller number of bytes, possibly {@code 0}.
+     * This may result from any of a number of conditions; reaching end of file
+     * before {@code n} bytes have been skipped is only one possibility.
+     * The actual number of bytes skipped is returned. If {@code n} is
+     * negative, the {@code skip} method for class {@code SourceChannelImpl} always
+     * returns 0, and no bytes are skipped. Subclasses may handle the negative
+     * value differently.
+     *
+     * @implSpec
+     * The {@code skip} method implementation of this class creates an off-heap
+     * byte array and then repeatedly reads into it until {@code n} bytes
+     * have been read or the end of the stream has been reached. Subclasses are
+     * encouraged to provide a more efficient implementation of this method.
+     * For instance, the implementation may depend on the ability to seek.
+     *
+     * @param      n   the number of bytes to be skipped.
+     * @return     the actual number of bytes skipped which might be zero.
+     * @throws     IOException  if an I/O error occurs.
+     */
+    public long skip(long n) throws IOException {
+        if (n < 1)
+            return 0;
+
+        try {
+            return ((SocketChannelImpl) sc).skip(n);
+        } catch (AsynchronousCloseException x) {
+            close();
+            throw x;
+        }
+    }
 }

--- a/test/jdk/java/nio/channels/Channels/Skip.java
+++ b/test/jdk/java/nio/channels/Channels/Skip.java
@@ -44,7 +44,7 @@ import org.testng.annotations.Test;
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
  * @run testng/othervm/timeout=180 Skip
- * @bug 8265891
+ * @bug 8337974
  * @summary Tests whether sun.nio.ch.ChannelInputStream.skip and
  *          sun.nio.ch.SocketInputStream.skip conform to the
  *          InputStream.skip specification

--- a/test/jdk/java/nio/channels/Channels/Skip.java
+++ b/test/jdk/java/nio/channels/Channels/Skip.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.Pipe;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run testng/othervm/timeout=180 Skip
+ * @bug 8265891
+ * @summary Tests whether sun.nio.ch.ChannelInputStream.skip and
+ *          sun.nio.ch.SocketInputStream.skip conform to the
+ *          InputStream.skip specification
+ * @key randomness
+ */
+public class Skip extends SkipBase {
+
+    /*
+     * Provides test scenarios, i.e., input streams to be tested.
+     */
+    @DataProvider
+    public static Object[] streams() {
+        return new Object[] {
+            // tests FileChannel.skip() optimized case
+            fileChannelInput(),
+
+            // tests SourceChannelImpl.skip() optimized case
+            sourceChannelImplInput(),
+
+            // tests SocketChannel.skip() optimized case
+            socketChannelInput(),
+
+            // tests InputStream.skip() default case
+            readableByteChannelInput()
+        };
+    }
+
+    /*
+     * Testing API compliance: 0...n bytes of input stream must be
+     * skipped, and the remainder of bytes must not be changed.
+     */
+    @Test(dataProvider = "streams")
+    public void testStreamContents(InputStreamProvider inputStreamProvider) throws Exception {
+        assertStreamContents(inputStreamProvider);
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a file channel
+     */
+    private static InputStreamProvider fileChannelInput() {
+        return bytes -> {
+            Path path = Files.createTempFile(CWD, "fileChannelInput", null);
+            Files.write(path, bytes);
+            FileChannel fileChannel = FileChannel.open(path);
+            return Channels.newInputStream(fileChannel);
+        };
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a pipe channel
+     */
+    private static InputStreamProvider sourceChannelImplInput() {
+        return bytes -> {
+            Pipe pipe = Pipe.open();
+            new Thread(() -> {
+                try (OutputStream os = Channels.newOutputStream(pipe.sink())) {
+                    os.write(bytes);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }).start();
+            return Channels.newInputStream(pipe.source());
+        };
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a socket channel
+     */
+    private static InputStreamProvider socketChannelInput() {
+        return bytes -> {
+            try {
+                SocketAddress loopback = new InetSocketAddress(
+                        InetAddress.getLoopbackAddress(), 0);
+                ServerSocketChannel serverSocket = ServerSocketChannel.open()
+                        .bind(loopback);
+                new Thread(() -> {
+                    try (SocketChannel client = SocketChannel.open(
+                                serverSocket.getLocalAddress());
+                            OutputStream os = Channels.newOutputStream(client)) {
+                        os.write(bytes);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        try {
+                            serverSocket.close();
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }).start();
+                return Channels.newInputStream(serverSocket.accept());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+}

--- a/test/jdk/java/nio/channels/Channels/SkipBase.java
+++ b/test/jdk/java/nio/channels/Channels/SkipBase.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.function.ToLongFunction;
+
+import jdk.test.lib.RandomFactory;
+
+import static java.lang.String.format;
+import static java.nio.file.StandardOpenOption.*;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+class SkipBase {
+    static final int MIN_SIZE      = 10_000;
+    static final int MAX_SIZE_INCR = 100_000_000 - MIN_SIZE;
+
+    static final int ITERATIONS = 10;
+
+    static final Random RND = RandomFactory.getRandom();
+
+    static final Path CWD = Path.of(".");
+
+    /*
+     * Asserts that the skipped content is correct, i.e. compares the bytes
+     * still in the input stream to those expected. The position of the input
+     * stream before the skip is zero (BOF), and the number of bytes to skip is
+     * "all bytes til EOF".
+     */
+    static void checkSkippedContents(InputStreamProvider inputStreamProvider,
+            byte[] inBytes) throws Exception {
+        checkSkippedContents(inputStreamProvider, inBytes, inBytes.length);
+    }
+
+    /*
+     * Asserts that the skipped content is correct, i.e. compares the bytes
+     * still in the input stream to those expected. The position of the input
+     * stream before the skip is zero (BOF). The number of bytes to skip is
+     * provided by the caller.
+     */
+    static void checkSkippedContents(InputStreamProvider inputStreamProvider,
+            byte[] inBytes, long count) throws Exception {
+        checkSkippedContents(inputStreamProvider, inBytes, 0, count, false);
+    }
+
+    /*
+     * Asserts that the skipped content is correct, i.e. compares the bytes
+     * still in the input stream to those expected. The position of the input
+     * stream before the skip and the number of bytes to skip are provided by
+     * the caller.
+     */
+    static void checkSkippedContents(InputStreamProvider inputStreamProvider,
+            byte[] inBytes, int posIn, long count, boolean mustNotSkipAnything) throws Exception {
+        try (InputStream in = inputStreamProvider.input(inBytes)) {
+            // consume bytes until starting position
+            in.readNBytes(posIn);
+            long reported = in.skip(count);
+            byte[] reminder = in.readAllBytes();
+
+            if (mustNotSkipAnything)
+                assertTrue(reported == 0, format("must not skip any bytes, but skipped %d", reported));
+            assertTrue(reported >= 0 && reported <= count, format("reported %d bytes but should report between 0 and %d", reported, count));
+            int expectedRemainingCount = inBytes.length - posIn - Math.toIntExact(reported);
+            assertEquals(reminder.length, expectedRemainingCount,
+                    format("remaining %d bytes but should remain %d", reminder.length, expectedRemainingCount));
+            assertTrue(Arrays.equals(reminder, 0, reminder.length,
+                    inBytes, posIn + Math.toIntExact(reported), inBytes.length),
+                    "remaining bytes are dissimilar");
+        }
+    }
+
+    /*
+     * Creates an array of random size (between min and min + maxRandomAdditive)
+     * filled with random bytes
+     */
+    static byte[] createRandomBytes(int min, int maxRandomAdditive) {
+        byte[] bytes = new byte[min + (maxRandomAdditive == 0 ? 0 : RND.nextInt(maxRandomAdditive))];
+        RND.nextBytes(bytes);
+        return bytes;
+    }
+
+    interface InputStreamProvider {
+        InputStream input(byte... bytes) throws Exception;
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a readable byte
+     * channel but is not a file channel.
+     */
+    static InputStreamProvider readableByteChannelInput() {
+        return bytes -> Channels.newInputStream(Channels.newChannel(new ByteArrayInputStream(bytes)));
+    }
+
+    /*
+     * Testing API compliance: 0...n bytes of input stream must be
+     * skipped, and the remainder of bytes must not be changed.
+     */
+    static void assertStreamContents(InputStreamProvider inputStreamProvider) throws Exception {
+        // tests empty input stream
+        checkSkippedContents(inputStreamProvider, new byte[0]);
+
+        // tests input stream with a length between 1k and 4k
+        checkSkippedContents(inputStreamProvider, createRandomBytes(1024, 3072));
+
+        // tests input stream with several data chunks, as 16k is more than a
+        // single chunk can hold
+        checkSkippedContents(inputStreamProvider, createRandomBytes(16384, 16384));
+
+        // tests randomly chosen starting positions and counts
+        for (int i = 0; i < ITERATIONS; i++) {
+            byte[] inBytes = createRandomBytes(MIN_SIZE, MAX_SIZE_INCR);
+            int posIn = RND.nextInt(inBytes.length);
+            long count = RND.nextLong(MIN_SIZE + MAX_SIZE_INCR - posIn);
+            checkSkippedContents(inputStreamProvider, inBytes, posIn, count, false);
+        }
+
+        // tests reading beyond source EOF (must not skip any bytes)
+        checkSkippedContents(inputStreamProvider, createRandomBytes(4096, 0),
+                4096, 1, true);
+    }
+
+}

--- a/test/jdk/java/nio/channels/Channels/Skip_2GB.java
+++ b/test/jdk/java/nio/channels/Channels/Skip_2GB.java
@@ -51,7 +51,7 @@ import static org.testng.Assert.assertTrue;
  * @library /test/lib
  * @build jdk.test.lib.RandomFactory
  * @run testng/othervm/timeout=180 Skip_2GB
- * @bug 8278268
+ * @bug 8337974
  * @summary Tests if ChannelInputStream.skip and SocketInputStream.skip
  *          correctly skip 2GB+.
  * @key randomness

--- a/test/jdk/java/nio/channels/Channels/Skip_2GB.java
+++ b/test/jdk/java/nio/channels/Channels/Skip_2GB.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.Channels;
+import java.nio.channels.FileChannel;
+import java.nio.channels.Pipe;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.lang.String.format;
+import static java.nio.file.StandardOpenOption.*;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/*
+ * @test
+ * @library /test/lib
+ * @build jdk.test.lib.RandomFactory
+ * @run testng/othervm/timeout=180 Skip_2GB
+ * @bug 8278268
+ * @summary Tests if ChannelInputStream.skip and SocketInputStream.skip
+ *          correctly skip 2GB+.
+ * @key randomness
+ */
+public class Skip_2GB extends SkipBase {
+
+    /*
+     * Provides test scenarios, i.e., input streams to be tested.
+     */
+    @DataProvider
+    public static Object[] streams() {
+        return new Object[] {
+            // tests FileChannel.skip() optimized case
+            fileChannelInput_2G(),
+
+            // tests SourceChannelImpl.skip() optimized case
+            sourceChannelImplInput_2G(),
+
+            // tests SourceChannelImpl.skip() optimized case
+            socketChannelInput_2G(),
+
+            // tests InputStream.skip() default case
+            readableByteChannelInput_2G()
+        };
+    }
+
+    /*
+     * Testing API compliance: > 0...n bytes of input stream must be
+     * skipped, and the remainder of bytes must not be changed.
+     */
+    @Test(dataProvider = "streams")
+    public void testStreamContents(InputStreamProvider_2G inputStreamProvider) throws Exception {
+        assertStreamContentsUsingFiles(inputStreamProvider);
+    }
+
+    /*
+     * Testing API compliance: > 0...n bytes of input stream must be
+     * skipped, and the remainder of bytes must not be changed.
+     */
+    static void assertStreamContentsUsingFiles(InputStreamProvider_2G inputStreamProvider) throws Exception {
+        Path inBytes = createRandomBytesFile(Integer.MAX_VALUE - 1L,
+                Integer.MAX_VALUE + 1L, Integer.MAX_VALUE);
+        try {
+            checkSkippedContents(inputStreamProvider, inBytes);
+        } finally {
+            Files.deleteIfExists(inBytes);
+        }
+    }
+
+    /*
+     * Asserts that the skipped content is correct, i.e. compares the bytes
+     * still in the input stream to those expected. The position of the input
+     * stream before the skip is zero (BOF), and the number of bytes to skip is
+     * "all bytes til EOF".
+     */
+    static void checkSkippedContents(InputStreamProvider_2G inputStreamProvider,
+            Path inBytes) throws Exception {
+        checkSkippedContents(inputStreamProvider, inBytes, Files.size(inBytes));
+    }
+
+    /*
+     * Asserts that the skipped content is correct, i.e. compares the bytes
+     * still in the input stream to those expected. The position of the input
+     * stream before the skip is zero (BOF). The number of bytes to skip is
+     * provided by the caller.
+     */
+    static void checkSkippedContents(InputStreamProvider_2G inputStreamProvider,
+            Path inBytes, long count) throws Exception {
+        checkSkippedContents(inputStreamProvider, inBytes, 0, count, false);
+    }
+
+    /*
+     * Asserts that the skipped content is correct, i.e. compares the bytes
+     * still in the input stream to those expected. The position of the input
+     * stream before the skip and the number of bytes to skip are provided by
+     * the caller.
+     */
+    static void checkSkippedContents(InputStreamProvider_2G inputStreamProvider,
+            Path inBytes, long posIn, long count, boolean mustNotSkipAnything)
+            throws Exception {
+        try (InputStream in = inputStreamProvider.input(inBytes)) {
+            // consume bytes until starting position
+            for (long bytesToConsume = posIn; bytesToConsume > 0;
+                    bytesToConsume -= in.readNBytes(Math.toIntExact(
+                            Math.min(Integer.MAX_VALUE, bytesToConsume))).length);
+
+            long reported = in.skip(count);
+
+            if (mustNotSkipAnything)
+                assertTrue(reported == 0,
+                        format("must not skip any bytes, but skipped %d", reported));
+
+            // store all remaining bytes in a file
+            Path actualRemainderFile = CWD.resolve(
+                    format("test3GBActual_skip%s.tmp", RND.nextInt(Integer.MAX_VALUE)));
+            try {
+                try (OutputStream os = Files.newOutputStream(actualRemainderFile,
+                        CREATE_NEW, WRITE, SPARSE)) {
+                    in.transferTo(os);
+                }
+
+                assertTrue(reported >= 0 && reported <= count,
+                        format("reported %d bytes but should report between 0 and %d", reported, count));
+
+                long expectedRemainderLength = Files.size(inBytes) - posIn - reported;
+                long actualRemainderLength = Files.size(actualRemainderFile);
+                assertEquals(actualRemainderLength, expectedRemainderLength,
+                        format("remaining %d bytes but should remain %d", actualRemainderLength, expectedRemainderLength));
+
+                // store expected remaining bytes in a file
+                Path expectedRemainderFile = CWD.resolve(
+                        format("test3GBExpected_skip%s.tmp", RND.nextInt(Integer.MAX_VALUE)));
+                try (OutputStream os = Files.newOutputStream(expectedRemainderFile,
+                        CREATE_NEW, WRITE, SPARSE)) {
+                    try (FileChannel fc = FileChannel.open(inBytes)) {
+                        fc.position(posIn + reported);
+                        try (InputStream is = Channels.newInputStream(fc)) {
+                            is.transferTo(os);
+                        }
+                    }
+
+                    // Check similarity of content
+                    assertEquals(Files.mismatch(expectedRemainderFile,
+                            actualRemainderFile), -1, "remaining bytes are dissimilar");
+                } finally {
+                    Files.deleteIfExists(expectedRemainderFile);
+                }
+            } finally {
+                Files.deleteIfExists(actualRemainderFile);
+            }
+        }
+    }
+
+    interface InputStreamProvider_2G {
+        InputStream input(Path bytes) throws Exception;
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a file channel
+     */
+    private static InputStreamProvider_2G fileChannelInput_2G() {
+        return bytes -> {
+            FileChannel fileChannel = FileChannel.open(bytes);
+            return Channels.newInputStream(fileChannel);
+        };
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a pipe channel
+     */
+    private static InputStreamProvider_2G sourceChannelImplInput_2G() {
+        return bytes -> {
+            Pipe pipe = Pipe.open();
+            new Thread(() -> {
+                try (OutputStream os = Channels.newOutputStream(pipe.sink());
+                        InputStream is = Files.newInputStream(bytes)) {
+                    is.transferTo(os);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }).start();
+            return Channels.newInputStream(pipe.source());
+        };
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a socket channel
+     */
+    private static InputStreamProvider_2G socketChannelInput_2G() {
+        return bytes -> {
+            try {
+                SocketAddress loopback = new InetSocketAddress(
+                        InetAddress.getLoopbackAddress(), 0);
+                ServerSocketChannel serverSocket = ServerSocketChannel.open()
+                        .bind(loopback);
+                new Thread(() -> {
+                    try (SocketChannel client = SocketChannel.open(
+                                serverSocket.getLocalAddress());
+                            OutputStream os = Channels.newOutputStream(client);
+                            InputStream is = Files.newInputStream(bytes)) {
+                        is.transferTo(os);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    } finally {
+                        try {
+                            serverSocket.close();
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                }).start();
+                return Channels.newInputStream(serverSocket.accept());
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+    /*
+     * Creates a provider for an input stream which wraps a readable byte
+     * channel but is not a file channel.
+     */
+    static InputStreamProvider_2G readableByteChannelInput_2G() {
+        return bytes -> Channels.newInputStream(Channels.newChannel(
+                new BufferedInputStream(Files.newInputStream(bytes))));
+    }
+
+    /*
+     * Creates a sparse file of random size (between min and min + maxRandomAdditive)
+     * filled with random bytes starting at the provided position.
+     */
+    static Path createRandomBytesFile(long pos, long min, long maxRandomAdditive) throws IOException {
+        Path randomBytesFile = CWD.resolve(
+            format("test3GBSource_skip%s.tmp", RND.nextInt(Integer.MAX_VALUE)));
+        try (FileChannel fc = FileChannel.open(randomBytesFile, CREATE_NEW, WRITE, SPARSE)) {
+            fc.position(pos);
+            try (OutputStream os = Channels.newOutputStream(fc)) {
+                long remaining = min +
+                        (maxRandomAdditive == 0 ? 0 : RND.nextLong(maxRandomAdditive)) - pos;
+                while (remaining > 0) {
+                    int n = Math.toIntExact(Math.min(16384, remaining));
+                    byte[] bytes = createRandomBytes(n, 0);
+                    os.write(bytes);
+                    remaining -= n;
+                }
+            }
+        }
+        return randomBytesFile;
+    }
+
+}


### PR DESCRIPTION
# Targets

The major target of this issue is to reduce execution time of `ChannelInputStream::skip(long)`. In particular, make `skip(n)` run noticable faster than `read(new byte[n])` on pipes and sockets in the optimal case, but don't run noticable slower in the worst case.

A side target of this issue is to provide unit testing for `ChannelInputStream::skip(long)`. In particular, provide unit testing for files, pipes and sockets.

An appreciated benefit of this issue is reduced resource consumption (in the sense of CPU cycles, Java Heap, power consumption, CO2 footprint, etc.) of `ChannelInputStream::skip(long)`. Albeit, as it is not a target, this was not acitvely monitored.


# Non-Targets

It is not a target to improve any other methods of the mentioned or any other class. Such changes should go in separate issues.

It is not a target to add any new *public* APIs. The public API shall be kept unchanged. All changes implied by the current improvement shall be purely *internal* to OpenJDK.

It is not a target to improve other source types besides pipes and sockets.


# Description

What users expect from `InputStream::skip`, besides comfort, is "at least some" measurable benefit over `InputStream::read`. Otherwise skipping instead of reading makes no sense to users.

For files, OpenJDK already applies an effective `seek`-based optimization. For pipes and sockets, benefits were neglectible so far, as `skip` more or less was simply an alias for `read`.

Hence, this issue proposes optimized implementations for `ChannelInputStream::skip` in the pipes and sockets cases.


# Implementation

The abstract idea behind this issue is to prevent transmission of skipped data into the JVM's on-heap memory in the pipes and socket cases. As a Java application obviously is not interested in skipped data, copying it into the Java heap is a waste of both, time and heap, and induces (albeit neglectible) GC stress without any benefit.

Hence, this pull request changes the implementation of `ChannelInputStream::skip` in the following aspects:
1. On *all* operating systems, for pipe and socket channels, `skip` is implemented in C. While the data *still is* transferred form the source into the OS kernel and from the OS kernel into the JVM's off-heap memory, it is *not* transferred into the JVM's on-heap memory.
2. For *Linux* pipes only, `splice` is used with `/dev/null` as the target. Data is neither transferred from the source into the OS kernel, nor from the OS kernel into neither the JVM's off- nor on-heap memory.

For the latter, `/dev/null` is kept open permanently, as dynamically closing and reopening it imposes a considerable performance penalty, while keeping it open imposes only neglectable overhead.

Note: The implementation is mostly copied from existing code of the `read` case and of the `transferTo` test suite. I deliberately tried to modify only the very essential pieces, so the code stays comparable with `read` and the `transferTo` test suite, and hence, stays easiliy maintainable together with that origins.

# Benchmarking

## Case Selection
Benchmarking was performed for pipes only, and only on Linux (Debian on WSL2) and Windows (W2K Pro), but on the exact same hardware. Linux and Windows are assumed to be not only the most used operating systems, but to also cover a big diversity of I/O performance behaviors (Linux is know to be rather fast, Windows is known to be rather slow). On Windows, NIO pipes are actually utilizing OS sockets in OpenJDK 23, so effectively sockets are benchmarked implicitly by the pipes benchmark).

Benchmarking was performed on the optimized branch and on OpenJDK 23 main branch as a baseline.

## Results
The charts below indicate that on both tested operating systems and on both tested source types, performance should in no case be noticable slower than the baseline.

There is clear evidence, that in some many cases, the optimization is faster than the baseline, and in few cases, it is even considerably faster.

In particular, pipes on Linux showed up to 17.5 times the baseline throughput), and "pipes" (effectively: sockets) on Windows reached up to 1.54 times the baseline.

Note: X-axis is logarithmic. Candlesticks reflect error range.

![grafik](https://github.com/user-attachments/assets/5a8c81c2-cced-465a-84b8-bd4f5382689e)

![grafik](https://github.com/user-attachments/assets/21ff33c3-91d7-4acb-8b9f-0a531f0e7d6c)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337974](https://bugs.openjdk.org/browse/JDK-8337974): ChannelInputStream::skip can use splice (linux) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20489/head:pull/20489` \
`$ git checkout pull/20489`

Update a local copy of the PR: \
`$ git checkout pull/20489` \
`$ git pull https://git.openjdk.org/jdk.git pull/20489/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20489`

View PR using the GUI difftool: \
`$ git pr show -t 20489`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20489.diff">https://git.openjdk.org/jdk/pull/20489.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20489#issuecomment-2273066598)
</details>
