### PR TITLE
8336843: Deprecate java.util.zip.ZipError for removal

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipError.java
+++ b/src/java.base/share/classes/java/util/zip/ZipError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/zip/ZipError.java
+++ b/src/java.base/share/classes/java/util/zip/ZipError.java
@@ -27,10 +27,11 @@ package java.util.zip;
 
 /**
  * Signals that an unrecoverable error has occurred.
- *
+ * @deprecated Use {@link ZipException} instead.
  * @author  Dave Bristor
  * @since   1.6
  */
+@Deprecated(since="24", forRemoval = true)
 public class ZipError extends InternalError {
     @java.io.Serial
     private static final long serialVersionUID = 853973422266861979L;

--- a/src/java.base/share/classes/java/util/zip/ZipError.java
+++ b/src/java.base/share/classes/java/util/zip/ZipError.java
@@ -27,7 +27,10 @@ package java.util.zip;
 
 /**
  * Signals that an unrecoverable error has occurred.
- * @deprecated Use {@link ZipException} instead.
+ * @deprecated This error became obsolete in JDK 9. Use
+ * {@link ZipException} instead. Code needing to catch this
+ * error when running on JDK 8 or earlier releases may catch
+ * the parent {@link InternalError} instead.
  * @author  Dave Bristor
  * @since   1.6
  */

--- a/src/java.base/share/classes/java/util/zip/ZipError.java
+++ b/src/java.base/share/classes/java/util/zip/ZipError.java
@@ -27,10 +27,9 @@ package java.util.zip;
 
 /**
  * Signals that an unrecoverable error has occurred.
- * @deprecated This error became obsolete in JDK 9. Use
- * {@link ZipException} instead. Code needing to catch this
- * error when running on JDK 8 or earlier releases may catch
- * the parent {@link InternalError} instead.
+ *
+ * @deprecated ZipError is no longer used and is obsolete.
+ * {@link ZipException} should be used instead.
  * @author  Dave Bristor
  * @since   1.6
  */


### PR DESCRIPTION
Please review this PR which suggests to deprecate the unused class `java.util.zip.ZipError` for removal.

The class has been unsed by OpenJDK since  the ZIP API was rewritten from native to Java in JDK 9.

I opted to not explain the reason for the deprecation in detail, but instead simply point to `ZipException` as an alternative. Should more explanation be desired, I could prepend that with a note saying that the class is unused since JDK 9.

A CSR for this API update has been drafted, I'll update the Specification section there once we reach a concensus on the deprecation note in this PR.

This deprecation was initially suggested here: https://mail.openjdk.org/pipermail/core-libs-dev/2024-June/125720.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8338663](https://bugs.openjdk.org/browse/JDK-8338663) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issues
 * [JDK-8336843](https://bugs.openjdk.org/browse/JDK-8336843): Deprecate java.util.zip.ZipError for removal (**Enhancement** - P4)
 * [JDK-8338663](https://bugs.openjdk.org/browse/JDK-8338663): Deprecate java.util.zip.ZipError for removal (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20642/head:pull/20642` \
`$ git checkout pull/20642`

Update a local copy of the PR: \
`$ git checkout pull/20642` \
`$ git pull https://git.openjdk.org/jdk.git pull/20642/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20642`

View PR using the GUI difftool: \
`$ git pr show -t 20642`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20642.diff">https://git.openjdk.org/jdk/pull/20642.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20642#issuecomment-2307283941)