### PR TITLE
8336655: java/net/httpclient/DigestEchoClient.java IOException: HTTP/1.1 header parser received no bytes

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/ConnectionPool.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/ConnectionPool.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 
 import jdk.internal.net.http.common.Deadline;
 import jdk.internal.net.http.common.FlowTube;
+import jdk.internal.net.http.common.Log;
 import jdk.internal.net.http.common.Logger;
 import jdk.internal.net.http.common.TimeLine;
 import jdk.internal.net.http.common.TimeSource;
@@ -492,13 +493,13 @@ final class ConnectionPool {
 
     // Remove a connection from the pool.
     // should only be called while holding the ConnectionPool stateLock.
-    private void removeFromPool(HttpConnection c) {
+    private boolean removeFromPool(HttpConnection c) {
         assert stateLock.isHeldByCurrentThread();
         if (c instanceof PlainHttpConnection) {
-            removeFromPool(c, plainPool);
+            return removeFromPool(c, plainPool);
         } else {
             assert c.isSecure() : "connection " + c + " is not secure!";
-            removeFromPool(c, sslPool);
+            return removeFromPool(c, sslPool);
         }
     }
 
@@ -529,13 +530,29 @@ final class ConnectionPool {
             debug.log("%s : ConnectionPool.cleanup(%s)",
                     String.valueOf(c.getConnectionFlow()), error);
         stateLock.lock();
+        boolean removed;
         try {
-            removeFromPool(c);
+            removed = removeFromPool(c);
             expiryList.remove(c);
         } finally {
             stateLock.unlock();
         }
-        c.close();
+        if (!removed) {
+            // this should not happen; the cleanup may have consumed
+            // some data that wasn't supposed to be consumed, so
+            // the only thing we can do is log it and close the
+            // connection.
+            if (Log.errors()) {
+                Log.logError("WARNING: CleanupTrigger triggered for" +
+                        " a connection not found in the pool: closing {0}", c);
+            } else if (debug.on()) {
+                debug.log("WARNING: CleanupTrigger triggered for" +
+                        " a connection not found in the pool: closing %s", c);
+            }
+            c.close(new IOException("Unexpected cleanup triggered for non pooled connection"));
+        } else {
+            c.close();
+        }
     }
 
     /**
@@ -549,6 +566,7 @@ final class ConnectionPool {
 
         private final HttpConnection connection;
         private volatile boolean done;
+        private volatile boolean dropped;
 
         public CleanupTrigger(HttpConnection connection) {
             this.connection = connection;
@@ -566,6 +584,7 @@ final class ConnectionPool {
 
         @Override
         public void onSubscribe(Flow.Subscription subscription) {
+            if (dropped || done) return;
             subscription.request(1);
         }
         @Override
@@ -585,6 +604,11 @@ final class ConnectionPool {
         @Override
         public String toString() {
             return "CleanupTrigger(" + connection.getConnectionFlow() + ")";
+        }
+
+        @Override
+        public void dropSubscription() {
+            dropped = true;
         }
     }
 }

--- a/src/java.net.http/share/classes/jdk/internal/net/http/SocketTube.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/SocketTube.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -573,6 +573,8 @@ final class SocketTube implements FlowTube {
                     debug.log("read publisher: dropping pending subscriber: "
                               + previous.subscriber);
                 previous.errorRef.compareAndSet(null, errorRef.get());
+                // make sure no data will be routed to the old subscriber.
+                previous.stopReading();
                 previous.signalOnSubscribe();
                 if (subscriptionImpl.completed) {
                     previous.signalCompletion();
@@ -606,6 +608,7 @@ final class SocketTube implements FlowTube {
             volatile boolean subscribed;
             volatile boolean cancelled;
             volatile boolean completed;
+            volatile boolean stopped;
 
             public ReadSubscription(InternalReadSubscription impl,
                                     TubeSubscriber subscriber) {
@@ -623,11 +626,11 @@ final class SocketTube implements FlowTube {
 
             @Override
             public void request(long n) {
-                if (!cancelled) {
+                if (!cancelled && !stopped) {
                     impl.request(n);
                 } else {
                     if (debug.on())
-                        debug.log("subscription cancelled, ignoring request %d", n);
+                        debug.log("subscription stopped or cancelled, ignoring request %d", n);
                 }
             }
 
@@ -660,6 +663,20 @@ final class SocketTube implements FlowTube {
                 if (errorRef.get() != null) {
                     signalCompletion();
                 }
+            }
+
+            /**
+             * Called when switching subscriber on the {@link InternalReadSubscription}.
+             * This subscriber is the old subscriber. Demand on the internal
+             * subscription will be reset and reading will be paused until the
+             * new subscriber is subscribed.
+             * This should ensure that no data is routed to this subscriber
+             * until the new subscriber is subscribed.
+             */
+            void stopReading() {
+                stopped = true;
+                impl.demand.reset();
+                impl.pauseReadEvent();
             }
         }
 

--- a/test/jdk/java/net/httpclient/DigestEchoClient.java
+++ b/test/jdk/java/net/httpclient/DigestEchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ import static java.lang.String.format;
  * @test
  * @summary this test verifies that a client may provides authorization
  *          headers directly when connecting with a server.
- * @bug 8087112
+ * @bug 8087112 8336655
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters jdk.test.lib.net.SimpleSSLContext
  *        DigestEchoServer ReferenceTracker DigestEchoClient


### PR DESCRIPTION
Please find here a fix for [8336655: java/net/httpclient/DigestEchoClient.java IOException: HTTP/1.1 header parser received no bytes](https://bugs.openjdk.org/browse/JDK-8336655).

This fix has been seen failing intermittently on the mainline.

When an HTTP/1.1 connection is returned to the HTTP/1.1 pool, a CleanupTrigger is registered with the connection. The purpose of the CleanupTrigger is to get the connection socket registered with the selector while the connection is idle in the pool, so that it can be closed and removed from the pool if the peer closes the socket. It will also close and remove the connection from the pool if the peer sends unexpected data. 

When the connection is taken out of the pool to handle the next exchange, the CleanupTrigger is replaced with the exchange HTTP/1.1 publisher/subscribers. The read suscriber is registered first, to make sure that it is in place before the request headers are sent to the server, so that the response headers are delivered to the exchange subscriber (and not to the CleanupTrigger) when they arrive.

However, there's a catch. The subscibers are actually switched in the read scheduler, which means there's an opportunity for the write scheduler to sneak in first. This fix makes sure that reading for the CleanupTrigger is paused first, so that even if the write scheduler loop starts up first, no data will be delivered by the read loop until the exchange subscriber gets subscribed. This should prevent any data to reach the CleanupTrigger after the new exchange has been started.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336655](https://bugs.openjdk.org/browse/JDK-8336655): java/net/httpclient/DigestEchoClient.java IOException: HTTP/1.1 header parser received no bytes (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20571/head:pull/20571` \
`$ git checkout pull/20571`

Update a local copy of the PR: \
`$ git checkout pull/20571` \
`$ git pull https://git.openjdk.org/jdk.git pull/20571/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20571`

View PR using the GUI difftool: \
`$ git pr show -t 20571`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20571.diff">https://git.openjdk.org/jdk/pull/20571.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20571#issuecomment-2286832273)