### PR TITLE
8338202: Shenandoah: Improve handshake closure labels

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -823,7 +823,7 @@ void ShenandoahConcurrentGC::op_weak_roots() {
   // Perform handshake to flush out dead oops
   {
     ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_weak_roots_rendezvous);
-    heap->rendezvous_threads();
+    heap->rendezvous_threads("Shenandoah Concurrent Weak Roots");
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentMark.cpp
@@ -179,7 +179,7 @@ private:
   SATBMarkQueueSet& _qset;
 public:
   ShenandoahFlushSATBHandshakeClosure(SATBMarkQueueSet& qset) :
-    HandshakeClosure("Shenandoah Flush SATB Handshake"),
+    HandshakeClosure("Shenandoah Flush SATB"),
     _qset(qset) {}
 
   void do_thread(Thread* thread) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -1744,12 +1744,12 @@ void ShenandoahHeap::parallel_heap_region_iterate(ShenandoahHeapRegionClosure* b
 
 class ShenandoahRendezvousClosure : public HandshakeClosure {
 public:
-  inline ShenandoahRendezvousClosure() : HandshakeClosure("ShenandoahRendezvous") {}
+  inline ShenandoahRendezvousClosure(const char* name) : HandshakeClosure(name) {}
   inline void do_thread(Thread* thread) {}
 };
 
-void ShenandoahHeap::rendezvous_threads() {
-  ShenandoahRendezvousClosure cl;
+void ShenandoahHeap::rendezvous_threads(const char* name) {
+  ShenandoahRendezvousClosure cl(name);
   Handshake::execute(&cl);
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.hpp
@@ -400,7 +400,7 @@ private:
   void update_heap_region_states(bool concurrent);
   void rebuild_free_set(bool concurrent);
 
-  void rendezvous_threads();
+  void rendezvous_threads(const char* name);
   void recycle_trash();
 public:
   void notify_gc_progress();

--- a/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahUnload.cpp
@@ -168,7 +168,7 @@ void ShenandoahUnload::unload() {
   // Make sure stale metadata and nmethods are no longer observable
   {
     ShenandoahTimingsTracker t(ShenandoahPhaseTimings::conc_class_unload_rendezvous);
-    heap->rendezvous_threads();
+    heap->rendezvous_threads("Shenandoah Class Unloading");
   }
 
   // Purge stale metadata and nmethods that were unlinked


### PR DESCRIPTION
Currently, Shenandoah has a few handshakes that have not very clear names, "ShenandoahRendezvous". Would be good to make them more explicit.

Before:

```
Event: 2.593 Executing VM operation: Shenandoah Init Marking
Event: 2.594 Executing VM operation: Shenandoah Init Marking done
Event: 2.599 Executing VM operation: HandshakeAllThreads (Shenandoah Flush SATB Handshake)
Event: 2.599 Executing VM operation: HandshakeAllThreads (Shenandoah Flush SATB Handshake) done
Event: 2.599 Executing VM operation: HandshakeAllThreads (Shenandoah Flush SATB Handshake)
Event: 2.599 Executing VM operation: HandshakeAllThreads (Shenandoah Flush SATB Handshake) done
Event: 2.599 Executing VM operation: Shenandoah Final Mark and Start Evacuation
Event: 2.600 Executing VM operation: Shenandoah Final Mark and Start Evacuation done
Event: 2.600 Executing VM operation: HandshakeAllThreads (ShenandoahRendezvous)
Event: 2.600 Executing VM operation: HandshakeAllThreads (ShenandoahRendezvous) done
Event: 2.604 Executing VM operation: HandshakeAllThreads (ShenandoahRendezvous)
Event: 2.604 Executing VM operation: HandshakeAllThreads (ShenandoahRendezvous) done
Event: 2.605 Executing VM operation: CleanClassLoaderDataMetaspaces
Event: 2.606 Executing VM operation: CleanClassLoaderDataMetaspaces done
Event: 2.606 Executing VM operation: Shenandoah Init Update References
Event: 2.606 Executing VM operation: Shenandoah Init Update References done
Event: 2.611 Executing VM operation: HandshakeAllThreads (Shenandoah Update Thread Roots)
Event: 2.611 Executing VM operation: HandshakeAllThreads (Shenandoah Update Thread Roots) done
Event: 2.611 Executing VM operation: Shenandoah Final Update References
Event: 2.611 Executing VM operation: Shenandoah Final Update References done 
```

After:

```
Event: 1.043 Executing VM operation: Shenandoah Init Marking        
Event: 1.044 Executing VM operation: Shenandoah Init Marking done
Event: 1.050 Executing VM operation: HandshakeAllThreads (Shenandoah Flush SATB)
Event: 1.050 Executing VM operation: HandshakeAllThreads (Shenandoah Flush SATB) done
Event: 1.050 Executing VM operation: HandshakeAllThreads (Shenandoah Flush SATB)
Event: 1.050 Executing VM operation: HandshakeAllThreads (Shenandoah Flush SATB) done
Event: 1.050 Executing VM operation: Shenandoah Final Mark and Start Evacuation
Event: 1.050 Executing VM operation: Shenandoah Final Mark and Start Evacuation done
Event: 1.051 Executing VM operation: HandshakeAllThreads (Shenandoah Concurrent Weak Roots)
Event: 1.051 Executing VM operation: HandshakeAllThreads (Shenandoah Concurrent Weak Roots) done
Event: 1.055 Executing VM operation: Shenandoah Init Update References
Event: 1.055 Executing VM operation: Shenandoah Init Update References done
Event: 1.064 Executing VM operation: HandshakeAllThreads (Shenandoah Update Thread Roots)
Event: 1.064 Executing VM operation: HandshakeAllThreads (Shenandoah Update Thread Roots) done
Event: 1.064 Executing VM operation: Shenandoah Final Update References
Event: 1.064 Executing VM operation: Shenandoah Final Update References done
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338202](https://bugs.openjdk.org/browse/JDK-8338202): Shenandoah: Improve handshake closure labels (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20549/head:pull/20549` \
`$ git checkout pull/20549`

Update a local copy of the PR: \
`$ git checkout pull/20549` \
`$ git pull https://git.openjdk.org/jdk.git pull/20549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20549`

View PR using the GUI difftool: \
`$ git pr show -t 20549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20549.diff">https://git.openjdk.org/jdk/pull/20549.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20549#issuecomment-2284054631)