### PR TITLE
8338979: Avoid bootstrapped switches in the classfile API

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassFileImpl.java
@@ -83,17 +83,28 @@ public record ClassFileImpl(StackMapsOption stackMapsOption,
         var chro = classHierarchyResolverOption;
         var amo = attributeMapperOption;
         for (var o : options) {
-            switch (o) {
-                case StackMapsOption oo -> smo = oo;
-                case DebugElementsOption oo -> deo = oo;
-                case LineNumbersOption oo -> lno = oo;
-                case AttributesProcessingOption oo -> apo = oo;
-                case ConstantPoolSharingOption oo -> cpso = oo;
-                case ShortJumpsOption oo -> sjo = oo;
-                case DeadCodeOption oo -> dco = oo;
-                case DeadLabelsOption oo -> dlo = oo;
-                case ClassHierarchyResolverOption oo -> chro = oo;
-                case AttributeMapperOption oo -> amo = oo;
+            if (o instanceof StackMapsOption oo) {
+                smo = oo;
+            } else if (o instanceof DebugElementsOption oo) {
+                deo = oo;
+            } else if (o instanceof LineNumbersOption oo) {
+                lno = oo;
+            } else if (o instanceof AttributesProcessingOption oo) {
+                apo = oo;
+            } else if (o instanceof ConstantPoolSharingOption oo) {
+                cpso = oo;
+            } else if (o instanceof ShortJumpsOption oo) {
+                sjo = oo;
+            } else if (o instanceof DeadCodeOption oo) {
+                dco = oo;
+            } else if (o instanceof DeadLabelsOption oo) {
+                dlo = oo;
+            } else if (o instanceof ClassHierarchyResolverOption oo) {
+                chro = oo;
+            } else if (o instanceof AttributeMapperOption oo) {
+                amo = oo;
+            } else { // null or unknown Option type
+                throw new IllegalArgumentException("Invalid option: " + o);
             }
         }
         return new ClassFileImpl(smo, deo, lno, apo, cpso, sjo, dco, dlo, chro, amo);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
@@ -161,13 +161,14 @@ public class StackMapDecoder {
 
     private static void writeTypeInfo(BufWriterImpl bw, VerificationTypeInfo vti) {
         bw.writeU1(vti.tag());
-        switch (vti) {
-            case SimpleVerificationTypeInfo svti ->
+        switch (vti.tag()) {
+            case VT_TOP, VT_INTEGER, VT_FLOAT, VT_DOUBLE, VT_LONG, VT_NULL, VT_UNINITIALIZED_THIS ->
                 {}
-            case ObjectVerificationTypeInfo ovti ->
-                bw.writeIndex(ovti.className());
-            case UninitializedVerificationTypeInfo uvti ->
-                bw.writeU2(bw.labelContext().labelToBci(uvti.newTarget()));
+            case VT_OBJECT ->
+                bw.writeIndex(((ObjectVerificationTypeInfo)vti).className());
+            case VT_UNINITIALIZED ->
+                bw.writeU2(bw.labelContext().labelToBci(((UninitializedVerificationTypeInfo)vti).newTarget()));
+            default -> throw new IllegalArgumentException("Invalid verification type tag: " + vti.tag());
         }
     }
 


### PR DESCRIPTION
Noticed these on a few startup tests in code generating proxies. Desugaring switch expressions reduce risk of bootstrap circularity from any future changes to switch bootstrapping (which itself depends on the classfile API). It's also a tiny improvement to startup performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338979](https://bugs.openjdk.org/browse/JDK-8338979): Avoid bootstrapped switches in the classfile API (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20714/head:pull/20714` \
`$ git checkout pull/20714`

Update a local copy of the PR: \
`$ git checkout pull/20714` \
`$ git pull https://git.openjdk.org/jdk.git pull/20714/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20714`

View PR using the GUI difftool: \
`$ git pr show -t 20714`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20714.diff">https://git.openjdk.org/jdk/pull/20714.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20714#issuecomment-2310257565)