### PR TITLE
8336756: Improve ClassFile Annotation writing

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
+++ b/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
@@ -97,10 +97,7 @@ public sealed interface AnnotationValue {
      * @since 22
      */
     @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
-    sealed interface OfConstant
-            extends AnnotationValue
-            permits OfString, OfDouble, OfFloat, OfLong, OfInt, OfShort, OfChar, OfByte,
-                    OfBoolean, AnnotationImpl.OfConstantImpl {
+    sealed interface OfConstant extends AnnotationValue {
         /**
          * {@return the constant pool entry backing this constant element}
          *


### PR DESCRIPTION
Clean up annotation writing in classfile api: remove the redundant `Util.Writable` interfaces.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336756](https://bugs.openjdk.org/browse/JDK-8336756): Improve ClassFile Annotation writing (**Enhancement** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20635/head:pull/20635` \
`$ git checkout pull/20635`

Update a local copy of the PR: \
`$ git checkout pull/20635` \
`$ git pull https://git.openjdk.org/jdk.git pull/20635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20635`

View PR using the GUI difftool: \
`$ git pr show -t 20635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20635.diff">https://git.openjdk.org/jdk/pull/20635.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20635#issuecomment-2297526809)