### PR TITLE
    8338677: Improve startup of memory access var handles by simplifying combinator chains

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -101,7 +101,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static AbstractMemorySegmentImpl checkSegment(Object obb, Object encl, long base, boolean ro) {
         AbstractMemorySegmentImpl oo = (AbstractMemorySegmentImpl)Objects.requireNonNull(obb);
-        Utils.checkEnclosingLayout(oo, base, (MemoryLayout)encl);
+        Utils.checkEnclosingLayout(oo, base, (MemoryLayout)encl, ro);
         return oo;
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -28,6 +28,7 @@ import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.vm.annotation.ForceInline;
 
+import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.MemorySegment;
 import java.lang.ref.Reference;
 
@@ -45,7 +46,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 
     static final int NON_PLAIN_ACCESS_MIN_ALIGN_MASK = $BoxType$.BYTES - 1;
 
-    static final VarForm FORM = new VarForm(VarHandleSegmentAs$Type$s.class, MemorySegment.class, $type$.class, long.class);
+    static final VarForm FORM = new VarForm(VarHandleSegmentAs$Type$s.class, MemorySegment.class, $type$.class, MemoryLayout.class, long.class, long.class);
 
     VarHandleSegmentAs$Type$s(boolean be, long alignmentMask, boolean exact) {
         super(FORM, be, alignmentMask, exact);
@@ -53,7 +54,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 
     @Override
     final MethodType accessModeTypeUncached(VarHandle.AccessType accessType) {
-        return accessType.accessModeType(MemorySegment.class, $type$.class, long.class);
+        return accessType.accessModeType(MemorySegment.class, $type$.class, MemoryLayout.class, long.class, long.class);
     }
 
     @Override
@@ -97,70 +98,76 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 #end[floatingPoint]
 
     @ForceInline
-    static AbstractMemorySegmentImpl checkReadOnly(Object obb, boolean ro) {
+    static AbstractMemorySegmentImpl checkSegment(Object obb, Object encl, long base, boolean ro) {
         AbstractMemorySegmentImpl oo = (AbstractMemorySegmentImpl)Objects.requireNonNull(obb);
-        oo.checkReadOnly(ro);
+        MemoryLayout layout = (MemoryLayout)encl;
+        oo.checkAccess(base, layout.byteSize(), ro);
+        if (!oo.isAlignedForElement(base, layout)) {
+            throw new IllegalArgumentException(String.format(
+                    "Target offset %d is incompatible with alignment constraint %d (of %s) for segment %s"
+                    , base, layout.byteAlignment(), layout, oo));
+        }
         return oo;
     }
 
     @ForceInline
-    static long offsetNonPlain(AbstractMemorySegmentImpl bb, long offset, long alignmentMask) {
+    static long offsetNonPlain(AbstractMemorySegmentImpl bb, long base, long offset, long alignmentMask) {
         if ((alignmentMask & NON_PLAIN_ACCESS_MIN_ALIGN_MASK) != NON_PLAIN_ACCESS_MIN_ALIGN_MASK) {
             throw VarHandleSegmentViewBase.newUnsupportedAccessModeForAlignment(alignmentMask + 1);
         }
-        return offsetPlain(bb, offset);
+        return offsetPlain(bb, base, offset);
     }
 
     @ForceInline
-    static long offsetPlain(AbstractMemorySegmentImpl bb, long offset) {
-        long base = bb.unsafeGetOffset();
-        return base + offset;
+    static long offsetPlain(AbstractMemorySegmentImpl bb, long base, long offset) {
+        long segment_base = bb.unsafeGetOffset();
+        return segment_base + base + offset;
     }
 
     @ForceInline
-    static $type$ get(VarHandle ob, Object obb, long base) {
+    static $type$ get(VarHandle ob, Object obb, Object encl, long base, long offset) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, true);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, true);
 #if[floatingPoint]
         $rawType$ rawValue = SCOPED_MEMORY_ACCESS.get$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetPlain(bb, base),
+                offsetPlain(bb, base, offset),
                 handle.be);
         return $Type$.$rawType$BitsTo$Type$(rawValue);
 #else[floatingPoint]
 #if[byte]
         return SCOPED_MEMORY_ACCESS.get$Type$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetPlain(bb, base));
+                offsetPlain(bb, base, offset));
 #else[byte]
         return SCOPED_MEMORY_ACCESS.get$Type$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetPlain(bb, base),
+                offsetPlain(bb, base, offset),
                 handle.be);
 #end[byte]
 #end[floatingPoint]
     }
 
     @ForceInline
-    static void set(VarHandle ob, Object obb, long base, $type$ value) {
+    static void set(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
 #if[floatingPoint]
         SCOPED_MEMORY_ACCESS.put$RawType$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetPlain(bb, base),
+                offsetPlain(bb, base, offset),
                 $Type$.$type$ToRaw$RawType$Bits(value),
                 handle.be);
 #else[floatingPoint]
 #if[byte]
         SCOPED_MEMORY_ACCESS.put$Type$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetPlain(bb, base),
+                offsetPlain(bb, base, offset),
                 value);
 #else[byte]
         SCOPED_MEMORY_ACCESS.put$Type$Unaligned(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetPlain(bb, base),
+                offsetPlain(bb, base, offset),
                 value,
                 handle.be);
 #end[byte]
@@ -168,223 +175,223 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     }
 
     @ForceInline
-    static $type$ getVolatile(VarHandle ob, Object obb, long base) {
+    static $type$ getVolatile(VarHandle ob, Object obb, Object encl, long base, long offset) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, true);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, true);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Volatile(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offsetNonPlain(bb, base, handle.alignmentMask)));
+                                  offsetNonPlain(bb, base, offset, handle.alignmentMask)));
     }
 
     @ForceInline
-    static void setVolatile(VarHandle ob, Object obb, long base, $type$ value) {
+    static void setVolatile(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Volatile(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, offset, handle.alignmentMask),
                 convEndian(handle.be, value));
     }
 
     @ForceInline
-    static $type$ getAcquire(VarHandle ob, Object obb, long base) {
+    static $type$ getAcquire(VarHandle ob, Object obb, Object encl, long base, long offset) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, true);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, true);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offsetNonPlain(bb, base, handle.alignmentMask)));
+                                  offsetNonPlain(bb, base, offset, handle.alignmentMask)));
     }
 
     @ForceInline
-    static void setRelease(VarHandle ob, Object obb, long base, $type$ value) {
+    static void setRelease(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, offset, handle.alignmentMask),
                 convEndian(handle.be, value));
     }
 
     @ForceInline
-    static $type$ getOpaque(VarHandle ob, Object obb, long base) {
+    static $type$ getOpaque(VarHandle ob, Object obb, Object encl, long base, long offset) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, true);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, true);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.get$RawType$Opaque(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offsetNonPlain(bb, base, handle.alignmentMask)));
+                                  offsetNonPlain(bb, base, offset, handle.alignmentMask)));
     }
 
     @ForceInline
-    static void setOpaque(VarHandle ob, Object obb, long base, $type$ value) {
+    static void setOpaque(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         SCOPED_MEMORY_ACCESS.put$RawType$Opaque(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, offset, handle.alignmentMask),
                 convEndian(handle.be, value));
     }
 #if[CAS]
 
     @ForceInline
-    static boolean compareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean compareAndSet(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return SCOPED_MEMORY_ACCESS.compareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, offset, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
     @ForceInline
-    static $type$ compareAndExchange(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+    static $type$ compareAndExchange(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, offset, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
     @ForceInline
-    static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+    static $type$ compareAndExchangeAcquire(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, offset, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
     @ForceInline
-    static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+    static $type$ compareAndExchangeRelease(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.compareAndExchange$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, offset, handle.alignmentMask),
                                   convEndian(handle.be, expected), convEndian(handle.be, value)));
     }
 
     @ForceInline
-    static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean weakCompareAndSetPlain(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Plain(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, offset, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
     @ForceInline
-    static boolean weakCompareAndSet(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean weakCompareAndSet(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, offset, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
     @ForceInline
-    static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean weakCompareAndSetAcquire(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Acquire(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, offset, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
     @ForceInline
-    static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, long base, $type$ expected, $type$ value) {
+    static boolean weakCompareAndSetRelease(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ expected, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return SCOPED_MEMORY_ACCESS.weakCompareAndSet$RawType$Release(bb.sessionImpl(),
                 bb.unsafeGetBase(),
-                offsetNonPlain(bb, base, handle.alignmentMask),
+                offsetNonPlain(bb, base, offset, handle.alignmentMask),
                 convEndian(handle.be, expected), convEndian(handle.be, value));
     }
 
     @ForceInline
-    static $type$ getAndSet(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndSet(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, offset, handle.alignmentMask),
                                   convEndian(handle.be, value)));
     }
 
     @ForceInline
-    static $type$ getAndSetAcquire(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndSetAcquire(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Acquire(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, offset, handle.alignmentMask),
                                   convEndian(handle.be, value)));
     }
 
     @ForceInline
-    static $type$ getAndSetRelease(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndSetRelease(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         return convEndian(handle.be,
                           SCOPED_MEMORY_ACCESS.getAndSet$RawType$Release(bb.sessionImpl(),
                                   bb.unsafeGetBase(),
-                                  offsetNonPlain(bb, base, handle.alignmentMask),
+                                  offsetNonPlain(bb, base, offset, handle.alignmentMask),
                                   convEndian(handle.be, value)));
     }
 #end[CAS]
 #if[AtomicAdd]
 
     @ForceInline
-    static $type$ getAndAdd(VarHandle ob, Object obb, long base, $type$ delta) {
+    static $type$ getAndAdd(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     delta);
         } else {
-            return getAndAddConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), delta);
+            return getAndAddConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), delta);
         }
     }
 
     @ForceInline
-    static $type$ getAndAddAcquire(VarHandle ob, Object obb, long base, $type$ delta) {
+    static $type$ getAndAddAcquire(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     delta);
         } else {
-            return getAndAddConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), delta);
+            return getAndAddConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), delta);
         }
     }
 
     @ForceInline
-    static $type$ getAndAddRelease(VarHandle ob, Object obb, long base, $type$ delta) {
+    static $type$ getAndAddRelease(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ delta) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndAdd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     delta);
         } else {
-            return getAndAddConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), delta);
+            return getAndAddConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), delta);
         }
     }
 
@@ -403,44 +410,44 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 #if[Bitwise]
 
     @ForceInline
-    static $type$ getAndBitwiseOr(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseOr(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseOrConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseOrConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), value);
         }
     }
 
     @ForceInline
-    static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseOrRelease(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseOrConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseOrConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), value);
         }
     }
 
     @ForceInline
-    static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseOrAcquire(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseOr$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseOrConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseOrConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), value);
         }
     }
 
@@ -457,44 +464,44 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     }
 
     @ForceInline
-    static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseAnd(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseAndConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseAndConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), value);
         }
     }
 
     @ForceInline
-    static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseAndRelease(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseAndConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseAndConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), value);
         }
     }
 
     @ForceInline
-    static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseAndAcquire(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseAnd$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseAndConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseAndConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), value);
         }
     }
 
@@ -512,44 +519,44 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
 
 
     @ForceInline
-    static $type$ getAndBitwiseXor(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseXor(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseXorConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseXorConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), value);
         }
     }
 
     @ForceInline
-    static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseXorRelease(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Release(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseXorConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseXorConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), value);
         }
     }
 
     @ForceInline
-    static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, long base, $type$ value) {
+    static $type$ getAndBitwiseXorAcquire(VarHandle ob, Object obb, Object encl, long base, long offset, $type$ value) {
         VarHandleSegmentViewBase handle = (VarHandleSegmentViewBase)ob;
-        AbstractMemorySegmentImpl bb = checkReadOnly(obb, false);
+        AbstractMemorySegmentImpl bb = checkSegment(obb, encl, base, false);
         if (handle.be == BE) {
             return SCOPED_MEMORY_ACCESS.getAndBitwiseXor$RawType$Acquire(bb.sessionImpl(),
                     bb.unsafeGetBase(),
-                    offsetNonPlain(bb, base, handle.alignmentMask),
+                    offsetNonPlain(bb, base, offset, handle.alignmentMask),
                     value);
         } else {
-            return getAndBitwiseXorConvEndianWithCAS(bb, offsetNonPlain(bb, base, handle.alignmentMask), value);
+            return getAndBitwiseXorConvEndianWithCAS(bb, offsetNonPlain(bb, base, offset, handle.alignmentMask), value);
         }
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -101,7 +101,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static AbstractMemorySegmentImpl checkSegment(Object obb, Object encl, long base, boolean ro) {
         AbstractMemorySegmentImpl oo = (AbstractMemorySegmentImpl)Objects.requireNonNull(obb);
-        Utils.checkEnclosingLayout(oo, base, (MemoryLayout)encl, ro);
+        oo.checkEnclosingLayout(base, (MemoryLayout)encl, ro);
         return oo;
     }
 

--- a/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
+++ b/src/java.base/share/classes/java/lang/invoke/X-VarHandleSegmentView.java.template
@@ -25,6 +25,7 @@
 package java.lang.invoke;
 
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
+import jdk.internal.foreign.Utils;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.vm.annotation.ForceInline;
 
@@ -100,13 +101,7 @@ final class VarHandleSegmentAs$Type$s extends VarHandleSegmentViewBase {
     @ForceInline
     static AbstractMemorySegmentImpl checkSegment(Object obb, Object encl, long base, boolean ro) {
         AbstractMemorySegmentImpl oo = (AbstractMemorySegmentImpl)Objects.requireNonNull(obb);
-        MemoryLayout layout = (MemoryLayout)encl;
-        oo.checkAccess(base, layout.byteSize(), ro);
-        if (!oo.isAlignedForElement(base, layout)) {
-            throw new IllegalArgumentException(String.format(
-                    "Target offset %d is incompatible with alignment constraint %d (of %s) for segment %s"
-                    , base, layout.byteAlignment(), layout, oo));
-        }
+        Utils.checkEnclosingLayout(oo, base, (MemoryLayout)encl);
         return oo;
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -373,6 +373,16 @@ public abstract sealed class AbstractMemorySegmentImpl
         sessionImpl().checkValidState();
     }
 
+    @ForceInline
+    public final void checkEnclosingLayout(long offset, MemoryLayout enclosing, boolean readOnly) {
+        checkAccess(offset, enclosing.byteSize(), readOnly);
+        if (!isAlignedForElement(offset, enclosing)) {
+            throw new IllegalArgumentException(String.format(
+                    "Target offset %d is incompatible with alignment constraint %d (of %s) for segment %s"
+                    , offset, enclosing.byteAlignment(), enclosing, this));
+        }
+    }
+
     public abstract long unsafeGetOffset();
 
     public abstract Object unsafeGetBase();

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -239,9 +239,7 @@ public class LayoutPath {
     private static long addScaledOffset(long base, long index, long stride, long bound) {
         Objects.checkIndex(index, bound);
         // note: the below can overflow, depending on 'base'. When constructing var handles
-        // through the layout API, this is never the case, as the segment offset is checked
-        // against the segment size. But when using 'byteOffsetHandle' this might return a
-        // negative value. Seems incompatible also with scale(), which use exact operations.
+        // through the layout API, this is never the case, as the injected 'base' is always 0.
         return base + (stride * index);
     }
 
@@ -286,7 +284,7 @@ public class LayoutPath {
     }
 
     private static void checkEnclosingLayout(MemorySegment segment, long offset, MemoryLayout enclosing) {
-        Utils.checkEnclosingLayout(segment, offset, enclosing, true);
+        ((AbstractMemorySegmentImpl)segment).checkEnclosingLayout(offset, enclosing, true);
     }
 
     public MemoryLayout layout() {

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -77,7 +77,7 @@ public class LayoutPath {
                     MethodType.methodType(MemorySegment.class, long.class, long.class));
             MH_SLICE_LAYOUT = lookup.findVirtual(MemorySegment.class, "asSlice",
                     MethodType.methodType(MemorySegment.class, long.class, MemoryLayout.class));
-            MH_CHECK_ENCL_LAYOUT = lookup.findStatic(LayoutPath.class, "checkEnclosingLayout",
+            MH_CHECK_ENCL_LAYOUT = lookup.findStatic(Utils.class, "checkEnclosingLayout",
                     MethodType.methodType(void.class, MemorySegment.class, long.class, MemoryLayout.class));
             MH_SEGMENT_RESIZE = lookup.findStatic(LayoutPath.class, "resizeSegment",
                     MethodType.methodType(MemorySegment.class, MemorySegment.class));
@@ -283,15 +283,6 @@ public class LayoutPath {
         }
 
         return sliceHandle;
-    }
-
-    private static void checkEnclosingLayout(MemorySegment segment, long offset, MemoryLayout enclosing) {
-        ((AbstractMemorySegmentImpl)segment).checkAccess(offset, enclosing.byteSize(), true);
-        if (!((AbstractMemorySegmentImpl) segment).isAlignedForElement(offset, enclosing)) {
-            throw new IllegalArgumentException(String.format(
-                    "Target offset %d is incompatible with alignment constraint %d (of %s) for segment %s"
-                    , offset, enclosing.byteAlignment(), enclosing, segment));
-        }
     }
 
     public MemoryLayout layout() {

--- a/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/LayoutPath.java
@@ -77,7 +77,7 @@ public class LayoutPath {
                     MethodType.methodType(MemorySegment.class, long.class, long.class));
             MH_SLICE_LAYOUT = lookup.findVirtual(MemorySegment.class, "asSlice",
                     MethodType.methodType(MemorySegment.class, long.class, MemoryLayout.class));
-            MH_CHECK_ENCL_LAYOUT = lookup.findStatic(Utils.class, "checkEnclosingLayout",
+            MH_CHECK_ENCL_LAYOUT = lookup.findStatic(LayoutPath.class, "checkEnclosingLayout",
                     MethodType.methodType(void.class, MemorySegment.class, long.class, MemoryLayout.class));
             MH_SEGMENT_RESIZE = lookup.findStatic(LayoutPath.class, "resizeSegment",
                     MethodType.methodType(MemorySegment.class, MemorySegment.class));
@@ -283,6 +283,10 @@ public class LayoutPath {
         }
 
         return sliceHandle;
+    }
+
+    private static void checkEnclosingLayout(MemorySegment segment, long offset, MemoryLayout enclosing) {
+        Utils.checkEnclosingLayout(segment, offset, enclosing, true);
     }
 
     public MemoryLayout layout() {

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -242,8 +242,8 @@ public final class Utils {
     }
 
     @ForceInline
-    public static void checkEnclosingLayout(MemorySegment segment, long offset, MemoryLayout enclosing) {
-        ((AbstractMemorySegmentImpl)segment).checkAccess(offset, enclosing.byteSize(), true);
+    public static void checkEnclosingLayout(MemorySegment segment, long offset, MemoryLayout enclosing, boolean readOnly) {
+        ((AbstractMemorySegmentImpl)segment).checkAccess(offset, enclosing.byteSize(), readOnly);
         if (!((AbstractMemorySegmentImpl) segment).isAlignedForElement(offset, enclosing)) {
             throw new IllegalArgumentException(String.format(
                     "Target offset %d is incompatible with alignment constraint %d (of %s) for segment %s"

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -241,16 +241,6 @@ public final class Utils {
         }
     }
 
-    @ForceInline
-    public static void checkEnclosingLayout(MemorySegment segment, long offset, MemoryLayout enclosing, boolean readOnly) {
-        ((AbstractMemorySegmentImpl)segment).checkAccess(offset, enclosing.byteSize(), readOnly);
-        if (!((AbstractMemorySegmentImpl) segment).isAlignedForElement(offset, enclosing)) {
-            throw new IllegalArgumentException(String.format(
-                    "Target offset %d is incompatible with alignment constraint %d (of %s) for segment %s"
-                    , offset, enclosing.byteAlignment(), enclosing, segment));
-        }
-    }
-
     private static long computePadding(long offset, long align) {
         boolean isAligned = offset == 0 || offset % align == 0;
         if (isAligned) {

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -241,6 +241,16 @@ public final class Utils {
         }
     }
 
+    @ForceInline
+    public static void checkEnclosingLayout(MemorySegment segment, long offset, MemoryLayout enclosing) {
+        ((AbstractMemorySegmentImpl)segment).checkAccess(offset, enclosing.byteSize(), true);
+        if (!((AbstractMemorySegmentImpl) segment).isAlignedForElement(offset, enclosing)) {
+            throw new IllegalArgumentException(String.format(
+                    "Target offset %d is incompatible with alignment constraint %d (of %s) for segment %s"
+                    , offset, enclosing.byteAlignment(), enclosing, segment));
+        }
+    }
+
     private static long computePadding(long offset, long align) {
         boolean isAligned = offset == 0 || offset % align == 0;
         if (isAligned) {

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -63,7 +63,8 @@ public final class Utils {
     private static final MethodHandle BYTE_TO_BOOL;
     private static final MethodHandle BOOL_TO_BYTE;
     private static final MethodHandle ADDRESS_TO_LONG;
-    private static final MethodHandle LONG_TO_ADDRESS;
+    private static final MethodHandle LONG_TO_ADDRESS_TARGET;
+    private static final MethodHandle LONG_TO_ADDRESS_NO_TARGET;
 
     static {
         try {
@@ -74,8 +75,10 @@ public final class Utils {
                     MethodType.methodType(byte.class, boolean.class));
             ADDRESS_TO_LONG = lookup.findStatic(SharedUtils.class, "unboxSegment",
                     MethodType.methodType(long.class, MemorySegment.class));
-            LONG_TO_ADDRESS = lookup.findStatic(Utils.class, "longToAddress",
+            LONG_TO_ADDRESS_TARGET = lookup.findStatic(Utils.class, "longToAddress",
                     MethodType.methodType(MemorySegment.class, long.class, AddressLayout.class));
+            LONG_TO_ADDRESS_NO_TARGET = lookup.findStatic(Utils.class, "longToAddress",
+                    MethodType.methodType(MemorySegment.class, long.class));
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
         }
@@ -129,8 +132,10 @@ public final class Utils {
         if (layout.carrier() == boolean.class) {
             handle = MethodHandles.filterValue(handle, BOOL_TO_BYTE, BYTE_TO_BOOL);
         } else if (layout instanceof AddressLayout addressLayout) {
-            handle = MethodHandles.filterValue(handle,
-                    ADDRESS_TO_LONG, MethodHandles.insertArguments(LONG_TO_ADDRESS, 1, addressLayout));
+            MethodHandle longToAddressAdapter = addressLayout.targetLayout().isPresent() ?
+                    MethodHandles.insertArguments(LONG_TO_ADDRESS_TARGET, 1, addressLayout) :
+                    LONG_TO_ADDRESS_NO_TARGET;
+            handle = MethodHandles.filterValue(handle, ADDRESS_TO_LONG, longToAddressAdapter);
         }
         return handle;
     }
@@ -141,6 +146,11 @@ public final class Utils {
 
     private static byte booleanToByte(boolean b) {
         return b ? (byte)1 : (byte)0;
+    }
+
+    @ForceInline
+    public static MemorySegment longToAddress(long addr) {
+        return longToAddress(addr, 0, 1);
     }
 
     @ForceInline

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -75,7 +75,7 @@ public final class Utils {
             ADDRESS_TO_LONG = lookup.findStatic(SharedUtils.class, "unboxSegment",
                     MethodType.methodType(long.class, MemorySegment.class));
             LONG_TO_ADDRESS = lookup.findStatic(Utils.class, "longToAddress",
-                    MethodType.methodType(MemorySegment.class, long.class, long.class, long.class));
+                    MethodType.methodType(MemorySegment.class, long.class, AddressLayout.class));
         } catch (Throwable ex) {
             throw new ExceptionInInitializerError(ex);
         }
@@ -130,10 +130,7 @@ public final class Utils {
             handle = MethodHandles.filterValue(handle, BOOL_TO_BYTE, BYTE_TO_BOOL);
         } else if (layout instanceof AddressLayout addressLayout) {
             handle = MethodHandles.filterValue(handle,
-                    MethodHandles.explicitCastArguments(ADDRESS_TO_LONG, MethodType.methodType(baseCarrier, MemorySegment.class)),
-                    MethodHandles.explicitCastArguments(MethodHandles.insertArguments(LONG_TO_ADDRESS, 1,
-                                    pointeeByteSize(addressLayout), pointeeByteAlign(addressLayout)),
-                            MethodType.methodType(MemorySegment.class, baseCarrier)));
+                    ADDRESS_TO_LONG, MethodHandles.insertArguments(LONG_TO_ADDRESS, 1, addressLayout));
         }
         return handle;
     }
@@ -144,6 +141,11 @@ public final class Utils {
 
     private static byte booleanToByte(boolean b) {
         return b ? (byte)1 : (byte)0;
+    }
+
+    @ForceInline
+    public static MemorySegment longToAddress(long addr, AddressLayout layout) {
+        return longToAddress(addr, pointeeByteSize(layout), pointeeByteAlign(layout));
     }
 
     @ForceInline


### PR DESCRIPTION
This PR reduces the amount of lambda forms (LFs) which are created when generating var handles for simple struct field accessors. This contributes to the startup regression seen in [JDK-8337505](https://bugs.openjdk.org/browse/JDK-8337505).

There are essentially three sources of excessive var handle adaptation:

1. `LayoutPath::dereferenceHandle` has to do some very complex adaptation (including a permute) in order to inject alignment and size checks (against the enclosing layout) on the generated var handle.
2. Even in simple cases (e.g. when there's no dynamic coordinate), the offset of the accessed field is added to the var handle via an expensive collect adapter.
3. When we adapt a `long` var handle to work on `MemorySegment` using an `AddressLayout`, we make no distinction on whether the address layout has a target layout or not. In the latter case (common!) we can adapt more simply.

The meat of this PR is to address (1) by changing the shape of the generated helpers in the `X-VarHandleSegmentView.java.template` class. That is, the method for doing a plain get will now have the following shape:

```
T get(MemorySegment segment, MemoryLayout enclosing, long base, long offset)
```

Where:
* `segment` is the segment being accessed
* `enclosing` is the enclosing layout (the root of the selected layout path) against which to check size and alignment
* `base` is the public-facing offset passed by the user when calling `get` on the var handle
* `offset` is the offset at which the selected layout element can be found from the root (this can be replaced with an expression that takes several dynamic indices and turn them into a single offset)

With this organization, it is easy to see how, in order to create a memory access var handle for a struct field `S.f` we only need to:
* inject the enclosing layout `S` into the var handle (into the `enclosing` coordinate)
* inject the offset of `S.f` into the var handle (into the `offset` coordinate)

This way, we get our plain old memory access var handle featuring only two coordinates: a segment and an offset. Note how, to get there, we only needed very simple adaptations (e.g. `MethodHandles::insertCoordinates`).

#### Evaluation

I did some tests using the benchmark in [JDK-8337505](https://bugs.openjdk.org/browse/JDK-8337505) to assess the impact of this change on startup. To evaluate startup, I ran the benchmark 50 times and then took some stats. Here's what the numbers look before this change (AVG = average, MED = median):

```
AVG        0.196ms
MED        0.198ms
MAX        0.201ms
MIN        0.186ms
```

And here's after this change:

```
AVG        0.179ms
MED        0.180ms
MAX        0.183ms
MIN        0.174ms
```

This is a good 10% speedup. The number of generated LFs for this test went from 99 to 67 (we're at the point where most LFs are from static initializers in the `LayoutPath` and `Utils` classes).

I also run all the memory benhmarks starting with `LoopOver` before and after the change, and verified no unwanted change in peak performance.

#### Future work

There's more work to do here. One possible option is to tweak the template further to also generate variants for `MemorySegment` and `boolean`, so that no adaptation is required in those cases. Some preliminary examples seem to show another 10ms gain with this approach.

Another option would be to add some FFM code to the `HelloClasslist` class, so that some of the generated classes can be optimized at link-time. This also seems to yield another 10ms gain (I have not tried to see if this adds up with the gain in the previously described approach, but I would say probably not - at least not fully).

Many thanks to @cl4es for the invaluable help and moral support :-)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338677](https://bugs.openjdk.org/browse/JDK-8338677): Improve startup of memory access var handles by simplifying combinator chains (**Enhancement** - P3)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20647/head:pull/20647` \
`$ git checkout pull/20647`

Update a local copy of the PR: \
`$ git checkout pull/20647` \
`$ git pull https://git.openjdk.org/jdk.git pull/20647/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20647`

View PR using the GUI difftool: \
`$ git pr show -t 20647`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20647.diff">https://git.openjdk.org/jdk/pull/20647.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20647#issuecomment-2299461682)