### PR TITLE
8338469: com/sun/jdi/DataDumpTest.java failed with Not a debuggee, or not listening for debugger to attach

### DIFF
--- a/test/jdk/com/sun/jdi/DataDumpTest.java
+++ b/test/jdk/com/sun/jdi/DataDumpTest.java
@@ -97,7 +97,7 @@ public class DataDumpTest {
 
             out.waitFor(); // Wait for the debuggee to exit
 
-            System.out.println("Deuggee output:");
+            System.out.println("Debuggee output:");
             System.out.println(firstChar + out.getOutput());
 
             // All these strings are part of the debug agent data dump output.

--- a/test/jdk/com/sun/jdi/DataDumpTest.java
+++ b/test/jdk/com/sun/jdi/DataDumpTest.java
@@ -84,6 +84,11 @@ public class DataDumpTest {
         try {
             p = pb.start();
             InputStream is = p.getInputStream();
+
+            // Read the first character of output to make sure we've waited until the
+            // debuggee is ready. This will be the debug agent's "Listening..." message.
+            char firstChar = (char)is.read();
+
             out = new OutputAnalyzer(p);
 
             // Attach a debugger and do the data dump. The data dump output will appear
@@ -93,7 +98,7 @@ public class DataDumpTest {
             out.waitFor(); // Wait for the debuggee to exit
 
             System.out.println("Deuggee output:");
-            System.out.println(out.getOutput());
+            System.out.println(firstChar + out.getOutput());
 
             // All these strings are part of the debug agent data dump output.
             out.shouldHaveExitValue(0);


### PR DESCRIPTION
There are issues with the test attaching to the debuggee too soon, and the debug agent isn't ready. yet. This test is based on ProcessAttachTest, which does not have this issue. I eventually realized the reason why is because ProcessAttachTest has this little snippet of code, which I had removed from DataDumpTest:

             // Wait for the process to start
            InputStream is = p.getInputStream();
            is.read(); 

This is waiting for the start of the debug agent's "Listening..." message. I've re-added this to DataDumpTest, and it seems to fix the issue. Tested by running 20 times with `-Xcomp` on all supported platforms with no failures. It used to fail about 2/3 of the time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338469](https://bugs.openjdk.org/browse/JDK-8338469): com/sun/jdi/DataDumpTest.java failed with Not a debuggee, or not listening for debugger to attach (**Bug** - P4)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20604/head:pull/20604` \
`$ git checkout pull/20604`

Update a local copy of the PR: \
`$ git checkout pull/20604` \
`$ git pull https://git.openjdk.org/jdk.git pull/20604/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20604`

View PR using the GUI difftool: \
`$ git pr show -t 20604`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20604.diff">https://git.openjdk.org/jdk/pull/20604.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20604#issuecomment-2292357054)