### PR TITLE
8338248: PartialArrayStateAllocator::Impl leaks Arena array

### DIFF
--- a/src/hotspot/share/gc/shared/partialArrayState.cpp
+++ b/src/hotspot/share/gc/shared/partialArrayState.cpp
@@ -100,6 +100,8 @@ PartialArrayStateAllocator::Impl::~Impl() {
   for (uint i = 0; i < _num_workers; ++i) {
     _arenas[i].~Arena();
   }
+
+  FREE_C_HEAP_ARRAY(Arena*, _arenas);
 }
 
 PartialArrayState* PartialArrayStateAllocator::Impl::allocate(uint worker_id,

--- a/src/hotspot/share/gc/shared/partialArrayState.cpp
+++ b/src/hotspot/share/gc/shared/partialArrayState.cpp
@@ -100,7 +100,6 @@ PartialArrayStateAllocator::Impl::~Impl() {
   for (uint i = 0; i < _num_workers; ++i) {
     _arenas[i].~Arena();
   }
-
   FREE_C_HEAP_ARRAY(Arena*, _arenas);
 }
 


### PR DESCRIPTION
Simple fix for a memory leak

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338248](https://bugs.openjdk.org/browse/JDK-8338248): PartialArrayStateAllocator::Impl leaks Arena array (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20557/head:pull/20557` \
`$ git checkout pull/20557`

Update a local copy of the PR: \
`$ git checkout pull/20557` \
`$ git pull https://git.openjdk.org/jdk.git pull/20557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20557`

View PR using the GUI difftool: \
`$ git pr show -t 20557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20557.diff">https://git.openjdk.org/jdk/pull/20557.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20557#issuecomment-2284609635)