### PR TITLE
8338330: Fix -Wzero-as-null-pointer-constant warnings from THROW_XXX_0

### DIFF
--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3403,7 +3403,7 @@ JVM_ENTRY_NO_ENV(void*, JVM_LoadLibrary(const char* name, jboolean throwExceptio
                                   vmSymbols::java_lang_UnsatisfiedLinkError(),
                                   msg, Exceptions::unsafe_to_utf8);
 
-      THROW_HANDLE_0(h_exception);
+      THROW_HANDLE_NULL(h_exception);
     } else {
       log_info(library)("Failed to load library %s", name);
       return load_result;

--- a/src/hotspot/share/runtime/reflection.cpp
+++ b/src/hotspot/share/runtime/reflection.cpp
@@ -1004,9 +1004,9 @@ static oop invoke(InstanceKlass* klass,
           // JVMTI internal flag reset is needed in order to report InvocationTargetException
           JvmtiExport::clear_detected_exception(THREAD);
           JavaCallArguments args(Handle(THREAD, resolution_exception));
-          THROW_ARG_0(vmSymbols::java_lang_reflect_InvocationTargetException(),
-                      vmSymbols::throwable_void_signature(),
-                      &args);
+          THROW_ARG_NULL(vmSymbols::java_lang_reflect_InvocationTargetException(),
+                         vmSymbols::throwable_void_signature(),
+                         &args);
         }
       }  else {
         // if the method can be overridden, we resolve using the vtable index.
@@ -1028,9 +1028,9 @@ static oop invoke(InstanceKlass* klass,
             Handle h_origexception = Exceptions::new_exception(THREAD,
               vmSymbols::java_lang_AbstractMethodError(), ss.as_string());
             JavaCallArguments args(h_origexception);
-            THROW_ARG_0(vmSymbols::java_lang_reflect_InvocationTargetException(),
-              vmSymbols::throwable_void_signature(),
-              &args);
+            THROW_ARG_NULL(vmSymbols::java_lang_reflect_InvocationTargetException(),
+                           vmSymbols::throwable_void_signature(),
+                           &args);
           }
         }
       }
@@ -1117,9 +1117,9 @@ static oop invoke(InstanceKlass* klass,
     JvmtiExport::clear_detected_exception(THREAD);
 
     JavaCallArguments args(Handle(THREAD, target_exception));
-    THROW_ARG_0(vmSymbols::java_lang_reflect_InvocationTargetException(),
-                vmSymbols::throwable_void_signature(),
-                &args);
+    THROW_ARG_NULL(vmSymbols::java_lang_reflect_InvocationTargetException(),
+                   vmSymbols::throwable_void_signature(),
+                   &args);
   } else {
     if (rtype == T_BOOLEAN || rtype == T_BYTE || rtype == T_CHAR || rtype == T_SHORT) {
       narrow((jvalue*)result.get_value_addr(), rtype, CHECK_NULL);

--- a/src/hotspot/share/utilities/exceptions.hpp
+++ b/src/hotspot/share/utilities/exceptions.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -310,6 +310,9 @@ class Exceptions {
 
 #define THROW_NULL(name)                    THROW_(name, nullptr)
 #define THROW_MSG_NULL(name, message)       THROW_MSG_(name, message, nullptr)
+
+#define THROW_HANDLE_NULL(e)                THROW_HANDLE_(e, nullptr)
+#define THROW_ARG_NULL(name, signature, arg) THROW_ARG_(name, signature, arg, nullptr)
 
 // The CATCH macro checks that no exception has been thrown by a function; it is used at
 // call sites about which is statically known that the callee cannot throw an exception


### PR DESCRIPTION
Please review this change to add THROW_ARG_NULL and THROW_HANDLE_NULL macros,
and use them instead of the corresponding THROW_XXX_0 macros in contexts where
a pointer value is needed.  This removes some -Wzero-as-null-pointer-constant
warnings.

There aren't many uses of either (only one of the HANDLE variant).  An
alternative would have been to change the callers to use the unsuffixed
variant with a nullptr value argument.  Adding the macros is consistent with
other THROW variants, and seems a little bit more readable.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338330](https://bugs.openjdk.org/browse/JDK-8338330): Fix -Wzero-as-null-pointer-constant warnings from THROW_XXX_0 (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20574/head:pull/20574` \
`$ git checkout pull/20574`

Update a local copy of the PR: \
`$ git checkout pull/20574` \
`$ git pull https://git.openjdk.org/jdk.git pull/20574/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20574`

View PR using the GUI difftool: \
`$ git pr show -t 20574`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20574.diff">https://git.openjdk.org/jdk/pull/20574.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20574#issuecomment-2287246880)