### PR TITLE
8335577: runtime/cds/appcds/TestParallelGCWithCDS.java still fails with JNI error

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/TestParallelGCWithCDS.java
@@ -116,8 +116,9 @@ public class TestParallelGCWithCDS {
                 } else {
                     String pattern = "((Too small maximum heap)" +
                                      "|(GC triggered before VM initialization completed)" +
-                                     "|(java.lang.OutOfMemoryError: Java heap space)" +
-                                     "|(Initial heap size set to a larger value than the maximum heap size))";
+                                     "|(Initial heap size set to a larger value than the maximum heap size)" +
+                                     "|(java.lang.OutOfMemoryError)" +
+                                     "|(Error: A JNI error has occurred, please check your installation and try again))";
                     out.shouldMatch(pattern);
                     out.shouldNotHaveFatalError();
                 }


### PR DESCRIPTION
A simple test fix by adding the matching of the following patterns:

```
Error: A JNI error has occurred, please check your installation and try again
java.lang.OutOfMemoryError
```
Ran the test 25 times on windows-x64 and linux-x64 without failure with the following vm args:
`-Xcomp -ea -esa -XX:CompileThreshold=100 -XX:+UnlockExperimentalVMOptions -server -XX:+TieredCompilation -XX:-UseCompressedOops`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335577](https://bugs.openjdk.org/browse/JDK-8335577): runtime/cds/appcds/TestParallelGCWithCDS.java still fails with JNI error (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20700/head:pull/20700` \
`$ git checkout pull/20700`

Update a local copy of the PR: \
`$ git checkout pull/20700` \
`$ git pull https://git.openjdk.org/jdk.git pull/20700/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20700`

View PR using the GUI difftool: \
`$ git pr show -t 20700`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20700.diff">https://git.openjdk.org/jdk/pull/20700.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20700#issuecomment-2308103397)