### PR TITLE
8337715: Update --release 23 symbol information for JDK 23 build 37

### DIFF
--- a/src/jdk.compiler/share/data/symbols/java.base-N.sym.txt
+++ b/src/jdk.compiler/share/data/symbols/java.base-N.sym.txt
@@ -462,18 +462,6 @@ class name java/net/Socket
 method name <init> descriptor (Ljava/lang/String;IZ)V thrownTypes java/io/IOException flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="1.1")
 method name <init> descriptor (Ljava/net/InetAddress;IZ)V thrownTypes java/io/IOException flags 1 deprecated true runtimeAnnotations @Ljava/lang/Deprecated;(forRemoval=Ztrue,since="1.1")
 
-class name java/nio/HeapByteBuffer
-method name hashCode descriptor ()I flags 1
-
-class name java/nio/HeapByteBufferR
-method name hashCode descriptor ()I flags 1
-
-class name java/nio/HeapCharBuffer
-method name hashCode descriptor ()I flags 1
-
-class name java/nio/HeapCharBufferR
-method name hashCode descriptor ()I flags 1
-
 class name java/security/Provider
 header extends java/util/Properties nestMembers java/security/Provider$Service flags 421
 innerclass innerClass java/util/Map$Entry outerClass java/util/Map innerClassName Entry flags 609


### PR DESCRIPTION
JDK-8337824 fixed in b36 made a change visible in the symbol files; no further changes in b37.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337715](https://bugs.openjdk.org/browse/JDK-8337715): Update --release 23 symbol information for JDK 23 build 37 (**Sub-task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20685/head:pull/20685` \
`$ git checkout pull/20685`

Update a local copy of the PR: \
`$ git checkout pull/20685` \
`$ git pull https://git.openjdk.org/jdk.git pull/20685/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20685`

View PR using the GUI difftool: \
`$ git pr show -t 20685`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20685.diff">https://git.openjdk.org/jdk/pull/20685.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20685#issuecomment-2305561801)