### PR TITLE
8337951: Test sun/security/validator/samedn.sh CertificateNotYetValidException: NotBefore validation

### DIFF
--- a/test/jdk/sun/security/validator/samedn.sh
+++ b/test/jdk/sun/security/validator/samedn.sh
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2010, 2013, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -62,10 +62,11 @@ $KT -genkeypair -alias ca1 -dname CN=CA -keyalg rsa -sigalg md5withrsa -ext bc -
 $KT -genkeypair -alias ca2 -dname CN=CA -keyalg rsa -sigalg sha1withrsa -ext bc -startdate -1y
 $KT -genkeypair -alias user -dname CN=User -keyalg rsa
 
-# 2. Signing: ca -> user
+# 2. Signing: ca -> user. The startdate is set to 1 minute in the past to ensure the certificate
+# is valid at the time of validation and to prevent any issues with timing discrepancies
 
-$KT -certreq -alias user | $KT -gencert -rfc -alias ca1 > samedn1.certs
-$KT -certreq -alias user | $KT -gencert -rfc -alias ca2 > samedn2.certs
+$KT -certreq -alias user | $KT -gencert -rfc -alias ca1 -startdate -1M > samedn1.certs
+$KT -certreq -alias user | $KT -gencert -rfc -alias ca2 -startdate -1M > samedn2.certs
 
 # 3. Append the ca file
 


### PR DESCRIPTION
The test sun/security/validator/samedn.sh failed once due to the following reason:

`Caused by: java.security.cert.CertificateNotYetValidException: NotBefore: Tue Aug 06 14:41:13 GMT 2024`

This test generates several certificates using the keytool as a precondition, and then validates their certificate paths.

This failure is very rare and could not be reproduced. However, based on the failure logs, the test finished at **14:41:12**, while the test certificate's NotBefore time was set to **14:41:13**. It is possible that when the certificate was created, keytool **rounded up** the NotBefore time to the nearest second. As a result, the test may have validated the certificate just before it became valid.

The proposed fix is to set the NotBefore time to one minute in the past, ensuring the certificate will be valid when running the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337951](https://bugs.openjdk.org/browse/JDK-8337951): Test sun/security/validator/samedn.sh CertificateNotYetValidException: NotBefore validation (**Bug** - P3)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20728/head:pull/20728` \
`$ git checkout pull/20728`

Update a local copy of the PR: \
`$ git checkout pull/20728` \
`$ git pull https://git.openjdk.org/jdk.git pull/20728/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20728`

View PR using the GUI difftool: \
`$ git pr show -t 20728`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20728.diff">https://git.openjdk.org/jdk/pull/20728.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20728#issuecomment-2314674099)