### PR TITLE
8338011: CDS archived heap object support for 64-bit Windows

### DIFF
--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2178,21 +2178,35 @@ bool FileMapInfo::map_heap_region_impl() {
   // Map the archived heap data. No need to call MemTracker::record_virtual_memory_type()
   // for mapped region as it is part of the reserved java heap, which is already recorded.
   char* addr = (char*)_mapped_heap_memregion.start();
-  char* base = map_memory(_fd, _full_path, r->file_offset(),
-                          addr, _mapped_heap_memregion.byte_size(), r->read_only(),
-                          r->allow_exec());
-  if (base == nullptr || base != addr) {
-    dealloc_heap_region();
-    log_info(cds)("UseSharedSpaces: Unable to map at required address in java heap. "
-                  INTPTR_FORMAT ", size = " SIZE_FORMAT " bytes",
-                  p2i(addr), _mapped_heap_memregion.byte_size());
-    return false;
-  }
+  char* base;
 
-  if (VerifySharedSpaces && !r->check_region_crc(base)) {
-    dealloc_heap_region();
-    log_info(cds)("UseSharedSpaces: mapped heap region is corrupt");
-    return false;
+  if (MetaspaceShared::use_windows_memory_mapping()) {
+    if (!read_region(MetaspaceShared::hp, addr, 
+                     align_up(_mapped_heap_memregion.byte_size(), os::vm_page_size()),
+                     /* do_commit = */ true)) {
+      dealloc_heap_region();
+      log_error(cds)("Failed to read archived heap region at " INTPTR_FORMAT, p2i(addr));
+      return false;
+    }
+    // Checks for VerifySharedSpaces is already done inside read_region()
+    base = addr;
+  } else {
+    base = map_memory(_fd, _full_path, r->file_offset(),
+                      addr, _mapped_heap_memregion.byte_size(), r->read_only(),
+                      r->allow_exec());
+    if (base == nullptr || base != addr) {
+      dealloc_heap_region();
+      log_info(cds)("UseSharedSpaces: Unable to map at required address in java heap. "
+                    INTPTR_FORMAT ", size = " SIZE_FORMAT " bytes",
+                    p2i(addr), _mapped_heap_memregion.byte_size());
+      return false;
+    }
+
+    if (VerifySharedSpaces && !r->check_region_crc(base)) {
+      dealloc_heap_region();
+      log_info(cds)("UseSharedSpaces: mapped heap region is corrupt");
+      return false;
+    }
   }
 
   r->set_mapped_base(base);

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2185,7 +2185,7 @@ bool FileMapInfo::map_heap_region_impl() {
                      align_up(_mapped_heap_memregion.byte_size(), os::vm_page_size()),
                      /* do_commit = */ true)) {
       dealloc_heap_region();
-      log_error(cds)("Failed to read archived heap region at " INTPTR_FORMAT, p2i(addr));
+      log_error(cds)("Failed to read archived heap region into " INTPTR_FORMAT, p2i(addr));
       return false;
     }
     // Checks for VerifySharedSpaces is already done inside read_region()

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -2181,7 +2181,7 @@ bool FileMapInfo::map_heap_region_impl() {
   char* base;
 
   if (MetaspaceShared::use_windows_memory_mapping()) {
-    if (!read_region(MetaspaceShared::hp, addr, 
+    if (!read_region(MetaspaceShared::hp, addr,
                      align_up(_mapped_heap_memregion.byte_size(), os::vm_page_size()),
                      /* do_commit = */ true)) {
       dealloc_heap_region();

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -1554,7 +1554,6 @@ void HeapShared::archive_object_subgraphs(ArchivableStaticFieldInfo fields[],
   //     by any of these static fields.
   //     At runtime, these classes are initialized before X's archived fields
   //     are restored by HeapShared::initialize_from_archived_subgraph().
-  int i;
   for (int i = 0; fields[i].valid(); ) {
     ArchivableStaticFieldInfo* info = &fields[i];
     const char* klass_name = info->klass_name;

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -621,7 +621,7 @@
 #define COMPILER_HEADER(basename)        XSTR(COMPILER_HEADER_STEM(basename).hpp)
 #define COMPILER_HEADER_INLINE(basename) XSTR(COMPILER_HEADER_STEM(basename).inline.hpp)
 
-#if INCLUDE_CDS && INCLUDE_G1GC && defined(_LP64) && !defined(_WINDOWS)
+#if INCLUDE_CDS && INCLUDE_G1GC && defined(_LP64)
 #define INCLUDE_CDS_JAVA_HEAP 1
 #define CDS_JAVA_HEAP_ONLY(x) x
 #define NOT_CDS_JAVA_HEAP(x)


### PR DESCRIPTION
We didn't support CDS archived heap object on Windows because

- The Windows implementation of `os::map_memory()` cannot map the contents of a file into a region that's already reserved by the garbage collector.
- We had a high failure rate for mapping the CDS archive on Windows due to ASLR, sometimes as high as 50%. So it didn't seem worth the effort (mainly testing) to support archived heap objects on Windows.

Both of the above issues were fixed in [JDK-8231610](https://bugs.openjdk.org/browse/JDK-8231610), so we should add the support to Windows now.

(Tested on Oracle CI tiers 1-7)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338011](https://bugs.openjdk.org/browse/JDK-8338011): CDS archived heap object support for 64-bit Windows (**Enhancement** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**) 🔄 Re-review required (review applies to [8c79b888](https://git.openjdk.org/jdk/pull/20514/files/8c79b888ca0081480ccad08950a0de221a944ba6))
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20514/head:pull/20514` \
`$ git checkout pull/20514`

Update a local copy of the PR: \
`$ git checkout pull/20514` \
`$ git pull https://git.openjdk.org/jdk.git pull/20514/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20514`

View PR using the GUI difftool: \
`$ git pr show -t 20514`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20514.diff">https://git.openjdk.org/jdk/pull/20514.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20514#issuecomment-2276799604)