### PR TITLE
8336384: AbstractQueuedSynchronizer.acquire should cancel acquire when failing due to a LinkageError or other errors

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -369,14 +369,19 @@ public abstract class AbstractQueuedLongSynchronizer
             } else if (node.status == 0) {
                 node.status = WAITING;          // enable signal and recheck
             } else {
-                long nanos;
                 spins = postSpins = (byte)((postSpins << 1) | 1);
-                if (!timed)
-                    LockSupport.park(this);
-                else if ((nanos = time - System.nanoTime()) > 0L)
-                    LockSupport.parkNanos(this, nanos);
-                else
-                    break;
+                try {
+                    long nanos;
+                    if (!timed)
+                        LockSupport.park(this);
+                    else if ((nanos = time - System.nanoTime()) > 0L)
+                        LockSupport.parkNanos(this, nanos);
+                    else
+                        break;
+                } catch (Error ex) {            // rethrow VM errors
+                    cancelAcquire(node, interrupted, interruptible);
+                    throw ex;
+                }
                 node.clearStatus();
                 if ((interrupted |= Thread.interrupted()) && interruptible)
                     break;

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -378,8 +378,8 @@ public abstract class AbstractQueuedLongSynchronizer
                         LockSupport.parkNanos(this, nanos);
                     else
                         break;
-                } catch (Error ex) {            // rethrow VM errors
-                    cancelAcquire(node, interrupted, interruptible);
+                } catch (Error | RuntimeException ex) {
+                    cancelAcquire(node, interrupted, interruptible); // cancel & rethrow
                     throw ex;
                 }
                 node.clearStatus();

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -757,8 +757,8 @@ public abstract class AbstractQueuedSynchronizer
                         LockSupport.parkNanos(this, nanos);
                     else
                         break;
-                } catch (Error ex) {            // rethrow VM errors
-                    cancelAcquire(node, interrupted, interruptible);
+                } catch (Error | RuntimeException ex) {
+                    cancelAcquire(node, interrupted, interruptible); // cancel & rethrow
                     throw ex;
                 }
                 node.clearStatus();


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336384](https://bugs.openjdk.org/browse/JDK-8336384): AbstractQueuedSynchronizer.acquire should cancel acquire when failing due to a LinkageError or other errors (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20548/head:pull/20548` \
`$ git checkout pull/20548`

Update a local copy of the PR: \
`$ git checkout pull/20548` \
`$ git pull https://git.openjdk.org/jdk.git pull/20548/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20548`

View PR using the GUI difftool: \
`$ git pr show -t 20548`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20548.diff">https://git.openjdk.org/jdk/pull/20548.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20548#issuecomment-2284041291)