### PR TITLE
8338015: Fix "Java Java" typo in package info file of java.lang.classfile

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -26,8 +26,8 @@
 /**
  * <h2>Provides classfile parsing, generation, and transformation library.</h2>
  * The {@code java.lang.classfile} package contains classes for reading, writing, and
- * modifying Java class files, as specified in Chapter {@jvms 4} of the <cite>Java
- * Java Virtual Machine Specification</cite>.
+ * modifying Java class files, as specified in Chapter {@jvms 4} of the
+ * <cite>Java Virtual Machine Specification</cite>.
  *
  * <h2>Reading classfiles</h2>
  * The main class for reading classfiles is {@link java.lang.classfile.ClassModel}; we


### PR DESCRIPTION
Easy fix of an accidentally repeated "Java".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338015](https://bugs.openjdk.org/browse/JDK-8338015): Fix "Java Java" typo in package info file of java.lang.classfile (**Bug** - P4)


### Reviewers
 * [Jie Fu](https://openjdk.org/census#jiefu) (@DamonFool - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20505/head:pull/20505` \
`$ git checkout pull/20505`

Update a local copy of the PR: \
`$ git checkout pull/20505` \
`$ git pull https://git.openjdk.org/jdk.git pull/20505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20505`

View PR using the GUI difftool: \
`$ git pr show -t 20505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20505.diff">https://git.openjdk.org/jdk/pull/20505.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20505#issuecomment-2274806535)