### PR TITLE
8338768: Introduce runtime lookup to check for static builds

### DIFF
--- a/make/modules/jdk.jdwp.agent/Lib.gmk
+++ b/make/modules/jdk.jdwp.agent/Lib.gmk
@@ -60,8 +60,8 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     EXTRA_HEADER_DIRS := \
         include \
         libjdwp/export \
-        java.base:libjava \
-        java.base:libjvm, \
+        java.base:libjava, \
+    JDK_LIBS := java.base:libjvm, \
     LIBS_linux := $(LIBDL), \
     LIBS_macosx := -liconv, \
     LIBS_aix := -liconv, \

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -473,9 +473,9 @@ void os::init_system_properties_values() {
     if (pslash != nullptr) {
       *pslash = '\0';            // Get rid of /{client|server|hotspot}.
     }
-#ifdef STATIC_BUILD
-    strcat(buf, "/lib");
-#endif
+    if (is_vm_statically_linked()) {
+      strcat(buf, "/lib");
+    }
 
     Arguments::set_dll_dir(buf);
 
@@ -1093,19 +1093,20 @@ void *os::Bsd::dlopen_helper(const char *filename, int mode, char *ebuf, int ebu
 
 #ifdef __APPLE__
 void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
-#ifdef STATIC_BUILD
-  return os::get_default_process_handle();
-#else
+  if (is_vm_statically_linked()) {
+    return os::get_default_process_handle();
+  }
+
   log_info(os)("attempting shared library load of %s", filename);
 
   return os::Bsd::dlopen_helper(filename, RTLD_LAZY, ebuf, ebuflen);
-#endif // STATIC_BUILD
 }
 #else
 void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
-#ifdef STATIC_BUILD
-  return os::get_default_process_handle();
-#else
+  if (is_vm_statically_linked()) {
+    return os::get_default_process_handle();
+  }
+
   log_info(os)("attempting shared library load of %s", filename);
 
   void* result;
@@ -1269,7 +1270,6 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   }
 
   return nullptr;
-#endif // STATIC_BUILD
 }
 #endif // !__APPLE__
 

--- a/src/hotspot/share/compiler/disassembler.cpp
+++ b/src/hotspot/share/compiler/disassembler.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@
 #include "memory/universe.hpp"
 #include "oops/oop.inline.hpp"
 #include "runtime/handles.inline.hpp"
+#include "runtime/java.hpp"
 #include "runtime/os.hpp"
 #include "runtime/stubCodeGenerator.hpp"
 #include "runtime/stubRoutines.hpp"
@@ -785,13 +786,13 @@ bool Disassembler::load_library(outputStream* st) {
   os::jvm_path(buf, sizeof(buf));
   int jvm_offset = -1;
   int lib_offset = -1;
-#ifdef STATIC_BUILD
-  char* p = strrchr(buf, '/');
-  *p = '\0';
-  strcat(p, "/lib/");
-  lib_offset = jvm_offset = (int)strlen(buf);
-#else
-  {
+
+  if (is_vm_statically_linked()) {
+    char* p = strrchr(buf, '/');
+    *p = '\0';
+    strcat(p, "/lib/");
+    lib_offset = jvm_offset = (int)strlen(buf);
+  } else {
     // Match "libjvm" instead of "jvm" on *nix platforms. Creates better matches.
     // Match "[lib]jvm[^/]*" in jvm_path.
     const char* base = buf;
@@ -805,7 +806,6 @@ bool Disassembler::load_library(outputStream* st) {
     if (p != nullptr) jvm_offset = p - base + 3; // this points to 'j' in libjvm.
 #endif
   }
-#endif
 
   // Find the disassembler shared library.
   // Search for several paths derived from libjvm, in this order:

--- a/src/hotspot/share/include/jvm.h
+++ b/src/hotspot/share/include/jvm.h
@@ -180,6 +180,9 @@ JVM_IsContinuationsSupported(void);
 JNIEXPORT jboolean JNICALL
 JVM_IsForeignLinkerSupported(void);
 
+JNIEXPORT jboolean JNICALL
+JVM_IsStaticallyLinked(void);
+
 JNIEXPORT void JNICALL
 JVM_InitializeFromArchive(JNIEnv* env, jclass cls);
 

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -3448,6 +3448,10 @@ JVM_LEAF(jboolean, JVM_IsForeignLinkerSupported(void))
   return ForeignGlobals::is_foreign_linker_supported() ? JNI_TRUE : JNI_FALSE;
 JVM_END
 
+JVM_ENTRY_NO_ENV(jboolean, JVM_IsStaticallyLinked(void))
+  return is_vm_statically_linked() ? JNI_TRUE : JNI_FALSE;
+JVM_END
+
 // String support ///////////////////////////////////////////////////////////////////////////
 
 JVM_ENTRY(jstring, JVM_InternString(JNIEnv *env, jstring str))

--- a/src/hotspot/share/runtime/java.hpp
+++ b/src/hotspot/share/runtime/java.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,6 +58,9 @@ extern void vm_exit_during_initialization(const char* error, const char* message
 extern void vm_shutdown_during_initialization(const char* error, const char* message = nullptr);
 
 extern void vm_exit_during_cds_dumping(const char* error, const char* message = nullptr);
+
+// This is defined in linkType.cpp due to linking restraints
+extern bool is_vm_statically_linked();
 
 /**
  * With the integration of the changes to handle the version string

--- a/src/hotspot/share/runtime/linkType.cpp
+++ b/src/hotspot/share/runtime/linkType.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "runtime/java.hpp"
+
+// This is in a separate file since it will need to be compiled to two different
+// object files, depending on if we are going to build a static or a dynamic
+// library.
+
+bool is_vm_statically_linked(void) {
+#ifdef STATIC_BUILD
+  return true;
+#else
+  return false;
+#endif
+}

--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -428,9 +428,9 @@ GetJVMPath(const char *jrepath, const char *jvmtype,
 
     JLI_TraceLauncher("Does `%s' exist ... ", jvmpath);
 
-#ifdef STATIC_BUILD
-    return JNI_TRUE;
-#else
+    if (JLI_IsStaticallyLinked()) {
+        return JNI_TRUE;
+    }
     if (stat(jvmpath, &s) == 0) {
         JLI_TraceLauncher("yes.\n");
         return JNI_TRUE;
@@ -438,7 +438,6 @@ GetJVMPath(const char *jrepath, const char *jvmtype,
         JLI_TraceLauncher("no.\n");
         return JNI_FALSE;
     }
-#endif
 }
 
 /*
@@ -451,18 +450,18 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
 
     if (GetApplicationHome(path, pathsize)) {
         /* Is JRE co-located with the application? */
-#ifdef STATIC_BUILD
-        char jvm_cfg[MAXPATHLEN];
-        JLI_Snprintf(jvm_cfg, sizeof(jvm_cfg), "%s/lib/jvm.cfg", path);
-        if (access(jvm_cfg, F_OK) == 0) {
-            return JNI_TRUE;
+        if (JLI_IsStaticallyLinked()) {
+            char jvm_cfg[MAXPATHLEN];
+            JLI_Snprintf(jvm_cfg, sizeof(jvm_cfg), "%s/lib/jvm.cfg", path);
+            if (access(jvm_cfg, F_OK) == 0) {
+                return JNI_TRUE;
+            }
+        } else {
+            JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
+            if (access(libjava, F_OK) == 0) {
+                return JNI_TRUE;
+            }
         }
-#else
-        JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
-        if (access(libjava, F_OK) == 0) {
-            return JNI_TRUE;
-        }
-#endif
         /* ensure storage for path + /jre + NULL */
         if ((JLI_StrLen(path) + 4 + 1) > (size_t) pathsize) {
             JLI_TraceLauncher("Insufficient space to store JRE path\n");
@@ -481,23 +480,24 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
     Dl_info selfInfo;
     dladdr(&GetJREPath, &selfInfo);
 
-#ifdef STATIC_BUILD
-    char jvm_cfg[MAXPATHLEN];
-    char *p = NULL;
-    strncpy(jvm_cfg, selfInfo.dli_fname, MAXPATHLEN);
-    p = strrchr(jvm_cfg, '/'); *p = '\0';
-    p = strrchr(jvm_cfg, '/');
-    if (strcmp(p, "/.") == 0) {
-      *p = '\0';
-      p = strrchr(jvm_cfg, '/'); *p = '\0';
+    if (JLI_IsStaticallyLinked()) {
+        char jvm_cfg[MAXPATHLEN];
+        char *p = NULL;
+        strncpy(jvm_cfg, selfInfo.dli_fname, MAXPATHLEN);
+        p = strrchr(jvm_cfg, '/'); *p = '\0';
+        p = strrchr(jvm_cfg, '/');
+        if (strcmp(p, "/.") == 0) {
+            *p = '\0';
+            p = strrchr(jvm_cfg, '/'); *p = '\0';
+        } else {
+          *p = '\0';
+        }
+        strncpy(path, jvm_cfg, pathsize);
+        strncat(jvm_cfg, "/lib/jvm.cfg", MAXPATHLEN);
+        if (access(jvm_cfg, F_OK) == 0) {
+           return JNI_TRUE;
+        }
     }
-    else *p = '\0';
-    strncpy(path, jvm_cfg, pathsize);
-    strncat(jvm_cfg, "/lib/jvm.cfg", MAXPATHLEN);
-    if (access(jvm_cfg, F_OK) == 0) {
-      return JNI_TRUE;
-    }
-#endif
 
     char *realPathToSelf = realpath(selfInfo.dli_fname, path);
     if (realPathToSelf != path) {
@@ -549,11 +549,12 @@ LoadJavaVM(const char *jvmpath, InvocationFunctions *ifn)
 
     JLI_TraceLauncher("JVM path is %s\n", jvmpath);
 
-#ifndef STATIC_BUILD
-    libjvm = dlopen(jvmpath, RTLD_NOW + RTLD_GLOBAL);
-#else
-    libjvm = dlopen(NULL, RTLD_FIRST);
-#endif
+    if (!JLI_IsStaticallyLinked()) {
+        libjvm = dlopen(jvmpath, RTLD_NOW + RTLD_GLOBAL);
+    } else {
+        libjvm = dlopen(NULL, RTLD_FIRST);
+    }
+
     if (libjvm == NULL) {
         JLI_ReportErrorMessage(DLL_ERROR1, __LINE__);
         JLI_ReportErrorMessage(DLL_ERROR2, jvmpath, dlerror());
@@ -603,14 +604,13 @@ SetExecname(char **argv)
     char* exec_path = NULL;
     {
         Dl_info dlinfo;
-
-#ifdef STATIC_BUILD
         void *fptr;
-        fptr = (void *)&SetExecname;
-#else
-        int (*fptr)();
-        fptr = (int (*)())dlsym(RTLD_DEFAULT, "main");
-#endif
+
+        if (JLI_IsStaticallyLinked()) {
+            fptr = (void *)&SetExecname;
+        } else {
+            fptr = dlsym(RTLD_DEFAULT, "main");
+        }
         if (fptr == NULL) {
             JLI_ReportErrorMessage(DLL_ERROR3, dlerror());
             return JNI_FALSE;

--- a/src/java.base/share/native/libjli/jli_util.h
+++ b/src/java.base/share/native/libjli/jli_util.h
@@ -113,6 +113,9 @@ JLI_SetTraceLauncher();
 
 jboolean JLI_IsTraceLauncher();
 
+// This is defined in link_type.c due to linking restraints
+jboolean JLI_IsStaticallyLinked();
+
 /*
  * JLI_List - a dynamic list of char*
  */

--- a/src/java.base/share/native/libjli/link_type.c
+++ b/src/java.base/share/native/libjli/link_type.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "jni.h"
+
+// This is in a separate file since it will need to be compiled to two different
+// object files, depending on if we are going to build a static or a dynamic
+// library.
+
+jboolean JLI_IsStaticallyLinked(void) {
+#ifdef STATIC_BUILD
+  return JNI_TRUE;
+#else
+  return JNI_FALSE;
+#endif
+}

--- a/src/jdk.jdwp.agent/share/native/libjdwp/transport.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/transport.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,7 @@
  * questions.
  */
 
+#include "jvm.h"
 #include "util.h"
 #include "utf_util.h"
 #include "transport.h"
@@ -121,7 +122,11 @@ static void *
 loadTransportLibrary(const char *libdir, const char *name)
 {
     char buf[MAXPATHLEN*2+100];
-#ifndef STATIC_BUILD
+
+    if (JVM_IsStaticallyLinked()) {
+        return (dbgsysLoadLibrary(NULL, buf, sizeof(buf)));
+    }
+
     void *handle;
     char libname[MAXPATHLEN+2];
     const char *plibdir;
@@ -145,9 +150,6 @@ loadTransportLibrary(const char *libdir, const char *name)
     /* dlopen (unix) / LoadLibrary (windows) the transport library */
     handle = dbgsysLoadLibrary(libname, buf, sizeof(buf));
     return handle;
-#else
-    return (dbgsysLoadLibrary(NULL, buf, sizeof(buf)));
-#endif
 }
 
 /*


### PR DESCRIPTION
As a preparation for Hermetic Java, we need to have a way to look up during runtime if we are using a statically linked library or not.

This change will be the first step needed towards compiling the object files only once, and then link them into either dynamic or static libraries. (The only exception will be the linktype.c[pp] files, which needs to be compiled twice, once for the dynamic libraries and once for the static libraries.) Getting there will require further work though. 

This is part of the changes that make up the draft PR https://github.com/openjdk/jdk/pull/19478, which I have broken out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338768](https://bugs.openjdk.org/browse/JDK-8338768): Introduce runtime lookup to check for static builds (**Enhancement** - P3)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Jiangli Zhou](https://openjdk.org/census#jiangli) (@jianglizhou - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Contributors
 * Magnus Ihse Bursie `<ihse@openjdk.org>`
 * Jiangli Zhou `<jiangli@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20666/head:pull/20666` \
`$ git checkout pull/20666`

Update a local copy of the PR: \
`$ git checkout pull/20666` \
`$ git pull https://git.openjdk.org/jdk.git pull/20666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20666`

View PR using the GUI difftool: \
`$ git pr show -t 20666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20666.diff">https://git.openjdk.org/jdk/pull/20666.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20666#issuecomment-2303079498)