### PR TITLE
8332158: [XWayland] test/jdk/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -375,7 +375,7 @@ java/awt/Modal/MultipleDialogs/MultipleDialogs3Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs4Test.java 8198665 macosx-all
 java/awt/Modal/MultipleDialogs/MultipleDialogs5Test.java 8198665 macosx-all
 java/awt/Mouse/EnterExitEvents/DragWindowOutOfFrameTest.java 8177326 macosx-all
-java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8005021,8332158 macosx-all,linux-x64
+java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java 8005021 macosx-all
 java/awt/Mouse/EnterExitEvents/FullscreenEnterEventTest.java 8051455 macosx-all
 java/awt/Mouse/MouseModifiersUnitTest/MouseModifiersUnitTest_Standard.java 7124407,8302787  macosx-all,windows-all
 java/awt/Mouse/RemovedComponentMouseListener/RemovedComponentMouseListener.java 8157170 macosx-all

--- a/test/jdk/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java
+++ b/test/jdk/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2006, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,19 @@
  * @bug 7154048
  * @summary Programmatically resized  window does not receive mouse entered/exited events
  * @author  alexandr.scherbatiy area=awt.event
+ * @library /test/lib
+ * @build   jdk.test.lib.Platform
  * @run main ResizingFrameTest
  */
 
-import java.awt.*;
-import java.awt.event.*;
-import javax.swing.*;
+import java.awt.Frame;
+import java.awt.Robot;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+
+import jdk.test.lib.Platform;
 
 public class ResizingFrameTest {
 
@@ -41,6 +48,9 @@ public class ResizingFrameTest {
     private static JFrame frame;
 
     public static void main(String[] args) throws Exception {
+        if (Platform.isOnWayland()) {
+            return;
+        }
 
         Robot robot = new Robot();
         robot.setAutoDelay(50);


### PR DESCRIPTION
There are two mouse pointer locations on Wayland:

`#1` Wayland compositor - can be controlled by a physical mouse device, or libei, this location is visible on a screen as a mouse cursor and is propagated to `#2`.

`#2` Inside the XWayland server - most of the time this is the same as `#1`, unless we have changed it programmatically, e.g. by using the XTest extension protocol, but it does not move the visible mouse cursor in `#1`.
Our tests in X11 compatibility mode using this approach(aka `java.awt.Robot#mouseMove`)

This test moves the mouse cursor to a specific location over a window in `#2`, which most likely isn't the same as the visible cursor location in `#1`.
If the window was moved/resized and placed under the visible cursor location, that cursor location is also set for `#2`, and from the test's perspective, the mouse has just been moved to a different location without the test expecting it, causing unexpected mouse enter/exit events.

We can try to smooth this out with additional `robot.mouseMove` calls, but it looks like we are missing the point of the test.
So for now it is better to skip the test on Wayland.

Another way is to use libei to move the visible mouse cursor on the system ([JDK-8280983](https://bugs.openjdk.org/browse/JDK-8280983)), but its support is not yet widespread on supported systems.

Testing looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8332158](https://bugs.openjdk.org/browse/JDK-8332158): [XWayland] test/jdk/java/awt/Mouse/EnterExitEvents/ResizingFrameTest.java (**Bug** - P3)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20717/head:pull/20717` \
`$ git checkout pull/20717`

Update a local copy of the PR: \
`$ git checkout pull/20717` \
`$ git pull https://git.openjdk.org/jdk.git pull/20717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20717`

View PR using the GUI difftool: \
`$ git pr show -t 20717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20717.diff">https://git.openjdk.org/jdk/pull/20717.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20717#issuecomment-2310884912)