### PR TITLE
8337815: Relax G1EvacStats atomic operations

### DIFF
--- a/src/hotspot/share/gc/g1/g1EvacStats.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1EvacStats.inline.hpp
@@ -30,25 +30,25 @@
 #include "runtime/atomic.hpp"
 
 inline void G1EvacStats::add_direct_allocated(size_t value) {
-  Atomic::add(&_direct_allocated, value);
+  Atomic::add(&_direct_allocated, value, memory_order_relaxed);
 }
 
 inline void G1EvacStats::add_num_plab_filled(size_t value) {
-  Atomic::add(&_num_plab_filled, value);
+  Atomic::add(&_num_plab_filled, value, memory_order_relaxed);
 }
 
 inline void G1EvacStats::add_num_direct_allocated(size_t value) {
-  Atomic::add(&_num_direct_allocated, value);
+  Atomic::add(&_num_direct_allocated, value, memory_order_relaxed);
 }
 
 inline void G1EvacStats::add_region_end_waste(size_t value) {
-  Atomic::add(&_region_end_waste, value);
-  Atomic::inc(&_regions_filled);
+  Atomic::add(&_region_end_waste, value, memory_order_relaxed);
+  Atomic::inc(&_regions_filled, memory_order_relaxed);
 }
 
 inline void G1EvacStats::add_failure_used_and_waste(size_t used, size_t waste) {
-  Atomic::add(&_failure_used, used);
-  Atomic::add(&_failure_waste, waste);
+  Atomic::add(&_failure_used, used, memory_order_relaxed);
+  Atomic::add(&_failure_waste, waste, memory_order_relaxed);
 }
 
 #endif // SHARE_GC_G1_G1EVACSTATS_INLINE_HPP


### PR DESCRIPTION
This PR should slightly improve the performance of G1EvacStats by using `memory_order_relaxed` instead of the default `memory_order_conservative`.
Since the original bug report says

>I doubt it would show on benchmarks, this is a paper-cut issue.

I haven't benchmarked this change for performance.

The change passes all tests in `gc/g1` locally on x86_64 linux.