### PR TITLE
8338160: Fix -Wzero-as-null-pointer-constant warnings in management.cpp

### DIFF
--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1820,7 +1820,7 @@ JVM_END
 // of a given length and return the objArrayOop
 static objArrayOop get_memory_usage_objArray(jobjectArray array, int length, TRAPS) {
   if (array == nullptr) {
-    THROW_(vmSymbols::java_lang_NullPointerException(), 0);
+    THROW_NULL(vmSymbols::java_lang_NullPointerException());
   }
 
   objArrayOop oa = objArrayOop(JNIHandles::resolve_non_null(array));
@@ -1828,16 +1828,16 @@ static objArrayOop get_memory_usage_objArray(jobjectArray array, int length, TRA
 
   // array must be of the given length
   if (length != array_h->length()) {
-    THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-               "The length of the given MemoryUsage array does not match the number of memory pools.", 0);
+    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
+                   "The length of the given MemoryUsage array does not match the number of memory pools.");
   }
 
   // check if the element of array is of type MemoryUsage class
   Klass* usage_klass = Management::java_lang_management_MemoryUsage_klass(CHECK_NULL);
   Klass* element_klass = ObjArrayKlass::cast(array_h->klass())->element_klass();
   if (element_klass != usage_klass) {
-    THROW_MSG_(vmSymbols::java_lang_IllegalArgumentException(),
-               "The element type is not MemoryUsage class", 0);
+    THROW_MSG_NULL(vmSymbols::java_lang_IllegalArgumentException(),
+                   "The element type is not MemoryUsage class");
   }
 
   return array_h();


### PR DESCRIPTION
Please review this trivial change to remove some
-Wzero-as-null-pointer-constant warnings in management.cpp.  Uses of THROW_
and THROW_MSG_ in a pointer context with a literal 0 value argument are
changed to use the corresponding _NULL suffixed macro without the value
argument.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338160](https://bugs.openjdk.org/browse/JDK-8338160): Fix -Wzero-as-null-pointer-constant warnings in management.cpp (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20541/head:pull/20541` \
`$ git checkout pull/20541`

Update a local copy of the PR: \
`$ git checkout pull/20541` \
`$ git pull https://git.openjdk.org/jdk.git pull/20541/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20541`

View PR using the GUI difftool: \
`$ git pr show -t 20541`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20541.diff">https://git.openjdk.org/jdk/pull/20541.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20541#issuecomment-2283288704)