### PR TITLE
8338280: Parallel: Inline ParallelCompactData::verify_clear

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -521,18 +521,13 @@ bool ParallelCompactData::summarize(SplitInfo& split_info,
 }
 
 #ifdef ASSERT
-void ParallelCompactData::verify_clear(const PSVirtualSpace* vspace)
+void ParallelCompactData::verify_clear()
 {
-  const size_t* const beg = (const size_t*)vspace->committed_low_addr();
-  const size_t* const end = (const size_t*)vspace->committed_high_addr();
+  const size_t* const beg = (const size_t*) _region_vspace->committed_low_addr();
+  const size_t* const end = (const size_t*) _region_vspace->committed_high_addr();
   for (const size_t* p = beg; p < end; ++p) {
     assert(*p == 0, "not zero");
   }
-}
-
-void ParallelCompactData::verify_clear()
-{
-  verify_clear(_region_vspace);
 }
 #endif  // #ifdef ASSERT
 

--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -393,7 +393,6 @@ public:
   inline bool       is_region_aligned(HeapWord* addr) const;
 
 #ifdef  ASSERT
-  void verify_clear(const PSVirtualSpace* vspace);
   void verify_clear();
 #endif  // #ifdef ASSERT
 


### PR DESCRIPTION
Trivial inlining a method to its sole caller.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338280](https://bugs.openjdk.org/browse/JDK-8338280): Parallel: Inline ParallelCompactData::verify_clear (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20561/head:pull/20561` \
`$ git checkout pull/20561`

Update a local copy of the PR: \
`$ git checkout pull/20561` \
`$ git pull https://git.openjdk.org/jdk.git pull/20561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20561`

View PR using the GUI difftool: \
`$ git pr show -t 20561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20561.diff">https://git.openjdk.org/jdk/pull/20561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20561#issuecomment-2285551529)