### PR TITLE
8338888: SystemDictionary::class_name_symbol has incorrect length check

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -261,12 +261,16 @@ Symbol* SystemDictionary::class_name_symbol(const char* name, Symbol* exception,
   if (name == nullptr) {
     THROW_MSG_NULL(exception, "No class name given");
   }
-  if ((int)strlen(name) > Symbol::max_length()) {
+  if (strlen(name) > static_cast<size_t>(Symbol::max_length())) {
     // It's impossible to create this class;  the name cannot fit
     // into the constant pool.
+    // To avoid internal snprintf INT_MAX limit we reduce the maximum length
+    // of name to print, by the length of the rest of the formatted message.
+    int print_limit = INT_MAX - 45;
     Exceptions::fthrow(THREAD_AND_LOCATION, exception,
-                       "Class name exceeds maximum length of %d: %s",
+                       "Class name exceeds maximum length of %d: %.*s",
                        Symbol::max_length(),
+                       print_limit,
                        name);
     return nullptr;
   }

--- a/src/hotspot/share/classfile/systemDictionary.cpp
+++ b/src/hotspot/share/classfile/systemDictionary.cpp
@@ -261,21 +261,32 @@ Symbol* SystemDictionary::class_name_symbol(const char* name, Symbol* exception,
   if (name == nullptr) {
     THROW_MSG_NULL(exception, "No class name given");
   }
-  if (strlen(name) > static_cast<size_t>(Symbol::max_length())) {
+  size_t name_len = strlen(name);
+  if (name_len > static_cast<size_t>(Symbol::max_length())) {
     // It's impossible to create this class;  the name cannot fit
-    // into the constant pool.
-    // To avoid internal snprintf INT_MAX limit we reduce the maximum length
-    // of name to print, by the length of the rest of the formatted message.
-    int print_limit = INT_MAX - 45;
-    Exceptions::fthrow(THREAD_AND_LOCATION, exception,
-                       "Class name exceeds maximum length of %d: %.*s",
-                       Symbol::max_length(),
-                       print_limit,
-                       name);
+    // into the constant pool. If necessary report an abridged name
+    // in the exception message.
+    if (name_len > static_cast<size_t>(MaxStringPrintSize)) {
+      Exceptions::fthrow(THREAD_AND_LOCATION, exception,
+                         "Class name exceeds maximum length of %d: %.*s ... (%zu characters omitted) ... %.*s",
+                         Symbol::max_length(),
+                         MaxStringPrintSize / 2,
+                         name,
+                         name_len - 2 * (MaxStringPrintSize / 2), // allows for odd value
+                         MaxStringPrintSize / 2,
+                         name + name_len - MaxStringPrintSize / 2);
+    }
+    else {
+      Exceptions::fthrow(THREAD_AND_LOCATION, exception,
+                         "Class name exceeds maximum length of %d: %s",
+                         Symbol::max_length(),
+                         name);
+    }
     return nullptr;
   }
   // Callers should ensure that the name is never an illegal UTF8 string.
-  assert(UTF8::is_legal_utf8((const unsigned char*)name, (int)strlen(name), false),
+  assert(UTF8::is_legal_utf8((const unsigned char*)name,
+                             static_cast<int>(name_len), false),
          "Class name is not a valid utf8 string.");
 
   // Make a new symbol for the class name.

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
@@ -45,30 +45,35 @@ Java_NoClassDefFoundErrorTest_callFindClass(JNIEnv *env, jclass klass, jstring c
     cls = (*env)->FindClass(env, c_name);
 }
 
-JNIEXPORT jboolean JNICALL
-Java_NoClassDefFoundErrorTest_tryCallDefineClass(JNIEnv *env, jclass klass) {
+
+static char* giant_string() {
     size_t len = ((size_t)INT_MAX) + 3;
     char* c_name = malloc(len * sizeof(char));
     if (c_name != NULL) {
-      memset(c_name, 0x59595959, len-1); // YYYY...
-      c_name[len - 1] = '\0';
-      (*env)->DefineClass(env, c_name, NULL, NULL, 0);
-      free(c_name);
-      return JNI_TRUE;
+        memset(c_name, 0x59595959, len-1); // YYYY...
+        c_name[len - 1] = '\0';
+    }
+    return c_name;
+}
+
+JNIEXPORT jboolean JNICALL
+Java_NoClassDefFoundErrorTest_tryCallDefineClass(JNIEnv *env, jclass klass) {
+    char* c_name =  giant_string();
+    if (c_name != NULL) {
+        (*env)->DefineClass(env, c_name, NULL, NULL, 0);
+        free(c_name);
+        return JNI_TRUE;
     }
     return JNI_FALSE;
 }
 
 JNIEXPORT jboolean JNICALL
 Java_NoClassDefFoundErrorTest_tryCallFindClass(JNIEnv *env, jclass klass) {
-    size_t len = ((size_t)INT_MAX) + 3;
-    char* c_name = malloc(len * sizeof(char));
+    char* c_name =  giant_string();
     if (c_name != NULL) {
-      memset(c_name, 0x59595959, len-1); // YYYY...
-      c_name[len - 1] = '\0';
-      jclass cls = (*env)->FindClass(env, c_name);
-      free(c_name);
-      return JNI_TRUE;
+        jclass cls = (*env)->FindClass(env, c_name);
+        free(c_name);
+        return JNI_TRUE;
     }
     return JNI_FALSE;
 }

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
@@ -50,7 +50,7 @@ static char* giant_string() {
     size_t len = ((size_t)INT_MAX) + 3;
     char* c_name = malloc(len * sizeof(char));
     if (c_name != NULL) {
-        memset(c_name, 0x59595959, len-1); // YYYY...
+        memset(c_name, 0x59595959, len - 1); // YYYY...
         c_name[len - 1] = '\0';
     }
     return c_name;
@@ -58,7 +58,7 @@ static char* giant_string() {
 
 JNIEXPORT jboolean JNICALL
 Java_NoClassDefFoundErrorTest_tryCallDefineClass(JNIEnv *env, jclass klass) {
-    char* c_name =  giant_string();
+    char* c_name = giant_string();
     if (c_name != NULL) {
         (*env)->DefineClass(env, c_name, NULL, NULL, 0);
         free(c_name);
@@ -69,7 +69,7 @@ Java_NoClassDefFoundErrorTest_tryCallDefineClass(JNIEnv *env, jclass klass) {
 
 JNIEXPORT jboolean JNICALL
 Java_NoClassDefFoundErrorTest_tryCallFindClass(JNIEnv *env, jclass klass) {
-    char* c_name =  giant_string();
+    char* c_name = giant_string();
     if (c_name != NULL) {
         jclass cls = (*env)->FindClass(env, c_name);
         free(c_name);

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,6 +22,10 @@
  */
 
 #include <jni.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+
 
 JNIEXPORT void JNICALL
 Java_NoClassDefFoundErrorTest_callDefineClass(JNIEnv *env, jclass klass, jstring className) {
@@ -41,4 +45,30 @@ Java_NoClassDefFoundErrorTest_callFindClass(JNIEnv *env, jclass klass, jstring c
     cls = (*env)->FindClass(env, c_name);
 }
 
+JNIEXPORT jboolean JNICALL
+Java_NoClassDefFoundErrorTest_tryCallDefineClass(JNIEnv *env, jclass klass) {
+    size_t len = ((size_t)INT_MAX) + 3;
+    char* c_name = malloc(len * sizeof(char));
+    if (c_name != NULL) {
+      memset(c_name, 0x59595959, len-1); // YYYY...
+      c_name[len - 1] = '\0';
+      (*env)->DefineClass(env, c_name, NULL, NULL, 0);
+      free(c_name);
+      return JNI_TRUE;
+    }
+    return JNI_FALSE;
+}
 
+JNIEXPORT jboolean JNICALL
+Java_NoClassDefFoundErrorTest_tryCallFindClass(JNIEnv *env, jclass klass) {
+    size_t len = ((size_t)INT_MAX) + 3;
+    char* c_name = malloc(len * sizeof(char));
+    if (c_name != NULL) {
+      memset(c_name, 0x59595959, len-1); // YYYY...
+      c_name[len - 1] = '\0';
+      jclass cls = (*env)->FindClass(env, c_name);
+      free(c_name);
+      return JNI_TRUE;
+    }
+    return JNI_FALSE;
+}

--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
@@ -50,7 +50,7 @@ static char* giant_string() {
     size_t len = ((size_t)INT_MAX) + 3;
     char* c_name = malloc(len * sizeof(char));
     if (c_name != NULL) {
-        memset(c_name, 0x59595959, len - 1); // YYYY...
+        memset(c_name, 'Y', len - 1);
         c_name[len - 1] = '\0';
     }
     return c_name;


### PR DESCRIPTION
The name length check was incorrectly truncating the length to an int, which is wrong if the name is > `INT_MAX`. Added a test for this case to the existing test cases and fixed an issue with the call to `Exceptions::fthrow` that can hit the `INT_MAX` limitations of `os::vsnprintf` (this is the first in a serious of fixes that will mainly be done under [JDK-8328882](https://bugs.openjdk.org/browse/JDK-8328882) or subtasks thereof).

Testing:
 - updated test
 - tiers 1-3 (sanity)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338888](https://bugs.openjdk.org/browse/JDK-8338888): SystemDictionary::class_name_symbol has incorrect length check (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [49f88740](https://git.openjdk.org/jdk/pull/20709/files/49f88740aa49f39b64fc53ce78ff7feea664cd56)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20709/head:pull/20709` \
`$ git checkout pull/20709`

Update a local copy of the PR: \
`$ git checkout pull/20709` \
`$ git pull https://git.openjdk.org/jdk.git pull/20709/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20709`

View PR using the GUI difftool: \
`$ git pr show -t 20709`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20709.diff">https://git.openjdk.org/jdk/pull/20709.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20709#issuecomment-2309201827)