### PR TITLE
8338314: JFR: Split JFRCheckpoint VM operation

### DIFF
--- a/src/hotspot/share/jfr/recorder/service/jfrRecorderService.hpp
+++ b/src/hotspot/share/jfr/recorder/service/jfrRecorderService.hpp
@@ -35,6 +35,8 @@ class JfrStorage;
 class JfrStringPool;
 
 class JfrRecorderService : public StackObj {
+  friend class JfrSafepointClearVMOperation;
+  friend class JfrSafepointWriteVMOperation;
  private:
   JfrCheckpointManager& _checkpoint_manager;
   JfrChunkWriter& _chunkwriter;

--- a/src/hotspot/share/runtime/vmOperation.hpp
+++ b/src/hotspot/share/runtime/vmOperation.hpp
@@ -87,7 +87,8 @@
   template(HeapWalkOperation)                     \
   template(HeapIterateOperation)                  \
   template(ReportJavaOutOfMemory)                 \
-  template(JFRCheckpoint)                         \
+  template(JFRSafepointClear)                     \
+  template(JFRSafepointWrite)                     \
   template(ShenandoahFullGC)                      \
   template(ShenandoahInitMark)                    \
   template(ShenandoahFinalMarkStartEvac)          \


### PR DESCRIPTION
Investigating JFR crashes is a bit tedious, as Events section in `hs_err` shows just:

```
Event: 3.006 Executing VM operation: JFRCheckpoint
Event: 3.006 Executing VM operation: JFRCheckpoint done
```

What is that `JFRCheckpoint` doing is unclear, because it can do two separate things: clear or write. It would be good if we could disambiguate the two. Since there are only two flavors of checkpoint, I think we can just split the VMOp into two more precisely named ones, so it gives us e.g.:

```
Event: 2.462 Executing VM operation: JFRSafepointClear
Event: 2.463 Executing VM operation: JFRSafepointClear done
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338314](https://bugs.openjdk.org/browse/JDK-8338314): JFR: Split JFRCheckpoint VM operation (**Enhancement** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20570/head:pull/20570` \
`$ git checkout pull/20570`

Update a local copy of the PR: \
`$ git checkout pull/20570` \
`$ git pull https://git.openjdk.org/jdk.git pull/20570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20570`

View PR using the GUI difftool: \
`$ git pr show -t 20570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20570.diff">https://git.openjdk.org/jdk/pull/20570.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20570#issuecomment-2286608662)