### PR TITLE
8338810: PPC, s390x: LightweightSynchronizer::exit asserts, missing lock

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2902,7 +2902,11 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     // Check for monitor (0b10).
     ld(mark, oopDesc::mark_offset_in_bytes(), obj);
     andi_(t, mark, markWord::monitor_value);
-    bne(CCR0, inflated);
+    if (!UseObjectMonitorTable) {
+      bne(CCR0, inflated);
+    } else {
+      bne(CCR0, push_and_slow);
+    }
 
 #ifdef ASSERT
     // Check header not unlocked (0b01).

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -6286,6 +6286,7 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(Register obj, Regis
 
   BLOCK_COMMENT("compiler_fast_lightweight_unlock {");
   { // Lightweight Unlock
+    NearLabel push_and_slow_path;
 
     // Check if obj is top of lock-stack.
     z_lgf(top, Address(Z_thread, ls_top_offset));
@@ -6315,7 +6316,11 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(Register obj, Regis
     // Check for monitor (0b10).
     z_lg(mark, Address(obj, mark_offset));
     z_tmll(mark, markWord::monitor_value);
-    z_brnaz(inflated);
+    if (!UseObjectMonitorTable) {
+      z_brnaz(inflated);
+    } else {
+      z_brnaz(push_and_slow_path);
+    }
 
 #ifdef ASSERT
     // Check header not unlocked (0b01).
@@ -6334,6 +6339,7 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(Register obj, Regis
       branch_optimized(Assembler::bcondEqual, unlocked);
     }
 
+    bind(push_and_slow_path);
     // Restore lock-stack and handle the unlock in runtime.
     z_lgf(top, Address(Z_thread, ls_top_offset));
     DEBUG_ONLY(z_stg(obj, Address(Z_thread, top));)


### PR DESCRIPTION
[JDK-8338638](https://bugs.openjdk.org/browse/JDK-8338638) made me realise that PPC and s390x have the same issue.

The issue is that the C2 unlock path will check if the monitor is inflated after popping of the last entry on the lock stack. With UseObjectMonitorTable (without the the cache lookup implemented), the slow path is incorrectly taken without resting the popped oop. Currently the runtime expects the the lock stack to be consistent (have an entry) in exit if a the monitor is anonymously inflated.

I'll provide a bandaid fix which pushes back the oop before the calling to the runtime.

A future enhancement for all platform would be to allow the C2 entry point to redo the push when taking the slow path and it realises that the monitor is anonymously inflated or it is fast locked and the lock stack does not contain the oop. (Removing all the push back logic from the emitted C2 unlock nodes)

I am unable to test ppc and s390x, so I have not verified that the issue is reproduced nor that this fixes it. 
Hopefully @TheRealMDoerr and @offamitkumar can assist me here with running `test/hotspot/jtreg/runtime/Monitor/UseObjectMonitorTableTest.java` with and without the patch on PPC and s390x respectively. 
Thanks in advance. (And sorry for integrating without better testing of your respective platforms)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338810](https://bugs.openjdk.org/browse/JDK-8338810): PPC, s390x: LightweightSynchronizer::exit asserts, missing lock (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20672/head:pull/20672` \
`$ git checkout pull/20672`

Update a local copy of the PR: \
`$ git checkout pull/20672` \
`$ git pull https://git.openjdk.org/jdk.git pull/20672/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20672`

View PR using the GUI difftool: \
`$ git pr show -t 20672`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20672.diff">https://git.openjdk.org/jdk/pull/20672.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20672#issuecomment-2303881323)