### PR TITLE
8337982: Remove dead undef assrt0n

### DIFF
--- a/src/hotspot/share/memory/metaspace/blockTree.cpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.cpp
@@ -178,8 +178,6 @@ void BlockTree::verify() const {
   // (which also verifies that we visited every node, or at least
   //  as many nodes as are in this tree)
   _counter.check(counter);
-
-  #undef assrt0n
 }
 
 void BlockTree::zap_range(MetaWord* p, size_t word_size) {


### PR DESCRIPTION
Hello everyone,

`blockTree.cpp` contains an `#undef` that is never defined anywhere.
This is dead code should be removed.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337982](https://bugs.openjdk.org/browse/JDK-8337982): Remove dead undef assrt0n (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20493/head:pull/20493` \
`$ git checkout pull/20493`

Update a local copy of the PR: \
`$ git checkout pull/20493` \
`$ git pull https://git.openjdk.org/jdk.git pull/20493/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20493`

View PR using the GUI difftool: \
`$ git pr show -t 20493`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20493.diff">https://git.openjdk.org/jdk/pull/20493.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20493#issuecomment-2273831014)