### PR TITLE
8338834: Remove unused import declarations in java.compiler

### DIFF
--- a/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Filer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,10 +25,8 @@
 
 package javax.annotation.processing;
 
-import javax.tools.JavaFileManager;
 import javax.tools.*;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import java.io.IOException;
 

--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -25,10 +25,6 @@
 
 package javax.lang.model;
 
-import java.util.Collections;
-import java.util.Set;
-import java.util.HashSet;
-
 /**
  * Source versions of the Java programming language.
  *

--- a/src/java.compiler/share/classes/javax/lang/model/element/Element.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/Element.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package javax.lang.model.element;
 
 
 import java.lang.annotation.Annotation;
-import java.lang.annotation.AnnotationTypeMismatchException;
-import java.lang.annotation.IncompleteAnnotationException;
 import java.util.List;
 import java.util.Set;
 

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
  */
 
 package javax.lang.model.element;
-
-import jdk.internal.javac.PreviewFeature;
 
 import java.util.List;
 import javax.lang.model.type.*;

--- a/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/VariableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
  */
 
 package javax.lang.model.element;
-
-import jdk.internal.javac.PreviewFeature;
 
 import javax.lang.model.util.Elements;
 import javax.lang.model.type.TypeMirror;

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeVariable.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeVariable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,6 @@ package javax.lang.model.type;
 
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeParameterElement;
-import javax.lang.model.util.Types;
-
 
 /**
  * Represents a type variable.

--- a/src/java.compiler/share/classes/javax/lang/model/type/TypeVisitor.java
+++ b/src/java.compiler/share/classes/javax/lang/model/type/TypeVisitor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package javax.lang.model.type;
 
-import javax.lang.model.element.*;
 import javax.lang.model.util.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractAnnotationValueVisitorPreview.java
@@ -28,7 +28,6 @@ package javax.lang.model.util;
 import jdk.internal.javac.PreviewFeature;
 
 import static javax.lang.model.SourceVersion.*;
-import javax.lang.model.SourceVersion;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.annotation.processing.ProcessingEnvironment;
 

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractElementVisitorPreview.java
@@ -29,9 +29,6 @@ import jdk.internal.javac.PreviewFeature;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
-import javax.lang.model.element.RecordComponentElement;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitor9.java
@@ -26,7 +26,6 @@
 package javax.lang.model.util;
 
 import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.type.*;
 import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
 

--- a/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/AbstractTypeVisitorPreview.java
@@ -29,7 +29,6 @@ import jdk.internal.javac.PreviewFeature;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.element.ElementKind.*;
 import static javax.lang.model.SourceVersion.*;
 

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitor9.java
@@ -28,7 +28,6 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementKindVisitorPreview.java
@@ -30,7 +30,6 @@ import jdk.internal.javac.PreviewFeature;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
-import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner14.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,6 @@ package javax.lang.model.util;
 
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
-import javax.lang.model.element.ElementVisitor;
 import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
 

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner7.java
@@ -28,7 +28,6 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScanner9.java
@@ -28,7 +28,6 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 

--- a/src/java.compiler/share/classes/javax/lang/model/util/ElementScannerPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/ElementScannerPreview.java
@@ -27,13 +27,9 @@ package javax.lang.model.util;
 
 import jdk.internal.javac.PreviewFeature;
 
-import java.util.List;
-import java.util.ArrayList;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.*;
-import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleAnnotationValueVisitorPreview.java
@@ -29,7 +29,6 @@ import jdk.internal.javac.PreviewFeature;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitor7.java
@@ -28,7 +28,6 @@ package javax.lang.model.util;
 import javax.lang.model.element.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleElementVisitorPreview.java
@@ -29,9 +29,6 @@ import jdk.internal.javac.PreviewFeature;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.SourceVersion;
-import javax.lang.model.element.ElementVisitor;
-import javax.lang.model.element.RecordComponentElement;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor6.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import javax.lang.model.type.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
-import javax.lang.model.type.TypeVisitor;
 
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor7.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor7.java
@@ -29,7 +29,6 @@ import javax.lang.model.type.*;
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
-import javax.lang.model.type.TypeVisitor;
 
 /**
  * A simple visitor of types with default behavior appropriate for the

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor9.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitor9.java
@@ -27,7 +27,6 @@ package javax.lang.model.util;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.lang.model.SourceVersion;
-import javax.lang.model.type.IntersectionType;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/SimpleTypeVisitorPreview.java
@@ -29,7 +29,6 @@ import jdk.internal.javac.PreviewFeature;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.SourceVersion;
 import static javax.lang.model.SourceVersion.*;
 
 /**

--- a/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitorPreview.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/TypeKindVisitorPreview.java
@@ -29,7 +29,6 @@ import jdk.internal.javac.PreviewFeature;
 
 import javax.annotation.processing.SupportedSourceVersion;
 import javax.annotation.processing.ProcessingEnvironment;
-import javax.lang.model.SourceVersion;
 import javax.lang.model.type.*;
 import static javax.lang.model.SourceVersion.*;
 

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -25,9 +25,6 @@
 
 package javax.lang.model.util;
 
-import java.lang.annotation.Annotation;
-import java.lang.annotation.AnnotationTypeMismatchException;
-import java.lang.annotation.IncompleteAnnotationException;
 import java.util.List;
 import javax.lang.model.element.*;
 import javax.lang.model.type.*;


### PR DESCRIPTION
Please review this simple cleanup. I tested it first by usual means, and then additionally compared documentation before and after the change.

How did I end up with this cleanup? I finally got tired of an eyesore which greyed-out unused imports in my IDE are. So I removed them as per IDE suggestion and then had some fun chasing bugs. Who would've thought that removing imports can be so painful?

During my bug chase, I created the following issues, from which you could guess the kind of bugs I ran into:

  * https://youtrack.jetbrains.com/issue/IDEA-358082/Import-of-a-symbol-referred-to-by-snippet-target-is-considered-unused
  * https://youtrack.jetbrains.com/issue/IDEA-358073/Support-changes-in-documentation-inheritance
  * https://bugs.openjdk.org/browse/JDK-8338833

And a bonus one:

  * https://bugs.openjdk.org/browse/JDK-8338838

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338834](https://bugs.openjdk.org/browse/JDK-8338834): Remove unused import declarations in java.compiler (**Bug** - P5)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20679/head:pull/20679` \
`$ git checkout pull/20679`

Update a local copy of the PR: \
`$ git checkout pull/20679` \
`$ git pull https://git.openjdk.org/jdk.git pull/20679/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20679`

View PR using the GUI difftool: \
`$ git pr show -t 20679`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20679.diff">https://git.openjdk.org/jdk/pull/20679.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20679#issuecomment-2305156550)