### PR TITLE
8337622: IllegalArgumentException in java.lang.reflect.Field.get

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.cpp
+++ b/src/hotspot/share/classfile/javaClasses.cpp
@@ -1452,19 +1452,12 @@ void java_lang_Class::compute_offsets() {
 
   InstanceKlass* k = vmClasses::Class_klass();
   CLASS_FIELDS_DO(FIELD_COMPUTE_OFFSET);
-
-  // Init lock is a C union with component_mirror.  Only instanceKlass mirrors have
-  // init_lock and only ArrayKlass mirrors have component_mirror.  Since both are oops
-  // GC treats them the same.
-  _init_lock_offset = _component_mirror_offset;
-
   CLASS_INJECTED_FIELDS(INJECTED_FIELD_COMPUTE_OFFSET);
 }
 
 #if INCLUDE_CDS
 void java_lang_Class::serialize_offsets(SerializeClosure* f) {
   f->do_bool(&_offsets_computed);
-  f->do_u4((u4*)&_init_lock_offset);
 
   CLASS_FIELDS_DO(FIELD_SERIALIZE_OFFSET);
 

--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -209,6 +209,7 @@ class java_lang_String : AllStatic {
   macro(java_lang_Class, static_oop_field_count, int_signature,     false) \
   macro(java_lang_Class, protection_domain,      object_signature,  false) \
   macro(java_lang_Class, source_file,            object_signature,  false) \
+  macro(java_lang_Class, init_lock,              object_signature,  false)
 
 class java_lang_Class : AllStatic {
   friend class VMStructs;

--- a/test/hotspot/jtreg/runtime/reflect/ComponentTypeFieldTest.java
+++ b/test/hotspot/jtreg/runtime/reflect/ComponentTypeFieldTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/runtime/reflect/ComponentTypeFieldTest.java
+++ b/test/hotspot/jtreg/runtime/reflect/ComponentTypeFieldTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8337622
+ * @summary (reflect) java.lang.Class componentType field not found.
+ * @library /test/lib
+ * @modules java.base/java.lang:open
+ * @run main ComponentTypeFieldTest
+ */
+
+import java.lang.reflect.Field;
+import static jdk.test.lib.Asserts.*;
+
+public class ComponentTypeFieldTest {
+
+    public static void main(String[] args) throws Exception {
+        Field f = Class.class.getDeclaredField("componentType");
+        f.setAccessible(true);
+        Object val = f.get(Runnable.class);
+        assertTrue(val == null);
+        System.out.println("val is " + val);
+
+        Object arrayVal = f.get(Integer[].class);
+        System.out.println("val is " + arrayVal);
+        String arrayValString = arrayVal.toString();
+        assertTrue(arrayValString.equals("class java.lang.Integer"));
+    }
+}


### PR DESCRIPTION
Make the object init_lock be an injected field in the mirror so that reflecting on componentType will not inadvertently return the init_lock.  The init_lock is a Java object and the VM holds it during class linking and uses it to set state during class initialization.
Tested with tier1-8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337622](https://bugs.openjdk.org/browse/JDK-8337622): IllegalArgumentException in java.lang.reflect.Field.get (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) 🔄 Re-review required (review applies to [56c8c7b0](https://git.openjdk.org/jdk/pull/20498/files/56c8c7b05fa106e375f43d10b1aad1a867ff2c76))
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20498/head:pull/20498` \
`$ git checkout pull/20498`

Update a local copy of the PR: \
`$ git checkout pull/20498` \
`$ git pull https://git.openjdk.org/jdk.git pull/20498/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20498`

View PR using the GUI difftool: \
`$ git pr show -t 20498`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20498.diff">https://git.openjdk.org/jdk/pull/20498.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20498#issuecomment-2274101942)