### PR TITLE
8190329: [macos] Swing InterOp Platform.exit() crash

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -36,6 +36,8 @@
 #import "ThreadUtilities.h"
 #import "JNIUtilities.h"
 
+extern JavaVM *jvm;
+
 #define MASK(KEY) \
     (sun_lwawt_macosx_CPlatformWindow_ ## KEY)
 
@@ -631,6 +633,11 @@ AWT_ASSERT_APPKIT_THREAD;
 - (void) _deliverMoveResizeEvent {
 AWT_ASSERT_APPKIT_THREAD;
 
+    JNIEnv *pEnv = nil;
+    jint ret = (*jvm)->GetEnv(jvm, &pEnv, JNI_VERSION_1_4);
+    if (ret == JNI_EDETACHED) {
+        return;
+    }
     // deliver the event if this is a user-initiated live resize or as a side-effect
     // of a Java initiated resize, because AppKit can override the bounds and force
     // the bounds of the window to avoid the Dock or remain on screen.

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/AWTWindow.m
@@ -36,8 +36,6 @@
 #import "ThreadUtilities.h"
 #import "JNIUtilities.h"
 
-extern JavaVM *jvm;
-
 #define MASK(KEY) \
     (sun_lwawt_macosx_CPlatformWindow_ ## KEY)
 
@@ -633,11 +631,6 @@ AWT_ASSERT_APPKIT_THREAD;
 - (void) _deliverMoveResizeEvent {
 AWT_ASSERT_APPKIT_THREAD;
 
-    JNIEnv *pEnv = nil;
-    jint ret = (*jvm)->GetEnv(jvm, &pEnv, JNI_VERSION_1_4);
-    if (ret == JNI_EDETACHED) {
-        return;
-    }
     // deliver the event if this is a user-initiated live resize or as a side-effect
     // of a Java initiated resize, because AppKit can override the bounds and force
     // the bounds of the window to avoid the Dock or remain on screen.

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -126,6 +126,7 @@ AWT_ASSERT_APPKIT_THREAD;
         [ThreadUtilities setApplicationOwner:NO];
         return nil;
     }
+    [ThreadUtilities setApplicationOwner:YES];
 
     sApplicationDelegate = [[ApplicationDelegate alloc] init];
     return sApplicationDelegate;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -117,16 +117,20 @@ AWT_ASSERT_APPKIT_THREAD;
     // don't install the EAWT delegate if another kind of NSApplication is installed, like say, Safari
     BOOL shouldInstall = NO;
     BOOL overrideDelegate = (getenv("AWT_OVERRIDE_NSDELEGATE") != NULL);
+    BOOL isApplicationOwner = NO;
     if (NSApp != nil) {
         if ([NSApp isMemberOfClass:[NSApplication class]] && overrideDelegate) shouldInstall = YES;
-        if ([NSApp isKindOfClass:[NSApplicationAWT class]]) shouldInstall = YES;
+        if ([NSApp isKindOfClass:[NSApplicationAWT class]]) {
+            shouldInstall = YES;
+            isApplicationOwner = YES;
+        }
     }
     checked = YES;
     if (!shouldInstall) {
         [ThreadUtilities setApplicationOwner:NO];
         return nil;
     }
-    [ThreadUtilities setApplicationOwner:YES];
+    [ThreadUtilities setApplicationOwner:isApplicationOwner];
 
     sApplicationDelegate = [[ApplicationDelegate alloc] init];
     return sApplicationDelegate;

--- a/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/awt/ApplicationDelegate.m
@@ -122,7 +122,10 @@ AWT_ASSERT_APPKIT_THREAD;
         if ([NSApp isKindOfClass:[NSApplicationAWT class]]) shouldInstall = YES;
     }
     checked = YES;
-    if (!shouldInstall) return nil;
+    if (!shouldInstall) {
+        [ThreadUtilities setApplicationOwner:NO];
+        return nil;
+    }
 
     sApplicationDelegate = [[ApplicationDelegate alloc] init];
     return sApplicationDelegate;

--- a/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.h
+++ b/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.h
+++ b/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.h
@@ -131,6 +131,7 @@ __attribute__((visibility("default")))
 + (JNIEnv*)getJNIEnvUncached;
 + (void)detachCurrentThread;
 + (void)setAppkitThreadGroup:(jobject)group;
++ (void)setApplicationOwner:(BOOL)owner;
 
 + (void)performOnMainThreadWaiting:(BOOL)wait block:(void (^)())block;
 + (void)performOnMainThread:(SEL)aSelector on:(id)target withObject:(id)arg waitUntilDone:(BOOL)wait;

--- a/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
+++ b/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@
 
 // The following must be named "jvm", as there are extern references to it in AWT
 JavaVM *jvm = NULL;
-static BOOL isNSApplicationOwner = YES;
+static BOOL isNSApplicationOwner = NO;
 static JNIEnv *appKitEnv = NULL;
 static jobject appkitThreadGroup = NULL;
 static NSString* JavaRunLoopMode = @"AWTRunLoopMode";

--- a/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
+++ b/src/java.desktop/macosx/native/libosxapp/ThreadUtilities.m
@@ -31,6 +31,7 @@
 
 // The following must be named "jvm", as there are extern references to it in AWT
 JavaVM *jvm = NULL;
+static BOOL isNSApplicationOwner = YES;
 static JNIEnv *appKitEnv = NULL;
 static jobject appkitThreadGroup = NULL;
 static NSString* JavaRunLoopMode = @"AWTRunLoopMode";
@@ -59,12 +60,20 @@ static inline void attachCurrentThread(void** env) {
                                            nil];
 }
 
++ (void)setApplicationOwner:(BOOL)owner {
+    isNSApplicationOwner = owner;
+}
+
 + (JNIEnv*)getJNIEnv {
 AWT_ASSERT_APPKIT_THREAD;
-    if (appKitEnv == NULL) {
-        attachCurrentThread((void **)&appKitEnv);
+    if (isNSApplicationOwner) {
+        if (appKitEnv == NULL) {
+            attachCurrentThread((void **)&appKitEnv);
+        }
+        return appKitEnv;
+    } else {
+        return [ThreadUtilities getJNIEnvUncached];
     }
-    return appKitEnv;
 }
 
 + (JNIEnv*)getJNIEnvUncached {


### PR DESCRIPTION
The testcase calls Platform.exit before the dialog is made visible but
on macOS, JavaFX takes over the AppKit thread and uses that as the FX application thread. As part of the FX platform shutdown process, it detaches that thread from the JVM. This means that the AppKit thread is no longer available to Java processes
so AWT crashes when it ties to access appkit thread.
Fix is made to check if the thread has been detached for move-resize notification event before proceeding..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8190329](https://bugs.openjdk.org/browse/JDK-8190329): [macos] Swing InterOp Platform.exit() crash (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Contributors
 * Kevin Rushforth `<kcr@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20688/head:pull/20688` \
`$ git checkout pull/20688`

Update a local copy of the PR: \
`$ git checkout pull/20688` \
`$ git pull https://git.openjdk.org/jdk.git pull/20688/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20688`

View PR using the GUI difftool: \
`$ git pr show -t 20688`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20688.diff">https://git.openjdk.org/jdk/pull/20688.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20688#issuecomment-2306697992)