### PR TITLE
8338538: [JVMCI] Allow HotSpotJVMCIRuntime#getJObjectValue to be called by a HotSpot CompileBroker compiler thread

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -710,7 +710,8 @@ C2V_END
 
 C2V_VMENTRY_0(jlong, getJObjectValue, (JNIEnv* env, jobject, jobject constant_jobject))
     requireNotInHotSpot("getJObjectValue", JVMCI_CHECK_0);
-    // Ensure that we are not using the top-most JNIHandleBlock, which is never released.
+    // Ensure that current JNI handle scope is not the top-most JNIHandleBlock as handles
+    // in that scope are only released when the thread exits.
     if (!THREAD->has_last_Java_frame() && THREAD->active_handles()->pop_frame_link() == nullptr) {
         JVMCI_THROW_MSG_0(IllegalStateException, err_msg("Cannot call getJObjectValue without Java frame anchor or a pushed JNI handle block"));
     }

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -710,8 +710,9 @@ C2V_END
 
 C2V_VMENTRY_0(jlong, getJObjectValue, (JNIEnv* env, jobject, jobject constant_jobject))
     requireNotInHotSpot("getJObjectValue", JVMCI_CHECK_0);
-    if (!THREAD->has_last_Java_frame()) {
-        JVMCI_THROW_MSG_0(IllegalStateException, err_msg("Cannot call getJObjectValue without Java frame anchor"));
+    // Ensure that we are not using the top-most JNIHandleBlock, which is never released.
+    if (!THREAD->has_last_Java_frame() && THREAD->active_handles()->pop_frame_link() == nullptr) {
+        JVMCI_THROW_MSG_0(IllegalStateException, err_msg("Cannot call getJObjectValue without Java frame anchor or a pushed JNI handle block"));
     }
     JVMCIObject constant = JVMCIENV->wrap(constant_jobject);
     Handle constant_value = JVMCIENV->asConstant(constant, JVMCI_CHECK_0);


### PR DESCRIPTION
The `HotSpotJVMCIRuntime#getJObjectValue` method is currently invoked in two distinct scenarios:

Truffle Compiler: In this scenario, the method is called by a Truffle compiler thread. This thread is an ordinary Java thread that enters the shared library compiler (libgraal) via a Java native method call. Consequently, it always has a valid `JavaFrameAnchor` when invoking `HotSpotJVMCIRuntime#getJObjectValue` within the shared library compiler.

Host Compiler: In the second scenario, the method is called by a HotSpot CompileBroker compiler thread while inlining a Truffle call target into a host method. Here, the compiler thread is a JavaThread in the `_thread_in_vm` state before entering the shared library compiler (libgraal) and does not have a `JavaFrameAnchor`.

The `HotSpotJVMCIRuntime#getJObjectValue` method currently supports only the first scenario by asserting that the caller has a `JavaFrameAnchor`. However, this method should be adapted to also support the second scenario, where the caller thread lacks a `JavaFrameAnchor` but has an explicitly pushed JNI handle block. It is crucial that the `HotSpotJVMCIRuntime#getJObjectValue` method ensures it does not use the top-most `JNIHandleBlock`, which is never released. Utilizing this block for Java constants could potentially lead to memory leaks in the Java heap. To accommodate both scenarios, the method should be modified to allow execution also by threads without a `JavaFrameAnchor` provided they have an explicitly pushed JNI handle block.

Implementation Details: The method determines whether the caller thread has pushed a JNI handle block by using `THREAD->active_handles()->pop_frame_link()`. The `pop_frame_link` is set when [JavaThread::push_jni_handle_block](https://github.com/openjdk/jdk/blob/bd4160cea8b6b0fcf0507199ed76a12f5d0aaba9/src/hotspot/share/runtime/javaThread.cpp#L1360) is called and is reset in [JavaThread::pop_jni_handle_block](https://github.com/openjdk/jdk/blob/bd4160cea8b6b0fcf0507199ed76a12f5d0aaba9/src/hotspot/share/runtime/javaThread.cpp#L1371). Each active JavaThread has a non-null `_active_handles` pointer, which is initialized in [JavaThread::run](https://github.com/openjdk/jdk/blob/bd4160cea8b6b0fcf0507199ed76a12f5d0aaba9/src/hotspot/share/runtime/javaThread.cpp#L730).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338538](https://bugs.openjdk.org/browse/JDK-8338538): [JVMCI] Allow HotSpotJVMCIRuntime#getJObjectValue to be called by a HotSpot CompileBroker compiler thread (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20620/head:pull/20620` \
`$ git checkout pull/20620`

Update a local copy of the PR: \
`$ git checkout pull/20620` \
`$ git pull https://git.openjdk.org/jdk.git pull/20620/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20620`

View PR using the GUI difftool: \
`$ git pr show -t 20620`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20620.diff">https://git.openjdk.org/jdk/pull/20620.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20620#issuecomment-2295259402)