### PR TITLE
8300800: UB: Shift exponent 32 is too large for 32-bit type 'int'

### DIFF
--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -295,7 +295,7 @@ static int expandLogicalImmediate(uint32_t immN, uint32_t immr,
     uint64_t and_bits_sub = replicate(and_bit, 1, nbits);
     uint64_t or_bits_sub = replicate(or_bit, 1, nbits);
     uint64_t and_bits_top = (and_bits_sub << nbits) | ones(nbits);
-    uint64_t or_bits_top = (0 << nbits) | or_bits_sub;
+    uint64_t or_bits_top = (0UL << nbits) | or_bits_sub;
 
     tmask = ((tmask
               & (replicate(and_bits_top, 2 * nbits, 32 / nbits)))

--- a/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/immediate_aarch64.cpp
@@ -295,7 +295,7 @@ static int expandLogicalImmediate(uint32_t immN, uint32_t immr,
     uint64_t and_bits_sub = replicate(and_bit, 1, nbits);
     uint64_t or_bits_sub = replicate(or_bit, 1, nbits);
     uint64_t and_bits_top = (and_bits_sub << nbits) | ones(nbits);
-    uint64_t or_bits_top = (0UL << nbits) | or_bits_sub;
+    uint64_t or_bits_top = (UCONST64(0) << nbits) | or_bits_sub;
 
     tmask = ((tmask
               & (replicate(and_bits_top, 2 * nbits, 32 / nbits)))


### PR DESCRIPTION
The operand of shift which is a constant `0` changed to `unsigned long`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8300800](https://bugs.openjdk.org/browse/JDK-8300800): UB: Shift exponent 32 is too large for 32-bit type 'int' (**Bug** - P4)


### Reviewers
 * [Gerard Ziemski](https://openjdk.org/census#gziemski) (@gerard-ziemski - Committer) 🔄 Re-review required (review applies to [9143adaf](https://git.openjdk.org/jdk/pull/20530/files/9143adaf6b5a99fba0a348f384ed535d78203201))
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20530/head:pull/20530` \
`$ git checkout pull/20530`

Update a local copy of the PR: \
`$ git checkout pull/20530` \
`$ git pull https://git.openjdk.org/jdk.git pull/20530/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20530`

View PR using the GUI difftool: \
`$ git pr show -t 20530`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20530.diff">https://git.openjdk.org/jdk/pull/20530.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20530#issuecomment-2278462787)