### PR TITLE
8338623: StackCounter adding extraneous slots for receiver invoke instructions

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackCounter.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackCounter.java
@@ -313,13 +313,14 @@ public final class StackCounter {
                         var cpe = cp.entryByIndex(bcs.getIndexU2());
                         var nameAndType = opcode == INVOKEDYNAMIC ? ((DynamicConstantPoolEntry)cpe).nameAndType() : ((MemberRefEntry)cpe).nameAndType();
                         var mtd = Util.methodTypeSymbol(nameAndType);
-                        addStackSlot(Util.slotSize(mtd.returnType()) - Util.parameterSlots(mtd));
+                        var delta = Util.slotSize(mtd.returnType()) - Util.parameterSlots(mtd);
                         if (opcode != INVOKESTATIC && opcode != INVOKEDYNAMIC) {
-                            addStackSlot(-1);
+                            delta--;
                         }
+                        addStackSlot(delta);
                     }
                     case MULTIANEWARRAY ->
-                        addStackSlot (1 - bcs.getU1(bcs.bci + 3));
+                        addStackSlot(1 - bcs.getU1(bcs.bci + 3));
                     case JSR -> {
                         addStackSlot(+1);
                         jump(bcs.dest()); //here we lost track of the exact stack size after return from subroutine


### PR DESCRIPTION
StackCounter was adding return type slots before deducting receiver slot, so code like
```java
int b() { return this.hashCode(); }
```
will be counted as having a max stack of 2. Avoid this problem by only calling `addStackSlot` once for each instruction.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338623](https://bugs.openjdk.org/browse/JDK-8338623): StackCounter adding extraneous slots for receiver invoke instructions (**Bug** - P3)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20637/head:pull/20637` \
`$ git checkout pull/20637`

Update a local copy of the PR: \
`$ git checkout pull/20637` \
`$ git pull https://git.openjdk.org/jdk.git pull/20637/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20637`

View PR using the GUI difftool: \
`$ git pr show -t 20637`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20637.diff">https://git.openjdk.org/jdk/pull/20637.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20637#issuecomment-2298009830)