### PR TITLE
8338019: Fix simple -Wzero-as-null-pointer-constant warnings in riscv code

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -542,7 +542,7 @@ void LIR_Assembler::const2mem(LIR_Opr src, LIR_Opr dest, BasicType type, CodeEmi
       insn = &MacroAssembler::sw; break;
     case T_OBJECT:    // fall through
     case T_ARRAY:
-      assert(c->as_jobject() == 0, "should be");
+      assert(c->as_jobject() == nullptr, "should be");
       if (UseCompressedOops && !wide) {
         insn = &MacroAssembler::sw;
       } else {

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -1066,4 +1066,4 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
 
 #undef __
 
-const char *Runtime1::pd_name_for_address(address entry) { Unimplemented(); return 0; }
+const char *Runtime1::pd_name_for_address(address entry) { Unimplemented(); }

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -269,7 +269,7 @@ void frame::patch_pc(Thread* thread, address pc) {
 
   // Either the return address is the original one or we are going to
   // patch in the same address that's already there.
-  assert(_pc == pc_old || pc == pc_old || pc_old == 0, "must be");
+  assert(_pc == pc_old || pc == pc_old || pc_old == nullptr, "must be");
   DEBUG_ONLY(address old_pc = _pc;)
   *pc_addr = pc;
   _pc = pc; // must be set before call to get_deopt_original_pc

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -685,7 +685,7 @@ address NativeJump::jump_destination() const {
   // load
 
   // return -1 if jump to self or to 0
-  if ((dest == (address) this) || dest == 0) {
+  if ((dest == (address) this) || dest == nullptr) {
     dest = (address) -1;
   }
 
@@ -714,7 +714,7 @@ address NativeGeneralJump::jump_destination() const {
   // a general jump
 
   // return -1 if jump to self or to 0
-  if ((dest == (address) this) || dest == 0) {
+  if ((dest == (address) this) || dest == nullptr) {
     dest = (address) -1;
   }
 


### PR DESCRIPTION
Hi, 
Same as  [JDK-8337786](https://bugs.openjdk.org/browse/JDK-8337786) for aarch64, similar build warnings exist on riscv. Please help review this trivial change that replaces some uses of literal 0 as a null pointer constant in riscv code to instead use nullptr.

### Testing
- [x] Run tier1 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338019](https://bugs.openjdk.org/browse/JDK-8338019): Fix simple -Wzero-as-null-pointer-constant warnings in riscv code (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20506/head:pull/20506` \
`$ git checkout pull/20506`

Update a local copy of the PR: \
`$ git checkout pull/20506` \
`$ git pull https://git.openjdk.org/jdk.git pull/20506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20506`

View PR using the GUI difftool: \
`$ git pr show -t 20506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20506.diff">https://git.openjdk.org/jdk/pull/20506.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20506#issuecomment-2274891422)