### PR TITLE
8336729: C2: Div/Mod nodes without zero check could be split through iv phi of outer loop of long counted loop nest resulting in SIGFPE

### DIFF
--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1578,7 +1578,7 @@ private:
   bool identical_backtoback_ifs(Node *n);
   bool can_split_if(Node *n_ctrl);
   bool cannot_split_division(const Node* n, const Node* region) const;
-  static bool is_divisor_counted_loop_phi(const Node* divisor, const Node* loop);
+  static bool is_divisor_loop_phi(const Node* divisor, const Node* loop);
   bool loop_phi_backedge_type_contains_zero(const Node* phi_divisor, const Type* zero) const;
 
   // Determine if a method is too big for a/another round of split-if, based on

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -295,12 +295,12 @@ bool PhaseIdealLoop::cannot_split_division(const Node* n, const Node* region) co
   }
 
   Node* divisor = n->in(2);
-  return is_divisor_counted_loop_phi(divisor, region) &&
+  return is_divisor_loop_phi(divisor, region) &&
          loop_phi_backedge_type_contains_zero(divisor, zero);
 }
 
-bool PhaseIdealLoop::is_divisor_counted_loop_phi(const Node* divisor, const Node* loop) {
-  return loop->is_BaseCountedLoop() && divisor->is_Phi() && divisor->in(0) == loop;
+bool PhaseIdealLoop::is_divisor_loop_phi(const Node* divisor, const Node* loop) {
+  return loop->is_Loop() && divisor->is_Phi() && divisor->in(0) == loop;
 }
 
 bool PhaseIdealLoop::loop_phi_backedge_type_contains_zero(const Node* phi_divisor, const Type* zero) const {

--- a/test/hotspot/jtreg/compiler/splitif/TestSplitDivisionThroughPhi.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestSplitDivisionThroughPhi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,28 @@
 *                   compiler.splitif.TestSplitDivisionThroughPhi
 */
 
+/**
+ * @test
+ * @key stress randomness
+ * @bug 8336729
+ * @requires vm.compiler2.enabled
+ * @summary Test various cases of divisions/modulo which should not be split through iv phis.
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:LoopUnrollLimit=0 -XX:+StressGCM -XX:StressSeed=3434
+ *                   -XX:CompileCommand=compileonly,compiler.splitif.TestSplitDivisionThroughPhi::*
+ *                   compiler.splitif.TestSplitDivisionThroughPhi
+ */
+
+/**
+ * @test
+ * @key stress randomness
+ * @bug 8336729
+ * @requires vm.compiler2.enabled
+ * @summary Test various cases of divisions/modulo which should not be split through iv phis.
+ * @run main/othervm -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:LoopUnrollLimit=0 -XX:+StressGCM
+ *                   -XX:CompileCommand=compileonly,compiler.splitif.TestSplitDivisionThroughPhi::*
+ *                   compiler.splitif.TestSplitDivisionThroughPhi
+ */
+
 package compiler.splitif;
 
 public class TestSplitDivisionThroughPhi {
@@ -61,6 +83,8 @@ public class TestSplitDivisionThroughPhi {
             testPushDivLThruPhiInChain();
             testPushModLThruPhi();
             testPushModLThruPhiInChain();
+            testPushDivLThruPhiForOuterLongLoop();
+            testPushModLThruPhiForOuterLongLoop();
         }
     }
 
@@ -75,6 +99,27 @@ public class TestSplitDivisionThroughPhi {
             // as input which has type [0..8]. We end up executing a division by zero on the last iteration because
             // the DivI it is not pinned to the loop exit test and can freely float above the loop exit check.
             iFld = 10 / i;
+        }
+    }
+
+    // Fixed with JDK-8336792.
+    static void testPushDivLThruPhiForOuterLongLoop() {
+        // This loop is first transformed into a LongCountedLoop in the first loop opts phase.
+        // In the second loop opts phase, the LongCountedLoop is split into an inner and an outer loop. Both get the
+        // same iv phi type which is [2..10]. Only the inner loop is transformed into a CountedLoopNode while the outer
+        // loop is still a LoopNode. We run into the same problem as described in testPushDivIThruPhi() when splitting
+        // the DivL node through the long iv phi of the outer LoopNode.
+        // The fix for JDK-8299259 only prevents this splitting for CountedLoopNodes. We now extend it to LoopNodes
+        // in general.
+        for (long i = 10; i > 1; i -= 2) {
+            lFld = 10 / i;
+        }
+    }
+
+    // Same as testPushDivLThruPhiForOuterLongLoop() but for ModL.
+    static void testPushModLThruPhiForOuterLongLoop() {
+        for (int i = 10; i > 1; i -= 2) {
+            iFld = 10 % i;
         }
     }
 

--- a/test/hotspot/jtreg/compiler/splitif/TestSplitDivisionThroughPhi.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestSplitDivisionThroughPhi.java
@@ -102,7 +102,7 @@ public class TestSplitDivisionThroughPhi {
         }
     }
 
-    // Fixed with JDK-8336792.
+    // Fixed with JDK-8336729.
     static void testPushDivLThruPhiForOuterLongLoop() {
         // This loop is first transformed into a LongCountedLoop in the first loop opts phase.
         // In the second loop opts phase, the LongCountedLoop is split into an inner and an outer loop. Both get the

--- a/test/hotspot/jtreg/compiler/splitif/TestSplitDivisionThroughPhi.java
+++ b/test/hotspot/jtreg/compiler/splitif/TestSplitDivisionThroughPhi.java
@@ -24,7 +24,7 @@
 /**
 * @test
 * @key stress randomness
-* @bug 8299259
+* @bug 8299259 8336729
 * @requires vm.compiler2.enabled
 * @summary Test various cases of divisions/modulo which should not be split through iv phis.
 * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:LoopUnrollLimit=0 -XX:+StressGCM -XX:StressSeed=884154126
@@ -35,7 +35,7 @@
 /**
 * @test
 * @key stress randomness
-* @bug 8299259
+* @bug 8299259 8336729
 * @requires vm.compiler2.enabled
 * @summary Test various cases of divisions/modulo which should not be split through iv phis.
 * @run main/othervm -Xbatch -XX:+UnlockDiagnosticVMOptions -XX:LoopUnrollLimit=0 -XX:+StressGCM


### PR DESCRIPTION
The previous fix for preventing `Div/Mod` nodes to be split through iv phis when their divisor could become zero (see [JDK-8299259](https://bugs.openjdk.org/browse/JDK-8299259)) is not complete. Originally, we thought that it is enough to prevent a split through the phi if it belongs to a `BaseCountedLoop`:
https://github.com/openjdk/jdk/blob/da7311bbe37c2b9632b117d52a77c659047820b7/src/hotspot/share/opto/loopopts.cpp#L302-L304

The reasoning behind this was that the iv phi type of `BaseCountedLoops` can be improved in such a way that it does not contain zero but the backedge input can include zero:
https://github.com/openjdk/jdk/blob/da7311bbe37c2b9632b117d52a77c659047820b7/test/hotspot/jtreg/compiler/splitif/TestSplitDivisionThroughPhi.java#L69-L78

This optimization is not possible for `LoopNodes` where we know nothing about the number of iterations. 

However, there was an oversight: A `LongCountedLoop` is later split into an inner and an outer `LoopNode` where the inner loop is transformed into a `CountedLoop` while the outer loop stays a `LoopNode`. Both loops share the same optimized iv phi type as the original `LongCountedLoop`! Therefore, we can have the same situation as fixed in JDK-8299259 but with a `LoopNode` instead of a `CountedLoopNode` (see https://github.com/openjdk/jdk/pull/11900 for more details).

The simplest way to fix this is to extend the bailout fix of JDK-8299259 to not only apply to `BaseCountedLoopNodes` but to `LoopNodes` in general which is what I propose with this patch.

Thanks to @eme64 for extracting the original simpler reproducer to reproduce this problem easier. I've added an even simpler non-jasm reproducer in this patch in favor of the original jasm reproducer.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336729](https://bugs.openjdk.org/browse/JDK-8336729): C2: Div/Mod nodes without zero check could be split through iv phi of outer loop of long counted loop nest resulting in SIGFPE (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) 🔄 Re-review required (review applies to [8ba74170](https://git.openjdk.org/jdk/pull/20594/files/8ba7417073dc54ab4dc5b060cfe3a7f9097ef336))
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Contributors
 * Emanuel Peter `<epeter@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20594/head:pull/20594` \
`$ git checkout pull/20594`

Update a local copy of the PR: \
`$ git checkout pull/20594` \
`$ git pull https://git.openjdk.org/jdk.git pull/20594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20594`

View PR using the GUI difftool: \
`$ git pr show -t 20594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20594.diff">https://git.openjdk.org/jdk/pull/20594.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20594#issuecomment-2291094579)