### PR TITLE
8338662: Shenandoah: Remove excessive ShenandoahVerifier::verify_during_evacuation 

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahConcurrentGC.cpp
@@ -613,12 +613,6 @@ void ShenandoahConcurrentGC::op_final_mark() {
       // From here on, we need to update references.
       heap->set_has_forwarded_objects(true);
 
-      // Verify before arming for concurrent processing.
-      // Otherwise, verification can trigger stack processing.
-      if (ShenandoahVerify) {
-        heap->verifier()->verify_during_evacuation();
-      }
-
       // Arm nmethods/stack for concurrent processing
       ShenandoahCodeRoots::arm_nmethods_for_evac();
       ShenandoahStackWatermark::change_epoch_id();

--- a/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahDegeneratedGC.cpp
@@ -276,12 +276,12 @@ void ShenandoahDegenGC::op_prepare_evacuation() {
   }
 
   if (!heap->collection_set()->is_empty()) {
+    if (ShenandoahVerify) {
+      heap->verifier()->verify_before_evacuation();
+    }
+
     heap->set_evacuation_in_progress(true);
     heap->set_has_forwarded_objects(true);
-
-    if(ShenandoahVerify) {
-      heap->verifier()->verify_during_evacuation();
-    }
   } else {
     if (ShenandoahVerify) {
       heap->verifier()->verify_after_concmark();

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -654,14 +654,6 @@ void ShenandoahVerifier::verify_at_safepoint(const char *label,
         enabled = true;
         expected = ShenandoahHeap::HAS_FORWARDED;
         break;
-      case _verify_gcstate_evacuation:
-        enabled = true;
-        expected = ShenandoahHeap::HAS_FORWARDED | ShenandoahHeap::EVACUATION;
-        if (!_heap->is_stw_gc_in_progress()) {
-          // Only concurrent GC sets this.
-          expected |= ShenandoahHeap::WEAK_ROOTS;
-        }
-        break;
       case _verify_gcstate_stable:
         enabled = true;
         expected = ShenandoahHeap::STABLE;
@@ -841,18 +833,6 @@ void ShenandoahVerifier::verify_before_evacuation() {
           _verify_liveness_complete,                 // liveness data must be complete here
           _verify_regions_disable,                   // trash regions not yet recycled
           _verify_gcstate_stable_weakroots           // heap is still stable, weakroots are in progress
-  );
-}
-
-void ShenandoahVerifier::verify_during_evacuation() {
-  verify_at_safepoint(
-          "During Evacuation",
-          _verify_forwarded_allow,    // some forwarded references are allowed
-          _verify_marked_disable,     // walk only roots
-          _verify_cset_disable,       // some cset references are not forwarded yet
-          _verify_liveness_disable,   // liveness data might be already stale after pre-evacs
-          _verify_regions_disable,    // trash regions not yet recycled
-          _verify_gcstate_evacuation  // evacuation is in progress
   );
 }
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.hpp
@@ -133,10 +133,7 @@ public:
     _verify_gcstate_stable_weakroots,
 
     // Nothing is in progress, some objects are forwarded
-    _verify_gcstate_forwarded,
-
-    // Evacuation is in progress, some objects are forwarded
-    _verify_gcstate_evacuation
+    _verify_gcstate_forwarded
   } VerifyGCState;
 
   struct VerifyOptions {
@@ -175,7 +172,6 @@ public:
   void verify_before_concmark();
   void verify_after_concmark();
   void verify_before_evacuation();
-  void verify_during_evacuation();
   void verify_before_updaterefs();
   void verify_after_updaterefs();
   void verify_before_fullgc();


### PR DESCRIPTION
`ShenandoahVerifier::verify_during_evacuation` is a relaxed version of `ShenandoahVerifier::verify_before_evacuation`. In current code, "during" verification is called shortly after "before" check, which really gains us nothing checking-wise, and only really wastes verification time. This is the only "during" verification check we have, all other checks verify things before/after the phases. It makes sense to remove "during evac" verification check for extra debug performance and cleanliness. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [x] Linux x86_64 server fastdebug, `all` with `-XX:+UseShenandoahGC -XX:+ShenandoahVerify`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338662](https://bugs.openjdk.org/browse/JDK-8338662): Shenandoah: Remove excessive ShenandoahVerifier::verify_during_evacuation (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20641/head:pull/20641` \
`$ git checkout pull/20641`

Update a local copy of the PR: \
`$ git checkout pull/20641` \
`$ git pull https://git.openjdk.org/jdk.git pull/20641/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20641`

View PR using the GUI difftool: \
`$ git pr show -t 20641`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20641.diff">https://git.openjdk.org/jdk/pull/20641.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20641#issuecomment-2298518765)