### PR TITLE
8338488: Add screen capture for failure case

### DIFF
--- a/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
@@ -29,6 +29,10 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Robot;
 import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
 
 /*
  * @test
@@ -78,6 +82,12 @@ public class CheckboxCheckerScalingTest {
             });
 
             if (!checkmarkFound) {
+                try {
+                    ImageIO.write(imageAfterChecked, "png",
+                            new File("imageAfterChecked.png"));
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
                 throw new RuntimeException("Checkmark not scaled");
             }
             System.out.println("Test Passed");


### PR DESCRIPTION
open/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java is failing intermittently on Linux (https://bugs.openjdk.org/browse/JDK-8338153). As part of analysis I've updated the test with image writing on failure condition.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338488](https://bugs.openjdk.org/browse/JDK-8338488): Add screen capture for failure case (**Sub-task** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20614/head:pull/20614` \
`$ git checkout pull/20614`

Update a local copy of the PR: \
`$ git checkout pull/20614` \
`$ git pull https://git.openjdk.org/jdk.git pull/20614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20614`

View PR using the GUI difftool: \
`$ git pr show -t 20614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20614.diff">https://git.openjdk.org/jdk/pull/20614.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20614#issuecomment-2293375819)