### PR TITLE
8338884: java/nio/file/attribute/BasicFileAttributeView/CreationTime.java#tmp fails on alinux3

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -114,6 +114,8 @@ ifeq ($(call isTargetOs, linux), true)
   # stripping during the test libraries' build.
   BUILD_JDK_JTREG_LIBRARIES_CFLAGS_libFib := -g
   BUILD_JDK_JTREG_LIBRARIES_STRIP_SYMBOLS_libFib := false
+  # nio tests' libCreationTimeHelper native needs -ldl linker flag
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libCreationTimeHelper := -ldl
 endif
 
 ifeq ($(ASAN_ENABLED), true)

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -106,11 +106,12 @@ public class CreationTime {
                 supportsCreationTimeWrite = true;
             }
         } else if (Platform.isLinux()) {
-            // Creation time read depends on statx system call support
-            supportsCreationTimeRead = Linker.nativeLinker().defaultLookup().find("statx").isPresent();
-            // Linux system doesn't support birth time on tmpfs filesystem for now
-            if( Files.getFileStore(file).type().contentEquals("tmpfs") ) {
-                supportsCreationTimeRead = false;
+            // Creation time read depends on statx system call support and on the file
+            // system storing the birth time. The tmpfs file system type does not store
+            // the birth time.
+            boolean statxIsPresent = Linker.nativeLinker().defaultLookup().find("statx").isPresent();
+            if (statxIsPresent && !Files.getFileStore(file).type().contentEquals("tmpfs")) {
+                supportsCreationTimeRead = true;
             }
             // Creation time updates are not supported on Linux
             supportsCreationTimeWrite = false;

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -108,6 +108,10 @@ public class CreationTime {
         } else if (Platform.isLinux()) {
             // Creation time read depends on statx system call support
             supportsCreationTimeRead = Linker.nativeLinker().defaultLookup().find("statx").isPresent();
+            // Linux system doesn't support birth time on tmpfs filesystem for now
+            if( Files.getFileStore(file).type().contentEquals("tmpfs") ) {
+                supportsCreationTimeRead = false;
+            }
             // Creation time updates are not supported on Linux
             supportsCreationTimeWrite = false;
         }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -77,7 +77,7 @@ public class CreationTime {
         FileTime creationTime = creationTime(file);
         Instant now = Instant.now();
         if (Math.abs(creationTime.toMillis()-now.toEpochMilli()) > 10000L) {
-            System.out.println("creationTime.toMillis() == " + creationTime.toMillis());
+            System.err.println("creationTime.toMillis() == " + creationTime.toMillis());
             System.err.println("File creation time reported as: " + creationTime);
             throw new RuntimeException("Expected to be close to: " + now);
         }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -25,18 +25,18 @@
  * @bug 8011536 8151430 8316304 8334339
  * @summary Basic test for creationTime attribute on platforms/file systems
  *     that support it, tests using /tmp directory.
- * @library  ../.. /test/lib
- * @build jdk.test.lib.Platform
- * @run main/native CreationTime
+ * @library  ../.. /test/lib /java/foreign
+ * @build jdk.test.lib.Platform NativeTestHelper
+ * @run main/othervm --enable-native-access=ALL-UNNAMED CreationTime
  */
 
 /* @test id=cwd
  * @summary Basic test for creationTime attribute on platforms/file systems
  *     that support it, tests using the test scratch directory, the test
  *     scratch directory maybe at diff disk partition to /tmp on linux.
- * @library  ../.. /test/lib
- * @build jdk.test.lib.Platform
- * @run main/native CreationTime .
+ * @library  ../.. /test/lib /java/foreign
+ * @build jdk.test.lib.Platform NativeTestHelper
+ * @run main/othervm --enable-native-access=ALL-UNNAMED CreationTime .
  */
 
 import java.lang.foreign.Linker;
@@ -107,7 +107,11 @@ public class CreationTime {
             }
         } else if (Platform.isLinux()) {
             // Creation time read depends on statx system call support
-            supportsCreationTimeRead = CreationTimeHelper.linuxIsCreationTimeSupported(file.toAbsolutePath().toString());
+            try {
+                supportsCreationTimeRead = CreationTimeHelper.linuxIsCreationTimeSupported(file.toAbsolutePath().toString());
+            } catch (Throwable e) {
+                supportsCreationTimeRead = false;
+            }
             // Creation time updates are not supported on Linux
             supportsCreationTimeWrite = false;
         }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -44,9 +44,7 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import java.nio.file.attribute.*;
 import java.time.Instant;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 import jdk.test.lib.Platform;
 import jtreg.SkippedException;

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -81,7 +81,7 @@ public class CreationTime {
             System.out.println("creationTime.toMillis() == " + creationTime.toMillis());
             // If the file system doesn't support birth time, then skip this test
             if (creationTime.toMillis() == 0) {
-                throw new SkippedException("birth time not support for: " + file);
+                throw new SkippedException("birth time not supported for: " + file);
             } else {
                 err.println("File creation time reported as: " + creationTime);
                 throw new RuntimeException("Expected to be close to: " + now);

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -122,8 +122,8 @@ public class CreationTime {
             Files.setLastModifiedTime(file, FileTime.from(plusHour));
             FileTime current = creationTime(file);
             if (!current.equals(creationTime)) {
-                System.out.println("current = " + current);
-                System.out.println("creationTime = " + creationTime);
+                System.err.println("current = " + current);
+                System.err.println("creationTime = " + creationTime);
                 throw new RuntimeException("Creation time should not have changed");
             }
         }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -44,7 +44,9 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import java.nio.file.attribute.*;
 import java.time.Instant;
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
 
 import jdk.test.lib.Platform;
 import jtreg.SkippedException;
@@ -107,10 +109,10 @@ public class CreationTime {
             }
         } else if (Platform.isLinux()) {
             // Creation time read depends on statx system call support and on the file
-            // system storing the birth time. The tmpfs file system type does not store
+            // system storing the birth time. The tmpfs/ext3/nfs etc. file system type does not store
             // the birth time.
             boolean statxIsPresent = Linker.nativeLinker().defaultLookup().find("statx").isPresent();
-            if (statxIsPresent && !Files.getFileStore(file).type().contentEquals("tmpfs")) {
+            if (statxIsPresent && supportBirthTimeOnLinux(file)) {
                 supportsCreationTimeRead = true;
             }
             // Creation time updates are not supported on Linux
@@ -144,6 +146,25 @@ public class CreationTime {
             if (Math.abs(creationTime.toMillis()-current.toMillis()) > 1000L)
                 throw new RuntimeException("Creation time not changed");
         }
+    }
+
+
+    /**
+     * read the output of linux command `stat -c "%w" file`, if the output is "-",
+     * then the file system doesn't support birth time
+     */
+    public static boolean supportBirthTimeOnLinux(Path file) {
+        try {
+            String filePath = file.toAbsolutePath().toString();
+            ProcessBuilder pb = new ProcessBuilder("stat", "-c", "%w", filePath);
+            pb.redirectErrorStream(true);
+            Process p = pb.start();
+            BufferedReader b = new BufferedReader(new InputStreamReader(p.getInputStream()));
+            String l = b.readLine();
+            if (l != null && l.equals("-")) { return false; }
+        } catch(Exception e) {
+        }
+        return true;
     }
 
     public static void main(String[] args) throws IOException {

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -108,7 +108,8 @@ public class CreationTime {
         } else if (Platform.isLinux()) {
             // Creation time read depends on statx system call support
             try {
-                supportsCreationTimeRead = CreationTimeHelper.linuxIsCreationTimeSupported(file.toAbsolutePath().toString());
+                supportsCreationTimeRead = CreationTimeHelper.
+                        linuxIsCreationTimeSupported(file.toAbsolutePath().toString());
             } catch (Throwable e) {
                 supportsCreationTimeRead = false;
             }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -44,9 +44,7 @@ import java.nio.file.Path;
 import java.nio.file.Files;
 import java.nio.file.attribute.*;
 import java.time.Instant;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 
 import jdk.test.lib.Platform;
 import jtreg.SkippedException;
@@ -109,7 +107,7 @@ public class CreationTime {
             }
         } else if (Platform.isLinux()) {
             // Creation time read depends on statx system call support
-            supportsCreationTimeRead = CreationTimeHelper.linuxIsCreationTimeSupported();
+            supportsCreationTimeRead = CreationTimeHelper.linuxIsCreationTimeSupported(file.toAbsolutePath().toString());
             // Creation time updates are not supported on Linux
             supportsCreationTimeWrite = false;
         }
@@ -124,8 +122,11 @@ public class CreationTime {
             Instant plusHour = Instant.now().plusSeconds(60L * 60L);
             Files.setLastModifiedTime(file, FileTime.from(plusHour));
             FileTime current = creationTime(file);
-            if (!current.equals(creationTime))
+            if (!current.equals(creationTime)) {
+                System.out.println("current = " + current);
+                System.out.println("creationTime = " + creationTime);
                 throw new RuntimeException("Creation time should not have changed");
+            }
         }
 
         /**

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -27,7 +27,7 @@
  *     that support it, tests using /tmp directory.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
- * @run main CreationTime
+ * @run main/native CreationTime
  */
 
 /* @test id=cwd
@@ -36,7 +36,7 @@
  *     scratch directory maybe at diff disk partition to /tmp on linux.
  * @library  ../.. /test/lib
  * @build jdk.test.lib.Platform
- * @run main CreationTime .
+ * @run main/native CreationTime .
  */
 
 import java.lang.foreign.Linker;

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,8 +52,6 @@ import jtreg.SkippedException;
 
 public class CreationTime {
 
-    private static final java.io.PrintStream err = System.err;
-
     /**
      * Reads the creationTime attribute
      */
@@ -79,13 +78,8 @@ public class CreationTime {
         Instant now = Instant.now();
         if (Math.abs(creationTime.toMillis()-now.toEpochMilli()) > 10000L) {
             System.out.println("creationTime.toMillis() == " + creationTime.toMillis());
-            // If the file system doesn't support birth time, then skip this test
-            if (creationTime.toMillis() == 0) {
-                throw new SkippedException("birth time not supported for: " + file);
-            } else {
-                err.println("File creation time reported as: " + creationTime);
-                throw new RuntimeException("Expected to be close to: " + now);
-            }
+            System.err.println("File creation time reported as: " + creationTime);
+            throw new RuntimeException("Expected to be close to: " + now);
         }
 
         /**

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java
@@ -28,7 +28,7 @@
  *     that support it, tests using /tmp directory.
  * @library  ../.. /test/lib /java/foreign
  * @build jdk.test.lib.Platform NativeTestHelper
- * @run main/othervm --enable-native-access=ALL-UNNAMED CreationTime
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED CreationTime
  */
 
 /* @test id=cwd
@@ -37,7 +37,7 @@
  *     scratch directory maybe at diff disk partition to /tmp on linux.
  * @library  ../.. /test/lib /java/foreign
  * @build jdk.test.lib.Platform NativeTestHelper
- * @run main/othervm --enable-native-access=ALL-UNNAMED CreationTime .
+ * @run main/othervm/native --enable-native-access=ALL-UNNAMED CreationTime .
  */
 
 import java.lang.foreign.Linker;

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+public class CreationTimeHelper {
+
+    static {
+        System.loadLibrary("CreationTimeHelper");
+    }
+
+    // Helper so as to determine 'statx' support on the runtime system
+    static native boolean linuxIsCreationTimeSupported();
+}

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,5 +27,5 @@ public class CreationTimeHelper {
     }
 
     // Helper so as to determine 'statx' support on the runtime system
-    static native boolean linuxIsCreationTimeSupported();
+    static native boolean linuxIsCreationTimeSupported(String file);
 }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
@@ -44,6 +44,8 @@ public class CreationTimeHelper extends NativeTestHelper {
     // Helper so as to determine 'statx' support on the runtime system
     // static boolean linuxIsCreationTimeSupported(String file);
     static boolean linuxIsCreationTimeSupported(String file) throws Throwable {
+        if (!abi.defaultLookup().find("statx").isPresent())
+            return false;
         try (var arena = Arena.ofConfined()) {
             MemorySegment s = arena.allocateFrom(file);
             return (boolean)methodHandle.invokeExact(s);

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTimeHelper.java
@@ -37,7 +37,8 @@ public class CreationTimeHelper extends NativeTestHelper {
 
     final static Linker abi = Linker.nativeLinker();
     static final SymbolLookup lookup = SymbolLookup.loaderLookup();
-    final static MethodHandle methodHandle = abi.downcallHandle(lookup.findOrThrow("linuxIsCreationTimeSupported"),
+    final static MethodHandle methodHandle = abi.
+            downcallHandle(lookup.findOrThrow("linuxIsCreationTimeSupported"),
             FunctionDescriptor.of(C_BOOL, C_POINTER));
 
     // Helper so as to determine 'statx' support on the runtime system

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include "jni.h"
+#if defined(__linux__)
+#include <dlfcn.h>
+#endif
+
+// static native boolean linuxIsCreationTimeSupported()
+JNIEXPORT jboolean JNICALL
+Java_CreationTimeHelper_linuxIsCreationTimeSupported(JNIEnv *env, jclass cls)
+{
+#if defined(__linux__)
+    void* statx_func = dlsym(RTLD_DEFAULT, "statx");
+    return statx_func != NULL ? JNI_TRUE : JNI_FALSE;
+#else
+    return JNI_FALSE;
+#endif
+}

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -115,7 +115,11 @@ EXPORT bool linuxIsCreationTimeSupported(char* file) {
     if (ret != 0) {
         return false;
     }
-    if (stx.stx_mask & STATX_BTIME)
+    // On some systems where statx is available but birth time might still not
+    // be supported as it's file system specific. The only reliable way to
+    // check for supported or not is looking at the filled in STATX_BTIME bit
+    // in the returned statx buffer mask.
+    if ((stx.stx_mask & STATX_BTIME) != 0)
         return true;
     return false;
 #else

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -21,6 +21,7 @@
  * questions.
  */
 #include "jni.h"
+#if defined(__linux__)
 #include <linux/fcntl.h>
 #include <stdio.h>
 #include <string.h>
@@ -78,13 +79,11 @@ struct my_statx
   __uint64_t __statx_pad2[14];
 };
 
-#if defined(__linux__)
 typedef int statx_func(int dirfd, const char *restrict pathname, int flags,
                        unsigned int mask, struct my_statx *restrict statxbuf);
-#endif
-#if defined(__linux__)
+
 static statx_func* my_statx_func = NULL;
-#endif
+#endif  //#defined(__linux__)
 
 // static native boolean linuxIsCreationTimeSupported()
 JNIEXPORT jboolean JNICALL

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2024 Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,17 +21,110 @@
  * questions.
  */
 #include "jni.h"
-#if defined(__linux__)
+#include <linux/fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <bits/types.h>
 #include <dlfcn.h>
+#ifndef STATX_BASIC_STATS
+#define STATX_BASIC_STATS 0x000007ffU
+#endif
+#ifndef STATX_BTIME
+#define STATX_BTIME 0x00000800U
+#endif
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#ifndef RTLD_DEFAULT
+#define RTLD_DEFAULT RTLD_LOCAL
+#endif
+
+/*
+ * Timestamp structure for the timestamps in struct statx.
+ */
+struct my_statx_timestamp {
+        __int64_t   tv_sec;
+        __uint32_t  tv_nsec;
+        __int32_t   __reserved;
+};
+
+/*
+ * struct statx used by statx system call on >= glibc 2.28
+ * systems
+ */
+struct my_statx
+{
+  __uint32_t stx_mask;
+  __uint32_t stx_blksize;
+  __uint64_t stx_attributes;
+  __uint32_t stx_nlink;
+  __uint32_t stx_uid;
+  __uint32_t stx_gid;
+  __uint16_t stx_mode;
+  __uint16_t __statx_pad1[1];
+  __uint64_t stx_ino;
+  __uint64_t stx_size;
+  __uint64_t stx_blocks;
+  __uint64_t stx_attributes_mask;
+  struct my_statx_timestamp stx_atime;
+  struct my_statx_timestamp stx_btime;
+  struct my_statx_timestamp stx_ctime;
+  struct my_statx_timestamp stx_mtime;
+  __uint32_t stx_rdev_major;
+  __uint32_t stx_rdev_minor;
+  __uint32_t stx_dev_major;
+  __uint32_t stx_dev_minor;
+  __uint64_t __statx_pad2[14];
+};
+
+#if defined(__linux__)
+typedef int statx_func(int dirfd, const char *restrict pathname, int flags,
+                       unsigned int mask, struct my_statx *restrict statxbuf);
+#endif
+#if defined(__linux__)
+static statx_func* my_statx_func = NULL;
 #endif
 
 // static native boolean linuxIsCreationTimeSupported()
 JNIEXPORT jboolean JNICALL
-Java_CreationTimeHelper_linuxIsCreationTimeSupported(JNIEnv *env, jclass cls)
-{
+Java_CreationTimeHelper_linuxIsCreationTimeSupported(JNIEnv *env, jclass cls, jstring file) {
 #if defined(__linux__)
-    void* statx_func = dlsym(RTLD_DEFAULT, "statx");
-    return statx_func != NULL ? JNI_TRUE : JNI_FALSE;
+    struct my_statx stx;
+    int ret, atflag = AT_SYMLINK_NOFOLLOW;
+    memset(&stx, 0xbf, sizeof(stx));
+    unsigned int mask = STATX_BASIC_STATS | STATX_BTIME;
+
+    my_statx_func = (statx_func*) dlsym(RTLD_DEFAULT, "statx");
+    if (my_statx_func == NULL) {
+        return JNI_FALSE;
+    }
+
+    if (file == NULL) {
+        printf("input file error!\n");
+        return JNI_FALSE;
+    }
+    const char *utfChars = (*env)->GetStringUTFChars(env, file, NULL);
+    if (utfChars == NULL) {
+        printf("jstring convert to char array error!\n");
+        return JNI_FALSE;
+    }
+
+    ret = my_statx_func(AT_FDCWD, utfChars, atflag, mask, &stx);
+
+    if (file != NULL && utfChars != NULL) {
+        (*env)->ReleaseStringUTFChars(env, file, utfChars);
+    }
+
+    #ifdef DEBUG
+    printf("birth time = %ld\n", stx.stx_btime.tv_sec);
+    #endif
+    if (ret != 0) {
+        return JNI_FALSE;
+    }
+    if (stx.stx_mask & STATX_BTIME)
+        return JNI_TRUE;
+    return JNI_FALSE;
 #else
     return JNI_FALSE;
 #endif

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -122,6 +122,6 @@ EXPORT bool linuxIsCreationTimeSupported(char* file) {
         return true;
     return false;
 #else
-    return JNI_FALSE;
+    return false;
 #endif
 }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -21,13 +21,7 @@
  * questions.
  */
 #include "export.h"
-#if (__STDC_VERSION__ >= 199901L)
-  #include <stdbool.h>
-#else
-  #define bool int
-  #define true 1
-  #define false 0
-#endif
+#include <stdbool.h>
 #if defined(__linux__)
 #include <linux/fcntl.h>
 #include <stdio.h>

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -86,9 +86,8 @@ static statx_func* my_statx_func = NULL;
 // static boolean linuxIsCreationTimeSupported(char* file)
 EXPORT bool linuxIsCreationTimeSupported(char* file) {
 #if defined(__linux__)
-    struct my_statx stx;
+    struct my_statx stx = {0};
     int ret, atflag = AT_SYMLINK_NOFOLLOW;
-    memset(&stx, 0xbf, sizeof(stx));
     unsigned int mask = STATX_BASIC_STATS | STATX_BTIME;
 
     my_statx_func = (statx_func*) dlsym(RTLD_DEFAULT, "statx");

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -41,9 +41,6 @@
 #ifndef STATX_BTIME
 #define STATX_BTIME 0x00000800U
 #endif
-#ifndef _GNU_SOURCE
-#define _GNU_SOURCE
-#endif
 #ifndef RTLD_DEFAULT
 #define RTLD_DEFAULT RTLD_LOCAL
 #endif

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -101,10 +101,6 @@ EXPORT bool linuxIsCreationTimeSupported(char* file) {
     }
 
     ret = my_statx_func(AT_FDCWD, file, atflag, mask, &stx);
-
-    #ifdef DEBUG
-    printf("birth time = %ld\n", stx.stx_btime.tv_sec);
-    #endif
     if (ret != 0) {
         return false;
     }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -21,7 +21,6 @@
  * questions.
  */
 #include "export.h"
-#if defined(__linux__)
 #if (__STDC_VERSION__ >= 199901L)
   #include <stdbool.h>
 #else
@@ -29,6 +28,7 @@
   #define true 1
   #define false 0
 #endif
+#if defined(__linux__)
 #include <linux/fcntl.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Hi all,
On alinux3(alibaba cloud linux version 3) system, the `/tmp` disk partition is mounted as tmpfs filesystem type, this filesystem type doesn't support create time(birth time).

Before this PR, this test [check](https://github.com/openjdk/jdk/blob/master/test/jdk/java/nio/file/attribute/BasicFileAttributeView/CreationTime.java#L110) if there is `statx` system call present or not to determise the test environment support birth time or not. I think it's not enough when the tested filesystem type is `tmpfs`. When the tested filesystem type is `tmpfs`, then the tested file doesn't support birth time.

On RHEL 8 tmpfs doesn't seem to support birth time, but on F39 tmpfs does seem to support birth time. Looks like this might be related to the kernel version. It's difficult to enumerate all the combination of file system type and linux kernel version to determine the testd file support birth time or not. So in this PR, I get the result from `statx` linux syscall, to determine the testd file support birth time or not.

Test fix only, the change has been verified, risk is low.

Additional test:

- [x] Alinux3 glibc:2.32
1.  /tmp/file supportsCreationTimeRead == false
2. ./file supportsCreationTimeRead == true
- [x] CentOS7 docker container glibc:2.17
1.  /tmp/file supportsCreationTimeRead == false
2. ./file supportsCreationTimeRead == false

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8338884](https://bugs.openjdk.org/browse/JDK-8338884): java/nio/file/attribute/BasicFileAttributeView/CreationTime.java#tmp fails on alinux3 (**Bug** - P3)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20687/head:pull/20687` \
`$ git checkout pull/20687`

Update a local copy of the PR: \
`$ git checkout pull/20687` \
`$ git pull https://git.openjdk.org/jdk.git pull/20687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20687`

View PR using the GUI difftool: \
`$ git pr show -t 20687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20687.diff">https://git.openjdk.org/jdk/pull/20687.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20687#issuecomment-2306140521)