### PR TITLE
8338819: JFR: Internal events causes crash when no other events are in use

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
+++ b/src/hotspot/share/jfr/jni/jfrUpcalls.cpp
@@ -191,6 +191,10 @@ void JfrUpcalls::new_bytes_eager_instrumentation(jlong trace_id,
 
 bool JfrUpcalls::unhide_internal_types(TRAPS) {
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(THREAD));
+  if (!initialize(THREAD)) {
+    log_error(jfr, system)("JfrUpcall could not be initialized.");
+    return false;
+  }
   JavaValue result(T_VOID);
   const Klass* klass = SystemDictionary::resolve_or_fail(jvm_upcalls_class_sym, true, CHECK_false);
   assert(klass != nullptr, "invariant");


### PR DESCRIPTION
Could I have a review of a PR that fixes an issue with internal events.

Testing: tier1 + jdk/jdk/jfr + manual check

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338819](https://bugs.openjdk.org/browse/JDK-8338819): JFR: Internal events causes crash when no other events are in use (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20676/head:pull/20676` \
`$ git checkout pull/20676`

Update a local copy of the PR: \
`$ git checkout pull/20676` \
`$ git pull https://git.openjdk.org/jdk.git pull/20676/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20676`

View PR using the GUI difftool: \
`$ git pr show -t 20676`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20676.diff">https://git.openjdk.org/jdk/pull/20676.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20676#issuecomment-2305199873)