### PR TITLE
8338315: G1: G1CardTableEntryClosure:do_card_ptr remove unused parameter worker_id

### DIFF
--- a/src/hotspot/share/gc/g1/g1CardTableEntryClosure.hpp
+++ b/src/hotspot/share/gc/g1/g1CardTableEntryClosure.hpp
@@ -36,7 +36,7 @@ public:
   typedef CardTable::CardValue CardValue;
 
   // Process the card whose card table entry is "card_ptr".
-  virtual void do_card_ptr(CardValue* card_ptr, uint worker_id) = 0;
+  virtual void do_card_ptr(CardValue* card_ptr) = 0;
 
   // Process all the card_ptrs in node.
   void apply_to_buffer(BufferNode* node, uint worker_id) {
@@ -44,7 +44,7 @@ public:
     size_t capacity = node->capacity();
     for (size_t i = node->index(); i < capacity; ++i) {
       CardValue* card_ptr = static_cast<CardValue*>(buffer[i]);
-      do_card_ptr(card_ptr, worker_id);
+      do_card_ptr(card_ptr);
     }
   }
 };

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1230,11 +1230,10 @@ class G1MergeHeapRootsTask : public WorkerTask {
       _cards_skipped(0)
     {}
 
-    void do_card_ptr(CardValue* card_ptr, uint worker_id) {
+    void do_card_ptr(CardValue* card_ptr) override {
       // The only time we care about recording cards that
       // contain references that point into the collection set
       // is during RSet updating within an evacuation pause.
-      // In this case worker_id should be the id of a GC worker thread.
       assert(SafepointSynchronize::is_at_safepoint(), "not during an evacuation pause");
 
       uint const region_idx = _ct->region_idx_for(card_ptr);
@@ -1342,6 +1341,7 @@ public:
       FREE_C_HEAP_ARRAY(Stack, _dirty_card_buffers);
     }
   }
+
   virtual void work(uint worker_id) {
     G1CollectedHeap* g1h = G1CollectedHeap::heap();
     G1GCPhaseTimes* p = g1h->phase_times();

--- a/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
+++ b/src/hotspot/share/gc/g1/g1YoungGCPostEvacuateTasks.cpp
@@ -522,7 +522,7 @@ public:
     _g1_ct(g1h->card_table()),
     _evac_failure_regions(evac_failure_regions) { }
 
-  void do_card_ptr(CardValue* card_ptr, uint worker_id) {
+  void do_card_ptr(CardValue* card_ptr) override {
     G1HeapRegion* hr = region_for_card(card_ptr);
 
     // Should only dirty cards in regions that won't be freed.


### PR DESCRIPTION
Please review this trivial change to remove an unused parameter worker_id in G1CardTableEntryClosure:do_card_ptr.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338315](https://bugs.openjdk.org/browse/JDK-8338315): G1: G1CardTableEntryClosure:do_card_ptr remove unused parameter worker_id (**Enhancement** - P5)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20569/head:pull/20569` \
`$ git checkout pull/20569`

Update a local copy of the PR: \
`$ git checkout pull/20569` \
`$ git pull https://git.openjdk.org/jdk.git pull/20569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20569`

View PR using the GUI difftool: \
`$ git pr show -t 20569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20569.diff">https://git.openjdk.org/jdk/pull/20569.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20569#issuecomment-2286790853)