### PR TITLE
8338406: BytecodeHelpers using wrong bootstrap method descriptor for condy

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
@@ -275,15 +275,7 @@ public class BytecodeHelpers {
         List<LoadableConstantEntry> staticArgs = new ArrayList<>(bootstrapArgs.length);
         for (ConstantDesc bootstrapArg : bootstrapArgs)
             staticArgs.add(constantPool.loadableConstantEntry(bootstrapArg));
-
-        var bootstrapDesc = desc.bootstrapMethod();
-        ClassEntry bsOwner = constantPool.classEntry(bootstrapDesc.owner());
-        NameAndTypeEntry bsNameAndType = constantPool.nameAndTypeEntry(bootstrapDesc.methodName(),
-                                                               bootstrapDesc.invocationType());
-        int bsRefKind = bootstrapDesc.refKind();
-
-        MemberRefEntry memberRefEntry = toBootstrapMemberRef(constantPool, bsRefKind, bsOwner, bsNameAndType, bootstrapDesc.isOwnerInterface());
-        MethodHandleEntry methodHandleEntry = constantPool.methodHandleEntry(bsRefKind, memberRefEntry);
+        MethodHandleEntry methodHandleEntry = handleDescToHandleInfo(constantPool, desc.bootstrapMethod());
         BootstrapMethodEntry bme = constantPool.bsmEntry(methodHandleEntry, staticArgs);
         return constantPool.constantDynamicEntry(bme,
                                                  constantPool.nameAndTypeEntry(desc.constantName(),

--- a/test/jdk/jdk/classfile/ConstantDescSymbolsTest.java
+++ b/test/jdk/jdk/classfile/ConstantDescSymbolsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,14 @@
 
 /*
  * @test
- * @bug 8304031
- * @summary Testing that primitive class descs are encoded properly as loadable constants.
- * @run junit PrimitiveClassConstantTest
+ * @bug 8304031 8338406
+ * @summary Testing handling of various constant descriptors in ClassFile API.
+ * @run junit ConstantDescSymbolsTest
  */
 
 import java.lang.constant.ClassDesc;
+import java.lang.constant.DynamicConstantDesc;
+import java.lang.constant.MethodHandleDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -37,18 +39,16 @@ import java.lang.classfile.ClassFile;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import static java.lang.constant.ConstantDescs.CD_Class;
-import static java.lang.constant.ConstantDescs.CD_Object;
-import static java.lang.constant.ConstantDescs.CD_int;
-import static java.lang.constant.ConstantDescs.CD_long;
-import static java.lang.constant.ConstantDescs.INIT_NAME;
-import static java.lang.constant.ConstantDescs.MTD_void;
 import static java.lang.classfile.ClassFile.ACC_PUBLIC;
+import static java.lang.constant.ConstantDescs.*;
 
-public final class PrimitiveClassConstantTest {
+import static org.junit.jupiter.api.Assertions.*;
 
+final class ConstantDescSymbolsTest {
+
+    // Testing that primitive class descs are encoded properly as loadable constants.
     @Test
-    public void test() throws Throwable {
+    void testPrimitiveClassDesc() throws Throwable {
         ClassDesc ape = ClassDesc.of("Ape");
         var lookup = MethodHandles.lookup();
         Class<?> a = lookup.defineClass(ClassFile.of().build(ape, clb -> {
@@ -73,7 +73,33 @@ public final class PrimitiveClassConstantTest {
         Supplier<?> t = (Supplier<?>) lookup.findConstructor(a, MethodType.methodType(void.class))
                 .asType(MethodType.methodType(Supplier.class))
                 .invokeExact();
-        Assertions.assertSame(int.class, t.get());
+        assertSame(int.class, t.get());
     }
 
+    // Tests that condy symbols with non-static-method bootstraps are using the right lookup descriptor.
+    @Test
+    void testConstantDynamicNonStaticBootstrapMethod() throws Throwable {
+        record CondyBoot(MethodHandles.Lookup lookup, String name, Class<?> type) {}
+        var bootClass = CondyBoot.class.describeConstable().orElseThrow();
+        var bootMhDesc = MethodHandleDesc.ofConstructor(bootClass, CD_MethodHandles_Lookup, CD_String, CD_Class);
+        var condyDesc = DynamicConstantDesc.of(bootMhDesc);
+
+        var targetCd = ClassDesc.of("Bat");
+        var lookup = MethodHandles.lookup();
+        Class<?> a = lookup.defineClass(ClassFile.of().build(targetCd, clb -> {
+            clb.withInterfaceSymbols(Supplier.class.describeConstable().orElseThrow())
+                    .withMethodBody(INIT_NAME, MTD_void, ACC_PUBLIC, cob -> cob
+                            .aload(0).invokespecial(CD_Object, INIT_NAME, MTD_void).return_())
+                    .withMethodBody("get", MethodTypeDesc.of(CD_Object), ACC_PUBLIC, cob -> cob
+                            .loadConstant(condyDesc).areturn());
+        }));
+        @SuppressWarnings("unchecked")
+        Supplier<CondyBoot> t = (Supplier<CondyBoot>) lookup.findConstructor(a, MethodType.methodType(void.class))
+                .asType(MethodType.methodType(Supplier.class)).invokeExact();
+        var cb = t.get();
+        assertEquals(MethodHandles.Lookup.ORIGINAL, cb.lookup.lookupModes() & MethodHandles.Lookup.ORIGINAL);
+        assertSame(a, cb.lookup.lookupClass());
+        assertEquals(DEFAULT_NAME, cb.name);
+        assertEquals(CondyBoot.class, cb.type);
+    }
 }


### PR DESCRIPTION
`BytecodeHelpers.handleConstantDescToHandleInfo` is incorrectly using `DirectMethodHandleDesc.invocationType`, which accidentally works for static bootstrap methods so it's discovered only now with more extensive testing from bytebuddy. Cleaned up by reusing the correct `handleDescToHandleInfo` instead. Thanks to @raphw for the report.

For now, a workaround can be instead of using `DynamicConstantDesc`, translate to `ConstantDynamicEntry` in user applications.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338406](https://bugs.openjdk.org/browse/JDK-8338406): BytecodeHelpers using wrong bootstrap method descriptor for condy (**Bug** - P3)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20586/head:pull/20586` \
`$ git checkout pull/20586`

Update a local copy of the PR: \
`$ git checkout pull/20586` \
`$ git pull https://git.openjdk.org/jdk.git pull/20586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20586`

View PR using the GUI difftool: \
`$ git pr show -t 20586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20586.diff">https://git.openjdk.org/jdk/pull/20586.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20586#issuecomment-2289357602)