### PR TITLE
8258483: [TESTBUG] gtest CollectorPolicy.young_scaled_initial_ergo_vm fails if heap is too small

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -196,7 +196,7 @@ TEST_OTHER_VM(CollectorPolicy, young_cmd) {
 
   // If NewSize is set on command line, but is larger than the min
   // heap size, it should only be used for initial young size.
-  TestGenCollectorPolicy::SetNewSizeCmd setter_large(20 * M);
-  TestGenCollectorPolicy::CheckYoungInitial checker_large(20 * M);
+  TestGenCollectorPolicy::SetNewSizeCmd setter_large(40 * M);
+  TestGenCollectorPolicy::CheckYoungInitial checker_large(40 * M);
   TestGenCollectorPolicy::TestWrapper::test(&setter_large, &checker_large);
 }

--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -67,7 +67,7 @@ class TestGenCollectorPolicy {
       MinHeapSize = 40 * M;
       FLAG_SET_ERGO(InitialHeapSize, 100 * M);
       FLAG_SET_ERGO(NewSize, 1 * M);
-      FLAG_SET_ERGO(MaxNewSize, 30 * M);
+      FLAG_SET_ERGO(MaxNewSize, 40 * M);
 
       ASSERT_NO_FATAL_FAILURE(setter1->execute());
 

--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -67,7 +67,7 @@ class TestGenCollectorPolicy {
       MinHeapSize = 40 * M;
       FLAG_SET_ERGO(InitialHeapSize, 100 * M);
       FLAG_SET_ERGO(NewSize, 1 * M);
-      FLAG_SET_ERGO(MaxNewSize, 80 * M);
+      FLAG_SET_ERGO(MaxNewSize, 30 * M);
 
       ASSERT_NO_FATAL_FAILURE(setter1->execute());
 
@@ -163,6 +163,9 @@ class TestGenCollectorPolicy {
 // should use it for min but calculate the initial young size
 // using NewRatio.
 TEST_VM(CollectorPolicy, young_scaled_initial_ergo) {
+  if (MaxHeapSize < 134217728) {
+      return;
+  }
   TestGenCollectorPolicy::SetNewSizeErgo setter(20 * M);
   TestGenCollectorPolicy::CheckScaledYoungInitial checker;
 
@@ -175,6 +178,9 @@ TEST_VM(CollectorPolicy, young_scaled_initial_ergo) {
 // the rest of the VM lifetime. This is an irreversible change and
 // could impact other tests so we use TEST_OTHER_VM
 TEST_OTHER_VM(CollectorPolicy, young_cmd) {
+  if (MaxHeapSize < 134217728) {
+    return;
+  }
   // If NewSize is set on the command line, it should be used
   // for both min and initial young size if less than min heap.
   TestGenCollectorPolicy::SetNewSizeCmd setter(20 * M);
@@ -187,7 +193,7 @@ TEST_OTHER_VM(CollectorPolicy, young_cmd) {
 
   // If NewSize is set on command line, but is larger than the min
   // heap size, it should only be used for initial young size.
-  TestGenCollectorPolicy::SetNewSizeCmd setter_large(80 * M);
-  TestGenCollectorPolicy::CheckYoungInitial checker_large(80 * M);
+  TestGenCollectorPolicy::SetNewSizeCmd setter_large(20 * M);
+  TestGenCollectorPolicy::CheckYoungInitial checker_large(20 * M);
   TestGenCollectorPolicy::TestWrapper::test(&setter_large, &checker_large);
 }

--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -159,11 +159,14 @@ class TestGenCollectorPolicy {
 // depends on so many other configurable variables. These tests only try to
 // verify that there are some basic rules for NewSize honored by the policies.
 
+// Tests require at least 128M of MaxHeap
+// otherwise ergnomic  is different and generation sizes might be changed.
+
 // If NewSize has been ergonomically set, the collector policy
 // should use it for min but calculate the initial young size
 // using NewRatio.
 TEST_VM(CollectorPolicy, young_scaled_initial_ergo) {
-  if (MaxHeapSize < 134217728) {
+  if (MaxHeapSize < 128 * M) {
       return;
   }
   TestGenCollectorPolicy::SetNewSizeErgo setter(20 * M);
@@ -178,7 +181,7 @@ TEST_VM(CollectorPolicy, young_scaled_initial_ergo) {
 // the rest of the VM lifetime. This is an irreversible change and
 // could impact other tests so we use TEST_OTHER_VM
 TEST_OTHER_VM(CollectorPolicy, young_cmd) {
-  if (MaxHeapSize < 134217728) {
+  if (MaxHeapSize < 128 * M) {
     return;
   }
   // If NewSize is set on the command line, it should be used

--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -160,7 +160,7 @@ class TestGenCollectorPolicy {
 // verify that there are some basic rules for NewSize honored by the policies.
 
 // Tests require at least 128M of MaxHeap
-// otherwise ergnomic  is different and generation sizes might be changed.
+// otherwise ergonomic is different and generation sizes might be changed.
 
 // If NewSize has been ergonomically set, the collector policy
 // should use it for min but calculate the initial young size


### PR DESCRIPTION
The tests CollectorPolicy.* checks SerialGC policy. They might fail if MaxHeapSize is too small.

If heap is not enough for then VM change ergonomic scheme and print warning about this. The test is not checking this case.
The GC ergonomic has very different cases and only main workflow is covered. The goal of fix is not to improve test but pass in reasonable environment or silently pass if other.

I have updated test so it pass if heap is at least 128M (since it is SerialGC, it seems reasonable for testing in smaller containers) or skipped otherwise. 

Testing: tier1, running these tests manually with 90/128/256M to check that they pass in such environment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8258483](https://bugs.openjdk.org/browse/JDK-8258483): [TESTBUG] gtest CollectorPolicy.young_scaled_initial_ergo_vm fails if heap is too small (**Bug** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20656/head:pull/20656` \
`$ git checkout pull/20656`

Update a local copy of the PR: \
`$ git checkout pull/20656` \
`$ git pull https://git.openjdk.org/jdk.git pull/20656/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20656`

View PR using the GUI difftool: \
`$ git pr show -t 20656`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20656.diff">https://git.openjdk.org/jdk/pull/20656.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20656#issuecomment-2299983457)