### PR TITLE
8338897: Small startup regression remains after JDK-8309622 and JDK-8331932

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -988,17 +988,23 @@ public final class Locale implements Cloneable, Serializable {
             if (locale != null) {
                 return locale;
             }
-            return LOCALE_CACHE.computeIfAbsent(baseloc, LOCALE_CREATOR);
+            return LocaleCache.cache(baseloc);
         } else {
             LocaleKey key = new LocaleKey(baseloc, extensions);
-            return LOCALE_CACHE.computeIfAbsent(key, LOCALE_CREATOR);
+            return LocaleCache.cache(key);
         }
     }
 
-    private static final ReferencedKeyMap<Object, Locale> LOCALE_CACHE
-            = ReferencedKeyMap.create(true, ReferencedKeyMap.concurrentHashMapSupplier());
+    private static class LocaleCache implements Function<Object, Locale> {
+        private static final ReferencedKeyMap<Object, Locale> LOCALE_CACHE
+                = ReferencedKeyMap.create(true, ReferencedKeyMap.concurrentHashMapSupplier());
 
-    private static final Function<Object, Locale> LOCALE_CREATOR = new Function<>() {
+        private static final Function<Object, Locale> LOCALE_CREATOR = new LocaleCache();
+
+        public static Locale cache(Object key) {
+            return LOCALE_CACHE.computeIfAbsent(key, LOCALE_CREATOR);
+        }
+
         @Override
         public Locale apply(Object key) {
             if (key instanceof BaseLocale base) {
@@ -1007,7 +1013,7 @@ public final class Locale implements Cloneable, Serializable {
             LocaleKey lk = (LocaleKey)key;
             return new Locale(lk.base, lk.exts);
         }
-    };
+    }
 
     private static final class LocaleKey {
 

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -995,7 +995,7 @@ public final class Locale implements Cloneable, Serializable {
         }
     }
 
-    private static class LocaleCache implements Function<Object, Locale> {
+    private static final class LocaleCache implements Function<Object, Locale> {
         private static final ReferencedKeyMap<Object, Locale> LOCALE_CACHE
                 = ReferencedKeyMap.create(true, ReferencedKeyMap.concurrentHashMapSupplier());
 


### PR DESCRIPTION
#14404 caused some startup regressions, where the main cause of startup increase in that change was due the use of - and the not very optimized state of - runtime bootstrapped switches. This was remedied by a series of optimizations to the switch bootstrap methods and finally a desugaring of the switch added by #14404. Now @shipilev reports that there appears to be some lingering startup issue from #14404. 

One thing that stands out is a couple of caches which are being eagerly initialized regardless of user locale. This PR makes those caches lazily initialized and slightly more efficient (no need to implement `UnaryOperator` after inlining some code). Avoids loading 4 classes if running the HelloStream startup test in a locale that's in the set of constant base locales, 2 otherwise. This doesn't really do much to move the needle for startup on my setup, but tentatively it's the only remaining inefficiency I've found that came from #14404.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8338897](https://bugs.openjdk.org/browse/JDK-8338897): Small startup regression remains after JDK-8309622 and JDK-8331932 (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20713/head:pull/20713` \
`$ git checkout pull/20713`

Update a local copy of the PR: \
`$ git checkout pull/20713` \
`$ git pull https://git.openjdk.org/jdk.git pull/20713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20713`

View PR using the GUI difftool: \
`$ git pr show -t 20713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20713.diff">https://git.openjdk.org/jdk/pull/20713.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20713#issuecomment-2310235043)