### PR TITLE
8311993: Test serviceability/sa/UniqueVtableTest.java failed: duplicate vtables detected

### DIFF
--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -399,8 +399,11 @@ static bool setImageAndSymbolPath(JNIEnv* env, jobject obj) {
   IDebugSymbols* ptrIDebugSymbols = (IDebugSymbols*)env->GetLongField(obj, ptrIDebugSymbols_ID);
   CHECK_EXCEPTION_(false);
 
-  ptrIDebugSymbols->SetImagePath(imagePath);
-  ptrIDebugSymbols->SetSymbolPath(symbolPath);
+  COM_VERIFY_OK_(ptrIDebugSymbols->SetImagePath(imagePath),
+                 "Windbg Error: SetImagePath failed!", false);
+  COM_VERIFY_OK_(ptrIDebugSymbols->SetSymbolPath(symbolPath),
+                 "Windbg Error: SetSymbolPath failed!", false);
+
   return true;
 }
 
@@ -829,6 +832,8 @@ JNIEXPORT jstring JNICALL Java_sun_jvm_hotspot_debugger_windbg_WindbgDebuggerLoc
   return res;
 }
 
+#define SYMBOL_BUFSIZE 512
+
 /*
  * Class:     sun_jvm_hotspot_debugger_windbg_WindbgDebuggerLocal
  * Method:    lookupByName0
@@ -852,10 +857,22 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_windbg_WindbgDebuggerLocal
   if (ptrIDebugSymbols->GetOffsetByName(name, &offset) != S_OK) {
     return (jlong) 0;
   }
+
+  // See JDK-8311993: WinDbg intermittently returns offset of "module!class::`vftable'" symbol
+  // when requested for decorated "class" or "class*" (i.e. "??_7class@@6B@"/"??_7class*@@6B@").
+  // As a workaround check if returned symbol contains requested symbol.
+  ULONG64 disp = 0L;
+  char buf[512];
+  memset(buf, 0, sizeof(buf));
+  if (ptrIDebugSymbols->GetNameByOffset(offset, buf, sizeof(buf), 0, &disp) ==  S_OK) {
+    if (strstr(buf, name) == nullptr) {
+      return (jlong)0;
+    }
+  }
+
   return (jlong) offset;
 }
 
-#define SYMBOL_BUFSIZE 512
 /*
  * Class:     sun_jvm_hotspot_debugger_windbg_WindbgDebuggerLocal
  * Method:    lookupByAddress0

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -864,7 +864,7 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_windbg_WindbgDebuggerLocal
   ULONG64 disp = 0L;
   char buf[SYMBOL_BUFSIZE];
   memset(buf, 0, sizeof(buf));
-  if (ptrIDebugSymbols->GetNameByOffset(offset, buf, sizeof(buf), 0, &disp) ==  S_OK) {
+  if (ptrIDebugSymbols->GetNameByOffset(offset, buf, sizeof(buf), 0, &disp) == S_OK) {
     if (strstr(buf, name) == nullptr) {
       return (jlong)0;
     }

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -862,7 +862,7 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_windbg_WindbgDebuggerLocal
   // when requested for decorated "class" or "class*" (i.e. "??_7class@@6B@"/"??_7class*@@6B@").
   // As a workaround check if returned symbol contains requested symbol.
   ULONG64 disp = 0L;
-  char buf[512];
+  char buf[SYMBOL_BUFSIZE];
   memset(buf, 0, sizeof(buf));
   if (ptrIDebugSymbols->GetNameByOffset(offset, buf, sizeof(buf), 0, &disp) ==  S_OK) {
     if (strstr(buf, name) == nullptr) {


### PR DESCRIPTION
On Windows SA agent gets a class vtable from symbols, exported from jvm.dll (it exports symbols like "??_7" + type + "@@6B@").
But symbol lookup function first requests WinDbg about the symbol.
Sometimes WinDbg routine IDebugSymbols::GetOffsetByName() returns offset for both class and class pointer types. Returned offsets correspond to symbols like "jvm!class_name::`vftable'".
The behavior is intermittent, I was not able to find what is the reason.
The fix adds workaround for the case - if GetOffsetByName succeeded, we check if corresponding symbol contains requested one.
So it returns expected offset for non-vtable symbols like "MaxJNILocalCapacity" (GetOffsetByName returns offset for "jvm!MaxJNILocalCapacity"), but returns 0 for vtlb lookup.

Additionally added check for results of IDebugSymbols::SetImagePath/SetSymbolPath

Testing: tier1,tier2,hs-tier5-svc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8311993](https://bugs.openjdk.org/browse/JDK-8311993): Test serviceability/sa/UniqueVtableTest.java failed: duplicate vtables detected (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [e42280af](https://git.openjdk.org/jdk/pull/20684/files/e42280afdfe899f29c9fd00d933761a2143ed5ac)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20684/head:pull/20684` \
`$ git checkout pull/20684`

Update a local copy of the PR: \
`$ git checkout pull/20684` \
`$ git pull https://git.openjdk.org/jdk.git pull/20684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20684`

View PR using the GUI difftool: \
`$ git pr show -t 20684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20684.diff">https://git.openjdk.org/jdk/pull/20684.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20684#issuecomment-2305530184)