### PR TITLE
8338402: GHA: some of bundles may not get removed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -371,7 +371,7 @@ jobs:
               -H 'Accept: application/vnd.github+json' \
               -H 'Authorization: Bearer ${{ github.token }}' \
               -H 'X-GitHub-Api-Version: 2022-11-28' \
-              '${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts')"
+              '${{ github.api_url }}/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts?per_page=100')"
           BUNDLE_ARTIFACT_IDS="$(echo "$ALL_ARTIFACT_IDS" | jq -r -c '.artifacts | map(select(.name|startswith("bundles-"))) | .[].id')"
           for id in $BUNDLE_ARTIFACT_IDS; do
             echo "Removing $id"


### PR DESCRIPTION
Some of bundles may not get removed. This is follows [JDK-8336928](https://bugs.openjdk.org/browse/JDK-8336928). Problem does not always show up, so I have not seen it in my test runs, but since then I have seen some GHA runs affected by this.

**Details:**
Turns out, that call to list artifacts is by default limited to first 30 artifacts. GHA of openjdk currently produces 75 artifacts of which 10 are bundles (built jdk). Problem happens if build on some platform takes too long and enough test results (other platforms) got uploaded in meantime. Bundle can then be shifted down in list and not fall into list of first 30 artifacts. Problem can be fixed by increasing per_page limit ([API allows up to 100](https://docs.github.com/en/rest/actions/artifacts?apiVersion=2022-11-28#list-workflow-run-artifacts)).

**Testing:**
GHA: OK (see [artifacts in summary tab](https://github.com/zzambers/jdk/actions/runs/10373518734#artifacts))

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338402](https://bugs.openjdk.org/browse/JDK-8338402): GHA: some of bundles may not get removed (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20585/head:pull/20585` \
`$ git checkout pull/20585`

Update a local copy of the PR: \
`$ git checkout pull/20585` \
`$ git pull https://git.openjdk.org/jdk.git pull/20585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20585`

View PR using the GUI difftool: \
`$ git pr show -t 20585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20585.diff">https://git.openjdk.org/jdk/pull/20585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20585#issuecomment-2288976501)