### PR TITLE
8338690: CompactNumberInstance.format incorrectly formats some numbers (few vs many)

### DIFF
--- a/src/java.base/share/classes/java/text/DecimalFormat.java
+++ b/src/java.base/share/classes/java/text/DecimalFormat.java
@@ -1799,6 +1799,14 @@ public class DecimalFormat extends NumberFormat {
         }
     }
 
+    /**
+     * {@return the {@code DigitList} used by this {@code DecimalFormat} instance}
+     * Declared as package-private, intended for {@code CompactNumberFormat}.
+     */
+    DigitList getDigitList() {
+        return digitList;
+    }
+
     // ======== End fast-path formatting logic for double =========================
 
     /**

--- a/test/jdk/java/text/Format/CompactNumberFormat/TestCompactNumber.java
+++ b/test/jdk/java/text/Format/CompactNumberFormat/TestCompactNumber.java
@@ -22,7 +22,7 @@
  */
 /*
  * @test
- * @bug 8177552 8217721 8222756 8295372 8306116 8319990
+ * @bug 8177552 8217721 8222756 8295372 8306116 8319990 8338690
  * @summary Checks the functioning of compact number format
  * @modules jdk.localedata
  * @run testng/othervm TestCompactNumber
@@ -60,6 +60,9 @@ public class TestCompactNumber {
     private static final NumberFormat FORMAT_IT_SHORT = NumberFormat
             .getCompactNumberInstance(Locale.ITALIAN, NumberFormat.Style.SHORT);
 
+    private static final NumberFormat FORMAT_IT_LONG = NumberFormat
+            .getCompactNumberInstance(Locale.ITALIAN, NumberFormat.Style.LONG);
+
     private static final NumberFormat FORMAT_CA_LONG = NumberFormat
             .getCompactNumberInstance(Locale.of("ca"), NumberFormat.Style.LONG);
 
@@ -89,6 +92,13 @@ public class TestCompactNumber {
             .getCompactNumberInstance(Locale.ITALIAN, NumberFormat.Style.LONG);
     private static final NumberFormat FORMAT_PT_LONG_FD4 = NumberFormat
             .getCompactNumberInstance(Locale.of("pt"), NumberFormat.Style.LONG);
+
+    private static final NumberFormat FORMAT_PL_LONG = NumberFormat
+            .getCompactNumberInstance(Locale.of("pl"), NumberFormat.Style.LONG);
+
+    private static final NumberFormat FORMAT_FR_LONG = NumberFormat
+            .getCompactNumberInstance(Locale.FRENCH, NumberFormat.Style.LONG);
+
     static {
         FORMAT_ES_LONG_FD1.setMaximumFractionDigits(1);
         FORMAT_DE_LONG_FD2.setMaximumFractionDigits(2);
@@ -359,6 +369,12 @@ public class TestCompactNumber {
             {FORMAT_DE_LONG_FD2, 1_234_500, "1,23 Millionen"},
             {FORMAT_IT_LONG_FD3, 1_234_500, "1,234 milioni"},
             {FORMAT_PT_LONG_FD4, 1_234_500, "1,2345 milh\u00f5es"},
+
+            // 8338690
+            {FORMAT_PL_LONG, 5_000, "5 tysi\u0119cy"},
+            {FORMAT_PL_LONG, 4_949, "5 tysi\u0119cy"},
+            {FORMAT_FR_LONG, 1_949, "2 mille"},
+            {FORMAT_IT_LONG, 1_949, "2 mila"},
         };
     }
 
@@ -466,6 +482,10 @@ public class TestCompactNumber {
                 {FORMAT_DE_LONG_FD2, "1,23 Millionen", 1_230_000L, Long.class},
                 {FORMAT_IT_LONG_FD3, "1,234 milioni", 1_234_000L, Long.class},
                 {FORMAT_PT_LONG_FD4, "1,2345 milh\u00f5es", 1_234_500L, Long.class},
+                // 8338690
+                {FORMAT_PL_LONG, "5 tysi\u0119cy", 5_000L, Long.class},
+                {FORMAT_FR_LONG, "2 mille", 2_000L, Long.class},
+                {FORMAT_IT_LONG, "2 mila", 2_000L, Long.class},
         };
     }
 
@@ -514,6 +534,10 @@ public class TestCompactNumber {
             {FORMAT_SL_LONG, "5 milijon", 5L},
             {FORMAT_SL_LONG, "5 milijona", 5L},
             {FORMAT_SL_LONG, "5 milijone", 5L},
+            // 8338690
+            {FORMAT_PL_LONG, "5 tysiące", 5L},
+            {FORMAT_FR_LONG, "2 millier", 2L},
+            {FORMAT_IT_LONG, "2 mille", 2L},
         };
     }
 


### PR DESCRIPTION
Fixing an issue wrt wrong plural suffix with compact format for some locales. It was retrieving the suffix based on the value before the rounding, which ended up in wrong plural expression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338690](https://bugs.openjdk.org/browse/JDK-8338690): CompactNumberInstance.format incorrectly formats some numbers (few vs many) (**Bug** - P4)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20680/head:pull/20680` \
`$ git checkout pull/20680`

Update a local copy of the PR: \
`$ git checkout pull/20680` \
`$ git pull https://git.openjdk.org/jdk.git pull/20680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20680`

View PR using the GUI difftool: \
`$ git pr show -t 20680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20680.diff">https://git.openjdk.org/jdk/pull/20680.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20680#issuecomment-2305162524)