### PR TITLE
8338109: java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java duplicate in ProblemList

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -375,7 +375,7 @@ java/awt/Modal/MultipleDialogs/MultipleDialogs3Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs4Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs5Test.java 8198665 macosx-all
 java/awt/Mouse/EnterExitEvents/DragWindowOutOfFrameTest.java 8177326 macosx-all
-java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8005021 macosx-all
+java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8005021,8332158 macosx-all,linux-x64
 java/awt/Mouse/EnterExitEvents/FullscreenEnterEventTest.java 8051455 macosx-all
 java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersUnitTest_Standard.java 7124407,8302787  macosx-all,windows-all
 java/awt/Mouse/RemovedComponentMouseListener/RemovedComponentMouseListener.java 8157170 macosx-all
@@ -475,7 +475,6 @@ java/awt/Choice/SelectNewItemTest/SelectNewItemTest.java 8324782 macosx-all
 
 # Wayland related
 
-java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8332158 linux-x64
 java/awt/FullScreen/FullscreenWindowProps/FullscreenWindowProps.java 8280991 linux-x64
 java/awt/FullScreen/SetFullScreenTest.java 8332155 linux-x64
 


### PR DESCRIPTION
[JDK-8337320 ](https://bugs.openjdk.org/browse/JDK-8337320) introduced the second mention of the java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java in problem list.

This causes the test to fail on MacOS

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338109](https://bugs.openjdk.org/browse/JDK-8338109): java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java duplicate in ProblemList (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20521/head:pull/20521` \
`$ git checkout pull/20521`

Update a local copy of the PR: \
`$ git checkout pull/20521` \
`$ git pull https://git.openjdk.org/jdk.git pull/20521/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20521`

View PR using the GUI difftool: \
`$ git pr show -t 20521`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20521.diff">https://git.openjdk.org/jdk/pull/20521.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20521#issuecomment-2277658362)