### PR TITLE
8337302: Undefined type variable results in null

### DIFF
--- a/src/java.base/share/classes/java/lang/TypeNotPresentException.java
+++ b/src/java.base/share/classes/java/lang/TypeNotPresentException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/TypeNotPresentException.java
+++ b/src/java.base/share/classes/java/lang/TypeNotPresentException.java
@@ -28,9 +28,9 @@ package java.lang;
 /**
  * Thrown when an application tries to access a type using a string
  * representing the type's name, but no definition for the type with
- * the specified name can be found.   This exception differs from
- * {@link ClassNotFoundException} in that {@code ClassNotFoundException} is a
- * checked exception, whereas this exception is unchecked.
+ * the specified name can be found. This exception differs from
+ * {@link ClassNotFoundException} in that {@code ClassNotFoundException}
+ * is a checked exception, whereas this exception is unchecked.
  *
  * <p>Note that this exception may be used when undefined type variables
  * are accessed as well as when types (e.g., classes, interfaces or
@@ -48,15 +48,15 @@ public class TypeNotPresentException extends RuntimeException {
     private static final long serialVersionUID = -5101214195716534496L;
 
     /**
-     * The type name.
+     * The type name or the name of a type variable.
      */
     private String typeName;
 
     /**
-     * Constructs a {@code TypeNotPresentException} for the named type
-     * with the specified cause.
+     * Constructs a {@code TypeNotPresentException} for the named type or
+     * type variable with the specified cause.
      *
-     * @param typeName the fully qualified name of the unavailable type
+     * @param typeName the fully qualified name of the unavailable type or type variable
      * @param cause the exception that was thrown when the system attempted to
      *    load the named type, or {@code null} if unavailable or inapplicable
      */
@@ -66,9 +66,9 @@ public class TypeNotPresentException extends RuntimeException {
     }
 
     /**
-     * Returns the fully qualified name of the unavailable type.
+     * Returns the fully qualified name of the unavailable type or type variable name.
      *
-     * @return the fully qualified name of the unavailable type
+     * @return the fully qualified name of the unavailable type or type variable name
      */
     public String typeName() { return typeName;}
 }

--- a/src/java.base/share/classes/sun/reflect/generics/factory/CoreReflectionFactory.java
+++ b/src/java.base/share/classes/sun/reflect/generics/factory/CoreReflectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/reflect/generics/factory/CoreReflectionFactory.java
+++ b/src/java.base/share/classes/sun/reflect/generics/factory/CoreReflectionFactory.java
@@ -106,7 +106,11 @@ public class CoreReflectionFactory implements GenericsFactory {
     }
 
     public TypeVariable<?> findTypeVariable(String name){
-        return getScope().lookup(name);
+        TypeVariable<?> variable = getScope().lookup(name);
+        if (variable == null) {
+            throw new TypeNotPresentException(name, null);
+        }
+        return variable;
     }
 
     public Type makeNamedType(String name){

--- a/test/jdk/java/lang/reflect/Generics/TestMissingTypeVariable.java
+++ b/test/jdk/java/lang/reflect/Generics/TestMissingTypeVariable.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @library /test/lib
+ * @bug 8337302
+ * @enablePreview
+ * @summary Tests that an exception is thrown if a type variable is not declared
+ */
+
+import jdk.test.lib.ByteCodeLoader;
+
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.Signature;
+import java.lang.classfile.attribute.SignatureAttribute;
+import java.lang.constant.ClassDesc;
+import java.lang.reflect.Type;
+
+public class TestMissingTypeVariable {
+
+    public static void main(String[] args) throws Exception {
+        ClassFile cf = ClassFile.of();
+        byte[] bytes = cf.build(
+                ClassDesc.of("sample.MissingVariable"),
+                classBuilder -> {
+                    classBuilder.withSuperclass(ClassDesc.of("java.lang.Object"));
+                    classBuilder.withField("f",
+                            ClassDesc.of("java.lang.Object"),
+                            fieldBuilder -> fieldBuilder.with(SignatureAttribute.of(Signature.parseFrom("TA;"))));
+                });
+        Class<?> missing = ByteCodeLoader.load("sample.MissingVariable", bytes);
+        try {
+            Type type = missing.getField("f").getGenericType();
+            throw new IllegalStateException("Expected TypeNotPresentException but got: " + type);
+        } catch (TypeNotPresentException e) {
+            if (!"A".equals(e.typeName())) {
+                throw new IllegalStateException("Unexpected name: " + e.typeName());
+            }
+        }
+    }
+}

--- a/test/jdk/java/lang/reflect/Generics/TestMissingTypeVariable.java
+++ b/test/jdk/java/lang/reflect/Generics/TestMissingTypeVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/lang/reflect/Generics/TestMissingTypeVariable.java
+++ b/test/jdk/java/lang/reflect/Generics/TestMissingTypeVariable.java
@@ -35,6 +35,7 @@ import java.lang.classfile.ClassFile;
 import java.lang.classfile.Signature;
 import java.lang.classfile.attribute.SignatureAttribute;
 import java.lang.constant.ClassDesc;
+import java.lang.reflect.AccessFlag;
 import java.lang.reflect.Type;
 
 public class TestMissingTypeVariable {
@@ -45,9 +46,10 @@ public class TestMissingTypeVariable {
                 ClassDesc.of("sample.MissingVariable"),
                 classBuilder -> {
                     classBuilder.withSuperclass(ClassDesc.of("java.lang.Object"));
+                    classBuilder.withFlags(AccessFlag.PUBLIC);
                     classBuilder.withField("f",
                             ClassDesc.of("java.lang.Object"),
-                            fieldBuilder -> fieldBuilder.with(SignatureAttribute.of(Signature.parseFrom("TA;"))));
+                            fieldBuilder -> fieldBuilder.withFlags(AccessFlag.PUBLIC).with(SignatureAttribute.of(Signature.parseFrom("TA;"))));
                 });
         Class<?> missing = ByteCodeLoader.load("sample.MissingVariable", bytes);
         try {

--- a/test/jdk/java/lang/reflect/Generics/TestMissingTypeVariable.java
+++ b/test/jdk/java/lang/reflect/Generics/TestMissingTypeVariable.java
@@ -51,6 +51,12 @@ public class TestMissingTypeVariable {
                             ClassDesc.of("java.lang.Object"),
                             fieldBuilder -> fieldBuilder.withFlags(AccessFlag.PUBLIC).with(SignatureAttribute.of(Signature.parseFrom("TA;"))));
                 });
+        /*
+          package sample;
+          public class MissingVariable {
+            public A f; // undeclared type variable
+          }
+         */
         Class<?> missing = ByteCodeLoader.load("sample.MissingVariable", bytes);
         try {
             Type type = missing.getField("f").getGenericType();


### PR DESCRIPTION
When a type uses a type variable without a declaration, no exception is thrown. This change triggers a `TypeNotFoundException` to be thrown.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8338198](https://bugs.openjdk.org/browse/JDK-8338198) to be approved

### Issues
 * [JDK-8337302](https://bugs.openjdk.org/browse/JDK-8337302): Undefined type variable results in null (**Bug** - P4)
 * [JDK-8338198](https://bugs.openjdk.org/browse/JDK-8338198): Undefined type variables now cause TypeNotPresentException (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20535/head:pull/20535` \
`$ git checkout pull/20535`

Update a local copy of the PR: \
`$ git checkout pull/20535` \
`$ git pull https://git.openjdk.org/jdk.git pull/20535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20535`

View PR using the GUI difftool: \
`$ git pr show -t 20535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20535.diff">https://git.openjdk.org/jdk/pull/20535.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20535#issuecomment-2282910048)