### PR TITLE
8335120: assert(!target->can_be_statically_bound() || target == cha_monomorphic_target) failed

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2116,7 +2116,7 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
   }
 
   if (cha_monomorphic_target != nullptr) {
-    assert(!target->can_be_statically_bound() || target == cha_monomorphic_target, "");
+    assert(!target->can_be_statically_bound() || target->equals(cha_monomorphic_target), "");
     assert(!cha_monomorphic_target->is_abstract(), "");
     if (!cha_monomorphic_target->can_be_statically_bound(actual_recv)) {
       // If we inlined because CHA revealed only a single target method,

--- a/src/hotspot/share/ci/ciMethod.cpp
+++ b/src/hotspot/share/ci/ciMethod.cpp
@@ -782,6 +782,22 @@ bool ciMethod::can_omit_stack_trace() const {
 }
 
 // ------------------------------------------------------------------
+// ciMethod::equals
+//
+// Returns true if the methods are the same, taking redefined methods
+// into account.
+bool ciMethod::equals(const ciMethod* m) const {
+  if (this == m) return true;
+  VM_ENTRY_MARK;
+  Method* m1 = this->get_Method();
+  Method* m2 = m->get_Method();
+  if (m1->is_old()) m1 = m1->get_new_method();
+  if (m2->is_old()) m2 = m2->get_new_method();
+  return m1 == m2;
+}
+
+
+// ------------------------------------------------------------------
 // ciMethod::resolve_invoke
 //
 // Given a known receiver klass, find the target for the call.

--- a/src/hotspot/share/ci/ciMethod.hpp
+++ b/src/hotspot/share/ci/ciMethod.hpp
@@ -366,6 +366,8 @@ class ciMethod : public ciMetadata {
 
   bool can_omit_stack_trace() const;
 
+  bool equals(const ciMethod* m) const;
+
   // Replay data methods
   static void dump_name_as_ascii(outputStream* st, Method* method);
   void dump_name_as_ascii(outputStream* st);


### PR DESCRIPTION
The failing test uses class redefinition, which happen at safepoints.  Because JIT compiler threads do not block safepoints, compiler threads can sometimes see multiple versions of the same method.  The above assert can fail if target and cha_monomorphic_target are different versions of the same method.  The fix is to introduce ciMethod::equals to deal with this possibility.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335120](https://bugs.openjdk.org/browse/JDK-8335120): assert(!target-&gt;can_be_statically_bound() || target == cha_monomorphic_target) failed (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20730/head:pull/20730` \
`$ git checkout pull/20730`

Update a local copy of the PR: \
`$ git checkout pull/20730` \
`$ git pull https://git.openjdk.org/jdk.git pull/20730/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20730`

View PR using the GUI difftool: \
`$ git pr show -t 20730`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20730.diff">https://git.openjdk.org/jdk/pull/20730.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20730#issuecomment-2312997336)