### PR TITLE
8338728: Misc issues in memory layout javadoc

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -666,11 +666,12 @@ public sealed interface MemoryLayout
      * element in position {@code k} (where {@code k <= m}) then two layout paths
      * {@code P} and {@code Q} are derived, where P contains all the path elements from
      * 0 to {@code k - 1} and {@code Q} contains all the path elements from {@code k + 1}
-     * to {@code m} (if any). Then, the returned var handle is computed as follows:
+     * to {@code m} ({@code Q} could be an empty layout path if {@code k == m}).
+     * Then, the returned var handle is computed as follows:
      *
      * {@snippet lang = "java":
      * VarHandle baseHandle = this.varHandle(P);
-     * MemoryLayout target = ((AddressLayout)this.select(Q)).targetLayout().get();
+     * MemoryLayout target = ((AddressLayout)this.select(P)).targetLayout().get();
      * VarHandle targetHandle = target.varHandle(Q);
      * targetHandle = MethodHandles.insertCoordinates(targetHandle, 1, 0L); // always access nested targets at offset 0
      * targetHandle = MethodHandles.collectCoordinates(targetHandle, 0,
@@ -972,8 +973,8 @@ public sealed interface MemoryLayout
         }
 
         /**
-         * {@return a path element that dereferences an address layout as its
-         * {@linkplain AddressLayout#targetLayout() target layout} (where set)}
+         * {@return a path element that selects the {@linkplain AddressLayout#targetLayout() target layout} of
+         * an address layout (where set)}
          */
         static PathElement dereferenceElement() {
             return LayoutPath.DereferenceElement.instance();

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -664,14 +664,14 @@ public sealed interface MemoryLayout
      * <p>
      * If the provided layout path has size {@code m} and contains a dereference path
      * element in position {@code k} (where {@code k <= m}) then two layout paths
-     * {@code P} and {@code P'} are derived, where P contains all the path elements from
-     * 0 to {@code k - 1} and {@code P'} contains all the path elements from {@code k + 1}
+     * {@code P} and {@code Q} are derived, where P contains all the path elements from
+     * 0 to {@code k - 1} and {@code Q} contains all the path elements from {@code k + 1}
      * to {@code m} (if any). Then, the returned var handle is computed as follows:
      *
      * {@snippet lang = "java":
      * VarHandle baseHandle = this.varHandle(P);
-     * MemoryLayout target = ((AddressLayout)this.select(P)).targetLayout().get();
-     * VarHandle targetHandle = target.varHandle(P);
+     * MemoryLayout target = ((AddressLayout)this.select(Q)).targetLayout().get();
+     * VarHandle targetHandle = target.varHandle(Q);
      * targetHandle = MethodHandles.insertCoordinates(targetHandle, 1, 0L); // always access nested targets at offset 0
      * targetHandle = MethodHandles.collectCoordinates(targetHandle, 0,
      *         baseHandle.toMethodHandle(VarHandle.AccessMode.GET));
@@ -944,7 +944,7 @@ public sealed interface MemoryLayout
          * is computed as follows:
          * <ul>
          *    <li>if {@code F > 0}, then {@code B = ceilDiv(C - S, F)}</li>
-         *    <li>if {@code F < 0}, then {@code B = ceilDiv(-(S + 1), -F)}</li>
+         *    <li>if {@code F < 0}, then {@code B = ceilDiv(S + 1, -F)}</li>
          * </ul>
          * That is, the size of the returned open path element is {@code B}.
          *

--- a/test/jdk/java/foreign/TestDereferencePath.java
+++ b/test/jdk/java/foreign/TestDereferencePath.java
@@ -119,6 +119,30 @@ public class TestDereferencePath {
         }
     }
 
+    static final MemoryLayout A_VALUE = MemoryLayout.structLayout(
+            ValueLayout.ADDRESS.withName("b")
+                    .withTargetLayout(ValueLayout.JAVA_INT)
+    );
+
+    static final VarHandle a_value = A_VALUE.varHandle(
+            PathElement.groupElement("b"), PathElement.dereferenceElement());
+
+    @Test
+    public void testDerefValue() {
+        try (Arena arena = Arena.ofConfined()) {
+            // init structs
+            MemorySegment a = arena.allocate(A);
+            MemorySegment b = arena.allocate(ValueLayout.JAVA_INT);
+            // init struct fields
+            a.set(ValueLayout.ADDRESS, 0, b);
+            b.set(ValueLayout.JAVA_INT, 0, 42);
+            // dereference
+            int val = (int) a_value.get(a, 0L);
+            assertEquals(val, 42);
+        }
+    }
+
+
     @Test(expectedExceptions = IllegalArgumentException.class)
     void testBadDerefInSelect() {
         A.select(PathElement.groupElement("b"), PathElement.dereferenceElement());


### PR DESCRIPTION
This PR fixes two minor issues in the `MemoryLayout` javadoc:
* the section describing dereference path talks about `P` and `P'` but then only uses `P` in the code;
* the `ceilDiv` math on the `PathElement::sequenceElement(long, long)` is wrong, as the division returns a negative number for F < 0, which is incorrect

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338728](https://bugs.openjdk.org/browse/JDK-8338728): Misc issues in memory layout javadoc (**Enhancement** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20659/head:pull/20659` \
`$ git checkout pull/20659`

Update a local copy of the PR: \
`$ git checkout pull/20659` \
`$ git pull https://git.openjdk.org/jdk.git pull/20659/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20659`

View PR using the GUI difftool: \
`$ git pr show -t 20659`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20659.diff">https://git.openjdk.org/jdk/pull/20659.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20659#issuecomment-2301626342)