### PR TITLE
8333098: ubsan: bytecodeInfo.cpp:318:59: runtime error: division by zero

### DIFF
--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -315,7 +315,13 @@ bool InlineTree::should_not_inline(ciMethod* callee_method, ciMethod* caller_met
       int invoke_count     = caller_method->interpreter_invocation_count();
       assert(invoke_count != 0, "require invocation count greater than zero");
       double freq = (double)call_site_count / (double)invoke_count;
-      double min_freq = MAX2(MinInlineFrequencyRatio, 1.0 / CompilationPolicy::min_invocations());
+      double min_freq = 0.0;
+      int cp_min_inv = CompilationPolicy::min_invocations();
+      if (cp_min_inv == 0) {
+        min_freq = MinInlineFrequencyRatio;
+      } else {
+        min_freq = MAX2(MinInlineFrequencyRatio, 1.0 / cp_min_inv);
+      }
 
       if (freq < min_freq) {
         set_msg("low call site frequency");

--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -315,13 +315,8 @@ bool InlineTree::should_not_inline(ciMethod* callee_method, ciMethod* caller_met
       int invoke_count     = caller_method->interpreter_invocation_count();
       assert(invoke_count != 0, "require invocation count greater than zero");
       double freq = (double)call_site_count / (double)invoke_count;
-      double min_freq = 0.0;
-      int cp_min_inv = CompilationPolicy::min_invocations();
-      if (cp_min_inv == 0) {
-        min_freq = MinInlineFrequencyRatio;
-      } else {
-        min_freq = MAX2(MinInlineFrequencyRatio, 1.0 / cp_min_inv);
-      }
+      int cp_min_inv = MAX2(1, CompilationPolicy::min_invocations());
+      double min_freq = MAX2(MinInlineFrequencyRatio, 1.0 / cp_min_inv);
 
       if (freq < min_freq) {
         set_msg("low call site frequency");

--- a/src/hotspot/share/opto/bytecodeInfo.cpp
+++ b/src/hotspot/share/opto/bytecodeInfo.cpp
@@ -315,6 +315,7 @@ bool InlineTree::should_not_inline(ciMethod* callee_method, ciMethod* caller_met
       int invoke_count     = caller_method->interpreter_invocation_count();
       assert(invoke_count != 0, "require invocation count greater than zero");
       double freq = (double)call_site_count / (double)invoke_count;
+      // avoid division by 0, set divisor to at least 1
       int cp_min_inv = MAX2(1, CompilationPolicy::min_invocations());
       double min_freq = MAX2(MinInlineFrequencyRatio, 1.0 / cp_min_inv);
 


### PR DESCRIPTION
When running test
compiler/classUnloading/methodUnloading/TestOverloadCompileQueues.java
with ubsan enabled binaries we run into the issue reported below.
Reason seems to be that we divide by zero in the code in some special cases (we should instead check for `CompilationPolicy::min_invocations() == 0 `and handle it separately).

/jdk/src/hotspot/share/opto/bytecodeInfo.cpp:318:59: runtime error: division by zero
    #0 0x7f5145c0dda2 in InlineTree::should_not_inline(ciMethod*, ciMethod*, int, bool&, ciCallProfile&) src/hotspot/share/opto/bytecodeInfo.cpp:318
    #1 0x7f51466366d7 in InlineTree::try_to_inline(ciMethod*, ciMethod*, int, JVMState*, ciCallProfile&, bool&) src/hotspot/share/opto/bytecodeInfo.cpp:382
    #2 0x7f514663d36b in InlineTree::ok_to_inline(ciMethod*, JVMState*, ciCallProfile&, bool&) src/hotspot/share/opto/bytecodeInfo.cpp:596
    #3 0x7f51470dffd6 in Compile::call_generator(ciMethod*, int, bool, JVMState*, bool, float, ciKlass*, bool) src/hotspot/share/opto/doCall.cpp:189
    #4 0x7f51470e18ab in Parse::do_call() src/hotspot/share/opto/doCall.cpp:641
    #5 0x7f514887dbf1 in Parse::do_one_block() src/hotspot/share/opto/parse1.cpp:1607
    #6 0x7f514887fefa in Parse::do_all_blocks() src/hotspot/share/opto/parse1.cpp:724
    #7 0x7f514888d4da in Parse::Parse(JVMState*, ciMethod*, float) src/hotspot/share/opto/parse1.cpp:628
    #8 0x7f51469d8418 in ParseGenerator::generate(JVMState*) src/hotspot/share/opto/callGenerator.cpp:99
    #9 0x7f5146d99cff in Compile::Compile(ciEnv*, ciMethod*, int, Options, DirectiveSet*) src/hotspot/share/opto/compile.cpp:793
    #10 0x7f51469d5ebf in C2Compiler::compile_method(ciEnv*, ciMethod*, int, bool, DirectiveSet*) src/hotspot/share/opto/c2compiler.cpp:142
    #11 0x7f5146db0274 in CompileBroker::invoke_compiler_on_method(CompileTask*) src/hotspot/share/compiler/compileBroker.cpp:2303
    #12 0x7f5146db2826 in CompileBroker::compiler_thread_loop() src/hotspot/share/compiler/compileBroker.cpp:1961
    #13 0x7f51478d475a in JavaThread::thread_main_inner() src/hotspot/share/runtime/javaThread.cpp:759
    #14 0x7f51491620ea in Thread::call_run() src/hotspot/share/runtime/thread.cpp:225
    #15 0x7f51487ac201 in thread_native_entry src/hotspot/os/linux/os_linux.cpp:846
    #16 0x7f514e5cf6e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 2f8d3c2d0f4d7888c2598d2ff6356537f5708a73)
    #17 0x7f514db1550e in clone (/lib64/libc.so.6+0x11850e) (BuildId: f732026552f6adff988b338e92d466bc81a01c37)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8333098](https://bugs.openjdk.org/browse/JDK-8333098): ubsan: bytecodeInfo.cpp:318:59: runtime error: division by zero (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20615/head:pull/20615` \
`$ git checkout pull/20615`

Update a local copy of the PR: \
`$ git checkout pull/20615` \
`$ git pull https://git.openjdk.org/jdk.git pull/20615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20615`

View PR using the GUI difftool: \
`$ git pr show -t 20615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20615.diff">https://git.openjdk.org/jdk/pull/20615.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20615#issuecomment-2293381423)