### PR TITLE
8339191: JFR: Bulk read support for ChunkInputStream

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 
 final class ChunkInputStream extends InputStream {
     private final Iterator<RepositoryChunk> chunks;
@@ -85,10 +86,7 @@ final class ChunkInputStream extends InputStream {
                 if (r != -1) {
                     return r;
                 }
-                stream.close();
-                currentChunk.release();
-                stream = null;
-                currentChunk = null;
+                advance();
             }
             if (!nextStream()) {
                 return -1;
@@ -97,14 +95,60 @@ final class ChunkInputStream extends InputStream {
     }
 
     @Override
-    public void close() throws IOException {
+    public int read(byte[] buf, int off, int len) throws IOException {
+        Objects.checkFromIndexSize(off, len, buf.length);
+        if (len == 0) {
+            return 0;
+        }
+
+        int totalRead = 0;
+        while (len > 0) {
+            if (stream == null) {
+                advance();
+                if (!nextStream()) {
+                    return totalRead > 0 ? totalRead : -1;
+                }
+            }
+            int read = stream.read(buf, off, len);
+            if (read <= 0) {
+                advance();
+                continue;
+            } else {
+                totalRead += read;
+                len -= read;
+                if (len == 0) {
+                    return totalRead;
+                }
+                off += read;
+            }
+        }
+        return totalRead;
+    }
+
+    private void advance() throws IOException {
+        closeStream();
+        closeChunk();
+    }
+
+    private void closeStream() throws IOException {
         if (stream != null) {
             stream.close();
             stream = null;
         }
-        while (currentChunk != null) {
+    }
+
+    private void closeChunk() {
+        if (currentChunk != null) {
             currentChunk.release();
             currentChunk = null;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        closeStream();
+        while (currentChunk != null) {
+            closeChunk();
             if (!nextChunk()) {
                 return;
             }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
@@ -87,7 +87,6 @@ final class ChunkInputStream extends InputStream {
                     return r;
                 }
                 closeStream();
-                closeChunk();
             }
             if (!nextStream()) {
                 return -1;
@@ -120,7 +119,6 @@ final class ChunkInputStream extends InputStream {
                 off += read;
             } else {
                 closeStream();
-                closeChunk();
             }
         }
         return totalRead;
@@ -131,6 +129,7 @@ final class ChunkInputStream extends InputStream {
             stream.close();
             stream = null;
         }
+        closeChunk();
     }
 
     private void closeChunk() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/ChunkInputStream.java
@@ -86,7 +86,8 @@ final class ChunkInputStream extends InputStream {
                 if (r != -1) {
                     return r;
                 }
-                advance();
+                closeStream();
+                closeChunk();
             }
             if (!nextStream()) {
                 return -1;
@@ -104,30 +105,25 @@ final class ChunkInputStream extends InputStream {
         int totalRead = 0;
         while (len > 0) {
             if (stream == null) {
-                advance();
+                closeChunk();
                 if (!nextStream()) {
                     return totalRead > 0 ? totalRead : -1;
                 }
             }
             int read = stream.read(buf, off, len);
-            if (read <= 0) {
-                advance();
-                continue;
-            } else {
+            if (read > -1) {
                 totalRead += read;
                 len -= read;
                 if (len == 0) {
                     return totalRead;
                 }
                 off += read;
+            } else {
+                closeStream();
+                closeChunk();
             }
         }
         return totalRead;
-    }
-
-    private void advance() throws IOException {
-        closeStream();
-        closeChunk();
     }
 
     private void closeStream() throws IOException {

--- a/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamBulkRead.java
+++ b/test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamBulkRead.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Palantir Technologies, Inc. and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test TestChunkInputStreamBulkRead
+ * @key jfr
+ * @requires vm.hasJFR
+ * @library /test/lib
+ * @run main/othervm jdk.jfr.api.consumer.TestChunkInputStreamBulkRead
+ */
+package jdk.jfr.api.consumer;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import jdk.jfr.Recording;
+import jdk.test.lib.Asserts;
+
+public class TestChunkInputStreamBulkRead {
+
+    public static void main(String[] args) throws Exception {
+        try (Recording r = new Recording()) {
+            r.start();
+            try (Recording s = new Recording()) {
+                s.start();
+                s.stop();
+            }
+            r.stop();
+            try (InputStream stream = r.getStream(null, null);
+                 ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+                long read = stream.transferTo(output);
+                System.out.printf("Read %d bytes from JFR stream%n", read);
+                Asserts.assertEquals(r.getSize(), read);
+
+                byte[] actual = output.toByteArray();
+                Asserts.assertEqualsByteArray(r.getStream(null, null).readAllBytes(), actual);
+
+                Path dumpFile = Paths.get("recording.jfr").toAbsolutePath().normalize();
+                r.dump(dumpFile);
+                System.out.printf("Dumped recording to %s (%d bytes)%n", dumpFile, Files.size(dumpFile));
+                Asserts.assertEqualsByteArray(Files.readAllBytes(dumpFile), actual);
+            }
+        }
+    }
+}


### PR DESCRIPTION
I would like to contribute an improvement to reading JFR recordings via `InputStream` by implementing `InputStream#read(byte[], int, int)` in `ChunkInputStream` to support bulk reads and avoid many expensive single byte `read()`.

Testing: `test/jdk/jdk/jfr/api/consumer/TestChunkInputStreamBulkRead.java`, `jdk_jfr`

While looking through some JFRs recently, I noticed some significant time spent in `java.io.BufferedInputStream#getBufIfOpen()` that traced back to transferring (via `InputStream#transferTo(OutputStream)` JFR profile recording being read via `InputStream` returned by `jdk.jfr.Recording#getStream(Instant , Instant)`. What caught my eye were calls to single byte `jdk.jfr.internal.ChunkInputStream#read()` rather than `read(byte[], int, int)` as seen in the stacktrace from JFR.

<img width="776" alt="image" src="https://github.com/user-attachments/assets/b92398cd-2761-4600-8cfe-ea1bada6efd2">

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339191](https://bugs.openjdk.org/browse/JDK-8339191): JFR: Bulk read support for ChunkInputStream (**Enhancement** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20534/head:pull/20534` \
`$ git checkout pull/20534`

Update a local copy of the PR: \
`$ git checkout pull/20534` \
`$ git pull https://git.openjdk.org/jdk.git pull/20534/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20534`

View PR using the GUI difftool: \
`$ git pr show -t 20534`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20534.diff">https://git.openjdk.org/jdk/pull/20534.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20534#issuecomment-2316122199)