### PR TITLE
8338158: Cleanup ShouldNotXXX uses in machnode.cpp

### DIFF
--- a/src/hotspot/share/opto/machnode.cpp
+++ b/src/hotspot/share/opto/machnode.cpp
@@ -45,9 +45,9 @@ int MachOper::reg(PhaseRegAlloc *ra_, const Node *node, int idx) const {
 }
 intptr_t  MachOper::constant() const { return 0x00; }
 relocInfo::relocType MachOper::constant_reloc() const { return relocInfo::none; }
-jdouble MachOper::constantD() const { ShouldNotReachHere(); return 0.0; }
-jfloat  MachOper::constantF() const { ShouldNotReachHere(); return 0.0; }
-jlong   MachOper::constantL() const { ShouldNotReachHere(); return CONST64(0) ; }
+jdouble MachOper::constantD() const { ShouldNotReachHere(); }
+jfloat  MachOper::constantF() const { ShouldNotReachHere(); }
+jlong   MachOper::constantL() const { ShouldNotReachHere(); }
 TypeOopPtr *MachOper::oop() const { return nullptr; }
 int MachOper::ccode() const { return 0x00; }
 // A zero, default, indicates this value is not needed.
@@ -62,8 +62,8 @@ int MachOper::index_position() const { return -1; }  // no index input
 // Check for PC-Relative displacement
 relocInfo::relocType MachOper::disp_reloc() const { return relocInfo::none; }
 // Return the label
-Label*   MachOper::label()  const { ShouldNotReachHere(); return 0; }
-intptr_t MachOper::method() const { ShouldNotReachHere(); return 0; }
+Label*   MachOper::label()  const { ShouldNotReachHere(); }
+intptr_t MachOper::method() const { ShouldNotReachHere(); }
 
 
 //------------------------------negate-----------------------------------------
@@ -80,7 +80,6 @@ const Type *MachOper::type() const {
 //------------------------------in_RegMask-------------------------------------
 const RegMask *MachOper::in_RegMask(int index) const {
   ShouldNotReachHere();
-  return nullptr;
 }
 
 //------------------------------dump_spec--------------------------------------
@@ -93,14 +92,12 @@ void MachOper::dump_spec(outputStream *st) const { }
 // Print any per-operand special info
 uint MachOper::hash() const {
   ShouldNotCallThis();
-  return 5;
 }
 
 //------------------------------cmp--------------------------------------------
 // Print any per-operand special info
 bool MachOper::cmp( const MachOper &oper ) const {
   ShouldNotCallThis();
-  return opcode() == oper.opcode();
 }
 
 //------------------------------hash-------------------------------------------
@@ -207,7 +204,6 @@ void MachNode::fill_new_machnode(MachNode* node) const {
 // Return an equivalent instruction using memory for cisc_operand position
 MachNode *MachNode::cisc_version(int offset) {
   ShouldNotCallThis();
-  return nullptr;
 }
 
 void MachNode::use_cisc_RegMask() {


### PR DESCRIPTION
Please review this change to machnode.cpp to remove dead code following calls
to ShouldNotReachHere() and ShouldNotCallThis().  This takes advantage of the
availability and use of [[noreturn]] attributes on all supported platforms,
and makes all uses of those functions in this file consistent in this respect.

As a side effect, this removes some -Wzero-as-null-pointer-constant warnings.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338158](https://bugs.openjdk.org/browse/JDK-8338158): Cleanup ShouldNotXXX uses in machnode.cpp (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20540/head:pull/20540` \
`$ git checkout pull/20540`

Update a local copy of the PR: \
`$ git checkout pull/20540` \
`$ git pull https://git.openjdk.org/jdk.git pull/20540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20540`

View PR using the GUI difftool: \
`$ git pr show -t 20540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20540.diff">https://git.openjdk.org/jdk/pull/20540.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20540#issuecomment-2283277661)