### PR TITLE
8338445: jdk.internal.loader.URLClassPath may leak JarFile instance when dealing with unexpected Class-Path entry in manifest

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -59,7 +59,6 @@ import java.util.Properties;
 import java.util.StringTokenizer;
 import java.util.jar.JarFile;
 import java.util.zip.CRC32;
-import java.util.zip.ZipEntry;
 import java.util.jar.JarEntry;
 import java.util.jar.Manifest;
 import java.util.jar.Attributes;
@@ -453,7 +452,7 @@ public class URLClassPath {
                             " local classpath for " + url + ", cause:" + e);
                 }
                 if (loader != null) {
-                    closeLoaderIgnoreEx(loader);
+                    closeQuietly(loader);
                 }
                 continue;
             } catch (SecurityException se) {
@@ -464,7 +463,7 @@ public class URLClassPath {
                     System.err.println("Failed to access " + url + ", " + se );
                 }
                 if (loader != null) {
-                    closeLoaderIgnoreEx(loader);
+                    closeQuietly(loader);
                 }
                 continue;
             }
@@ -479,7 +478,7 @@ public class URLClassPath {
     }
 
     // closes the given loader and ignores any IOException that may occur during close
-    private static void closeLoaderIgnoreEx(final Loader loader) {
+    private static void closeQuietly(final Loader loader) {
         try {
             loader.close();
         } catch (IOException ioe) {

--- a/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
+++ b/src/java.base/share/classes/jdk/internal/loader/URLClassPath.java
@@ -442,8 +442,8 @@ public class URLClassPath {
             final URL[] loaderClassPathURLs;
             try {
                 loader = getLoader(url);
-                // If the loader defines a local class path then construct
-                // and add the URLs as the next URLs to be opened.
+                // If the loader defines a local class path then add the
+                // URLs as the next URLs to be opened.
                 loaderClassPathURLs = loader.getClassPath();
             } catch (IOException e) {
                 // log the error and close the unusable loader (if any)

--- a/test/jdk/java/net/URLClassLoader/JarLoaderCloseTest.java
+++ b/test/jdk/java/net/URLClassLoader/JarLoaderCloseTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
+import java.util.stream.Stream;
+
+import jdk.test.lib.util.JarUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/*
+ * @test
+ * @bug 8338445
+ * @summary verify that the jdk.internal.loader.URLClassPath closes the JarFile
+ *          instances that it no longer uses for loading
+ * @library /test/lib
+ * @build jdk.test.lib.util.JarUtils
+ * @comment This test expects MalformedURLException for some specific URLs.
+ *          We use othervm to prevent interference from other tests which
+ *          might have installed custom URLStreamHandler(s)
+ * @run junit/othervm JarLoaderCloseTest
+ */
+public class JarLoaderCloseTest {
+
+    private static final String RESOURCE_NAME = "foo-bar.txt";
+    private static final String RESOURCE_CONTENT = "Hello world";
+    private static final Path TEST_SCRATCH_DIR = Path.of(".");
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        // create a file which will be added to the jar that gets tested
+        Files.writeString(TEST_SCRATCH_DIR.resolve(RESOURCE_NAME), RESOURCE_CONTENT);
+    }
+
+    static Stream<Arguments> malformedClassPaths() {
+        return Stream.of(
+                Arguments.of("C:\\foo\\bar\\hello/world.jar lib2.jar"),
+                Arguments.of("C:/hello/world/foo.jar"),
+                Arguments.of("lib4.jar C:\\bar\\foo\\world/hello.jar")
+        );
+    }
+
+    /*
+     * Creates a jar with a manifest which has a Class-Path entry value with malformed URLs.
+     * Then uses a URLClassLoader backed by the jar file in its classpath, loads some resource,
+     * closes the URLClassLoader and then expects that the underlying jar file can be deleted
+     * from the filesystem.
+     */
+    @ParameterizedTest
+    @MethodSource("malformedClassPaths")
+    public void testMalformedClassPathEntry(final String classPathValue) throws Exception {
+        final Manifest manifest = createManifestWithClassPath(classPathValue);
+        final Path jar = Files.createTempFile(TEST_SCRATCH_DIR, "8338445", ".jar");
+        // create the jar with the given manifest and an arbitrary file
+        JarUtils.createJarFile(jar, manifest, TEST_SCRATCH_DIR, Path.of(RESOURCE_NAME));
+        System.out.println("created jar at " + jar + " with manifest:");
+        manifest.write(System.out);
+        final URL[] urlClassPath = new URL[]{jar.toUri().toURL()};
+        // Create a URLClassLoader backed by the jar file and load a non-existent resource just to
+        // exercise the URLClassPath code of loading the jar and parsing the Class-Path entry.
+        // Then close the classloader. After the classloader is closed
+        // issue a delete on the underlying jar file on the filesystem. The delete is expected
+        // to succeed.
+        try (final URLClassLoader cl = new URLClassLoader(urlClassPath)) {
+            try (final InputStream is = cl.getResourceAsStream("non-existent.txt")) {
+                assertNull(is, "unexpectedly found a resource in classpath "
+                        + Arrays.toString(urlClassPath));
+            }
+        }
+        // now delete the jar file and verify the delete worked
+        Files.delete(jar);
+        assertFalse(Files.exists(jar), jar + " exists even after being deleted");
+    }
+
+    static Stream<Arguments> missingButParsableClassPaths() {
+        return Stream.of(
+                Arguments.of("/home/me/hello/world.jar lib9.jar"),
+                Arguments.of("lib10.jar")
+        );
+    }
+
+    /*
+     * Creates a jar with a manifest which has a Class-Path entry value with URLs that are parsable
+     * but point to files that don't exist on the filesystem.
+     * Then uses a URLClassLoader backed by the jar file in its classpath, loads some resource,
+     * closes the URLClassLoader and then expects that the underlying jar file can be deleted
+     * from the filesystem.
+     */
+    @ParameterizedTest
+    @MethodSource("missingButParsableClassPaths")
+    public void testParsableClassPathEntry(final String classPathValue) throws Exception {
+        final Manifest manifest = createManifestWithClassPath(classPathValue);
+        final Path jar = Files.createTempFile(TEST_SCRATCH_DIR, "8338445", ".jar");
+        // create the jar with the given manifest and an arbitrary file
+        JarUtils.createJarFile(jar, manifest, TEST_SCRATCH_DIR, Path.of(RESOURCE_NAME));
+        System.out.println("created jar at " + jar + " with manifest:");
+        manifest.write(System.out);
+        final URL[] urlClassPath = new URL[]{jar.toUri().toURL()};
+        // Create a URLClassLoader backed by the jar file and load a resource
+        // and verify the resource contents.
+        // Then close the classloader. After the classloader is closed
+        // issue a delete on the underlying jar file on the filesystem. The delete is expected
+        // to succeed.
+        try (final URLClassLoader cl = new URLClassLoader(urlClassPath)) {
+            try (final InputStream is = cl.getResourceAsStream(RESOURCE_NAME)) {
+                assertNotNull(is, RESOURCE_NAME + " not located by classloader in classpath "
+                        + Arrays.toString(urlClassPath));
+                final String content = new String(is.readAllBytes(), US_ASCII);
+                assertEquals(RESOURCE_CONTENT, content, "unexpected content in " + RESOURCE_NAME);
+            }
+        }
+        // now delete the jar file and verify the delete worked
+        Files.delete(jar);
+        assertFalse(Files.exists(jar), jar + " exists even after being deleted");
+    }
+
+    private static Manifest createManifestWithClassPath(final String classPathValue) {
+        final Manifest manifest = new Manifest();
+        final Attributes mainAttributes = manifest.getMainAttributes();
+        mainAttributes.putValue("Manifest-Version", "1.0");
+        mainAttributes.putValue("Class-Path", classPathValue);
+        return manifest;
+    }
+}

--- a/test/jdk/java/net/URLClassLoader/JarLoaderCloseTest.java
+++ b/test/jdk/java/net/URLClassLoader/JarLoaderCloseTest.java
@@ -62,7 +62,7 @@ public class JarLoaderCloseTest {
 
     @BeforeAll
     static void beforeAll() throws Exception {
-        // create a file which will be added to the jar that gets tested
+        // create a file which will be added to the JAR file that gets tested
         Files.writeString(TEST_SCRATCH_DIR.resolve(RESOURCE_NAME), RESOURCE_CONTENT);
     }
 
@@ -75,9 +75,9 @@ public class JarLoaderCloseTest {
     }
 
     /*
-     * Creates a jar with a manifest which has a Class-Path entry value with malformed URLs.
-     * Then uses a URLClassLoader backed by the jar file in its classpath, loads some resource,
-     * closes the URLClassLoader and then expects that the underlying jar file can be deleted
+     * Creates a JAR file with a manifest which has a Class-Path entry value with malformed URLs.
+     * Then uses a URLClassLoader backed by the JAR file in its classpath, loads some resource,
+     * closes the URLClassLoader and then expects that the underlying JAR file can be deleted
      * from the filesystem.
      */
     @ParameterizedTest
@@ -85,15 +85,15 @@ public class JarLoaderCloseTest {
     public void testMalformedClassPathEntry(final String classPathValue) throws Exception {
         final Manifest manifest = createManifestWithClassPath(classPathValue);
         final Path jar = Files.createTempFile(TEST_SCRATCH_DIR, "8338445", ".jar");
-        // create the jar with the given manifest and an arbitrary file
+        // create the JAR file with the given manifest and an arbitrary file
         JarUtils.createJarFile(jar, manifest, TEST_SCRATCH_DIR, Path.of(RESOURCE_NAME));
         System.out.println("created jar at " + jar + " with manifest:");
         manifest.write(System.out);
         final URL[] urlClassPath = new URL[]{jar.toUri().toURL()};
-        // Create a URLClassLoader backed by the jar file and load a non-existent resource just to
+        // Create a URLClassLoader backed by the JAR file and load a non-existent resource just to
         // exercise the URLClassPath code of loading the jar and parsing the Class-Path entry.
         // Then close the classloader. After the classloader is closed
-        // issue a delete on the underlying jar file on the filesystem. The delete is expected
+        // issue a delete on the underlying JAR file on the filesystem. The delete is expected
         // to succeed.
         try (final URLClassLoader cl = new URLClassLoader(urlClassPath)) {
             try (final InputStream is = cl.getResourceAsStream("non-existent.txt")) {
@@ -101,7 +101,7 @@ public class JarLoaderCloseTest {
                         + Arrays.toString(urlClassPath));
             }
         }
-        // now delete the jar file and verify the delete worked
+        // now delete the JAR file and verify the delete worked
         Files.delete(jar);
         assertFalse(Files.exists(jar), jar + " exists even after being deleted");
     }
@@ -114,10 +114,10 @@ public class JarLoaderCloseTest {
     }
 
     /*
-     * Creates a jar with a manifest which has a Class-Path entry value with URLs that are parsable
-     * but point to files that don't exist on the filesystem.
-     * Then uses a URLClassLoader backed by the jar file in its classpath, loads some resource,
-     * closes the URLClassLoader and then expects that the underlying jar file can be deleted
+     * Creates a JAR file with a manifest which has a Class-Path entry value with URLs
+     * that are parsable but point to files that don't exist on the filesystem.
+     * Then uses a URLClassLoader backed by the JAR file in its classpath, loads some resource,
+     * closes the URLClassLoader and then expects that the underlying JAR file can be deleted
      * from the filesystem.
      */
     @ParameterizedTest
@@ -125,15 +125,15 @@ public class JarLoaderCloseTest {
     public void testParsableClassPathEntry(final String classPathValue) throws Exception {
         final Manifest manifest = createManifestWithClassPath(classPathValue);
         final Path jar = Files.createTempFile(TEST_SCRATCH_DIR, "8338445", ".jar");
-        // create the jar with the given manifest and an arbitrary file
+        // create the JAR file with the given manifest and an arbitrary file
         JarUtils.createJarFile(jar, manifest, TEST_SCRATCH_DIR, Path.of(RESOURCE_NAME));
         System.out.println("created jar at " + jar + " with manifest:");
         manifest.write(System.out);
         final URL[] urlClassPath = new URL[]{jar.toUri().toURL()};
-        // Create a URLClassLoader backed by the jar file and load a resource
+        // Create a URLClassLoader backed by the JAR file and load a resource
         // and verify the resource contents.
         // Then close the classloader. After the classloader is closed
-        // issue a delete on the underlying jar file on the filesystem. The delete is expected
+        // issue a delete on the underlying JAR file on the filesystem. The delete is expected
         // to succeed.
         try (final URLClassLoader cl = new URLClassLoader(urlClassPath)) {
             try (final InputStream is = cl.getResourceAsStream(RESOURCE_NAME)) {
@@ -143,7 +143,7 @@ public class JarLoaderCloseTest {
                 assertEquals(RESOURCE_CONTENT, content, "unexpected content in " + RESOURCE_NAME);
             }
         }
-        // now delete the jar file and verify the delete worked
+        // now delete the JAR file and verify the delete worked
         Files.delete(jar);
         assertFalse(Files.exists(jar), jar + " exists even after being deleted");
     }

--- a/test/jdk/java/net/URLClassLoader/JarLoaderCloseTest.java
+++ b/test/jdk/java/net/URLClassLoader/JarLoaderCloseTest.java
@@ -29,13 +29,11 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
-import java.util.stream.Stream;
 
 import jdk.test.lib.util.JarUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -66,14 +64,6 @@ public class JarLoaderCloseTest {
         Files.writeString(TEST_SCRATCH_DIR.resolve(RESOURCE_NAME), RESOURCE_CONTENT);
     }
 
-    static Stream<Arguments> malformedClassPaths() {
-        return Stream.of(
-                Arguments.of("C:\\foo\\bar\\hello/world.jar lib2.jar"),
-                Arguments.of("C:/hello/world/foo.jar"),
-                Arguments.of("lib4.jar C:\\bar\\foo\\world/hello.jar")
-        );
-    }
-
     /*
      * Creates a JAR file with a manifest which has a Class-Path entry value with malformed URLs.
      * Then uses a URLClassLoader backed by the JAR file in its classpath, loads some resource,
@@ -81,7 +71,11 @@ public class JarLoaderCloseTest {
      * from the filesystem.
      */
     @ParameterizedTest
-    @MethodSource("malformedClassPaths")
+    @ValueSource(strings = {
+            "C:\\foo\\bar\\hello/world.jar lib2.jar",
+            "C:/hello/world/foo.jar",
+            "lib4.jar C:\\bar\\foo\\world/hello.jar"
+    })
     public void testMalformedClassPathEntry(final String classPathValue) throws Exception {
         final Manifest manifest = createManifestWithClassPath(classPathValue);
         final Path jar = Files.createTempFile(TEST_SCRATCH_DIR, "8338445", ".jar");
@@ -106,13 +100,6 @@ public class JarLoaderCloseTest {
         assertFalse(Files.exists(jar), jar + " exists even after being deleted");
     }
 
-    static Stream<Arguments> missingButParsableClassPaths() {
-        return Stream.of(
-                Arguments.of("/home/me/hello/world.jar lib9.jar"),
-                Arguments.of("lib10.jar")
-        );
-    }
-
     /*
      * Creates a JAR file with a manifest which has a Class-Path entry value with URLs
      * that are parsable but point to files that don't exist on the filesystem.
@@ -121,7 +108,10 @@ public class JarLoaderCloseTest {
      * from the filesystem.
      */
     @ParameterizedTest
-    @MethodSource("missingButParsableClassPaths")
+    @ValueSource(strings = {
+            "/home/me/hello/world.jar lib9.jar",
+            "lib10.jar"
+    })
     public void testParsableClassPathEntry(final String classPathValue) throws Exception {
         final Manifest manifest = createManifestWithClassPath(classPathValue);
         final Path jar = Files.createTempFile(TEST_SCRATCH_DIR, "8338445", ".jar");


### PR DESCRIPTION
Can I please get a review of this change which proposes to fix the issue noted in https://bugs.openjdk.org/browse/JDK-8338445?

The JDK internal class `jdk.internal.loader.URLClassPath` is used by classloader implementations in the JDK (for example by the `java.net.URLClassLoader` and the `jdk.internal.loader.ClassLoaders$AppClassLoader`). The implementation in `URLClassPath` constructs internal `Loader`s for each URL that is in the classpath of that instance. `Loader` implementations hold on to underlying resources from which the classpath resources are served by the `URLClassPath`.

When constructing a `Loader`, the `URLClassPath` allows the loader implementation to parse a local classpath for that specific `Loader`. For example, the `JarLoader` (an internal class of the JDK) will parse `Class-Path` attribute in the jar file's manifest to construct additional URLs that will be included in the classpath through which resources will be served by `URLClassPath`. While parsing the local classpath, if the `Loader` instance runs into any `IOException` or a `SecurityException`, the `URLClassPath` will ignore that specific instance of the `Loader` and will not hold on to it as a classpath element.

As noted earlier, `Loader` instances may hold onto underlying resources. When the `URLClassPath` ignores such `Loader`(s) and doesn't call `close()` on them, then that results in potential resource leaks. The linked JBS issue demonstrates a case where the `JarFile` held by the `JarLoader` doesn't get closed (until GC garbage collects the `JarLoader` and thus the `JarFile`), when the `URLClassPath` ignores that `JarLoader` due to an `IOException` when the `JarLoader` is parsing the `Class-Path` value from the jar's manifest.

The commit in this PR addresses the issue by calling `close()` on such `Loader`s that get rejected by the `URLClassPath` when either an `IOException` or a `SecurityException` gets thrown when constructing the `Loader` or parsing the local classpath.

A new jtreg test has been introduced which consistently reproduces this issue (on Windows) and verifies the fix. Additionally tier1, tier2 and tier3 testing has completed with this change without any failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338445](https://bugs.openjdk.org/browse/JDK-8338445): jdk.internal.loader.URLClassPath may leak JarFile instance when dealing with unexpected Class-Path entry in manifest (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [b5bf8412](https://git.openjdk.org/jdk/pull/20691/files/b5bf84128555adc2edacedd0c849dd6fd6af071e)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Christian Stein](https://openjdk.org/census#cstein) (@sormuras - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20691/head:pull/20691` \
`$ git checkout pull/20691`

Update a local copy of the PR: \
`$ git checkout pull/20691` \
`$ git pull https://git.openjdk.org/jdk.git pull/20691/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20691`

View PR using the GUI difftool: \
`$ git pr show -t 20691`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20691.diff">https://git.openjdk.org/jdk/pull/20691.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20691#issuecomment-2306830627)