### PR TITLE
8337597: Macros should be defined in the global namespace in src/hotspot/share/memory/metaspace

### DIFF
--- a/src/hotspot/share/memory/metaspace/blockTree.cpp
+++ b/src/hotspot/share/memory/metaspace/blockTree.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,11 +31,6 @@
 #include "utilities/globalDefinitions.hpp"
 #include "utilities/growableArray.hpp"
 #include "utilities/ostream.hpp"
-
-namespace metaspace {
-
-// Needed to prevent linker errors on MacOS and AIX
-const size_t BlockTree::MinWordSize;
 
 #define NODE_FORMAT \
   "@" PTR_FORMAT \
@@ -74,6 +69,15 @@ const size_t BlockTree::MinWordSize;
 // Assert, prints tree and specific given node
 #define tree_assert_invalid_node(cond, failure_node) \
   tree_assert(cond, "Invalid node: " NODE_FORMAT, NODE_FORMAT_ARGS(failure_node))
+
+#endif // ASSERT
+
+namespace metaspace {
+
+// Needed to prevent linker errors on MacOS and AIX
+const size_t BlockTree::MinWordSize;
+
+#ifdef ASSERT
 
 // walkinfo keeps a node plus the size corridor it and its children
 //  are supposed to be in.

--- a/src/hotspot/share/memory/metaspace/chunkManager.cpp
+++ b/src/hotspot/share/memory/metaspace/chunkManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -41,10 +41,10 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-namespace metaspace {
-
 #define LOGFMT         "ChkMgr @" PTR_FORMAT " (%s)"
 #define LOGFMT_ARGS    p2i(this), this->_name
+
+namespace metaspace {
 
 // Return a single chunk to the freelist and adjust accounting. No merge is attempted.
 void ChunkManager::return_chunk_simple_locked(Metachunk* c) {

--- a/src/hotspot/share/memory/metaspace/internalStats.cpp
+++ b/src/hotspot/share/memory/metaspace/internalStats.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -44,6 +44,9 @@ void InternalStats::print_on(outputStream* st) {
 #define PRINT_COUNTER(name)  st->print_cr("%s: " UINTX_FORMAT ".", xstr(name), _##name);
   ALL_MY_COUNTERS(PRINT_COUNTER, PRINT_COUNTER)
 #undef PRINT_COUNTER
+
+#undef xstr
+#undef str
 
 }
 

--- a/src/hotspot/share/memory/metaspace/metaspaceArena.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceArena.cpp
@@ -45,10 +45,10 @@
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 
-namespace metaspace {
-
 #define LOGFMT         "Arena @" PTR_FORMAT " (%s)"
 #define LOGFMT_ARGS    p2i(this), this->_name
+
+namespace metaspace {
 
 // Returns the level of the next chunk to be added, acc to growth policy.
 chunklevel_t MetaspaceArena::next_chunk_level() const {

--- a/src/hotspot/share/memory/metaspace/metaspaceArenaGrowthPolicy.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceArenaGrowthPolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -99,6 +99,8 @@ const ArenaGrowthPolicy* ArenaGrowthPolicy::policy_for_space_type(Metaspace::Met
   DEFINE_CLASS_FOR_ARRAY(refl_class)
   DEFINE_CLASS_FOR_ARRAY(boot_non_class)
   DEFINE_CLASS_FOR_ARRAY(boot_class)
+
+#undef DEFINE_CLASS_FOR_ARRAY
 
   if (is_class) {
     switch(space_type) {

--- a/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
+++ b/src/hotspot/share/memory/metaspace/virtualSpaceList.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -37,10 +37,10 @@
 #include "runtime/atomic.hpp"
 #include "runtime/mutexLocker.hpp"
 
-namespace metaspace {
-
 #define LOGFMT         "VsList @" PTR_FORMAT " (%s)"
 #define LOGFMT_ARGS    p2i(this), this->_name
+
+namespace metaspace {
 
 // Create a new, empty, expandable list.
 VirtualSpaceList::VirtualSpaceList(const char* name, CommitLimiter* commit_limiter) :


### PR DESCRIPTION
Hi everyone,

Metaspace currently contains macros that appear to be scoped within the `metaspace` namespace, but in reality, their scope is global. To avoid confusion, these macros should be moved to the global namespace.

Additionally, there are instances where macros are defined within functions for localized use. Moving these macros outside the functions would introduce unnecessary complexity. Instead, I’ve opted to `#undef` these macros immediately after their use, ensuring they remain accessible only within their respective functions.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337597](https://bugs.openjdk.org/browse/JDK-8337597): Macros should be defined in the global namespace in src/hotspot/share/memory/metaspace (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20610/head:pull/20610` \
`$ git checkout pull/20610`

Update a local copy of the PR: \
`$ git checkout pull/20610` \
`$ git pull https://git.openjdk.org/jdk.git pull/20610/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20610`

View PR using the GUI difftool: \
`$ git pr show -t 20610`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20610.diff">https://git.openjdk.org/jdk/pull/20610.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20610#issuecomment-2293668090)