### PR TITLE
8338190: TOC vertical offsets not updated when document size changes

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
@@ -461,7 +461,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
         })
     }
     // Resize handler
-    function handleResize(e) {
+    new ResizeObserver((entries) => {
         if (expanded) {
             if (windowWidth !== window.innerWidth) {
                 collapse();
@@ -475,7 +475,5 @@ document.addEventListener("DOMContentLoaded", function(e) {
             handleScroll();
         }
         setTopMargin();
-    }
-    window.addEventListener("orientationchange", handleResize);
-    window.addEventListener("resize", handleResize);
+    }).observe(document.body);
 });


### PR DESCRIPTION
Please review a simple change to switch to a [better suited API](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to track changes in document size in `javadoc`-generated pages. In addition to changes in the size of the browser viewport, the new code handles changes coming from page content, such as showing different subsets of members in a member summary table.

This issue is labeled `noreg-hard` since we don't have a way to test resize behaviour in an automated way. I manually tested the change in Chrome, Firefox and Safari on various desktop and mobile platforms. The `ResizeObserver` API has been implemented in supported browsers [between early 2018 and early 2020](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver/ResizeObserver#browser_compatibility).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338190](https://bugs.openjdk.org/browse/JDK-8338190): TOC vertical offsets not updated when document size changes (**Bug** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20547/head:pull/20547` \
`$ git checkout pull/20547`

Update a local copy of the PR: \
`$ git checkout pull/20547` \
`$ git pull https://git.openjdk.org/jdk.git pull/20547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20547`

View PR using the GUI difftool: \
`$ git pr show -t 20547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20547.diff">https://git.openjdk.org/jdk/pull/20547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20547#issuecomment-2283935428)