### PR TITLE
8338490: Serial: Move Generation::print_on to subclasses

### DIFF
--- a/src/hotspot/share/gc/serial/defNewGeneration.cpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.cpp
@@ -846,18 +846,21 @@ void DefNewGeneration::verify() {
 }
 
 void DefNewGeneration::print_on(outputStream* st) const {
-  Generation::print_on(st);
+  st->print(" %-10s", name());
+
+  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+            capacity()/K, used()/K);
+  st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
+               p2i(_virtual_space.low_boundary()),
+               p2i(_virtual_space.high()),
+               p2i(_virtual_space.high_boundary()));
+
   st->print("  eden");
   eden()->print_on(st);
   st->print("  from");
   from()->print_on(st);
   st->print("  to  ");
   to()->print_on(st);
-}
-
-
-const char* DefNewGeneration::name() const {
-  return "def new generation";
 }
 
 HeapWord* DefNewGeneration::allocate(size_t word_size) {

--- a/src/hotspot/share/gc/serial/defNewGeneration.hpp
+++ b/src/hotspot/share/gc/serial/defNewGeneration.hpp
@@ -234,8 +234,7 @@ class DefNewGeneration: public Generation {
   void update_counters();
 
   // Printing
-  virtual const char* name() const;
-  virtual const char* short_name() const { return "DefNew"; }
+  const char* name() const { return "DefNew"; }
 
   void print_on(outputStream* st) const;
 

--- a/src/hotspot/share/gc/serial/generation.cpp
+++ b/src/hotspot/share/gc/serial/generation.cpp
@@ -58,15 +58,3 @@ Generation::Generation(ReservedSpace rs, size_t initial_size) :
 size_t Generation::max_capacity() const {
   return reserved().byte_size();
 }
-
-void Generation::print() const { print_on(tty); }
-
-void Generation::print_on(outputStream* st)  const {
-  st->print(" %-20s", name());
-  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
-             capacity()/K, used()/K);
-  st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
-              p2i(_virtual_space.low_boundary()),
-              p2i(_virtual_space.high()),
-              p2i(_virtual_space.high_boundary()));
-}

--- a/src/hotspot/share/gc/serial/generation.hpp
+++ b/src/hotspot/share/gc/serial/generation.hpp
@@ -103,13 +103,6 @@ class Generation: public CHeapObj<mtGC> {
     return _reserved.contains(p);
   }
 
-  // Printing
-  virtual const char* name() const = 0;
-  virtual const char* short_name() const = 0;
-
-  virtual void print() const;
-  virtual void print_on(outputStream* st) const;
-
   virtual void verify() = 0;
 
 public:

--- a/src/hotspot/share/gc/serial/serialHeap.cpp
+++ b/src/hotspot/share/gc/serial/serialHeap.cpp
@@ -882,12 +882,12 @@ void SerialHeap::verify(VerifyOption option /* ignored */) {
 }
 
 void SerialHeap::print_on(outputStream* st) const {
-  if (_young_gen != nullptr) {
-    _young_gen->print_on(st);
-  }
-  if (_old_gen != nullptr) {
-    _old_gen->print_on(st);
-  }
+  assert(_young_gen != nullptr, "precondition");
+  assert(_old_gen   != nullptr, "precondition");
+
+  _young_gen->print_on(st);
+  _old_gen->print_on(st);
+
   MetaspaceUtils::print_on(st);
 }
 
@@ -908,7 +908,7 @@ void SerialHeap::print_heap_change(const PreGenGCValues& pre_gc_values) const {
   log_info(gc, heap)(HEAP_CHANGE_FORMAT" "
                      HEAP_CHANGE_FORMAT" "
                      HEAP_CHANGE_FORMAT,
-                     HEAP_CHANGE_FORMAT_ARGS(def_new_gen->short_name(),
+                     HEAP_CHANGE_FORMAT_ARGS(def_new_gen->name(),
                                              pre_gc_values.young_gen_used(),
                                              pre_gc_values.young_gen_capacity(),
                                              def_new_gen->used(),
@@ -924,7 +924,7 @@ void SerialHeap::print_heap_change(const PreGenGCValues& pre_gc_values) const {
                                              def_new_gen->from()->used(),
                                              def_new_gen->from()->capacity()));
   log_info(gc, heap)(HEAP_CHANGE_FORMAT,
-                     HEAP_CHANGE_FORMAT_ARGS(old_gen()->short_name(),
+                     HEAP_CHANGE_FORMAT_ARGS(old_gen()->name(),
                                              pre_gc_values.old_gen_used(),
                                              pre_gc_values.old_gen_capacity(),
                                              old_gen()->used(),

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -440,7 +440,15 @@ void TenuredGeneration::verify() {
 }
 
 void TenuredGeneration::print_on(outputStream* st)  const {
-  Generation::print_on(st);
-  st->print("   the");
+  st->print(" %-10s", name());
+
+  st->print(" total " SIZE_FORMAT "K, used " SIZE_FORMAT "K",
+            capacity()/K, used()/K);
+  st->print_cr(" [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT ")",
+               p2i(_virtual_space.low_boundary()),
+               p2i(_virtual_space.high()),
+               p2i(_virtual_space.high_boundary()));
+
+  st->print("  the");
   _the_space->print_on(st);
 }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.cpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.cpp
@@ -449,6 +449,6 @@ void TenuredGeneration::print_on(outputStream* st)  const {
                p2i(_virtual_space.high()),
                p2i(_virtual_space.high_boundary()));
 
-  st->print("  the");
+  st->print("   the");
   _the_space->print_on(st);
 }

--- a/src/hotspot/share/gc/serial/tenuredGeneration.hpp
+++ b/src/hotspot/share/gc/serial/tenuredGeneration.hpp
@@ -121,8 +121,7 @@ public:
                     CardTableRS* remset);
 
   // Printing
-  const char* name() const { return "tenured generation"; }
-  const char* short_name() const { return "Tenured"; }
+  const char* name() const { return "Tenured"; }
 
   // Iteration
   void object_iterate(ObjectClosure* blk);


### PR DESCRIPTION
Trivial inlining a virtual method to subclasses and some cleanup to related methods.

The gc-log is slightly updated due to the change of the name of generations. Log before&after shown below:

```
# baseline

[2.417s][debug][gc,heap] GC(0)  def new generation   total 153600K, used 76645K [0x000000060d800000, 0x0000000617ea0000, 0x00000006b3aa0000)
[2.417s][debug][gc,heap] GC(0)   eden space 136576K,  56% used [0x000000060d800000, 0x00000006122d9538, 0x0000000615d60000)
[2.417s][debug][gc,heap] GC(0)   from space 17024K,   0% used [0x0000000615d60000, 0x0000000615d60000, 0x0000000616e00000)
[2.417s][debug][gc,heap] GC(0)   to   space 17024K,   0% used [0x0000000616e00000, 0x0000000616e00000, 0x0000000617ea0000)
[2.417s][debug][gc,heap] GC(0)  tenured generation   total 341376K, used 0K [0x00000006b3aa0000, 0x00000006c8800000, 0x0000000800000000)
[2.417s][debug][gc,heap] GC(0)    the space 341376K,   0% used [0x00000006b3aa0000, 0x00000006b3aa0000, 0x00000006c8800000)

# new

[9.846s][debug][gc,heap] GC(0)  DefNew     total 153600K, used 71165K [0x000000060d800000, 0x0000000617ea0000, 0x00000006b3aa0000)
[9.846s][debug][gc,heap] GC(0)   eden space 136576K,  52% used [0x000000060d800000, 0x0000000611d7f708, 0x0000000615d60000)
[9.846s][debug][gc,heap] GC(0)   from space 17024K,   0% used [0x0000000615d60000, 0x0000000615d60000, 0x0000000616e00000)
[9.846s][debug][gc,heap] GC(0)   to   space 17024K,   0% used [0x0000000616e00000, 0x0000000616e00000, 0x0000000617ea0000)
[9.846s][debug][gc,heap] GC(0)  Tenured    total 341376K, used 0K [0x00000006b3aa0000, 0x00000006c8800000, 0x0000000800000000)
[9.846s][debug][gc,heap] GC(0)    the space 341376K,   0% used [0x00000006b3aa0000, 0x00000006b3aa0000, 0x00000006c8800000)

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338490](https://bugs.openjdk.org/browse/JDK-8338490): Serial: Move Generation::print_on to subclasses (**Enhancement** - P4)


### Reviewers
 * [Guoxiong Li](https://openjdk.org/census#gli) (@lgxbslgx - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20607/head:pull/20607` \
`$ git checkout pull/20607`

Update a local copy of the PR: \
`$ git checkout pull/20607` \
`$ git pull https://git.openjdk.org/jdk.git pull/20607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20607`

View PR using the GUI difftool: \
`$ git pr show -t 20607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20607.diff">https://git.openjdk.org/jdk/pull/20607.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20607#issuecomment-2292953399)