### PR TITLE
8338365: [PPC64, s390] Out-of-bounds array access in secondary_super_cache

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2170,7 +2170,6 @@ do {                                                                  \
          (result        == R8_ARG6      || result        == noreg), "registers must match ppc64.ad"); \
 } while(0)
 
-// Return true: we succeeded in generating this code
 void MacroAssembler::lookup_secondary_supers_table(Register r_sub_klass,
                                                    Register r_super_klass,
                                                    Register temp1,
@@ -2292,9 +2291,8 @@ void MacroAssembler::lookup_secondary_supers_table_slow_path(Register r_super_kl
 
   // The bitmap is full to bursting.
   // Implicit invariant: BITMAP_FULL implies (length > 0)
-  assert(Klass::SECONDARY_SUPERS_BITMAP_FULL == ~uintx(0), "");
-  cmpdi(CCR0, r_bitmap, -1);
-  beq(CCR0, L_huge);
+  cmpwi(CCR0, r_array_length, (int32_t)Klass::SECONDARY_SUPERS_TABLE_SIZE - 2);
+  bgt(CCR0, L_huge);
 
   // NB! Our caller has checked bits 0 and 1 in the bitmap. The
   // current slot (at secondary_supers[r_array_index]) has not yet

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3320,7 +3320,7 @@ void MacroAssembler::lookup_secondary_supers_table_slow_path(Register r_super_kl
   NearLabel L_huge;
 
   // The bitmap is full to bursting.
-  z_cghi(r_array_length, Klass::SECONDARY_SUPERS_BITMAP_FULL - 2);
+  z_chi(r_array_length, Klass::SECONDARY_SUPERS_BITMAP_FULL - 2);
   z_brh(L_huge);
 
   // NB! Our caller has checked bits 0 and 1 in the bitmap. The

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3320,8 +3320,8 @@ void MacroAssembler::lookup_secondary_supers_table_slow_path(Register r_super_kl
   NearLabel L_huge;
 
   // The bitmap is full to bursting.
-  z_cghi(r_bitmap, Klass::SECONDARY_SUPERS_BITMAP_FULL);
-  z_bre(L_huge);
+  z_cghi(r_array_length, Klass::SECONDARY_SUPERS_BITMAP_FULL - 2);
+  z_brh(L_huge);
 
   // NB! Our caller has checked bits 0 and 1 in the bitmap. The
   // current slot (at secondary_supers[r_array_index]) has not yet


### PR DESCRIPTION
Port for s390x and PPC for the bug: [JDK-8337958](https://bugs.openjdk.org/browse/JDK-8337958), Out-of-bounds array access in secondary_super_cache

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338365](https://bugs.openjdk.org/browse/JDK-8338365): [PPC64, s390] Out-of-bounds array access in secondary_super_cache (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**) 🔄 Re-review required (review applies to [7edd7326](https://git.openjdk.org/jdk/pull/20578/files/7edd7326520194b6f807b398eb096dcce7420a63))
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20578/head:pull/20578` \
`$ git checkout pull/20578`

Update a local copy of the PR: \
`$ git checkout pull/20578` \
`$ git pull https://git.openjdk.org/jdk.git pull/20578/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20578`

View PR using the GUI difftool: \
`$ git pr show -t 20578`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20578.diff">https://git.openjdk.org/jdk/pull/20578.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20578#issuecomment-2288234025)