### PR TITLE
8337408: Use GetTempPath2 API instead of GetTempPath

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1521,10 +1521,9 @@ const char* os::get_temp_directory() {
   static char path_buf[MAX_PATH];
   if (_GetTempPath2A != nullptr) {
     if (_GetTempPath2A(MAX_PATH, path_buf) > 0) {
-    return path_buf;
+      return path_buf;
     }
-  }
-  else if (GetTempPath(MAX_PATH, path_buf) > 0) {
+  } else if (GetTempPath(MAX_PATH, path_buf) > 0) {
     return path_buf;
   }
   path_buf[0] = '\0';
@@ -4719,6 +4718,14 @@ jint os::init_2(void) {
   }
   log_info(os, thread)("The SetThreadDescription API is%s available.", _SetThreadDescription == nullptr ? " not" : "");
 
+  // Lookup GetTempPath2
+  if (_kernelbase != nullptr) {
+    _GetTempPath2A =
+      reinterpret_cast<GetTempPath2AFnPtr>(
+                                         GetProcAddress(_kernelbase,
+                                                        "GetTempPath2A"));
+  }
+  log_info(os, thread)("The _GetTempPath2A API is%s available.", _GetTempPath2A == nullptr ? " not" : "");
 
   return JNI_OK;
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1019,6 +1019,10 @@ typedef HRESULT (WINAPI *GetThreadDescriptionFnPtr)(HANDLE, PWSTR*);
 static SetThreadDescriptionFnPtr _SetThreadDescription = nullptr;
 DEBUG_ONLY(static GetThreadDescriptionFnPtr _GetThreadDescription = nullptr;)
 
+// For dynamic lookup of GetTempPath2 API
+typedef DWORD (WINAPI *GetTempPath2AFnPtr)(DWORD, LPSTR);
+static GetTempPath2AFnPtr _GetTempPath2A = nullptr;
+
 // forward decl.
 static errno_t convert_to_unicode(char const* char_path, LPWSTR* unicode_path);
 
@@ -1515,12 +1519,16 @@ int os::closedir(DIR *dirp) {
 // directory not the java application's temp directory, ala java.io.tmpdir.
 const char* os::get_temp_directory() {
   static char path_buf[MAX_PATH];
-  if (GetTempPath(MAX_PATH, path_buf) > 0) {
+  if (_GetTempPath2A != nullptr) {
+    if (_GetTempPath2A(MAX_PATH, path_buf) > 0) {
     return path_buf;
-  } else {
-    path_buf[0] = '\0';
+    }
+  }
+  else if (GetTempPath(MAX_PATH, path_buf) > 0) {
     return path_buf;
   }
+  path_buf[0] = '\0';
+  return path_buf;
 }
 
 // Needs to be in os specific directory because windows requires another

--- a/src/jdk.jpackage/windows/native/common/WinSysInfo.cpp
+++ b/src/jdk.jpackage/windows/native/common/WinSysInfo.cpp
@@ -42,7 +42,7 @@ DWORD _GetTempPathW(DWORD nBufferLength, LPWSTR lpBuffer)
     if (!_GetTempPath2WInitialized) {
         HINSTANCE _kernelbase = LoadLibrary(TEXT("kernelbase.dll"));
         if (_kernelbase != nullptr) {
-            _GetTempPath2W = 
+            _GetTempPath2W =
                 reinterpret_cast<GetTempPath2WFnPtr>(
                     GetProcAddress(_kernelbase, "GetTempPath2W"));
         }


### PR DESCRIPTION
Use the GetTempPath2 APIs instead of the GetTempPath APIs in native code across the OpenJDK repository to retrieve the temporary directory path, as GetTempPath2 provides enhanced security. While GetTempPath may still function without errors, using GetTempPath2 reduces the risk of potential exploits for users.


The code to dynamically load GetTempPath2 is duplicated due to the following reasons.  I would appreciate any suggestions to remove the duplication where possible:

1. The changes span across four different folders—java.base, jdk.package, jdk.attach, and hotspot—with no shared code between them.
2. Some parts of the code use version A, while others use version W (ANSI vs. Unicode).
3. Some parts of the code are written in C others in C++.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337408](https://bugs.openjdk.org/browse/JDK-8337408): Use GetTempPath2 API instead of GetTempPath (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20600/head:pull/20600` \
`$ git checkout pull/20600`

Update a local copy of the PR: \
`$ git checkout pull/20600` \
`$ git pull https://git.openjdk.org/jdk.git pull/20600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20600`

View PR using the GUI difftool: \
`$ git pr show -t 20600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20600.diff">https://git.openjdk.org/jdk/pull/20600.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20600#issuecomment-2291727405)