### PR TITLE
8339635: StringConcatFactory optimization for CompactStrings off

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2638,6 +2638,10 @@ public final class System {
                 return new StringConcatHelper.Concat1(constants);
             }
 
+            public byte stringInitCoder() {
+                return String.COMPACT_STRINGS ? String.LATIN1 : String.UTF16;
+            }
+
             public int getCharsLatin1(long i, int index, byte[] buf) {
                 return StringLatin1.getChars(i, index, buf);
             }

--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1215,7 +1215,7 @@ public final class StringConcatFactory {
                 }
             }
 
-            if (maybeUTF16Count == 0 || JLA.stringInitCoder() != 0) {
+            if (maybeUTF16Count == 0) {
                 return null;
             }
 

--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1202,6 +1202,10 @@ public final class StringConcatFactory {
          * Returns null if no such parameter exists or CompactStrings is off.
          */
         private static MethodTypeDesc coderArgsIfMaybeUTF16(MethodType concatArgs) {
+            if (JLA.stringInitCoder() != 0) {
+                return null;
+            }
+
             int parameterCount = concatArgs.parameterCount();
 
             int maybeUTF16Count = 0;

--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1198,7 +1198,8 @@ public final class StringConcatFactory {
 
         /**
          * Construct the MethodType of the coder method. The first parameter is the initialized coder.
-         * Only parameter types which can be UTF16 are added. Returns null if no such parameter exists.
+         * Only parameter types which can be UTF16 are added.
+         * Returns null if no such parameter exists or CompactStrings is off.
          */
         private static MethodTypeDesc coderArgsIfMaybeUTF16(MethodType concatArgs) {
             int parameterCount = concatArgs.parameterCount();
@@ -1210,7 +1211,7 @@ public final class StringConcatFactory {
                 }
             }
 
-            if (maybeUTF16Count == 0) {
+            if (maybeUTF16Count == 0 || JLA.stringInitCoder() != 0) {
                 return null;
             }
 

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -452,6 +452,8 @@ public interface JavaLangAccess {
 
     Object stringConcat1(String[] constants);
 
+    byte stringInitCoder();
+
     /**
      * Join strings
      */

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -452,6 +452,9 @@ public interface JavaLangAccess {
 
     Object stringConcat1(String[] constants);
 
+    /**
+     * Get the string initial coder, When COMPACT_STRINGS is on, it returns 0, and when it is off, it returns 1.
+     */
     byte stringInitCoder();
 
     /**


### PR DESCRIPTION
A small optimization, when CompactStrings is turned off, the coder method is not generated, which improves the startup performance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339635](https://bugs.openjdk.org/browse/JDK-8339635): StringConcatFactory optimization for CompactStrings off (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20722/head:pull/20722` \
`$ git checkout pull/20722`

Update a local copy of the PR: \
`$ git checkout pull/20722` \
`$ git pull https://git.openjdk.org/jdk.git pull/20722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20722`

View PR using the GUI difftool: \
`$ git pr show -t 20722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20722.diff">https://git.openjdk.org/jdk/pull/20722.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20722#issuecomment-2332821082)