### PR TITLE
8205957: setfldw001/TestDescription.java fails with bad field value

### DIFF
--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -409,8 +409,7 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
             // Must extract verified entry point from HotSpotNmethod after VM to Java
             // transition in JavaCallWrapper constructor so that it is safe with
             // respect to nmethod sweeping.
-            address
-                verified_entry_point = (address) HotSpotJVMCI::InstalledCode::entryPoint(nullptr, alternative_target());
+            address verified_entry_point = (address) HotSpotJVMCI::InstalledCode::entryPoint(nullptr, alternative_target());
             if (verified_entry_point != nullptr) {
               thread->set_jvmci_alternate_call_target(verified_entry_point);
               entry_point = method->adapter()->get_i2c_entry();

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -358,12 +358,8 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
   CompilationPolicy::compile_if_required(method, CHECK);
 
   // Since the call stub sets up like the interpreter we call the from_interpreted_entry
-  // so we can go compiled via a i2c. Otherwise initial entry method will always
-  // run interpreted.
+  // so we can go compiled via a i2c.
   address entry_point = method->from_interpreted_entry();
-  if (JvmtiExport::can_post_interpreter_events() && thread->is_interp_only_mode()) {
-    entry_point = method->interpreter_entry();
-  }
 
   // Figure out if the result value is an oop or not (Note: This is a different value
   // than result_type. result_type will be T_INT of oops. (it is about size)
@@ -412,6 +408,12 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
         }
       }
 #endif
+
+      // What to do if JVMCI set adapter?
+      if (JvmtiExport::can_post_interpreter_events() && thread->is_interp_only_mode()) {
+        entry_point = method->interpreter_entry();
+      }
+
       StubRoutines::call_stub()(
         (address)&link,
         // (intptr_t*)&(result->_value), // see NOTE above (compiler problem)

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -392,30 +392,33 @@ void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaC
       intptr_t* parameter_address = args->parameters();
 
       address entry_point;
-      if (JvmtiExport::can_post_interpreter_events() && thread->is_interp_only_mode()) {
-        entry_point = method->interpreter_entry();
-      }
-      else {
-        // Since the call stub sets up like the interpreter we call the from_interpreted_entry
-        // so we can go compiled via a i2c.
-        entry_point = method->from_interpreted_entry();
+      {
+        // The enter_interp_only_mode use handshake to set interp_only mode
+        // so no safepoint should be allowed between is_interp_only_mode() and call
+        NoSafepointVerifier nsv;
+        if (JvmtiExport::can_post_interpreter_events() && thread->is_interp_only_mode()) {
+          entry_point = method->interpreter_entry();
+        } else {
+          // Since the call stub sets up like the interpreter we call the from_interpreted_entry
+          // so we can go compiled via a i2c.
+          entry_point = method->from_interpreted_entry();
 #if INCLUDE_JVMCI
-        // Gets the alternative target (if any) that should be called
-        Handle alternative_target = args->alternative_target();
-        if (!alternative_target.is_null()) {
-          // Must extract verified entry point from HotSpotNmethod after VM to Java
-          // transition in JavaCallWrapper constructor so that it is safe with
-          // respect to nmethod sweeping.
-          address
-              verified_entry_point = (address) HotSpotJVMCI::InstalledCode::entryPoint(nullptr, alternative_target());
-          if (verified_entry_point != nullptr) {
-            thread->set_jvmci_alternate_call_target(verified_entry_point);
-            entry_point = method->adapter()->get_i2c_entry();
+          // Gets the alternative target (if any) that should be called
+          Handle alternative_target = args->alternative_target();
+          if (!alternative_target.is_null()) {
+            // Must extract verified entry point from HotSpotNmethod after VM to Java
+            // transition in JavaCallWrapper constructor so that it is safe with
+            // respect to nmethod sweeping.
+            address
+                verified_entry_point = (address) HotSpotJVMCI::InstalledCode::entryPoint(nullptr, alternative_target());
+            if (verified_entry_point != nullptr) {
+              thread->set_jvmci_alternate_call_target(verified_entry_point);
+              entry_point = method->adapter()->get_i2c_entry();
+            }
           }
-        }
 #endif
+        }
       }
-
       StubRoutines::call_stub()(
         (address)&link,
         // (intptr_t*)&(result->_value), // see NOTE above (compiler problem)

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -29,11 +29,6 @@
 
 vmTestbase/nsk/jvmti/AttachOnDemand/attach020/TestDescription.java 8287324 generic-all
 
-vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java#id0            8205957 generic-all
-vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java#logging        8205957 generic-all
-vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java#id0     8205957 generic-all
-vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java#logging 8205957 generic-all
-
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 linux-x64,windows-x64

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001/TestDescription.java
@@ -47,11 +47,3 @@
  *          /test/lib
  * @run main/othervm/native -agentlib:setfmodw001 nsk.jvmti.SetFieldModificationWatch.setfmodw001
  */
-
-/*
- * @test id=logging
- *
- * @library /vmTestbase
- *          /test/lib
- * @run main/othervm/native -agentlib:setfmodw001 -XX:TraceJVMTI=ec+,+ioe,+s -Xlog:jvmti=trace:file=vm.%p.log nsk.jvmti.SetFieldModificationWatch.setfmodw001
- */


### PR DESCRIPTION
The summary of the problem. Test is intermittently failing because can't get expected field watch event.
The test is failing to get event in the 'setfmodw001b' thread with Xcomp only.
I verified that frame with the method 'run' of setfmodw001b is compiled when line
118: setfmodw001.setWatch(4);
is executed, however the thread is in interp_only mode. The watch events are supported by interpreter only and just ignored by compiled code.

The reason of failure is race beteween setting interp_only mode in line

https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001.java#L75

 and calling method call_helper while
 the method run()
https://github.com/openjdk/jdk/blob/master/test/hotspot/jtreg/vmTestbase/nsk/jvmti/SetFieldModificationWatch/setfmodw001.java#L116

 in newly created thread 'setfmodw001b' is invoked.

The javaCalls:call are used to invoke methods from hotspot, so it might be rare issues. But still, synchronization might be improved.
The
void JavaCalls::call_helper(JavaValue* result, const methodHandle& method, JavaCallArguments* args, TRAPS)

checks if interp_only mode is set and use 'Method::from_interpreted_entry()' if not. However the interp_only might be set later before compiled method is called (or enter first safe point?). This might happens in safepoint during transition via handshake.
So the running thread is in interp_only mode however the run() method is compiled and executed already and never going to be deoptimized.

The additional setWatch calls don't try to deptimize method that are already in interp_only mode.

BTW, the when JVMCI is enabled and verified adapter exists it is also will be loaded even in interp_only mode set. There is not race here, just ignoring of interp_only mode.

I run failing test with Xcomp ~1000 times and tiers1-5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8205957](https://bugs.openjdk.org/browse/JDK-8205957): setfldw001/TestDescription.java fails with bad field value (**Bug** - P3)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20587/head:pull/20587` \
`$ git checkout pull/20587`

Update a local copy of the PR: \
`$ git checkout pull/20587` \
`$ git pull https://git.openjdk.org/jdk.git pull/20587/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20587`

View PR using the GUI difftool: \
`$ git pr show -t 20587`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20587.diff">https://git.openjdk.org/jdk/pull/20587.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20587#issuecomment-2291346614)