### PR TITLE
8338882: Clarify matching order of MessageFormat subformat factory styles

### DIFF
--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -701,9 +701,9 @@ public class MessageFormat extends Format {
      * converted to a String pattern, the {@code FormatType} and {@code FormatStyle}
      * will be omitted from the {@code FormatElement}.
      * @implNote This implementation does not guarantee the order of
-     * {@code FormatStyle} matching. That is, the {@code FormatStyle} produced
-     * may not be equivalent to the style passed, in the instance that multiple
-     * styles have equivalent patterns.
+     * {@code FormatStyle} matching. That is, a {@code FormatStyle} produced
+     * may not be equivalent to the corresponding style passed, in the instance
+     * that multiple styles have equivalent patterns.
      */
     public String toPattern() {
         // later, make this more extensible

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -700,6 +700,10 @@ public class MessageFormat extends Format {
      * is semantically equivalent to this instance. If a subformat cannot be
      * converted to a String pattern, the {@code FormatType} and {@code FormatStyle}
      * will be omitted from the {@code FormatElement}.
+     * @implNote This implementation does not guarantee the order of
+     * {@code FormatStyle} matching. That is, the {@code FormatStyle} produced
+     * may not be equivalent to the style passed, in the instance that multiple
+     * styles have equivalent patterns.
      */
     public String toPattern() {
         // later, make this more extensible

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -692,7 +692,10 @@ public class MessageFormat extends Format {
      * represents the current state of this {@code MessageFormat}}
      *
      * The string is constructed from internal information and therefore
-     * does not necessarily equal the previously applied pattern.
+     * does not necessarily equal the previously applied pattern. The order of
+     * {@code FormatStyle} matching is not guaranteed. That is, a {@code
+     * FormatStyle} produced may not be equivalent to the corresponding style passed,
+     * in the instance that multiple styles are equivalent.
      *
      * @implSpec The implementation in {@link MessageFormat} returns a
      * string that, when passed to a {@code MessageFormat()} constructor
@@ -700,10 +703,6 @@ public class MessageFormat extends Format {
      * is semantically equivalent to this instance. If a subformat cannot be
      * converted to a String pattern, the {@code FormatType} and {@code FormatStyle}
      * will be omitted from the {@code FormatElement}.
-     * @implNote This implementation does not guarantee the order of
-     * {@code FormatStyle} matching. That is, a {@code FormatStyle} produced
-     * may not be equivalent to the corresponding style passed, in the instance
-     * that multiple styles have equivalent patterns.
      */
     public String toPattern() {
         // later, make this more extensible


### PR DESCRIPTION
Please review this PR which clarifies that the matching order of format styles for MessageFormat sub formats is not guaranteed. A corresponding CSR has also been drafted.

This is relevant when a locale provides equivalent patterns for multiple format factory styles. For example, a locale X could provide some equivalent date style "xyz" for both a MEDIUM and LONG style. Thus invoking toPattern() could output `date`, `date,medium`, or `date,long` depending on the order of such matching.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8338921](https://bugs.openjdk.org/browse/JDK-8338921) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8338882](https://bugs.openjdk.org/browse/JDK-8338882): Clarify matching order of MessageFormat subformat factory styles (**Bug** - P4)
 * [JDK-8338921](https://bugs.openjdk.org/browse/JDK-8338921): Clarify matching order of MessageFormat subformat factory styles (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20695/head:pull/20695` \
`$ git checkout pull/20695`

Update a local copy of the PR: \
`$ git checkout pull/20695` \
`$ git pull https://git.openjdk.org/jdk.git pull/20695/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20695`

View PR using the GUI difftool: \
`$ git pr show -t 20695`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20695.diff">https://git.openjdk.org/jdk/pull/20695.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20695#issuecomment-2307736006)