### PR TITLE
8337318: Deoptimization::relock_objects fails assert(monitor->owner() == Thread::current()) failed: must be

### DIFF
--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -596,8 +596,8 @@ bool ObjectSynchronizer::enter_fast_impl(Handle obj, BasicLock* lock, JavaThread
 
         log_info(monitorinflation)("LockStack capacity exceeded, inflating.");
         ObjectMonitor* monitor = inflate_for(locking_thread, lock_stack.bottom(), inflate_cause_vm_internal);
-        assert(monitor->owner() == Thread::current(), "must be owner=" PTR_FORMAT " current=" PTR_FORMAT " mark=" PTR_FORMAT,
-               p2i(monitor->owner()), p2i(Thread::current()), monitor->object()->mark_acquire().value());
+        assert(monitor->owner() == locking_thread, "must be owner=" PTR_FORMAT " locking_thread=" PTR_FORMAT " mark=" PTR_FORMAT,
+               p2i(monitor->owner()), p2i(locking_thread), monitor->object()->mark_acquire().value());
         assert(!lock_stack.is_full(), "must have made room here");
       }
 

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -288,6 +288,7 @@ class EATestsTarget {
 
         // Relocking test cases
         new EARelockingSimpleTarget()                                                       .run();
+        new EARelockingWithManyLightweightLocksTarget()                                     .run();
         new EARelockingSimpleWithAccessInOtherThreadTarget()                                .run();
         new EARelockingSimpleWithAccessInOtherThread_02_DynamicCall_Target()                .run();
         new EARelockingRecursiveTarget()                                                    .run();
@@ -413,6 +414,7 @@ public class EATests extends TestScaffold {
 
         // Relocking test cases
         new EARelockingSimple()                                                       .run(this);
+        new EARelockingWithManyLightweightLocks()                                     .run(this);
         new EARelockingSimpleWithAccessInOtherThread()                                .run(this);
         new EARelockingSimpleWithAccessInOtherThread_02_DynamicCall()                 .run(this);
         new EARelockingRecursive()                                                    .run(this);
@@ -1791,6 +1793,85 @@ class EARelockingSimpleTarget extends EATestCaseBaseTarget {
         XYVal l1 = new XYVal(4, 2);
         synchronized (l1) {
             dontinline_brkpt();
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Like {@link EARelockingSimple}. The difference is that there are many
+ * lightweight locked objects when the relocking is done. With
+ * <code>-XX:LockingMode=2</code> the lock stack of the thread will be full
+ * because of this.
+ */
+
+class EARelockingWithManyLightweightLocks extends EATestCaseBaseDebugger {
+
+    public void runTestCase() throws Exception {
+        BreakpointEvent bpe = resumeTo(TARGET_TESTCASE_BASE_NAME, "dontinline_brkpt", "()V");
+        printStack(bpe.thread());
+        @SuppressWarnings("unused")
+        ObjectReference o = getLocalRef(bpe.thread().frame(1), XYVAL_NAME, "l1");
+    }
+}
+
+class EARelockingWithManyLightweightLocksTarget extends EATestCaseBaseTarget {
+
+    static class Lock {
+    }
+
+    public static Lock L0, L1, L2, L3, L4, L5, L6, L7, L8, L9;
+
+    void allocateLocks() {
+        L0 = new Lock();
+        L1 = new Lock();
+        L2 = new Lock();
+        L3 = new Lock();
+        L4 = new Lock();
+        L5 = new Lock();
+        L6 = new Lock();
+        L7 = new Lock();
+        L8 = new Lock();
+        L9 = new Lock();
+    }
+
+    @Override
+    public void setUp() {
+        super.setUp();
+        allocateLocks();
+    }
+
+    @Override
+    public void warmupDone() {
+        super.warmupDone();
+        allocateLocks();    // get rid of already inflated ones
+    }
+
+    public void dontinline_testMethod() {
+        XYVal l1 = new XYVal(4, 2);
+        synchronized(L0) {
+            synchronized(L1) {
+                synchronized(L2) {
+                    synchronized(L3) {
+                        synchronized(L4) {
+                            synchronized(L5) {
+                                synchronized(L6) {
+                                    synchronized(L7) {
+                                        synchronized(L8) {
+                                            synchronized(L9) {
+                                                synchronized (l1) {
+                                                    dontinline_brkpt();
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 SAP SE. All rights reserved.
+ * Copyright (c) 2020, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The assert is wrong.  During deoptimization, the locking_thread is not the current thread, and that's the thread we should assert is the owner.
Reproduced in tier8 with com/sun/jdi/EATests.java, with LockStack CAPACITY=1 and not reproduced with the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337318](https://bugs.openjdk.org/browse/JDK-8337318): Deoptimization::relock_objects fails assert(monitor-&gt;owner() == Thread::current()) failed: must be (**Bug** - P3)


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) 🔄 Re-review required (review applies to [8a73754e](https://git.openjdk.org/jdk/pull/20553/files/8a73754e19d98f2fd598213807ef986be2cde6d3))
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Contributors
 * Richard Reingruber `<rrich@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20553/head:pull/20553` \
`$ git checkout pull/20553`

Update a local copy of the PR: \
`$ git checkout pull/20553` \
`$ git pull https://git.openjdk.org/jdk.git pull/20553/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20553`

View PR using the GUI difftool: \
`$ git pr show -t 20553`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20553.diff">https://git.openjdk.org/jdk/pull/20553.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20553#issuecomment-2284395658)