### PR TITLE
8337976: Insufficient error recovery in parser for switch inside class body

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5251,7 +5251,12 @@ public class Attr extends JCTree.Visitor {
 
     public void visitErroneous(JCErroneous tree) {
         if (tree.errs != null) {
-            Env<AttrContext> errEnv = env.dup(env.tree, env.info.dup());
+            Symbol fakeOwner =
+                new MethodSymbol(BLOCK, names.empty, null,
+                    env.info.scope.owner);
+            Env<AttrContext> errEnv =
+                    env.dup(env.tree,
+                            env.info.dup(env.info.scope.dupUnshared(fakeOwner)));
             errEnv.info.returnResult = unknownExprInfo;
             for (JCTree err : tree.errs)
                 attribTree(err, errEnv, new ResultInfo(KindSelector.ERR, pt()));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5251,12 +5251,18 @@ public class Attr extends JCTree.Visitor {
 
     public void visitErroneous(JCErroneous tree) {
         if (tree.errs != null) {
-            Symbol fakeOwner =
-                new MethodSymbol(BLOCK, names.empty, null,
-                    env.info.scope.owner);
+            WriteableScope newScope = env.info.scope;
+
+            if (env.tree instanceof JCClassDecl) {
+                Symbol fakeOwner =
+                    new MethodSymbol(BLOCK, names.empty, null,
+                        env.info.scope.owner);
+                newScope = newScope.dupUnshared(fakeOwner);
+            }
+
             Env<AttrContext> errEnv =
                     env.dup(env.tree,
-                            env.info.dup(env.info.scope.dupUnshared(fakeOwner)));
+                            env.info.dup(newScope));
             errEnv.info.returnResult = unknownExprInfo;
             for (JCTree err : tree.errs)
                 attribTree(err, errEnv, new ResultInfo(KindSelector.ERR, pt()));

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4918,6 +4918,10 @@ public class JavacParser implements Parser {
                isRecordStart() && allowRecords;
     }
 
+    /**
+     * {@return true if and only if the current token is definitelly a token that
+     *  starts a statement.}
+     */
     private boolean isDefiniteStatementStartToken() {
         return switch (token.kind) {
             case IF, WHILE, DO, SWITCH, RETURN, TRY, FOR, ASSERT, BREAK,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -1400,8 +1400,7 @@ public class JavacParser implements Parser {
     protected JCExpression term3() {
         int pos = token.pos;
         JCExpression t;
-        List<JCExpression> typeArgs = isMode(EXPR) || !isMode(TYPE) ? typeArgumentsOpt(EXPR)
-                                                                    : null;
+        List<JCExpression> typeArgs = typeArgumentsOpt(EXPR);
         switch (token.kind) {
         case QUES:
             if (isMode(TYPE) && isMode(TYPEARG) && !isMode(NOPARAMS)) {
@@ -1729,13 +1728,6 @@ public class JavacParser implements Parser {
                 }
             }
             // Not reachable.
-        case LT:
-            if (isMode(TYPE) && !isMode(EXPR)) {
-                t = toP(F.at(token.pos).Ident(ident()));
-                t = typeArgumentsOpt(t);
-                break;
-            }
-            return illegal();
         default:
             return illegal();
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/VirtualParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/VirtualParser.java
@@ -62,7 +62,7 @@ public class VirtualParser extends JavacParser {
     }
 
     @Override
-    protected JCErroneous syntaxError(int pos, List<JCTree> errs, Error errorKey) {
+    protected JCErroneous syntaxError(int pos, List<? extends JCTree> errs, Error errorKey) {
         hasErrors = true;
         return F.Erroneous();
     }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -1616,6 +1616,9 @@ compiler.err.file.sb.on.source.or.patch.path.for.module=\
 compiler.err.no.java.lang=\
     Unable to find package java.lang in platform classes
 
+compiler.err.statement.not.expected=\
+    statements not expected outside of methods and initializers
+
 #####
 
 # Fatal Errors

--- a/test/langtools/tools/javac/diags/examples/StatementNotExpected.java
+++ b/test/langtools/tools/javac/diags/examples/StatementNotExpected.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+// key: compiler.err.statement.not.expected
+
+class StatementNotExpected {
+    return null;
+}

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326 8312093 8312204 8315452
+ * @bug 7073631 7159445 7156633 8028235 8065753 8205418 8205913 8228451 8237041 8253584 8246774 8256411 8256149 8259050 8266436 8267221 8271928 8275097 8293897 8295401 8304671 8310326 8312093 8312204 8315452 8337976
  * @summary tests error and diagnostics positions
  * @author  Jan Lahoda
  * @modules jdk.compiler/com.sun.tools.javac.api
@@ -2407,6 +2407,119 @@ public class JavacParserTest extends TestCase {
                      """
                      package test;
                      (ERROR: public )""");
+    }
+
+    @Test //JDK-8337976
+    void testStatementsInClass() throws IOException {
+        String code = """
+                      package test;
+                      public class Test {
+                          if (true);
+                          while (true);
+                          do {} while (true);
+                          for ( ; ; );
+                          switch (0) { default: }
+                          assert true;
+                          break;
+                          continue;
+                          return ;
+                          throw new RuntimeException();
+                          try {
+                          } catch (RuntimeException ex) {}
+                      }
+                      """;
+        DiagnosticCollector<JavaFileObject> coll =
+                new DiagnosticCollector<>();
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, coll,
+                List.of("--enable-preview", "--source", SOURCE_VERSION),
+                null, Arrays.asList(new MyFileObject(code)));
+        CompilationUnitTree cut = ct.parse().iterator().next();
+
+        String result = toStringWithErrors(cut).replaceAll("\\R", "\n");
+        System.out.println("RESULT\n" + result);
+        assertEquals("incorrect AST",
+                     result,
+                     """
+                     package test;
+                     \n\
+                     public class Test {
+                         (ERROR: if (true) ;)
+                         (ERROR: while (true) ;)
+                         (ERROR: do {
+                     } while (true);)
+                         (ERROR: for (; ; ) ;)
+                         (ERROR: switch (0) {
+                     default:
+
+                     })
+                         (ERROR: assert true;)
+                         (ERROR: break;)
+                         (ERROR: continue;)
+                         (ERROR: return;)
+                         (ERROR: throw new RuntimeException();)
+                         (ERROR: try {
+                     } catch (RuntimeException ex) {
+                     })
+                     }""");
+
+        List<String> codes = new LinkedList<>();
+
+        for (Diagnostic<? extends JavaFileObject> d : coll.getDiagnostics()) {
+            codes.add(d.getLineNumber() + ":" + d.getColumnNumber() + ":" + d.getCode());
+        }
+
+        assertEquals("testStatementsInClass: " + codes,
+                     List.of("3:5:compiler.err.statement.not.expected",
+                             "4:5:compiler.err.statement.not.expected",
+                             "5:5:compiler.err.statement.not.expected",
+                             "6:5:compiler.err.statement.not.expected",
+                             "7:5:compiler.err.statement.not.expected",
+                             "8:5:compiler.err.statement.not.expected",
+                             "9:5:compiler.err.statement.not.expected",
+                             "10:5:compiler.err.statement.not.expected",
+                             "11:5:compiler.err.statement.not.expected",
+                             "12:5:compiler.err.statement.not.expected",
+                             "13:5:compiler.err.statement.not.expected"),
+                     codes);
+    }
+
+    @Test //JDK-8337976
+    void testTypeParametersMissingName() throws IOException {
+        String code = """
+                      package test;
+                      public class Test {
+                          void test(<?> p) {}
+                      }
+                      """;
+        DiagnosticCollector<JavaFileObject> coll =
+                new DiagnosticCollector<>();
+        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, coll,
+                List.of("--enable-preview", "--source", SOURCE_VERSION),
+                null, Arrays.asList(new MyFileObject(code)));
+        CompilationUnitTree cut = ct.parse().iterator().next();
+
+        String result = toStringWithErrors(cut).replaceAll("\\R", "\n");
+        System.out.println("RESULT\n" + result);
+        assertEquals("incorrect AST",
+                     result,
+                     """
+                     package test;
+                     \n\
+                     public class Test {
+                         \n\
+                         void test(<error><?> p) {
+                         }
+                     }""");
+
+        List<String> codes = new LinkedList<>();
+
+        for (Diagnostic<? extends JavaFileObject> d : coll.getDiagnostics()) {
+            codes.add(d.getLineNumber() + ":" + d.getColumnNumber() + ":" + d.getCode());
+        }
+
+        assertEquals("testTypeParametersMissingName: " + codes,
+                     List.of("3:15:compiler.err.expected"),
+                     codes);
     }
 
     void run(String[] args) throws Exception {

--- a/test/langtools/tools/javac/parser/JavacParserTest.java
+++ b/test/langtools/tools/javac/parser/JavacParserTest.java
@@ -2483,45 +2483,6 @@ public class JavacParserTest extends TestCase {
                      codes);
     }
 
-    @Test //JDK-8337976
-    void testTypeParametersMissingName() throws IOException {
-        String code = """
-                      package test;
-                      public class Test {
-                          void test(<?> p) {}
-                      }
-                      """;
-        DiagnosticCollector<JavaFileObject> coll =
-                new DiagnosticCollector<>();
-        JavacTaskImpl ct = (JavacTaskImpl) tool.getTask(null, fm, coll,
-                List.of("--enable-preview", "--source", SOURCE_VERSION),
-                null, Arrays.asList(new MyFileObject(code)));
-        CompilationUnitTree cut = ct.parse().iterator().next();
-
-        String result = toStringWithErrors(cut).replaceAll("\\R", "\n");
-        System.out.println("RESULT\n" + result);
-        assertEquals("incorrect AST",
-                     result,
-                     """
-                     package test;
-                     \n\
-                     public class Test {
-                         \n\
-                         void test(<error><?> p) {
-                         }
-                     }""");
-
-        List<String> codes = new LinkedList<>();
-
-        for (Diagnostic<? extends JavaFileObject> d : coll.getDiagnostics()) {
-            codes.add(d.getLineNumber() + ":" + d.getColumnNumber() + ":" + d.getCode());
-        }
-
-        assertEquals("testTypeParametersMissingName: " + codes,
-                     List.of("3:15:compiler.err.expected"),
-                     codes);
-    }
-
     void run(String[] args) throws Exception {
         int passed = 0, failed = 0;
         final Pattern p = (args != null && args.length > 0)

--- a/test/langtools/tools/javac/records/RecordCompilationTests.java
+++ b/test/langtools/tools/javac/records/RecordCompilationTests.java
@@ -1358,7 +1358,7 @@ class RecordCompilationTests extends CompilationTestCase {
         try {
             String[] testOptions = {};
             setCompileOptions(testOptions);
-            assertFail("compiler.err.illegal.start.of.type",
+            assertFail("compiler.err.statement.not.expected",
                     "class R {\n" +
                             "    record RR(int i) {\n" +
                             "        return null;\n" +

--- a/test/langtools/tools/javac/recovery/T8337976.java
+++ b/test/langtools/tools/javac/recovery/T8337976.java
@@ -1,0 +1,11 @@
+/**
+ * @test /nodynamiccopyright/
+ * @bug 8337976
+ * @summary Verify javac does not crash and produces nice errors for certain erroneous code.
+ * @compile/fail/ref=T8337976.out -XDrawDiagnostics -XDshould-stop.at=FLOW -XDdev T8337976.java
+ */
+public class T8337976 {
+    switch (0) { default: }
+    void test(<?> p) {}
+    undefined u;
+}

--- a/test/langtools/tools/javac/recovery/T8337976.java
+++ b/test/langtools/tools/javac/recovery/T8337976.java
@@ -5,7 +5,6 @@
  * @compile/fail/ref=T8337976.out -XDrawDiagnostics -XDshould-stop.at=FLOW -XDdev T8337976.java
  */
 public class T8337976 {
-    switch (0) { default: }
-    void test(<?> p) {}
-    undefined u;
+    switch (0) { default: undefined u;}
+    if (true) { undefined u; }
 }

--- a/test/langtools/tools/javac/recovery/T8337976.out
+++ b/test/langtools/tools/javac/recovery/T8337976.out
@@ -1,4 +1,5 @@
 T8337976.java:8:5: compiler.err.statement.not.expected
-T8337976.java:9:15: compiler.err.expected: token.identifier
-T8337976.java:10:5: compiler.err.cant.resolve.location: kindname.class, undefined, , , (compiler.misc.location: kindname.class, T8337976, null)
-3 errors
+T8337976.java:9:5: compiler.err.statement.not.expected
+T8337976.java:8:27: compiler.err.cant.resolve.location: kindname.class, undefined, , , (compiler.misc.location: kindname.class, T8337976, null)
+T8337976.java:9:17: compiler.err.cant.resolve.location: kindname.class, undefined, , , (compiler.misc.location: kindname.class, T8337976, null)
+4 errors

--- a/test/langtools/tools/javac/recovery/T8337976.out
+++ b/test/langtools/tools/javac/recovery/T8337976.out
@@ -1,4 +1,4 @@
-T8337976.java:6:5: compiler.err.statement.not.expected
-T8337976.java:7:15: compiler.err.expected: token.identifier
-T8337976.java:8:5: compiler.err.cant.resolve.location: kindname.class, undefined, , , (compiler.misc.location: kindname.class, T8337976, null)
+T8337976.java:8:5: compiler.err.statement.not.expected
+T8337976.java:9:15: compiler.err.expected: token.identifier
+T8337976.java:10:5: compiler.err.cant.resolve.location: kindname.class, undefined, , , (compiler.misc.location: kindname.class, T8337976, null)
 3 errors

--- a/test/langtools/tools/javac/recovery/T8337976.out
+++ b/test/langtools/tools/javac/recovery/T8337976.out
@@ -1,0 +1,4 @@
+T8337976.java:6:5: compiler.err.statement.not.expected
+T8337976.java:7:15: compiler.err.expected: token.identifier
+T8337976.java:8:5: compiler.err.cant.resolve.location: kindname.class, undefined, , , (compiler.misc.location: kindname.class, T8337976, null)
+3 errors


### PR DESCRIPTION
Consider this code:
```
public class T9999999 {
    switch (0) { default: }
}
```

When trying to compile this, javac crashes:

```
$ .../jdk-22/bin/javac -XDdev /tmp/T9999999.java
/tmp/T9999999.java:2: error: switch expression does not have any result expressions
    switch (0) { default: } f;
    ^
1 error
An exception has occurred in the compiler (22.0.1-internal). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com/) after checking the Bug Database (https://bugs.java.com/) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.AssertionError: Unexpected tree: switch (0) {
default:

} with kind: SWITCH_EXPRESSION within: switch (0) {
default:

} with kind: SWITCH_EXPRESSION
        at jdk.compiler/com.sun.tools.javac.util.Assert.error(Assert.java:162)
        at jdk.compiler/com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.validateAnnotatedType(Attr.java:5881)
        at jdk.compiler/com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.visitVarDef(Attr.java:5727)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCVariableDecl.accept(JCTree.java:1022)
        at jdk.compiler/com.sun.tools.javac.tree.TreeScanner.scan(TreeScanner.java:50)
        at jdk.compiler/com.sun.tools.javac.comp.Attr$TypeAnnotationsValidator.visitClassDef(Attr.java:5780)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCClassDecl.accept(JCTree.java:814)
        at jdk.compiler/com.sun.tools.javac.comp.Attr.validateTypeAnnotations(Attr.java:5677)
        at jdk.compiler/com.sun.tools.javac.code.TypeAnnotations.lambda$validateTypeAnnotationsSignatures$1(TypeAnnotations.java:144)
        at jdk.compiler/com.sun.tools.javac.comp.Annotate.flush(Annotate.java:200)
        at jdk.compiler/com.sun.tools.javac.comp.Annotate.unblockAnnotations(Annotate.java:144)
        at jdk.compiler/com.sun.tools.javac.comp.Annotate.enterDone(Annotate.java:157)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.enterDone(JavaCompiler.java:1827)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.enterTrees(JavaCompiler.java:1081)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:947)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:319)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:178)
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:66)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:52)
printing javac parameters to: /home/jlahoda/src/jdk/jdk/javac.20240809_163551.args
```

The problem is that while parsing a the class body, javac will try to parse a type (as a type of a field or method), but finds the switch. Which will get parsed as an expression, and used as the type of the field `f`. This then crashes type annotation validation, but generally does not make much sense.

The proposal here is to check if there's a token that inevitably is a start of a statement used inside a class (or interface, enum, annotation type or record), and if yes, parse the input as a statement.

As a result, the parser tolerates statements inside a class body. The statement's tree is wrapped inside an `ErroneousTree`, so that it is obvious it is not a correct AST.

The attribution is also tweaked a bit to handle the augmented AST better.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337976](https://bugs.openjdk.org/browse/JDK-8337976): Insufficient error recovery in parser for switch inside class body (**Bug** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20526/head:pull/20526` \
`$ git checkout pull/20526`

Update a local copy of the PR: \
`$ git checkout pull/20526` \
`$ git pull https://git.openjdk.org/jdk.git pull/20526/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20526`

View PR using the GUI difftool: \
`$ git pr show -t 20526`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20526.diff">https://git.openjdk.org/jdk/pull/20526.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20526#issuecomment-2278161017)