### PR TITLE
8338564: Remove obsolete AbstractNamedEntry::equals method

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -534,15 +534,6 @@ public abstract sealed class AbstractPoolEntry {
         public String asInternalName() {
             return ref1.stringValue();
         }
-
-        @Override
-        public boolean equals(Object o) {
-            if (o == this) { return true; }
-            if (o instanceof AbstractNamedEntry ne) {
-                return tag == ne.tag() && name().equals(ref1());
-            }
-            return false;
-        }
     }
 
     public static final class ClassEntryImpl extends AbstractNamedEntry implements ClassEntry {


### PR DESCRIPTION
Method `jdk.internal.classfile.impl.AbstractPoolEntry.AbstractNamedEntry::equals` implementation is invalid.
Fortunately it is overridden with valid implementation in all its sub types and it can be removed.

This patch removes the obsolete an invalid method implementation.

Please review.

Thanks,
Adam