### PR TITLE
8338668: Test javax/swing/JFileChooser/8080628/bug8080628.java doesn't test for GTK L&F

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/8080628/bug8080628.java
+++ b/test/jdk/javax/swing/JFileChooser/8080628/bug8080628.java
@@ -33,7 +33,17 @@ import sun.swing.SwingUtilities2;
  * @test
  * @bug 8080628
  * @summary No mnemonics on Open and Save buttons in JFileChooser.
- * @author Alexey Ivanov
+ * @requires os.family != "linux"
+ * @modules java.desktop/sun.swing
+ * @run main bug8080628
+ */
+
+/*
+ * @test
+ * @bug 8080628
+ * @key headful
+ * @summary No mnemonics on Open and Save buttons in JFileChooser.
+ * @requires os.family == "linux"
  * @modules java.desktop/sun.swing
  * @run main bug8080628
  */
@@ -81,8 +91,10 @@ public class bug8080628 {
                 try {
                     UIManager.setLookAndFeel(info.getClassName());
                 } catch (final UnsupportedLookAndFeelException ignored) {
+                    System.out.println("Unsupported L&F: " + info.getClassName());
                     continue;
                 }
+                System.out.println("Testing L&F: " + info.getClassName());
 
                 for (Locale locale : LOCALES) {
                     for (String key : MNEMONIC_KEYS) {
@@ -102,5 +114,4 @@ public class bug8080628 {
             exception = e;
         }
     }
-
 }

--- a/test/jdk/javax/swing/JFileChooser/8080628/bug8080628.java
+++ b/test/jdk/javax/swing/JFileChooser/8080628/bug8080628.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -114,4 +114,5 @@ public class bug8080628 {
             exception = e;
         }
     }
+
 }


### PR DESCRIPTION
This test should have failed with the [changeset](https://github.com/openjdk/jdk/pull/20612) proposed for [JDK-4795384](https://bugs.openjdk.org/browse/JDK-4795384) but it didn't because GTK look and feel isn't supported in headless environment.

Fix is to run the test with headful environment on linux platform. 

Tested in CI pipeline and link attached to JBS.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338668](https://bugs.openjdk.org/browse/JDK-8338668): Test javax/swing/JFileChooser/8080628/bug8080628.java doesn't test for GTK L&amp;F (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20671/head:pull/20671` \
`$ git checkout pull/20671`

Update a local copy of the PR: \
`$ git checkout pull/20671` \
`$ git pull https://git.openjdk.org/jdk.git pull/20671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20671`

View PR using the GUI difftool: \
`$ git pr show -t 20671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20671.diff">https://git.openjdk.org/jdk/pull/20671.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20671#issuecomment-2303816250)