### PR TITLE
8338939: Simplify processing of hidden class names

### DIFF
--- a/src/hotspot/share/jfr/support/jfrSymbolTable.cpp
+++ b/src/hotspot/share/jfr/support/jfrSymbolTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,10 @@
  */
 
 #include "precompiled.hpp"
-#include "classfile/javaClasses.inline.hpp"
 #include "classfile/classLoaderData.hpp"
+#include "classfile/javaClasses.hpp"
 #include "jfr/support/jfrSymbolTable.hpp"
-#include "oops/instanceKlass.hpp"
-#include "oops/oop.inline.hpp"
+#include "oops/klass.hpp"
 #include "oops/symbol.hpp"
 #include "runtime/mutexLocker.hpp"
 
@@ -200,7 +199,7 @@ traceid JfrSymbolTable::bootstrap_name(bool leakp) {
 
 traceid JfrSymbolTable::mark(const Symbol* sym, bool leakp /* false */) {
   assert(sym != nullptr, "invariant");
-  return mark((uintptr_t)sym->identity_hash(), sym, leakp);
+  return mark(sym->identity_hash(), sym, leakp);
 }
 
 traceid JfrSymbolTable::mark(uintptr_t hash, const Symbol* sym, bool leakp) {
@@ -236,59 +235,48 @@ traceid JfrSymbolTable::mark(uintptr_t hash, const char* str, bool leakp) {
 }
 
 /*
-* hidden classes symbol is the external name +
-* the address of its InstanceKlass slash appended:
-*   java.lang.invoke.LambdaForm$BMH/22626602
-*
-* caller needs ResourceMark
-*/
-
-uintptr_t JfrSymbolTable::hidden_klass_name_hash(const InstanceKlass* ik) {
-  assert(ik != nullptr, "invariant");
-  assert(ik->is_hidden(), "invariant");
-  const oop mirror = ik->java_mirror_no_keepalive();
-  assert(mirror != nullptr, "invariant");
-  return (uintptr_t)mirror->identity_hash();
-}
-
-static const char* create_hidden_klass_symbol(const InstanceKlass* ik, uintptr_t hash) {
-  assert(ik != nullptr, "invariant");
-  assert(ik->is_hidden(), "invariant");
-  assert(hash != 0, "invariant");
-  char* hidden_symbol = nullptr;
-  const oop mirror = ik->java_mirror_no_keepalive();
-  assert(mirror != nullptr, "invariant");
-  char hash_buf[40];
-  os::snprintf_checked(hash_buf, sizeof(hash_buf), "/" UINTX_FORMAT, hash);
-  const size_t hash_len = strlen(hash_buf);
-  const size_t result_len = ik->name()->utf8_length();
-  hidden_symbol = NEW_RESOURCE_ARRAY(char, result_len + hash_len + 1);
-  ik->name()->as_klass_external_name(hidden_symbol, (int)result_len + 1);
-  assert(strlen(hidden_symbol) == result_len, "invariant");
-  strcpy(hidden_symbol + result_len, hash_buf);
-  assert(strlen(hidden_symbol) == result_len + hash_len, "invariant");
-  return hidden_symbol;
-}
-
-bool JfrSymbolTable::is_hidden_klass(const Klass* k) {
+ * The hidden class symbol is the external name with the
+ * address of its Klass slash appended.
+ *
+ * This is done by replacing the '+' delimiter with a '/'
+ * in a copy of the already mangled hidden class name.
+ *
+ * "java/lang/invoke/LambdaForm$DMH+0x0000000037144c00"
+ *  becomes
+ * "java/lang/invoke/LambdaForm$DMH/0x0000000037144c00"
+ *
+ * Caller needs ResourceMark.
+ */
+static const char* create_hidden_klass_name(const Klass* k, uintptr_t hash) {
   assert(k != nullptr, "invariant");
-  return k->is_instance_klass() && ((const InstanceKlass*)k)->is_hidden();
+  assert(k->is_hidden(), "invariant");
+  assert(hash != 0, "invariant");
+  const Symbol* const name = k->name();
+  assert(name != nullptr, "invariant");
+  assert(name->identity_hash() == hash, "invariant");
+  const size_t len = static_cast<size_t>(name->utf8_length());
+  char* hidden_klass_name = NEW_RESOURCE_ARRAY(char, len + 1);
+  strncpy(hidden_klass_name, name->as_C_string(), len + 1);
+  char* const plus_position = strrchr(hidden_klass_name, '+');
+  assert(plus_position != nullptr, "invariant");
+  *plus_position = '/'; // replace the '+' delimiter with a '/'
+  assert(strlen(hidden_klass_name) == len, "invariant");
+  return hidden_klass_name;
 }
 
-traceid JfrSymbolTable::mark_hidden_klass_name(const InstanceKlass* ik, bool leakp) {
-  assert(ik != nullptr, "invariant");
-  assert(ik->is_hidden(), "invariant");
-  const uintptr_t hash = hidden_klass_name_hash(ik);
-  const char* const hidden_symbol = create_hidden_klass_symbol(ik, hash);
-  return mark(hash, hidden_symbol, leakp);
+traceid JfrSymbolTable::mark_hidden_klass_name(const Klass* k, bool leakp) {
+  assert(k != nullptr, "invariant");
+  assert(k->is_hidden(), "invariant");
+  assert(k->name() != nullptr, "invariant");
+  const uintptr_t hash = k->name()->identity_hash();;
+  return mark(hash, create_hidden_klass_name(k, hash), leakp);
 }
 
 traceid JfrSymbolTable::mark(const Klass* k, bool leakp) {
   assert(k != nullptr, "invariant");
   traceid symbol_id = 0;
-  if (is_hidden_klass(k)) {
-    assert(k->is_instance_klass(), "invariant");
-    symbol_id = mark_hidden_klass_name((const InstanceKlass*)k, leakp);
+  if (k->is_hidden()) {
+    symbol_id = mark_hidden_klass_name(k, leakp);
   } else {
     Symbol* const sym = k->name();
     if (sym != nullptr) {

--- a/src/hotspot/share/jfr/support/jfrSymbolTable.cpp
+++ b/src/hotspot/share/jfr/support/jfrSymbolTable.cpp
@@ -241,9 +241,9 @@ traceid JfrSymbolTable::mark(uintptr_t hash, const char* str, bool leakp) {
  * This is done by replacing the '+' delimiter with a '/'
  * in a copy of the already mangled hidden class name.
  *
- * "java/lang/invoke/LambdaForm$DMH+0x0000000037144c00"
+ * "java.lang.invoke.LambdaForm$DMH+0x0000000037144c00"
  *  becomes
- * "java/lang/invoke/LambdaForm$DMH/0x0000000037144c00"
+ * "java.lang.invoke.LambdaForm$DMH/0x0000000037144c00"
  *
  * Caller needs ResourceMark.
  */
@@ -256,7 +256,7 @@ static const char* create_hidden_klass_name(const Klass* k, uintptr_t hash) {
   assert(name->identity_hash() == hash, "invariant");
   const size_t len = static_cast<size_t>(name->utf8_length());
   char* hidden_klass_name = NEW_RESOURCE_ARRAY(char, len + 1);
-  strncpy(hidden_klass_name, name->as_C_string(), len + 1);
+  strncpy(hidden_klass_name, name->as_klass_external_name(), len + 1);
   char* const plus_position = strrchr(hidden_klass_name, '+');
   assert(plus_position != nullptr, "invariant");
   *plus_position = '/'; // replace the '+' delimiter with a '/'

--- a/src/hotspot/share/jfr/support/jfrSymbolTable.cpp
+++ b/src/hotspot/share/jfr/support/jfrSymbolTable.cpp
@@ -238,38 +238,15 @@ traceid JfrSymbolTable::mark(uintptr_t hash, const char* str, bool leakp) {
  * The hidden class symbol is the external name with the
  * address of its Klass slash appended.
  *
- * This is done by replacing the '+' delimiter with a '/'
- * in a copy of the already mangled hidden class name.
- *
- * "java.lang.invoke.LambdaForm$DMH+0x0000000037144c00"
- *  becomes
  * "java.lang.invoke.LambdaForm$DMH/0x0000000037144c00"
  *
  * Caller needs ResourceMark.
  */
-static const char* create_hidden_klass_name(const Klass* k, uintptr_t hash) {
-  assert(k != nullptr, "invariant");
-  assert(k->is_hidden(), "invariant");
-  assert(hash != 0, "invariant");
-  const Symbol* const name = k->name();
-  assert(name != nullptr, "invariant");
-  assert(name->identity_hash() == hash, "invariant");
-  const size_t len = static_cast<size_t>(name->utf8_length());
-  char* hidden_klass_name = NEW_RESOURCE_ARRAY(char, len + 1);
-  strncpy(hidden_klass_name, name->as_klass_external_name(), len + 1);
-  char* const plus_position = strrchr(hidden_klass_name, '+');
-  assert(plus_position != nullptr, "invariant");
-  *plus_position = '/'; // replace the '+' delimiter with a '/'
-  assert(strlen(hidden_klass_name) == len, "invariant");
-  return hidden_klass_name;
-}
-
 traceid JfrSymbolTable::mark_hidden_klass_name(const Klass* k, bool leakp) {
   assert(k != nullptr, "invariant");
   assert(k->is_hidden(), "invariant");
-  assert(k->name() != nullptr, "invariant");
   const uintptr_t hash = k->name()->identity_hash();;
-  return mark(hash, create_hidden_klass_name(k, hash), leakp);
+  return mark(hash, k->external_name(), leakp);
 }
 
 traceid JfrSymbolTable::mark(const Klass* k, bool leakp) {

--- a/src/hotspot/share/jfr/support/jfrSymbolTable.cpp
+++ b/src/hotspot/share/jfr/support/jfrSymbolTable.cpp
@@ -245,7 +245,7 @@ traceid JfrSymbolTable::mark(uintptr_t hash, const char* str, bool leakp) {
 traceid JfrSymbolTable::mark_hidden_klass_name(const Klass* k, bool leakp) {
   assert(k != nullptr, "invariant");
   assert(k->is_hidden(), "invariant");
-  const uintptr_t hash = k->name()->identity_hash();;
+  const uintptr_t hash = k->name()->identity_hash();
   return mark(hash, k->external_name(), leakp);
 }
 

--- a/src/hotspot/share/jfr/support/jfrSymbolTable.hpp
+++ b/src/hotspot/share/jfr/support/jfrSymbolTable.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,15 +100,12 @@ class JfrSymbolTable : public JfrCHeapObj {
   traceid mark(const Symbol* sym, bool leakp = false);
   traceid mark(const char* str, bool leakp = false);
   traceid mark(uintptr_t hash, const char* str, bool leakp);
+  traceid mark_hidden_klass_name(const Klass* k, bool leakp);
   traceid bootstrap_name(bool leakp);
 
   bool has_entries() const { return has_symbol_entries() || has_string_entries(); }
   bool has_symbol_entries() const { return _symbol_list != nullptr; }
   bool has_string_entries() const { return _string_list != nullptr; }
-
-  traceid mark_hidden_klass_name(const InstanceKlass* k, bool leakp);
-  bool is_hidden_klass(const Klass* k);
-  uintptr_t hidden_klass_name_hash(const InstanceKlass* ik);
 
   // hashtable(s) callbacks
   void on_link(const SymbolEntry* entry);


### PR DESCRIPTION
Greetings,

The name symbol for hidden (anonymous) classes has evolved. Initially, it consisted of only a base class name, e.g., "java/lang/invoke/LambdaForm$BMH", so JFR had to introduce a scheme for disambiguating one anonymous class from another.

The scheme (which still exists in JFR) appends the Java class mirror's hashcode to the base class name, e.g., "java/lang/invoke/LambdaForm$BMH/22626602".

With [JDK-8238358](https://bugs.openjdk.org/browse/JDK-8238358), the disambiguation of hidden class names is now intrinsic to the processing by the ClassFileParser. This is done by appending the InstanceKlass address to the base class name, e.g., "java/lang/invoke/LambdaForm$BMH+0x000000001d190000".

An argument can be made that JFR specialization for hidden (anonymous) classes may no longer be necessary. Indeed, the result now involves a "double" disambiguation: e.g., "java/lang/invoke/LambdaForm$BMH+0x000000001d190000/231202600".

It is now possible to simplify the handling of hidden (anonymous) class names, which avoids using the Java mirror oop. We might want to keep the "/" construct as that might be an implicit invariant on users' expectations (quickly done by replacing "+" with "/").

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338939](https://bugs.openjdk.org/browse/JDK-8338939): Simplify processing of hidden class names (**Enhancement** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20708/head:pull/20708` \
`$ git checkout pull/20708`

Update a local copy of the PR: \
`$ git checkout pull/20708` \
`$ git pull https://git.openjdk.org/jdk.git pull/20708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20708`

View PR using the GUI difftool: \
`$ git pr show -t 20708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20708.diff">https://git.openjdk.org/jdk/pull/20708.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20708#issuecomment-2308952358)