### PR TITLE
8338938: The result of the combine method of SettingsControl is not used

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Control.java
@@ -141,7 +141,7 @@ final class Control {
             @Override
             public String run() {
                 try {
-                    delegate.combine(Collections.unmodifiableSet(values));
+                    return delegate.combine(Collections.unmodifiableSet(values));
                 } catch (Throwable t) {
                     // Prevent malicious user to propagate exception callback in the wrong context
                     Logger.log(LogTag.JFR_SETTING, LogLevel.WARN, "Exception occurred when combining " + values + " for " + getClass());

--- a/test/jdk/jdk/jfr/api/settings/TestFilterEvents.java
+++ b/test/jdk/jdk/jfr/api/settings/TestFilterEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,6 +70,7 @@ public class TestFilterEvents {
         continuous.enable(HTTPGetEvent.class).with("threadNames", "\"unused-threadname-1\"");
         assertEquals(0, makeProfilingRecording("\"unused-threadname-2\""));
         assertEquals(1, makeProfilingRecording("\"" + Thread.currentThread().getName() + "\""));
+        assertEquals(2, makeCombineControl());
         continuous.close();
     }
 
@@ -91,6 +92,34 @@ public class TestFilterEvents {
             recording.stop();
 
             return Events.fromRecording(recording).size();
+        }
+    }
+
+    private static int makeCombineControl() throws Exception {
+        try (Recording r1 = new Recording()) {
+            r1.enable(HTTPPostEvent.class).with("uriFilter", "https://www.example.com/list");
+            r1.start();
+
+            try (Recording r2 = new Recording()) {
+                r2.enable(HTTPPostEvent.class).with("uriFilter", "https://www.example.com/get");
+                r2.start();
+
+                HTTPPostEvent e1 = new HTTPPostEvent();
+                e1.uri = "https://www.example.com/list";
+                e1.commit();
+
+                HTTPPostEvent e2 = new HTTPPostEvent();
+                e2.uri = "https://www.example.com/get";
+                e2.commit();
+
+                HTTPPostEvent e3 = new HTTPPostEvent();
+                e3.uri = "https://www.example.com/put";
+                e3.commit();
+            }
+
+            r1.stop();
+
+            return Events.fromRecording(r1).size();
         }
     }
 


### PR DESCRIPTION
Could you please review this PR that SettingsControl does not work properly when configured with multiple records.

Regards,
Chihiro

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338938](https://bugs.openjdk.org/browse/JDK-8338938): The result of the combine method of SettingsControl is not used (**Bug** - P2)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20707/head:pull/20707` \
`$ git checkout pull/20707`

Update a local copy of the PR: \
`$ git checkout pull/20707` \
`$ git pull https://git.openjdk.org/jdk.git pull/20707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20707`

View PR using the GUI difftool: \
`$ git pr show -t 20707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20707.diff">https://git.openjdk.org/jdk/pull/20707.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20707#issuecomment-2308893287)