### PR TITLE
8339030: frame::print_value_on(outputStream* st, JavaThread *thread) doesn't need thread argument

### DIFF
--- a/src/hotspot/share/oops/instanceStackChunkKlass.cpp
+++ b/src/hotspot/share/oops/instanceStackChunkKlass.cpp
@@ -226,7 +226,7 @@ public:
                   p2i(fs.sp()), fs.is_interpreted(), f.frame_size(),
                   fs.is_interpreted() ? 0 : f.compiled_frame_stack_argsize());
   #ifdef ASSERT
-    f.print_value_on(_st, nullptr);
+    f.print_value_on(_st);
   #else
     f.print_on(_st);
   #endif

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2582,7 +2582,7 @@ WB_ENTRY(void, WB_VerifyFrames(JNIEnv* env, jobject wb, jboolean log, jboolean u
   for (StackFrameStream fst(JavaThread::current(), update_map, true); !fst.is_done(); fst.next()) {
     frame* current_frame = fst.current();
     if (log) {
-      current_frame->print_value_on(&st, nullptr);
+      current_frame->print_value_on(&st);
     }
     current_frame->verify(fst.register_map());
   }

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -877,7 +877,7 @@ inline void FreezeBase::before_freeze_java_frame(const frame& f, const frame& ca
     LogStream ls(lt);
     ls.print_cr("======== FREEZING FRAME interpreted: %d bottom: %d", f.is_interpreted_frame(), is_bottom_frame);
     ls.print_cr("fsize: %d argsize: %d", fsize, argsize);
-    f.print_value_on(&ls, nullptr);
+    f.print_value_on(&ls);
   }
   assert(caller.is_interpreted_frame() == Interpreter::contains(caller.pc()), "");
 }
@@ -886,7 +886,7 @@ inline void FreezeBase::after_freeze_java_frame(const frame& hf, bool is_bottom_
   LogTarget(Trace, continuations) lt;
   if (lt.develop_is_enabled()) {
     LogStream ls(lt);
-    DEBUG_ONLY(hf.print_value_on(&ls, nullptr);)
+    DEBUG_ONLY(hf.print_value_on(&ls);)
     assert(hf.is_heap_frame(), "should be");
     DEBUG_ONLY(print_frame_layout(hf, false, &ls);)
     if (is_bottom_frame) {
@@ -2027,7 +2027,7 @@ NOINLINE intptr_t* ThawBase::thaw_slow(stackChunkOop chunk, bool return_barrier)
     LogStream ls(lt);
     ls.print_cr("top hframe before (thaw):");
     assert(heap_frame.is_heap_frame(), "should have created a relative frame");
-    heap_frame.print_value_on(&ls, nullptr);
+    heap_frame.print_value_on(&ls);
   }
 
 #if INCLUDE_ZGC || INCLUDE_SHENANDOAHGC
@@ -2124,7 +2124,7 @@ inline void ThawBase::before_thaw_java_frame(const frame& hf, const frame& calle
     LogStream ls(lt);
     ls.print_cr("======== THAWING FRAME: %d", num_frame);
     assert(hf.is_heap_frame(), "should be");
-    hf.print_value_on(&ls, nullptr);
+    hf.print_value_on(&ls);
   }
   assert(bottom == _cont.is_entry_frame(caller), "bottom: %d is_entry_frame: %d", bottom, _cont.is_entry_frame(hf));
 }
@@ -2394,7 +2394,7 @@ void ThawBase::finish_thaw(frame& f) {
   if (lt.develop_is_enabled()) {
     LogStream ls(lt);
     ls.print_cr("top hframe after (thaw):");
-    _cont.last_frame().print_value_on(&ls, nullptr);
+    _cont.last_frame().print_value_on(&ls);
   }
 }
 
@@ -2406,7 +2406,7 @@ void ThawBase::push_return_frame(frame& f) { // see generate_cont_thaw
   if (lt.develop_is_enabled()) {
     LogStream ls(lt);
     ls.print_cr("push_return_frame");
-    f.print_value_on(&ls, nullptr);
+    f.print_value_on(&ls);
   }
 
   assert(f.sp() - frame::metadata_words_at_bottom >= _top_stack_address, "overwrote past thawing space"
@@ -2467,7 +2467,7 @@ static inline intptr_t* thaw_internal(JavaThread* thread, const Continuation::th
   if (lt.develop_is_enabled()) {
     LogStream ls(lt);
     ls.print_cr("Jumping to frame (thaw):");
-    frame(sp).print_value_on(&ls, nullptr);
+    frame(sp).print_value_on(&ls);
   }
 #endif
 

--- a/src/hotspot/share/runtime/frame.cpp
+++ b/src/hotspot/share/runtime/frame.cpp
@@ -511,7 +511,7 @@ const char* frame::print_name() const {
   return "C";
 }
 
-void frame::print_value_on(outputStream* st, JavaThread *thread) const {
+void frame::print_value_on(outputStream* st) const {
   NOT_PRODUCT(address begin = pc()-40;)
   NOT_PRODUCT(address end   = nullptr;)
 
@@ -550,7 +550,7 @@ void frame::print_value_on(outputStream* st, JavaThread *thread) const {
 }
 
 void frame::print_on(outputStream* st) const {
-  print_value_on(st,nullptr);
+  print_value_on(st);
   if (is_interpreted_frame()) {
     interpreter_frame_print_on(st);
   }

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -433,8 +433,8 @@ class frame {
   void describe_pd(FrameValues& values, int frame_no);
 
  public:
-  void print_value() const { print_value_on(tty,nullptr); }
-  void print_value_on(outputStream* st, JavaThread *thread) const;
+  void print_value() const { print_value_on(tty); }
+  void print_value_on(outputStream *st) const;
   void print_on(outputStream* st) const;
   void interpreter_frame_print_on(outputStream* st) const;
   void print_on_error(outputStream* st, char* buf, int buflen, bool verbose = false) const;

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -434,7 +434,7 @@ class frame {
 
  public:
   void print_value() const { print_value_on(tty); }
-  void print_value_on(outputStream *st) const;
+  void print_value_on(outputStream* st) const;
   void print_on(outputStream* st) const;
   void interpreter_frame_print_on(outputStream* st) const;
   void print_on_error(outputStream* st, char* buf, int buflen, bool verbose = false) const;

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1906,7 +1906,7 @@ void JavaThread::trace_frames() {
   int frame_no = 1;
   for (StackFrameStream fst(this, true /* update */, true /* process_frames */); !fst.is_done(); fst.next()) {
     tty->print("  %d. ", frame_no++);
-    fst.current()->print_value_on(tty, this);
+    fst.current()->print_value_on(tty);
     tty->cr();
   }
 }

--- a/src/hotspot/share/runtime/vframe.cpp
+++ b/src/hotspot/share/runtime/vframe.cpp
@@ -622,7 +622,7 @@ javaVFrame* vframeStreamCommon::asJavaVFrame() {
 
 #ifndef PRODUCT
 void vframe::print(outputStream* output) {
-  if (WizardMode) _fr.print_value_on(output, nullptr);
+  if (WizardMode) _fr.print_value_on(output);
 }
 
 void vframe::print_value(outputStream* output) const {
@@ -737,7 +737,7 @@ void javaVFrame::print_activation(int index, outputStream* output) const {
 // ------------- externalVFrame --------------
 
 void externalVFrame::print(outputStream* output) {
-  _fr.print_value_on(output, nullptr);
+  _fr.print_value_on(output);
 }
 
 void externalVFrame::print_value(outputStream* output) const {


### PR DESCRIPTION
Method
frame::print_value_on(outputStream* st, JavaThread *thread) doesn't need thread argument

it usually is called with nullptr as second arg except
JavaThread::trace_frames()
where it is called with this.

It seems that thread has never been used since 2007 so makes sense just to get rid of it.

Tested building all builds available in CI and running tier13

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339030](https://bugs.openjdk.org/browse/JDK-8339030): frame::print_value_on(outputStream* st, JavaThread *thread) doesn't need thread argument (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20721/head:pull/20721` \
`$ git checkout pull/20721`

Update a local copy of the PR: \
`$ git checkout pull/20721` \
`$ git pull https://git.openjdk.org/jdk.git pull/20721/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20721`

View PR using the GUI difftool: \
`$ git pr show -t 20721`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20721.diff">https://git.openjdk.org/jdk/pull/20721.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20721#issuecomment-2311336200)