### PR TITLE
8338815: Add separation to exception message in JavacFileManager.DirectoryContainer

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/file/JavacFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -514,7 +514,7 @@ public class JavacFileManager extends BaseFileManager implements StandardJavaFil
                                     file.resolveAgainst(directory), userPath, file);
                             resultList.append(fe);
                         } catch (InvalidPathException e) {
-                            throw new IOException("error accessing directory " + directory + e);
+                            throw new IOException("error accessing directory " + directory +": " + e);
                         }
                     }
                 }


### PR DESCRIPTION
Please review this trivial PR which injects a `": "` separator between the directory name and the exeption toString when constructing the IOException message in `JavacFileManager.DirectoryContainer.list`.

This changes the javac error message from:

`error accessing directory Z:\invalid-pathjava.nio.file.InvalidPathException: Illegal char <:> at index 4: file:txt`

into:

`error accessing directory Z:\invalid-path: java.nio.file.InvalidPathException: Illegal char <:> at index 4: file:txt`

We could alternatively use some other separator, such as a `", "`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338815](https://bugs.openjdk.org/browse/JDK-8338815): Add separation to exception message in JavacFileManager.DirectoryContainer (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20673/head:pull/20673` \
`$ git checkout pull/20673`

Update a local copy of the PR: \
`$ git checkout pull/20673` \
`$ git pull https://git.openjdk.org/jdk.git pull/20673/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20673`

View PR using the GUI difftool: \
`$ git pr show -t 20673`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20673.diff">https://git.openjdk.org/jdk/pull/20673.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20673#issuecomment-2304096042)