### PR TITLE
8335181: Incorrect handling of HTTP/2 GOAWAY frames in HttpClient

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ExchangeImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ExchangeImpl.java
@@ -58,6 +58,10 @@ abstract class ExchangeImpl<T> {
 
     final Exchange<T> exchange;
 
+    // this will be set to true only when the peer explicitly states (through a GOAWAY frame or
+    // a relevant error code in reset frame) that the corresponding stream (id) wasn't processed
+    private volatile boolean unprocessedByPeer;
+
     ExchangeImpl(Exchange<T> e) {
         // e == null means a http/2 pushed stream
         this.exchange = e;
@@ -266,10 +270,12 @@ abstract class ExchangeImpl<T> {
     // an Expect-Continue
     void expectContinueFailed(int rcode) { }
 
-    // This method returns false - every exchange is considered as processed by the peer,
-    // unless the peer explicitly states (through a GOAWAY frame) that the
-    // corresponding stream wasn't processed
-    boolean isUnprocessedByPeer() {
-        return false;
+    final boolean isUnprocessedByPeer() {
+        return this.unprocessedByPeer;
+    }
+
+    // Marks the exchange as unprocessed by the peer
+    final void markUnprocessedByPeer() {
+        this.unprocessedByPeer = true;
     }
 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/ExchangeImpl.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ExchangeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -265,4 +265,11 @@ abstract class ExchangeImpl<T> {
     // Called when server returns non 100 response to
     // an Expect-Continue
     void expectContinueFailed(int rcode) { }
+
+    // This method returns false - every exchange is considered as processed by the peer,
+    // unless the peer explicitly states (through a GOAWAY frame) that the
+    // corresponding stream wasn't processed
+    boolean isUnprocessedByPeer() {
+        return false;
+    }
 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,6 +47,8 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
@@ -358,6 +360,7 @@ class Http2Connection  {
     private final String key; // for HttpClientImpl.connections map
     private final FramesDecoder framesDecoder;
     private final FramesEncoder framesEncoder = new FramesEncoder();
+    private final AtomicLong lastProcessedStreamInGoAway = new AtomicLong(-1);
 
     /**
      * Send Window controller for both connection and stream windows.
@@ -725,7 +728,9 @@ class Http2Connection  {
 
     void close() {
         if (markHalfClosedLocal()) {
-            if (connection.channel().isOpen()) {
+            // we send a GOAWAY frame only if the remote side hasn't already indicated
+            // the intention to close the connection by previously sending a GOAWAY of its own
+            if (connection.channel().isOpen() && !isMarked(closedState, HALF_CLOSED_REMOTE)) {
                 Log.logTrace("Closing HTTP/2 connection: to {0}", connection.address());
                 GoAwayFrame f = new GoAwayFrame(0,
                         ErrorFrame.NO_ERROR,
@@ -1205,13 +1210,45 @@ class Http2Connection  {
         sendUnorderedFrame(frame);
     }
 
-    private void handleGoAway(GoAwayFrame frame)
-        throws IOException
-    {
-        if (markHalfClosedLRemote()) {
-            shutdown(new IOException(
-                    connection.channel().getLocalAddress()
-                            + ": GOAWAY received"));
+    private void handleGoAway(final GoAwayFrame frame) {
+        final long lastProcessedStream = frame.getLastStream();
+        assert lastProcessedStream >= 0 : "unexpected last stream id: "
+                + lastProcessedStream + " in GOAWAY frame";
+        setFinalStream(); // don't allow any new streams on this connection
+        markHalfClosedRemote();
+        if (debug.on()) {
+            debug.log("processing incoming GOAWAY with last processed stream id:%s in frame %s",
+                    lastProcessedStream, frame);
+        }
+        // see if this connection has previously received a GOAWAY from the peer and if yes
+        // then check if this new last processed stream id is lesser than the previous
+        // known last processed stream id. Only update the last processed stream id if the new
+        // one is lesser than the previous one.
+        long prevLastProcessed = lastProcessedStreamInGoAway.get();
+        while (prevLastProcessed == -1 || lastProcessedStream < prevLastProcessed) {
+            if (lastProcessedStreamInGoAway.compareAndSet(prevLastProcessed,
+                    lastProcessedStream)) {
+                break;
+            }
+            prevLastProcessed = lastProcessedStreamInGoAway.get();
+        }
+        handlePeerUnprocessedStreams(lastProcessedStreamInGoAway.get());
+    }
+
+    private void handlePeerUnprocessedStreams(final long lastProcessedStream) {
+        final AtomicInteger numClosed = new AtomicInteger(); // atomic merely to allow usage within lambda
+        streams.forEach((id, exchange) -> {
+            if (id > lastProcessedStream) {
+                // any streams with an stream id higher than the last processed stream
+                // can be retried (on a new connection). we close the exchange as unprocessed
+                // to facilitate the retrying.
+                client2.client().theExecutor().execute(exchange::closeAsUnprocessed);
+                numClosed.incrementAndGet();
+            }
+        });
+        if (debug.on()) {
+            debug.log(numClosed.get() + " stream(s), with id greater than " + lastProcessedStream
+                    + ", will be closed as unprocessed");
         }
     }
 
@@ -1745,7 +1782,7 @@ class Http2Connection  {
         return markClosedState(HALF_CLOSED_LOCAL);
     }
 
-    private boolean markHalfClosedLRemote() {
+    private boolean markHalfClosedRemote() {
         return markClosedState(HALF_CLOSED_REMOTE);
     }
 

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1242,7 +1242,7 @@ class Http2Connection  {
                 // any streams with an stream id higher than the last processed stream
                 // can be retried (on a new connection). we close the exchange as unprocessed
                 // to facilitate the retrying.
-                client2.client().theExecutor().execute(exchange::closeAsUnprocessed);
+                client2.client().theExecutor().ensureExecutedAsync(exchange::closeAsUnprocessed);
                 numClosed.incrementAndGet();
             }
         });

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Http2Connection.java
@@ -1214,8 +1214,9 @@ class Http2Connection  {
         final long lastProcessedStream = frame.getLastStream();
         assert lastProcessedStream >= 0 : "unexpected last stream id: "
                 + lastProcessedStream + " in GOAWAY frame";
-        setFinalStream(); // don't allow any new streams on this connection
+
         markHalfClosedRemote();
+        setFinalStream(); // don't allow any new streams on this connection
         if (debug.on()) {
             debug.log("processing incoming GOAWAY with last processed stream id:%s in frame %s",
                     lastProcessedStream, frame);

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -640,18 +640,19 @@ class Stream<T> extends ExchangeImpl<T> {
             } finally {
                 stateLock.unlock();
             }
-            try {
-                final int error = frame.getErrorCode();
-                if (error == ErrorFrame.REFUSED_STREAM) {
-                    // A REFUSED_STREAM error code implies that the stream wasn't processed by the
-                    // peer and the client is free to retry the request afresh.
-                    // Here we arrange for the request to be retried.
-                    if (debug.on()) {
-                        debug.log("request unprocessed by peer (REFUSED_STREAM) " + this.request);
-                    }
-                    closeAsUnprocessed();
-                    return;
+            final int error = frame.getErrorCode();
+            if (error == ErrorFrame.REFUSED_STREAM) {
+                // A REFUSED_STREAM error code implies that the stream wasn't processed by the
+                // peer and the client is free to retry the request afresh.
+                // Here we arrange for the request to be retried.
+                if (debug.on()) {
+                    debug.log("request unprocessed by peer (REFUSED_STREAM) " + this.request);
                 }
+                closeAsUnprocessed();
+                return;
+
+            }
+            try {
                 final String reason = ErrorFrame.stringForCode(error);
                 final IOException ioe = new IOException("Received RST_STREAM: " + reason);
                 if (debug.on()) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -640,19 +640,18 @@ class Stream<T> extends ExchangeImpl<T> {
             } finally {
                 stateLock.unlock();
             }
-            final int error = frame.getErrorCode();
-            if (error == ErrorFrame.REFUSED_STREAM) {
-                // A REFUSED_STREAM error code implies that the stream wasn't processed by the
-                // peer and the client is free to retry the request afresh.
-                // Here we arrange for the request to be retried.
-                if (debug.on()) {
-                    debug.log("request unprocessed by peer (REFUSED_STREAM) " + this.request);
-                }
-                closeAsUnprocessed();
-                return;
-
-            }
             try {
+                final int error = frame.getErrorCode();
+                if (error == ErrorFrame.REFUSED_STREAM) {
+                    // A REFUSED_STREAM error code implies that the stream wasn't processed by the
+                    // peer and the client is free to retry the request afresh.
+                    // Here we arrange for the request to be retried.
+                    if (debug.on()) {
+                        debug.log("request unprocessed by peer (REFUSED_STREAM) " + this.request);
+                    }
+                    closeAsUnprocessed();
+                    return;
+                }
                 final String reason = ErrorFrame.stringForCode(error);
                 final IOException ioe = new IOException("Received RST_STREAM: " + reason);
                 if (debug.on()) {

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -644,20 +644,35 @@ class Stream<T> extends ExchangeImpl<T> {
                 stateLock.unlock();
             }
             try {
-                int error = frame.getErrorCode();
-                IOException e = new IOException("Received RST_STREAM: "
-                        + ErrorFrame.stringForCode(error));
-                if (errorRef.compareAndSet(null, e)) {
-                    if (subscriber != null) {
-                        subscriber.onError(e);
+                final int error = frame.getErrorCode();
+                if (error == ErrorFrame.REFUSED_STREAM) {
+                    // A REFUSED_STREAM error code implies that the stream wasn't processed by the
+                    // peer and the client is free to retry the request afresh.
+                    // Here we arrange for the request to be retried.
+                    this.unprocessedByPeer = true;
+                    errorRef.compareAndSet(null, new IOException("request not processed by peer"));
+                    if (debug.on()) {
+                        debug.log("request unprocessed by peer (REFUSED_STREAM) " + this.request);
+                    }
+                } else {
+                    final String reason = ErrorFrame.stringForCode(error);
+                    final IOException failureCause = new IOException("Received RST_STREAM: " + reason);
+                    if (debug.on()) {
+                        debug.log(streamid + " received RST_STREAM with code: " + reason);
+                    }
+                    if (errorRef.compareAndSet(null, failureCause)) {
+                        if (subscriber != null) {
+                            subscriber.onError(failureCause);
+                        }
                     }
                 }
-                completeResponseExceptionally(e);
+                final Throwable failureCause = errorRef.get();
+                completeResponseExceptionally(failureCause);
                 if (!requestBodyCF.isDone()) {
-                    requestBodyCF.completeExceptionally(errorRef.get()); // we may be sending the body..
+                    requestBodyCF.completeExceptionally(failureCause); // we may be sending the body..
                 }
                 if (responseBodyCF != null) {
-                    responseBodyCF.completeExceptionally(errorRef.get());
+                    responseBodyCF.completeExceptionally(failureCause);
                 }
             } finally {
                 connection.decrementStreamsCount(streamid);
@@ -1666,7 +1681,9 @@ class Stream<T> extends ExchangeImpl<T> {
     }
 
     final String dbgString() {
-        return connection.dbgString() + "/Stream("+streamid+")";
+        final int id = streamid;
+        final String sid = id == 0 ? "?" : String.valueOf(id);
+        return connection.dbgString() + "/Stream(" + sid + ")";
     }
 
     /**

--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -640,27 +640,27 @@ class Stream<T> extends ExchangeImpl<T> {
             } finally {
                 stateLock.unlock();
             }
+            final int error = frame.getErrorCode();
+            if (error == ErrorFrame.REFUSED_STREAM) {
+                // A REFUSED_STREAM error code implies that the stream wasn't processed by the
+                // peer and the client is free to retry the request afresh.
+                // Here we arrange for the request to be retried.
+                if (debug.on()) {
+                    debug.log("request unprocessed by peer (REFUSED_STREAM) " + this.request);
+                }
+                closeAsUnprocessed();
+                return;
+
+            }
             try {
-                final int error = frame.getErrorCode();
-                if (error == ErrorFrame.REFUSED_STREAM) {
-                    // A REFUSED_STREAM error code implies that the stream wasn't processed by the
-                    // peer and the client is free to retry the request afresh.
-                    // Here we arrange for the request to be retried.
-                    markUnprocessedByPeer();
-                    errorRef.compareAndSet(null, new IOException("request not processed by peer"));
-                    if (debug.on()) {
-                        debug.log("request unprocessed by peer (REFUSED_STREAM) " + this.request);
-                    }
-                } else {
-                    final String reason = ErrorFrame.stringForCode(error);
-                    final IOException failureCause = new IOException("Received RST_STREAM: " + reason);
-                    if (debug.on()) {
-                        debug.log(streamid + " received RST_STREAM with code: " + reason);
-                    }
-                    if (errorRef.compareAndSet(null, failureCause)) {
-                        if (subscriber != null) {
-                            subscriber.onError(failureCause);
-                        }
+                final String reason = ErrorFrame.stringForCode(error);
+                final IOException ioe = new IOException("Received RST_STREAM: " + reason);
+                if (debug.on()) {
+                    debug.log(streamid + " received RST_STREAM with code: " + reason);
+                }
+                if (errorRef.compareAndSet(null, ioe)) {
+                    if (subscriber != null) {
+                        subscriber.onError(ioe);
                     }
                 }
                 final Throwable failureCause = errorRef.get();

--- a/src/java.net.http/share/classes/jdk/internal/net/http/frame/GoAwayFrame.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/frame/GoAwayFrame.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -57,7 +57,9 @@ public class GoAwayFrame extends ErrorFrame {
 
     @Override
     public String toString() {
-        return super.toString() + " Debugdata: " + new String(debugData, UTF_8);
+        return super.toString()
+                + " lastStreamId=" + lastStream
+                + ", Debugdata: " + new String(debugData, UTF_8);
     }
 
     public int getLastStream() {

--- a/test/jdk/java/net/httpclient/http2/H2GoAwayTest.java
+++ b/test/jdk/java/net/httpclient/http2/H2GoAwayTest.java
@@ -1,0 +1,373 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.net.ssl.SSLContext;
+
+import jdk.httpclient.test.lib.http2.Http2Handler;
+import jdk.httpclient.test.lib.http2.Http2TestExchange;
+import jdk.httpclient.test.lib.http2.Http2TestServer;
+import jdk.httpclient.test.lib.http2.Http2TestServerConnection;
+import jdk.internal.net.http.frame.ErrorFrame;
+import jdk.test.lib.net.SimpleSSLContext;
+import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import static java.net.http.HttpClient.Version.HTTP_2;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/*
+ * @test
+ * @bug 8335181
+ * @summary verify that the HttpClient correctly handles incoming GOAWAY frames and
+ *          retries any unprocessed requests on a new connection
+ * @library /test/lib /test/jdk/java/net/httpclient/lib
+ * @build jdk.httpclient.test.lib.http2.Http2TestServer
+ *        jdk.test.lib.net.SimpleSSLContext
+ * @run junit H2GoAwayTest
+ */
+public class H2GoAwayTest {
+    private static final String REQ_PATH = "/test";
+    private static Http2TestServer server;
+    private static String REQ_URI_BASE;
+    private static SSLContext sslCtx;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        sslCtx = new SimpleSSLContext().get();
+        assertNotNull(sslCtx, "SSLContext couldn't be created");
+        server = new Http2TestServer("localhost", true, sslCtx);
+        server.addHandler(new Handler(), REQ_PATH);
+        server.start();
+        System.out.println("Server started at " + server.getAddress());
+        REQ_URI_BASE = URIBuilder.newBuilder().scheme("https")
+                .loopback()
+                .port(server.getAddress().getPort())
+                .path(REQ_PATH)
+                .build().toString();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        if (server != null) {
+            System.out.println("Stopping server at " + server.getAddress());
+            server.stop();
+        }
+    }
+
+    /**
+     * Verifies that when several requests are sent using send() and the server
+     * connection is configured to send a GOAWAY after processing only a few requests, then
+     * the remaining requests are retried on a different connection
+     */
+    @Test
+    public void testSequential() throws Exception {
+        final RequestApprover reqApprover = new RequestApprover();
+        server.setRequestApprover(reqApprover::allowNewRequest);
+        try (final HttpClient client = HttpClient.newBuilder().version(HTTP_2)
+                .sslContext(sslCtx).build()) {
+            final String[] reqMethods = {"HEAD", "GET", "POST"};
+            for (final String reqMethod : reqMethods) {
+                final int numReqs = RequestApprover.MAX_REQS_PER_CONN + 3;
+                final Set<String> connectionKeys = new LinkedHashSet<>();
+                for (int i = 1; i <= numReqs; i++) {
+                    final URI reqURI = new URI(REQ_URI_BASE + "?seq&" + reqMethod + "=" + i);
+                    final HttpRequest req = HttpRequest.newBuilder()
+                            .uri(reqURI)
+                            .method(reqMethod, HttpRequest.BodyPublishers.noBody())
+                            .build();
+                    System.out.println("initiating request " + req);
+                    final HttpResponse<String> resp = client.send(req, BodyHandlers.ofString());
+                    final String respBody = resp.body();
+                    System.out.println("received response: " + respBody);
+                    assertEquals(200, resp.statusCode(),
+                            "unexpected status code for request " + resp.request());
+                    // response body is the logical key of the connection on which the
+                    // request was handled
+                    connectionKeys.add(respBody);
+                }
+                System.out.println("connections involved in handling the requests: "
+                        + connectionKeys);
+                // all requests have finished, we now just do a basic check that
+                // more than one connection was involved in processing these requests
+                assertEquals(2, connectionKeys.size(),
+                        "unexpected number of connections " + connectionKeys);
+            }
+        } finally {
+            server.setRequestApprover(null); // reset
+        }
+    }
+
+    /**
+     * Verifies that when a server responds with a GOAWAY and then never processes the new retried
+     * requests on a new connection too, then the application code receives the request failure.
+     * This tests the send() API of the HttpClient.
+     */
+    @Test
+    public void testUnprocessedRaisesException() throws Exception {
+        try (final HttpClient client = HttpClient.newBuilder().version(HTTP_2)
+                .sslContext(sslCtx).build()) {
+            final Random random = new Random();
+            final String[] reqMethods = {"HEAD", "GET", "POST"};
+            for (final String reqMethod : reqMethods) {
+                final int maxAllowedReqs = 2;
+                final int numReqs = maxAllowedReqs + 3; // 3 more requests than max allowed
+                // create a random set of request paths that will be allowed to be processed
+                // on the server
+                final Set<String> allowedReqPaths = new HashSet<>();
+                while (allowedReqPaths.size() < maxAllowedReqs) {
+                    final int rnd = random.nextInt(1, numReqs + 1);
+                    final String reqPath = REQ_PATH + "?sync&" + reqMethod + "=" + rnd;
+                    allowedReqPaths.add(reqPath);
+                }
+                // configure the approver
+                final OnlyAllowSpecificPaths reqApprover = new OnlyAllowSpecificPaths(allowedReqPaths);
+                server.setRequestApprover(reqApprover::allowNewRequest);
+                try {
+                    int numSuccess = 0;
+                    int numFailed = 0;
+                    for (int i = 1; i <= numReqs; i++) {
+                        final String reqQueryPart = "?sync&" + reqMethod + "=" + i;
+                        final URI reqURI = new URI(REQ_URI_BASE + reqQueryPart);
+                        final HttpRequest req = HttpRequest.newBuilder()
+                                .uri(reqURI)
+                                .method(reqMethod, HttpRequest.BodyPublishers.noBody())
+                                .build();
+                        System.out.println("initiating request " + req);
+                        if (allowedReqPaths.contains(REQ_PATH + reqQueryPart)) {
+                            // expected to successfully complete
+                            numSuccess++;
+                            final HttpResponse<String> resp = client.send(req, BodyHandlers.ofString());
+                            final String respBody = resp.body();
+                            System.out.println("received response: " + respBody);
+                            assertEquals(200, resp.statusCode(),
+                                    "unexpected status code for request " + resp.request());
+                        } else {
+                            // expected to fail as unprocessed
+                            try {
+                                final HttpResponse<String> resp = client.send(req, BodyHandlers.ofString());
+                                fail("Request was expected to fail as unprocessed,"
+                                        + " but got response: " + resp.body() + ", status code: "
+                                        + resp.statusCode());
+                            } catch (IOException ioe) {
+                                // verify it failed for the right reason
+                                if (ioe.getMessage() == null
+                                        || !ioe.getMessage().contains("request not processed by peer")) {
+                                    // propagate the original failure
+                                    throw ioe;
+                                }
+                                numFailed++; // failed due to right reason
+                                System.out.println("received expected failure: " + ioe
+                                        + ", for request " + reqURI);
+                            }
+                        }
+                    }
+                    // verify the correct number of requests succeeded/failed
+                    assertEquals(maxAllowedReqs, numSuccess, "unexpected number of requests succeeded");
+                    assertEquals((numReqs - maxAllowedReqs), numFailed, "unexpected number of requests failed");
+                } finally {
+                    server.setRequestApprover(null); // reset
+                }
+            }
+        }
+    }
+
+    /**
+     * Verifies that when a server responds with a GOAWAY and then never processes the new retried
+     * requests on a new connection too, then the application code receives the request failure.
+     * This tests the sendAsync() API of the HttpClient.
+     */
+    @Test
+    public void testUnprocessedRaisesExceptionAsync() throws Throwable {
+        try (final HttpClient client = HttpClient.newBuilder().version(HTTP_2)
+                .sslContext(sslCtx).build()) {
+            final Random random = new Random();
+            final String[] reqMethods = {"HEAD", "GET", "POST"};
+            for (final String reqMethod : reqMethods) {
+                final int maxAllowedReqs = 2;
+                final int numReqs = maxAllowedReqs + 3; // 3 more requests than max allowed
+                // create a random set of request paths that will be allowed to be processed
+                // on the server
+                final Set<String> allowedReqPaths = new HashSet<>();
+                while (allowedReqPaths.size() < maxAllowedReqs) {
+                    final int rnd = random.nextInt(1, numReqs + 1);
+                    final String reqPath = REQ_PATH + "?async&" + reqMethod + "=" + rnd;
+                    allowedReqPaths.add(reqPath);
+                }
+                // configure the approver
+                final OnlyAllowSpecificPaths reqApprover = new OnlyAllowSpecificPaths(allowedReqPaths);
+                server.setRequestApprover(reqApprover::allowNewRequest);
+                try {
+                    final List<Future<HttpResponse<String>>> futures = new ArrayList<>();
+                    for (int i = 1; i <= numReqs; i++) {
+                        final URI reqURI = new URI(REQ_URI_BASE + "?async&" + reqMethod + "=" + i);
+                        final HttpRequest req = HttpRequest.newBuilder()
+                                .uri(reqURI)
+                                .method(reqMethod, HttpRequest.BodyPublishers.noBody())
+                                .build();
+                        System.out.println("initiating request " + req);
+                        final Future<HttpResponse<String>> f = client.sendAsync(req, BodyHandlers.ofString());
+                        futures.add(f);
+                    }
+                    // wait for responses
+                    int numFailed = 0;
+                    int numSuccess = 0;
+                    for (int i = 1; i <= numReqs; i++) {
+                        try {
+                            final HttpResponse<String> resp = futures.get(i - 1).get();
+                            numSuccess++;
+                            final String respBody = resp.body();
+                            System.out.println("request: " + resp.request()
+                                    + ", received response: " + respBody);
+                            assertEquals(200, resp.statusCode(),
+                                    "unexpected status code for request " + resp.request());
+                        } catch (ExecutionException ee) {
+                            final Throwable cause = ee.getCause();
+                            if (!(cause instanceof IOException ioe)) {
+                                throw cause;
+                            }
+                            // verify it failed for the right reason
+                            if (ioe.getMessage() == null
+                                    || !ioe.getMessage().contains("request not processed by peer")) {
+                                // propagate the original failure
+                                throw ioe;
+                            }
+                            numFailed++; // failed due to the right reason
+                            System.out.println("received expected failure: " + ioe
+                                    + ", for request "
+                                    + REQ_URI_BASE + "?async&" + reqMethod + "=" + i);
+                        }
+                    }
+                    // verify the correct number of requests succeeded/failed
+                    assertEquals(maxAllowedReqs, numSuccess, "unexpected number of requests succeeded");
+                    assertEquals((numReqs - maxAllowedReqs), numFailed, "unexpected number of requests failed");
+                } finally {
+                    server.setRequestApprover(null); // reset
+                }
+            }
+        }
+    }
+
+    // only allows requests with certain paths to be processed, irrespective of which
+    // server connection is serving them. requests which don't match the allowed
+    // paths will not be processed and a GOAWAY frame will be sent.
+    private static final class OnlyAllowSpecificPaths {
+        private final Set<String> allowedReqPaths;
+
+        private OnlyAllowSpecificPaths(final Set<String> allowedReqPaths) {
+            this.allowedReqPaths = Set.copyOf(allowedReqPaths);
+        }
+
+        public boolean allowNewRequest(final Http2TestServerConnection serverConn,
+                                       final String reqPath) {
+            if (allowedReqPaths.contains(reqPath)) {
+                // allowed
+                return true;
+            }
+            System.out.println("sending GOAWAY on server connection " + serverConn
+                    + " for request: " + reqPath);
+            try {
+                serverConn.sendGoAway(ErrorFrame.NO_ERROR);
+            } catch (IOException e) {
+                System.err.println("Failed to send GOAWAY on server connection: "
+                        + serverConn + ", request: " + reqPath + ", due to: " + e);
+                e.printStackTrace();
+            }
+            return false;
+        }
+    }
+
+    // allows a certain number of requests per server connection, before sending a GOAWAY
+    // for any subsequent requests on that connection
+    private static final class RequestApprover {
+        private static final int MAX_REQS_PER_CONN = 6;
+        private final Map<Http2TestServerConnection, AtomicInteger> numApproved =
+                new ConcurrentHashMap<>();
+        private final Map<Http2TestServerConnection, AtomicInteger> numDisapproved =
+                new ConcurrentHashMap<>();
+
+        public boolean allowNewRequest(final Http2TestServerConnection serverConn,
+                                       final String reqPath) {
+            final AtomicInteger approved = numApproved.computeIfAbsent(serverConn,
+                    (k) -> new AtomicInteger());
+            int curr = approved.get();
+            while (curr < MAX_REQS_PER_CONN) {
+                if (approved.compareAndSet(curr, curr + 1)) {
+                    return true; // new request allowed
+                }
+                curr = approved.get();
+            }
+            final AtomicInteger disapproved = numDisapproved.computeIfAbsent(serverConn,
+                    (k) -> new AtomicInteger());
+            final int numUnprocessed = disapproved.incrementAndGet();
+            System.out.println(approved.get() + " processed, "
+                    + numUnprocessed + " unprocessed requests so far," +
+                    " sending GOAWAY on connection " + serverConn);
+            try {
+                serverConn.sendGoAway(ErrorFrame.NO_ERROR);
+            } catch (IOException e) {
+                System.err.println("Failed to send GOAWAY on server connection: "
+                        + serverConn + ", due to: " + e);
+                e.printStackTrace();
+            }
+            return false;
+        }
+    }
+
+    private static final class Handler implements Http2Handler {
+
+        @Override
+        public void handle(final Http2TestExchange exchange) throws IOException {
+            final String connectionKey = exchange.getConnectionKey();
+            System.out.println(connectionKey + " responding to request: "
+                    + exchange.getRequestURI());
+            final byte[] response = connectionKey.getBytes(UTF_8);
+            exchange.sendResponseHeaders(200, response.length);
+            try (final OutputStream os = exchange.getResponseBody()) {
+                os.write(response);
+            }
+        }
+    }
+}

--- a/test/jdk/java/net/httpclient/http2/H2GoAwayTest.java
+++ b/test/jdk/java/net/httpclient/http2/H2GoAwayTest.java
@@ -284,8 +284,7 @@ public class H2GoAwayTest {
             this.maxAllowedReqs = maxAllowedReqs;
         }
 
-        public boolean allowNewRequest(final String serverConnKey,
-                                       final String reqPath) {
+        public boolean allowNewRequest(final String serverConnKey) {
             final int approved = numApproved.incrementAndGet();
             return approved <= maxAllowedReqs;
         }
@@ -301,7 +300,7 @@ public class H2GoAwayTest {
         private final Map<String, AtomicInteger> numDisapproved =
                 new ConcurrentHashMap<>();
 
-        public boolean allowNewRequest(final String serverConnKey, final String reqPath) {
+        public boolean allowNewRequest(final String serverConnKey) {
             final AtomicInteger approved = numApproved.computeIfAbsent(serverConnKey,
                     (k) -> new AtomicInteger());
             int curr = approved.get();

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -58,7 +58,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
-import java.util.function.BiPredicate;
+import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -721,7 +721,7 @@ public interface HttpServerAdapters {
         public abstract HttpTestContext addHandler(HttpTestHandler handler, String root);
         public abstract InetSocketAddress getAddress();
         public abstract Version getVersion();
-        public abstract void setRequestApprover(final BiPredicate<String, String> approver);
+        public abstract void setRequestApprover(final Predicate<String> approver);
 
         public String serverAuthority() {
             InetSocketAddress address = getAddress();
@@ -872,7 +872,7 @@ public interface HttpServerAdapters {
             public Version getVersion() { return Version.HTTP_1_1; }
 
             @Override
-            public void setRequestApprover(final BiPredicate<String, String> approver) {
+            public void setRequestApprover(final Predicate<String> approver) {
                 throw new UnsupportedOperationException("not supported");
             }
         }
@@ -928,7 +928,7 @@ public interface HttpServerAdapters {
             public Version getVersion() { return Version.HTTP_2; }
 
             @Override
-            public void setRequestApprover(final BiPredicate<String, String> approver) {
+            public void setRequestApprover(final Predicate<String> approver) {
                 this.impl.setRequestApprover(approver);
             }
         }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/common/HttpServerAdapters.java
@@ -58,6 +58,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
+import java.util.function.BiPredicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -239,6 +240,7 @@ public interface HttpServerAdapters {
         public abstract String getRequestMethod();
         public abstract void close();
         public abstract InetSocketAddress getRemoteAddress();
+        public abstract String getConnectionKey();
         public void serverPush(URI uri, HttpHeaders headers, byte[] body) {
             ByteArrayInputStream bais = new ByteArrayInputStream(body);
             serverPush(uri, headers, bais);
@@ -253,7 +255,7 @@ public interface HttpServerAdapters {
             return new Http1TestExchange(exchange);
         }
         public static HttpTestExchange of(Http2TestExchange exchange) {
-            return new Http2TestExchangeImpl(exchange);
+            return new H2ExchangeImpl(exchange);
         }
 
         abstract void doFilter(Filter.Chain chain) throws IOException;
@@ -306,15 +308,21 @@ public interface HttpServerAdapters {
             public URI getRequestURI() { return exchange.getRequestURI(); }
             @Override
             public String getRequestMethod() { return exchange.getRequestMethod(); }
+
+            @Override
+            public String getConnectionKey() {
+                return exchange.getLocalAddress() + "->" + exchange.getRemoteAddress();
+            }
+
             @Override
             public String toString() {
                 return this.getClass().getSimpleName() + ": " + exchange.toString();
             }
         }
 
-        private static final class Http2TestExchangeImpl extends HttpTestExchange {
+        private static final class H2ExchangeImpl extends HttpTestExchange {
             private final Http2TestExchange exchange;
-            Http2TestExchangeImpl(Http2TestExchange exch) {
+            H2ExchangeImpl(Http2TestExchange exch) {
                 this.exchange = exch;
             }
             @Override
@@ -361,6 +369,11 @@ public interface HttpServerAdapters {
             @Override
             public InetSocketAddress getRemoteAddress() {
                 return exchange.getRemoteAddress();
+            }
+
+            @Override
+            public String getConnectionKey() {
+                return exchange.getConnectionKey();
             }
 
             @Override
@@ -708,6 +721,7 @@ public interface HttpServerAdapters {
         public abstract HttpTestContext addHandler(HttpTestHandler handler, String root);
         public abstract InetSocketAddress getAddress();
         public abstract Version getVersion();
+        public abstract void setRequestApprover(final BiPredicate<String, String> approver);
 
         public String serverAuthority() {
             InetSocketAddress address = getAddress();
@@ -856,6 +870,11 @@ public interface HttpServerAdapters {
                         impl.getAddress().getPort());
             }
             public Version getVersion() { return Version.HTTP_1_1; }
+
+            @Override
+            public void setRequestApprover(final BiPredicate<String, String> approver) {
+                throw new UnsupportedOperationException("not supported");
+            }
         }
 
         private static class Http1TestContext extends HttpTestContext {
@@ -907,6 +926,11 @@ public interface HttpServerAdapters {
                         impl.getAddress().getPort());
             }
             public Version getVersion() { return Version.HTTP_2; }
+
+            @Override
+            public void setRequestApprover(final BiPredicate<String, String> approver) {
+                this.impl.setRequestApprover(approver);
+            }
         }
 
         private static class Http2TestContext

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchange.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchange.java
@@ -73,12 +73,8 @@ public interface Http2TestExchange {
     CompletableFuture<Long> sendPing();
 
     /**
-     * {@return a string that identifies the underlying connection for this exchange}
-     * @apiNote
-     * This connection key can be useful to figure out whether two exchanges
-     * were performed on the same underlying connection.
+     * {@return the identification of the connection on which this exchange is being
+     * processed}
      */
-    default String getConnectionKey() {
-        return "{local=%s, remote=%s}".formatted(getLocalAddress(), getRemoteAddress());
-    }
+    String getConnectionKey();
 }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchange.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,4 +71,14 @@ public interface Http2TestExchange {
      * It may also complete exceptionally
      */
     CompletableFuture<Long> sendPing();
+
+    /**
+     * {@return a string that identifies the underlying connection for this exchange}
+     * @apiNote
+     * This connection key can be useful to figure out whether two exchanges
+     * were performed on the same underlying connection.
+     */
+    default String getConnectionKey() {
+        return "{local=%s, remote=%s}".formatted(getLocalAddress(), getRemoteAddress());
+    }
 }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestExchangeImpl.java
@@ -220,6 +220,11 @@ public class Http2TestExchangeImpl implements Http2TestExchange {
         }
     }
 
+    @Override
+    public String getConnectionKey() {
+        return conn.connectionKey();
+    }
+
     private boolean isHeadRequest() {
         return HEAD.equalsIgnoreCase(getRequestMethod());
     }

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
@@ -32,7 +32,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import javax.net.ServerSocketFactory;
@@ -62,9 +61,8 @@ public class Http2TestServer implements AutoCloseable {
     final Set<Http2TestServerConnection> connections;
     final Properties properties;
     final String name;
-    // request approver which takes the server connection key and the incoming request path
-    // as inputs
-    private volatile BiPredicate<String, String> newRequestApprover;
+    // request approver which takes the server connection key as the input
+    private volatile Predicate<String> newRequestApprover;
 
     private static ThreadFactory defaultThreadFac =
         (Runnable r) -> {
@@ -291,11 +289,11 @@ public class Http2TestServer implements AutoCloseable {
         return serverName;
     }
 
-    public void setRequestApprover(final BiPredicate<String, String> approver) {
+    public void setRequestApprover(final Predicate<String> approver) {
         this.newRequestApprover = approver;
     }
 
-    BiPredicate<String, String> getRequestApprover() {
+    Predicate<String> getRequestApprover() {
         return this.newRequestApprover;
     }
 

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
@@ -62,6 +62,8 @@ public class Http2TestServer implements AutoCloseable {
     final Set<Http2TestServerConnection> connections;
     final Properties properties;
     final String name;
+    // request approver which takes the server connection instance and the incoming request path
+    // as inputs
     private volatile BiPredicate<Http2TestServerConnection, String> newRequestApprover;
 
     private static ThreadFactory defaultThreadFac =

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServer.java
@@ -62,9 +62,9 @@ public class Http2TestServer implements AutoCloseable {
     final Set<Http2TestServerConnection> connections;
     final Properties properties;
     final String name;
-    // request approver which takes the server connection instance and the incoming request path
+    // request approver which takes the server connection key and the incoming request path
     // as inputs
-    private volatile BiPredicate<Http2TestServerConnection, String> newRequestApprover;
+    private volatile BiPredicate<String, String> newRequestApprover;
 
     private static ThreadFactory defaultThreadFac =
         (Runnable r) -> {
@@ -291,18 +291,12 @@ public class Http2TestServer implements AutoCloseable {
         return serverName;
     }
 
-    public void setRequestApprover(final BiPredicate<Http2TestServerConnection, String> approver) {
+    public void setRequestApprover(final BiPredicate<String, String> approver) {
         this.newRequestApprover = approver;
     }
 
-    public boolean shouldProcessNewHTTPRequest(final Http2TestServerConnection serverConn,
-                                               final String reqPath) {
-        final BiPredicate<Http2TestServerConnection, String> approver = this.newRequestApprover;
-        if (approver == null) {
-            // by the default the server will process new requests
-            return true;
-        }
-        return approver.test(serverConn, reqPath);
+    BiPredicate<String, String> getRequestApprover() {
+        return this.newRequestApprover;
     }
 
     private synchronized void putConnection(InetSocketAddress addr, Http2TestServerConnection c) {

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
@@ -82,6 +82,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -641,7 +642,7 @@ public class Http2TestServerConnection {
 
         // skip processing the request if configured to do so
         final String connKey = connectionKey();
-        if (!shouldProcessNewHTTPRequest(connKey, path)) {
+        if (!shouldProcessNewHTTPRequest(connKey)) {
             System.err.println("Rejecting primordial stream 1 and sending GOAWAY" +
                     " on server connection " + connKey + ", for request: " + path);
             sendGoAway(ErrorFrame.NO_ERROR);
@@ -661,12 +662,12 @@ public class Http2TestServerConnection {
         });
     }
 
-    private boolean shouldProcessNewHTTPRequest(final String serverConnKey, final String reqPath) {
-        final BiPredicate<String, String> approver = this.server.getRequestApprover();
+    private boolean shouldProcessNewHTTPRequest(final String serverConnKey) {
+        final Predicate<String> approver = this.server.getRequestApprover();
         if (approver == null) {
             return true; // process the request
         }
-        return approver.test(serverConnKey, reqPath);
+        return approver.test(serverConnKey);
     }
 
     final String connectionKey() {
@@ -718,7 +719,7 @@ public class Http2TestServerConnection {
         // skip processing the request if the server is configured to do so
         final String connKey = connectionKey();
         final String path = headers.firstValue(":path").orElse("");
-        if (!shouldProcessNewHTTPRequest(connKey, path)) {
+        if (!shouldProcessNewHTTPRequest(connKey)) {
             System.err.println("Rejecting stream " + streamid
                     + " and sending GOAWAY on server connection "
                     + connKey + ", for request: " + path);


### PR DESCRIPTION
This is a fresh version of the PR that I had opened here https://github.com/openjdk/jdk/pull/20442. A `git merge` command ended up causing unexpected issues with that old PR.

The commits in this PR are the ones which were already reviewed and a new one which was done to implement Daniel's suggestion in the review. test repeat 50 of java/net/httpclient had passed without any issues for that old PR. But before integrating this PR, I will rerun all relevant tests again to be sure nothing unexpected shows up.

Sorry that this has to be reviewed afresh.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335181](https://bugs.openjdk.org/browse/JDK-8335181): Incorrect handling of HTTP/2 GOAWAY frames in HttpClient (**Bug** - P3)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20567/head:pull/20567` \
`$ git checkout pull/20567`

Update a local copy of the PR: \
`$ git checkout pull/20567` \
`$ git pull https://git.openjdk.org/jdk.git pull/20567/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20567`

View PR using the GUI difftool: \
`$ git pr show -t 20567`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20567.diff">https://git.openjdk.org/jdk/pull/20567.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20567#issuecomment-2286277254)