### PR TITLE
8338155: Fix -Wzero-as-null-pointer-constant warnings involving PTHREAD_MUTEX_INITIALIZER

### DIFF
--- a/src/hotspot/os/linux/os_perf_linux.cpp
+++ b/src/hotspot/os/linux/os_perf_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -430,7 +430,10 @@ static int get_boot_time(uint64_t* time) {
 }
 
 static int perf_context_switch_rate(double* rate) {
+  PRAGMA_DIAG_PUSH
+  PRAGMA_ZERO_AS_NULL_POINTER_CONSTANT_IGNORED
   static pthread_mutex_t contextSwitchLock = PTHREAD_MUTEX_INITIALIZER;
+  PRAGMA_DIAG_POP
   static uint64_t      bootTime;
   static uint64_t      lastTimeNanos;
   static uint64_t      lastSwitches;

--- a/src/hotspot/os/posix/threadCritical_posix.cpp
+++ b/src/hotspot/os/posix/threadCritical_posix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2014 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 #include "runtime/javaThread.hpp"
 #include "runtime/threadCritical.hpp"
+#include "utilities/compilerWarnings.hpp"
 
 // put OS-includes here
 # include <pthread.h>
@@ -35,7 +36,12 @@
 //
 
 static pthread_t             tc_owner = 0;
+
+PRAGMA_DIAG_PUSH
+PRAGMA_ZERO_AS_NULL_POINTER_CONSTANT_IGNORED
 static pthread_mutex_t       tc_mutex = PTHREAD_MUTEX_INITIALIZER;
+PRAGMA_DIAG_POP
+
 static int                   tc_count = 0;
 
 ThreadCritical::ThreadCritical() {

--- a/src/hotspot/share/utilities/compilerWarnings.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -80,6 +80,10 @@
 
 #ifndef PRAGMA_NONNULL_IGNORED
 #define PRAGMA_NONNULL_IGNORED
+#endif
+
+#ifndef PRAGMA_ZERO_AS_NULL_POINTER_CONSTANT_IGNORED
+#define PRAGMA_ZERO_AS_NULL_POINTER_CONSTANT_IGNORED
 #endif
 
 // Support warnings for use of certain C functions, except where explicitly

--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,6 +66,9 @@
 #endif
 
 #define PRAGMA_NONNULL_IGNORED PRAGMA_DISABLE_GCC_WARNING("-Wnonnull")
+
+#define PRAGMA_ZERO_AS_NULL_POINTER_CONSTANT_IGNORED \
+  PRAGMA_DISABLE_GCC_WARNING("-Wzero-as-null-pointer-constant")
 
 #if (__GNUC__ >= 10)
 // TODO: Re-enable warning attribute for Clang once


### PR DESCRIPTION
Please review this change to remove -Wzero-as-null-pointer-constant warnings
involving the use of PTHREAD_MUTEX_INITIALIZER.  We obviously can't change the
initializer macro, and we can't avoid it.  So we suppress that warning where
the initializer is used.

This involved adding a suppression pragma macro for that warning, which we
haven't needed for any of the previous work on removing them.  Hopefully we
won't need it for many (or any) other places, but there are still a few places
triggering that warning, and not all of them are otherwise simple to resolve.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338155](https://bugs.openjdk.org/browse/JDK-8338155): Fix -Wzero-as-null-pointer-constant warnings involving PTHREAD_MUTEX_INITIALIZER (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20537/head:pull/20537` \
`$ git checkout pull/20537`

Update a local copy of the PR: \
`$ git checkout pull/20537` \
`$ git pull https://git.openjdk.org/jdk.git pull/20537/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20537`

View PR using the GUI difftool: \
`$ git pr show -t 20537`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20537.diff">https://git.openjdk.org/jdk/pull/20537.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20537#issuecomment-2283255341)