### PR TITLE
8334780: Crash: assert(h_array_list.not_null()) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
@@ -136,7 +136,9 @@ jobject JdkJfrEvent::get_all_klasses(TRAPS) {
   transform_klasses_to_local_jni_handles(event_subklasses, THREAD);
 
   Handle h_array_list(THREAD, new_java_util_arraylist(THREAD));
-  assert(h_array_list.not_null(), "invariant");
+  if (h_array_list.is_null()) {
+    return empty_java_util_arraylist;
+  }
 
   static const char add_method_name[] = "add";
   static const char add_method_signature[] = "(Ljava/lang/Object;)Z";


### PR DESCRIPTION
Greetings,

this change adjusts an incorrect assert, as new_java_util_arraylist() has CHECK_NULL constructs on exceptions.

Testing: jdk_jfr

Cheers
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334780](https://bugs.openjdk.org/browse/JDK-8334780): Crash: assert(h_array_list.not_null()) failed: invariant (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20512/head:pull/20512` \
`$ git checkout pull/20512`

Update a local copy of the PR: \
`$ git checkout pull/20512` \
`$ git pull https://git.openjdk.org/jdk.git pull/20512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20512`

View PR using the GUI difftool: \
`$ git pr show -t 20512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20512.diff">https://git.openjdk.org/jdk/pull/20512.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20512#issuecomment-2276123526)