### PR TITLE
8328880: Events::log_exception should limit the size of the logging message

### DIFF
--- a/src/hotspot/share/utilities/events.cpp
+++ b/src/hotspot/share/utilities/events.cpp
@@ -151,7 +151,9 @@ void UnloadingEventLog::log(Thread* thread, InstanceKlass* ik) {
   ik->name()->print_value_on(&st);
 }
 
-void ExceptionsEventLog::log(Thread* thread, Handle h_exception, const char* message, const char* file, int line) {
+void ExceptionsEventLog::log(Thread* thread, Handle h_exception,
+                             const char* message, const char* file, int line,
+                             int message_length_limit) {
   if (!should_log()) return;
 
   double timestamp = fetch_timestamp();
@@ -163,8 +165,11 @@ void ExceptionsEventLog::log(Thread* thread, Handle h_exception, const char* mes
                   _records[index].data.size());
   st.print("Exception <");
   h_exception->print_value_on(&st);
-  st.print("%s%s> (" PTR_FORMAT ") \n"
+  if (message != nullptr) {
+    int len = message_length_limit > 0 ? message_length_limit : (int)strlen(message);
+    st.print(": %.*s", len, message);
+  }
+  st.print("> (" PTR_FORMAT ") \n"
            "thrown [%s, line %d]",
-           message ? ": " : "", message ? message : "",
            p2i(h_exception()), file, line);
 }

--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -207,7 +207,9 @@ class ExceptionsEventLog : public ExtendedStringEventLog {
   ExceptionsEventLog(const char* name, const char* short_name, int count = LogEventsBufferEntries)
    : ExtendedStringEventLog(name, short_name, count) {}
 
-  void log(Thread* thread, Handle h_exception, const char* message, const char* file, int line);
+  // Message length limit of zero means no limit.
+  void log(Thread* thread, Handle h_exception, const char* message,
+           const char* file, int line, int message_length_limit=0);
 };
 
 
@@ -275,7 +277,7 @@ class Events : AllStatic {
 
   // Log exception related message
   static void log_exception(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
-  static void log_exception(Thread* thread, Handle h_exception, const char* message, const char* file, int line);
+  static void log_exception(Thread* thread, Handle h_exception, const char* message, const char* file, int line, int message_length_limit=0);
 
   static void log_redefinition(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
 
@@ -345,9 +347,11 @@ inline void Events::log_exception(Thread* thread, const char* format, ...) {
   }
 }
 
-inline void Events::log_exception(Thread* thread, Handle h_exception, const char* message, const char* file, int line) {
+inline void Events::log_exception(Thread* thread, Handle h_exception,
+                                  const char* message, const char* file,
+                                  int line, int message_length_limit) {
   if (LogEvents && _exceptions != nullptr) {
-    _exceptions->log(thread, h_exception, message, file, line);
+    _exceptions->log(thread, h_exception, message, file, line, message_length_limit);
   }
 }
 

--- a/src/hotspot/share/utilities/events.hpp
+++ b/src/hotspot/share/utilities/events.hpp
@@ -209,7 +209,7 @@ class ExceptionsEventLog : public ExtendedStringEventLog {
 
   // Message length limit of zero means no limit.
   void log(Thread* thread, Handle h_exception, const char* message,
-           const char* file, int line, int message_length_limit=0);
+           const char* file, int line, int message_length_limit = 0);
 };
 
 
@@ -277,7 +277,7 @@ class Events : AllStatic {
 
   // Log exception related message
   static void log_exception(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
-  static void log_exception(Thread* thread, Handle h_exception, const char* message, const char* file, int line, int message_length_limit=0);
+  static void log_exception(Thread* thread, Handle h_exception, const char* message, const char* file, int line, int message_length_limit = 0);
 
   static void log_redefinition(Thread* thread, const char* format, ...) ATTRIBUTE_PRINTF(2, 3);
 

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -183,7 +183,7 @@ void Exceptions::_throw(JavaThread* thread, const char* file, int line, Handle h
   thread->set_pending_exception(h_exception(), file, line);
 
   // vm log
-  Events::log_exception(thread, h_exception, message, file, line);
+  Events::log_exception(thread, h_exception, message, file, line, MAX_LEN);
 }
 
 


### PR DESCRIPTION
This simple enhancement allows for `Exceptions::_throw` to limit the message length printed by `Events::log_exception` in the same way that unified logging is limited. We simply allow a `message_length_limit` variable to be passed down - default value zero which means no limit (i.e. the full `strlen` of the message will be printed).

Testing:
- tiers 1-3

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8328880](https://bugs.openjdk.org/browse/JDK-8328880): Events::log_exception should limit the size of the logging message (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20638/head:pull/20638` \
`$ git checkout pull/20638`

Update a local copy of the PR: \
`$ git checkout pull/20638` \
`$ git pull https://git.openjdk.org/jdk.git pull/20638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20638`

View PR using the GUI difftool: \
`$ git pr show -t 20638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20638.diff">https://git.openjdk.org/jdk/pull/20638.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20638#issuecomment-2297995168)