### PR TITLE
8338785: The java.awt.datatransfer.SystemFlavorMap#FLAVOR_MAP_KEY field is not used

### DIFF
--- a/src/java.datatransfer/share/classes/java/awt/datatransfer/SystemFlavorMap.java
+++ b/src/java.datatransfer/share/classes/java/awt/datatransfer/SystemFlavorMap.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,8 +60,6 @@ public final class SystemFlavorMap implements FlavorMap, FlavorTable {
      * Constant prefix used to tag Java types converted to native platform type.
      */
     private static String JavaMIME = "JAVA_DATAFLAVOR:";
-
-    private static final Object FLAVOR_MAP_KEY = new Object();
 
     /**
      * The list of valid, decoded text flavor representation classes, in order


### PR DESCRIPTION
The unused `java.awt.datatransfer.SystemFlavorMap#FLAVOR_MAP_KEY` field is deleted.

It was unused since [8037485](https://bugs.openjdk.org/browse/JDK-8037485): Refactor java.awt.datatransfer to eliminate dependency on AWT.

See:
https://github.com/openjdk/jdk/commit/0fecd7769453dfb3ef1609b057a9e69aee57d0c1#diff-2c0c7e0dbcabe2bced2907f383bdb4e2a3ed64686c219f37f7c6469ecc47d4baL198

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338785](https://bugs.openjdk.org/browse/JDK-8338785): The java.awt.datatransfer.SystemFlavorMap#FLAVOR_MAP_KEY field is not used (**Bug** - P5)


### Reviewers
 * @SWinxy (no known openjdk.org user name / role)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20670/head:pull/20670` \
`$ git checkout pull/20670`

Update a local copy of the PR: \
`$ git checkout pull/20670` \
`$ git pull https://git.openjdk.org/jdk.git pull/20670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20670`

View PR using the GUI difftool: \
`$ git pr show -t 20670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20670.diff">https://git.openjdk.org/jdk/pull/20670.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20670#issuecomment-2305121897)