### PR TITLE
8338595: Add more linesize for MIME decoder in macro bench test Base64Decode

### DIFF
--- a/test/micro/org/openjdk/bench/java/util/Base64Decode.java
+++ b/test/micro/org/openjdk/bench/java/util/Base64Decode.java
@@ -50,7 +50,7 @@ public class Base64Decode {
             "112", "512", "1000", "20000", "50000"})
     private int maxNumBytes;
 
-    @Param({"4"})
+    @Param({"4", "32", "76", "128"})
     private int lineSize;
 
     private byte[] lineSeparator = {'\r', '\n'};


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?

Currently, lineSize linesize for MIME case in macro bench test Base64Decode is only "4", but in Base64.Encoder default linesize for MIME encoder is 76.
It's helpful to add more linesize, e.g. 76 and so on.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338595](https://bugs.openjdk.org/browse/JDK-8338595): Add more linesize for MIME decoder in macro bench test Base64Decode (**Enhancement** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20630/head:pull/20630` \
`$ git checkout pull/20630`

Update a local copy of the PR: \
`$ git checkout pull/20630` \
`$ git pull https://git.openjdk.org/jdk.git pull/20630/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20630`

View PR using the GUI difftool: \
`$ git pr show -t 20630`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20630.diff">https://git.openjdk.org/jdk/pull/20630.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20630#issuecomment-2297005797)