### PR TITLE
8338935: Micro-optimizations for startup

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2594,6 +2594,14 @@ public final class System {
                 StringLatin1.inflate(src, srcOff, dst, dstOff, len);
             }
 
+            public byte stringCoder(String s) {
+                return s.coder();
+            }
+
+            public int countGreaterThanZero(String s) {
+                return StringCoding.countGreaterThanZero(s);
+            }
+
             public int decodeASCII(byte[] src, int srcOff, char[] dst, int dstOff, int len) {
                 return String.decodeASCII(src, srcOff, dst, dstOff, len);
             }

--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -632,34 +632,72 @@ public sealed interface CodeBuilder
         if (value == null || value == ConstantDescs.NULL)
             return aconst_null();
         if (value instanceof Number) {
-            if (value instanceof Integer iVal)
-                return switch (iVal) {
-                    case -1 -> iconst_m1();
-                    case 0 -> iconst_0();
-                    case 1 -> iconst_1();
-                    case 2 -> iconst_2();
-                    case 3 -> iconst_3();
-                    case 4 -> iconst_4();
-                    case 5 -> iconst_5();
-                    default -> (iVal >= Byte.MIN_VALUE && iVal <= Byte.MAX_VALUE) ? bipush(iVal)
-                            : (iVal >= Short.MIN_VALUE && iVal <= Short.MAX_VALUE) ? sipush(iVal)
-                            : ldc(constantPool().intEntry(iVal));
-                };
-            if (value instanceof Long lVal)
-                return lVal == 0L ? lconst_0()
-                        : lVal == 1L ? lconst_1()
-                        : ldc(constantPool().longEntry(lVal));
-            if (value instanceof Float fVal)
-                return Float.floatToRawIntBits(fVal) == 0 ? fconst_0()
-                        : fVal == 1.0f ? fconst_1()
-                        : fVal == 2.0f ? fconst_2()
-                        : ldc(constantPool().floatEntry(fVal));
-            if (value instanceof Double dVal)
-                return Double.doubleToRawLongBits(dVal) == 0L ? dconst_0()
-                        : dVal == 1.0d ? dconst_1()
-                        : ldc(constantPool().doubleEntry(dVal));
+            if (value instanceof Integer) return loadConstant((int)    value);
+            if (value instanceof Long   ) return loadConstant((long)   value);
+            if (value instanceof Float  ) return loadConstant((float)  value);
+            if (value instanceof Double ) return loadConstant((double) value);
         }
         return ldc(value);
+    }
+
+
+
+    /**
+     * Generate an instruction pushing a constant int value onto the operand stack.
+     * @param value the int value
+     * @return this builder
+     * @since 24
+     */
+    default CodeBuilder loadConstant(int value) {
+        return switch (value) {
+            case -1 -> iconst_m1();
+            case  0 -> iconst_0();
+            case  1 -> iconst_1();
+            case  2 -> iconst_2();
+            case  3 -> iconst_3();
+            case  4 -> iconst_4();
+            case  5 -> iconst_5();
+            default -> (value >= Byte.MIN_VALUE  && value <= Byte.MAX_VALUE ) ? bipush(value)
+                    : (value >= Short.MIN_VALUE && value <= Short.MAX_VALUE) ? sipush(value)
+                    : ldc(constantPool().intEntry(value));
+        };
+    }
+
+    /**
+     * Generate an instruction pushing a constant long value onto the operand stack.
+     * @param value the long value
+     * @return this builder
+     * @since 24
+     */
+    default CodeBuilder loadConstant(long value) {
+        return value == 0l ? lconst_0()
+                : value == 1l ? lconst_1()
+                : ldc(constantPool().longEntry(value));
+    }
+
+    /**
+     * Generate an instruction pushing a constant float value onto the operand stack.
+     * @param value the float value
+     * @return this builder
+     * @since 24
+     */
+    default CodeBuilder loadConstant(float value) {
+        return Float.floatToRawIntBits(value) == 0 ? fconst_0()
+                : value == 1.0f                       ? fconst_1()
+                : value == 2.0f                       ? fconst_2()
+                : ldc(constantPool().floatEntry(value));
+    }
+
+    /**
+     * Generate an instruction pushing a constant double value onto the operand stack.
+     * @param value the double value
+     * @return this builder
+     * @since 24
+     */
+    default CodeBuilder loadConstant(double value) {
+        return Double.doubleToRawLongBits(value) == 0l ? dconst_0()
+                : value == 1.0d                           ? dconst_1()
+                : ldc(constantPool().doubleEntry(value));
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/TypeKind.java
+++ b/src/java.base/share/classes/java/lang/classfile/TypeKind.java
@@ -29,8 +29,11 @@ import java.lang.classfile.instruction.DiscontinuedInstruction;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.invoke.TypeDescriptor;
+import jdk.internal.constant.PrimitiveClassDescImpl;
 import jdk.internal.javac.PreviewFeature;
 import jdk.internal.vm.annotation.Stable;
+
+import static jdk.internal.constant.PrimitiveClassDescImpl.*;
 
 /**
  * Describes the data types Java Virtual Machine operates on.
@@ -239,12 +242,41 @@ public enum TypeKind {
     }
 
     /**
-     * {@return the type associated with the specified field descriptor}
-     * @param descriptor the field descriptor
+     * {@return the type associated with the specified ClassDesc}
+     * @param desc the ClassDesc
      */
-    public static TypeKind from(TypeDescriptor.OfField<?> descriptor) {
-        return descriptor.isPrimitive() // implicit null check
-                ? fromDescriptor(descriptor.descriptorString())
-                : REFERENCE;
+    public static TypeKind from(ClassDesc desc) {
+        if (desc == null) throw new NullPointerException();
+        if (desc instanceof PrimitiveClassDescImpl) {
+            if (desc == CD_void   ) return VOID;
+            if (desc == CD_boolean) return BOOLEAN;
+            if (desc == CD_int    ) return INT;
+            if (desc == CD_long   ) return LONG;
+            if (desc == CD_byte   ) return BYTE;
+            if (desc == CD_float  ) return FLOAT;
+            if (desc == CD_double ) return DOUBLE;
+            if (desc == CD_short  ) return SHORT;
+            else                    return CHAR;
+        }
+        return REFERENCE;
+    }
+
+    /**
+     * {@return the type associated with the specified class}
+     * @param cl the class
+     */
+    public static TypeKind from(Class<?> cl) {
+        if (cl.isPrimitive()) {
+            if (cl == void.class   ) return VOID;
+            if (cl == boolean.class) return BOOLEAN;
+            if (cl == int.class    ) return INT;
+            if (cl == long.class   ) return LONG;
+            if (cl == byte.class   ) return BYTE;
+            if (cl == float.class  ) return FLOAT;
+            if (cl == double.class ) return DOUBLE;
+            if (cl == char.class   ) return CHAR;
+            return SHORT;
+        }
+        return REFERENCE;
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -319,7 +319,7 @@ class InvokerBytecodeGenerator {
         clb.withMethodBody(CLASS_INIT_NAME, MTD_void, ACC_STATIC, new Consumer<>() {
             @Override
             public void accept(CodeBuilder cob) {
-                cob.loadConstant(classDesc)
+                cob.ldc(classDesc)
                    .invokestatic(CD_MethodHandles, "classData", MTD_Object_Class);
                 if (classData.size() == 1) {
                     ClassData p = classData.get(0);
@@ -1659,7 +1659,7 @@ class InvokerBytecodeGenerator {
             clb.withMethodBody("dummy", MTD_void, ACC_STATIC, new Consumer<>() {
                 @Override
                 public void accept(CodeBuilder cob) {
-                    cob.loadConstant(os.toString());
+                    cob.ldc(os.toString());
                     cob.pop();
                     cob.return_();
                 }

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -196,7 +196,16 @@ class LambdaForm {
             };
         }
         static BasicType basicType(Class<?> type) {
-            return basicType(Wrapper.basicTypeChar(type));
+            if (type == int.class
+                    || type == short.class
+                    || type == byte.class
+                    || type == char.class
+                    || type == boolean.class) return I_TYPE;
+            if (type == long.class   ) return J_TYPE;
+            if (type == float.class  ) return F_TYPE;
+            if (type == double.class ) return D_TYPE;
+            if (type == void.class   ) return V_TYPE;
+            else                       return L_TYPE;
         }
         static int[] basicTypeOrds(BasicType[] types) {
             if (types == null) {

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -391,6 +391,13 @@ public interface JavaLangAccess {
      */
     void inflateBytesToChars(byte[] src, int srcOff, char[] dst, int dstOff, int len);
 
+    byte stringCoder(String s);
+
+    /**
+     * if string#coder() is Latin1 return the count of string#value() leading greater than zero, else return 0
+     */
+    int countGreaterThanZero(String s);
+
     /**
      * Decodes ASCII from the source byte array into the destination
      * char array.

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractAttributeMapper.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractAttributeMapper.java
@@ -62,13 +62,14 @@ public sealed abstract class AbstractAttributeMapper<T extends Attribute<T>>
     }
 
     @Override
-    public final void writeAttribute(BufWriter buf, T attr) {
+    public final void writeAttribute(BufWriter writer, T attr) {
+        BufWriterImpl buf = (BufWriterImpl) writer;
         buf.writeIndex(buf.constantPool().utf8Entry(name));
-        buf.writeInt(0);
+        buf.skip(4);
         int start = buf.size();
         writeBody(buf, attr);
         int written = buf.size() - start;
-        buf.patchInt(start - 4, 4, written);
+        buf.patchInt(start - 4, written);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -446,7 +446,7 @@ public abstract sealed class AbstractPoolEntry {
                             throw new IllegalArgumentException();
                         }
                         int byteLengthFinal = byteLength;
-                        pool.patchInt(pool.size() - i - 2, 2, byteLengthFinal);
+                        pool.patchU2(pool.size() - i - 2, byteLengthFinal);
                         for (int j = i; j < charLength; ++j) {
                             c1 = (stringValue).charAt(j);
                             if (c1 >= '\001' && c1 <= '\177') {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -409,60 +409,14 @@ public abstract sealed class AbstractPoolEntry {
 
         @Override
         void writeTo(BufWriterImpl pool) {
+            pool.writeU1(tag);
             if (rawBytes != null) {
-                pool.writeU1(tag);
                 pool.writeU2(rawLen);
                 pool.writeBytes(rawBytes, offset, rawLen);
             }
             else {
                 // state == STRING and no raw bytes
-                if (stringValue.length() > 65535) {
-                    throw new IllegalArgumentException("string too long");
-                }
-                pool.writeU1(tag);
-                pool.writeU2(charLen);
-                for (int i = 0; i < charLen; ++i) {
-                    char c = stringValue.charAt(i);
-                    if (c >= '\001' && c <= '\177') {
-                        // Optimistic writing -- hope everything is bytes
-                        // If not, we bail out, and alternate path patches the length
-                        pool.writeU1((byte) c);
-                    }
-                    else {
-                        int charLength = stringValue.length();
-                        int byteLength = i;
-                        char c1;
-                        for (int j = i; j < charLength; ++j) {
-                            c1 = (stringValue).charAt(j);
-                            if (c1 >= '\001' && c1 <= '\177') {
-                                byteLength++;
-                            } else if (c1 > '\u07FF') {
-                                byteLength += 3;
-                            } else {
-                                byteLength += 2;
-                            }
-                        }
-                        if (byteLength > 65535) {
-                            throw new IllegalArgumentException();
-                        }
-                        int byteLengthFinal = byteLength;
-                        pool.patchU2(pool.size() - i - 2, byteLengthFinal);
-                        for (int j = i; j < charLength; ++j) {
-                            c1 = (stringValue).charAt(j);
-                            if (c1 >= '\001' && c1 <= '\177') {
-                                pool.writeU1((byte) c1);
-                            } else if (c1 > '\u07FF') {
-                                pool.writeU1((byte) (0xE0 | c1 >> 12 & 0xF));
-                                pool.writeU1((byte) (0x80 | c1 >> 6 & 0x3F));
-                                pool.writeU1((byte) (0x80 | c1 & 0x3F));
-                            } else {
-                                pool.writeU1((byte) (0xC0 | c1 >> 6 & 0x1F));
-                                pool.writeU1((byte) (0x80 | c1 & 0x3F));
-                            }
-                        }
-                        break;
-                    }
-                }
+                pool.writeUTF(stringValue);
             }
         }
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -233,65 +233,68 @@ public abstract sealed class AbstractPoolEntry {
                 state = State.BYTE;
             }
             else {
-                char[] chararr = new char[rawLen];
-                int chararr_count = singleBytes;
-                // Inflate prefix of bytes to characters
-                JLA.inflateBytesToChars(rawBytes, offset, chararr, 0, singleBytes);
-
-                int px = offset + singleBytes;
-                int utfend = offset + rawLen;
-                while (px < utfend) {
-                    int c = (int) rawBytes[px] & 0xff;
-                    switch (c >> 4) {
-                        case 0, 1, 2, 3, 4, 5, 6, 7: {
-                            // 0xxx xxxx
-                            px++;
-                            chararr[chararr_count++] = (char) c;
-                            hash = 31 * hash + c;
-                            break;
-                        }
-                        case 12, 13: {
-                            // 110x xxxx  10xx xxxx
-                            px += 2;
-                            if (px > utfend) {
-                                throw new CpException("malformed input: partial character at end");
-                            }
-                            int char2 = rawBytes[px - 1];
-                            if ((char2 & 0xC0) != 0x80) {
-                                throw new CpException("malformed input around byte " + px);
-                            }
-                            char v = (char) (((c & 0x1F) << 6) | (char2 & 0x3F));
-                            chararr[chararr_count++] = v;
-                            hash = 31 * hash + v;
-                            break;
-                        }
-                        case 14: {
-                            // 1110 xxxx  10xx xxxx  10xx xxxx
-                            px += 3;
-                            if (px > utfend) {
-                                throw new CpException("malformed input: partial character at end");
-                            }
-                            int char2 = rawBytes[px - 2];
-                            int char3 = rawBytes[px - 1];
-                            if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80)) {
-                                throw new CpException("malformed input around byte " + (px - 1));
-                            }
-                            char v = (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | (char3 & 0x3F));
-                            chararr[chararr_count++] = v;
-                            hash = 31 * hash + v;
-                            break;
-                        }
-                        default:
-                            // 10xx xxxx,  1111 xxxx
-                            throw new CpException("malformed input around byte " + px);
-                    }
-                }
-                this.hash = hashString(hash);
-                charLen = chararr_count;
-                this.chars = chararr;
-                state = State.CHAR;
+                inflateCHAR(singleBytes, hash);
             }
+        }
 
+        private void inflateCHAR(int singleBytes, int hash) throws CpException {
+            char[] chararr = new char[rawLen];
+            int chararr_count = singleBytes;
+            // Inflate prefix of bytes to characters
+            JLA.inflateBytesToChars(rawBytes, offset, chararr, 0, singleBytes);
+
+            int px = offset + singleBytes;
+            int utfend = offset + rawLen;
+            while (px < utfend) {
+                int c = (int) rawBytes[px] & 0xff;
+                switch (c >> 4) {
+                    case 0, 1, 2, 3, 4, 5, 6, 7: {
+                        // 0xxx xxxx
+                        px++;
+                        chararr[chararr_count++] = (char) c;
+                        hash = 31 * hash + c;
+                        break;
+                    }
+                    case 12, 13: {
+                        // 110x xxxx  10xx xxxx
+                        px += 2;
+                        if (px > utfend) {
+                            throw new CpException("malformed input: partial character at end");
+                        }
+                        int char2 = rawBytes[px - 1];
+                        if ((char2 & 0xC0) != 0x80) {
+                            throw new CpException("malformed input around byte " + px);
+                        }
+                        char v = (char) (((c & 0x1F) << 6) | (char2 & 0x3F));
+                        chararr[chararr_count++] = v;
+                        hash = 31 * hash + v;
+                        break;
+                    }
+                    case 14: {
+                        // 1110 xxxx  10xx xxxx  10xx xxxx
+                        px += 3;
+                        if (px > utfend) {
+                            throw new CpException("malformed input: partial character at end");
+                        }
+                        int char2 = rawBytes[px - 2];
+                        int char3 = rawBytes[px - 1];
+                        if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80)) {
+                            throw new CpException("malformed input around byte " + (px - 1));
+                        }
+                        char v = (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | (char3 & 0x3F));
+                        chararr[chararr_count++] = v;
+                        hash = 31 * hash + v;
+                        break;
+                    }
+                    default:
+                        // 10xx xxxx,  1111 xxxx
+                        throw new CpException("malformed input around byte " + px);
+                }
+            }
+            this.hash = hashString(hash);
+            charLen = chararr_count;
+            this.chars = chararr;
+            state = State.CHAR;
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -167,12 +167,34 @@ public final class BufWriterImpl implements BufWriter {
         this.offset = prevOffset;
     }
 
+    public void patchU2(int offset, int x) {
+        byte[] elems = this.elems;
+        elems[offset    ] = (byte) (x >> 8);
+        elems[offset + 1] = (byte)  x;
+    }
+
+    public void patchInt(int offset, int x) {
+        byte[] elems = this.elems;
+        elems[offset    ] = (byte) (x >> 24);
+        elems[offset + 1] = (byte) (x >> 16);
+        elems[offset + 2] = (byte) (x >> 8);
+        elems[offset + 3] = (byte)  x;
+    }
+
     @Override
     public void writeIntBytes(int intSize, long intValue) {
         reserveSpace(intSize);
         for (int i = 0; i < intSize; i++) {
             elems[offset++] = (byte) ((intValue >> 8 * (intSize - i - 1)) & 0xFF);
         }
+    }
+
+    public void skip(int skipSize) {
+        int nextOffset = offset + skipSize;
+        if (nextOffset > elems.length) {
+            grow(nextOffset);
+        }
+        this.offset = nextOffset;
     }
 
     @Override
@@ -218,7 +240,7 @@ public final class BufWriterImpl implements BufWriter {
     @Override
     public void writeIndexOrZero(PoolEntry entry) {
         if (entry == null || entry.index() == 0)
-            writeU2(0);
+            skip(2);
         else
             writeIndex(entry);
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,83 +57,125 @@ public class BytecodeHelpers {
 
     public static Opcode loadOpcode(TypeKind tk, int slot) {
         return switch (tk) {
-            case INT, SHORT, BYTE, CHAR, BOOLEAN -> switch (slot) {
-                case 0 -> Opcode.ILOAD_0;
-                case 1 -> Opcode.ILOAD_1;
-                case 2 -> Opcode.ILOAD_2;
-                case 3 -> Opcode.ILOAD_3;
-                default -> (slot < 256) ? Opcode.ILOAD : Opcode.ILOAD_W;
-            };
-            case LONG -> switch (slot) {
-                case 0 -> Opcode.LLOAD_0;
-                case 1 -> Opcode.LLOAD_1;
-                case 2 -> Opcode.LLOAD_2;
-                case 3 -> Opcode.LLOAD_3;
-                default -> (slot < 256) ? Opcode.LLOAD : Opcode.LLOAD_W;
-            };
-            case DOUBLE -> switch (slot) {
-                case 0 -> Opcode.DLOAD_0;
-                case 1 -> Opcode.DLOAD_1;
-                case 2 -> Opcode.DLOAD_2;
-                case 3 -> Opcode.DLOAD_3;
-                default -> (slot < 256) ? Opcode.DLOAD : Opcode.DLOAD_W;
-            };
-            case FLOAT -> switch (slot) {
-                case 0 -> Opcode.FLOAD_0;
-                case 1 -> Opcode.FLOAD_1;
-                case 2 -> Opcode.FLOAD_2;
-                case 3 -> Opcode.FLOAD_3;
-                default -> (slot < 256) ? Opcode.FLOAD : Opcode.FLOAD_W;
-            };
-            case REFERENCE -> switch (slot) {
-                case 0 -> Opcode.ALOAD_0;
-                case 1 -> Opcode.ALOAD_1;
-                case 2 -> Opcode.ALOAD_2;
-                case 3 -> Opcode.ALOAD_3;
-                default -> (slot < 256) ? Opcode.ALOAD : Opcode.ALOAD_W;
-            };
-            case VOID -> throw new IllegalArgumentException("void");
+            case INT, SHORT, BYTE, CHAR, BOOLEAN
+                           -> iload(slot);
+            case LONG      -> lload(slot);
+            case DOUBLE    -> dload(slot);
+            case FLOAT     -> fload(slot);
+            case REFERENCE -> aload(slot);
+            case VOID      -> throw new IllegalArgumentException("void");
+        };
+    }
+
+    public static Opcode aload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.ALOAD_0;
+            case 1 -> Opcode.ALOAD_1;
+            case 2 -> Opcode.ALOAD_2;
+            case 3 -> Opcode.ALOAD_3;
+            default -> (slot < 256) ? Opcode.ALOAD : Opcode.ALOAD_W;
+        };
+    }
+
+    public static Opcode fload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.FLOAD_0;
+            case 1 -> Opcode.FLOAD_1;
+            case 2 -> Opcode.FLOAD_2;
+            case 3 -> Opcode.FLOAD_3;
+            default -> (slot < 256) ? Opcode.FLOAD : Opcode.FLOAD_W;
+        };
+    }
+
+    public static Opcode dload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.DLOAD_0;
+            case 1 -> Opcode.DLOAD_1;
+            case 2 -> Opcode.DLOAD_2;
+            case 3 -> Opcode.DLOAD_3;
+            default -> (slot < 256) ? Opcode.DLOAD : Opcode.DLOAD_W;
+        };
+    }
+
+    public static Opcode lload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.LLOAD_0;
+            case 1 -> Opcode.LLOAD_1;
+            case 2 -> Opcode.LLOAD_2;
+            case 3 -> Opcode.LLOAD_3;
+            default -> (slot < 256) ? Opcode.LLOAD : Opcode.LLOAD_W;
+        };
+    }
+
+    public static Opcode iload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.ILOAD_0;
+            case 1 -> Opcode.ILOAD_1;
+            case 2 -> Opcode.ILOAD_2;
+            case 3 -> Opcode.ILOAD_3;
+            default -> (slot < 256) ? Opcode.ILOAD : Opcode.ILOAD_W;
         };
     }
 
     public static Opcode storeOpcode(TypeKind tk, int slot) {
         return switch (tk) {
-            case INT, SHORT, BYTE, CHAR, BOOLEAN -> switch (slot) {
-                case 0 -> Opcode.ISTORE_0;
-                case 1 -> Opcode.ISTORE_1;
-                case 2 -> Opcode.ISTORE_2;
-                case 3 -> Opcode.ISTORE_3;
-                default -> (slot < 256) ? Opcode.ISTORE : Opcode.ISTORE_W;
-            };
-            case LONG -> switch (slot) {
-                case 0 -> Opcode.LSTORE_0;
-                case 1 -> Opcode.LSTORE_1;
-                case 2 -> Opcode.LSTORE_2;
-                case 3 -> Opcode.LSTORE_3;
-                default -> (slot < 256) ? Opcode.LSTORE : Opcode.LSTORE_W;
-            };
-            case DOUBLE -> switch (slot) {
-                case 0 -> Opcode.DSTORE_0;
-                case 1 -> Opcode.DSTORE_1;
-                case 2 -> Opcode.DSTORE_2;
-                case 3 -> Opcode.DSTORE_3;
-                default -> (slot < 256) ? Opcode.DSTORE : Opcode.DSTORE_W;
-            };
-            case FLOAT -> switch (slot) {
-                case 0 -> Opcode.FSTORE_0;
-                case 1 -> Opcode.FSTORE_1;
-                case 2 -> Opcode.FSTORE_2;
-                case 3 -> Opcode.FSTORE_3;
-                default -> (slot < 256) ? Opcode.FSTORE : Opcode.FSTORE_W;
-            };
-            case REFERENCE -> switch (slot) {
-                case 0 -> Opcode.ASTORE_0;
-                case 1 -> Opcode.ASTORE_1;
-                case 2 -> Opcode.ASTORE_2;
-                case 3 -> Opcode.ASTORE_3;
-                default -> (slot < 256) ? Opcode.ASTORE : Opcode.ASTORE_W;
-            };
-            case VOID -> throw new IllegalArgumentException("void");
+            case INT, SHORT, BYTE, CHAR, BOOLEAN
+                           -> istore(slot);
+            case LONG      -> lstore(slot);
+            case DOUBLE    -> dstore(slot);
+            case FLOAT     -> fstore(slot);
+            case REFERENCE -> astore(slot);
+            case VOID      -> throw new IllegalArgumentException("void");
+        };
+    }
+
+    public static Opcode astore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.ASTORE_0;
+            case 1 -> Opcode.ASTORE_1;
+            case 2 -> Opcode.ASTORE_2;
+            case 3 -> Opcode.ASTORE_3;
+            default -> (slot < 256) ? Opcode.ASTORE : Opcode.ASTORE_W;
+        };
+    }
+
+    public static Opcode fstore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.FSTORE_0;
+            case 1 -> Opcode.FSTORE_1;
+            case 2 -> Opcode.FSTORE_2;
+            case 3 -> Opcode.FSTORE_3;
+            default -> (slot < 256) ? Opcode.FSTORE : Opcode.FSTORE_W;
+        };
+    }
+
+    public static Opcode dstore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.DSTORE_0;
+            case 1 -> Opcode.DSTORE_1;
+            case 2 -> Opcode.DSTORE_2;
+            case 3 -> Opcode.DSTORE_3;
+            default -> (slot < 256) ? Opcode.DSTORE : Opcode.DSTORE_W;
+        };
+    }
+
+    public static Opcode lstore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.LSTORE_0;
+            case 1 -> Opcode.LSTORE_1;
+            case 2 -> Opcode.LSTORE_2;
+            case 3 -> Opcode.LSTORE_3;
+            default -> (slot < 256) ? Opcode.LSTORE : Opcode.LSTORE_W;
+        };
+    }
+
+    public static Opcode istore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.ISTORE_0;
+            case 1 -> Opcode.ISTORE_1;
+            case 2 -> Opcode.ISTORE_2;
+            case 3 -> Opcode.ISTORE_3;
+            default -> (slot < 256) ? Opcode.ISTORE : Opcode.ISTORE_W;
         };
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
@@ -192,7 +192,7 @@ public final class DirectClassBuilder
         boolean written = constantPool.writeBootstrapMethods(tail);
         if (written) {
             // Update attributes count
-            tail.patchInt(attributesOffset, 2, attributes.size() + 1);
+            tail.patchU2(attributesOffset, attributes.size() + 1);
         }
 
         // Now we can make the head

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -206,7 +206,7 @@ public final class DirectCodeBuilder
             }
         }
         if (handlersSize < handlers.size())
-            buf.patchInt(pos, 2, handlersSize);
+            buf.patchU2(pos, handlersSize);
     }
 
     private void buildContent() {
@@ -243,7 +243,7 @@ public final class DirectCodeBuilder
                             }
                         }
                         if (crSize < characterRanges.size())
-                            b.patchInt(pos, 2, crSize);
+                            b.patchU2(pos, crSize);
                     }
                 };
                 attributes.withAttribute(a);
@@ -266,7 +266,7 @@ public final class DirectCodeBuilder
                             }
                         }
                         if (lvSize < localVariables.size())
-                            b.patchInt(pos, 2, lvSize);
+                            b.patchU2(pos, lvSize);
                     }
                 };
                 attributes.withAttribute(a);
@@ -469,8 +469,13 @@ public final class DirectCodeBuilder
         if (deferredLabels != null) {
             for (DeferredLabel dl : deferredLabels) {
                 int branchOffset = labelToBci(dl.label) - dl.instructionPc;
-                if (dl.size == 2 && (short)branchOffset != branchOffset) throw new LabelOverflowException();
-                bytecodesBufWriter.patchInt(dl.labelPc, dl.size, branchOffset);
+                if (dl.size == 2) {
+                    if ((short)branchOffset != branchOffset) throw new LabelOverflowException();
+                    bytecodesBufWriter.patchU2(dl.labelPc, branchOffset);
+                } else {
+                    assert dl.size == 4;
+                    bytecodesBufWriter.patchInt(dl.labelPc, branchOffset);
+                }
             }
         }
     }
@@ -590,13 +595,13 @@ public final class DirectCodeBuilder
         writeBytecode(opcode);
         bytecodesBufWriter.writeIndex(ref);
         bytecodesBufWriter.writeU1(count);
-        bytecodesBufWriter.writeU1(0);
+        bytecodesBufWriter.skip(1);
     }
 
     public void writeInvokeDynamic(InvokeDynamicEntry ref) {
         writeBytecode(INVOKEDYNAMIC);
         bytecodesBufWriter.writeIndex(ref);
-        bytecodesBufWriter.writeU2(0);
+        bytecodesBufWriter.skip(2);
     }
 
     public void writeNewObject(ClassEntry type) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,6 +63,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static java.lang.classfile.Opcode.*;
+
+import static jdk.internal.classfile.impl.BytecodeHelpers.*;
 
 public final class DirectCodeBuilder
         extends AbstractDirectBuilder<CodeModel>
@@ -1474,6 +1477,66 @@ public final class DirectCodeBuilder
     @Override
     public CodeBuilder tableswitch(int low, int high, Label defaultTarget, List<SwitchCase> cases) {
         writeTableSwitch(low, high, defaultTarget, cases);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder iload(int slot) {
+        writeLocalVar(BytecodeHelpers.iload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder lload(int slot) {
+        writeLocalVar(BytecodeHelpers.lload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder fload(int slot) {
+        writeLocalVar(BytecodeHelpers.fload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder dload(int slot) {
+        writeLocalVar(BytecodeHelpers.dload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder aload(int slot) {
+        writeLocalVar(BytecodeHelpers.aload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder istore(int slot) {
+        writeLocalVar(BytecodeHelpers.istore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder lstore(int slot) {
+        writeLocalVar(BytecodeHelpers.lstore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder fstore(int slot) {
+        writeLocalVar(BytecodeHelpers.fstore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder dstore(int slot) {
+        writeLocalVar(BytecodeHelpers.dstore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder astore(int slot) {
+        writeLocalVar(BytecodeHelpers.astore(slot), slot);
         return this;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -142,8 +142,8 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
             for (int i = parentBsmSize; i < bsmSize; i++)
                 bootstrapMethodEntry(i).writeTo(buf);
             int attrLen = buf.size() - pos;
-            buf.patchInt(pos + 2, 4, attrLen - 6);
-            buf.patchInt(pos + 6, 2, bsmSize);
+            buf.patchInt(pos + 2, attrLen - 6);
+            buf.patchU2(pos + 6, bsmSize);
         }
         else {
             UnboundAttribute<BootstrapMethodsAttribute> a

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/UnboundAttribute.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/UnboundAttribute.java
@@ -849,11 +849,11 @@ public abstract sealed class UnboundAttribute<T extends Attribute<T>>
         @Override
         public void writeTo(BufWriterImpl b) {
             b.writeIndex(b.constantPool().utf8Entry(mapper.name()));
-            b.writeInt(0);
+            b.skip(4);
             int start = b.size();
             writeBody(b);
             int written = b.size() - start;
-            b.patchInt(start - 4, 4, written);
+            b.patchInt(start - 4, written);
         }
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -56,6 +56,10 @@ import java.lang.classfile.components.ClassPrinter;
 import java.nio.ByteBuffer;
 import java.util.function.Consumer;
 
+import static jdk.internal.constant.PrimitiveClassDescImpl.CD_double;
+import static jdk.internal.constant.PrimitiveClassDescImpl.CD_long;
+import static jdk.internal.constant.PrimitiveClassDescImpl.CD_void;
+
 /**
  * Helper to create and manipulate type descriptors, where type descriptors are
  * represented as JVM type descriptor strings and symbols are represented as
@@ -249,16 +253,11 @@ public class Util {
     }
 
     public static int slotSize(ClassDesc desc) {
-        return switch (desc.descriptorString().charAt(0)) {
-            case 'V' -> 0;
-            case 'D','J' -> 2;
-            default -> 1;
-        };
+        return desc == CD_void ? 0 : isDoubleSlot(desc) ? 2 : 1;
     }
 
     public static boolean isDoubleSlot(ClassDesc desc) {
-        char ch = desc.descriptorString().charAt(0);
-        return ch == 'D' || ch == 'J';
+        return desc == CD_double || desc == CD_long;
     }
 
     public static void dumpMethod(SplitConstantPool cp,

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -281,8 +281,7 @@ public class Util {
                                     b.writeU2(-1);//max locals
                                     b.writeInt(bytecode.limit());
                                     b.writeBytes(bytecode.array(), 0, bytecode.limit());
-                                    b.writeU2(0);//exception handlers
-                                    b.writeU2(0);//attributes
+                                    b.skip(4);//exception handlers & attributes
                                 }
                     }))));
             ClassPrinter.toYaml(clm.methods().get(0).code().get(), ClassPrinter.Verbosity.TRACE_ALL, dump);

--- a/test/jdk/jdk/classfile/TypeKindTest.java
+++ b/test/jdk/jdk/classfile/TypeKindTest.java
@@ -30,13 +30,15 @@
 import org.junit.jupiter.api.Test;
 
 import java.lang.classfile.TypeKind;
+import java.lang.constant.ClassDesc;
 
 import static org.junit.Assert.assertThrows;
 
 class TypeKindTest {
     @Test
     void testContracts() {
-        assertThrows(NullPointerException.class, () -> TypeKind.from(null));
+        assertThrows(NullPointerException.class, () -> TypeKind.from((Class) null));
+        assertThrows(NullPointerException.class, () -> TypeKind.from((ClassDesc) null));
 
         assertThrows(NullPointerException.class, () -> TypeKind.fromDescriptor(null));
         assertThrows(IllegalArgumentException.class, () -> TypeKind.fromDescriptor(""));

--- a/test/micro/org/openjdk/bench/java/lang/classfile/TypeKindFrom.java
+++ b/test/micro/org/openjdk/bench/java/lang/classfile/TypeKindFrom.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.classfile;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
+import java.lang.classfile.TypeKind;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 1, time = 2)
+@Measurement(iterations = 3, time = 1)
+@Fork(jvmArgsAppend = "--enable-preview", value = 3)
+@State(Scope.Thread)
+public class TypeKindFrom {
+    @Param({"B", "C", "Z", "S", "I", "F", "J", "D", "V", "java.lang.Object"})
+    public String typeName;
+    public Class<?> type;
+    public ClassDesc classDesc;
+
+    @Setup
+    public void setup() throws Exception {
+        type = switch (typeName) {
+            case "B" -> byte.class;
+            case "C" -> char.class;
+            case "Z" -> boolean.class;
+            case "S" -> short.class;
+            case "I" -> int.class;
+            case "J" -> long.class;
+            case "F" -> float.class;
+            case "D" -> void.class;
+            case "V" -> void.class;
+            default -> Class.forName(typeName);
+        };
+        classDesc = ClassDesc.ofInternalName(typeName.replace('.', '/'));
+    }
+
+    @Benchmark
+    public void fromClass(Blackhole bh) {
+        bh.consume(TypeKind.from(type));
+    }
+
+    @Benchmark
+    public void fromClassDesc(Blackhole bh) {
+        bh.consume(TypeKind.from(classDesc));
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/classfile/Utf8EntryWriteTo.java
+++ b/test/micro/org/openjdk/bench/java/lang/classfile/Utf8EntryWriteTo.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.classfile;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+import java.lang.classfile.constantpool.ConstantPoolBuilder;
+import java.lang.classfile.*;
+import java.lang.constant.*;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import static java.lang.classfile.ClassFile.*;
+import static java.lang.constant.ConstantDescs.*;
+
+import jdk.internal.classfile.impl.*;
+/**
+ * Test various operations on
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 1, time = 2)
+@Measurement(iterations = 3, time = 1)
+@Fork(jvmArgsAppend = "--enable-preview", value = 3)
+@State(Scope.Thread)
+public class Utf8EntryWriteTo {
+    static final ClassDesc STRING_BUILDER = ClassDesc.ofDescriptor("Ljava/lang/StringBuilder;");
+    static final MethodTypeDesc MTD_append = MethodTypeDesc.of(STRING_BUILDER, CD_String);
+    static final MethodTypeDesc MTD_String = MethodTypeDesc.of(CD_String);
+    static final ClassDesc CLASS_DESC = ClassDesc.ofDescriptor("Lorg/openjdk/bench/java/lang/classfile/String$$StringConcat;");
+
+    @Param({"ascii", "utf8_2_bytes", "utf8_3_bytes", "emoji"})
+    public String charType;
+    public String[] constants;
+
+    @Setup
+    public void setup() throws Exception {
+        byte[] bytes = HexFormat.of().parseHex(
+                switch (charType) {
+                    case "ascii"        -> "78";
+                    case "utf8_2_bytes" -> "c2a9";
+                    case "utf8_3_bytes" -> "e6b8a9";
+                    case "emoji"        -> "e29da3efb88f";
+                    default -> throw new IllegalArgumentException("bad charType: " + charType);
+                }
+        );
+        String s = new String(bytes, 0, bytes.length, StandardCharsets.UTF_8);
+        constants = new String[128];
+        for (int i = 0; i < constants.length; i++) {
+            constants[i] = s.repeat(32);
+        }
+    }
+
+    @Benchmark
+    public void writeTo(Blackhole bh) {
+        bh.consume(generate(constants));
+    }
+
+    private static byte[] generate(String[] constants) {
+        return ClassFile.of().build(
+                CLASS_DESC,
+                new Consumer<ClassBuilder>() {
+                    @Override
+                    public void accept(ClassBuilder clb) {
+                        clb.withFlags(ACC_FINAL | ACC_SUPER | ACC_SYNTHETIC)
+                           .withMethodBody(
+                                   "concat",
+                                   MTD_String, ACC_FINAL | ACC_PRIVATE | ACC_STATIC,
+                                   new Consumer<CodeBuilder>() {
+                                       @Override
+                                       public void accept(CodeBuilder cb) {
+                                           cb.new_(STRING_BUILDER)
+                                             .dup()
+                                             .invokespecial(STRING_BUILDER, "<init>", MTD_void);
+                                           for (String constant : constants) {
+                                               cb.ldc(constant)
+                                                 .invokevirtual(STRING_BUILDER, "append", MTD_append);
+                                           }
+                                           cb.invokevirtual(STRING_BUILDER, "toString", MTD_String)
+                                             .areturn();
+                                       }
+                                   }
+                           );
+                    }
+                }
+        );
+    }
+}


### PR DESCRIPTION
Make some minor optimizations for the startup process, including:
1. Use String.concat for simple string concatenation.
2. Use char for strings of length 1.
3. Cache ReferenceClassDescImpl of MemberName
4. Break the big method and make inline possible
5. To be more friendly to MergeStore, modify the implementation of writeU2/writeInt of BufWriterImpl

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338935](https://bugs.openjdk.org/browse/JDK-8338935): Micro-optimizations for startup (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20669/head:pull/20669` \
`$ git checkout pull/20669`

Update a local copy of the PR: \
`$ git checkout pull/20669` \
`$ git pull https://git.openjdk.org/jdk.git pull/20669/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20669`

View PR using the GUI difftool: \
`$ git pr show -t 20669`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20669.diff">https://git.openjdk.org/jdk/pull/20669.diff</a>

</details>
