### PR TITLE
8338700: AttributeMapper type parameter should be bounded by Attribute

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/AttributeMapper.java
+++ b/src/java.base/share/classes/java/lang/classfile/AttributeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ import jdk.internal.javac.PreviewFeature;
  * @since 22
  */
 @PreviewFeature(feature = PreviewFeature.Feature.CLASSFILE_API)
-public interface AttributeMapper<A> {
+public interface AttributeMapper<A extends Attribute<A>> {
 
     /**
      * Attribute stability indicator

--- a/src/java.base/share/classes/java/lang/classfile/package-info.java
+++ b/src/java.base/share/classes/java/lang/classfile/package-info.java
@@ -147,7 +147,7 @@
  * ClassReader, int)} method for mapping from the classfile format
  * to an attribute instance, and the
  * {@link java.lang.classfile.AttributeMapper#writeAttribute(java.lang.classfile.BufWriter,
- * java.lang.Object)} method for mapping back to the classfile format.  It also
+ * java.lang.classfile.Attribute)} method for mapping back to the classfile format.  It also
  * contains metadata including the attribute name, the set of classfile entities
  * where the attribute is applicable, and whether multiple attributes of the
  * same kind are allowed on a single entity.

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AttributeHolder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AttributeHolder.java
@@ -54,7 +54,7 @@ public class AttributeHolder {
     }
 
     @SuppressWarnings("unchecked")
-    <A> A get(AttributeMapper<A> am) {
+    <A extends Attribute<A>> A get(AttributeMapper<A> am) {
         for (Attribute<?> a : attributes)
             if (a.attributeMapper() == am)
                 return (A)a;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundAttribute.java
@@ -148,7 +148,7 @@ public abstract sealed class BoundAttribute<T extends Attribute<T>>
                 mapper = customAttributes.apply(name);
             }
             if (mapper != null) {
-                filled.add((Attribute<?>) Objects.requireNonNull(mapper.readAttribute(enclosing, reader, p)));
+                filled.add(Objects.requireNonNull(mapper.readAttribute(enclosing, reader, p)));
             } else {
                 AttributeMapper<UnknownAttribute> fakeMapper = new AttributeMapper<>() {
                     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -224,7 +224,7 @@ public class Util {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> void writeAttribute(BufWriterImpl writer, Attribute<?> attr) {
+    private static <T extends Attribute<T>> void writeAttribute(BufWriterImpl writer, Attribute<?> attr) {
         if (attr instanceof CustomAttribute<?> ca) {
             var mapper = (AttributeMapper<T>) ca.attributeMapper();
             mapper.writeAttribute(writer, (T) ca);


### PR DESCRIPTION
A minor oversight in AttributeMapper type parameter bounds, that it should be bounded by Attribute. Only real impact is in BoundAttribute.readAttributes where a cast is now omitted, as other sites of access like Attribute::attributeMapper has already bounded the returned type argument.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8338774](https://bugs.openjdk.org/browse/JDK-8338774) to be approved

### Issues
 * [JDK-8338700](https://bugs.openjdk.org/browse/JDK-8338700): AttributeMapper type parameter should be bounded by Attribute (**Bug** - P4)
 * [JDK-8338774](https://bugs.openjdk.org/browse/JDK-8338774): AttributeMapper type parameter should be bounded by Attribute (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20668/head:pull/20668` \
`$ git checkout pull/20668`

Update a local copy of the PR: \
`$ git checkout pull/20668` \
`$ git pull https://git.openjdk.org/jdk.git pull/20668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20668`

View PR using the GUI difftool: \
`$ git pr show -t 20668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20668.diff">https://git.openjdk.org/jdk/pull/20668.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20668#issuecomment-2303286980)