### PR TITLE
8338760: Adjust the comment after UseObjectMonitorTable

### DIFF
--- a/src/hotspot/share/oops/markWord.hpp
+++ b/src/hotspot/share/oops/markWord.hpp
@@ -53,7 +53,8 @@
 //    [ptr             | 00]  locked             ptr points to real header on stack (stack-locking in use)
 //    [header          | 00]  locked             locked regular object header (fast-locking in use)
 //    [header          | 01]  unlocked           regular object header
-//    [ptr             | 10]  monitor            inflated lock (header is swapped out)
+//    [ptr             | 10]  monitor            inflated lock (header is swapped out, UseObjectMonitorTable == false)
+//    [header          | 10]  monitor            inflated lock (UseObjectMonitorTable == true)
 //    [ptr             | 11]  marked             used to mark an object
 //    [0 ............ 0| 00]  inflating          inflation in progress (stack-locking in use)
 //


### PR DESCRIPTION
Hi,
Can you help to review this simple comment change?
After reading description and code of https://github.com/openjdk/jdk/pull/20067, seems to me this comment should be changed accordingly. But I could be wrong. 
Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338760](https://bugs.openjdk.org/browse/JDK-8338760): Adjust the comment after UseObjectMonitorTable (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20663/head:pull/20663` \
`$ git checkout pull/20663`

Update a local copy of the PR: \
`$ git checkout pull/20663` \
`$ git pull https://git.openjdk.org/jdk.git pull/20663/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20663`

View PR using the GUI difftool: \
`$ git pr show -t 20663`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20663.diff">https://git.openjdk.org/jdk/pull/20663.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20663#issuecomment-2302680961)