### PR TITLE
8337595: Remove empty statements in src/hotspot/share/memory/metaspace

### DIFF
--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.hpp
@@ -85,7 +85,7 @@ void print_percentage(outputStream* st, size_t total, size_t part);
          SIZE_FORMAT_X " is not aligned to "                 \
          SIZE_FORMAT_X, (size_t)(uintptr_t)value, (size_t)(alignment))
 #define assert_is_aligned_metaspace_pointer(p) \
-  assert_is_aligned((p), metaspace::AllocationAlignmentByteSize);
+  assert_is_aligned((p), metaspace::AllocationAlignmentByteSize)
 #else
 #define assert_is_aligned(value, alignment)
 #define assert_is_aligned_metaspace_pointer(pointer)
@@ -141,8 +141,8 @@ void print_number_of_classes(outputStream* out, uintx classes, uintx classes_sha
 #define HAVE_UL
 
 #ifdef HAVE_UL
-#define UL(level, message)        log_##level(metaspace)(LOGFMT ": " message, LOGFMT_ARGS);
-#define UL2(level, message, ...)  log_##level(metaspace)(LOGFMT ": " message, LOGFMT_ARGS, __VA_ARGS__);
+#define UL(level, message)        log_##level(metaspace)(LOGFMT ": " message, LOGFMT_ARGS)
+#define UL2(level, message, ...)  log_##level(metaspace)(LOGFMT ": " message, LOGFMT_ARGS, __VA_ARGS__)
 #else
 #define UL(level, ...)
 #define UL2(level, ...)


### PR DESCRIPTION
Hi everyone,

Some of the macro definitions in `metaspaceCommon.hpp` include semicolons, resulting in empty statements being inserted when invoked. This behavior is unclear and could potentially lead to bugs.

This PR removes the semicolons from these macros, aligning them with other metaspace macros.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337595](https://bugs.openjdk.org/browse/JDK-8337595): Remove empty statements in src/hotspot/share/memory/metaspace (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20552/head:pull/20552` \
`$ git checkout pull/20552`

Update a local copy of the PR: \
`$ git checkout pull/20552` \
`$ git pull https://git.openjdk.org/jdk.git pull/20552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20552`

View PR using the GUI difftool: \
`$ git pr show -t 20552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20552.diff">https://git.openjdk.org/jdk/pull/20552.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20552#issuecomment-2284238637)