### PR TITLE
8337317: serviceability/jvmti tests failed with FATAL ERROR in native method: Failed during the GetClassSignature call

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
@@ -21,6 +21,7 @@
  * questions.
  */
 
+#include <stdlib.h>
 #include <string.h>
 #include "jvmti.h"
 
@@ -35,6 +36,9 @@ static jvmtiEnv *jvmti = nullptr;
 static jint class_load_count = 0;
 static jint class_prep_count = 0;
 static bool failed = false;
+// JVMTI_ERROR_WRONG_PHASE guard
+static jrawMonitorID event_mon = nullptr;
+static bool is_vm_dead = false;
 
 #define LOG0(str)             { printf(str); fflush(stdout); }
 #define LOG1(str, arg)        { printf(str, arg); fflush(stdout); }
@@ -46,6 +50,24 @@ static bool failed = false;
     jni->FatalError(msg); \
     return; \
   }
+
+struct MonitorLock {
+  MonitorLock() {
+    jvmtiError err = jvmti->RawMonitorEnter(event_mon);
+    if (err != JVMTI_ERROR_NONE) {
+      LOG1("RawMonitorEnter returned error: %d\n", err);
+      abort();
+    }
+  }
+
+  ~MonitorLock() {
+    jvmtiError err = jvmti->RawMonitorExit(event_mon);
+    if (err != JVMTI_ERROR_NONE) {
+      LOG1("RawMonitorExit returned error: %d\n", err);
+      abort();
+    }
+  }
+};
 
 /* Return the jmethodID of j.l.Class.isHidden() method. */
 static jmethodID
@@ -247,16 +269,21 @@ check_hidden_class_array(jvmtiEnv* jvmti, JNIEnv* jni, jclass klass_array, const
   LOG0("### Native agent: check_hidden_class_array finished\n");
 }
 
-/* Process a CLASS_LOAD or aClassPrepare event. */
+/* Process a CLASS_LOAD or a ClassPrepare event. */
 static void process_class_event(jvmtiEnv* jvmti, JNIEnv* jni, jclass klass,
                                 jint* event_count_ptr, const char* event_name) {
   char* sig = nullptr;
   char* gsig = nullptr;
   jvmtiError err;
 
+  MonitorLock lock;
+  if (is_vm_dead) {
+    return;
+  }
+
   // get class signature
   err = jvmti->GetClassSignature(klass, &sig, &gsig);
-  CHECK_JVMTI_ERROR(jni, err, "ClassLoad event: Error in JVMTI GetClassSignature");
+  CHECK_JVMTI_ERROR(jni, err, "ClassLoad/ClassPrepare event: Error in JVMTI GetClassSignature");
 
   // check if this is an expected class event for hidden class
   if (strlen(sig) > strlen(SIG_START) &&
@@ -301,6 +328,14 @@ VMInit(jvmtiEnv* jvmti, JNIEnv* jni, jthread thread) {
   CHECK_JVMTI_ERROR(jni, err, "VMInit event: Error in enabling ClassPrepare events notification");
 }
 
+static void JNICALL
+VMDeath(jvmtiEnv *jvmti, JNIEnv* jni) {
+  MonitorLock lock;
+
+  LOG0("VMDeath\n");
+  is_vm_dead = true;
+}
+
 JNIEXPORT jint JNICALL
 Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   jvmtiEventCallbacks callbacks;
@@ -313,11 +348,19 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
     return JNI_ERR;
   }
 
+  err = jvmti->CreateRawMonitor("Event Monitor", &event_mon);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG1("Agent_OnLoad: CreateRawMonitor failed: %d\n", err);
+    failed = true;
+    return JNI_ERR;
+  }
+
   // set required event callbacks
   memset(&callbacks, 0, sizeof(callbacks));
   callbacks.ClassLoad = &ClassLoad;
   callbacks.ClassPrepare = &ClassPrepare;
   callbacks.VMInit = &VMInit;
+  callbacks.VMDeath = &VMDeath;
 
   err = jvmti->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks));
   if (err != JVMTI_ERROR_NONE) {

--- a/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
@@ -21,7 +21,6 @@
  * questions.
  */
 
-#include <stdlib.h>
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.hpp"

--- a/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
@@ -24,6 +24,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include "jvmti.h"
+#include "jvmti_common.hpp"
 
 extern "C" {
 
@@ -34,24 +35,6 @@ static bool is_vm_dead = false;
 
 static int number_of_allocation = 0;
 
-struct MonitorLock {
-  MonitorLock() {
-    jvmtiError err = jvmti->RawMonitorEnter(event_mon);
-    if (err != JVMTI_ERROR_NONE) {
-      printf("RawMonitorEnter returned error: %d\n", err);
-      abort();
-    }
-  }
-
-  ~MonitorLock() {
-    jvmtiError err = jvmti->RawMonitorExit(event_mon);
-    if (err != JVMTI_ERROR_NONE) {
-      printf("RawMonitorExit returned error: %d\n", err);
-      abort();
-    }
-  }
-};
-
 extern JNIEXPORT void JNICALL
 VMObjectAlloc(jvmtiEnv *jvmti,
               JNIEnv* jni,
@@ -59,7 +42,7 @@ VMObjectAlloc(jvmtiEnv *jvmti,
               jobject object,
               jclass cls,
               jlong size) {
-  MonitorLock lock;
+  RawMonitorLocker locker(jvmti, jni, event_mon);
   if (is_vm_dead) {
     return;
   }
@@ -79,7 +62,7 @@ VMObjectAlloc(jvmtiEnv *jvmti,
 
 static void JNICALL
 VMDeath(jvmtiEnv *jvmti, JNIEnv* jni) {
-  MonitorLock lock;
+  RawMonitorLocker locker(jvmti, jni, event_mon);
 
   printf("VMDeath\n");
   is_vm_dead = true;

--- a/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
@@ -52,7 +52,7 @@ VMObjectAlloc(jvmtiEnv *jvmti,
     jni->FatalError("Failed during the GetClassSignature call");
   }
 
-  printf("VMObjectAlloc called for %s\n", signature);
+  LOG("VMObjectAlloc called for %s\n", signature);
 
   if (!strcmp(signature, "LVMObjectAllocTest;")) {
     number_of_allocation++;
@@ -63,7 +63,7 @@ static void JNICALL
 VMDeath(jvmtiEnv *jvmti, JNIEnv* jni) {
   RawMonitorLocker locker(jvmti, jni, event_mon);
 
-  printf("VMDeath\n");
+  LOG("VMDeath\n");
   is_vm_dead = true;
 }
 
@@ -84,7 +84,7 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
 
   err = jvmti->CreateRawMonitor("Event Monitor", &event_mon);
   if (err != JVMTI_ERROR_NONE) {
-    printf("Agent_OnLoad: CreateRawMonitor failed: %d\n", err);
+    LOG("Agent_OnLoad: CreateRawMonitor failed: %d\n", err);
     return JNI_ERR;
   }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
@@ -21,7 +21,6 @@
  * questions.
  */
 
-#include <stdlib.h>
 #include <string.h>
 #include "jvmti.h"
 #include "jvmti_common.hpp"


### PR DESCRIPTION
The fix adds guards against JVMTI_ERROR_WRONG_PHASE error in event handlers

Testing: hotspot/jtreg/serviceability/jvmti on all platforms

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337317](https://bugs.openjdk.org/browse/JDK-8337317): serviceability/jvmti tests failed with FATAL ERROR in native method: Failed during the GetClassSignature call (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) Review applies to [e03df5eb](https://git.openjdk.org/jdk/pull/20699/files/e03df5eb3125b17e420543893e7975e575709c1c)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20699/head:pull/20699` \
`$ git checkout pull/20699`

Update a local copy of the PR: \
`$ git checkout pull/20699` \
`$ git pull https://git.openjdk.org/jdk.git pull/20699/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20699`

View PR using the GUI difftool: \
`$ git pr show -t 20699`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20699.diff">https://git.openjdk.org/jdk/pull/20699.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20699#issuecomment-2307966280)