### PR TITLE
8338611: java.lang.module specification wording not aligned with JEP 261

### DIFF
--- a/src/java.base/share/classes/java/lang/module/package-info.java
+++ b/src/java.base/share/classes/java/lang/module/package-info.java
@@ -154,9 +154,9 @@
  * application module specified to the 'java' launcher. When compiling code in
  * the unnamed module, or at run-time when the main application class is loaded
  * from the class path, then the default set of root modules is implementation
- * specific. In the JDK the default set of root modules contains every module
- * that is observable on the upgrade module path or among the system modules,
- * and that exports at least one package without qualification. </p>
+ * specific. In the JDK the default set of root modules contains every module on
+ * the upgrade module path or among the system modules that exports at least one
+ * package, without qualification. </p>
  *
  * <h3> Observable modules </h3>
  *


### PR DESCRIPTION
The `java.lang.module` package specification defines the default set of root modules as “every module that is observable on the upgrade module path or among the system modules, and that exports at least one package without qualification.” There’s no need to use the term “observable” here, since any module in those two locations is, by definition, observable.

This should be changed to align with the wording in [JEP 261](https://openjdk.org/jeps/261#Root-modules): “every module on the upgrade module path or among the system modules that exports at least one package, without qualification.”

This is not a substantive specification change, so a CSR is not required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338611](https://bugs.openjdk.org/browse/JDK-8338611): java.lang.module specification wording not aligned with JEP 261 (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20632/head:pull/20632` \
`$ git checkout pull/20632`

Update a local copy of the PR: \
`$ git checkout pull/20632` \
`$ git pull https://git.openjdk.org/jdk.git pull/20632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20632`

View PR using the GUI difftool: \
`$ git pr show -t 20632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20632.diff">https://git.openjdk.org/jdk/pull/20632.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20632#issuecomment-2297483114)