### PR TITLE
8338281: jshell does not run shutdown hooks

### DIFF
--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/ExecutionControlForwarder.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/ExecutionControlForwarder.java
@@ -177,7 +177,7 @@ class ExecutionControlForwarder {
                     } catch (Throwable ex) {
                         // JShell-core not waiting for a result, ignore
                     }
-                    return true;
+                    return false;
                 }
                 default: {
                     Object arg = in.readObject();

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
@@ -71,6 +71,8 @@ import jdk.jshell.execution.impl.ConsoleImpl.ConsoleOutputStream;
  */
 public class JdiDefaultExecutionControl extends JdiExecutionControl {
 
+    private static final int SHUTDOWN_TIMEOUT = 1; //1 second
+
     private VirtualMachine vm;
     private Process process;
     private final String remoteAgent;
@@ -270,7 +272,7 @@ public class JdiDefaultExecutionControl extends JdiExecutionControl {
         super.close();
         if (process != null) {
             try {
-                process.waitFor(1, TimeUnit.SECONDS);
+                process.waitFor(SHUTDOWN_TIMEOUT, TimeUnit.SECONDS);
             } catch (InterruptedException ex) {
                 debug(ex, "waitFor remote");
             }

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
@@ -270,9 +270,16 @@ public class JdiDefaultExecutionControl extends JdiExecutionControl {
     @Override
     public void close() {
         super.close();
-        if (process != null) {
+
+        Process remoteProcess;
+
+        synchronized (this) {
+            remoteProcess = this.process;
+        }
+
+        if (remoteProcess != null) {
             try {
-                process.waitFor(SHUTDOWN_TIMEOUT, TimeUnit.SECONDS);
+                remoteProcess.waitFor(SHUTDOWN_TIMEOUT, TimeUnit.SECONDS);
             } catch (InterruptedException ex) {
                 debug(ex, "waitFor remote");
             }

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/JdiDefaultExecutionControl.java
@@ -49,6 +49,7 @@ import com.sun.jdi.VMDisconnectedException;
 import com.sun.jdi.VirtualMachine;
 import java.io.PrintStream;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import jdk.jshell.JShellConsole;
 import jdk.jshell.execution.JdiDefaultExecutionControl.JdiStarter.TargetDescription;
@@ -267,6 +268,13 @@ public class JdiDefaultExecutionControl extends JdiExecutionControl {
     @Override
     public void close() {
         super.close();
+        if (process != null) {
+            try {
+                process.waitFor(1, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                debug(ex, "waitFor remote");
+            }
+        }
         disposeVM();
     }
 

--- a/test/langtools/jdk/jshell/KullaTesting.java
+++ b/test/langtools/jdk/jshell/KullaTesting.java
@@ -167,8 +167,12 @@ public class KullaTesting {
     }
 
     @BeforeMethod
-    public void setUp() {
-        setUp(b -> {});
+    public void setUp(Method testMethod) {
+        setUp(testMethod, b -> {});
+    }
+
+    public void setUp(Method testMethod, Consumer<JShell.Builder> bc) {
+        setUp(bc);
     }
 
     public void setUp(Consumer<JShell.Builder> bc) {

--- a/test/langtools/jdk/jshell/KullaTesting.java
+++ b/test/langtools/jdk/jshell/KullaTesting.java
@@ -167,12 +167,8 @@ public class KullaTesting {
     }
 
     @BeforeMethod
-    public void setUp(Method testMethod) {
-        setUp(testMethod, b -> {});
-    }
-
-    public void setUp(Method testMethod, Consumer<JShell.Builder> bc) {
-        setUp(bc);
+    public void setUp() {
+        setUp(b -> {});
     }
 
     public void setUp(Consumer<JShell.Builder> bc) {

--- a/test/langtools/jdk/jshell/ShutdownTest.java
+++ b/test/langtools/jdk/jshell/ShutdownTest.java
@@ -141,7 +141,9 @@ public class ShutdownTest extends KullaTesting {
                                 //ignored
                             }
                         }))
-                        """.replace("$TEMPORARY", temporary.toAbsolutePath().toString()));
+                        """.replace("$TEMPORARY", temporary.toAbsolutePath()
+                                                           .toString()
+                                                           .replace("\\", "\\\\")));
         getState().close();
         assertFalse(Files.exists(temporary));
     }

--- a/test/langtools/jdk/jshell/ShutdownTest.java
+++ b/test/langtools/jdk/jshell/ShutdownTest.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import org.testng.annotations.BeforeMethod;
 
 public class ShutdownTest extends KullaTesting {
 
@@ -145,9 +146,21 @@ public class ShutdownTest extends KullaTesting {
         assertFalse(Files.exists(temporary));
     }
 
+    private Method currentTestMethod;
+
+    @BeforeMethod
+    public void setUp(Method testMethod) {
+        currentTestMethod = testMethod;
+        super.setUp();
+    }
+
+    @BeforeMethod
+    public void setUp() {
+    }
+
     @Override
-    public void setUp(Method testMethod, Consumer<JShell.Builder> bc) {
-        Consumer<JShell.Builder> augmentedBuilder = switch (testMethod.getName()) {
+    public void setUp(Consumer<JShell.Builder> bc) {
+        Consumer<JShell.Builder> augmentedBuilder = switch (currentTestMethod.getName()) {
             case "testRunShutdownHooks" -> builder -> {
                 builder.executionEngine(Presets.TEST_STANDARD_EXECUTION);
                 bc.accept(builder);


### PR DESCRIPTION
JShell normally runs user's snippets in a separate VM. And JShell is shutting down, it will send a CLOSE command to the remote agent, and then destroy the remote process. But, the remote process, after receiving the CLOSE command will not finish on its own, run until it is destroyed by `Process.destroy`.

And `Process.destroy` may or may not run any shutdown hooks installed, which is the main point of this bug.

This patch does the following:
 - the remote agent now exits when receiving the CLOSE event (the command loop is stopped, and then the `main` method finishes)
 - the JShell's close will wait for a moment for the remote process to finish

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8338281: jshell does not run shutdown hooks`

### Issue
 * [JDK-8338281](https://bugs.openjdk.org/browse/JDK-8338281): jshell does not run shutdown hooks (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20599/head:pull/20599` \
`$ git checkout pull/20599`

Update a local copy of the PR: \
`$ git checkout pull/20599` \
`$ git pull https://git.openjdk.org/jdk.git pull/20599/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20599`

View PR using the GUI difftool: \
`$ git pr show -t 20599`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20599.diff">https://git.openjdk.org/jdk/pull/20599.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20599#issuecomment-2291620908)