### PR TITLE
8338931: ZipEntry.flag could be made internal to ZipOutputStream

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipEntry.java
+++ b/src/java.base/share/classes/java/util/zip/ZipEntry.java
@@ -56,7 +56,6 @@ public class ZipEntry implements ZipConstants, Cloneable {
     boolean csizeSet = false; // Only true if csize was explicitly set by
                         // a call to setCompressedSize()
     int method = -1;    // compression method
-    int flag = 0;       // general purpose flag
     byte[] extra;       // optional extra field data for entry
     String comment;     // optional comment string for entry
     int externalFileAttributes = -1; // File type, setuid, setgid, sticky, POSIX permissions
@@ -131,7 +130,6 @@ public class ZipEntry implements ZipConstants, Cloneable {
         csize = e.csize;
         csizeSet = e.csizeSet;
         method = e.method;
-        flag = e.flag;
         extra = e.extra;
         comment = e.comment;
         externalFileAttributes = e.externalFileAttributes;

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -689,7 +689,6 @@ public class ZipFile implements ZipConstants, Closeable {
         } else {
             e = new ZipEntry(name);
         }
-        e.flag = CENFLG(cen, pos);
         e.xdostime = CENTIM(cen, pos);
         e.crc = CENCRC(cen, pos);
         e.size = CENLEN(cen, pos);

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -62,11 +62,11 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
     private static class XEntry {
         final ZipEntry entry;
         final long offset;
-        final int flag;
-        public XEntry(ZipEntry entry, long offset, int flag) {
+        final int flags;
+        public XEntry(ZipEntry entry, long offset, int flags) {
             this.entry = entry;
             this.offset = offset;
-            this.flag = flag;
+            this.flags = flags;
         }
     }
 
@@ -286,7 +286,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
                         while (!def.finished()) {
                             deflate();
                         }
-                        if ((current.flag & 8) == 0) {
+                        if ((current.flags & 8) == 0) {
                             // verify size, compressed size, and crc-32 settings
                             if (e.size != def.getBytesRead()) {
                                 throw new ZipException(
@@ -416,7 +416,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      */
     private void writeLOC(XEntry xentry) throws IOException {
         ZipEntry e = xentry.entry;
-        int flag = xentry.flag;
+        int flag = xentry.flags;
         boolean hasZip64 = false;
         int elen = getExtraLen(e.extra);
 
@@ -553,7 +553,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      */
     private void writeCEN(XEntry xentry) throws IOException {
         ZipEntry e  = xentry.entry;
-        int flag = xentry.flag;
+        int flag = xentry.flags;
         int version = version(e);
         long csize = e.csize;
         long size = e.size;

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -62,11 +62,11 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
     private static class XEntry {
         final ZipEntry entry;
         final long offset;
-        final int flags;
-        public XEntry(ZipEntry entry, long offset, int flags) {
+        final int flag;
+        public XEntry(ZipEntry entry, long offset, int flag) {
             this.entry = entry;
             this.offset = offset;
-            this.flags = flags;
+            this.flag = flag;
         }
     }
 
@@ -286,7 +286,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
                         while (!def.finished()) {
                             deflate();
                         }
-                        if ((current.flags & 8) == 0) {
+                        if ((current.flag & 8) == 0) {
                             // verify size, compressed size, and crc-32 settings
                             if (e.size != def.getBytesRead()) {
                                 throw new ZipException(
@@ -416,7 +416,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      */
     private void writeLOC(XEntry xentry) throws IOException {
         ZipEntry e = xentry.entry;
-        int flag = xentry.flags;
+        int flag = xentry.flag;
         boolean hasZip64 = false;
         int elen = getExtraLen(e.extra);
 
@@ -553,7 +553,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      */
     private void writeCEN(XEntry xentry) throws IOException {
         ZipEntry e  = xentry.entry;
-        int flag = xentry.flags;
+        int flag = xentry.flag;
         int version = version(e);
         long csize = e.csize;
         long size = e.size;


### PR DESCRIPTION
Please review this refactoring PR which moves the `ZipEntry.flag` field back to `ZipOutputStream.XEntry`.

Moving this field will save four bytes from the `ZipEntry` object size and also saves an unneccessary read in `ZipFile.getZipEntry`.

Testing:

This PR is a refactoring of existing code and does not update any tests. I added the label `noreg-cleanup` to the JBS issue.

The following runs clean:

```
make test TEST="test/jdk/java/util/zip"
make test TEST="test/jdk/java/util/jar"
```

Performance:

The JMH benchmark `java.util.zip.ZipFileGetEntry.getEntryHit` show a small but consistent improvement (2-3%).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338931](https://bugs.openjdk.org/browse/JDK-8338931): ZipEntry.flag could be made internal to ZipOutputStream (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20702/head:pull/20702` \
`$ git checkout pull/20702`

Update a local copy of the PR: \
`$ git checkout pull/20702` \
`$ git pull https://git.openjdk.org/jdk.git pull/20702/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20702`

View PR using the GUI difftool: \
`$ git pr show -t 20702`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20702.diff">https://git.openjdk.org/jdk/pull/20702.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20702#issuecomment-2308383993)