### PR TITLE
8325397: sun/java2d/Disposer/TestDisposerRace.java fails in linux-aarch64

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -278,6 +278,40 @@ public abstract class AbstractQueuedLongSynchronizer
     }
 
     /**
+     * Repeatedly invokes acquire, if its execution throws an Error or a Runtime Exception,
+     * using an Unsafe.park-based backoff
+     * @param node which to reacquire
+     * @param arg the acquire argument
+     */
+    private final void reacquire(Node node, long arg) {
+        try {
+            acquire(node, arg, false, false, false, 0L);
+        } catch (Error | RuntimeException firstEx) {
+            // While we currently do not emit an JFR events in this situation, mainly
+            // because the conditions under which this happens are such that it
+            // cannot be presumed to be possible to actually allocate an event, and
+            // using a preconstructed one would have limited value in serviceability.
+            // Having said that, the following place would be the more appropriate
+            // place to put such logic:
+            //     emit JFR event
+
+            for (long nanos = 1L;;) {
+                U.park(false, nanos); // must use Unsafe park to sleep
+                if (nanos < 1L << 30)            // max about 1 second
+                    nanos <<= 1;
+
+                try {
+                    acquire(node, arg, false, false, false, 0L);
+                } catch (Error | RuntimeException ignored) {
+                    continue;
+                }
+
+                throw firstEx;
+            }
+        }
+    }
+
+    /**
      * Main acquire method, invoked by all exported acquire methods.
      *
      * @param node null unless a reacquiring Condition
@@ -1299,7 +1333,7 @@ public abstract class AbstractQueuedLongSynchronizer
             }
             LockSupport.setCurrentBlocker(null);
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (interrupted)
                 Thread.currentThread().interrupt();
         }
@@ -1346,7 +1380,7 @@ public abstract class AbstractQueuedLongSynchronizer
             }
             LockSupport.setCurrentBlocker(null);
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (interrupted) {
                 if (cancelled) {
                     unlinkCancelledWaiters(node);
@@ -1389,7 +1423,7 @@ public abstract class AbstractQueuedLongSynchronizer
                     LockSupport.parkNanos(this, nanos);
             }
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (cancelled) {
                 unlinkCancelledWaiters(node);
                 if (interrupted)
@@ -1433,7 +1467,7 @@ public abstract class AbstractQueuedLongSynchronizer
                     LockSupport.parkUntil(this, abstime);
             }
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (cancelled) {
                 unlinkCancelledWaiters(node);
                 if (interrupted)
@@ -1478,7 +1512,7 @@ public abstract class AbstractQueuedLongSynchronizer
                     LockSupport.parkNanos(this, nanos);
             }
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (cancelled) {
                 unlinkCancelledWaiters(node);
                 if (interrupted)

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -657,6 +657,40 @@ public abstract class AbstractQueuedSynchronizer
     }
 
     /**
+     * Repeatedly invokes acquire, if its execution throws an Error or a Runtime Exception,
+     * using an Unsafe.park-based backoff
+     * @param node which to reacquire
+     * @param arg the acquire argument
+     */
+    private final void reacquire(Node node, int arg) {
+        try {
+            acquire(node, arg, false, false, false, 0L);
+        } catch (Error | RuntimeException firstEx) {
+            // While we currently do not emit an JFR events in this situation, mainly
+            // because the conditions under which this happens are such that it
+            // cannot be presumed to be possible to actually allocate an event, and
+            // using a preconstructed one would have limited value in serviceability.
+            // Having said that, the following place would be the more appropriate
+            // place to put such logic:
+            //     emit JFR event
+
+            for (long nanos = 1L;;) {
+                U.park(false, nanos); // must use Unsafe park to sleep
+                if (nanos < 1L << 30)            // max about 1 second
+                    nanos <<= 1;
+
+                try {
+                    acquire(node, arg, false, false, false, 0L);
+                } catch (Error | RuntimeException ignored) {
+                    continue;
+                }
+
+                throw firstEx;
+            }
+        }
+    }
+
+    /**
      * Main acquire method, invoked by all exported acquire methods.
      *
      * @param node null unless a reacquiring Condition
@@ -1678,7 +1712,7 @@ public abstract class AbstractQueuedSynchronizer
             }
             LockSupport.setCurrentBlocker(null);
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (interrupted)
                 Thread.currentThread().interrupt();
         }
@@ -1725,7 +1759,7 @@ public abstract class AbstractQueuedSynchronizer
             }
             LockSupport.setCurrentBlocker(null);
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (interrupted) {
                 if (cancelled) {
                     unlinkCancelledWaiters(node);
@@ -1768,7 +1802,7 @@ public abstract class AbstractQueuedSynchronizer
                     LockSupport.parkNanos(this, nanos);
             }
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (cancelled) {
                 unlinkCancelledWaiters(node);
                 if (interrupted)
@@ -1812,7 +1846,7 @@ public abstract class AbstractQueuedSynchronizer
                     LockSupport.parkUntil(this, abstime);
             }
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (cancelled) {
                 unlinkCancelledWaiters(node);
                 if (interrupted)
@@ -1857,7 +1891,7 @@ public abstract class AbstractQueuedSynchronizer
                     LockSupport.parkNanos(this, nanos);
             }
             node.clearStatus();
-            acquire(node, savedState, false, false, false, 0L);
+            reacquire(node, savedState);
             if (cancelled) {
                 unlinkCancelledWaiters(node);
                 if (interrupted)

--- a/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
+++ b/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
@@ -23,6 +23,7 @@
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import javax.swing.SwingUtilities;
 
 import sun.java2d.Disposer;
@@ -39,14 +40,21 @@ public final class TestDisposerRace {
     private static final AtomicInteger recordsCount = new AtomicInteger();
     private static volatile boolean disposerDone = false;
 
+    private static final String KO_OVERFLOW = "Some records have not been disposed!";
+    private static final String KO_UNDERFLOW = "Disposed more records than were added!";
+
     public static void main(String[] args) throws Exception {
-        TestDisposerRace test = new TestDisposerRace();
-        test.run();
+        new TestDisposerRace().run();
 
         checkRecordsCountIsSane();
         if (recordsCount.get() > 0) {
+            System.err.println(KO_OVERFLOW); // In case the next line fails to allocate due to OOME
             throw new RuntimeException("Some records (" + recordsCount + ") have not been disposed");
         }
+    }
+
+    interface ThrowingRunnable<E extends Exception> {
+        void run() throws E;
     }
 
     TestDisposerRace() {
@@ -56,14 +64,14 @@ public final class TestDisposerRace {
     void run() throws Exception {
         generateOOME();
         for (int i = 0; i < 1000; ++i) {
-            SwingUtilities.invokeAndWait(Disposer::pollRemove);
-            if (i % 10 == 0) {
-                // Adding records will race with the diposer trying to remove them
+            retryOnOOME(() -> SwingUtilities.invokeAndWait(Disposer::pollRemove));
+
+            // Adding records will race with the diposer trying to remove them
+            if (i % 10 == 0)
                 addRecordsToDisposer(1000);
-            }
         }
 
-        Disposer.addObjectRecord(new Object(), new FinalDisposerRecord());
+        retryOnOOME(() -> Disposer.addObjectRecord(new Object(), new FinalDisposerRecord()));
 
         while (!disposerDone) {
              generateOOME();
@@ -72,18 +80,45 @@ public final class TestDisposerRace {
 
     private static void checkRecordsCountIsSane() {
         if (recordsCount.get() < 0) {
-            throw new RuntimeException("Disposed more records than were added");
+            throw new RuntimeException(KO_UNDERFLOW);
+        }
+    }
+
+    private static <T> T retryOnOOME(Supplier<T> allocator) {
+        for(;;) {
+            try {
+                return allocator.get();
+            } catch (OutOfMemoryError ignored1) {
+                try {
+                    Thread.sleep(1); // Give GC a little chance to run
+                } catch (InterruptedException ignored2) {}
+            }
+        }
+    }
+
+    private static <E extends Exception> void retryOnOOME(ThrowingRunnable<E> tr) throws E {
+        for(;;) {
+            try {
+                tr.run();
+                break;
+            } catch (OutOfMemoryError ignored1) {
+                try {
+                    Thread.sleep(1); // Give GC a little chance to run
+                } catch (InterruptedException ignored2) {}
+            }
         }
     }
 
     private void addRecordsToDisposer(int count) {
         checkRecordsCountIsSane();
 
-        recordsCount.addAndGet(count);
+        MyDisposerRecord disposerRecord = retryOnOOME(MyDisposerRecord::new);
 
-        MyDisposerRecord disposerRecord = new MyDisposerRecord();
-        for (int i = 0; i < count; i++) {
-            Disposer.addObjectRecord(new Object(), disposerRecord);
+        while(count > 0) {
+            recordsCount.incrementAndGet(); // pre-add to make sure it doesn't go negative
+            var o = retryOnOOME(Object::new);
+            retryOnOOME(() -> Disposer.addObjectRecord(o, disposerRecord));
+            --count;
         }
     }
 
@@ -106,8 +141,8 @@ public final class TestDisposerRace {
     }
 
     private static void generateOOME() throws Exception {
-        final List<Object> leak = new LinkedList<>();
         try {
+            final List<Object> leak = new LinkedList<>();
             while (true) {
                 leak.add(new byte[1024 * 1024]);
             }


### PR DESCRIPTION
My suspicion is that Condition::await() throws before having successfully reacquired the lock, and this exception is swallowed because Lock::unlock() then throws when invoke with an IllegalMonitorStateException as the current thread was not reestablished as the owner.

So this PR is intended to harden the reacquisition of await-ing methods in AQS and AQLS so that instead of throwing they spin-loop trying to reacquire the lock—at least a thread dump would show where the Thread is stuck trying to reacquire.

There's also the option of attempting to log a JFR event on the first reacquisition failure, but that might need to be done with a pre-created event as the cause of the failing acquisition may be an OOME.

I also needed to harden the TestDisposerRace itself, as it currently tries to provoke OOMEs but then proceeds to want to allocate objects used for the test itself. I'm not super-happy about the changes there, but they should be safer than before.

The first RuntimeException/Error encountered will be rethrown upon success to facilitate debugging.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325397](https://bugs.openjdk.org/browse/JDK-8325397): sun/java2d/Disposer/TestDisposerRace.java fails in linux-aarch64 (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20602/head:pull/20602` \
`$ git checkout pull/20602`

Update a local copy of the PR: \
`$ git checkout pull/20602` \
`$ git pull https://git.openjdk.org/jdk.git pull/20602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20602`

View PR using the GUI difftool: \
`$ git pr show -t 20602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20602.diff">https://git.openjdk.org/jdk/pull/20602.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20602#issuecomment-2326017826)