### PR TITLE
8338550: Do libubsan1 installation in test container only if requested

### DIFF
--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -321,10 +321,11 @@ public class DockerTestUtils {
 
     private static void generateDockerFile(Path dockerfile, String baseImage,
                                            String baseImageVersion) throws Exception {
-        String template =
-            "FROM %s:%s\n" +
-            "RUN apt-get install libubsan1\n" +
-            "COPY /jdk /jdk\n" +
+        String template = "FROM %s:%s\n";
+        if (baseImage.contains("ubuntu")) {
+            template += "RUN apt-get update && apt-get install -y libubsan1\n";
+        }
+        template = template + "COPY /jdk /jdk\n" +
             "ENV JAVA_HOME=/jdk\n" +
             "CMD [\"/bin/bash\"]\n";
         String dockerFileStr = String.format(template, baseImage, baseImageVersion);

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -322,8 +322,7 @@ public class DockerTestUtils {
     private static void generateDockerFile(Path dockerfile, String baseImage,
                                            String baseImageVersion) throws Exception {
         String template = "FROM %s:%s\n";
-        boolean isUbsan = Boolean.getBoolean("jdk.test.docker.image.isUbsan");
-        if (baseImage.contains("ubuntu") && isUbsan) {
+        if (baseImage.contains("ubuntu") && DockerfileConfig.isUbsan()) {
             template += "RUN apt-get update && apt-get install -y libubsan1\n";
         }
         template = template + "COPY /jdk /jdk\n" +

--- a/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerTestUtils.java
@@ -322,7 +322,8 @@ public class DockerTestUtils {
     private static void generateDockerFile(Path dockerfile, String baseImage,
                                            String baseImageVersion) throws Exception {
         String template = "FROM %s:%s\n";
-        if (baseImage.contains("ubuntu")) {
+        boolean isUbsan = Boolean.getBoolean("jdk.test.docker.image.isUbsan");
+        if (baseImage.contains("ubuntu") && isUbsan) {
             template += "RUN apt-get update && apt-get install -y libubsan1\n";
         }
         template = template + "COPY /jdk /jdk\n" +

--- a/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
+++ b/test/lib/jdk/test/lib/containers/docker/DockerfileConfig.java
@@ -37,6 +37,11 @@ import jdk.test.lib.Platform;
 // Note: base image version should not be an empty string. Use "latest" to get the latest version.
 
 public class DockerfileConfig {
+
+    public static boolean isUbsan() {
+        return Boolean.getBoolean("jdk.test.docker.image.isUbsan");
+    }
+
     public static String getBaseImageName() {
         String name = System.getProperty("jdk.test.docker.image.name");
         if (name != null) {


### PR DESCRIPTION
After [JDK-8333144](https://bugs.openjdk.org/browse/JDK-8333144) docker related tests do not work on manually configured distros other than the 'standard' Ubuntu. This is because the basic generated Dockerfile with the change from [JDK-8333144](https://bugs.openjdk.org/browse/JDK-8333144) assumes 'apt-get' being available, which is not the case when one runs the testing on RPM based distributions.
So let's limit the libubsan1 installation to Ubuntu;  also add an 'apt-get update' to get recent package lists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338550](https://bugs.openjdk.org/browse/JDK-8338550): Do libubsan1 installation in test container only if requested (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20624/head:pull/20624` \
`$ git checkout pull/20624`

Update a local copy of the PR: \
`$ git checkout pull/20624` \
`$ git pull https://git.openjdk.org/jdk.git pull/20624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20624`

View PR using the GUI difftool: \
`$ git pr show -t 20624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20624.diff">https://git.openjdk.org/jdk/pull/20624.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20624#issuecomment-2296324458)