### PR TITLE
8338304: clang on Linux - check for lld presence after JDK-8333189

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -71,8 +71,8 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
     LDFLAGS_CXX_PARTIAL_LINKING="$MACHINE_FLAG -r"
 
     if test "x$OPENJDK_TARGET_OS" = xlinux; then
+      # Clang needs the lld linker to work correctly
       BASIC_LDFLAGS="-fuse-ld=lld -Wl,--exclude-libs,ALL"
-      # Linux/clang toolchain needs now lld on the system to work
       UTIL_REQUIRE_PROGS(LLD, lld)
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then

--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -72,6 +72,8 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
 
     if test "x$OPENJDK_TARGET_OS" = xlinux; then
       BASIC_LDFLAGS="-fuse-ld=lld -Wl,--exclude-libs,ALL"
+      # Linux/clang toolchain needs now lld on the system to work
+      UTIL_REQUIRE_PROGS(LLD, lld)
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then
       BASIC_LDFLAGS="-Wl,-b64 -Wl,-brtl -Wl,-bnorwexec -Wl,-bnolibpath -Wl,-bnoexpall \


### PR DESCRIPTION
After [JDK-8333189](https://bugs.openjdk.org/browse/JDK-8333189) I get now this build error (when using clang on Linux) :
`clang: error: invalid linker name in argument '-fuse-ld=lld'`
We  should better check for lld in the configure process if it is required with clang .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8338304: clang on Linux - check for lld presence after JDK-8333189`

### Issue
 * [JDK-8338304](https://bugs.openjdk.org/browse/JDK-8338304): clang on Linux - check for lld presence after JDK-8333189 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20579/head:pull/20579` \
`$ git checkout pull/20579`

Update a local copy of the PR: \
`$ git checkout pull/20579` \
`$ git pull https://git.openjdk.org/jdk.git pull/20579/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20579`

View PR using the GUI difftool: \
`$ git pr show -t 20579`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20579.diff">https://git.openjdk.org/jdk/pull/20579.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20579#issuecomment-2288441847)