### PR TITLE
8282944: GHA: Add Alpine Linux x86_64 pre-integration check

### DIFF
--- a/.github/actions/config/action.yml
+++ b/.github/actions/config/action.yml
@@ -41,6 +41,6 @@ runs:
       id: read-config
       run: |
         # Extract value from configuration file
-        value="$(grep -h ${{ inputs.var }}= make/conf/github-actions.conf | cut -d '=' -f 2-)"
+        value="$(grep -h '^${{ inputs.var }}'= make/conf/github-actions.conf | cut -d '=' -f 2-)"
         echo "value=$value" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/build-alpine-linux.yml
+++ b/.github/workflows/build-alpine-linux.yml
@@ -66,7 +66,7 @@ jobs:
         include:
           - debug-level: debug
             flags: --with-debug-level=fastdebug
-            suffix: -debug
+            suffix: -debug+
 
     steps:
       - name: 'Checkout the JDK source'
@@ -75,7 +75,7 @@ jobs:
       - name: 'Install toolchain and dependencies'
         run: |
           apk update
-          apk add alpine-sdk alsa-lib-dev autoconf bash cups-dev cups-libs fontconfig-dev freetype-dev grep libx11-dev libxext-dev libxrandr-dev libxrender-dev libxt-dev libxtst-dev linux-headers zip ${{ inputs.apk-extra-packages }}
+          apk add alpine-sdk alsa-lib-dev autoconf bash cups-dev cups-libs fontconfig-dev freetype-dev grep libx11-dev libxext-dev libxrandr-dev libxrender-dev libxt-dev libxtst-dev linux-headers wget  zip ${{ inputs.apk-extra-packages }}
 
       - name: 'Get the BootJDK'
         id: bootjdk

--- a/.github/workflows/build-alpine-linux.yml
+++ b/.github/workflows/build-alpine-linux.yml
@@ -75,13 +75,19 @@ jobs:
       - name: 'Install toolchain and dependencies'
         run: |
           apk update
-          apk add alpine-sdk alsa-lib-dev autoconf bash cups-dev cups-libs fontconfig-dev freetype-dev grep libx11-dev libxext-dev libxrandr-dev libxrender-dev libxt-dev libxtst-dev linux-headers wget  zip ${{ inputs.apk-extra-packages }}
+          apk add alpine-sdk alsa-lib-dev autoconf bash cups-dev cups-libs fontconfig-dev freetype-dev grep libx11-dev libxext-dev libxrandr-dev libxrender-dev libxt-dev libxtst-dev linux-headers wget zip ${{ inputs.apk-extra-packages }}
 
       - name: 'Get the BootJDK'
         id: bootjdk
         uses: ./.github/actions/get-bootjdk
         with:
           platform: alpine-linux-x64
+
+      - name: 'Setup Java 17 (for jtreg)'
+        uses: actions/setup-java@v4
+        with:
+            distribution: 'temurin'
+            java-version: '17'
 
       - name: 'Get JTReg'
         id: jtreg

--- a/.github/workflows/build-alpine-linux.yml
+++ b/.github/workflows/build-alpine-linux.yml
@@ -83,20 +83,6 @@ jobs:
         with:
           platform: alpine-linux-x64
 
-      - name: 'Setup Java 17 (for jtreg)'
-        uses: actions/setup-java@v4
-        with:
-            distribution: 'temurin'
-            java-version: '17'
-
-      - name: 'Get JTReg'
-        id: jtreg
-        uses: ./.github/actions/get-jtreg
-
-      - name: 'Get GTest'
-        id: gtest
-        uses: ./.github/actions/get-gtest
-
       - name: 'Configure'
         run: >
           bash configure
@@ -104,8 +90,6 @@ jobs:
           ${{ matrix.flags }}
           --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
           --with-boot-jdk=${{ steps.bootjdk.outputs.path }}
-          --with-jtreg=${{ steps.jtreg.outputs.path }}
-          --with-gtest=${{ steps.gtest.outputs.path }}
           --with-zlib=system
           --with-jmod-compress=zip-1
           ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (

--- a/.github/workflows/build-alpine-linux.yml
+++ b/.github/workflows/build-alpine-linux.yml
@@ -72,6 +72,11 @@ jobs:
       - name: 'Checkout the JDK source'
         uses: actions/checkout@v4
 
+      - name: 'Install toolchain and dependencies'
+        run: |
+          apk update
+          apk add alpine-sdk alsa-lib-dev autoconf bash cups-dev cups-libs fontconfig-dev freetype-dev grep libx11-dev libxext-dev libxrandr-dev libxrender-dev libxt-dev libxtst-dev linux-headers zip ${{ inputs.apk-extra-packages }}
+
       - name: 'Get the BootJDK'
         id: bootjdk
         uses: ./.github/actions/get-bootjdk
@@ -85,11 +90,6 @@ jobs:
       - name: 'Get GTest'
         id: gtest
         uses: ./.github/actions/get-gtest
-
-      - name: 'Install toolchain and dependencies'
-        run: |
-          apk update
-          apk add alpine-sdk alsa-lib-dev autoconf bash cups-dev cups-libs fontconfig-dev freetype-dev grep libx11-dev libxext-dev libxrandr-dev libxrender-dev libxt-dev libxtst-dev linux-headers zip ${{ inputs.apk-extra-packages }}
 
       - name: 'Configure'
         run: >

--- a/.github/workflows/build-alpine-linux.yml
+++ b/.github/workflows/build-alpine-linux.yml
@@ -1,0 +1,122 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+name: 'Build (alpine-linux)'
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        required: true
+        type: string
+      extra-conf-options:
+        required: false
+        type: string
+      make-target:
+        required: false
+        type: string
+        default: 'product-bundles test-bundles'
+      debug-levels:
+        required: false
+        type: string
+        default: '[ "debug", "release" ]'
+      apk-extra-packages:
+        required: false
+        type: string
+      configure-arguments:
+        required: false
+        type: string
+      make-arguments:
+        required: false
+        type: string
+
+jobs:
+  build-linux:
+    name: build
+    runs-on: ubuntu-22.04
+    container:
+      image: alpine:3.20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        debug-level: ${{ fromJSON(inputs.debug-levels) }}
+        include:
+          - debug-level: debug
+            flags: --with-debug-level=fastdebug
+            suffix: -debug
+
+    steps:
+      - name: 'Checkout the JDK source'
+        uses: actions/checkout@v4
+
+      - name: 'Get the BootJDK'
+        id: bootjdk
+        uses: ./.github/actions/get-bootjdk
+        with:
+          platform: alpine-linux-x64
+
+      - name: 'Get JTReg'
+        id: jtreg
+        uses: ./.github/actions/get-jtreg
+
+      - name: 'Get GTest'
+        id: gtest
+        uses: ./.github/actions/get-gtest
+
+      - name: 'Install toolchain and dependencies'
+        run: |
+          apk update
+          apk add alpine-sdk alsa-lib-dev autoconf bash cups-dev cups-libs fontconfig-dev freetype-dev grep libx11-dev libxext-dev libxrandr-dev libxrender-dev libxt-dev libxtst-dev linux-headers zip ${{ inputs.apk-extra-packages }}
+
+      - name: 'Configure'
+        run: >
+          bash configure
+          --with-conf-name=${{ inputs.platform }}
+          ${{ matrix.flags }}
+          --with-version-opt=${GITHUB_ACTOR}-${GITHUB_SHA}
+          --with-boot-jdk=${{ steps.bootjdk.outputs.path }}
+          --with-jtreg=${{ steps.jtreg.outputs.path }}
+          --with-gtest=${{ steps.gtest.outputs.path }}
+          --with-zlib=system
+          --with-jmod-compress=zip-1
+          ${{ inputs.extra-conf-options }} ${{ inputs.configure-arguments }} || (
+          echo "Dumping config.log:" &&
+          cat config.log &&
+          exit 1)
+
+      - name: 'Build'
+        id: build
+        uses: ./.github/actions/do-build
+        with:
+          make-target: '${{ inputs.make-target }} ${{ inputs.make-arguments }}'
+          platform: ${{ inputs.platform }}
+          debug-suffix: '${{ matrix.suffix }}'
+
+      - name: 'Upload bundles'
+        uses: ./.github/actions/upload-bundles
+        with:
+          platform: ${{ inputs.platform }}
+          debug-suffix: '${{ matrix.suffix }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,9 @@ jobs:
   select:
     name: 'Select platforms'
     runs-on: ubuntu-22.04
+    env:
+      # List of platforms to exclude by default
+      EXCLUDED_PLATFORMS: 'alpine-linux-x64'
     outputs:
       linux-x64: ${{ steps.include.outputs.linux-x64 }}
       linux-x86-hs: ${{ steps.include.outputs.linux-x86-hs }}
@@ -80,8 +83,8 @@ jobs:
           # 'false' otherwise.
           # arg $1: platform name or names to look for
 
-          # List of platforms to exclude by default
-          EXCLUDED_PLATFORMS=("alpine-linux-x64")
+          # Convert EXCLUDED_PLATFORMS from a comma-separated string to an array
+          IFS=',' read -r -a excluded_array <<< "$EXCLUDED_PLATFORMS"
 
           function check_platform() {
             if [[ $GITHUB_EVENT_NAME == workflow_dispatch ]]; then
@@ -100,7 +103,7 @@ jobs:
             normalized_input="$(echo ,$input, | tr -d ' ')"
             if [[ "$normalized_input" == ",," ]]; then
               # For an empty input, assume all platforms should run, except those in the EXCLUDED_PLATFORMS list
-              for excluded in "${EXCLUDED_PLATFORMS[@]}"; do
+              for excluded in "${excluded_array[@]}"; do
                 if [[ "$1" == "$excluded" ]]; then
                   echo 'false'
                   return
@@ -118,7 +121,7 @@ jobs:
               done
 
               # If not explicitly included, check against the EXCLUDED_PLATFORMS list
-              for excluded in "${EXCLUDED_PLATFORMS[@]}"; do
+              for excluded in "${excluded_array[@]}"; do
                 if [[ "$1" == "$excluded" ]]; then
                   echo 'false'
                   return

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -365,7 +365,7 @@ jobs:
       - build-linux-x64-hs-minimal
       - build-linux-x64-hs-optimized
       - build-linux-cross-compile
-      - build-alpine-linux-hs
+      - build-alpine-linux-x64-hs
       - build-macos-x64
       - build-macos-aarch64
       - build-windows-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,11 +74,16 @@ jobs:
       - name: 'Check what jobs to run'
         id: include
         run: |
+          set -x
           # Determine which platform jobs to run
 
           # Returns 'true' if the input platform list matches any of the platform monikers given as argument,
           # 'false' otherwise.
           # arg $1: platform name or names to look for
+
+          # List of platforms to exclude by default
+          EXCLUDED_PLATFORMS=("alpine-linux-x64")
+
           function check_platform() {
             if [[ $GITHUB_EVENT_NAME == workflow_dispatch ]]; then
               input='${{ github.event.inputs.platforms }}'
@@ -95,7 +100,13 @@ jobs:
 
             normalized_input="$(echo ,$input, | tr -d ' ')"
             if [[ "$normalized_input" == ",," ]]; then
-              # For an empty input, assume all platforms should run
+              # For an empty input, assume all platforms should run, except those in the EXCLUDED_PLATFORMS list
+              for excluded in "${EXCLUDED_PLATFORMS[@]}"; do
+                if [[ "$1" == "$excluded" ]]; then
+                  echo 'false'
+                  return
+                fi
+              done
               echo 'true'
               return
             else
@@ -103,6 +114,14 @@ jobs:
               for part in $* ; do
                 if echo "$normalized_input" | grep -q -e ",$part," ; then
                   echo 'true'
+                  return
+                fi
+              done
+
+              # If not explicitly included, check against the EXCLUDED_PLATFORMS list
+              for excluded in "${EXCLUDED_PLATFORMS[@]}"; do
+                if [[ "$1" == "$excluded" ]]; then
+                  echo 'false'
                   return
                 fi
               done
@@ -232,7 +251,7 @@ jobs:
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     # We only run this job on manual triggers to save resources
-    if: ${{ github.event_name == 'workflow_dispatch' && needs.select.outputs.alpine-linux-x64 == 'true' }}
+    if: needs.select.outputs.alpine-linux-x64 == 'true'
 
   build-macos-x64:
     name: macos-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ on:
       platforms:
         description: 'Platform(s) to execute on (comma separated, e.g. "linux-x64, macos, aarch64")'
         required: true
-        default: 'linux-x64, linux-x86, linux-x64-variants, linux-cross-compile, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
+        default: 'linux-x64, linux-x86, linux-x64-variants, linux-cross-compile, alpine-linux-x64-hs, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
       configure-arguments:
         description: 'Additional configure arguments'
         required: false
@@ -62,6 +62,7 @@ jobs:
       linux-x86: ${{ steps.include.outputs.linux-x86 }}
       linux-x64-variants: ${{ steps.include.outputs.linux-x64-variants }}
       linux-cross-compile: ${{ steps.include.outputs.linux-cross-compile }}
+      alpine-linux-x64-hs: ${{ steps.include.outputs.alpine-linux-x64-hs }}
       macos-x64: ${{ steps.include.outputs.macos-x64 }}
       macos-aarch64: ${{ steps.include.outputs.macos-aarch64 }}
       windows-x64: ${{ steps.include.outputs.windows-x64 }}
@@ -220,6 +221,16 @@ jobs:
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-cross-compile == 'true'
 
+  build-alpine-linux-x64-hs:
+    name: alpine-linux-x64-hs
+    needs: select
+    uses: ./.github/workflows/build-alpine-linux.yml
+    with:
+      platform: alpine-linux-x64
+      configure-arguments: ${{ github.event.inputs.configure-arguments }}
+      make-arguments: ${{ github.event.inputs.make-arguments }}
+    if: needs.select.outputs.alpine-linux-x64-hs == 'true'
+
   build-macos-x64:
     name: macos-x64
     needs: select
@@ -353,6 +364,7 @@ jobs:
       - build-linux-x64-hs-minimal
       - build-linux-x64-hs-optimized
       - build-linux-cross-compile
+      - build-alpine-linux-hs
       - build-macos-x64
       - build-macos-aarch64
       - build-windows-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,6 +115,7 @@ jobs:
           echo "linux-x86=$(check_platform linux-x86 linux x86)" >> $GITHUB_OUTPUT
           echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
           echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
+          echo "alpine-linux-x64-hs=$(check_platform alpine-linux-x64-hs alpine-linux x64)" >> $GITHUB_OUTPUT
           echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
           echo "macos-aarch64=$(check_platform macos-aarch64 macos aarch64)" >> $GITHUB_OUTPUT
           echo "windows-x64=$(check_platform windows-x64 windows x64)" >> $GITHUB_OUTPUT

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -231,7 +231,8 @@ jobs:
       platform: alpine-linux-x64
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.alpine-linux-x64 == 'true'
+    # We only run this job on manual triggers to save resources
+    if: ${{ github.event_name == 'workflow_dispatch' && needs.select.outputs.alpine-linux-x64 == 'true' }}
 
   build-macos-x64:
     name: macos-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,6 +227,7 @@ jobs:
     uses: ./.github/workflows/build-alpine-linux.yml
     with:
       platform: alpine-linux-x64
+      make-target: 'hotspot'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.alpine-linux-x64-hs == 'true'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ on:
       platforms:
         description: 'Platform(s) to execute on (comma separated, e.g. "linux-x64, macos, aarch64")'
         required: true
-        default: 'linux-x64, linux-x86-hs, linux-x64-variants, linux-cross-compile, alpine-linux-x64-hs, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
+        default: 'linux-x64, linux-x86-hs, linux-x64-variants, linux-cross-compile, alpine-linux-x64, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
       configure-arguments:
         description: 'Additional configure arguments'
         required: false
@@ -62,7 +62,7 @@ jobs:
       linux-x86-hs: ${{ steps.include.outputs.linux-x86-hs }}
       linux-x64-variants: ${{ steps.include.outputs.linux-x64-variants }}
       linux-cross-compile: ${{ steps.include.outputs.linux-cross-compile }}
-      alpine-linux-x64-hs: ${{ steps.include.outputs.alpine-linux-x64-hs }}
+      alpine-linux-x64: ${{ steps.include.outputs.alpine-linux-x64 }}
       macos-x64: ${{ steps.include.outputs.macos-x64 }}
       macos-aarch64: ${{ steps.include.outputs.macos-aarch64 }}
       windows-x64: ${{ steps.include.outputs.windows-x64 }}
@@ -115,7 +115,7 @@ jobs:
           echo "linux-x86-hs=$(check_platform linux-x86-hs linux x86)" >> $GITHUB_OUTPUT
           echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
           echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
-          echo "alpine-linux-x64-hs=$(check_platform alpine-linux-x64-hs alpine-linux x64)" >> $GITHUB_OUTPUT
+          echo "alpine-linux-x64=$(check_platform alpine-linux-x64 alpine-linux x64)" >> $GITHUB_OUTPUT
           echo "macos-x64=$(check_platform macos-x64 macos x64)" >> $GITHUB_OUTPUT
           echo "macos-aarch64=$(check_platform macos-aarch64 macos aarch64)" >> $GITHUB_OUTPUT
           echo "windows-x64=$(check_platform windows-x64 windows x64)" >> $GITHUB_OUTPUT
@@ -223,16 +223,15 @@ jobs:
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.select.outputs.linux-cross-compile == 'true'
 
-  build-alpine-linux-x64-hs:
-    name: alpine-linux-x64-hs
+  build-alpine-linux-x64:
+    name: alpine-linux-x64
     needs: select
     uses: ./.github/workflows/build-alpine-linux.yml
     with:
       platform: alpine-linux-x64
-      make-target: 'hotspot'
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.select.outputs.alpine-linux-x64-hs == 'true'
+    if: needs.select.outputs.alpine-linux-x64 == 'true'
 
   build-macos-x64:
     name: macos-x64
@@ -357,7 +356,7 @@ jobs:
       - build-linux-x64-hs-minimal
       - build-linux-x64-hs-optimized
       - build-linux-cross-compile
-      - build-alpine-linux-x64-hs
+      - build-alpine-linux-x64
       - build-macos-x64
       - build-macos-aarch64
       - build-windows-x64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,7 +74,6 @@ jobs:
       - name: 'Check what jobs to run'
         id: include
         run: |
-          set -x
           # Determine which platform jobs to run
 
           # Returns 'true' if the input platform list matches any of the platform monikers given as argument,
@@ -250,7 +249,6 @@ jobs:
       platform: alpine-linux-x64
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
-    # We only run this job on manual triggers to save resources
     if: needs.select.outputs.alpine-linux-x64 == 'true'
 
   build-macos-x64:

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -32,6 +32,10 @@ LINUX_X64_BOOT_JDK_EXT=tar.gz
 LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk22.0.2/c9ecb94cd31b495da20a27d4581645e8/9/GPL/openjdk-22.0.2_linux-x64_bin.tar.gz
 LINUX_X64_BOOT_JDK_SHA256=41536f115668308ecf4eba92aaf6acaeb0936225828b741efd83b6173ba82963
 
+ALPINE_LINUX_X64_BOOT_JDK_EXT=tar.gz
+ALPINE_LINUX_X64_BOOT_JDK_URL=https://github.com/adoptium/temurin22-binaries/releases/download/jdk-22.0.2%2B9/OpenJDK22U-jdk_x64_alpine-linux_hotspot_22.0.2_9.tar.gz
+ALPINE_LINUX_X64_BOOT_JDK_SHA256=49f73414824b1a7c268a611225fa4d7ce5e25600201e0f1cd59f94d1040b5264
+
 MACOS_AARCH64_BOOT_JDK_EXT=tar.gz
 MACOS_AARCH64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk22.0.2/c9ecb94cd31b495da20a27d4581645e8/9/GPL/openjdk-22.0.2_macos-aarch64_bin.tar.gz
 MACOS_AARCH64_BOOT_JDK_SHA256=3dab98730234e1a87aec14bcb8171d2cae101e96ff4eed1dab96abbb08e843fd


### PR DESCRIPTION
Adds Alpine build CI job to the GitHub actions matrix. Currently this only builds hotspot. I can add tests too if people think that would be useful but for now I've left it as just build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8282944](https://bugs.openjdk.org/browse/JDK-8282944): GHA: Add Alpine Linux x86_64 pre-integration check (**Enhancement** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20577/head:pull/20577` \
`$ git checkout pull/20577`

Update a local copy of the PR: \
`$ git checkout pull/20577` \
`$ git pull https://git.openjdk.org/jdk.git pull/20577/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20577`

View PR using the GUI difftool: \
`$ git pr show -t 20577`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20577.diff">https://git.openjdk.org/jdk/pull/20577.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20577#issuecomment-2288223472)