### PR TITLE
8281533: Odd "preview" label in link/linkplain

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/LinkTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/LinkTaglet.java
@@ -224,6 +224,7 @@ public class LinkTaglet extends BaseTaglet {
                 labelContent = plainOrCode(isPlain, Text.of(utils.getSimpleName(refClass)));
             }
             return htmlWriter.getLink(new HtmlLinkInfo(config, HtmlLinkInfo.Kind.PLAIN, refClass)
+                    .skipPreview(isPlain)
                     .label(labelContent));
         } else if (refMem == null) {
             // This is a fragment reference since refClass and refFragment are not null but refMem is null.

--- a/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/TestPreview.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug      8250768 8261976 8277300 8282452 8287597 8325325 8325874 8297879
- *           8331947
+ *           8331947 8281533
  * @summary  test generated docs for items declared using preview
  * @library  ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -156,7 +156,20 @@ public class TestPreview extends JavadocTester {
                     <li><a href="../module-summary.html">java.base</a></li>
                     <li><a href="package-summary.html">preview</a></li>
                     <li><a href="Core.html" class="current-selection">Core</a></li>
-                    </ol>""");
+                    </ol>""",
+                """
+                    <div class="block">Preview feature. Links: <a href="CoreRecord.html" title="cla\
+                    ss in preview"><code>CoreRecord</code></a><sup><a href="CoreRecord.html#preview\
+                    -preview.CoreRecord">PREVIEW</a></sup>, <a href="CoreRecord.html" title="class \
+                    in preview"><code>core record</code></a><sup><a href="CoreRecord.html#preview-p\
+                    review.CoreRecord">PREVIEW</a></sup>,
+                     <a href="CoreRecord.html" title="class in preview">CoreRecord</a>, <a href="Co\
+                    reRecord.html" title="class in preview">core record</a>.</div>""",
+                """
+                    <li><a href="CoreRecord.html" title="class in preview"><code>CoreRecord</code><\
+                    /a><sup><a href="CoreRecord.html#preview-preview.CoreRecord">PREVIEW</a></sup><\
+                    /li>
+                    <li><a href="CoreRecord.html" title="class in preview">core record</a></li>""");
 
         // 8331947: Support preview features without JEP should not be included in Preview API page
         checkOutput("preview-list.html", false, "supportMethod");

--- a/test/langtools/jdk/javadoc/doclet/testPreview/api/preview/Core.java
+++ b/test/langtools/jdk/javadoc/doclet/testPreview/api/preview/Core.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,13 @@ package preview;
 import jdk.internal.javac.PreviewFeature;
 import jdk.internal.javac.PreviewFeature.Feature;
 
+/**
+ * Preview feature. Links: {@link CoreRecord}, {@link CoreRecord core record},
+ * {@linkplain CoreRecord}, {@linkplain CoreRecord core record}.
+ *
+ * @see CoreRecord
+ * @see CoreRecord core record
+ */
 @PreviewFeature(feature=Feature.TEST)
 public class Core {
 }


### PR DESCRIPTION
Please review a patch to suppress the `PREVIEW` and `RESTRICTED` superscript labels for JavaDoc tags that generate plain links such as `{@linkplain ...}`. The rationale is that the purpose of plain links is usually to have the label not "stick out" of the local context, which makes the superscript label look odd. 

The fix itself consists of a single line in `LinkTaglet.java`. The major part of the changed lines is to clean up the generation of `PREVIEW` and `RESTRICTED` labels in `HtmlLinkFactory.java`, which I have wanted to do for a long time. Instead of generating internal and external links and plain-text labels in separate code, I have moved the code to a common method that will generate the appropriate link or label. It is a bit of a code smell that the `getSuperscript` method uses nullness of parameters to decide which link format to use, but I didn't know any reasonably simple better way to do this. I did add proper doc comments to explain what is returned even though the code is private.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281533](https://bugs.openjdk.org/browse/JDK-8281533): Odd "preview" label in link/linkplain (**Enhancement** - P4)


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20626/head:pull/20626` \
`$ git checkout pull/20626`

Update a local copy of the PR: \
`$ git checkout pull/20626` \
`$ git pull https://git.openjdk.org/jdk.git pull/20626/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20626`

View PR using the GUI difftool: \
`$ git pr show -t 20626`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20626.diff">https://git.openjdk.org/jdk/pull/20626.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20626#issuecomment-2296754927)