### PR TITLE
8305896: Alternative full GC forwarding

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -35,6 +35,7 @@
 #include "gc/g1/g1HeapVerifier.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/gcArguments.hpp"
+#include "gc/shared/gcForwarding.hpp"
 #include "gc/shared/workerPolicy.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
@@ -247,6 +248,7 @@ void G1Arguments::initialize() {
 
 void G1Arguments::initialize_heap_flags_and_sizes() {
   GCArguments::initialize_heap_flags_and_sizes();
+  GCForwarding::initialize_flags(heap_reserved_size_bytes());
 }
 
 CollectedHeap* G1Arguments::create_heap() {

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -78,6 +78,7 @@
 #include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/concurrentGCBreakpoints.hpp"
 #include "gc/shared/gcBehaviours.hpp"
+#include "gc/shared/gcForwarding.hpp"
 #include "gc/shared/gcHeapSummary.hpp"
 #include "gc/shared/gcId.hpp"
 #include "gc/shared/gcTimer.hpp"
@@ -1433,6 +1434,8 @@ jint G1CollectedHeap::initialize() {
   CPUTimeCounters::create_counter(CPUTimeGroups::CPUTimeType::gc_service);
 
   G1InitLogger::print();
+
+  GCForwarding::initialize(heap_rs.region());
 
   return JNI_OK;
 }

--- a/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactTask.cpp
@@ -29,6 +29,7 @@
 #include "gc/g1/g1FullGCCompactionPoint.hpp"
 #include "gc/g1/g1FullGCCompactTask.hpp"
 #include "gc/g1/g1HeapRegion.inline.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "logging/log.hpp"
 #include "oops/oop.inline.hpp"
@@ -41,7 +42,7 @@ void G1FullGCCompactTask::G1CompactRegionClosure::clear_in_bitmap(oop obj) {
 
 size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
   size_t size = obj->size();
-  if (obj->is_forwarded()) {
+  if (GCForwarding::is_forwarded(obj)) {
     G1FullGCCompactTask::copy_object_to_new_location(obj);
   }
 
@@ -52,13 +53,13 @@ size_t G1FullGCCompactTask::G1CompactRegionClosure::apply(oop obj) {
 }
 
 void G1FullGCCompactTask::copy_object_to_new_location(oop obj) {
-  assert(obj->is_forwarded(), "Sanity!");
-  assert(obj->forwardee() != obj, "Object must have a new location");
+  assert(GCForwarding::is_forwarded(obj), "Sanity!");
+  assert(GCForwarding::forwardee(obj) != obj, "Object must have a new location");
 
   size_t size = obj->size();
   // Copy object and reinit its mark.
   HeapWord* obj_addr = cast_from_oop<HeapWord*>(obj);
-  HeapWord* destination = cast_from_oop<HeapWord*>(obj->forwardee());
+  HeapWord* destination = cast_from_oop<HeapWord*>(GCForwarding::forwardee(obj));
   Copy::aligned_conjoint_words(obj_addr, destination, size);
 
   // There is no need to transform stack chunks - marking already did that.
@@ -121,7 +122,7 @@ void G1FullGCCompactTask::compact_humongous_obj(G1HeapRegion* src_hr) {
   size_t word_size = obj->size();
 
   uint num_regions = (uint)G1CollectedHeap::humongous_obj_size_in_regions(word_size);
-  HeapWord* destination = cast_from_oop<HeapWord*>(obj->forwardee());
+  HeapWord* destination = cast_from_oop<HeapWord*>(GCForwarding::forwardee(obj));
 
   assert(collector()->mark_bitmap()->is_marked(obj), "Should only compact marked objects");
   collector()->mark_bitmap()->clear(obj);

--- a/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCCompactionPoint.cpp
@@ -26,6 +26,7 @@
 #include "gc/g1/g1FullCollector.inline.hpp"
 #include "gc/g1/g1FullGCCompactionPoint.hpp"
 #include "gc/g1/g1HeapRegion.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "gc/shared/preservedMarks.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "utilities/debug.hpp"
@@ -106,10 +107,10 @@ void G1FullGCCompactionPoint::forward(oop object, size_t size) {
     if (!object->is_forwarded()) {
       preserved_stack()->push_if_necessary(object, object->mark());
     }
-    object->forward_to(cast_to_oop(_compaction_top));
-    assert(object->is_forwarded(), "must be forwarded");
+    GCForwarding::forward_to(object, cast_to_oop(_compaction_top));
+    assert(GCForwarding::is_forwarded(object), "must be forwarded");
   } else {
-    assert(!object->is_forwarded(), "must not be forwarded");
+    assert(!GCForwarding::is_forwarded(object), "must not be forwarded");
   }
 
   // Update compaction values.
@@ -172,8 +173,8 @@ void G1FullGCCompactionPoint::forward_humongous(G1HeapRegion* hr) {
   preserved_stack()->push_if_necessary(obj, obj->mark());
 
   G1HeapRegion* dest_hr = _compaction_regions->at(range_begin);
-  obj->forward_to(cast_to_oop(dest_hr->bottom()));
-  assert(obj->is_forwarded(), "Object must be forwarded!");
+  GCForwarding::forward_to(obj, cast_to_oop(dest_hr->bottom()));
+  assert(GCForwarding::is_forwarded(obj), "Object must be forwarded!");
 
   // Add the humongous object regions to the compaction point.
   add_humongous(hr);

--- a/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCOopClosures.inline.hpp
@@ -32,6 +32,7 @@
 #include "gc/g1/g1FullCollector.inline.hpp"
 #include "gc/g1/g1FullGCMarker.inline.hpp"
 #include "gc/g1/g1HeapRegionRemSet.inline.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "memory/iterator.inline.hpp"
 #include "memory/universe.hpp"
 #include "oops/access.inline.hpp"
@@ -65,8 +66,8 @@ template <class T> inline void G1AdjustClosure::adjust_pointer(T* p) {
     return;
   }
 
-  if (obj->is_forwarded()) {
-    oop forwardee = obj->forwardee();
+  if (GCForwarding::is_forwarded(obj)) {
+    oop forwardee = GCForwarding::forwardee(obj);
     // Forwarded, just update.
     assert(G1CollectedHeap::heap()->is_in_reserved(forwardee), "should be in object space");
     RawAccess<IS_NOT_NULL>::oop_store(p, forwardee);

--- a/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1FullGCPrepareTask.inline.hpp
@@ -32,6 +32,7 @@
 #include "gc/g1/g1FullGCCompactionPoint.hpp"
 #include "gc/g1/g1FullGCScope.hpp"
 #include "gc/g1/g1HeapRegion.inline.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 
 void G1DetermineCompactionQueueClosure::free_empty_humongous_region(G1HeapRegion* hr) {
   _g1h->free_humongous_region(hr, nullptr);
@@ -114,10 +115,10 @@ inline bool G1DetermineCompactionQueueClosure::do_heap_region(G1HeapRegion* hr) 
 }
 
 inline size_t G1SerialRePrepareClosure::apply(oop obj) {
-  if (obj->is_forwarded()) {
+  if (GCForwarding::is_forwarded(obj)) {
     // We skip objects compiled into the first region or
     // into regions not part of the serial compaction point.
-    if (cast_from_oop<HeapWord*>(obj->forwardee()) < _dense_prefix_top) {
+    if (cast_from_oop<HeapWord*>(GCForwarding::forwardee(obj)) < _dense_prefix_top) {
       return obj->size();
     }
   }

--- a/src/hotspot/share/gc/parallel/parallelArguments.cpp
+++ b/src/hotspot/share/gc/parallel/parallelArguments.cpp
@@ -28,6 +28,7 @@
 #include "gc/parallel/parallelScavengeHeap.hpp"
 #include "gc/shared/adaptiveSizePolicy.hpp"
 #include "gc/shared/gcArguments.hpp"
+#include "gc/shared/gcForwarding.hpp"
 #include "gc/shared/genArguments.hpp"
 #include "gc/shared/workerPolicy.hpp"
 #include "logging/log.hpp"
@@ -127,6 +128,7 @@ void ParallelArguments::initialize_heap_flags_and_sizes() {
     // Redo everything from the start
     initialize_heap_flags_and_sizes_one_pass();
   }
+  GCForwarding::initialize_flags(heap_reserved_size_bytes());
 }
 
 size_t ParallelArguments::heap_reserved_size_bytes() {

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -33,6 +33,7 @@
 #include "gc/parallel/psPromotionManager.hpp"
 #include "gc/parallel/psScavenge.hpp"
 #include "gc/parallel/psVMOperations.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "gc/shared/gcHeapSummary.hpp"
 #include "gc/shared/gcLocker.inline.hpp"
 #include "gc/shared/gcWhen.hpp"
@@ -128,6 +129,8 @@ jint ParallelScavengeHeap::initialize() {
   CPUTimeCounters::create_counter(CPUTimeGroups::CPUTimeType::gc_parallel_workers);
 
   ParallelInitLogger::print();
+
+  GCForwarding::initialize(heap_rs.region());
 
   return JNI_OK;
 }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -45,6 +45,7 @@
 #include "gc/parallel/psYoungGen.hpp"
 #include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/gcCause.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "gc/shared/gcHeapSummary.hpp"
 #include "gc/shared/gcId.hpp"
 #include "gc/shared/gcLocker.hpp"
@@ -1592,7 +1593,7 @@ void PSParallelCompact::forward_to_new_addr() {
             oop obj = cast_to_oop(cur_addr);
             if (new_addr != cur_addr) {
               cm->preserved_marks()->push_if_necessary(obj, obj->mark());
-              obj->forward_to(cast_to_oop(new_addr));
+              GCForwarding::forward_to(obj, cast_to_oop(new_addr));
             }
             size_t obj_size = obj->size();
             live_words += obj_size;
@@ -1635,7 +1636,7 @@ void PSParallelCompact::verify_forward() {
       }
       oop obj = cast_to_oop(cur_addr);
       if (cur_addr != bump_ptr) {
-        assert(obj->forwardee() == cast_to_oop(bump_ptr), "inv");
+        assert(GCForwarding::forwardee(obj) == cast_to_oop(bump_ptr), "inv");
       }
       bump_ptr += obj->size();
       cur_addr += obj->size();
@@ -2398,8 +2399,8 @@ void MoveAndUpdateClosure::do_addr(HeapWord* addr, size_t words) {
   if (copy_destination() != source()) {
     DEBUG_ONLY(PSParallelCompact::check_new_location(source(), destination());)
     assert(source() != destination(), "inv");
-    assert(cast_to_oop(source())->is_forwarded(), "inv");
-    assert(cast_to_oop(source())->forwardee() == cast_to_oop(destination()), "inv");
+    assert(GCForwarding::is_forwarded(cast_to_oop(source())), "inv");
+    assert(GCForwarding::forwardee(cast_to_oop(source())) == cast_to_oop(destination()), "inv");
     Copy::aligned_conjoint_words(source(), copy_destination(), words);
     cast_to_oop(copy_destination())->init_mark();
   }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.inline.hpp
@@ -31,6 +31,7 @@
 #include "gc/parallel/parMarkBitMap.inline.hpp"
 #include "gc/shared/collectedHeap.hpp"
 #include "gc/shared/continuationGCSupport.inline.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/compressedOops.inline.hpp"
 #include "oops/klass.hpp"
@@ -79,7 +80,7 @@ inline void PSParallelCompact::adjust_pointer(T* p) {
     if (!obj->is_forwarded()) {
       return;
     }
-    oop new_obj = obj->forwardee();
+    oop new_obj = GCForwarding::forwardee(obj);
     assert(new_obj != nullptr, "non-null address for live objects");
     assert(new_obj != obj, "inv");
     assert(ParallelScavengeHeap::heap()->is_in_reserved(new_obj),

--- a/src/hotspot/share/gc/serial/serialArguments.cpp
+++ b/src/hotspot/share/gc/serial/serialArguments.cpp
@@ -23,9 +23,15 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/shared/gcForwarding.hpp"
 #include "gc/shared/genArguments.hpp"
 #include "gc/serial/serialArguments.hpp"
 #include "gc/serial/serialHeap.hpp"
+
+void SerialArguments::initialize_heap_flags_and_sizes() {
+  GenArguments::initialize_heap_flags_and_sizes();
+  GCForwarding::initialize_flags(MaxNewSize + MaxOldSize);
+}
 
 CollectedHeap* SerialArguments::create_heap() {
   return new SerialHeap();

--- a/src/hotspot/share/gc/serial/serialArguments.hpp
+++ b/src/hotspot/share/gc/serial/serialArguments.hpp
@@ -32,6 +32,7 @@ class CollectedHeap;
 class SerialArguments : public GenArguments {
 private:
   virtual CollectedHeap* create_heap();
+  void initialize_heap_flags_and_sizes();
 };
 
 #endif // SHARE_GC_SERIAL_SERIALARGUMENTS_HPP

--- a/src/hotspot/share/gc/serial/serialFullGC.cpp
+++ b/src/hotspot/share/gc/serial/serialFullGC.cpp
@@ -43,6 +43,7 @@
 #include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/continuationGCSupport.inline.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "gc/shared/gcHeapSummary.hpp"
 #include "gc/shared/gcTimer.hpp"
 #include "gc/shared/gcTrace.hpp"
@@ -230,7 +231,7 @@ class Compacter {
   static void forward_obj(oop obj, HeapWord* new_addr) {
     prefetch_write_scan(obj);
     if (cast_from_oop<HeapWord*>(obj) != new_addr) {
-      obj->forward_to(cast_to_oop(new_addr));
+      GCForwarding::forward_to(obj, cast_to_oop(new_addr));
     } else {
       assert(obj->is_gc_marked(), "inv");
       // This obj will stay in-place. Fix the markword.
@@ -255,7 +256,7 @@ class Compacter {
     prefetch_read_scan(addr);
 
     oop obj = cast_to_oop(addr);
-    oop new_obj = obj->forwardee();
+    oop new_obj = GCForwarding::forwardee(obj);
     HeapWord* new_addr = cast_from_oop<HeapWord*>(new_obj);
     assert(addr != new_addr, "inv");
     prefetch_write_copy(new_addr);
@@ -352,13 +353,13 @@ public:
       HeapWord* top = space->top();
 
       // Check if the first obj inside this space is forwarded.
-      if (!cast_to_oop(cur_addr)->is_forwarded()) {
+      if (!GCForwarding::is_forwarded(cast_to_oop(cur_addr))) {
         // Jump over consecutive (in-place) live-objs-chunk
         cur_addr = get_first_dead(i);
       }
 
       while (cur_addr < top) {
-        if (!cast_to_oop(cur_addr)->is_forwarded()) {
+        if (!GCForwarding::is_forwarded(cast_to_oop(cur_addr))) {
           cur_addr = *(HeapWord**) cur_addr;
           continue;
         }
@@ -624,8 +625,8 @@ template <class T> void SerialFullGC::adjust_pointer(T* p) {
     oop obj = CompressedOops::decode_not_null(heap_oop);
     assert(Universe::heap()->is_in(obj), "should be in heap");
 
-    if (obj->is_forwarded()) {
-      oop new_obj = obj->forwardee();
+    if (GCForwarding::is_forwarded(obj)) {
+      oop new_obj = GCForwarding::forwardee(obj);
       assert(is_object_aligned(new_obj), "oop must be aligned");
       RawAccess<IS_NOT_NULL>::oop_store(p, new_obj);
     }

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -40,6 +40,7 @@
 #include "gc/shared/collectedHeap.inline.hpp"
 #include "gc/shared/collectorCounters.hpp"
 #include "gc/shared/continuationGCSupport.inline.hpp"
+#include "gc/shared/gcForwarding.hpp"
 #include "gc/shared/gcId.hpp"
 #include "gc/shared/gcInitLogger.hpp"
 #include "gc/shared/gcLocker.inline.hpp"
@@ -199,6 +200,8 @@ jint SerialHeap::initialize() {
   _old_gen = new TenuredGeneration(old_rs, OldSize, MinOldSize, MaxOldSize, rem_set());
 
   GCInitLogger::print();
+
+  GCForwarding::initialize(_reserved);
 
   return JNI_OK;
 }

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -26,6 +26,7 @@
 #include "precompiled.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/gcArguments.hpp"
+#include "gc/shared/gcForwarding.hpp"
 #include "logging/log.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/globals.hpp"
@@ -60,6 +61,7 @@ void GCArguments::initialize_heap_sizes() {
   initialize_alignments();
   initialize_heap_flags_and_sizes();
   initialize_size_info();
+  GCForwarding::initialize_flags();
 }
 
 size_t GCArguments::compute_heap_alignment() {

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -26,7 +26,6 @@
 #include "precompiled.hpp"
 #include "gc/shared/cardTable.hpp"
 #include "gc/shared/gcArguments.hpp"
-#include "gc/shared/gcForwarding.hpp"
 #include "logging/log.hpp"
 #include "runtime/arguments.hpp"
 #include "runtime/globals.hpp"
@@ -61,7 +60,6 @@ void GCArguments::initialize_heap_sizes() {
   initialize_alignments();
   initialize_heap_flags_and_sizes();
   initialize_size_info();
-  GCForwarding::initialize_flags();
 }
 
 size_t GCArguments::compute_heap_alignment() {

--- a/src/hotspot/share/gc/shared/gcForwarding.cpp
+++ b/src/hotspot/share/gc/shared/gcForwarding.cpp
@@ -35,7 +35,7 @@ void GCForwarding::initialize_flags() {
   // object headers, we will disable the flag when the
   // heap size exceeds the narrow-encodable address space.
 
-  // size_t max_narrow_heap_size = (size_t(1) << (NUM_LOW_BITS_NARROW - SHIFT)) * HeapWordSize;
+  // size_t max_narrow_heap_size = (size_t(1) << (NumLowBitsNarrow - Shift)) * HeapWordSize;
   // if (UseCompactObjectHeaders && MaxHeapSize >= max_narrow_heap_size) {
   //  FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
   // }
@@ -44,11 +44,11 @@ void GCForwarding::initialize_flags() {
 void GCForwarding::initialize(MemRegion heap) {
 #ifdef _LP64
   _heap_base = heap.start();
-  if (heap.word_size() <= right_n_bits(NUM_LOW_BITS_NARROW - SHIFT)) {
-    _num_low_bits = NUM_LOW_BITS_NARROW;
+  if (heap.word_size() <= right_n_bits(NumLowBitsNarrow - Shift)) {
+    _num_low_bits = NumLowBitsNarrow;
   } else {
     // assert(!UseCompactObjectHeaders, "Compact object headers should be turned off for large heaps");
-    _num_low_bits = NUM_LOW_BITS_WIDE;
+    _num_low_bits = NumLowBitsWide;
   }
 #endif
 }

--- a/src/hotspot/share/gc/shared/gcForwarding.cpp
+++ b/src/hotspot/share/gc/shared/gcForwarding.cpp
@@ -30,15 +30,17 @@
 HeapWord* GCForwarding::_heap_base = nullptr;
 int GCForwarding::_num_low_bits = 0;
 
-void GCForwarding::initialize_flags() {
+void GCForwarding::initialize_flags(size_t max_heap_size) {
+#ifdef _LP64
   // Nothing to do here, yet. As soon as we have compact
   // object headers, we will disable the flag when the
   // heap size exceeds the narrow-encodable address space.
 
-  // size_t max_narrow_heap_size = (size_t(1) << (NumLowBitsNarrow - Shift)) * HeapWordSize;
-  // if (UseCompactObjectHeaders && MaxHeapSize >= max_narrow_heap_size) {
-  //  FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
+  // size_t max_narrow_heap_size = right_n_bits(NumLowBitsNarrow - Shift);
+  // if (UseCompactObjectHeaders && max_heap_size > max_narrow_heap_size * HeapWordSize) {
+  //   FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
   // }
+#endif
 }
 
 void GCForwarding::initialize(MemRegion heap) {

--- a/src/hotspot/share/gc/shared/gcForwarding.cpp
+++ b/src/hotspot/share/gc/shared/gcForwarding.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "gc/shared/gcForwarding.hpp"
+#include "memory/memRegion.hpp"
+#include "runtime/globals_extension.hpp"
+
+HeapWord* GCForwarding::_heap_base = nullptr;
+int GCForwarding::_num_low_bits = 0;
+
+void GCForwarding::initialize_flags() {
+  // Nothing to do here, yet. As soon as we have compact
+  // object headers, we will disable the flag when the
+  // heap size exceeds the narrow-encodable address space.
+
+  // size_t max_narrow_heap_size = (size_t(1) << (NUM_LOW_BITS_NARROW - SHIFT)) * HeapWordSize;
+  // if (UseCompactObjectHeaders && MaxHeapSize >= max_narrow_heap_size) {
+  //  FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
+  // }
+}
+
+void GCForwarding::initialize(MemRegion heap) {
+#ifdef _LP64
+  _heap_base = heap.start();
+  if (heap.word_size() <= right_n_bits(NUM_LOW_BITS_NARROW - SHIFT)) {
+    _num_low_bits = NUM_LOW_BITS_NARROW;
+  } else {
+    // assert(!UseCompactObjectHeaders, "Compact object headers should be turned off for large heaps");
+    _num_low_bits = NUM_LOW_BITS_WIDE;
+  }
+#endif
+}

--- a/src/hotspot/share/gc/shared/gcForwarding.hpp
+++ b/src/hotspot/share/gc/shared/gcForwarding.hpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_GC_SHARED_GCFORWARDING_HPP
+#define SHARE_GC_SHARED_GCFORWARDING_HPP
+
+#include "memory/allStatic.hpp"
+#include "memory/memRegion.hpp"
+#include "oops/markWord.hpp"
+#include "oops/oopsHierarchy.hpp"
+
+class GCForwarding : public AllStatic {
+  static const int NumKlassBits        = 32; // Will be 22 with Tiny Class-Pointers
+  static const int NUM_LOW_BITS_NARROW = BitsPerWord - NumKlassBits;
+  static const int NUM_LOW_BITS_WIDE   = BitsPerWord;
+  static const int SHIFT = markWord::lock_bits + markWord::lock_shift;
+
+  static HeapWord* _heap_base;
+  static int _num_low_bits;
+public:
+  static void initialize_flags();
+  static void initialize(MemRegion heap);
+  static inline void forward_to(oop from, oop to);
+  static inline oop forwardee(oop from);
+  static inline bool is_forwarded(oop obj);
+};
+
+#endif // SHARE_GC_SHARED_GCFORWARDING_HPP

--- a/src/hotspot/share/gc/shared/gcForwarding.hpp
+++ b/src/hotspot/share/gc/shared/gcForwarding.hpp
@@ -30,11 +30,19 @@
 #include "oops/markWord.hpp"
 #include "oops/oopsHierarchy.hpp"
 
+/*
+ * Implements forwarding for the full-GCs of Serial, Parallel, G1 and Shenandoan in
+ * a way that preserves upper N bits of object mark-words, which contain crucial
+ * Klass* information when running with compact headers. The encoding is similar to
+ * compressed-oops encoding: it basically subtracts the forwardee address from the
+ * heap-base, shifts that difference into the right place, and sets the lowest two
+ * bits (to indicate 'forwarded' state as usual).
+ */
 class GCForwarding : public AllStatic {
   static const int NumKlassBits        = 32; // Will be 22 with Tiny Class-Pointers
-  static const int NUM_LOW_BITS_NARROW = BitsPerWord - NumKlassBits;
-  static const int NUM_LOW_BITS_WIDE   = BitsPerWord;
-  static const int SHIFT = markWord::lock_bits + markWord::lock_shift;
+  static const int NumLowBitsNarrow = BitsPerWord - NumKlassBits;
+  static const int NumLowBitsWide   = BitsPerWord;
+  static const int Shift = markWord::lock_bits + markWord::lock_shift;
 
   static HeapWord* _heap_base;
   static int _num_low_bits;

--- a/src/hotspot/share/gc/shared/gcForwarding.hpp
+++ b/src/hotspot/share/gc/shared/gcForwarding.hpp
@@ -47,7 +47,7 @@ class GCForwarding : public AllStatic {
   static HeapWord* _heap_base;
   static int _num_low_bits;
 public:
-  static void initialize_flags();
+  static void initialize_flags(size_t max_heap_size);
   static void initialize(MemRegion heap);
   static inline void forward_to(oop from, oop to);
   static inline oop forwardee(oop from);

--- a/src/hotspot/share/gc/shared/gcForwarding.inline.hpp
+++ b/src/hotspot/share/gc/shared/gcForwarding.inline.hpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef GC_SHARED_GCFORWARDING_INLINE_HPP
+#define GC_SHARED_GCFORWARDING_INLINE_HPP
+
+#include "gc/shared/gcForwarding.hpp"
+#include "oops/oop.inline.hpp"
+#include "utilities/globalDefinitions.hpp"
+
+void GCForwarding::forward_to(oop from, oop to) {
+#ifdef _LP64
+  uintptr_t encoded = pointer_delta(cast_from_oop<HeapWord*>(to), _heap_base) << SHIFT;
+  assert(encoded <= static_cast<uintptr_t>(right_n_bits(_num_low_bits)), "encoded forwardee must fit");
+  uintptr_t mark = from->mark().value();
+  mark &= ~right_n_bits(_num_low_bits);
+  mark |= (encoded | markWord::marked_value);
+  from->set_mark(markWord(mark));
+#else
+  from->forward_to(to);
+#endif
+}
+
+oop GCForwarding::forwardee(oop from) {
+#ifdef _LP64
+  uintptr_t mark = from->mark().value();
+  HeapWord* decoded = _heap_base + ((mark & right_n_bits(_num_low_bits)) >> SHIFT);
+  return cast_to_oop(decoded);
+#else
+  return from->forwardee();
+#endif
+}
+
+bool GCForwarding::is_forwarded(oop obj) {
+  return obj->mark().is_marked();
+}
+
+#endif // GC_SHARED_GCFORWARDING_INLINE_HPP

--- a/src/hotspot/share/gc/shared/gcForwarding.inline.hpp
+++ b/src/hotspot/share/gc/shared/gcForwarding.inline.hpp
@@ -31,7 +31,7 @@
 
 void GCForwarding::forward_to(oop from, oop to) {
 #ifdef _LP64
-  uintptr_t encoded = pointer_delta(cast_from_oop<HeapWord*>(to), _heap_base) << SHIFT;
+  uintptr_t encoded = pointer_delta(cast_from_oop<HeapWord*>(to), _heap_base) << Shift;
   assert(encoded <= static_cast<uintptr_t>(right_n_bits(_num_low_bits)), "encoded forwardee must fit");
   uintptr_t mark = from->mark().value();
   mark &= ~right_n_bits(_num_low_bits);
@@ -45,7 +45,7 @@ void GCForwarding::forward_to(oop from, oop to) {
 oop GCForwarding::forwardee(oop from) {
 #ifdef _LP64
   uintptr_t mark = from->mark().value();
-  HeapWord* decoded = _heap_base + ((mark & right_n_bits(_num_low_bits)) >> SHIFT);
+  HeapWord* decoded = _heap_base + ((mark & right_n_bits(_num_low_bits)) >> Shift);
   return cast_to_oop(decoded);
 #else
   return from->forwardee();
@@ -53,7 +53,7 @@ oop GCForwarding::forwardee(oop from) {
 }
 
 bool GCForwarding::is_forwarded(oop obj) {
-  return obj->mark().is_marked();
+  return obj->mark().is_forwarded();
 }
 
 #endif // GC_SHARED_GCFORWARDING_INLINE_HPP

--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "precompiled.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "gc/shared/preservedMarks.inline.hpp"
 #include "gc/shared/workerThread.hpp"
 #include "gc/shared/workerUtils.hpp"
@@ -42,8 +43,8 @@ void PreservedMarks::restore() {
 
 void PreservedMarks::adjust_preserved_mark(PreservedMark* elem) {
   oop obj = elem->get_oop();
-  if (obj->is_forwarded()) {
-    elem->set_oop(obj->forwardee());
+  if (GCForwarding::is_forwarded(obj)) {
+    elem->set_oop(GCForwarding::forwardee(obj));
   }
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/gcArguments.hpp"
+#include "gc/shared/gcForwarding.hpp"
 #include "gc/shared/tlab_globals.hpp"
 #include "gc/shared/workerPolicy.hpp"
 #include "gc/shenandoah/shenandoahArguments.hpp"
@@ -196,6 +197,11 @@ void ShenandoahArguments::initialize_alignments() {
   }
   SpaceAlignment = align;
   HeapAlignment = align;
+}
+
+void ShenandoahArguments::initialize_heap_flags_and_sizes() {
+  GCArguments::initialize_heap_flags_and_sizes();
+  GCForwarding::initialize_flags(MaxHeapSize);
 }
 
 CollectedHeap* ShenandoahArguments::create_heap() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.hpp
@@ -35,6 +35,7 @@ private:
 
   virtual void initialize();
   virtual size_t conservative_max_heap_alignment();
+  virtual void initialize_heap_flags_and_sizes();
   virtual CollectedHeap* create_heap();
 };
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahFullGC.cpp
@@ -26,6 +26,7 @@
 
 #include "compiler/oopMap.hpp"
 #include "gc/shared/continuationGCSupport.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "gc/shared/preservedMarks.inline.hpp"
 #include "gc/shared/tlab_globals.hpp"
@@ -369,7 +370,7 @@ public:
     shenandoah_assert_not_forwarded(nullptr, p);
     if (_compact_point != cast_from_oop<HeapWord*>(p)) {
       _preserved_marks->push_if_necessary(p, p->mark());
-      p->forward_to(cast_to_oop(_compact_point));
+      GCForwarding::forward_to(p, cast_to_oop(_compact_point));
     }
     _compact_point += obj_size;
   }
@@ -492,7 +493,7 @@ void ShenandoahFullGC::calculate_target_humongous_objects() {
       if (start >= to_begin && start != r->index()) {
         // Fits into current window, and the move is non-trivial. Record the move then, and continue scan.
         _preserved_marks->get(0)->push_if_necessary(old_obj, old_obj->mark());
-        old_obj->forward_to(cast_to_oop(heap->get_region(start)->bottom()));
+        GCForwarding::forward_to(old_obj, cast_to_oop(heap->get_region(start)->bottom()));
         to_end = start;
         continue;
       }
@@ -752,8 +753,8 @@ private:
     if (!CompressedOops::is_null(o)) {
       oop obj = CompressedOops::decode_not_null(o);
       assert(_ctx->is_marked(obj), "must be marked");
-      if (obj->is_forwarded()) {
-        oop forw = obj->forwardee();
+      if (GCForwarding::is_forwarded(obj)) {
+        oop forw = GCForwarding::forwardee(obj);
         RawAccess<IS_NOT_NULL>::oop_store(p, forw);
       }
     }
@@ -863,9 +864,9 @@ public:
   void do_object(oop p) {
     assert(_heap->complete_marking_context()->is_marked(p), "must be marked");
     size_t size = p->size();
-    if (p->is_forwarded()) {
+    if (GCForwarding::is_forwarded(p)) {
       HeapWord* compact_from = cast_from_oop<HeapWord*>(p);
-      HeapWord* compact_to = cast_from_oop<HeapWord*>(p->forwardee());
+      HeapWord* compact_to = cast_from_oop<HeapWord*>(GCForwarding::forwardee(p));
       assert(compact_from != compact_to, "Forwarded object should move");
       Copy::aligned_conjoint_words(compact_from, compact_to, size);
       oop new_obj = cast_to_oop(compact_to);
@@ -970,7 +971,7 @@ void ShenandoahFullGC::compact_humongous_objects() {
     ShenandoahHeapRegion* r = heap->get_region(c - 1);
     if (r->is_humongous_start()) {
       oop old_obj = cast_to_oop(r->bottom());
-      if (!old_obj->is_forwarded()) {
+      if (!GCForwarding::is_forwarded(old_obj)) {
         // No need to move the object, it stays at the same slot
         continue;
       }
@@ -979,7 +980,7 @@ void ShenandoahFullGC::compact_humongous_objects() {
 
       size_t old_start = r->index();
       size_t old_end   = old_start + num_regions - 1;
-      size_t new_start = heap->heap_region_index_containing(old_obj->forwardee());
+      size_t new_start = heap->heap_region_index_containing(GCForwarding::forwardee(old_obj));
       size_t new_end   = new_start + num_regions - 1;
       assert(old_start != new_start, "must be real move");
       assert(r->is_stw_move_allowed(), "Region " SIZE_FORMAT " should be movable", r->index());

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -29,6 +29,7 @@
 
 #include "gc/shared/classUnloadingContext.hpp"
 #include "gc/shared/gcArguments.hpp"
+#include "gc/shared/gcForwarding.hpp"
 #include "gc/shared/gcTimer.hpp"
 #include "gc/shared/gcTraceTime.inline.hpp"
 #include "gc/shared/locationPrinter.inline.hpp"
@@ -421,6 +422,8 @@ jint ShenandoahHeap::initialize() {
   _control_thread = new ShenandoahControlThread();
 
   ShenandoahInitLogger::print();
+
+  GCForwarding::initialize(_heap_region);
 
   return JNI_OK;
 }

--- a/test/hotspot/gtest/gc/shared/test_preservedMarks.cpp
+++ b/test/hotspot/gtest/gc/shared/test_preservedMarks.cpp
@@ -23,63 +23,48 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/preservedMarks.inline.hpp"
+#include "gc/shared/gcForwarding.inline.hpp"
 #include "oops/oop.inline.hpp"
 #include "unittest.hpp"
 
-// Class to create a "fake" oop with a mark that will
-// return true for calls to must_be_preserved().
-class FakeOop {
-  // Align at least to 8 bytes, otherwise the lowest address bit
-  // could be interpreted as 'self-forwarded' when encoded as
-  // forwardee in the mark-word. This is required on 32 bit builds,
-  // where the oop could be 4-byte-aligned.
-  alignas(BytesPerLong) oopDesc _oop;
-
-public:
-  FakeOop() : _oop() { _oop.set_mark(originalMark()); }
-
-  oop get_oop() { return &_oop; }
-  markWord mark() { return _oop.mark(); }
-  void set_mark(markWord m) { _oop.set_mark(m); }
-  void forward_to(oop obj) {
-    markWord m = markWord::encode_pointer_as_mark(obj);
-    _oop.set_mark(m);
-  }
-
-  static markWord originalMark() { return markWord(markWord::lock_mask_in_place); }
-  static markWord changedMark()  { return markWord(0x4711); }
-};
+static markWord originalMark() { return markWord(markWord::lock_mask_in_place); }
+static markWord changedMark()  { return markWord(0x4711); }
 
 #define ASSERT_MARK_WORD_EQ(a, b) ASSERT_EQ((a).value(), (b).value())
 
 TEST_VM(PreservedMarks, iterate_and_restore) {
   PreservedMarks pm;
-  FakeOop o1;
-  FakeOop o2;
-  FakeOop o3;
-  FakeOop o4;
+
+  HeapWord fakeheap[32] = { nullptr };
+  HeapWord* heap = align_up(fakeheap, 8 * sizeof(HeapWord));
+  GCForwarding::initialize(MemRegion(&heap[0], &heap[16]));
+
+  oop o1 = cast_to_oop(&heap[0]); o1->set_mark(originalMark());
+  oop o2 = cast_to_oop(&heap[2]); o2->set_mark(originalMark());
+  oop o3 = cast_to_oop(&heap[4]); o3->set_mark(originalMark());
+  oop o4 = cast_to_oop(&heap[6]); o4->set_mark(originalMark());
 
   // Make sure initial marks are correct.
-  ASSERT_MARK_WORD_EQ(o1.mark(), FakeOop::originalMark());
-  ASSERT_MARK_WORD_EQ(o2.mark(), FakeOop::originalMark());
-  ASSERT_MARK_WORD_EQ(o3.mark(), FakeOop::originalMark());
-  ASSERT_MARK_WORD_EQ(o4.mark(), FakeOop::originalMark());
+  ASSERT_MARK_WORD_EQ(o1->mark(), originalMark());
+  ASSERT_MARK_WORD_EQ(o2->mark(), originalMark());
+  ASSERT_MARK_WORD_EQ(o3->mark(), originalMark());
+  ASSERT_MARK_WORD_EQ(o4->mark(), originalMark());
 
   // Change the marks and verify change.
-  o1.set_mark(FakeOop::changedMark());
-  o2.set_mark(FakeOop::changedMark());
-  ASSERT_MARK_WORD_EQ(o1.mark(), FakeOop::changedMark());
-  ASSERT_MARK_WORD_EQ(o2.mark(), FakeOop::changedMark());
+  o1->set_mark(changedMark());
+  o2->set_mark(changedMark());
+  ASSERT_MARK_WORD_EQ(o1->mark(), changedMark());
+  ASSERT_MARK_WORD_EQ(o2->mark(), changedMark());
 
   // Push o1 and o2 to have their marks preserved.
-  pm.push_if_necessary(o1.get_oop(), o1.mark());
-  pm.push_if_necessary(o2.get_oop(), o2.mark());
+  pm.push_if_necessary(o1, o1->mark());
+  pm.push_if_necessary(o2, o2->mark());
 
   // Fake a move from o1->o3 and o2->o4.
-  o1.forward_to(o3.get_oop());
-  o2.forward_to(o4.get_oop());
-  ASSERT_EQ(o1.get_oop()->forwardee(), o3.get_oop());
-  ASSERT_EQ(o2.get_oop()->forwardee(), o4.get_oop());
+  GCForwarding::forward_to(o1, o3);
+  GCForwarding::forward_to(o2, o4);
+  ASSERT_EQ(GCForwarding::forwardee(o1), o3);
+  ASSERT_EQ(GCForwarding::forwardee(o2), o4);
   // Adjust will update the PreservedMarks stack to
   // make sure the mark is updated at the new location.
   pm.adjust_during_full_gc();
@@ -87,6 +72,6 @@ TEST_VM(PreservedMarks, iterate_and_restore) {
   // Restore all preserved and verify that the changed
   // mark is now present at o3 and o4.
   pm.restore();
-  ASSERT_MARK_WORD_EQ(o3.mark(), FakeOop::changedMark());
-  ASSERT_MARK_WORD_EQ(o4.mark(), FakeOop::changedMark());
+  ASSERT_MARK_WORD_EQ(o3->mark(), changedMark());
+  ASSERT_MARK_WORD_EQ(o4->mark(), changedMark());
 }


### PR DESCRIPTION
Currently, the full-GC modes of Serial, Parallel, Shenandoah and G1 GCs are forwarding objects by over-writing the object header with the new object location. Unfortunately, for compact object headers ([JDK-8294992](https://bugs.openjdk.org/browse/JDK-8294992)) this would not work, because the crucial class information is also stored in the header, and we could no longer iterate over objects until the headers would be restored. Also, the preserved-headers tables would grow quite large because now all headers would be 'interesting' and would have to be preserved.

I propose to use an alternative encoding for full-GC (sliding-GC) so that the forwarding information fits into the lowest 32 bits of the header. The encoding is similar to compressed-oops encoding: it basically subtracts the forwardee address from the heap-base, shifts that difference into the right place, and sets the lowest two bits (to indicate 'forwarded' state as usual).

The current implementation preserves the upper 32 bits of the mark-word. This leaves 30 bits for encoding the forwardee, enough for 8GB of heap. As soon as we get Tiny Class-Pointers (planned as part of compact headers upstreaming), we only need 22 bits for the narrow Klass*, and can use 40 bits for forwardee encoding. That's enough for 8TB of heap. If somebody wants to run with larger heap than this, compact headers would be disabled. This change also adds some infrastructure to configure the flags, with the code commented out, to illustrate the intended use.

An earlier approach to address the problem has been proposed in https://github.com/openjdk/jdk/pull/13582. This has been implemented under the assumption that we would only have 30 bits to encode the forwardee. In the light of changed plans, I don't think it's worth the added complexity and risk of slight performance issues. I will revisit it in the future, for 4-byte-headers.

I also experimented with a different forwarding approach that would use per-region hashtables, but gave up on it for now, because performance was significantly worse than the sliding forwarding encoding.

This is in preparation of upstreaming compact object headers, and I intend to push it only once all the parts have been approved.

Testing:
 - [x] hotspot_gc
 - [x] tier1
 - [x] tier2
 - [x] tier3
 - [x] tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #20603 must be integrated first

### Issue
 * [JDK-8305896](https://bugs.openjdk.org/browse/JDK-8305896): Alternative full GC forwarding (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20605/head:pull/20605` \
`$ git checkout pull/20605`

Update a local copy of the PR: \
`$ git checkout pull/20605` \
`$ git pull https://git.openjdk.org/jdk.git pull/20605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20605`

View PR using the GUI difftool: \
`$ git pr show -t 20605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20605.diff">https://git.openjdk.org/jdk/pull/20605.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20605#issuecomment-2301837077)