### PR TITLE
8338101: remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3463,7 +3463,7 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
   }
 
   assert(aligned_base != nullptr,
-       "Did not manage to re-map after %d attempts (size %zu, alignment %zu, file descriptor %d)", max_attempts, size, alignment, file_desc);
+      "Did not manage to re-map after %d attempts (size %zu, alignment %zu, file descriptor %d)", max_attempts, size, alignment, file_desc);
 
   return aligned_base;
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3462,8 +3462,8 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
                                      os::attempt_reserve_memory_at(aligned_base, size, false, flag);
   }
 
-  assert(aligned_base != nullptr, "Did not manage to re-map after %d attempts?", max_attempts);
-  assert(aligned_base != nullptr, "Did not manage to re-map after %d attempts (size %zu, alignment %zu, file descriptor %d)", max_attempts, size, alignment, file_desc);
+  assert(aligned_base != nullptr,
+       "Did not manage to re-map after %d attempts (size %zu, alignment %zu, file descriptor %d)", max_attempts, size, alignment, file_desc);
 
   return aligned_base;
 }


### PR DESCRIPTION
After [JDK-8338058](https://bugs.openjdk.org/browse/JDK-8338058) by mistake an old assertion remained in map_or_reserve_memory_aligned; this has to be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8338101: remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058`

### Issue
 * [JDK-8338101](https://bugs.openjdk.org/browse/JDK-8338101): remove old remap assertion in map_or_reserve_memory_aligned  after JDK-8338058 (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20519/head:pull/20519` \
`$ git checkout pull/20519`

Update a local copy of the PR: \
`$ git checkout pull/20519` \
`$ git pull https://git.openjdk.org/jdk.git pull/20519/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20519`

View PR using the GUI difftool: \
`$ git pr show -t 20519`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20519.diff">https://git.openjdk.org/jdk/pull/20519.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20519#issuecomment-2277400016)