### PR TITLE
8338398: Trivially fix grammar and typos

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -2805,7 +2805,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
     /**
      * Exceptionally completes this CompletableFuture with
      * a {@link TimeoutException} if not otherwise completed
-     * before the given timeout.
+     * before the given timeout elapses.
      *
      * @param timeout how long to wait before completing exceptionally
      *        with a TimeoutException, in units of {@code unit}
@@ -2825,7 +2825,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
 
     /**
      * Completes this CompletableFuture with the given value if not
-     * otherwise completed before the given timeout.
+     * otherwise completed before the given timeout elapses.
      *
      * @param value the value to use upon timeout
      * @param timeout how long to wait before completing normally

--- a/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
+++ b/src/java.base/share/classes/java/util/concurrent/CompletableFuture.java
@@ -2805,7 +2805,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
     /**
      * Exceptionally completes this CompletableFuture with
      * a {@link TimeoutException} if not otherwise completed
-     * before the given timeout elapses.
+     * before the given timeout elapsed.
      *
      * @param timeout how long to wait before completing exceptionally
      *        with a TimeoutException, in units of {@code unit}
@@ -2825,7 +2825,7 @@ public class CompletableFuture<T> implements Future<T>, CompletionStage<T> {
 
     /**
      * Completes this CompletableFuture with the given value if not
-     * otherwise completed before the given timeout elapses.
+     * otherwise completed before the given timeout elapsed.
      *
      * @param value the value to use upon timeout
      * @param timeout how long to wait before completing normally

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -670,7 +670,7 @@ public class ForkJoinPool extends AbstractExecutorService {
      * period given by field keepAlive (default 60sec), which applies
      * to the first timeout of a quiescent pool. Subsequent cases use
      * minimal delays such that, if still quiescent, all will be
-     * released soon therafter. This is checked by setting the
+     * released soon thereafter. This is checked by setting the
      * "source" field of signallee to an invalid value, that will
      * remain invalid only if it did not process any tasks.
      *
@@ -855,7 +855,7 @@ public class ForkJoinPool extends AbstractExecutorService {
      * non-workers (which comply with Future.get() specs). Internal
      * usages of ForkJoinTasks ignore interrupt status when executing
      * or awaiting completion.  Otherwise, reporting task results or
-     * exceptions is preferred to throwing InterruptedExecptions,
+     * exceptions is preferred to throwing InterruptedExceptions,
      * which are in turn preferred to timeouts. Similarly, completion
      * status is preferred to reporting cancellation.  Cancellation is
      * reported as an unchecked exception by join(), and by worker

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
@@ -1072,7 +1072,7 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
 
     /**
      * Tries to join this task, returning true if it completed
-     * (possibly exceptionally) before the given timeout and
+     * (possibly exceptionally) before the given timeout elapses and
      * the current thread has not been interrupted.
      *
      * @param timeout the maximum time to wait
@@ -1097,7 +1097,7 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
 
     /**
      * Tries to join this task, returning true if it completed
-     * (possibly exceptionally) before the given timeout.
+     * (possibly exceptionally) before the given timeout elapses.
      *
      * @param timeout the maximum time to wait
      * @param unit the time unit of the timeout argument

--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinTask.java
@@ -1072,7 +1072,7 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
 
     /**
      * Tries to join this task, returning true if it completed
-     * (possibly exceptionally) before the given timeout elapses and
+     * (possibly exceptionally) before the given timeout elapsed and
      * the current thread has not been interrupted.
      *
      * @param timeout the maximum time to wait
@@ -1097,7 +1097,7 @@ public abstract class ForkJoinTask<V> implements Future<V>, Serializable {
 
     /**
      * Tries to join this task, returning true if it completed
-     * (possibly exceptionally) before the given timeout elapses.
+     * (possibly exceptionally) before the given timeout elapsed.
      *
      * @param timeout the maximum time to wait
      * @param unit the time unit of the timeout argument


### PR DESCRIPTION
This PR fixes a few trivial grammar issues and typos in documentation.

The main issue is the use of the word "timeout". To my mind, timeout, a duration, is not the same as deadline, which is a point in time, an instant, which allows "before" and "after". While one can think of timeout as of an event, which can occur, it usually expires, or elapses. An activity can also "time out" (phrasal verb).

I think the proposed change might read better and match wording already used throughout `java.util.concurrent.**`, for example, here:  

* https://github.com/openjdk/jdk/blob/00e6c63cd12e3f92d0c1d007aab4f74915616ffb/src/java.base/share/classes/java/util/concurrent/ExecutorService.java#L211-L223
* https://github.com/openjdk/jdk/blob/fbe4cc96e223882a18c7ff666fe6f68b3fa2cfe4/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java#L1019-L1036 

@DougLea, thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338398](https://bugs.openjdk.org/browse/JDK-8338398): Trivially fix grammar and typos (**Bug** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20584/head:pull/20584` \
`$ git checkout pull/20584`

Update a local copy of the PR: \
`$ git checkout pull/20584` \
`$ git pull https://git.openjdk.org/jdk.git pull/20584/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20584`

View PR using the GUI difftool: \
`$ git pr show -t 20584`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20584.diff">https://git.openjdk.org/jdk/pull/20584.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20584#issuecomment-2288798069)