### PR TITLE
8336148: Test runtime/locking/TestRecursiveMonitorChurn.java failed: Unexpected Inflation

### DIFF
--- a/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
+++ b/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
@@ -79,7 +79,7 @@ public class TestRecursiveMonitorChurn {
             final long fuzzy_max_difference = 10;
             if (Math.abs(monitor_count_change) < fuzzy_max_difference) {
                 final String type = monitor_count_change < 0 ? "deflation" : "inflation";
-                throw new SkippedException("Intermittent " + type + " detected. Invalid test." );
+                throw new SkippedException("Intermittent " + type + " detected. Invalid test.");
             }
 
             if (monitor_count_change < 0) {

--- a/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
+++ b/test/hotspot/jtreg/runtime/locking/TestRecursiveMonitorChurn.java
@@ -70,6 +70,18 @@ public class TestRecursiveMonitorChurn {
         if (pre_monitor_count != post_monitor_count) {
             final long monitor_count_change = post_monitor_count - pre_monitor_count;
             System.out.println("Unexpected change in monitor count: " + monitor_count_change);
+
+            // Intermittent deflation and inflation may occur due to running the test
+            // with stress flags (like DeoptimizeALot) or with added instrumentation
+            // which runs in the same VM.
+            // An arbitrary fuzzy max difference of 10 (= 0.01% of COUNT) is chosen to
+            // allow for these occurrences to be skipped while still catching regressions.
+            final long fuzzy_max_difference = 10;
+            if (Math.abs(monitor_count_change) < fuzzy_max_difference) {
+                final String type = monitor_count_change < 0 ? "deflation" : "inflation";
+                throw new SkippedException("Intermittent " + type + " detected. Invalid test." );
+            }
+
             if (monitor_count_change < 0) {
                 throw new RuntimeException("Unexpected Deflation");
             }


### PR DESCRIPTION
When writing the test I suspected that this might happen.

I wanted to see if we could get away without a fuzz factor on the post and pre inflation comparison.

I'll update the test with a fuzz factor that can handle that some spurious inflation from other sources can occur. Especially relevant now that class loading uses an ObjectLocker, which is why it occurred when instrumentation was added and not only with the -XX:+DeoptimizeALot flags.

Will run through the problematic tests and check that these help. All observed occurrences have been with a difference of one between pre and post inflation counts.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336148](https://bugs.openjdk.org/browse/JDK-8336148): Test runtime/locking/TestRecursiveMonitorChurn.java failed: Unexpected Inflation (**Bug** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) 🔄 Re-review required (review applies to [a2d51e0e](https://git.openjdk.org/jdk/pull/20551/files/a2d51e0e396a047efe0043976d86e85c17f0cf8c))
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20551/head:pull/20551` \
`$ git checkout pull/20551`

Update a local copy of the PR: \
`$ git checkout pull/20551` \
`$ git pull https://git.openjdk.org/jdk.git pull/20551/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20551`

View PR using the GUI difftool: \
`$ git pr show -t 20551`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20551.diff">https://git.openjdk.org/jdk/pull/20551.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20551#issuecomment-2284187152)