### PR TITLE
8338925: ProblemList runtime/interpreter/LastJsrTest.java on linux-all

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -119,6 +119,7 @@ runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/Thread/TestAlwaysPreTouchStacks.java 8335167 macosx-aarch64
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
+runtime/interpreter/LastJsrTest.java 8338924 linux-all
 
 
 applications/jcstress/copy.java 8229852 linux-all


### PR DESCRIPTION
A trivial fix to ProblemList runtime/interpreter/LastJsrTest.java on linux-all.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338925](https://bugs.openjdk.org/browse/JDK-8338925): ProblemList runtime/interpreter/LastJsrTest.java on linux-all (**Sub-task** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20696/head:pull/20696` \
`$ git checkout pull/20696`

Update a local copy of the PR: \
`$ git checkout pull/20696` \
`$ git pull https://git.openjdk.org/jdk.git pull/20696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20696`

View PR using the GUI difftool: \
`$ git pr show -t 20696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20696.diff">https://git.openjdk.org/jdk/pull/20696.diff</a>

</details>
