### PR TITLE
8338393: Parallel: Remove unused ParallelCompactData::clear_range

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.hpp
@@ -374,9 +374,6 @@ public:
                  HeapWord** target_next);
 
   void clear_range(size_t beg_region, size_t end_region);
-  void clear_range(HeapWord* beg, HeapWord* end) {
-    clear_range(addr_to_region_idx(beg), addr_to_region_idx(end));
-  }
 
   // Return the number of words between addr and the start of the region
   // containing addr.


### PR DESCRIPTION
Trivial removing dead code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338393](https://bugs.openjdk.org/browse/JDK-8338393): Parallel: Remove unused ParallelCompactData::clear_range (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20583/head:pull/20583` \
`$ git checkout pull/20583`

Update a local copy of the PR: \
`$ git checkout pull/20583` \
`$ git pull https://git.openjdk.org/jdk.git pull/20583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20583`

View PR using the GUI difftool: \
`$ git pr show -t 20583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20583.diff">https://git.openjdk.org/jdk/pull/20583.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20583#issuecomment-2288700415)