### PR TITLE
8336665: CCE in X509CRLImpl$TBSCertList.getCertIssuer

### DIFF
--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -286,10 +286,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
                     entry.getCertificateIssuerExtension();
             if (ciExt != null) {
                 GeneralNames names = ciExt.getNames();
-                X500Name issuerDN;
-                try {
-                    issuerDN = (X500Name) names.get(0).getName();
-                } catch (ClassCastException e) {
+                if (!(names.get(0).getName() instanceof X500Name issuerDN)) {
                     throw new CRLException("Parsing error: bad X500 issuer");
                 }
                 return issuerDN.asX500Principal();

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -280,13 +280,18 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
          *   prevCertIssuer if it does not exist
          */
         private X500Principal getCertIssuer(X509CRLEntryImpl entry,
-                                            X500Principal prevCertIssuer) {
+                X500Principal prevCertIssuer) throws CRLException {
 
             CertificateIssuerExtension ciExt =
                     entry.getCertificateIssuerExtension();
             if (ciExt != null) {
                 GeneralNames names = ciExt.getNames();
-                X500Name issuerDN = (X500Name) names.get(0).getName();
+                X500Name issuerDN = null;
+                try {
+                    issuerDN = (X500Name) names.get(0).getName();
+                } catch (ClassCastException e) {
+                    throw new CRLException("Parsing error: bad X500 issuer");
+                }
                 return issuerDN.asX500Principal();
             } else {
                 return prevCertIssuer;

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -286,7 +286,7 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
                     entry.getCertificateIssuerExtension();
             if (ciExt != null) {
                 GeneralNames names = ciExt.getNames();
-                X500Name issuerDN = null;
+                X500Name issuerDN;
                 try {
                     issuerDN = (X500Name) names.get(0).getName();
                 } catch (ClassCastException e) {

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -292,8 +292,8 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
                         return issuerDN.asX500Principal();
                     }
                 }
-                throw new CRLException("Parsing error: "
-                        + "issuer is not an X.500 DN");
+                throw new CRLException("Parsing error: CertificateIssuer "
+                         + "field does not contain an X.500 DN");
             } else {
                 return prevCertIssuer;
             }

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -286,11 +286,14 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
                     entry.getCertificateIssuerExtension();
             if (ciExt != null) {
                 GeneralNames names = ciExt.getNames();
-                if (!(names.get(0).getName() instanceof X500Name issuerDN)) {
-                    throw new CRLException("Parsing error: "
-                            + "issuer is not an X.500 DN");
+                Iterator<GeneralName> itr = names.iterator();
+                while (itr.hasNext()) {
+                    if (itr.next().getName() instanceof X500Name issuerDN) {
+                        return issuerDN.asX500Principal();
+                    }
                 }
-                return issuerDN.asX500Principal();
+                throw new CRLException("Parsing error: "
+                        + "issuer is not an X.500 DN");
             } else {
                 return prevCertIssuer;
             }

--- a/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
+++ b/src/java.base/share/classes/sun/security/x509/X509CRLImpl.java
@@ -287,7 +287,8 @@ public class X509CRLImpl extends X509CRL implements DerEncoder {
             if (ciExt != null) {
                 GeneralNames names = ciExt.getNames();
                 if (!(names.get(0).getName() instanceof X500Name issuerDN)) {
-                    throw new CRLException("Parsing error: bad X500 issuer");
+                    throw new CRLException("Parsing error: "
+                            + "issuer is not an X.500 DN");
                 }
                 return issuerDN.asX500Principal();
             } else {

--- a/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedCCE.java
+++ b/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedCCE.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8336665
+ * @summary Verify that generateCRLs method does not throw ClassCastException.
+ *          It should throw CRLException instead.
+ * @library /test/lib
+ */
+import java.security.NoSuchProviderException;
+import java.security.cert.*;
+import java.io.ByteArrayInputStream;
+import java.util.Base64;
+
+import jdk.test.lib.Utils;
+
+public class UnexpectedCCE {
+    static CertificateFactory cf = null;
+
+    public static void main(String[] av ) throws CertificateException,
+           NoSuchProviderException {
+
+        // "class sun.security.x509.OIDName cannot be cast
+        // to class sun.security.x509.X500Name"
+        byte[] encoded_1 = Base64.getDecoder().decode("""
+            MIIBljCCAVMCAQEwCwYHKoZIzjgEAwUAMC0xEzARBgoJkiaJk/IsZAEZEwNjb20xFjA\
+            UBgoJkiaJjvIsZAEZEwZ0ZXN0Q0EXDTAzMDcxNTE2MjAwNVoXDTAzMDcyMDE2MjAwNV\
+            owgdIwUwIBBBcNMDMwNzE1MTYyMDAzWjA/MD0GA1UdHQEB/wQzMDGILzETMBEGCgmSJ\
+            omT8ixkARkMA2NvbTEYMBYGCgmSJomT8ixkARkTCGNlcnRzUlVTMBICAQMXDTAzMDcx\
+            NTE2MjAwNFowUwIBAhcNMDMwNzE1MTYyMDA0WjA/MD0GA1UdIQEB/wQzMDEwGAYDVQQ\
+            DExEwDyqGMDEUMgAwgDAuRQA1MRYGCgmSJomT8ixkARkTCG15VGVzdENBMBICAQEXDT\
+            AzMDcxNTE2MjAwNFqgHzAdMA8GA1UdHAEB/wQFMAOEAf8wCgYDVR0UAwACAQIwCwYHK\
+            oZIzjgEAwUAAzAAMC0CFBaZDryEEOr8Cw7sOAAAAKaDgtHcAhUAkUenJpwYZgS6IPjy\
+            AjZG+RfHdO4=""");
+
+        // "class sun.security.x509.X400Address cannot be cast
+        // to class sun.security.x509.X500Name"
+        byte[] encoded_2 = Base64.getDecoder().decode("""
+            MIIBljCCAVMCAQEwCwYHKoZIzjgEAwUAMC0xEzARBgoJkiaJk/IsZAEZEwNjb20xFjA\
+            UBgoJkiaJk/IsZAEZEwZ0ZXN0J0EXDTAzMDcxNTE2MjAwNVoXDTAzMDcyMDE2MjAwNV\
+            owgdIwUwIBBBcNMDMwNzE1MTYyMDA0WjA/MD0GA1UdHQEB/wQzMDGkLzETMBEGCgmSJ\
+            omT8ixkARkTA2NvbTEYMBYGCgmSJomT8ixkARkTCGNlcnRzUlVTMBICAQMXDTAzMDcx\
+            NTE2MjAwNFowUwIBAhcNMDMwNzE1MTYyMDA0WjA/MD0GA1UdHQEB/wQzMDGjLzETMBE\
+            GCgmSJomT8ixkARkTA2NvGG0wMRYGCgmSJomT8ixkARkTCG15VGVzdENBMBICAQEXDT\
+            AzMDcxNTE2MjAwNVqgHzAdMGAGA1UdHAEB/wQFMAOEAf8wCgYDVR0UBAMCAQIwCwYHK\
+            oZIzjgEAwUAAzAAMC0CFBaZDryEEOr8Cw7sJa07gqaDgtHcAhUAkUenJpwYZgS6IPjy\
+            AjZG+RfHdO4=""");
+
+        cf = CertificateFactory.getInstance("X.509", "SUN");
+
+        run(encoded_1);
+        run(encoded_2);
+    }
+
+    private static void run(byte[] buf) {
+        Utils.runAndCheckException(
+                () -> cf.generateCRLs(new ByteArrayInputStream(buf)),
+                CRLException.class);
+    }
+}

--- a/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedCCE.java
+++ b/test/jdk/sun/security/x509/X509CRLImpl/UnexpectedCCE.java
@@ -41,8 +41,9 @@ public class UnexpectedCCE {
     public static void main(String[] av ) throws CertificateException,
            NoSuchProviderException {
 
-        // "class sun.security.x509.OIDName cannot be cast
-        // to class sun.security.x509.X500Name"
+        // Fuzzed data input stream looks like an x509.OIDName
+        // in the CertificateIssuerExtension. A CRLException is thrown
+        // because an X500Name is expected.
         byte[] encoded_1 = Base64.getDecoder().decode("""
             MIIBljCCAVMCAQEwCwYHKoZIzjgEAwUAMC0xEzARBgoJkiaJk/IsZAEZEwNjb20xFjA\
             UBgoJkiaJjvIsZAEZEwZ0ZXN0Q0EXDTAzMDcxNTE2MjAwNVoXDTAzMDcyMDE2MjAwNV\
@@ -54,8 +55,9 @@ public class UnexpectedCCE {
             oZIzjgEAwUAAzAAMC0CFBaZDryEEOr8Cw7sOAAAAKaDgtHcAhUAkUenJpwYZgS6IPjy\
             AjZG+RfHdO4=""");
 
-        // "class sun.security.x509.X400Address cannot be cast
-        // to class sun.security.x509.X500Name"
+        // Fuzzed data input stream looks like an x509.X400Address
+        // in the CertificateIssuerExtension. A CRLException is thrown
+        // because an X500Name is expected.
         byte[] encoded_2 = Base64.getDecoder().decode("""
             MIIBljCCAVMCAQEwCwYHKoZIzjgEAwUAMC0xEzARBgoJkiaJk/IsZAEZEwNjb20xFjA\
             UBgoJkiaJk/IsZAEZEwZ0ZXN0J0EXDTAzMDcxNTE2MjAwNVoXDTAzMDcyMDE2MjAwNV\


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8336665

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336665](https://bugs.openjdk.org/browse/JDK-8336665): CCE in X509CRLImpl$TBSCertList.getCertIssuer (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20528/head:pull/20528` \
`$ git checkout pull/20528`

Update a local copy of the PR: \
`$ git checkout pull/20528` \
`$ git pull https://git.openjdk.org/jdk.git pull/20528/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20528`

View PR using the GUI difftool: \
`$ git pr show -t 20528`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20528.diff">https://git.openjdk.org/jdk/pull/20528.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20528#issuecomment-2278456330)