### PR TITLE
8338512: JFR: Revert changes to TestCodeSweeper

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -743,6 +743,7 @@ jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-
 
 # jdk_jfr
 
+jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 

--- a/test/jdk/jdk/jfr/event/compiler/TestCodeSweeper.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCodeSweeper.java
@@ -27,11 +27,9 @@ import java.lang.management.MemoryPoolMXBean;
 import java.lang.reflect.Method;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
-import jdk.jfr.Event;
-import jdk.jfr.consumer.RecordingStream;
+import jdk.jfr.Recording;
 import jdk.jfr.consumer.RecordedEvent;
 import jdk.test.lib.Asserts;
 import jdk.test.lib.jfr.EventNames;
@@ -41,7 +39,7 @@ import jdk.test.whitebox.code.BlobType;
 import jdk.test.whitebox.code.CodeBlob;
 
 /**
- * Test for events: jdk.CodeCacheFull jdk.CompilationFailure
+ * Test for events: vm/code_cache/full vm/compiler/failure
  *
  * We verify that we should get at least one of each of the events listed above.
  *
@@ -60,15 +58,13 @@ import jdk.test.whitebox.code.CodeBlob;
  */
 
 public class TestCodeSweeper {
-    static class ProvocationEvent extends Event {
-    }
     private static final WhiteBox WHITE_BOX = WhiteBox.getWhiteBox();
     private static final int COMP_LEVEL_SIMPLE = 1;
     private static final int COMP_LEVEL_FULL_OPTIMIZATION = 4;
     private static final int SIZE = 1;
     private static final String METHOD_NAME = "verifyFullEvent";
-    private static final String EVENT_CODE_CACHE_FULL = EventNames.CodeCacheFull;
-    private static final String EVENT_COMPILATION_FAILURE = EventNames.CompilationFailure;
+    private static final String pathFull = EventNames.CodeCacheFull;
+    private static final String pathFailure = EventNames.CompilationFailure;
     public static final long SEGMENT_SIZE = WhiteBox.getWhiteBox().getUintxVMFlag("CodeCacheSegmentSize");
     public static final long MIN_BLOCK_LENGTH = WhiteBox.getWhiteBox().getUintxVMFlag("CodeCacheMinBlockLength");
     public static final long MIN_ALLOCATION = SEGMENT_SIZE * MIN_BLOCK_LENGTH;
@@ -81,41 +77,26 @@ public class TestCodeSweeper {
         System.out.println("This test will warn that the code cache is full.");
         System.out.println("That is expected and is the purpose of the test.");
         System.out.println("************************************************");
-        List<RecordedEvent> events = Collections.synchronizedList(new ArrayList<>());
-        try (RecordingStream rs = new RecordingStream()) {
-            rs.setReuse(false);
-            rs.enable(EVENT_CODE_CACHE_FULL);
-            rs.enable(EVENT_COMPILATION_FAILURE);
-            rs.onEvent(EVENT_CODE_CACHE_FULL, events::add);
-            rs.onEvent(EVENT_COMPILATION_FAILURE, events::add);
-            rs.onEvent(ProvocationEvent.class.getName(), e -> {
-                if (!events.isEmpty()) {
-                    rs.close();
-                    return;
-                }
-                // Retry if CodeCacheFull or CompilationFailure events weren't provoked
-                try {
-                    provokeEvents();
-                } catch (Exception ex) {
-                    ex.printStackTrace();
-                    rs.close();
-                }
-            });
-            rs.startAsync();
-            provokeEvents();
-            rs.awaitTermination();
-        }
+
+        Recording r = new Recording();
+        r.enable(pathFull);
+        r.enable(pathFailure);
+        r.start();
+        provokeEvents();
+        r.stop();
 
         int countEventFull = 0;
         int countEventFailure = 0;
+
+        List<RecordedEvent> events = Events.fromRecording(r);
         Events.hasEvents(events);
-        for (RecordedEvent event : new ArrayList<>(events)) {
+        for (RecordedEvent event : events) {
             switch (event.getEventType().getName()) {
-            case EVENT_CODE_CACHE_FULL:
+            case pathFull:
                 countEventFull++;
                 verifyFullEvent(event);
                 break;
-            case EVENT_COMPILATION_FAILURE:
+            case pathFailure:
                 countEventFailure++;
                 verifyFailureEvent(event);
                 break;
@@ -134,8 +115,6 @@ public class TestCodeSweeper {
     }
 
     private static void provokeEvents() throws NoSuchMethodException, InterruptedException {
-        System.out.println("provokeEvents()");
-        ProvocationEvent provocationEvent = new ProvocationEvent();
         // Prepare for later, since we don't want to trigger any compilation
         // setting this up.
         Method method = TestCodeSweeper.class.getDeclaredMethod(METHOD_NAME, new Class[] { RecordedEvent.class });
@@ -180,7 +159,6 @@ public class TestCodeSweeper {
         for (Long blob : blobs) {
             WHITE_BOX.freeCodeBlob(blob);
         }
-        provocationEvent.commit();
     }
 
     private static void verifyFullEvent(RecordedEvent event) throws Throwable {


### PR DESCRIPTION
Could I have a review of a PR that reverts the change to TestCodeSweeper.java.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338512](https://bugs.openjdk.org/browse/JDK-8338512): JFR: Revert changes to TestCodeSweeper (**Sub-task** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20617/head:pull/20617` \
`$ git checkout pull/20617`

Update a local copy of the PR: \
`$ git checkout pull/20617` \
`$ git pull https://git.openjdk.org/jdk.git pull/20617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20617`

View PR using the GUI difftool: \
`$ git pr show -t 20617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20617.diff">https://git.openjdk.org/jdk/pull/20617.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20617#issuecomment-2293775465)