### PR TITLE
8330159: [C2] Remove or clarify Compile::init_start

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1106,7 +1106,7 @@ void Compile::Init(bool aliasing) {
 }
 
 #ifdef ASSERT
-// Install the StartNode on this compile object.
+// Verify that the current StartNode is valid.
 void Compile::verify_start(StartNode* s) const {
   assert(failing() || s == start(), "should be StartNode");
 }

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -1106,7 +1106,6 @@ void Compile::Init(bool aliasing) {
 }
 
 #ifdef ASSERT
-//---------------------------verify_start----------------------------------------
 // Install the StartNode on this compile object.
 void Compile::verify_start(StartNode* s) {
   assert(failing() || s == start(), "should be StartNode");

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -754,14 +754,14 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
       init_tf(TypeFunc::make(domain, range));
       StartNode* s = new StartOSRNode(root(), domain);
       initial_gvn()->set_type_bottom(s);
-      DEBUG_ONLY(verify_start(s);)
+      verify_start(s);
       cg = CallGenerator::for_osr(method(), entry_bci());
     } else {
       // Normal case.
       init_tf(TypeFunc::make(method()));
       StartNode* s = new StartNode(root(), tf()->domain());
       initial_gvn()->set_type_bottom(s);
-      DEBUG_ONLY(verify_start(s);)
+      verify_start(s);
       if (method()->intrinsic_id() == vmIntrinsics::_Reference_get) {
         // With java.lang.ref.reference.get() we must go through the
         // intrinsic - even when get() is the root
@@ -1107,7 +1107,7 @@ void Compile::Init(bool aliasing) {
 
 #ifdef ASSERT
 // Install the StartNode on this compile object.
-void Compile::verify_start(StartNode* s) {
+void Compile::verify_start(StartNode* s) const {
   assert(failing() || s == start(), "should be StartNode");
 }
 #endif

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -754,14 +754,14 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
       init_tf(TypeFunc::make(domain, range));
       StartNode* s = new StartOSRNode(root(), domain);
       initial_gvn()->set_type_bottom(s);
-      init_start(s);
+      DEBUG_ONLY(verify_start(s);)
       cg = CallGenerator::for_osr(method(), entry_bci());
     } else {
       // Normal case.
       init_tf(TypeFunc::make(method()));
       StartNode* s = new StartNode(root(), tf()->domain());
       initial_gvn()->set_type_bottom(s);
-      init_start(s);
+      DEBUG_ONLY(verify_start(s);)
       if (method()->intrinsic_id() == vmIntrinsics::_Reference_get) {
         // With java.lang.ref.reference.get() we must go through the
         // intrinsic - even when get() is the root
@@ -1105,13 +1105,13 @@ void Compile::Init(bool aliasing) {
   probe_alias_cache(nullptr)->_index = AliasIdxTop;
 }
 
-//---------------------------init_start----------------------------------------
+#ifdef ASSERT
+//---------------------------verify_start----------------------------------------
 // Install the StartNode on this compile object.
-void Compile::init_start(StartNode* s) {
-  if (failing())
-    return; // already failing
-  assert(s == start(), "");
+void Compile::verify_start(StartNode* s) {
+  assert(failing() || s == start(), "should be StartNode");
 }
+#endif
 
 /**
  * Return the 'StartNode'. We must not have a pending failure, since the ideal graph

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -864,6 +864,7 @@ private:
   RootNode*    root() const                { return _root; }
   void         set_root(RootNode* r)       { _root = r; }
   StartNode*   start() const;              // (Derived from root.)
+  void         verify_start(StartNode* s) const NOT_DEBUG_RETURN;
   Node*        immutable_memory();
 
   Node*        recent_alloc_ctl() const    { return _recent_alloc_ctl; }
@@ -884,7 +885,6 @@ private:
             return (uint) val;
                                            }
 #ifdef ASSERT
-  void         verify_start(StartNode* s);
   void         set_phase_optimize_finished() { _phase_optimize_finished = true; }
   bool         phase_optimize_finished() const { return _phase_optimize_finished; }
   uint         count_live_nodes_by_graph_walk();

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -864,7 +864,6 @@ private:
   RootNode*    root() const                { return _root; }
   void         set_root(RootNode* r)       { _root = r; }
   StartNode*   start() const;              // (Derived from root.)
-  void         init_start(StartNode* s);
   Node*        immutable_memory();
 
   Node*        recent_alloc_ctl() const    { return _recent_alloc_ctl; }
@@ -885,6 +884,7 @@ private:
             return (uint) val;
                                            }
 #ifdef ASSERT
+  void         verify_start(StartNode* s);
   void         set_phase_optimize_finished() { _phase_optimize_finished = true; }
   bool         phase_optimize_finished() const { return _phase_optimize_finished; }
   uint         count_live_nodes_by_graph_walk();

--- a/src/hotspot/share/opto/generateOptoStub.cpp
+++ b/src/hotspot/share/opto/generateOptoStub.cpp
@@ -261,7 +261,7 @@ void GraphKit::gen_stub(address C_function,
                                           frameptr(),
                                           returnadr());
   root()->add_req(_gvn.transform(to_exc));  // bind to root to keep live
-  DEBUG_ONLY(C->verify_start(start);)
+  C->verify_start(start);
 
   //-----------------------------
   // If this is a normal subroutine return, issue the return and be done.

--- a/src/hotspot/share/opto/generateOptoStub.cpp
+++ b/src/hotspot/share/opto/generateOptoStub.cpp
@@ -261,7 +261,7 @@ void GraphKit::gen_stub(address C_function,
                                           frameptr(),
                                           returnadr());
   root()->add_req(_gvn.transform(to_exc));  // bind to root to keep live
-  C->init_start(start);
+  DEBUG_ONLY(C->verify_start(start);)
 
   //-----------------------------
   // If this is a normal subroutine return, issue the return and be done.


### PR DESCRIPTION
Compile::init_start method contained only an assertion. To cleanup, this method is removed and the locations where this method is called are replaced with the corresponding assertion. See issue: [JDK-8330159](https://bugs.openjdk.org/browse/JDK-8330159)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330159](https://bugs.openjdk.org/browse/JDK-8330159): [C2] Remove or clarify Compile::init_start (**Enhancement** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20715/head:pull/20715` \
`$ git checkout pull/20715`

Update a local copy of the PR: \
`$ git checkout pull/20715` \
`$ git pull https://git.openjdk.org/jdk.git pull/20715/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20715`

View PR using the GUI difftool: \
`$ git pr show -t 20715`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20715.diff">https://git.openjdk.org/jdk/pull/20715.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20715#issuecomment-2311283922)