### PR TITLE
8338922: Parallel: Add task queue stats support in full GC

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.cpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,6 +32,7 @@
 #include "gc/shared/preservedMarks.inline.hpp"
 #include "gc/shared/taskqueue.inline.hpp"
 #include "logging/log.hpp"
+#include "logging/logStream.hpp"
 #include "memory/iterator.inline.hpp"
 #include "oops/access.inline.hpp"
 #include "oops/compressedOops.inline.hpp"
@@ -195,6 +196,22 @@ void ParCompactionManager::push_shadow_region(size_t shadow_region) {
 
 void ParCompactionManager::remove_all_shadow_regions() {
   _shadow_region_array->clear();
+}
+
+void ParCompactionManager::print_task_queue_stats() {
+#if TASKQUEUE_STATS
+  if (!log_is_enabled(Trace, gc, task, stats)) {
+    return;
+  }
+
+  Log(gc, task, stats) log;
+  ResourceMark rm;
+  LogStream ls(log.trace());
+  outputStream* st = &ls;
+
+  _oop_task_queues->print_taskqueue_stats(st, "Oop Queue");
+  _objarray_task_queues->print_taskqueue_stats(st, "ObjArrayOop Queue");
+#endif // TASKQUEUE_STATS
 }
 
 #ifdef ASSERT

--- a/src/hotspot/share/gc/parallel/psCompactionManager.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -201,6 +201,9 @@ public:
   static bool steal(int queue_num, oop& t);
   static bool steal_objarray(int queue_num, ObjArrayTask& t);
   static bool steal(int queue_num, size_t& region);
+
+  // Print task queue stats
+  static void print_task_queue_stats();
 
   // Process tasks remaining on any marking stack
   void follow_marking_stacks();

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1294,6 +1294,8 @@ void PSParallelCompact::marking_phase(ParallelOldTracer *gc_tracer) {
 
     MarkFromRootsTask task(active_gc_threads);
     ParallelScavengeHeap::heap()->workers().run_task(&task);
+
+    ParCompactionManager::print_task_queue_stats();
   }
 
   // Process reference objects found during marking


### PR DESCRIPTION
Add capability to print out task queue stats in Parallel Compact GC, like other GCs.