### PR TITLE
8338630: Test java/nio/channels/DatagramChannel/SendReceiveMaxSize.java timeout

### DIFF
--- a/test/lib/jdk/test/lib/NetworkConfiguration.java
+++ b/test/lib/jdk/test/lib/NetworkConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,6 +142,13 @@ public class NetworkConfiguration {
         if (Platform.isWindows()) {
             String dName = nif.getDisplayName();
             if (dName != null && dName.contains("Teredo")) {
+                return false;
+            }
+        }
+
+        if (Platform.isLinux()) {
+            String dName = nif.getDisplayName();
+            if (dName != null && dName.contains("docker")) {
                 return false;
             }
         }


### PR DESCRIPTION
Hi,
On linux test environments which has docker service, `ifconfig` shows that `docker0` appears to be a virtual ethernet bridge which is created by the docker host. And the `docker0` virtual ethernet bridge may cause test `java/nio/channels/DatagramChannel/SendReceiveMaxSize.java` bind `docker0` ander network port. 
I think we should just skip "docker0" interfaces when looking for an IPv4 address for tests.
Test fix only, the risk is low.