### PR TITLE
8338124: C2 SuperWord: MulAddS2I input permutation still partially broken after JDK-8333840

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2272,7 +2272,7 @@ Node_List* PackSet::strided_pack_input_at_index_or_null(const Node_List* pack, c
     return nullptr; // size mismatch
   }
 
-  for (uint i = 1; i < pack->size(); i++) {
+  for (uint i = 0; i < pack->size(); i++) {
     if (pack->at(i)->in(index) != pack_in->at(i * stride + offset)) {
       return nullptr; // use-def mismatch
     }

--- a/test/hotspot/jtreg/compiler/loopopts/superword/TestMulAddS2I.java
+++ b/test/hotspot/jtreg/compiler/loopopts/superword/TestMulAddS2I.java
@@ -53,6 +53,7 @@ public class TestMulAddS2I {
     static final int[] GOLDEN_J;
     static final int[] GOLDEN_K;
     static final int[] GOLDEN_L;
+    static final int[] GOLDEN_M;
 
     static {
         for (int i = 0; i < RANGE; i++) {
@@ -71,6 +72,7 @@ public class TestMulAddS2I {
         GOLDEN_J = testj(new int[ITER]);
         GOLDEN_K = testk(new int[ITER]);
         GOLDEN_L = testl(new int[ITER]);
+        GOLDEN_M = testm(new int[ITER]);
     }
 
 
@@ -80,7 +82,7 @@ public class TestMulAddS2I {
     }
 
     @Run(test = {"testa", "testb", "testc", "testd", "teste", "testf", "testg", "testh",
-                 "testi", "testj", "testk", "testl"})
+                 "testi", "testj", "testk", "testl", "testm"})
     @Warmup(0)
     public static void run() {
         compare(testa(), GOLDEN_A, "testa");
@@ -95,6 +97,7 @@ public class TestMulAddS2I {
         compare(testj(new int[ITER]), GOLDEN_J, "testj");
         compare(testk(new int[ITER]), GOLDEN_K, "testk");
         compare(testl(new int[ITER]), GOLDEN_L, "testl");
+        compare(testm(new int[ITER]), GOLDEN_M, "testm");
     }
 
     public static void compare(int[] out, int[] golden, String name) {
@@ -299,4 +302,17 @@ public class TestMulAddS2I {
         return out;
     }
 
+    @Test
+    @IR(counts = {IRNode.MUL_ADD_S2I, "> 0"},
+        applyIfCPUFeatureOr = {"sse2", "true", "asimd", "true"})
+    @IR(counts = {IRNode.MUL_ADD_VS2VI, "= 0"})
+    public static int[] testm(int[] out) {
+        for (int i = 0; i < ITER-4; i+=4) {
+            // Unrolled, with some swaps that prevent vectorization.
+            out[i+0] += ((sArr1[2*i+0] * sArr2[2*i+1]) + (sArr1[2*i+1] * sArr2[2*i+0])); // bad
+            out[i+1] += ((sArr1[2*i+2] * sArr2[2*i+2]) + (sArr1[2*i+3] * sArr2[2*i+3])); // ok
+            // 2-element gap
+        }
+        return out;
+    }
 }


### PR DESCRIPTION
[JDK-8333840](https://bugs.openjdk.org/browse/JDK-8333840) attempted to fix some input permutation cases. Sadly, there is a typo which means that there can still be some broken cases that produce wrong results.

`MulAddS2I` is a special case, where we have to verify that the 4 inputs for all members of the pack are in the same permutation. I only started the checking on the second element. This worked on all my previous examples, but does not work on the added regression test. We must, of course, start the checking on the first element.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338124](https://bugs.openjdk.org/browse/JDK-8338124): C2 SuperWord: MulAddS2I input permutation still partially broken after JDK-8333840 (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20539/head:pull/20539` \
`$ git checkout pull/20539`

Update a local copy of the PR: \
`$ git checkout pull/20539` \
`$ git pull https://git.openjdk.org/jdk.git pull/20539/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20539`

View PR using the GUI difftool: \
`$ git pr show -t 20539`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20539.diff">https://git.openjdk.org/jdk/pull/20539.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20539#issuecomment-2283473007)