### PR TITLE
8338765: ScheduledThreadPoolExecutor struggles with extremely long delays

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ScheduledThreadPoolExecutor.java
+++ b/src/java.base/share/classes/java/util/concurrent/ScheduledThreadPoolExecutor.java
@@ -182,6 +182,11 @@ public class ScheduledThreadPoolExecutor
      */
     private static final AtomicLong sequencer = new AtomicLong();
 
+    /**
+     * Maximum delay is effectively 146 years
+     */
+    private static final long MAX_NANOS = (Long.MAX_VALUE >>> 1) - 1;
+
     private class ScheduledFutureTask<V>
             extends FutureTask<V> implements RunnableScheduledFuture<V> {
 
@@ -525,25 +530,7 @@ public class ScheduledThreadPoolExecutor
      * Returns the nanoTime-based trigger time of a delayed action.
      */
     long triggerTime(long delay) {
-        return System.nanoTime() +
-            ((delay < (Long.MAX_VALUE >> 1)) ? delay : overflowFree(delay));
-    }
-
-    /**
-     * Constrains the values of all delays in the queue to be within
-     * Long.MAX_VALUE of each other, to avoid overflow in compareTo.
-     * This may occur if a task is eligible to be dequeued, but has
-     * not yet been, while some other task is added with a delay of
-     * Long.MAX_VALUE.
-     */
-    private long overflowFree(long delay) {
-        Delayed head = (Delayed) super.getQueue().peek();
-        if (head != null) {
-            long headDelay = head.getDelay(NANOSECONDS);
-            if (headDelay < 0 && (delay - headDelay < 0))
-                delay = Long.MAX_VALUE + headDelay;
-        }
-        return delay;
+        return System.nanoTime() + Math.min(delay, MAX_NANOS);
     }
 
     /**


### PR DESCRIPTION
Unfortunately there is no good, deterministic reproducer which can be used as a regression test at this point in time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338765](https://bugs.openjdk.org/browse/JDK-8338765): ScheduledThreadPoolExecutor struggles with extremely long delays (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20653/head:pull/20653` \
`$ git checkout pull/20653`

Update a local copy of the PR: \
`$ git checkout pull/20653` \
`$ git pull https://git.openjdk.org/jdk.git pull/20653/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20653`

View PR using the GUI difftool: \
`$ git pr show -t 20653`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20653.diff">https://git.openjdk.org/jdk/pull/20653.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20653#issuecomment-2311733603)