### PR TITLE
8338688: Shenandoah: Avoid calling java_lang_Class accessors in asserts/verifier

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahAsserts.cpp
@@ -254,7 +254,7 @@ void ShenandoahAsserts::assert_correct(void* interior_loc, oop obj, const char* 
   // Do additional checks for special objects: their fields can hold metadata as well.
   // We want to check class loading/unloading did not corrupt them.
 
-  if (Universe::is_fully_initialized() && java_lang_Class::is_instance(obj)) {
+  if (Universe::is_fully_initialized() && (obj_klass == vmClasses::Class_klass())) {
     Metadata* klass = obj->metadata_field(java_lang_Class::klass_offset());
     if (klass != nullptr && !Metaspace::contains(klass)) {
       print_failure(_safe_all, obj, interior_loc, nullptr, "Shenandoah assert_correct failed",

--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -215,7 +215,7 @@ private:
     // Do additional checks for special objects: their fields can hold metadata as well.
     // We want to check class loading/unloading did not corrupt them.
 
-    if (java_lang_Class::is_instance(obj)) {
+    if (obj_klass == vmClasses::Class_klass()) {
       Metadata* klass = obj->metadata_field(java_lang_Class::klass_offset());
       check(ShenandoahAsserts::_safe_oop, obj,
             klass == nullptr || Metaspace::contains(klass),


### PR DESCRIPTION
In GC verification code, we are not always safe to touch the klass directly. This becomes a problem in Lilliput, where loading klass from the from-space is erroneous. Lilliput would replace `obj->klass()` with `obj->forward_safe_klass()` to make it right in GC code. But accessors like `java_lang_Class` would not be fixed: they would instead rely on barriers to always be called on to-space objects.

So we are better avoiding using these `java_lang_Class` accessors in GC verification code, and use the loaded `klass` directly. 

Additional tests:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [x] Linux x86_64 server fastdebug, `all` with `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338688](https://bugs.openjdk.org/browse/JDK-8338688): Shenandoah: Avoid calling java_lang_Class accessors in asserts/verifier (**Enhancement** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20651/head:pull/20651` \
`$ git checkout pull/20651`

Update a local copy of the PR: \
`$ git checkout pull/20651` \
`$ git pull https://git.openjdk.org/jdk.git pull/20651/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20651`

View PR using the GUI difftool: \
`$ git pr show -t 20651`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20651.diff">https://git.openjdk.org/jdk/pull/20651.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20651#issuecomment-2299340291)