### PR TITLE
8338740: java/net/httpclient/HttpsTunnelAuthTest.java fails with java.io.IOException: HTTP/1.1 header parser received no bytes

### DIFF
--- a/test/jdk/java/net/httpclient/ProxyServer.java
+++ b/test/jdk/java/net/httpclient/ProxyServer.java
@@ -195,6 +195,9 @@ public class ProxyServer extends Thread implements Closeable {
         volatile InputStream clientIn, serverIn;
         volatile OutputStream clientOut, serverOut;
 
+        volatile boolean proxyInClosed;
+        volatile boolean proxyOutClosed;
+
         final static int CR = 13;
         final static int LF = 10;
 
@@ -594,9 +597,7 @@ public class ProxyServer extends Thread implements Closeable {
                         if (log)
                             System.out.printf("Proxy Forwarding [request body]: total %d%n", body);
                     }
-                    closing = true;
-                    serverSocket.close();
-                    clientSocket.close();
+                    closeClientIn();
                 } catch (IOException e) {
                     if (!closing && debug) {
                         System.out.println("Proxy: " + e);
@@ -615,9 +616,7 @@ public class ProxyServer extends Thread implements Closeable {
                         if (log) System.out.printf("Proxy Forwarding [response]: %s%n", new String(bb, 0, n, UTF_8));
                         if (log) System.out.printf("Proxy Forwarding [response]: total %d%n", resp);
                     }
-                    closing = true;
-                    serverSocket.close();
-                    clientSocket.close();
+                    closeClientOut();
                 } catch (IOException e) {
                     if (!closing && debug) {
                         System.out.println("Proxy: " + e);
@@ -639,6 +638,28 @@ public class ProxyServer extends Thread implements Closeable {
             // might fail if we're closing, but we don't care.
             clientOut.write("HTTP/1.1 200 OK\r\n\r\n".getBytes());
             proxyCommon(false);
+        }
+
+        synchronized void closeClientIn() throws IOException {
+            closing = true;
+            proxyInClosed = true;
+            clientSocket.shutdownInput();
+            serverSocket.shutdownOutput();
+            if (proxyOutClosed) {
+                serverSocket.close();
+                clientSocket.close();
+            }
+        }
+
+        synchronized void closeClientOut() throws IOException {
+            closing = true;
+            proxyOutClosed = true;
+            serverSocket.shutdownInput();
+            clientSocket.shutdownOutput();
+            if (proxyInClosed) {
+                serverSocket.close();
+                clientSocket.close();
+            }
         }
 
         @Override

--- a/test/jdk/java/net/httpclient/ProxyServer.java
+++ b/test/jdk/java/net/httpclient/ProxyServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,8 +195,8 @@ public class ProxyServer extends Thread implements Closeable {
         volatile InputStream clientIn, serverIn;
         volatile OutputStream clientOut, serverOut;
 
-        volatile boolean proxyInClosed;
-        volatile boolean proxyOutClosed;
+        boolean proxyInClosed;  // only accessed from synchronized block
+        boolean proxyOutClosed; // only accessed from synchronized block
 
         final static int CR = 13;
         final static int LF = 10;


### PR DESCRIPTION
The `java/net/httpclient/HttpsTunnelAuthTest.java` has been observed failing intermittently with `java.io.IOException: HTTP/1.1 header parser received no bytes`, ... `Caused by: java.net.SocketException: Connection reset `.

My suspicion is that the ProxyServer used by this test is the cause of the reset: when a tunnel connection is established, the proxy server acts as an intermediary between the client and the server, and shuffles things around in two directions between two sockets. However, if one end of one of the two sockets gets closed, the proxy will abruptly close the two sockets, without waiting for inflight traffic on the other direction to quiesce. I believe this is what is causing the connection reset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338740](https://bugs.openjdk.org/browse/JDK-8338740): java/net/httpclient/HttpsTunnelAuthTest.java fails with java.io.IOException: HTTP/1.1 header parser received no bytes (**Bug** - P4)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20674/head:pull/20674` \
`$ git checkout pull/20674`

Update a local copy of the PR: \
`$ git checkout pull/20674` \
`$ git pull https://git.openjdk.org/jdk.git pull/20674/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20674`

View PR using the GUI difftool: \
`$ git pr show -t 20674`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20674.diff">https://git.openjdk.org/jdk/pull/20674.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20674#issuecomment-2315679221)