### PR TITLE
8338482: com/sun/jdi/ThreadMemoryLeakTest.java requires that compressed oops are enabled

### DIFF
--- a/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
+++ b/test/jdk/com/sun/jdi/ThreadMemoryLeakTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,9 @@
  * @bug 8297638
  * @summary JDI memory leak when creating and destroying many threads
  *
- * @comment Don't allow -Xcomp or -Xint as they impact memory useage and number of iterations
- * @requires (vm.compMode == "Xmixed")
+ * @comment Don't allow -Xcomp or -Xint as they impact memory useage and number of iterations.
+ *          Require compressed oops because not doing so increases memory usage.
+ * @requires (vm.compMode == "Xmixed") & vm.opt.final.UseCompressedOops
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
  * @run compile -g ThreadMemoryLeakTest.java
  * @comment run with -Xmx7m so any leak will quickly produce OOME


### PR DESCRIPTION
com/sun/jdi/ThreadMemoryLeakTest.java purposely runs with a small heap so it is easier to detect a memory leak with an OOME. Running without compressed oops uses more memory leading to an OOME even though there is no leak. We should require that this test be run only with compressed oops. 

Tested by running just this test without compress oops and verifying that the test is not run, and also running with compressed oops and verifying that it is run. I also did an `-Xcomp` run to verify that it still is not run with `-Xcomp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338482](https://bugs.openjdk.org/browse/JDK-8338482): com/sun/jdi/ThreadMemoryLeakTest.java requires that compressed oops are enabled (**Sub-task** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20606/head:pull/20606` \
`$ git checkout pull/20606`

Update a local copy of the PR: \
`$ git checkout pull/20606` \
`$ git pull https://git.openjdk.org/jdk.git pull/20606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20606`

View PR using the GUI difftool: \
`$ git pr show -t 20606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20606.diff">https://git.openjdk.org/jdk/pull/20606.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20606#issuecomment-2292854462)