### PR TITLE
8338153: java/awt/Checkbox/CheckboxCheckerScalingTest.java test failed on linux machine

### DIFF
--- a/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
@@ -46,7 +46,7 @@ import javax.imageio.ImageIO;
 public class CheckboxCheckerScalingTest {
     private static Frame frame;
     private static Checkbox checkbox;
-    private static Point point;
+    private static volatile Point point;
     private static volatile boolean checkmarkFound = false;
     private static final int TOLERANCE = 5;
     private static final int COLOR_CHECK_THRESHOLD = 8;
@@ -78,8 +78,7 @@ public class CheckboxCheckerScalingTest {
                     for (int j = 0; j < imageAfterChecked.getWidth(); j++) {
                         Color pixelColor = new Color(imageAfterChecked.getRGB(i, j));
                         if (compareColor(pixelColor)) {
-                            colorCounter++;
-                            if (colorCounter >= COLOR_CHECK_THRESHOLD) {
+                            if (++colorCounter >= COLOR_CHECK_THRESHOLD) {
                                 checkmarkFound = true;
                                 break check;
                             }

--- a/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
@@ -48,7 +48,7 @@ public class CheckboxCheckerScalingTest {
     private static Checkbox checkbox;
     private static BufferedImage imageAfterChecked;
     private static volatile boolean checkmarkFound = false;
-    private static final int TOLERANCE = 10;
+    private static final int TOLERANCE = 5;
     private static final int COLOR_CHECK_THRESHOLD = 8;
     private static int colorCounter = 0;
 

--- a/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
@@ -47,26 +47,14 @@ public class CheckboxCheckerScalingTest {
     private static Frame frame;
     private static Checkbox checkbox;
     private static BufferedImage imageAfterChecked;
-    private static volatile boolean checkmarkFound = true;
+    private static volatile boolean checkmarkFound = false;
     private static final int TOLERANCE = 10;
+    private static final int COLOR_CHECK_THRESHOLD = 8;
+    private static int colorCounter = 0;
 
     public static void main(String[] args) throws Exception {
         System.setProperty("sun.java2d.uiScale", "2");
         Robot robot = new Robot();
-        int[][] checkerIndexPattern = {
-                {0, 3},
-                {0, 4},
-                {1, 3},
-                {1, 4},
-                {1, 5},
-                {2, 4},
-                {2, 5},
-                {2, 6},
-                {3, 5},
-                {3, 6},
-                {4, 4},
-                {4, 5}
-        };
 
         try {
             EventQueue.invokeAndWait(() -> {
@@ -85,13 +73,20 @@ public class CheckboxCheckerScalingTest {
                 Point point = checkbox.getLocationOnScreen();
                 Rectangle rect = new Rectangle(point.x + 5, point.y + 7, 8, 8);
                 imageAfterChecked = robot.createScreenCapture(rect);
+                check:
+                {
+                    for (int i = 0; i < imageAfterChecked.getHeight(); i++) {
+                        for (int j = 0; j < imageAfterChecked.getWidth(); j++) {
+                            Color pixelColor = new Color(imageAfterChecked.getRGB(i, j));
+                            if (compareColor(pixelColor)) {
+                                colorCounter++;
+                                if (colorCounter >= COLOR_CHECK_THRESHOLD) {
+                                    checkmarkFound = true;
+                                    break check;
+                                }
+                            }
 
-                for (int i = 0; i < 12; i++) {
-                    Color pixelColor = new Color(imageAfterChecked.getRGB(
-                            checkerIndexPattern[i][0], checkerIndexPattern[i][1]));
-                    if (!compareColor(pixelColor)) {
-                        checkmarkFound = false;
-                        break;
+                        }
                     }
                 }
             });

--- a/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
@@ -47,7 +47,7 @@ public class CheckboxCheckerScalingTest {
     private static Frame frame;
     private static Checkbox checkbox;
     private static volatile Point point;
-    private static volatile boolean checkmarkFound = false;
+    private static boolean checkmarkFound = false;
     private static final int TOLERANCE = 5;
     private static final int COLOR_CHECK_THRESHOLD = 8;
     private static int colorCounter = 0;
@@ -58,7 +58,7 @@ public class CheckboxCheckerScalingTest {
 
         try {
             EventQueue.invokeAndWait(() -> {
-                frame = new Frame("ComboBox checker scaling test");
+                frame = new Frame("CheckBox checker scaling test");
                 checkbox = new Checkbox("one");
                 checkbox.setState(true);
                 frame.add(checkbox);

--- a/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
@@ -47,12 +47,27 @@ public class CheckboxCheckerScalingTest {
     private static Frame frame;
     private static Checkbox checkbox;
     private static BufferedImage imageAfterChecked;
-    private static volatile boolean checkmarkFound = false;
+    private static volatile boolean checkmarkFound = true;
     private static final int TOLERANCE = 10;
 
     public static void main(String[] args) throws Exception {
         System.setProperty("sun.java2d.uiScale", "2");
         Robot robot = new Robot();
+        int[][] checkerIndexPattern = {
+                {0, 3},
+                {0, 4},
+                {1, 3},
+                {1, 4},
+                {1, 5},
+                {2, 4},
+                {2, 5},
+                {2, 6},
+                {3, 5},
+                {3, 6},
+                {4, 4},
+                {4, 5}
+        };
+
         try {
             EventQueue.invokeAndWait(() -> {
                 frame = new Frame("ComboBox checker scaling test");
@@ -71,15 +86,12 @@ public class CheckboxCheckerScalingTest {
                 Rectangle rect = new Rectangle(point.x + 5, point.y + 7, 8, 8);
                 imageAfterChecked = robot.createScreenCapture(rect);
 
-                check: {
-                    for (int i = 0; i < imageAfterChecked.getHeight(); i++) {
-                        for (int j = 0; j < imageAfterChecked.getWidth(); j++) {
-                            Color pixelColor = new Color(imageAfterChecked.getRGB(i, j));
-                            if (compareColor(pixelColor)) {
-                                checkmarkFound = true;
-                                break check;
-                            }
-                        }
+                for (int i = 0; i < 12; i++) {
+                    Color pixelColor = new Color(imageAfterChecked.getRGB(
+                            checkerIndexPattern[i][0], checkerIndexPattern[i][1]));
+                    if (!compareColor(pixelColor)) {
+                        checkmarkFound = false;
+                        break;
                     }
                 }
             });

--- a/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
@@ -48,6 +48,7 @@ public class CheckboxCheckerScalingTest {
     private static Checkbox checkbox;
     private static BufferedImage imageAfterChecked;
     private static volatile boolean checkmarkFound = false;
+    private static final int TOLERANCE = 10;
 
     public static void main(String[] args) throws Exception {
         System.setProperty("sun.java2d.uiScale", "2");
@@ -58,6 +59,7 @@ public class CheckboxCheckerScalingTest {
                 checkbox = new Checkbox("one");
                 checkbox.setState(true);
                 frame.add(checkbox);
+                frame.setLocationRelativeTo(null);
                 frame.pack();
                 frame.setVisible(true);
             });
@@ -72,7 +74,8 @@ public class CheckboxCheckerScalingTest {
                 check: {
                     for (int i = 0; i < imageAfterChecked.getHeight(); i++) {
                         for (int j = 0; j < imageAfterChecked.getWidth(); j++) {
-                            if (Color.black.getRGB() == imageAfterChecked.getRGB(i, j)) {
+                            Color pixelColor = new Color(imageAfterChecked.getRGB(i, j));
+                            if (compareColor(pixelColor)) {
                                 checkmarkFound = true;
                                 break check;
                             }
@@ -98,5 +101,11 @@ public class CheckboxCheckerScalingTest {
                 }
             });
         }
+    }
+
+    private static boolean compareColor(Color c) {
+        return Math.abs(Color.black.getRed() - c.getRed()) < TOLERANCE &&
+                Math.abs(Color.black.getGreen() - c.getGreen()) < TOLERANCE &&
+                Math.abs(Color.black.getBlue() - c.getBlue()) < TOLERANCE;
     }
 }

--- a/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
+++ b/test/jdk/java/awt/Checkbox/CheckboxCheckerScalingTest.java
@@ -46,7 +46,7 @@ import javax.imageio.ImageIO;
 public class CheckboxCheckerScalingTest {
     private static Frame frame;
     private static Checkbox checkbox;
-    private static BufferedImage imageAfterChecked;
+    private static Point point;
     private static volatile boolean checkmarkFound = false;
     private static final int TOLERANCE = 5;
     private static final int COLOR_CHECK_THRESHOLD = 8;
@@ -69,27 +69,25 @@ public class CheckboxCheckerScalingTest {
 
             robot.waitForIdle();
             robot.delay(100);
-            EventQueue.invokeAndWait(() -> {
-                Point point = checkbox.getLocationOnScreen();
-                Rectangle rect = new Rectangle(point.x + 5, point.y + 7, 8, 8);
-                imageAfterChecked = robot.createScreenCapture(rect);
-                check:
-                {
-                    for (int i = 0; i < imageAfterChecked.getHeight(); i++) {
-                        for (int j = 0; j < imageAfterChecked.getWidth(); j++) {
-                            Color pixelColor = new Color(imageAfterChecked.getRGB(i, j));
-                            if (compareColor(pixelColor)) {
-                                colorCounter++;
-                                if (colorCounter >= COLOR_CHECK_THRESHOLD) {
-                                    checkmarkFound = true;
-                                    break check;
-                                }
+            EventQueue.invokeAndWait(() -> point = checkbox.getLocationOnScreen());
+            Rectangle rect = new Rectangle(point.x + 5, point.y + 7, 8, 8);
+            BufferedImage imageAfterChecked = robot.createScreenCapture(rect);
+            check:
+            {
+                for (int i = 0; i < imageAfterChecked.getHeight(); i++) {
+                    for (int j = 0; j < imageAfterChecked.getWidth(); j++) {
+                        Color pixelColor = new Color(imageAfterChecked.getRGB(i, j));
+                        if (compareColor(pixelColor)) {
+                            colorCounter++;
+                            if (colorCounter >= COLOR_CHECK_THRESHOLD) {
+                                checkmarkFound = true;
+                                break check;
                             }
-
                         }
+
                     }
                 }
-            });
+            }
 
             if (!checkmarkFound) {
                 try {


### PR DESCRIPTION
Test failed intermittently on particular host. Though analysis pointed out to a test frame at left top on that host, I've updated the test for further stabilizing it. Two things done here:
1. Move the frame to center of the screen rather than left top.
2. Added tolerance checks for color comparison - this is based on analysis reports where the image didn't had exact black color which is supposed to be. So like other test cases, providing some tolerance for comparison.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338153](https://bugs.openjdk.org/browse/JDK-8338153): java/awt/Checkbox/CheckboxCheckerScalingTest.java test failed on linux machine (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**) Review applies to [9a562914](https://git.openjdk.org/jdk/pull/20723/files/9a562914436d729c22a6f4bee1719d6217e6cc05)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20723/head:pull/20723` \
`$ git checkout pull/20723`

Update a local copy of the PR: \
`$ git checkout pull/20723` \
`$ git pull https://git.openjdk.org/jdk.git pull/20723/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20723`

View PR using the GUI difftool: \
`$ git pr show -t 20723`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20723.diff">https://git.openjdk.org/jdk/pull/20723.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20723#issuecomment-2311650300)