### PR TITLE
8338661: StackMapTable is invalid if frames appear in dead code

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AttributeHolder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AttributeHolder.java
@@ -53,6 +53,14 @@ public class AttributeHolder {
         Util.writeAttributes(buf, attributes);
     }
 
+    @SuppressWarnings("unchecked")
+    <A> A get(AttributeMapper<A> am) {
+        for (Attribute<?> a : attributes)
+            if (a.attributeMapper() == am)
+                return (A)a;
+        return null;
+    }
+
     boolean isPresent(AttributeMapper<?> am) {
         for (Attribute<?> a : attributes)
             if (a.attributeMapper() == am)

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackCounter.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackCounter.java
@@ -25,20 +25,23 @@
  */
 package jdk.internal.classfile.impl;
 
+import java.lang.classfile.Attributes;
 import java.lang.classfile.TypeKind;
+import java.lang.classfile.attribute.StackMapFrameInfo;
+import java.lang.classfile.attribute.StackMapTableAttribute;
 import java.lang.classfile.constantpool.ConstantDynamicEntry;
 import java.lang.classfile.constantpool.DynamicConstantPoolEntry;
 import java.lang.classfile.constantpool.MemberRefEntry;
+import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.nio.ByteBuffer;
 import java.util.ArrayDeque;
 import java.util.BitSet;
 import java.util.List;
 import java.util.Queue;
+import java.util.stream.Collectors;
 
 import static java.lang.classfile.ClassFile.*;
-import java.lang.constant.ClassDesc;
-import java.util.stream.Collectors;
 
 public final class StackCounter {
 
@@ -47,6 +50,7 @@ public final class StackCounter {
     static StackCounter of(DirectCodeBuilder dcb, BufWriterImpl buf) {
         return new StackCounter(
                 dcb,
+                dcb.attributes.get(Attributes.stackMapTable()),
                 buf.thisClass().asSymbol(),
                 dcb.methodInfo.methodName().stringValue(),
                 dcb.methodInfo.methodTypeSymbol(),
@@ -97,6 +101,7 @@ public final class StackCounter {
     }
 
     public StackCounter(LabelContext labelContext,
+                     StackMapTableAttribute smta,
                      ClassDesc thisClass,
                      String methodName,
                      MethodTypeDesc methodDesc,
@@ -111,8 +116,20 @@ public final class StackCounter {
         this.bytecode = bytecode;
         this.cp = cp;
         targets = new ArrayDeque<>();
-        maxStack = stack = rets = 0;
+        stack = rets = 0;
+        maxStack = handlers.isEmpty() ? 0 : 1;
         for (var h : handlers) targets.add(new Target(labelContext.labelToBci(h.handler), 1));
+        if (smta != null) {
+            for (var smfi : smta.entries()) {
+                int frameStack = smfi.stack().size();
+                for (var vti : smfi.stack()) {
+                    if (vti == StackMapFrameInfo.SimpleVerificationTypeInfo.ITEM_LONG
+                     || vti == StackMapFrameInfo.SimpleVerificationTypeInfo.ITEM_DOUBLE) frameStack++;
+                }
+                if (maxStack < frameStack) maxStack = frameStack;
+                targets.add(new Target(labelContext.labelToBci(smfi.target()), frameStack));
+            }
+        }
         maxLocals = isStatic ? 0 : 1;
         maxLocals += Util.parameterSlots(methodDesc);
         bcs = new RawBytecodeHelper(bytecode);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackCounter.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackCounter.java
@@ -313,13 +313,14 @@ public final class StackCounter {
                         var cpe = cp.entryByIndex(bcs.getIndexU2());
                         var nameAndType = opcode == INVOKEDYNAMIC ? ((DynamicConstantPoolEntry)cpe).nameAndType() : ((MemberRefEntry)cpe).nameAndType();
                         var mtd = Util.methodTypeSymbol(nameAndType);
-                        addStackSlot(Util.slotSize(mtd.returnType()) - Util.parameterSlots(mtd));
+                        var delta = Util.slotSize(mtd.returnType()) - Util.parameterSlots(mtd);
                         if (opcode != INVOKESTATIC && opcode != INVOKEDYNAMIC) {
-                            addStackSlot(-1);
+                            delta--;
                         }
+                        addStackSlot(delta);
                     }
                     case MULTIANEWARRAY ->
-                        addStackSlot (1 - bcs.getU1(bcs.bci + 3));
+                        addStackSlot(1 - bcs.getU1(bcs.bci + 3));
                     case JSR -> {
                         addStackSlot(+1);
                         jump(bcs.dest()); //here we lost track of the exact stack size after return from subroutine

--- a/test/jdk/jdk/classfile/StackMapsTest.java
+++ b/test/jdk/jdk/classfile/StackMapsTest.java
@@ -24,18 +24,25 @@
 /*
  * @test
  * @summary Testing Classfile stack maps generator.
- * @bug 8305990 8320222 8320618 8335475 8338623
+ * @bug 8305990 8320222 8320618 8335475 8338623 8338661
  * @build testdata.*
  * @run junit StackMapsTest
  */
 
 import java.lang.classfile.*;
 import java.lang.classfile.attribute.CodeAttribute;
+import java.lang.classfile.attribute.StackMapFrameInfo;
+import java.lang.classfile.attribute.StackMapTableAttribute;
 import java.lang.classfile.components.ClassPrinter;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.reflect.AccessFlag;
 import java.net.URI;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -44,11 +51,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static helpers.TestUtil.assertEmpty;
 import static java.lang.classfile.ClassFile.ACC_STATIC;
 import static java.lang.constant.ConstantDescs.*;
-
-import java.lang.constant.ClassDesc;
-import java.lang.constant.ConstantDescs;
-import java.lang.constant.MethodTypeDesc;
-import java.lang.reflect.AccessFlag;
 
 /**
  * StackMapsTest
@@ -367,5 +369,31 @@ class StackMapsTest {
             assertEquals(1, code.maxLocals());
             assertEquals(1, code.maxStack());
         }
+    }
+
+    @Test
+    void testDeadCodeCountersWithCustomSMTA() {
+        ClassDesc bar = ClassDesc.of("Bar");
+        byte[] bytes = ClassFile.of(ClassFile.StackMapsOption.DROP_STACK_MAPS).build(bar, clb -> clb
+                .withMethodBody(
+                        "foo", MethodTypeDesc.of(ConstantDescs.CD_long), ACC_STATIC, cob -> {
+                            cob.lconst_0().lreturn();
+                            Label f2 = cob.newBoundLabel();
+                            cob.lstore(0);
+                            Label f3 = cob.newBoundLabel();
+                            cob.lload(0).lreturn().with(
+                                    StackMapTableAttribute.of(List.of(
+                                    StackMapFrameInfo.of(f2,
+                                            List.of(),
+                                            List.of(StackMapFrameInfo.SimpleVerificationTypeInfo.ITEM_LONG)),
+                                    StackMapFrameInfo.of(f3,
+                                            List.of(StackMapFrameInfo.SimpleVerificationTypeInfo.ITEM_LONG),
+                                            List.of()))));
+                        }
+                ));
+        assertEmpty(ClassFile.of().verify(bytes));
+        var code = (CodeAttribute) ClassFile.of().parse(bytes).methods().getFirst().code().orElseThrow();
+        assertEquals(2, code.maxLocals());
+        assertEquals(2, code.maxStack());
     }
 }

--- a/test/micro/org/openjdk/bench/jdk/classfile/CodeAttributeTools.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/CodeAttributeTools.java
@@ -122,6 +122,7 @@ public class CodeAttributeTools {
     public void benchmarkStackCounter(Blackhole bh) {
         for (var d : data) bh.consume(new StackCounter(
                 d.labelContext(),
+                null,
                 d.thisClass(),
                 d.methodName(),
                 d.methodDesc(),


### PR DESCRIPTION
ClassFile API allows to build a class with dead code and provide custom `StackMapTable` attribute with user-specified frames covering the dead code.
`StackCounter` is responsible for calculation of `maxStack` and `maxLocals` in certain situations and it did not include the user-provided `StackMapTable` attribute. Dead code was skipped and `maxStack` or `maxLocals` might became underestimated.

This patch includes frames from user-provided `StackMapTable` attribute into the `StackCounter` calculations.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338661](https://bugs.openjdk.org/browse/JDK-8338661): StackMapTable is invalid if frames appear in dead code (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20644/head:pull/20644` \
`$ git checkout pull/20644`

Update a local copy of the PR: \
`$ git checkout pull/20644` \
`$ git pull https://git.openjdk.org/jdk.git pull/20644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20644`

View PR using the GUI difftool: \
`$ git pr show -t 20644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20644.diff">https://git.openjdk.org/jdk/pull/20644.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20644#issuecomment-2298935046)