### PR TITLE
Revert "8336655: java/net/httpclient/DigestEchoClient.java IOException: HTTP/1.1 header parser received no bytes"

### DIFF
--- a/test/jdk/java/net/httpclient/DigestEchoClient.java
+++ b/test/jdk/java/net/httpclient/DigestEchoClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ import static java.lang.String.format;
  * @test
  * @summary this test verifies that a client may provides authorization
  *          headers directly when connecting with a server.
- * @bug 8087112 8336655
+ * @bug 8087112
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.common.HttpServerAdapters jdk.test.lib.net.SimpleSSLContext
  *        DigestEchoServer ReferenceTracker DigestEchoClient


### PR DESCRIPTION
This reverts commit 6169613d9f3f0bf019d04a37a1d8f28f1463c17c.

I pushed that fix yesterday and this seems to be causing regression in the CI. Strange that my testing didn't reveal anything.

I would like to revert JDK-8336655 and take more time to hopefully come with a better fix.
