### PR TITLE
8338678: Erroneous parameterized type represented as <any>

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -2338,7 +2338,7 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             this.originalType = (originalType == null ? noType : originalType);
         }
 
-        private ErrorType(Type originalType, TypeSymbol tsym,
+        public ErrorType(Type originalType, TypeSymbol tsym,
                           List<TypeMetadata> metadata) {
             super(noType, List.nil(), null, metadata);
             this.tsym = tsym;
@@ -2392,10 +2392,6 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         public boolean isErroneous()             { return true; }
         public boolean isCompound()              { return false; }
         public boolean isInterface()             { return false; }
-
-        public List<Type> allparams()            { return List.nil(); }
-        @DefinedBy(Api.LANGUAGE_MODEL)
-        public List<Type> getTypeArguments()     { return List.nil(); }
 
         @DefinedBy(Api.LANGUAGE_MODEL)
         public TypeKind getKind() {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -5081,6 +5081,14 @@ public class Attr extends JCTree.Visitor {
                 }
                 owntype = types.createErrorType(tree.type);
             }
+        } else if (clazztype.hasTag(ERROR)) {
+            ErrorType parameterizedErroneous =
+                    new ErrorType(clazztype.getOriginalType(),
+                                  clazztype.tsym,
+                                  clazztype.getMetadata());
+
+            parameterizedErroneous.typarams_field = actuals;
+            owntype = parameterizedErroneous;
         }
         result = check(tree, owntype, KindSelector.TYP, resultInfo);
     }


### PR DESCRIPTION
Consider code like:
```
class C {
    Undefined u1;
    Undefined<UndefinedParam> u2;
}
```

The types of both `u1` and `u2` are erroneous, but the internal properties of the types are different. For `u1`, the erroneous type keeps the name (`Undefined`), while for `u2`, the type is simply `<any>`.

The proposal here is to improve the error recovery, and create a parameterized error type for the second case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338678](https://bugs.openjdk.org/browse/JDK-8338678): Erroneous parameterized type represented as &lt;any&gt; (**Task** - P4)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20716/head:pull/20716` \
`$ git checkout pull/20716`

Update a local copy of the PR: \
`$ git checkout pull/20716` \
`$ git pull https://git.openjdk.org/jdk.git pull/20716/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20716`

View PR using the GUI difftool: \
`$ git pr show -t 20716`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20716.diff">https://git.openjdk.org/jdk/pull/20716.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20716#issuecomment-2310356859)