### PR TITLE
8338937: Optimize the string concatenation of ClassDesc

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -4647,7 +4647,7 @@ public final class Class<T> implements java.io.Serializable,
             return Wrapper.forPrimitiveType(this).basicTypeString();
 
         if (isArray()) {
-            return "[" + componentType.descriptorString();
+            return "[".concat(componentType.descriptorString());
         } else if (isHidden()) {
             String name = getName();
             int index = name.indexOf('/');
@@ -4660,11 +4660,7 @@ public final class Class<T> implements java.io.Serializable,
                     .toString();
         } else {
             String name = getName().replace('.', '/');
-            return new StringBuilder(name.length() + 2)
-                    .append('L')
-                    .append(name)
-                    .append(';')
-                    .toString();
+            return StringConcatHelper.concat("L", name, ";");
         }
     }
 

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -783,4 +783,16 @@ final class StringConcatHelper {
         }
         throw new OutOfMemoryError("Overflow: String length out of range");
     }
+
+    static String concat(String prefix, String value, String suffix) {
+        if (prefix == null) prefix = "null";
+        if (value  == null) value  = "null";
+        if (suffix == null) suffix = "null";
+
+        byte coder = (byte) (prefix.coder() | value.coder() | suffix.coder());
+        int len = prefix.length() + value.length();
+        byte[] buf = newArrayWithSuffix(suffix, len, coder);
+        prepend(len, coder, buf, value, prefix);
+        return new String(buf, coder);
+    }
 }

--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -784,15 +784,19 @@ final class StringConcatHelper {
         throw new OutOfMemoryError("Overflow: String length out of range");
     }
 
-    static String concat(String prefix, String value, String suffix) {
-        if (prefix == null) prefix = "null";
-        if (value  == null) value  = "null";
-        if (suffix == null) suffix = "null";
-
-        byte coder = (byte) (prefix.coder() | value.coder() | suffix.coder());
-        int len = prefix.length() + value.length();
+    @ForceInline
+    private static String concat0(String prefix, String str, String suffix) {
+        byte coder = (byte) (prefix.coder() | str.coder() | suffix.coder());
+        int len = prefix.length() + str.length();
         byte[] buf = newArrayWithSuffix(suffix, len, coder);
-        prepend(len, coder, buf, value, prefix);
+        prepend(len, coder, buf, str, prefix);
         return new String(buf, coder);
+    }
+
+    @ForceInline
+    static String concat(String prefix, Object value, String suffix) {
+        if (prefix == null) prefix = "null";
+        if (suffix == null) suffix = "null";
+        return concat0(prefix, stringOf(value), suffix);
     }
 }

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2639,6 +2639,10 @@ public final class System {
                 return String.join(prefix, suffix, delimiter, elements, size);
             }
 
+            public String concat(String prefix, String value, String suffix) {
+                return StringConcatHelper.concat(prefix, value, suffix);
+            }
+
             public Object classData(Class<?> c) {
                 return c.getClassData();
             }

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2639,7 +2639,7 @@ public final class System {
                 return String.join(prefix, suffix, delimiter, elements, size);
             }
 
-            public String concat(String prefix, String value, String suffix) {
+            public String concat(String prefix, Object value, String suffix) {
                 return StringConcatHelper.concat(prefix, value, suffix);
             }
 

--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -36,6 +36,7 @@ import static java.util.stream.Collectors.joining;
 import static jdk.internal.constant.ConstantUtils.MAX_ARRAY_TYPE_DESC_DIMENSIONS;
 import static jdk.internal.constant.ConstantUtils.arrayDepth;
 import static jdk.internal.constant.ConstantUtils.binaryToInternal;
+import static jdk.internal.constant.ConstantUtils.concat;
 import static jdk.internal.constant.ConstantUtils.forPrimitiveType;
 import static jdk.internal.constant.ConstantUtils.internalToBinary;
 import static jdk.internal.constant.ConstantUtils.validateBinaryClassName;
@@ -83,7 +84,7 @@ public sealed interface ClassDesc
      */
     static ClassDesc of(String name) {
         validateBinaryClassName(name);
-        return ClassDesc.ofDescriptor("L" + binaryToInternal(name) + ";");
+        return ClassDesc.ofDescriptor(concat("L", binaryToInternal(name), ";"));
     }
 
     /**
@@ -109,7 +110,7 @@ public sealed interface ClassDesc
      */
     static ClassDesc ofInternalName(String name) {
         validateInternalClassName(name);
-        return ClassDesc.ofDescriptor("L" + name + ";");
+        return ClassDesc.ofDescriptor(concat("L", name, ";"));
     }
 
     /**
@@ -132,8 +133,8 @@ public sealed interface ClassDesc
             return of(className);
         }
         validateMemberName(className, false);
-        return ofDescriptor("L" + binaryToInternal(packageName) +
-                "/" + className + ";");
+        return ofDescriptor('L' + binaryToInternal(packageName) +
+                '/' + className + ';');
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -362,7 +362,7 @@ public sealed interface ClassDesc
             ClassDesc c = this;
             for (int i=0; i<depth; i++)
                 c = c.componentType();
-            return c.displayName() + "[]".repeat(depth);
+            return c.displayName().concat("[]".repeat(depth));
         }
         else
             throw new IllegalStateException(descriptorString());

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -125,7 +125,7 @@ class InvokerBytecodeGenerator {
             name = makeDumpableClassName(name);
         }
         this.name = name;
-        this.className = CLASS_PREFIX + name;
+        this.className = CLASS_PREFIX.concat(name);
         this.classDesc = ClassDesc.ofInternalName(className);
         this.lambdaForm = lambdaForm;
         this.invokerName = invokerName;
@@ -180,11 +180,16 @@ class InvokerBytecodeGenerator {
             if (ctr == null)  ctr = 0;
             DUMP_CLASS_FILES_COUNTERS.put(className, ctr+1);
         }
-        String sfx = ctr.toString();
-        while (sfx.length() < 3)
-            sfx = "0" + sfx;
-        className += sfx;
-        return className;
+
+        var buf = new StringBuilder(className.length() + 3).append(className);
+        int ctrVal = ctr;
+        if (ctrVal < 10) {
+            buf.repeat('0', 2);
+        } else if (ctrVal < 100) {
+            buf.append('0');
+        }
+        buf.append(ctrVal);
+        return buf.toString();
     }
 
     static class ClassData {

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -453,6 +453,11 @@ public interface JavaLangAccess {
      */
     String join(String prefix, String suffix, String delimiter, String[] elements, int size);
 
+    /**
+     * Concatenation of prefix and suffix characters to a String for early bootstrap
+     */
+    String concat(String prefix, String value, String suffix);
+
     /*
      * Get the class data associated with the given class.
      * @param c the class

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -456,7 +456,7 @@ public interface JavaLangAccess {
     /**
      * Concatenation of prefix and suffix characters to a String for early bootstrap
      */
-    String concat(String prefix, String value, String suffix);
+    String concat(String prefix, Object value, String suffix);
 
     /*
      * Get the class data associated with the given class.

--- a/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
@@ -35,12 +35,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import jdk.internal.access.JavaLangAccess;
+import jdk.internal.access.SharedSecrets;
 import static jdk.internal.constant.PrimitiveClassDescImpl.*;
 
 /**
  * Helper methods for the implementation of {@code java.lang.constant}.
  */
 public final class ConstantUtils {
+    private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
+
     /** an empty constant descriptor */
     public static final ConstantDesc[] EMPTY_CONSTANTDESC = new ConstantDesc[0];
     public static final ClassDesc[] EMPTY_CLASSDESC = new ClassDesc[0];
@@ -66,7 +70,7 @@ public final class ConstantUtils {
      * @param binaryName a binary name
      */
     public static ClassDesc binaryNameToDesc(String binaryName) {
-        return ReferenceClassDescImpl.ofValidated("L" + binaryToInternal(binaryName) + ";");
+        return ReferenceClassDescImpl.ofValidated(concat("L", binaryToInternal(binaryName), ";"));
     }
 
     /**
@@ -377,5 +381,9 @@ public final class ConstantUtils {
         return new IllegalArgumentException(String.format(
                         "Cannot create an array type descriptor with more than %d dimensions",
                         ConstantUtils.MAX_ARRAY_TYPE_DESC_DIMENSIONS));
+    }
+
+    public static String concat(String prefix, String value, String suffix) {
+        return JLA.concat(prefix, value, suffix);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
@@ -383,7 +383,7 @@ public final class ConstantUtils {
                         ConstantUtils.MAX_ARRAY_TYPE_DESC_DIMENSIONS));
     }
 
-    public static String concat(String prefix, String value, String suffix) {
+    public static String concat(String prefix, Object value, String suffix) {
         return JLA.concat(prefix, value, suffix);
     }
 }


### PR DESCRIPTION
The string concatenation of java.base module is implemented based on StringBuilder, which will result in extra object allocation and slow performance. We can solve this problem by using String.concat method and StringConcatHelper to provide concat method.

for example, 

* use "+"
```java
class ClassDesc {
    default String displayName() {
        c.displayName() + "[]".repeat(depth)
    }
}
```

bytecode:
```
106: new           #40                 // class java/lang/StringBuilder
109: dup
110: invokespecial #42                 // Method java/lang/StringBuilder."<init>":()V
113: aload_2
114: invokeinterface #195,  1          // InterfaceMethod displayName:()Ljava/lang/String;
119: invokevirtual #50                 // Method java/lang/StringBuilder.append:(Ljava/lang/String;)Ljava/lang/StringBuilder;
122: ldc           #198                // String []
124: iload_1
125: invokevirtual #200                // Method java/lang/String.repeat:(I)Ljava/lang/String;
128: invokevirtual #50                 // Method java/lang/StringBuilder.append:(Ljava/lang/String;)Ljava/lang/StringBuilder;
131: invokevirtual #53                 // Method java/lang/StringBuilder.toString:()Ljava/lang/String;
134: areturn
```

* use String#concat
```java
c.displayName().concat("[]".repeat(depth))
```

bytecode:
```
112: ldc           #198                // String []
114: iload_1
115: invokevirtual #200                // Method java/lang/String.repeat:(I)Ljava/lang/String;
118: invokevirtual #86                 // Method java/lang/String.concat:(Ljava/lang/String;)Ljava/lang/String;
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338937](https://bugs.openjdk.org/browse/JDK-8338937): Optimize the string concatenation of ClassDesc (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20705/head:pull/20705` \
`$ git checkout pull/20705`

Update a local copy of the PR: \
`$ git checkout pull/20705` \
`$ git pull https://git.openjdk.org/jdk.git pull/20705/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20705`

View PR using the GUI difftool: \
`$ git pr show -t 20705`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20705.diff">https://git.openjdk.org/jdk/pull/20705.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20705#issuecomment-2308850444)