### PR TITLE
8338010: WB_IsFrameDeoptimized miss ResourceMark

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -799,6 +799,7 @@ WB_END
 WB_ENTRY(jboolean, WB_IsFrameDeoptimized(JNIEnv* env, jobject o, jint depth))
   bool result = false;
   if (thread->has_last_Java_frame()) {
+    ResourceMark rm(THREAD);
     RegisterMap reg_map(thread,
                         RegisterMap::UpdateMap::include,
                         RegisterMap::ProcessFrames::include,


### PR DESCRIPTION
The method WB_IsFrameDeoptimized is used only by test com/sun/jdi/EATests.java and intermittently fails with virtual thread test factory.
The log explains how problem happens:
Stack: [0x000000f373e00000,0x000000f373f00000]
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V [jvm.dll+0xc956e1] os::win32::platform_print_native_stack+0x101 (os_windows_x86.cpp:235)
V [jvm.dll+0xf59abb] VMError::report+0x149b (vmError.cpp:1010)
V [jvm.dll+0xf5c15e] VMError::report_and_die+0x80e (vmError.cpp:1845)
V [jvm.dll+0x55796e] report_fatal+0x7e (debug.cpp:214)
V [jvm.dll+0xd4d591] ResourceArea::allocate_bytes+0x111 (resourceArea.inline.hpp:33)
V [jvm.dll+0xf44bef] vframe::new_vframe+0x7f (vframe.cpp:68)
V [jvm.dll+0x7fb97a] JavaThread::last_java_vframe+0x3a (javaThread.cpp:2044)
V [jvm.dll+0xf8f659] WB_IsFrameDeoptimized+0x219 (whitebox.cpp:798)
C 0x000001fbdebd3b96 (no source info available)

Testing by running test with and without thread factory & tier1.