### PR TITLE
8338844: C2: remove useless code in PhaseIdealLoop::place_outside_loop() after 8335709

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1272,9 +1272,7 @@ Node* PhaseIdealLoop::place_outside_loop(Node* useblock, IdealLoopTree* loop) co
   // Pick control right outside the loop
   for (;;) {
     Node* dom = idom(useblock);
-    if (loop->is_member(get_loop(dom)) ||
-        // NeverBranch nodes are not assigned to the loop when constructed
-        (dom->is_NeverBranch() && loop->is_member(get_loop(dom->in(0))))) {
+    if (loop->is_member(get_loop(dom))) {
       break;
     }
     useblock = dom;


### PR DESCRIPTION
This removes code that shouldn't be necessary now that the
NeverBranch/CProj nodes are assigned the correct loop. I proposed this
initially as part of https://github.com/openjdk/jdk/pull/20334 where
the recommendation was to take care of it separately to make
backports easier.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338844](https://bugs.openjdk.org/browse/JDK-8338844): C2: remove useless code in PhaseIdealLoop::place_outside_loop() after 8335709 (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20678/head:pull/20678` \
`$ git checkout pull/20678`

Update a local copy of the PR: \
`$ git checkout pull/20678` \
`$ git pull https://git.openjdk.org/jdk.git pull/20678/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20678`

View PR using the GUI difftool: \
`$ git pr show -t 20678`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20678.diff">https://git.openjdk.org/jdk/pull/20678.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20678#issuecomment-2305034490)