### PR TITLE
8338242: RoundingMode.HALF_UP gives different results with NumberFormat

### DIFF
--- a/src/java.base/share/classes/java/text/DigitList.java
+++ b/src/java.base/share/classes/java/text/DigitList.java
@@ -302,13 +302,12 @@ final class DigitList implements Cloneable {
     final void set(boolean isNegative, double source, int maximumDigits, boolean fixedPoint) {
 
         FloatingDecimal.BinaryToASCIIConverter fdConverter  = FloatingDecimal.getBinaryToASCIIConverter(source);
-        boolean hasBeenRoundedUp = fdConverter.digitsRoundedUp();
         boolean valueExactAsDecimal = fdConverter.decimalDigitsExact();
         assert !fdConverter.isExceptional();
         String digitsString = fdConverter.toJavaFormatString();
 
         set(isNegative, digitsString,
-            hasBeenRoundedUp, valueExactAsDecimal,
+            false, valueExactAsDecimal,
             maximumDigits, fixedPoint);
     }
 


### PR DESCRIPTION
Fix of problem RoundingMode.HALF_UP gives different results with NumberFormat

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338242](https://bugs.openjdk.org/browse/JDK-8338242): RoundingMode.HALF_UP gives different results with NumberFormat (**Bug** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20580/head:pull/20580` \
`$ git checkout pull/20580`

Update a local copy of the PR: \
`$ git checkout pull/20580` \
`$ git pull https://git.openjdk.org/jdk.git pull/20580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20580`

View PR using the GUI difftool: \
`$ git pr show -t 20580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20580.diff">https://git.openjdk.org/jdk/pull/20580.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20580#issuecomment-2292272327)