### PR TITLE
8328313: Archived module graph should allow identical --module-path to be specified during dump time and run time

### DIFF
--- a/src/hotspot/share/cds/cdsConfig.cpp
+++ b/src/hotspot/share/cds/cdsConfig.cpp
@@ -236,7 +236,7 @@ void CDSConfig::init_shared_archive_paths() {
 }
 
 void CDSConfig::check_internal_module_property(const char* key, const char* value) {
-  if (Arguments::is_internal_module_property(key)) {
+  if (Arguments::is_internal_module_property(key) && !Arguments::is_module_path_property(key)) {
     stop_using_optimized_module_handling();
     log_info(cds)("optimized module handling: disabled due to incompatible property: %s=%s", key, value);
   }

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -270,6 +270,7 @@ public:
   bool has_non_jar_in_classpath()          const { return _has_non_jar_in_classpath; }
   bool compressed_oops()                   const { return _compressed_oops; }
   bool compressed_class_pointers()         const { return _compressed_class_ptrs; }
+  bool has_full_module_graph()             const { return _has_full_module_graph; }
   size_t heap_roots_offset()               const { return _heap_roots_offset; }
   size_t heap_oopmap_start_pos()           const { return _heap_oopmap_start_pos; }
   size_t heap_ptrmap_start_pos()           const { return _heap_ptrmap_start_pos; }
@@ -343,6 +344,7 @@ private:
 
   static SharedPathTable       _shared_path_table;
   static bool                  _validating_shared_path_table;
+  static bool                  _mismatched_module_paths;
 
   // FileMapHeader describes the shared space data in the file to be
   // mapped.  This structure gets written to a file.  It is not a class, so
@@ -406,6 +408,7 @@ public:
   bool is_mapped()                            const { return _is_mapped; }
   void set_is_mapped(bool v)                        { _is_mapped = v; }
   const char* full_path()                     const { return _full_path; }
+  bool mismatched_module_paths()              const { return _mismatched_module_paths; }
 
   void set_requested_base(char* b)                  { header()->set_requested_base(b); }
   char* requested_base_address()           const    { return header()->requested_base_address(); }
@@ -554,6 +557,10 @@ public:
                     GrowableArray<const char*>* rp_array,
                     unsigned int dumptime_prefix_len,
                     unsigned int runtime_prefix_len) NOT_CDS_RETURN_(false);
+  bool  check_paths_unordered(int shared_path_start_idx, int num_paths,
+                              GrowableArray<const char*>* rp_array) NOT_CDS_RETURN_(false);
+  bool  is_jar_suffix(const char* filename);
+  void  extract_module_paths(const char* runtime_path, GrowableArray<const char*>* module_paths);
   bool  validate_boot_class_paths() NOT_CDS_RETURN_(false);
   bool  validate_app_class_paths(int shared_app_paths_len) NOT_CDS_RETURN_(false);
   bool  map_heap_region_impl() NOT_CDS_JAVA_HEAP_RETURN_(false);

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -1103,6 +1103,13 @@ bool HeapShared::archive_reachable_objects_from(int level,
     // these objects that are referenced (directly or indirectly) by static fields.
     ResourceMark rm;
     log_error(cds, heap)("Cannot archive object of class %s", orig_obj->klass()->external_name());
+    if (log_is_enabled(Trace, cds, heap)) {
+      WalkOopAndArchiveClosure* walker = WalkOopAndArchiveClosure::current();
+      if (walker != nullptr) {
+        LogStream ls(Log(cds, heap)::trace());
+        CDSHeapVerifier::trace_to_root(&ls, walker->referencing_obj());
+      }
+    }
     MetaspaceShared::unrecoverable_writing_error();
   }
 

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -791,6 +791,9 @@ void MetaspaceShared::preload_and_dump_impl(StaticArchiveBuilder& builder, TRAPS
     // Do this at the very end, when no Java code will be executed. Otherwise
     // some new strings may be added to the intern table.
     StringTable::allocate_shared_strings_array(CHECK);
+  } else {
+    log_info(cds)("Not dumping heap, reset CDSConfig::_is_using_optimized_module_handling");
+    CDSConfig::stop_using_optimized_module_handling();
   }
 #endif
 

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -183,6 +183,9 @@ JVM_IsForeignLinkerSupported(void);
 JNIEXPORT void JNICALL
 JVM_InitializeFromArchive(JNIEnv* env, jclass cls);
 
+JNIEXPORT jboolean JNICALL
+JVM_IsUsingOptimizedModuleHandling(void);
+
 JNIEXPORT void JNICALL
 JVM_RegisterLambdaProxyClassForArchiving(JNIEnv* env, jclass caller,
                                          jstring interfaceMethodName,

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3557,6 +3557,10 @@ JVM_ENTRY(void, JVM_InitializeFromArchive(JNIEnv* env, jclass cls))
   HeapShared::initialize_from_archived_subgraph(THREAD, k);
 JVM_END
 
+JVM_LEAF(jboolean, JVM_IsUsingOptimizedModuleHandling(void))
+  return CDSConfig::is_using_optimized_module_handling() ? JNI_TRUE : JNI_FALSE;
+JVM_END
+
 JVM_ENTRY(void, JVM_RegisterLambdaProxyClassForArchiving(JNIEnv* env,
                                               jclass caller,
                                               jstring interfaceMethodName,

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -333,6 +333,17 @@ bool Arguments::is_internal_module_property(const char* property) {
   return false;
 }
 
+// Return true if the key matches the --module-path property name ("jdk.module.path").
+bool Arguments::is_module_path_property(const char* key) {
+  if (strncmp(key, MODULE_PROPERTY_PREFIX, MODULE_PROPERTY_PREFIX_LEN) == 0) {
+    const char* property_suffix = key + MODULE_PROPERTY_PREFIX_LEN;
+    if (matches_property_suffix(property_suffix, PATH, PATH_LEN)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Process java launcher properties.
 void Arguments::process_sun_java_launcher_properties(JavaVMInitArgs* args) {
   // See if sun.java.launcher or sun.java.launcher.is_altjvm is defined.

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -461,6 +461,7 @@ class Arguments : AllStatic {
   static int  PropertyList_readable_count(SystemProperty* pl);
 
   static bool is_internal_module_property(const char* option);
+  static bool is_module_path_property(const char* key);
 
   // Miscellaneous System property value getter and setters.
   static void set_dll_dir(const char *value) { _sun_boot_library_path->set_value(value); }

--- a/src/java.base/share/classes/jdk/internal/loader/BuiltinClassLoader.java
+++ b/src/java.base/share/classes/jdk/internal/loader/BuiltinClassLoader.java
@@ -1085,4 +1085,9 @@ public class BuiltinClassLoader
         ucp = null;
         resourceCache = null;
     }
+
+    // Called during -Xshare:dump from AppClassLoader.resetArchivedStates().
+    void clearModuleToReader() {
+        if (!moduleToReader.isEmpty()) moduleToReader.clear();
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
+++ b/src/java.base/share/classes/jdk/internal/loader/ClassLoaders.java
@@ -216,6 +216,7 @@ public class ClassLoaders {
          */
         private void resetArchivedStates() {
             setClassPath(null);
+            clearModuleToReader();
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/misc/CDS.java
+++ b/src/java.base/share/classes/jdk/internal/misc/CDS.java
@@ -104,6 +104,11 @@ public class CDS {
     public static native long getRandomSeedForDumping();
 
     /**
+     * Returns the value of CDSConfig::_is_using_optimized_module_handling.
+     */
+    public static native boolean isUsingOptimizedModuleHandling();
+
+    /**
      * log lambda form invoker holder, name and method type
      */
     public static void logLambdaFormInvoker(String prefix, String holder, String name, String type) {

--- a/src/java.base/share/classes/jdk/internal/module/ArchivedModuleGraph.java
+++ b/src/java.base/share/classes/jdk/internal/module/ArchivedModuleGraph.java
@@ -108,6 +108,8 @@ class ArchivedModuleGraph {
     }
 
     static {
-        CDS.initializeFromArchive(ArchivedModuleGraph.class);
+        if (CDS.isUsingOptimizedModuleHandling()) {
+            CDS.initializeFromArchive(ArchivedModuleGraph.class);
+        }
     }
 }

--- a/src/java.base/share/native/libjava/CDS.c
+++ b/src/java.base/share/native/libjava/CDS.c
@@ -63,3 +63,8 @@ JNIEXPORT void JNICALL
 Java_jdk_internal_misc_CDS_dumpDynamicArchive(JNIEnv *env, jclass jcls, jstring archiveName) {
     JVM_DumpDynamicArchive(env, archiveName);
 }
+
+JNIEXPORT jboolean JNICALL
+Java_jdk_internal_misc_CDS_isUsingOptimizedModuleHandling(JNIEnv *env, jclass jcls) {
+    return JVM_IsUsingOptimizedModuleHandling();
+}

--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -437,6 +437,8 @@ hotspot_appcds_dynamic = \
  -runtime/cds/appcds/cacheObject \
  -runtime/cds/appcds/customLoader \
  -runtime/cds/appcds/dynamicArchive \
+ -runtime/cds/appcds/jigsaw/modulepath/ModulePathAndFMG.java \
+ -runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java \
  -runtime/cds/appcds/loaderConstraints/DynamicLoaderConstraintsTest.java \
  -runtime/cds/appcds/javaldr/ArrayTest.java \
  -runtime/cds/appcds/javaldr/ExceptionDuringDumpAtObjectsInitPhase.java \

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/module/ModuleOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/module/ModuleOption.java
@@ -110,19 +110,17 @@ public class ModuleOption {
             "-m", incubatorModule,
             "-version");
         oa.shouldHaveExitValue(0)
-          // module graph won't be archived with an incubator module
-          .shouldContain("archivedBootLayer not available, disabling full module graph");
+          // module graph will be archived with an incubator module
+          .shouldNotContain("archivedBootLayer not available, disabling full module graph");
 
         // run with the same incubator module
         oa = TestCommon.execCommon(
             loggingOption,
             "-m", incubatorModule,
             "-version");
-        oa.shouldContain("full module graph: disabled")
-          // module is not restored from archive
-          .shouldContain("define_module(): creation of module: jdk.incubator.vector")
-          .shouldContain("WARNING: Using incubator modules: jdk.incubator.vector")
-          .shouldContain("subgraph jdk.internal.module.ArchivedBootLayer is not recorde")
+        oa.shouldContain("use_full_module_graph = true")
+          .shouldMatch(".*Restored from archive:.*jdk.incubator.vector.*")
+          .shouldContain("resolve subgraph jdk.internal.module.ArchivedBootLayer")
           .shouldContain("module jdk.incubator.vector does not have a ModuleMainClass attribute, use -m <module>/<main-class>")
           .shouldHaveExitValue(1);
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndFMG.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/ModulePathAndFMG.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8328313
+ * @requires vm.cds & !vm.graal.enabled & vm.cds.write.archived.java.heap
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @run driver ModulePathAndFMG
+ * @summary test module path changes for full module graph handling.
+ *
+ */
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+
+import jdk.test.lib.cds.CDSTestUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class ModulePathAndFMG {
+
+    private static final Path USER_DIR = Paths.get(CDSTestUtils.getOutputDir());
+
+    private static final String TEST_SRC = System.getProperty("test.src");
+
+    private static final Path SRC_DIR = Paths.get(TEST_SRC, "src");
+    private static final Path MODS_DIR = Paths.get("mody");
+
+    // the module name of the test module
+    private static final String MAIN_MODULE = "com.bars";
+    private static final String TEST_MODULE = "com.foos";
+    private static final String DUP_MODULE = "com.foos3";
+
+    // the module main class
+    private static final String MAIN_CLASS = "com.bars.Main";
+    private static final String TEST_CLASS = "com.foos.Test";
+
+    private static String PATH_LIBS = "modylibs";
+    private static String DUP_LIBS = "duplibs";
+    private static Path libsDir = null;
+    private static Path dupDir = null;
+    private static Path mainJar = null;
+    private static Path testJar = null;
+    private static Path dupJar = null;
+
+    private static String CLASS_FOUND_MESSAGE = "com.foos.Test found";
+    private static String CLASS_NOT_FOUND_MESSAGE = "java.lang.ClassNotFoundException: com.foos.Test";
+    private static String OPTIMIZE_ENABLED = "] optimized module handling: enabled";
+    private static String OPTIMIZE_DISABLED = "] optimized module handling: disabled";
+    private static String FMG_ENABLED = "] full module graph: enabled";
+    private static String FMG_DISABLED = "] full module graph: disabled";
+    private static String MAIN_FROM_JAR = "class,load.*com.bars.Main.*[.]jar";
+    private static String MAIN_FROM_CDS = "class,load.*com.bars.Main.*shared objects file";
+    private static String TEST_FROM_JAR = "class,load.*com.foos.Test.*[.]jar";
+    private static String TEST_FROM_CDS = "class,load.*com.foos.Test.*shared objects file";
+    private static String MAP_FAILED  = "Unable to use shared archive";
+    private static String PATH_SEPARATOR = File.pathSeparator;
+
+    public static void buildTestModule() throws Exception {
+
+        // javac -d mods/$TESTMODULE src/$TESTMODULE/**
+        JarBuilder.compileModule(SRC_DIR.resolve(TEST_MODULE),
+                                 MODS_DIR.resolve(TEST_MODULE),
+                                 null);
+
+        // javac -d mods/$TESTMODULE --module-path MOD_DIR src/$TESTMODULE/**
+        JarBuilder.compileModule(SRC_DIR.resolve(MAIN_MODULE),
+                                 MODS_DIR.resolve(MAIN_MODULE),
+                                 MODS_DIR.toString());
+
+        libsDir = Files.createTempDirectory(USER_DIR, PATH_LIBS);
+        mainJar = libsDir.resolve(MAIN_MODULE + ".jar");
+        testJar = libsDir.resolve(TEST_MODULE + ".jar");
+
+        // modylibs contains both modules com.foos.jar, com.bars.jar
+        // build com.foos.jar
+        String classes = MODS_DIR.resolve(TEST_MODULE).toString();
+        JarBuilder.createModularJar(testJar.toString(), classes, TEST_CLASS);
+
+        // build com.bars.jar
+        classes = MODS_DIR.resolve(MAIN_MODULE).toString();
+        JarBuilder.createModularJar(mainJar.toString(), classes, MAIN_CLASS);
+
+        dupDir = Files.createTempDirectory(USER_DIR, DUP_LIBS);
+        dupJar = dupDir.resolve(DUP_MODULE + ".jar");
+        Files.copy(testJar, dupJar, StandardCopyOption.REPLACE_EXISTING);
+    }
+
+    public static void main(String... args) throws Exception {
+        runWithModulePath();
+    }
+
+    private static void tty(String... args) {
+        for (String s : args) {
+            System.out.print(s + " ");
+        }
+        System.out.print("\n");
+    }
+
+    public static void runWithModulePath(String... extraRuntimeArgs) throws Exception {
+        // compile the modules and create the modular jar files
+        buildTestModule();
+        String appClasses[] = {MAIN_CLASS, TEST_CLASS};
+        // create an archive with the classes in the modules built in the
+        // previous step
+        OutputAnalyzer output = TestCommon.createArchive(
+                                        null, appClasses,
+                                        "--module-path",
+                                        libsDir.toString(),
+                                        "-m", MAIN_MODULE);
+        TestCommon.checkDump(output);
+
+        tty("1. run with CDS on, with module path same as dump time");
+        String prefix[] = {"-Djava.class.path=", "-Xlog:cds,class+load,class+path=info"};
+        TestCommon.runWithModules(prefix,
+                                 null,               // --upgrade-module-path
+                                 libsDir.toString(), // --module-path
+                                 MAIN_MODULE)        // -m
+            .assertNormalExit(out -> {
+                out.shouldNotContain(OPTIMIZE_DISABLED)
+                   .shouldContain(OPTIMIZE_ENABLED)
+                   .shouldNotContain(FMG_DISABLED)
+                   .shouldContain(FMG_ENABLED)
+                   .shouldMatch(MAIN_FROM_CDS)       // archived Main class is for module only
+                   .shouldContain(CLASS_FOUND_MESSAGE);
+            });
+
+        tty("2. run with CDS on, with jar on path");
+        TestCommon.run("-Xlog:cds",
+                       "-Xlog:class+load",
+                       "-cp", mainJar.toString() + PATH_SEPARATOR + testJar.toString(),
+                       MAIN_CLASS)
+            .assertNormalExit(out -> {
+                out.shouldContain(CLASS_FOUND_MESSAGE)
+                   .shouldMatch(MAIN_FROM_JAR)
+                   .shouldMatch(TEST_FROM_JAR)
+                   .shouldContain(OPTIMIZE_DISABLED)
+                   .shouldNotContain(OPTIMIZE_ENABLED)
+                   .shouldContain(FMG_DISABLED)
+                   .shouldNotContain(FMG_ENABLED);
+            });
+
+        tty("3. run with CDS on, with --module-path, with jar should fail");
+        TestCommon.run("-Xlog:cds",
+                       "-Xlog:class+load",
+                       "-p", libsDir.toString(),
+                       "-cp", mainJar.toString(),
+                       MAIN_CLASS)
+            .assertNormalExit(out -> {
+                out.shouldContain(CLASS_NOT_FOUND_MESSAGE)
+                   .shouldMatch(MAIN_FROM_JAR)
+                   .shouldNotContain(FMG_ENABLED)
+                   .shouldNotContain(OPTIMIZE_ENABLED);
+            });
+
+        final String modularJarPath = mainJar.toString() + PATH_SEPARATOR + testJar.toString();
+
+        tty("4. run with CDS on, with modular jars specified --module-path, should pass");
+        TestCommon.runWithModules(prefix,
+                                 null,               // --upgrade-module-path
+                                 modularJarPath,     // --module-path
+                                 MAIN_MODULE)        // -m
+            .assertNormalExit(out -> {
+                out.shouldNotContain(OPTIMIZE_DISABLED)
+                   .shouldContain(OPTIMIZE_ENABLED)
+                   .shouldNotContain(FMG_DISABLED)
+                   .shouldContain(FMG_ENABLED)
+                   .shouldMatch(MAIN_FROM_CDS);       // archived Main class is for module only
+            });
+
+        final String extraModulePath = libsDir.toString() + PATH_SEPARATOR + dupDir.toString();
+        // create an archive with an extra module which is not referenced
+        output = TestCommon.createArchive(
+                                        null, appClasses,
+                                        "--module-path",
+                                        extraModulePath,
+                                        "-m", MAIN_MODULE);
+        TestCommon.checkDump(output);
+
+        tty("5. run with CDS on, without the extra module specified in dump time, should pass");
+        TestCommon.runWithModules(prefix,
+                                 null,               // --upgrade-module-path
+                                 libsDir.toString(), // --module-path
+                                 MAIN_MODULE)        // -m
+            .assertNormalExit(out -> {
+                out.shouldNotContain(OPTIMIZE_DISABLED)
+                   .shouldContain(OPTIMIZE_ENABLED)
+                   .shouldNotContain(FMG_DISABLED)
+                   .shouldContain(FMG_ENABLED)
+                   .shouldMatch(MAIN_FROM_CDS)       // archived Main class is for module only
+                   .shouldContain(CLASS_FOUND_MESSAGE);
+            });
+        tty("6. run with CDS on, with the extra module specified in dump time");
+        TestCommon.runWithModules(prefix,
+                                 null,               // --upgrade-module-path
+                                 extraModulePath,    // --module-path
+                                 MAIN_MODULE)        // -m
+            .assertNormalExit(out -> {
+                out.shouldNotContain(OPTIMIZE_ENABLED)
+                   .shouldContain(OPTIMIZE_DISABLED)
+                   .shouldNotContain(FMG_ENABLED)
+                   .shouldContain(FMG_DISABLED)
+                   .shouldMatch(MAIN_FROM_CDS)       // archived Main class is for module only
+                   .shouldContain(CLASS_FOUND_MESSAGE);
+            });
+
+        final String extraJarPath = modularJarPath + PATH_SEPARATOR + dupJar.toString();
+
+        // create an archive by specifying modular jars in the --module-path with an extra module which is not referenced
+        output = TestCommon.createArchive(
+                                        null, appClasses,
+                                        "--module-path",
+                                        extraJarPath,
+                                        "-m", MAIN_MODULE);
+        TestCommon.checkDump(output);
+        tty("7. run with CDS on, without the extra module specified in dump time, should pass");
+        TestCommon.runWithModules(prefix,
+                                 null,               // --upgrade-module-path
+                                 modularJarPath,     // --module-path
+                                 MAIN_MODULE)        // -m
+            .assertNormalExit(out -> {
+                out.shouldNotContain(OPTIMIZE_DISABLED)
+                   .shouldContain(OPTIMIZE_ENABLED)
+                   .shouldNotContain(FMG_DISABLED)
+                   .shouldContain(FMG_ENABLED)
+                   .shouldMatch(MAIN_FROM_CDS)       // archived Main class is for module only
+                   .shouldContain(CLASS_FOUND_MESSAGE);
+            });
+
+        tty("8. run with CDS on, with the extra module specified in dump time");
+        TestCommon.runWithModules(prefix,
+                                 null,               // --upgrade-module-path
+                                 extraJarPath,       // --module-path
+                                 MAIN_MODULE)        // -m
+            .assertNormalExit(out -> {
+                out.shouldNotContain(OPTIMIZE_ENABLED)
+                   .shouldContain(OPTIMIZE_DISABLED)
+                   .shouldNotContain(FMG_ENABLED)
+                   .shouldContain(FMG_DISABLED)
+                   .shouldMatch(MAIN_FROM_CDS)       // archived Main class is for module only
+                   .shouldContain(CLASS_FOUND_MESSAGE);
+            });
+        tty("9. same as test case 8 but with paths instead of modular jars in the --module-path");
+        TestCommon.runWithModules(prefix,
+                                 null,               // --upgrade-module-path
+                                 extraModulePath,    // --module-path
+                                 MAIN_MODULE)        // -m
+            .assertNormalExit(out -> {
+                out.shouldNotContain(OPTIMIZE_ENABLED)
+                   .shouldContain(OPTIMIZE_DISABLED)
+                   .shouldNotContain(FMG_ENABLED)
+                   .shouldContain(FMG_DISABLED)
+                   .shouldMatch(MAIN_FROM_CDS)       // archived Main class is for module only
+                   .shouldContain(CLASS_FOUND_MESSAGE);
+            });
+    }
+
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/modulepath/OptimizeModuleHandlingTest.java
@@ -24,7 +24,7 @@
 
 /**
  * @test
- * @requires vm.cds & !vm.graal.enabled
+ * @requires vm.cds & !vm.graal.enabled & vm.cds.write.archived.java.heap
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver OptimizeModuleHandlingTest
  * @summary test module path changes for optimization of
@@ -64,8 +64,8 @@ public class OptimizeModuleHandlingTest {
 
     private static String CLASS_FOUND_MESSAGE = "com.foos.Test found";
     private static String CLASS_NOT_FOUND_MESSAGE = "java.lang.ClassNotFoundException: com.foos.Test";
-    private static String OPTIMIZE_ENABLED = "optimized module handling: enabled";
-    private static String OPTIMIZE_DISABLED = "optimized module handling: disabled";
+    private static String OPTIMIZE_ENABLED = "] optimized module handling: enabled";
+    private static String OPTIMIZE_DISABLED = "] optimized module handling: disabled";
     private static String MAIN_FROM_JAR = "class,load.*com.bars.Main.*[.]jar";
     private static String MAIN_FROM_CDS = "class,load.*com.bars.Main.*shared objects file";
     private static String TEST_FROM_JAR = "class,load.*com.foos.Test.*[.]jar";
@@ -154,14 +154,14 @@ public class OptimizeModuleHandlingTest {
 
         // Following 5 - 10 test with CDS on
         tty("5. run with CDS on, with module path");
-        String prefix[] = {"-Djava.class.path=", "-Xlog:cds", "-Xlog:class+load"};
+        String prefix[] = {"-Djava.class.path=", "-Xlog:cds,class+load,class+path=info"};
         TestCommon.runWithModules(prefix,
                                  null,               // --upgrade-module-path
                                  libsDir.toString(), // --module-path
                                  MAIN_MODULE)        // -m
             .assertNormalExit(out -> {
-                out.shouldNotContain(OPTIMIZE_ENABLED)
-                   .shouldContain(OPTIMIZE_DISABLED)
+                out.shouldNotContain(OPTIMIZE_DISABLED)
+                   .shouldContain(OPTIMIZE_ENABLED)
                    .shouldMatch(MAIN_FROM_CDS)       // // archived Main class is for module only
                    .shouldContain(CLASS_FOUND_MESSAGE);
             });
@@ -174,8 +174,8 @@ public class OptimizeModuleHandlingTest {
                 out.shouldContain(CLASS_FOUND_MESSAGE)
                    .shouldMatch(MAIN_FROM_CDS)
                    .shouldMatch(TEST_FROM_CDS)
-                   .shouldContain(OPTIMIZE_DISABLED)
-                   .shouldNotContain(OPTIMIZE_ENABLED);
+                   .shouldContain(OPTIMIZE_ENABLED)
+                   .shouldNotContain(OPTIMIZE_DISABLED);
             });
         tty("7. run with CDS on, with jar on path");
         TestCommon.run("-Xlog:cds",
@@ -231,7 +231,6 @@ public class OptimizeModuleHandlingTest {
                        MAIN_CLASS)
             .assertAbnormalExit(out -> {
                 out.shouldNotContain(CLASS_FOUND_MESSAGE)
-                   .shouldContain(OPTIMIZE_DISABLED)           // mapping info
                    .shouldContain("shared class paths mismatch");
             });
     }


### PR DESCRIPTION
Prior to this patch, if `--module-path` is specified in the command line:
during CDS dump time, full module graph will not be included in the CDS archive;
during run time, full module graph will not be used.

With this patch, the full module graph will be included in the CDS archive with the `--module-path` option. During run time, if the same `--module-path` option is specified, the archived module graph will be used.

The checking of module paths between dump time and run time is more lenient compared with the checking of class paths; the ordering of the modules is unimportant, duplicate module names are ignored.
E.g. the following is considered a match:
dump time      runtime
m1,m2             m2,m1
m1,m2             m1,m2,m2

I included some [notes](https://bugs.openjdk.org/browse/JDK-8328313?focusedId=14699275&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14699275) in the bug report regarding some changes in the corelib classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328313](https://bugs.openjdk.org/browse/JDK-8328313): Archived module graph should allow identical --module-path to be specified during dump time and run time (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20636/head:pull/20636` \
`$ git checkout pull/20636`

Update a local copy of the PR: \
`$ git checkout pull/20636` \
`$ git pull https://git.openjdk.org/jdk.git pull/20636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20636`

View PR using the GUI difftool: \
`$ git pr show -t 20636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20636.diff">https://git.openjdk.org/jdk/pull/20636.diff</a>

</details>
