### PR TITLE
8298920: Improve microbenchmark build times

### DIFF
--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -282,8 +282,23 @@ define SetupJavaCompilationBody
     $1_FLAGS += -Xlint:$$(call CommaList, $$(addprefix -, $$($1_DISABLED_WARNINGS)))
   endif
 
-  ifneq ($$($1_CLASSPATH), )
-    $1_FLAGS += -cp $$(call PathList, $$($1_CLASSPATH))
+  $1_AUGMENTED_CLASSPATH := $$($1_CLASSPATH)
+  $1_API_TARGET := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_pubapi
+  $1_API_INTERNAL := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_internalapi
+
+  ifeq ($$($1_CREATE_API_DIGEST), true)
+    $1_API_DIGEST_FLAGS := \
+        -Xplugin:"depend $$($1_API_TARGET)" \
+        "-XDinternalAPIPath=$$($1_API_INTERNAL)" \
+        "-XDLOG_LEVEL=$(LOG_LEVEL)" \
+        #
+
+    $1_EXTRA_DEPS := $$(BUILDTOOLS_OUTPUTDIR)/depend/_the.COMPILE_DEPEND_batch
+    $1_AUGMENTED_CLASSPATH += $$(BUILDTOOLS_OUTPUTDIR)/depend
+  endif
+
+  ifneq ($$($1_AUGMENTED_CLASSPATH), )
+    $1_FLAGS += -cp $$(call PathList, $$($1_AUGMENTED_CLASSPATH))
   endif
 
   # Make sure the dirs exist, or that one of the EXTRA_FILES, that may not
@@ -411,9 +426,6 @@ define SetupJavaCompilationBody
     $1_MODFILELIST := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_batch.modfiles
     $1_MODFILELIST_FIXED := $$($1_MODFILELIST).fixed
 
-    $1_API_TARGET := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_pubapi
-    $1_API_INTERNAL := $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1_internalapi
-
     # Put headers in a temp dir to filter out those that actually
     # changed before copying them to the real header dir.
     ifneq (,$$($1_HEADERS))
@@ -441,17 +453,6 @@ define SetupJavaCompilationBody
         $$($1_EXCLUDE_FILES) $$($1_INCLUDE_FILES)
     $1_VARDEPS_FILE := $$(call DependOnVariable, $1_VARDEPS, \
         $$($1_BIN)$$($1_MODULE_SUBDIR)/_the.$1.vardeps)
-
-    ifeq ($$($1_CREATE_API_DIGEST), true)
-      $1_API_DIGEST_FLAGS := \
-          -classpath $$(BUILDTOOLS_OUTPUTDIR)/depend \
-          -Xplugin:"depend $$($1_API_TARGET)" \
-          "-XDinternalAPIPath=$$($1_API_INTERNAL)" \
-          "-XDLOG_LEVEL=$(LOG_LEVEL)" \
-          #
-
-      $1_EXTRA_DEPS := $$(BUILDTOOLS_OUTPUTDIR)/depend/_the.COMPILE_DEPEND_batch
-    endif
 
     # Create a file with all sources, to pass to javac in an @file.
     # $$($1_VARDEPS_FILE) is used as dependency to track changes in set of

--- a/make/common/JavaCompilation.gmk
+++ b/make/common/JavaCompilation.gmk
@@ -294,7 +294,10 @@ define SetupJavaCompilationBody
         #
 
     $1_EXTRA_DEPS := $$(BUILDTOOLS_OUTPUTDIR)/depend/_the.COMPILE_DEPEND_batch
-    $1_AUGMENTED_CLASSPATH += $$(BUILDTOOLS_OUTPUTDIR)/depend
+    # including the compilation output on the classpath, so that incremental
+    # compilations in unnamed module can refer to other classes from the same
+    # source root, which are not being recompiled in this compilation:
+    $1_AUGMENTED_CLASSPATH += $$(BUILDTOOLS_OUTPUTDIR)/depend $$($1_BIN)
   endif
 
   ifneq ($$($1_AUGMENTED_CLASSPATH), )

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -94,6 +94,7 @@ $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
     SMALL_JAVA := false, \
     CLASSPATH := $(JMH_COMPILE_JARS), \
+    CREATE_API_DIGEST := true, \
     DISABLED_WARNINGS := restricted this-escape processing rawtypes removal cast \
         serial preview dangling-doc-comments, \
     SRC := $(MICROBENCHMARK_SRC), \

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -93,7 +93,7 @@ $(eval $(call SetupJavaCompilation, BUILD_INDIFY, \
 $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
     SMALL_JAVA := false, \
-    CLASSPATH := $(JMH_COMPILE_JARS), \
+    CLASSPATH := $(JMH_COMPILE_JARS) $(MICROBENCHMARK_CLASSES), \
     CREATE_API_DIGEST := true, \
     DISABLED_WARNINGS := restricted this-escape processing rawtypes removal cast \
         serial preview dangling-doc-comments, \

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -93,7 +93,7 @@ $(eval $(call SetupJavaCompilation, BUILD_INDIFY, \
 $(eval $(call SetupJavaCompilation, BUILD_JDK_MICROBENCHMARK, \
     TARGET_RELEASE := $(TARGET_RELEASE_NEWJDK_UPGRADED), \
     SMALL_JAVA := false, \
-    CLASSPATH := $(JMH_COMPILE_JARS) $(MICROBENCHMARK_CLASSES), \
+    CLASSPATH := $(JMH_COMPILE_JARS), \
     CREATE_API_DIGEST := true, \
     DISABLED_WARNINGS := restricted this-escape processing rawtypes removal cast \
         serial preview dangling-doc-comments, \


### PR DESCRIPTION
Currently incremental builds for the microbenchmarks may take notable amount of time, like:
```
$ touch test/micro/org/openjdk/bench/java/io/BlackholedOutputStream.java; time make test TEST=jaxp:tier1
Building target 'test' in configuration 'linux-x86_64-server-release'
Compiling up to 656 files for BUILD_JDK_MICROBENCHMARK
Running Indify on microbenchmark classes
[snip]
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jaxp:tier1                                 0     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-x86_64-server-release'

real    0m37,581s
user    2m4,747s
sys     0m7,223s
```

The microbenchmark compilation is not using the `Depend` plugin that avoids recompilation of other files if the change files only contain minor changes (i.e. non-API changes). The patch here proposes to enhance the build to use the `Depend` plugin. The change that enables that is `CREATE_API_DIGEST := true,`, but since both the `Depend` plugin and JMH framework needs to be added to the classpath the patch re-organizes the code a little to properly augment the classpath.

With this patch, a build similar to the above might be:
```
$ touch test/micro/org/openjdk/bench/java/io/BlackholedOutputStream.java; time make test TEST=jaxp:tier1
Building target 'test' in configuration 'linux-x86_64-server-release'
Compiling up to 656 files for BUILD_JDK_MICROBENCHMARK
Running Indify on microbenchmark classes
[snip]
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jaxp:tier1                                 0     0     0     0
==============================
TEST SUCCESS

Finished building target 'test' in configuration 'linux-x86_64-server-release'

real    0m7,505s
user    0m14,128s
sys     0m3,158s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8298920](https://bugs.openjdk.org/browse/JDK-8298920): Improve microbenchmark build times (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**) Review applies to [f21c2b76](https://git.openjdk.org/jdk/pull/20616/files/f21c2b76ad054d1504c46a5617447559e267f72c)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20616/head:pull/20616` \
`$ git checkout pull/20616`

Update a local copy of the PR: \
`$ git checkout pull/20616` \
`$ git pull https://git.openjdk.org/jdk.git pull/20616/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20616`

View PR using the GUI difftool: \
`$ git pr show -t 20616`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20616.diff">https://git.openjdk.org/jdk/pull/20616.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20616#issuecomment-2293421756)