### PR TITLE
8338395: Add test coverage for instantiating NativePRNG with SecureRandomParameters

### DIFF
--- a/test/jdk/sun/security/provider/SecureRandom/StrongSecureRandom.java
+++ b/test/jdk/sun/security/provider/SecureRandom/StrongSecureRandom.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,12 +23,15 @@
 
 /*
  * @test
- * @bug 6425477 8141039
+ * @bug 6425477 8141039 8324648
+ * @library /test/lib
  * @summary Better support for generation of high entropy random numbers
  * @run main StrongSecureRandom
  */
 import java.security.*;
 import java.util.*;
+
+import static jdk.test.lib.Asserts.assertTrue;
 
 /**
  * This test assumes that the standard Sun providers are installed.
@@ -89,6 +92,27 @@ public class StrongSecureRandom {
         ba = sr.generateSeed(1);
         sr.nextBytes(ba);
         sr.setSeed(ba);
+
+        testParamsUnsupported("NativePRNG");
+        testParamsUnsupported("NativePRNGNonBlocking");
+        testParamsUnsupported("NativePRNGBlocking");
+    }
+
+    private static void testParamsUnsupported(String alg) throws NoSuchAlgorithmException {
+        System.out.println("Testing that " + alg + " does not support params");
+
+        try {
+            SecureRandom.getInstance(alg, new SecureRandomParameters() {});
+            throw new RuntimeException("Params should not be supported");
+        } catch (NoSuchAlgorithmException nsae) {
+            Throwable cause = nsae.getCause();
+            if (cause instanceof IllegalArgumentException) {
+                assertTrue(cause.getMessage().contains("Unsupported params"),
+                        "Unexpected error message: " + cause.getMessage());
+            } else {
+                throw nsae;
+            }
+        }
     }
 
     private static void testStrongInstance(boolean expected) throws Exception {


### PR DESCRIPTION
In order to improve performance when instantiating NativePRNG, a dummy constructor was added in the PR: https://github.com/openjdk/jdk/pull/17560 which takes and ignores a `java.security.SecureRandomParameters`, throwing an exception if any parameter is passed.

This PR adds test coverage for those scenarios where the constructor is called passing a not null parameter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338395](https://bugs.openjdk.org/browse/JDK-8338395): Add test coverage for instantiating NativePRNG with SecureRandomParameters (**Task** - P5)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20592/head:pull/20592` \
`$ git checkout pull/20592`

Update a local copy of the PR: \
`$ git checkout pull/20592` \
`$ git pull https://git.openjdk.org/jdk.git pull/20592/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20592`

View PR using the GUI difftool: \
`$ git pr show -t 20592`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20592.diff">https://git.openjdk.org/jdk/pull/20592.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20592#issuecomment-2291197119)