### PR TITLE
Efficient hidden class-based static string concatenation strategy

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2627,6 +2627,14 @@ public final class System {
                 return new StringConcatHelper.Concat1(constants);
             }
 
+            public byte stringInitCoder() {
+                return String.COMPACT_STRINGS ? String.LATIN1 : String.UTF16;
+            }
+
+            public byte stringCoder(String str) {
+                return str.coder();
+            }
+
             public int getCharsLatin1(long i, int index, byte[] buf) {
                 return StringLatin1.getChars(i, index, buf);
             }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -448,6 +448,10 @@ public interface JavaLangAccess {
 
     Object stringConcat1(String[] constants);
 
+    byte stringInitCoder();
+
+    byte stringCoder(String str);
+
     /**
      * Join strings
      */


### PR DESCRIPTION
PR #20273 uses non-static constants/length/coder in ConcatBase, which can solve the reuse problem well. However, when the number of parameters is greater than inlineThreshold, the performance will regress.

This PR improves this problem. When the parameter is greater than inlineThreshold, the static concat method is used, and the length and coder of constants are directly written into the bytecode to improve performance.
