### PR TITLE
8338344: Test TestPrivilegedMode.java intermittent fails java.lang.NoClassDefFoundError: jdk/test/lib/Platform

### DIFF
--- a/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,7 +100,7 @@ public class TestVMProcess {
         String bootClassPath = "-Xbootclasspath/a:.";
         if (testClassesOnBootClassPath) {
             // Add test classes themselves to boot classpath to make them privileged.
-            bootClassPath += File.pathSeparator + Utils.TEST_CLASSES;
+            bootClassPath += File.pathSeparator + Utils.TEST_CLASS_PATH;
         }
         cmds.add(bootClassPath);
         cmds.add("-XX:+UnlockDiagnosticVMOptions");

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
@@ -35,7 +35,6 @@ import jdk.test.lib.Asserts;
  * @summary Test that IR framework successfully adds test class to boot classpath in order to run in privileged mode.
  * @modules java.base/jdk.internal.vm.annotation
  * @library /test/lib /
- * @build jdk.test.lib.Platform
  * @run driver ir_framework.tests.TestPrivilegedMode
  */
 

--- a/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
+++ b/test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java
@@ -35,6 +35,7 @@ import jdk.test.lib.Asserts;
  * @summary Test that IR framework successfully adds test class to boot classpath in order to run in privileged mode.
  * @modules java.base/jdk.internal.vm.annotation
  * @library /test/lib /
+ * @build jdk.test.lib.Platform
  * @run driver ir_framework.tests.TestPrivilegedMode
  */
 


### PR DESCRIPTION
Hi,
  Test `test/hotspot/jtreg/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.java` always fails by ours daily CI with fastdebug build, but I can't reproduce this fail standalone.
  When the test fails `java.lang.NoClassDefFoundError: jdk/test/lib/Platform`, the `jdk/test/lib/Platform.class` locate in `/var/tmp/tone/run/jtreg/jt-work/jtreg/hotspot_jtreg/classes/5/test/lib`, but `bootClassPath` [set as](https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/compiler/lib/ir_framework/driver/TestVMProcess.java#L103) `/var/tmp/tone/run/jtreg/jt-work/jtreg/hotspot_jtreg/classes/5/testlibrary_tests/ir_framework/tests/TestPrivilegedMode.d` 
```java
bootClassPath += File.pathSeparator + Utils.TEST_CLASSES;
```

I think `bootClassPath` should set as `Utils.TEST_CLASS_PATH`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338344](https://bugs.openjdk.org/browse/JDK-8338344): Test TestPrivilegedMode.java intermittent fails java.lang.NoClassDefFoundError: jdk/test/lib/Platform (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20576/head:pull/20576` \
`$ git checkout pull/20576`

Update a local copy of the PR: \
`$ git checkout pull/20576` \
`$ git pull https://git.openjdk.org/jdk.git pull/20576/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20576`

View PR using the GUI difftool: \
`$ git pr show -t 20576`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20576.diff">https://git.openjdk.org/jdk/pull/20576.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20576#issuecomment-2287774633)