### PR TITLE
8338154: Fix -Wzero-as-null-pointer-constant warnings in gtest framework

### DIFF
--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -57,7 +57,8 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
         $(GTEST_FRAMEWORK_SRC)/googletest/src \
         $(GTEST_FRAMEWORK_SRC)/googlemock/src, \
     INCLUDE_FILES := gtest-all.cc gmock-all.cc, \
-    DISABLED_WARNINGS_gcc := undef unused-result format-nonliteral maybe-uninitialized, \
+    DISABLED_WARNINGS_gcc := undef unused-result format-nonliteral \
+        maybe-uninitialized zero-as-null-pointer-constant, \
     DISABLED_WARNINGS_clang := undef unused-result format-nonliteral, \
     DEFAULT_CFLAGS := false, \
     CFLAGS := $(JVM_CFLAGS) \

--- a/test/hotspot/gtest/gtestMain.cpp
+++ b/test/hotspot/gtest/gtestMain.cpp
@@ -336,7 +336,7 @@ static void run_in_new_thread(const args_t* args) {
 extern "C" void* thread_wrapper(void* p) {
   const args_t* const p_args = (const args_t*) p;
   runUnitTestsInner(p_args->argc, p_args->argv);
-  return 0;
+  return nullptr;
 }
 
 static void run_in_new_thread(const args_t* args) {


### PR DESCRIPTION
Please review this change to remove -Wzero-as-null-pointer-constant warnings
produced by the gtest framework when such warnings are enabled.

Warnings from the 3rd party GoogleTest are suppressed by disabling that
warning when compiling those files.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338154](https://bugs.openjdk.org/browse/JDK-8338154): Fix -Wzero-as-null-pointer-constant warnings in gtest framework (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20536/head:pull/20536` \
`$ git checkout pull/20536`

Update a local copy of the PR: \
`$ git checkout pull/20536` \
`$ git pull https://git.openjdk.org/jdk.git pull/20536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20536`

View PR using the GUI difftool: \
`$ git pr show -t 20536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20536.diff">https://git.openjdk.org/jdk/pull/20536.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20536#issuecomment-2283139510)