### PR TITLE
8335981: ProblemList runtime/Thread/TestAlwaysPreTouchStacks.java for MacOS

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -111,7 +111,7 @@ runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
-runtime/Thread/TestAlwaysPreTouchStacks.java 8335981 macosx-aarch64
+runtime/Thread/TestAlwaysPreTouchStacks.java 8335167 macosx-aarch64
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
 
 

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -111,7 +111,9 @@ runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
 runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
+runtime/Thread/TestAlwaysPreTouchStacks.java 8335981 macosx-aarch64
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
+
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
ProblemListed the failing test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335981](https://bugs.openjdk.org/browse/JDK-8335981): ProblemList runtime/Thread/TestAlwaysPreTouchStacks.java for MacOS (**Sub-task** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20496/head:pull/20496` \
`$ git checkout pull/20496`

Update a local copy of the PR: \
`$ git checkout pull/20496` \
`$ git pull https://git.openjdk.org/jdk.git pull/20496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20496`

View PR using the GUI difftool: \
`$ git pr show -t 20496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20496.diff">https://git.openjdk.org/jdk/pull/20496.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20496#issuecomment-2273847342)