### PR TITLE
8338062: JFR: Remove TestStartDuration.java and TestStartName.java from ProblemList.txt

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -745,8 +745,6 @@ jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-
 # jdk_jfr
 
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
-jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
-jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 
 ############################################################################


### PR DESCRIPTION
Could I have a review of a change that removes two tests from ProblemList.txt. 

The parsing of startup parameters was rewritten in Java for JDK 17 as part of [JDK-8265271](https://bugs.openjdk.org/browse/JDK-8265271) and I have run the tests several thousand times without a failure. 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338062](https://bugs.openjdk.org/browse/JDK-8338062): JFR: Remove TestStartDuration.java and TestStartName.java from ProblemList.txt (**Sub-task** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20511/head:pull/20511` \
`$ git checkout pull/20511`

Update a local copy of the PR: \
`$ git checkout pull/20511` \
`$ git pull https://git.openjdk.org/jdk.git pull/20511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20511`

View PR using the GUI difftool: \
`$ git pr show -t 20511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20511.diff">https://git.openjdk.org/jdk/pull/20511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20511#issuecomment-2276065176)