### PR TITLE
8335625: Update Javadoc for GetCpuLoad

### DIFF
--- a/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
@@ -130,21 +130,29 @@ public interface OperatingSystemMXBean extends
     public long getTotalMemorySize();
 
     /**
-     * Returns the "recent cpu usage" for the whole system. This value is a
+     * Returns the "recent CPU usage" for the whole system. This value is a
      * double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs
      * were idle during the recent period of time observed, while a value
      * of 1.0 means that all CPUs were actively running 100% of the time
-     * during the recent period being observed. All values between 0.0 and
-     * 1.0 are possible depending of the activities going on in the system.
-     * If the system recent cpu usage is not available, the method returns a
-     * negative value.
+     * during the recent period being observed.
      *
-     * @apiNote The recent period of observation is the duration since the last
-     * call made to this method, or {@link #getCpuLoad()}. For the very first
-     * invocation of this method, the recent period of observation is undefined.
+     * The recent period of observation is implementation-specific, and
+     * typically relates to the duration since the last call made to this
+     * method, or {@link #getCpuLoad()}. For the very first invocation, the
+     * recent period of observation is undefined.
+     *
+     * All values between 0.0 and 1.0 are possible dependent on the activities
+     * going on. If the recent CPU usage is not available, the method returns a
+     * negative value.
      *
      * @deprecated Use {@link #getCpuLoad()} instead of
      * this historically named method.
+     *
+     * @apiNote Callers should be aware of the possibility of other callers
+     * affecting the observation period and the result.
+     *
+     * @implNote There is only one observation period for the entire JVM
+     * process.
      *
      * @implSpec This implementation must return the same value
      * as {@link #getCpuLoad()}.
@@ -157,19 +165,26 @@ public interface OperatingSystemMXBean extends
     public default double getSystemCpuLoad() { return getCpuLoad(); }
 
     /**
-     * Returns the "recent cpu usage" for the operating environment. This value
+     * Returns the "recent CPU usage" for the operating environment. This value
      * is a double in the [0.0,1.0] interval. A value of 0.0 means that all CPUs
      * were idle during the recent period of time observed, while a value
      * of 1.0 means that all CPUs were actively running 100% of the time
-     * during the recent period being observed. All values between 0.0 and
-     * 1.0 are possible depending of the activities going on.
-     * If the recent cpu usage is not available, the method returns a
+     * during the recent period being observed.
+     *
+     * The recent period of observation is implementation-specific, and
+     * typically relates to the duration since the last call made to this
+     * method, or {@link #getSystemCpuLoad()}. For the very first invocation,
+     * the recent period of observation is undefined.
+     *
+     * All values between 0.0 and 1.0 are possible dependent on the activities
+     * going on. If the recent CPU usage is not available, the method returns a
      * negative value.
      *
-     * @apiNote The recent period of observation is the duration since the last
-     * call made to this method, or {@link #getSystemCpuLoad()}. For the very
-     * first invocation of this method, the recent period of observation is
-     * undefined.
+     * @apiNote Callers should be aware of the possibility of other callers
+     * affecting the observation period and the result.
+     *
+     * @implNote  There is only one observation period for the entire JVM
+     * process.
      *
      * @return the "recent cpu usage" for the whole operating environment;
      * a negative value if not available.
@@ -178,20 +193,29 @@ public interface OperatingSystemMXBean extends
     public double getCpuLoad();
 
     /**
-     * Returns the "recent cpu usage" for the Java Virtual Machine process.
+     * Returns the "recent CPU usage" for the Java Virtual Machine process.
      * This value is a double in the [0.0,1.0] interval. A value of 0.0 means
      * that none of the CPUs were running threads from the JVM process during
      * the recent period of time observed, while a value of 1.0 means that all
      * CPUs were actively running threads from the JVM 100% of the time
      * during the recent period being observed. Threads from the JVM include
-     * the application threads as well as the JVM internal threads. All values
-     * between 0.0 and 1.0 are possible depending of the activities going on
-     * in the JVM process and the whole system. If the Java Virtual Machine
-     * recent CPU usage is not available, the method returns a negative value.
+     * the application threads as well as the JVM internal threads.
      *
-     * @apiNote The recent period of observation is the duration since the last
-     * call made to this method. For the very first invocation of this method
-     * the recent period of observation is undefined.
+     * The recent period of observation is implementation-specific, and
+     * typically relates to the duration since the last call made to this
+     * method. For the very first invocation, the recent period of observation
+     * is undefined.
+     *
+     * All values between 0.0 and 1.0 are possible dependent on the activities
+     * going on in the JVM process and the whole system. If the Java Virtual
+     * Machine recent CPU usage is not available, the method returns a negative
+     * value.
+     *
+     * @apiNote Callers should be aware of the possibility of other callers
+     * affecting the observation period and the result.
+     *
+     * @implNote There is only one observation period for the entire JVM
+     * process.
      *
      * @return the "recent cpu usage" for the Java Virtual Machine process;
      * a negative value if not available.

--- a/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
@@ -139,6 +139,11 @@ public interface OperatingSystemMXBean extends
      * If the system recent cpu usage is not available, the method returns a
      * negative value.
      *
+     * <p> This method is not idempotent. The recent period of observation
+     * is the duration since the last call made to this method, or {@link #getCpuLoad()}.
+     * For the very first invocation of this method, the recent period of 
+     * observation is undefined.
+     *
      * @deprecated Use {@link #getCpuLoad()} instead of
      * this historically named method.
      *
@@ -162,6 +167,11 @@ public interface OperatingSystemMXBean extends
      * If the recent cpu usage is not available, the method returns a
      * negative value.
      *
+     * <p> This method is not idempotent. The recent period of observation
+     * is the duration since the last call made to this method, or {@link #getSystemCpuLoad()}.
+     * For the very first invocation of this method, the recent period of 
+     * observation is undefined.
+     *
      * @return the "recent cpu usage" for the whole operating environment;
      * a negative value if not available.
      * @since 14
@@ -179,6 +189,10 @@ public interface OperatingSystemMXBean extends
      * between 0.0 and 1.0 are possible depending of the activities going on
      * in the JVM process and the whole system. If the Java Virtual Machine
      * recent CPU usage is not available, the method returns a negative value.
+     *
+     * <p> This method is not idempotent. The recent period of observation
+     * is the duration since the last call made to this method. For the very first
+     * invocation of this method the recent period of observation is undefined.
      *
      * @return the "recent cpu usage" for the Java Virtual Machine process;
      * a negative value if not available.

--- a/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
@@ -141,7 +141,7 @@ public interface OperatingSystemMXBean extends
      *
      * <p> This method is not idempotent. The recent period of observation
      * is the duration since the last call made to this method, or {@link #getCpuLoad()}.
-     * For the very first invocation of this method, the recent period of 
+     * For the very first invocation of this method, the recent period of
      * observation is undefined.
      *
      * @deprecated Use {@link #getCpuLoad()} instead of
@@ -169,7 +169,7 @@ public interface OperatingSystemMXBean extends
      *
      * <p> This method is not idempotent. The recent period of observation
      * is the duration since the last call made to this method, or {@link #getSystemCpuLoad()}.
-     * For the very first invocation of this method, the recent period of 
+     * For the very first invocation of this method, the recent period of
      * observation is undefined.
      *
      * @return the "recent cpu usage" for the whole operating environment;

--- a/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
@@ -139,10 +139,9 @@ public interface OperatingSystemMXBean extends
      * If the system recent cpu usage is not available, the method returns a
      * negative value.
      *
-     * <p> This method is not idempotent. The recent period of observation
-     * is the duration since the last call made to this method, or {@link #getCpuLoad()}.
-     * For the very first invocation of this method, the recent period of
-     * observation is undefined.
+     * @apiNote The recent period of observation is the duration since the last
+     * call made to this method, or {@link #getCpuLoad()}. For the very first
+     * invocation of this method, the recent period of observation is undefined.
      *
      * @deprecated Use {@link #getCpuLoad()} instead of
      * this historically named method.
@@ -167,10 +166,10 @@ public interface OperatingSystemMXBean extends
      * If the recent cpu usage is not available, the method returns a
      * negative value.
      *
-     * <p> This method is not idempotent. The recent period of observation
-     * is the duration since the last call made to this method, or {@link #getSystemCpuLoad()}.
-     * For the very first invocation of this method, the recent period of
-     * observation is undefined.
+     * @apiNote The recent period of observation is the duration since the last
+     * call made to this method, or {@link #getSystemCpuLoad()}. For the very
+     * first invocation of this method, the recent period of observation is
+     * undefined.
      *
      * @return the "recent cpu usage" for the whole operating environment;
      * a negative value if not available.
@@ -190,9 +189,9 @@ public interface OperatingSystemMXBean extends
      * in the JVM process and the whole system. If the Java Virtual Machine
      * recent CPU usage is not available, the method returns a negative value.
      *
-     * <p> This method is not idempotent. The recent period of observation
-     * is the duration since the last call made to this method. For the very first
-     * invocation of this method the recent period of observation is undefined.
+     * @apiNote The recent period of observation is the duration since the last
+     * call made to this method. For the very first invocation of this method
+     * the recent period of observation is undefined.
      *
      * @return the "recent cpu usage" for the Java Virtual Machine process;
      * a negative value if not available.

--- a/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/OperatingSystemMXBean.java
@@ -151,9 +151,6 @@ public interface OperatingSystemMXBean extends
      * @apiNote Callers should be aware of the possibility of other callers
      * affecting the observation period and the result.
      *
-     * @implNote There is only one observation period for the entire JVM
-     * process.
-     *
      * @implSpec This implementation must return the same value
      * as {@link #getCpuLoad()}.
      *
@@ -183,9 +180,6 @@ public interface OperatingSystemMXBean extends
      * @apiNote Callers should be aware of the possibility of other callers
      * affecting the observation period and the result.
      *
-     * @implNote  There is only one observation period for the entire JVM
-     * process.
-     *
      * @return the "recent cpu usage" for the whole operating environment;
      * a negative value if not available.
      * @since 14
@@ -213,9 +207,6 @@ public interface OperatingSystemMXBean extends
      *
      * @apiNote Callers should be aware of the possibility of other callers
      * affecting the observation period and the result.
-     *
-     * @implNote There is only one observation period for the entire JVM
-     * process.
      *
      * @return the "recent cpu usage" for the Java Virtual Machine process;
      * a negative value if not available.


### PR DESCRIPTION
Can I get a review of this documentation update to clarify the usage of GetCpuLoad (and inherently deprecated GetSystemCpuLoad) and GetProcessCpuLoad.

Calling either of these methods in quick succession can lead to unrepresentative results due to too few data points.

This behavior is easy to reproduce on at least Linux (Windows implementation enforces a 500 ticks duration); when calling GetCpuLoad repeatedly CPU load values of either 0, 0.5, or 1 will be returned.
```
double cpuLoad1 = getCpuLoad();
double cpuLoad2 = getCpuLoad();   // not enough ticks has passed to give representative values
```
Worth noting is that this holds true even if getSystemCpuLoad() is called. 
```
double cpuLoad1 = getCpuLoad();
double cpuLoad2 = getSystemCpuLoad();   // not enough ticks has passed to give representative values, since getSystemCpuLoad effectively calls getCpuLoad.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8338904](https://bugs.openjdk.org/browse/JDK-8338904) to be approved

### Issues
 * [JDK-8335625](https://bugs.openjdk.org/browse/JDK-8335625): Update Javadoc for GetCpuLoad (**Enhancement** - P4)
 * [JDK-8338904](https://bugs.openjdk.org/browse/JDK-8338904): Update Javadoc for GetCpuLoad (**CSR**)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) Review applies to [af69aa88](https://git.openjdk.org/jdk/pull/20546/files/af69aa8813bec68117e666ff0f27aa31430cd95f)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20546/head:pull/20546` \
`$ git checkout pull/20546`

Update a local copy of the PR: \
`$ git checkout pull/20546` \
`$ git pull https://git.openjdk.org/jdk.git pull/20546/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20546`

View PR using the GUI difftool: \
`$ git pr show -t 20546`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20546.diff">https://git.openjdk.org/jdk/pull/20546.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20546#issuecomment-2301724862)