### PR TITLE
8338064: Give better error for ConcurrentHashTable corruption

### DIFF
--- a/src/hotspot/share/utilities/concurrentHashTable.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.hpp
@@ -65,6 +65,7 @@ class ConcurrentHashTable : public CHeapObj<F> {
   // the InternalTable or user-defined memory.
   class Node {
    private:
+    DEBUG_ONLY(size_t _saved_hash);
     Node * volatile _next;
     VALUE _value;
    public:
@@ -77,6 +78,10 @@ class ConcurrentHashTable : public CHeapObj<F> {
     Node* next() const;
     void set_next(Node* node)         { _next = node; }
     Node* const volatile * next_ptr() { return &_next; }
+#ifdef ASSERT
+    size_t saved_hash() const         { return _saved_hash; }
+    void set_saved_hash(size_t hash)  { _saved_hash = hash; }
+#endif
 
     VALUE* value()                    { return &_value; }
 

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -679,9 +679,9 @@ inline bool ConcurrentHashTable<CONFIG, F>::
         // Keep in odd list
         odd = aux->next_ptr();
       } else {
-        DEBUG_ONLY(fatal("Cannot resize table: Node hash code has changed possibly due to corruption of the contents."
-                         " Node hash code changed from " SIZE_FORMAT " to " SIZE_FORMAT, aux->saved_hash(), aux_hash));
-        fatal("Cannot resize table: Node hash code has changed possibly due to corruption of the contents.");
+        const char* msg = "Cannot resize table: Node hash code has changed possibly due to corruption of the contents.";
+        DEBUG_ONLY(fatal("%s Node hash code changed from " SIZE_FORMAT " to " SIZE_FORMAT, msg, aux->saved_hash(), aux_hash);)
+        NOT_DEBUG(fatal("%s", msg);)
       }
     }
     aux = aux_next;

--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -679,7 +679,9 @@ inline bool ConcurrentHashTable<CONFIG, F>::
         // Keep in odd list
         odd = aux->next_ptr();
       } else {
-        fatal("aux_index does not match even or odd indices");
+        DEBUG_ONLY(fatal("Cannot resize table: Node hash code has changed possibly due to corruption of the contents."
+                         " Node hash code changed from " SIZE_FORMAT " to " SIZE_FORMAT, aux->saved_hash(), aux_hash));
+        fatal("Cannot resize table: Node hash code has changed possibly due to corruption of the contents.");
       }
     }
     aux = aux_next;
@@ -892,6 +894,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   size_t i = 0;
   uintx hash = lookup_f.get_hash();
   Node* new_node = Node::create_node(_context, value, nullptr);
+  DEBUG_ONLY(new_node->set_saved_hash(hash);)
 
   while (true) {
     {
@@ -1117,6 +1120,7 @@ inline bool ConcurrentHashTable<CONFIG, F>::
   Bucket* bucket = get_bucket_in(table, hash);
   assert(!bucket->have_redirect() && !bucket->is_locked(), "bad");
   Node* new_node = Node::create_node(_context, value, bucket->first());
+  DEBUG_ONLY(new_node->set_saved_hash(hash);)
   if (!bucket->cas_first(new_node, bucket->first())) {
     assert(false, "bad");
   }

--- a/test/hotspot/jtreg/runtime/stringtable/StringTableCorruptionTest.java
+++ b/test/hotspot/jtreg/runtime/stringtable/StringTableCorruptionTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8333356
+ * @summary Verify new error message for corrupting string table contents.
+ * @requires vm.flagless
+ * @modules java.base/java.lang:open
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver StringTableCorruptionTest test
+ */
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class StringTableCorruptionTest {
+    public static void main(String[] args) throws Exception {
+        if (args.length > 0) {
+            ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("--add-opens", "java.base/java.lang=ALL-UNNAMED",
+                                                             "-XX:-CreateCoredumpOnCrash", "StringTableCorruptionTest");
+            OutputAnalyzer output = new OutputAnalyzer(pb.start());
+            output.shouldContain("Node hash code has changed possibly due to corruption of the contents.");
+            output.shouldNotHaveExitValue(0);
+            return;
+        }
+
+        Field f = String.class.getDeclaredField("value");
+        f.setAccessible(true);
+        f.set("s1".intern(), f.get("s2"));
+        for (int i = 0; i < 4_000_000; i++) {
+            ("s_" + i).intern();
+        }
+    }
+}


### PR DESCRIPTION
You get this message if the nodes of the concurrent hash table are corrupted or somehow don't yield the same hashcode as when the node was entered in the table.  This change makes the error message less obscure, and in debug mode compares the two hash codes.  The hash code is kept in the table in only debug mode, because we don't want the table to take a lot more memory.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338064](https://bugs.openjdk.org/browse/JDK-8338064): Give better error for ConcurrentHashTable corruption (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20503/head:pull/20503` \
`$ git checkout pull/20503`

Update a local copy of the PR: \
`$ git checkout pull/20503` \
`$ git pull https://git.openjdk.org/jdk.git pull/20503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20503`

View PR using the GUI difftool: \
`$ git pr show -t 20503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20503.diff">https://git.openjdk.org/jdk/pull/20503.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20503#issuecomment-2274555925)