### PR TITLE
8338856: [BACKOUT] JDK-8337828: CDS: Trim down minimum GC region alignment

### DIFF
--- a/src/hotspot/share/cds/archiveHeapWriter.hpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.hpp
@@ -112,10 +112,11 @@ class ArchiveHeapWriter : AllStatic {
 public:
   static const intptr_t NOCOOPS_REQUESTED_BASE = 0x10000000;
 
-  // The minimum region size of all collectors that are supported by CDS.
-  // G1 heap region size can never be smaller than 1M.
-  // Shenandoah heap region size can never be smaller than 256K.
-  static constexpr int MIN_GC_REGION_ALIGNMENT = 256 * K;
+  // The minimum region size of all collectors that are supported by CDS in
+  // ArchiveHeapLoader::can_map() mode. Currently only G1 is supported. G1's region size
+  // depends on -Xmx, but can never be smaller than 1 * M.
+  // (TODO: Perhaps change to 256K to be compatible with Shenandoah)
+  static constexpr int MIN_GC_REGION_ALIGNMENT = 1 * M;
 
 private:
   class EmbeddedOopRelocator;


### PR DESCRIPTION
This reverts commit 598169756c903bb1f77e35ea32717043bc166e3c.

Causes failures in deeper testing, see [JDK-8338753](https://bugs.openjdk.org/browse/JDK-8338753). I missed it, because my testing did not run with `-XX:-UseCompressedOops`. The test with many classes fails readily with this flag:

```
$ CONF=linux-x86_64-server-fastdebug make test TEST=runtime/cds/appcds/LotsOfClasses.java TEST_VM_OPTS=-XX:-UseCompressedOops

java.lang.RuntimeException: Hotspot crashed
at jdk.test.lib.cds.CDSTestUtils.executeAndLog(CDSTestUtils.java:699)
at jdk.test.lib.cds.CDSTestUtils.executeAndLog(CDSTestUtils.java:675)
at jdk.test.lib.cds.CDSTestUtils.createArchive(CDSTestUtils.java:270)
at jdk.test.lib.cds.CDSTestUtils.createArchiveAndCheck(CDSTestUtils.java:306)
at LotsOfClasses.main(LotsOfClasses.java:56)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:573)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:333)
at java.base/java.lang.Thread.run(Thread.java:1575)
```

This is really a VM bug that we crash and not exit nicely, but with the old value we are "lucky" these many classes still fit into 1M array. Backout to return to that point would do for now.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`
 - [x] Linux x86_64 server fastdebug, `runtime/cds` with `-XX:-UseCompressedOops`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338856](https://bugs.openjdk.org/browse/JDK-8338856): [BACKOUT] JDK-8337828: CDS: Trim down minimum GC region alignment (**Sub-task** - P2)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20681/head:pull/20681` \
`$ git checkout pull/20681`

Update a local copy of the PR: \
`$ git checkout pull/20681` \
`$ git pull https://git.openjdk.org/jdk.git pull/20681/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20681`

View PR using the GUI difftool: \
`$ git pr show -t 20681`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20681.diff">https://git.openjdk.org/jdk/pull/20681.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20681#issuecomment-2305292115)