### PR TITLE
8195686: ISO-8859-8-i charset cannot be decoded, should be mapped to ISO-8859-8

### DIFF
--- a/make/data/charsetmapping/charsets
+++ b/make/data/charsetmapping/charsets
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -871,8 +871,10 @@ charset ISO-8859-8 ISO_8859_8
     alias   8859_8
     alias   iso-ir-138
     alias   ISO_8859-8
+    alias   ISO-8859-8-I  
     alias   ISO_8859-8:1988
     alias   ISO8859-8
+    alias   ISO8859-8-I
     alias   cp916
     alias   916
     alias   ibm916

--- a/test/jdk/java/nio/charset/Charset/RegisteredCharsets.java
+++ b/test/jdk/java/nio/charset/Charset/RegisteredCharsets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /* @test
  * @bug 4473201 4696726 4652234 4482298 4784385 4966197 4267354 5015668
-        6911753 8071447 8186751 8242541 8260265 8301119
+        6911753 8071447 8186751 8242541 8260265 8301119 8195686
  * @summary Check that registered charsets are actually registered
  * @modules jdk.charsets
  * @run junit RegisteredCharsets
@@ -432,6 +432,8 @@ public class RegisteredCharsets {
                     "ISO_8859-8:1988",
                     "iso-ir-138",
                     "ISO_8859-8",
+                    "ISO-8859-8-I",
+                    "ISO8859-8-I",
                     "hebrew",
                     "8859_8",
                     "iso_8859-8:1988",


### PR DESCRIPTION
Mapping ISO-8859-8-I charset to ISO-8859-8.
Below mentioned 2 aliases are added as part of this:-
**ISO-8859-8-I**
**ISO8859-8-I**

The bug report for the same:- https://bugs.openjdk.org/browse/JDK-8195686

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 25 to be approved (needs to be created)

### Issue
 * [JDK-8195686](https://bugs.openjdk.org/browse/JDK-8195686): ISO-8859-8-i charset cannot be decoded, should be mapped to ISO-8859-8 (**Enhancement** - P4)


### Reviewers
 * [Steven Loomis](https://openjdk.org/census#srl) (@srl295 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20690/head:pull/20690` \
`$ git checkout pull/20690`

Update a local copy of the PR: \
`$ git checkout pull/20690` \
`$ git pull https://git.openjdk.org/jdk.git pull/20690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20690`

View PR using the GUI difftool: \
`$ git pr show -t 20690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20690.diff">https://git.openjdk.org/jdk/pull/20690.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20690#issuecomment-2306820190)
</details>
