### PR TITLE
8338543: ClassBuilder withMethod builders should cache the method type symbol

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/ClassBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassBuilder.java
@@ -276,10 +276,7 @@ public sealed interface ClassBuilder
                                         MethodTypeDesc descriptor,
                                         int methodFlags,
                                         Consumer<? super CodeBuilder> handler) {
-        return withMethodBody(constantPool().utf8Entry(name),
-                              constantPool().utf8Entry(descriptor),
-                              methodFlags,
-                              handler);
+        return withMethod(name, descriptor, methodFlags, mb -> mb.withCode(handler));
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedClassBuilder.java
@@ -24,6 +24,7 @@
  */
 package jdk.internal.classfile.impl;
 
+import java.lang.constant.MethodTypeDesc;
 import java.util.function.Consumer;
 
 import java.lang.classfile.*;
@@ -75,6 +76,15 @@ public final class ChainedClassBuilder
                                                          name, descriptor, flags, null)
                                        .run(handler)
                                        .toModel());
+        return this;
+    }
+
+    @Override
+    public ClassBuilder withMethod(String name, MethodTypeDesc descriptor, int flags, Consumer<? super MethodBuilder> handler) {
+        var mb = new BufferedMethodBuilder(terminal.constantPool, terminal.context,
+                constantPool().utf8Entry(name), constantPool().utf8Entry(descriptor), flags, null);
+        mb.mDesc = descriptor;
+        consumer.accept(mb.run(handler).toModel());
         return this;
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
@@ -26,6 +26,7 @@
 package jdk.internal.classfile.impl;
 
 import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -104,6 +105,13 @@ public final class DirectClassBuilder
                                    Consumer<? super MethodBuilder> handler) {
         return withMethod(new DirectMethodBuilder(constantPool, context, name, descriptor, flags, null)
                                   .run(handler));
+    }
+
+    @Override
+    public ClassBuilder withMethod(String name, MethodTypeDesc descriptor, int flags, Consumer<? super MethodBuilder> handler) {
+        var method = new DirectMethodBuilder(constantPool, context, constantPool.utf8Entry(name), constantPool.utf8Entry(descriptor), flags, null);
+        method.mDesc = descriptor;
+        return withMethod(method.run(handler));
     }
 
     @Override


### PR DESCRIPTION
In #20611 and other investigations, we noted that `MethodTypeDesc.ofDescriptor` is unnecessarily called due to missing caching in ClassBuilder. This patch adds that missing caching functionality.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338543](https://bugs.openjdk.org/browse/JDK-8338543): ClassBuilder withMethod builders should cache the method type symbol (**Sub-task** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20627/head:pull/20627` \
`$ git checkout pull/20627`

Update a local copy of the PR: \
`$ git checkout pull/20627` \
`$ git pull https://git.openjdk.org/jdk.git pull/20627/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20627`

View PR using the GUI difftool: \
`$ git pr show -t 20627`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20627.diff">https://git.openjdk.org/jdk/pull/20627.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20627#issuecomment-2296821926)