### PR TITLE
8339120: Use more fine-granular gcc unused warnings

### DIFF
--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -235,14 +235,14 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
       CFLAGS_WARNINGS_ARE_ERRORS="-Werror"
 
       # Additional warnings that are not activated by -Wall and -Wextra
-      WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wsign-compare \
-          -Wunused-function -Wundef -Wunused-value -Wreturn-type \
-          -Wtrampolines"
+      WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wreturn-type -Wsign-compare \
+          -Wtrampolines -Wundef -Wunused-const-variable -Wunused-function \
+          -Wunused-result -Wunused-value"
       WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"
       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"
 
-      DISABLED_WARNINGS="unused-parameter unused"
+      DISABLED_WARNINGS="unused-parameter"
       # gcc10/11 on ppc generate lots of abi warnings about layout of aggregates containing vectors
       if test "x$OPENJDK_TARGET_CPU_ARCH" = "xppc"; then
         DISABLED_WARNINGS="$DISABLED_WARNINGS psabi"

--- a/make/autoconf/flags-cflags.m4
+++ b/make/autoconf/flags-cflags.m4
@@ -236,7 +236,7 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
 
       # Additional warnings that are not activated by -Wall and -Wextra
       WARNINGS_ENABLE_ADDITIONAL="-Wpointer-arith -Wreturn-type -Wsign-compare \
-          -Wtrampolines -Wundef -Wunused-const-variable -Wunused-function \
+          -Wtrampolines -Wundef -Wunused-const-variable=1 -Wunused-function \
           -Wunused-result -Wunused-value"
       WARNINGS_ENABLE_ADDITIONAL_CXX="-Woverloaded-virtual -Wreorder"
       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"

--- a/make/common/TestFilesCompilation.gmk
+++ b/make/common/TestFilesCompilation.gmk
@@ -112,7 +112,9 @@ define SetupTestFilesCompilationBody
         CXXFLAGS := $$(TEST_CFLAGS) $$($1_CFLAGS) $$($1_CFLAGS_$$(name)), \
         LD_SET_ORIGIN := $$($1_LD_SET_ORIGIN), \
         LDFLAGS := $$($1_LDFLAGS_$$(name)), \
-        DISABLED_WARNINGS_gcc := format undef unused-function unused-value, \
+        DISABLED_WARNINGS_gcc := format undef unused-but-set-variable \
+            unused-const-variable unused-function unused-value \
+            unused-variable, \
         DISABLED_WARNINGS_clang := undef format-nonliteral \
             missing-field-initializers sometimes-uninitialized, \
         DEFAULT_LIBCXX := false, \

--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -135,7 +135,7 @@ define SetupBuildLauncherBody
           $$($1_CFLAGS), \
       CFLAGS_windows := $$($1_CFLAGS_windows), \
       EXTRA_HEADER_DIRS := java.base:libjvm, \
-      DISABLED_WARNINGS_gcc := unused-function, \
+      DISABLED_WARNINGS_gcc := unused-function unused-variable, \
       LDFLAGS := $$($1_LDFLAGS), \
       LDFLAGS_linux := $$(call SET_EXECUTABLE_ORIGIN,/../lib), \
       LDFLAGS_macosx := $$(call SET_EXECUTABLE_ORIGIN,/../lib), \

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -57,9 +57,9 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
         $(GTEST_FRAMEWORK_SRC)/googletest/src \
         $(GTEST_FRAMEWORK_SRC)/googlemock/src, \
     INCLUDE_FILES := gtest-all.cc gmock-all.cc, \
-    DISABLED_WARNINGS_gcc := undef unused-result format-nonliteral \
-        maybe-uninitialized zero-as-null-pointer-constant, \
-    DISABLED_WARNINGS_clang := undef unused-result format-nonliteral, \
+    DISABLED_WARNINGS_gcc := format-nonliteral maybe-uninitialized undef \
+        unused-const-variable unused-result zero-as-null-pointer-constant, \
+    DISABLED_WARNINGS_clang := format-nonliteral undef unused-result, \
     DEFAULT_CFLAGS := false, \
     CFLAGS := $(JVM_CFLAGS) \
         -I$(GTEST_FRAMEWORK_SRC)/googletest \

--- a/make/hotspot/lib/CompileGtest.gmk
+++ b/make/hotspot/lib/CompileGtest.gmk
@@ -58,7 +58,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBGTEST, \
         $(GTEST_FRAMEWORK_SRC)/googlemock/src, \
     INCLUDE_FILES := gtest-all.cc gmock-all.cc, \
     DISABLED_WARNINGS_gcc := format-nonliteral maybe-uninitialized undef \
-        unused-const-variable unused-result zero-as-null-pointer-constant, \
+        unused-result zero-as-null-pointer-constant, \
     DISABLED_WARNINGS_clang := format-nonliteral undef unused-result, \
     DEFAULT_CFLAGS := false, \
     CFLAGS := $(JVM_CFLAGS) \
@@ -100,6 +100,7 @@ $(eval $(call SetupJdkLibrary, BUILD_GTEST_LIBJVM, \
     CFLAGS_macosx := -DGTEST_OS_MAC=1, \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc) \
         undef stringop-overflow, \
+    DISABLED_WARNINGS_gcc_test_metaspace_misc.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_test_threadCpuLoad.cpp := address, \
     DISABLED_WARNINGS_clang := $(DISABLED_WARNINGS_clang) \
         undef switch format-nonliteral tautological-undefined-compare \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -179,6 +179,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc), \
     DISABLED_WARNINGS_gcc_ad_$(HOTSPOT_TARGET_CPU_ARCH).cpp := nonnull, \
     DISABLED_WARNINGS_gcc_bytecodeInterpreter.cpp := unused-label, \
+    DISABLED_WARNINGS_gcc_c1_Runtime1_aarch64.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_cgroupV1Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_cgroupV2Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_g1FreeIdSet.cpp := unused-const-variable, \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -92,7 +92,8 @@ CFLAGS_VM_VERSION := \
 DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
     empty-body implicit-fallthrough int-in-bool-context \
     maybe-uninitialized missing-field-initializers \
-    shift-negative-value unknown-pragmas
+    shift-negative-value unknown-pragmas unused-but-set-variable \
+    unused-const-variable unused-local-typedefs unused-variable
 
 DISABLED_WARNINGS_clang := sometimes-uninitialized \
     missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -195,6 +195,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_macroAssembler_ppc_sha.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
     DISABLED_WARNINGS_gcc_shenandoahLock.cpp := stringop-overflow, \
+    DISABLED_WARNINGS_gcc_stubGenerator_s390.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_templateInterpreterGenerator_x86.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_xGlobals_ppc.cpp := unused-const-variable, \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -192,10 +192,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_jvmciCodeInstaller.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_jvmFlag.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_jvmtiTagMap.cpp := stringop-overflow, \
+    DISABLED_WARNINGS_gcc_macroAssembler_ppc_sha.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
     DISABLED_WARNINGS_gcc_shenandoahLock.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_templateInterpreterGenerator_x86.cpp := unused-const-variable, \
+    DISABLED_WARNINGS_gcc_xGlobals_ppc.cpp := unused-const-variable, \
     DISABLED_WARNINGS_clang := $(DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_clang_arguments.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_codeBuffer.cpp := tautological-undefined-compare, \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -93,7 +93,7 @@ DISABLED_WARNINGS_gcc := array-bounds comment delete-non-virtual-dtor \
     empty-body implicit-fallthrough int-in-bool-context \
     maybe-uninitialized missing-field-initializers \
     shift-negative-value unknown-pragmas unused-but-set-variable \
-    unused-const-variable unused-local-typedefs unused-variable
+    unused-local-typedefs unused-variable
 
 DISABLED_WARNINGS_clang := sometimes-uninitialized \
     missing-braces delete-non-abstract-non-virtual-dtor unknown-pragmas
@@ -181,13 +181,20 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     DISABLED_WARNINGS_gcc_bytecodeInterpreter.cpp := unused-label, \
     DISABLED_WARNINGS_gcc_cgroupV1Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_cgroupV2Subsystem_linux.cpp := address, \
+    DISABLED_WARNINGS_gcc_g1FreeIdSet.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_handshake.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_interp_masm_x86.cpp := uninitialized, \
+    DISABLED_WARNINGS_gcc_javaClasses.cpp := unused-const-variable, \
+    DISABLED_WARNINGS_gcc_jfrChunkWriter.cpp := unused-const-variable, \
+    DISABLED_WARNINGS_gcc_jfrMemorySizer.cpp := unused-const-variable, \
+    DISABLED_WARNINGS_gcc_jfrTraceIdKlassQueue.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_jvmciCodeInstaller.cpp := stringop-overflow, \
+    DISABLED_WARNINGS_gcc_jvmFlag.cpp := unused-const-variable, \
     DISABLED_WARNINGS_gcc_jvmtiTagMap.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_postaloc.cpp := address, \
     DISABLED_WARNINGS_gcc_shenandoahLock.cpp := stringop-overflow, \
     DISABLED_WARNINGS_gcc_synchronizer.cpp := stringop-overflow, \
+    DISABLED_WARNINGS_gcc_templateInterpreterGenerator_x86.cpp := unused-const-variable, \
     DISABLED_WARNINGS_clang := $(DISABLED_WARNINGS_clang), \
     DISABLED_WARNINGS_clang_arguments.cpp := missing-field-initializers, \
     DISABLED_WARNINGS_clang_codeBuffer.cpp := tautological-undefined-compare, \

--- a/make/hotspot/lib/CompileJvm.gmk
+++ b/make/hotspot/lib/CompileJvm.gmk
@@ -178,6 +178,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJVM, \
     arguments.cpp_CXXFLAGS := $(CFLAGS_VM_VERSION), \
     DISABLED_WARNINGS_gcc := $(DISABLED_WARNINGS_gcc), \
     DISABLED_WARNINGS_gcc_ad_$(HOTSPOT_TARGET_CPU_ARCH).cpp := nonnull, \
+    DISABLED_WARNINGS_gcc_bytecodeInterpreter.cpp := unused-label, \
     DISABLED_WARNINGS_gcc_cgroupV1Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_cgroupV2Subsystem_linux.cpp := address, \
     DISABLED_WARNINGS_gcc_handshake.cpp := stringop-overflow, \

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -44,7 +44,7 @@ include lib/CoreLibraries.gmk
 $(eval $(call SetupJdkLibrary, BUILD_LIBNET, \
     NAME := net, \
     OPTIMIZATION := LOW, \
-    DISABLED_WARNINGS_gcc_net_util_md.c := format-nonliteral, \
+    DISABLED_WARNINGS_gcc_net_util_md.c := format-nonliteral unused-variable, \
     DISABLED_WARNINGS_gcc_NetworkInterface.c := unused-function, \
     DISABLED_WARNINGS_clang_net_util_md.c := format-nonliteral, \
     DISABLED_WARNINGS_clang_aix_DefaultProxySelector.c := \
@@ -116,6 +116,7 @@ ifeq ($(call isTargetOsType, unix), true)
       NAME := jsig, \
       OPTIMIZATION := LOW, \
       jsig.c_CFLAGS := -DHOTSPOT_VM_DISTRO='"$(HOTSPOT_VM_DISTRO)"', \
+      DISABLED_WARNINGS_gcc_jsig.c := unused-but-set-variable, \
       LIBS_linux := $(LIBDL), \
       LIBS_aix := $(LIBDL), \
   ))
@@ -186,6 +187,7 @@ ifeq ($(call isTargetOs, linux)+$(call isTargetCpu, x86_64)+$(INCLUDE_COMPILER2)
       LINK_TYPE := C++, \
       OPTIMIZATION := HIGH, \
       CXXFLAGS := -std=c++17, \
+      DISABLED_WARNINGS_gcc := unused-variable, \
       LIBS_linux := $(LIBDL) $(LIBM), \
   ))
 

--- a/make/modules/java.base/Lib.gmk
+++ b/make/modules/java.base/Lib.gmk
@@ -170,6 +170,7 @@ ifeq ($(ENABLE_FALLBACK_LINKER), true)
       NAME := fallbackLinker, \
       EXTRA_HEADER_DIRS := java.base:libjava, \
       CFLAGS := $(LIBFFI_CFLAGS), \
+      DISABLED_WARNINGS_gcc := implicit-function-declaration unused-variable, \
       LIBS := $(LIBFFI_LIBS), \
       LIBS_windows := ws2_32.lib, \
   ))

--- a/make/modules/java.base/lib/CoreLibraries.gmk
+++ b/make/modules/java.base/lib/CoreLibraries.gmk
@@ -35,6 +35,7 @@ endif
 $(eval $(call SetupJdkLibrary, BUILD_LIBVERIFY, \
     NAME := verify, \
     OPTIMIZATION := $(LIBVERIFY_OPTIMIZATION), \
+    DISABLED_WARNINGS_gcc_check_code.c := unused-variable, \
     EXTRA_HEADER_DIRS := libjava, \
     JDK_LIBS := libjvm, \
 ))
@@ -108,6 +109,9 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJIMAGE, \
     OPTIMIZATION := LOW, \
     EXTRA_HEADER_DIRS := libjava, \
     CFLAGS_unix := -UDEBUG, \
+    DISABLED_WARNINGS_gcc_imageDecompressor.cpp := unused-variable, \
+    DISABLED_WARNINGS_gcc_imageFile.cpp := unused-const-variable \
+        unused-variable, \
     LDFLAGS := $(LDFLAGS_CXX_JDK), \
     JDK_LIBS := libjvm, \
     LIBS_unix := $(LIBDL), \
@@ -167,7 +171,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJLI, \
     EXTRA_HEADER_DIRS := libjvm, \
     OPTIMIZATION := HIGH, \
     CFLAGS := $(LIBJLI_CFLAGS) $(LIBZ_CFLAGS), \
-    DISABLED_WARNINGS_gcc := unused-function, \
+    DISABLED_WARNINGS_gcc := unused-function unused-variable, \
     DISABLED_WARNINGS_clang := format-nonliteral deprecated-non-prototype, \
     LIBS_unix := $(LIBZ_LIBS), \
     LIBS_linux := $(LIBDL) -lpthread, \

--- a/make/modules/java.desktop/Lib.gmk
+++ b/make/modules/java.desktop/Lib.gmk
@@ -64,7 +64,7 @@ ifeq ($(call isTargetOs, aix), false)
       EXTRA_HEADER_DIRS := java.base:libjava, \
       CFLAGS := $(LIBJSOUND_CFLAGS), \
       CXXFLAGS := $(LIBJSOUND_CFLAGS), \
-      DISABLED_WARNINGS_gcc := undef, \
+      DISABLED_WARNINGS_gcc := undef unused-variable, \
       DISABLED_WARNINGS_clang := undef, \
       LIBS_linux := $(ALSA_LIBS), \
       LIBS_macosx := \

--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -179,10 +179,7 @@ ifeq ($(call isTargetOs, windows macosx), false)
       CFLAGS := -DHEADLESS=true $(CUPS_CFLAGS) $(FONTCONFIG_CFLAGS) \
           $(X_CFLAGS), \
       EXTRA_HEADER_DIRS := $(LIBAWT_HEADLESS_EXTRA_HEADER_DIRS), \
-      DISABLED_WARNINGS_gcc_AccelGlyphCache.c := unused-variable, \
-      DISABLED_WARNINGS_gcc_CUPSfuncs.c := unused-variable, \
-      DISABLED_WARNINGS_gcc_fontpath.c := unused-variable, \
-      DISABLED_WARNINGS_gcc_X11FontScaler_md.c := unused-variable, \
+      DISABLED_WARNINGS_gcc := unused-variable, \
       DISABLED_WARNINGS_gcc_X11Renderer.c := unused-function, \
       DISABLED_WARNINGS_gcc_X11SurfaceData.c := unused-function, \
       JDK_LIBS := libawt java.base:libjava, \

--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -106,6 +106,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBAWT, \
     CXXFLAGS := $(LIBAWT_CFLAGS) $(X_CFLAGS), \
     CFLAGS_gcc := -fgcse-after-reload, \
     EXTRA_HEADER_DIRS := $(LIBAWT_EXTRA_HEADER_DIRS), \
+    DISABLED_WARNINGS_gcc := unused-but-set-variable unused-variable, \
     DISABLED_WARNINGS_gcc_awt_LoadLibrary.c := unused-result, \
     DISABLED_WARNINGS_gcc_debug_mem.c := format-nonliteral, \
     DISABLED_WARNINGS_gcc_ProcessPath.c := maybe-uninitialized, \
@@ -178,6 +179,9 @@ ifeq ($(call isTargetOs, windows macosx), false)
       CFLAGS := -DHEADLESS=true $(CUPS_CFLAGS) $(FONTCONFIG_CFLAGS) \
           $(X_CFLAGS), \
       EXTRA_HEADER_DIRS := $(LIBAWT_HEADLESS_EXTRA_HEADER_DIRS), \
+      DISABLED_WARNINGS_gcc_CUPSfuncs.c := unused-variable, \
+      DISABLED_WARNINGS_gcc_fontpath.c := unused-variable, \
+      DISABLED_WARNINGS_gcc_X11FontScaler_md.c := unused-variable, \
       DISABLED_WARNINGS_gcc_X11Renderer.c := unused-function, \
       DISABLED_WARNINGS_gcc_X11SurfaceData.c := unused-function, \
       JDK_LIBS := libawt java.base:libjava, \
@@ -234,7 +238,8 @@ ifeq ($(call isTargetOs, windows macosx)+$(ENABLE_HEADLESS_ONLY), false+false)
       OPTIMIZATION := LOW, \
       CFLAGS := -DXAWT -DXAWT_HACK $(LIBAWT_XAWT_CFLAGS) \
           $(FONTCONFIG_CFLAGS) $(CUPS_CFLAGS) $(X_CFLAGS), \
-      DISABLED_WARNINGS_gcc := int-to-pointer-cast, \
+      DISABLED_WARNINGS_gcc := int-to-pointer-cast unused-const-variable \
+          unused-variable, \
       DISABLED_WARNINGS_gcc_awt_Taskbar.c := parentheses, \
       DISABLED_WARNINGS_gcc_GLXSurfaceData.c := unused-function, \
       DISABLED_WARNINGS_gcc_gtk3_interface.c := parentheses type-limits \
@@ -244,8 +249,10 @@ ifeq ($(call isTargetOs, windows macosx)+$(ENABLE_HEADLESS_ONLY), false+false)
       DISABLED_WARNINGS_gcc_screencast_pipewire.c := undef, \
       DISABLED_WARNINGS_gcc_screencast_portal.c := undef, \
       DISABLED_WARNINGS_gcc_sun_awt_X11_GtkFileDialogPeer.c := parentheses, \
+      DISABLED_WARNINGS_gcc_X11Color.c := unused-but-set-variable, \
       DISABLED_WARNINGS_gcc_X11SurfaceData.c := implicit-fallthrough \
-          pointer-to-int-cast, \
+          pointer-to-int-cast unused-but-set-variable, \
+      DISABLED_WARNINGS_gcc_X11TextRenderer_md.c := unused-but-set-variable, \
       DISABLED_WARNINGS_gcc_XlibWrapper.c := type-limits pointer-to-int-cast, \
       DISABLED_WARNINGS_gcc_XRBackendNative.c := maybe-uninitialized, \
       DISABLED_WARNINGS_gcc_XToolkit.c := unused-result, \

--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -236,8 +236,7 @@ ifeq ($(call isTargetOs, windows macosx)+$(ENABLE_HEADLESS_ONLY), false+false)
       OPTIMIZATION := LOW, \
       CFLAGS := -DXAWT -DXAWT_HACK $(LIBAWT_XAWT_CFLAGS) \
           $(FONTCONFIG_CFLAGS) $(CUPS_CFLAGS) $(X_CFLAGS), \
-      DISABLED_WARNINGS_gcc := int-to-pointer-cast unused-const-variable \
-          unused-variable, \
+      DISABLED_WARNINGS_gcc := int-to-pointer-cast unused-variable, \
       DISABLED_WARNINGS_gcc_awt_Taskbar.c := parentheses, \
       DISABLED_WARNINGS_gcc_GLXSurfaceData.c := unused-function, \
       DISABLED_WARNINGS_gcc_gtk3_interface.c := parentheses type-limits \

--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -179,6 +179,7 @@ ifeq ($(call isTargetOs, windows macosx), false)
       CFLAGS := -DHEADLESS=true $(CUPS_CFLAGS) $(FONTCONFIG_CFLAGS) \
           $(X_CFLAGS), \
       EXTRA_HEADER_DIRS := $(LIBAWT_HEADLESS_EXTRA_HEADER_DIRS), \
+      DISABLED_WARNINGS_gcc_AccelGlyphCache.c := unused-variable, \
       DISABLED_WARNINGS_gcc_CUPSfuncs.c := unused-variable, \
       DISABLED_WARNINGS_gcc_fontpath.c := unused-variable, \
       DISABLED_WARNINGS_gcc_X11FontScaler_md.c := unused-variable, \

--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -84,8 +84,8 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBLCMS, \
         libawt/java2d \
         java.base:libjvm, \
     HEADERS_FROM_SRC := $(LIBLCMS_HEADERS_FROM_SRC), \
-    DISABLED_WARNINGS_gcc := format-nonliteral type-limits \
-        stringop-truncation, \
+    DISABLED_WARNINGS_gcc := format-nonliteral stringop-truncation type-limits \
+        unused-variable, \
     DISABLED_WARNINGS_clang := format-nonliteral, \
     JDK_LIBS := libawt java.base:libjava, \
     LIBS_unix := $(LCMS_LIBS) $(LIBM), \

--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -281,51 +281,51 @@ endif
 ################################################################################
 
 ifeq ($(USE_EXTERNAL_HARFBUZZ), true)
-   LIBFONTMANAGER_EXTRA_SRC =
-   LIBFONTMANAGER_LIBS += $(HARFBUZZ_LIBS)
-   LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
+  LIBFONTMANAGER_EXTRA_SRC =
+  LIBFONTMANAGER_LIBS += $(HARFBUZZ_LIBS)
+  LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 else
-   LIBFONTMANAGER_EXTRA_SRC = libharfbuzz
+  LIBFONTMANAGER_EXTRA_SRC = libharfbuzz
 
-   ifeq ($(call isTargetOs, windows), false)
-     HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
+  ifeq ($(call isTargetOs, windows), false)
+    HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
         -DHAVE_SYSCONF -DHAVE_SYS_MMAN_H -DHAVE_UNISTD_H \
         -DHB_NO_PRAGMA_GCC_DIAGNOSTIC
-   endif
-   ifeq ($(call isTargetOs, linux macosx), true)
-     HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES -DHB_NO_VISIBILITY
-   endif
+  endif
+  ifeq ($(call isTargetOs, linux macosx), true)
+    HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES -DHB_NO_VISIBILITY
+  endif
 
-   # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
-   # hb-subset and hb-style APIs are not needed, excluded to cut on compilation
-   # time.
-   LIBFONTMANAGER_EXCLUDE_FILES += gsubgpos-context.cc hb-ft.cc hb-style.cc \
+  # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
+  # hb-subset and hb-style APIs are not needed, excluded to cut on compilation
+  # time.
+  LIBFONTMANAGER_EXCLUDE_FILES += gsubgpos-context.cc hb-ft.cc hb-style.cc \
       hb-subset-cff-common.cc hb-subset-cff1.cc hb-subset-cff2.cc \
       hb-subset-input.cc hb-subset-instancer-solver.cc hb-subset-plan.cc \
       hb-subset.cc
 
-   # list of disabled warnings and the compilers for which it was specifically
-   # added.
-   # array-bounds         -> GCC 12 on Alpine Linux
-   # parentheses          -> GCC 6
-   # range-loop-analysis  -> clang on Xcode12
+  # list of disabled warnings and the compilers for which it was specifically
+  # added.
+  # array-bounds         -> GCC 12 on Alpine Linux
+  # parentheses          -> GCC 6
+  # range-loop-analysis  -> clang on Xcode12
 
-   HARFBUZZ_DISABLED_WARNINGS_gcc := missing-field-initializers \
-       strict-aliasing unused-result array-bounds parentheses \
-       unused-const-variable unused-variable
-   # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
-   # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
-   # maybe-uninitialized required for GCC 8 builds. Not required for GCC 9+.
-   # calloc-transposed-args required for GCC 14 builds. (fixed upstream in
-   #  Harfbuzz 032c931e1c0cfb20f18e5acb8ba005775242bd92)
-   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type \
-       expansion-to-defined dangling-reference maybe-uninitialized \
-       calloc-transposed-args
-   HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers \
+  HARFBUZZ_DISABLED_WARNINGS_gcc := missing-field-initializers \
+      strict-aliasing unused-result array-bounds parentheses \
+      unused-variable
+  # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
+  # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
+  # maybe-uninitialized required for GCC 8 builds. Not required for GCC 9+.
+  # calloc-transposed-args required for GCC 14 builds. (fixed upstream in
+  #  Harfbuzz 032c931e1c0cfb20f18e5acb8ba005775242bd92)
+  HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type \
+      expansion-to-defined dangling-reference maybe-uninitialized \
+      calloc-transposed-args
+  HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers \
       range-loop-analysis
-   HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
+  HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
 
-   LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
+  LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 endif
 
 LIBFONTMANAGER_EXTRA_HEADER_DIRS := \

--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -281,51 +281,51 @@ endif
 ################################################################################
 
 ifeq ($(USE_EXTERNAL_HARFBUZZ), true)
-  LIBFONTMANAGER_EXTRA_SRC =
-  LIBFONTMANAGER_LIBS += $(HARFBUZZ_LIBS)
-  LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
+   LIBFONTMANAGER_EXTRA_SRC =
+   LIBFONTMANAGER_LIBS += $(HARFBUZZ_LIBS)
+   LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 else
-  LIBFONTMANAGER_EXTRA_SRC = libharfbuzz
+   LIBFONTMANAGER_EXTRA_SRC = libharfbuzz
 
-  ifeq ($(call isTargetOs, windows), false)
-    HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
+   ifeq ($(call isTargetOs, windows), false)
+     HARFBUZZ_CFLAGS += -DGETPAGESIZE -DHAVE_MPROTECT -DHAVE_PTHREAD \
         -DHAVE_SYSCONF -DHAVE_SYS_MMAN_H -DHAVE_UNISTD_H \
         -DHB_NO_PRAGMA_GCC_DIAGNOSTIC
-  endif
-  ifeq ($(call isTargetOs, linux macosx), true)
-    HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES -DHB_NO_VISIBILITY
-  endif
+   endif
+   ifeq ($(call isTargetOs, linux macosx), true)
+     HARFBUZZ_CFLAGS += -DHAVE_INTEL_ATOMIC_PRIMITIVES -DHB_NO_VISIBILITY
+   endif
 
-  # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
-  # hb-subset and hb-style APIs are not needed, excluded to cut on compilation
-  # time.
-  LIBFONTMANAGER_EXCLUDE_FILES += gsubgpos-context.cc hb-ft.cc hb-style.cc \
+   # hb-ft.cc is not presently needed, and requires freetype 2.4.2 or later.
+   # hb-subset and hb-style APIs are not needed, excluded to cut on compilation
+   # time.
+   LIBFONTMANAGER_EXCLUDE_FILES += gsubgpos-context.cc hb-ft.cc hb-style.cc \
       hb-subset-cff-common.cc hb-subset-cff1.cc hb-subset-cff2.cc \
       hb-subset-input.cc hb-subset-instancer-solver.cc hb-subset-plan.cc \
       hb-subset.cc
 
-  # list of disabled warnings and the compilers for which it was specifically
-  # added.
-  # array-bounds         -> GCC 12 on Alpine Linux
-  # parentheses          -> GCC 6
-  # range-loop-analysis  -> clang on Xcode12
+   # list of disabled warnings and the compilers for which it was specifically
+   # added.
+   # array-bounds         -> GCC 12 on Alpine Linux
+   # parentheses          -> GCC 6
+   # range-loop-analysis  -> clang on Xcode12
 
-  HARFBUZZ_DISABLED_WARNINGS_gcc := missing-field-initializers \
-      strict-aliasing unused-result array-bounds parentheses \
-      unused-variable
-  # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
-  # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
-  # maybe-uninitialized required for GCC 8 builds. Not required for GCC 9+.
-  # calloc-transposed-args required for GCC 14 builds. (fixed upstream in
-  #  Harfbuzz 032c931e1c0cfb20f18e5acb8ba005775242bd92)
-  HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type \
-      expansion-to-defined dangling-reference maybe-uninitialized \
-      calloc-transposed-args
-  HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers \
+   HARFBUZZ_DISABLED_WARNINGS_gcc := missing-field-initializers \
+       strict-aliasing unused-result array-bounds parentheses \
+       unused-variable
+   # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
+   # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
+   # maybe-uninitialized required for GCC 8 builds. Not required for GCC 9+.
+   # calloc-transposed-args required for GCC 14 builds. (fixed upstream in
+   #  Harfbuzz 032c931e1c0cfb20f18e5acb8ba005775242bd92)
+   HARFBUZZ_DISABLED_WARNINGS_CXX_gcc := class-memaccess noexcept-type \
+       expansion-to-defined dangling-reference maybe-uninitialized \
+       calloc-transposed-args
+   HARFBUZZ_DISABLED_WARNINGS_clang := missing-field-initializers \
       range-loop-analysis
-  HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
+   HARFBUZZ_DISABLED_WARNINGS_microsoft := 4267 4244
 
-  LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
+   LIBFONTMANAGER_CFLAGS += $(HARFBUZZ_CFLAGS)
 endif
 
 LIBFONTMANAGER_EXTRA_HEADER_DIRS := \

--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -118,7 +118,8 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJAVAJPEG, \
     INCLUDE_FILES := $(LIBJAVAJPEG_INCLUDE_FILES), \
     OPTIMIZATION := HIGHEST, \
     HEADERS_FROM_SRC := $(LIBJAVAJPEG_HEADERS_FROM_SRC), \
-    DISABLED_WARNINGS_gcc_imageioJPEG.c := clobbered array-bounds, \
+    DISABLED_WARNINGS_gcc_imageioJPEG.c := array-bounds clobbered \
+        unused-but-set-variable, \
     DISABLED_WARNINGS_gcc_jcmaster.c := implicit-fallthrough, \
     DISABLED_WARNINGS_gcc_jdphuff.c := shift-negative-value, \
     JDK_LIBS := java.base:libjava, \
@@ -224,7 +225,8 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
           maybe-uninitialized, \
       DISABLED_WARNINGS_gcc_splashscreen_impl.c := implicit-fallthrough \
           sign-compare unused-function, \
-      DISABLED_WARNINGS_gcc_splashscreen_sys.c := type-limits unused-result, \
+      DISABLED_WARNINGS_gcc_splashscreen_sys.c := type-limits \
+          unused-but-set-variable unused-result unused-variable, \
       DISABLED_WARNINGS_clang := deprecated-non-prototype, \
       DISABLED_WARNINGS_clang_dgif_lib.c := sign-compare, \
       DISABLED_WARNINGS_clang_gzwrite.c := format-nonliteral, \
@@ -309,7 +311,8 @@ else
    # range-loop-analysis  -> clang on Xcode12
 
    HARFBUZZ_DISABLED_WARNINGS_gcc := missing-field-initializers \
-       strict-aliasing unused-result array-bounds parentheses
+       strict-aliasing unused-result array-bounds parentheses \
+       unused-const-variable unused-variable
    # noexcept-type required for GCC 7 builds. Not required for GCC 8+.
    # expansion-to-defined required for GCC 9 builds. Not required for GCC 10+.
    # maybe-uninitialized required for GCC 8 builds. Not required for GCC 9+.

--- a/make/modules/java.management/Lib.gmk
+++ b/make/modules/java.management/Lib.gmk
@@ -37,6 +37,7 @@ endif
 $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT, \
     NAME := management, \
     OPTIMIZATION := $(LIBMANAGEMENT_OPTIMIZATION), \
+    DISABLED_WARNINGS_gcc_VMManagementImpl.c := unused-variable, \
     JDK_LIBS := java.base:libjava java.base:libjvm, \
     LIBS_aix := -lperfstat,\
     LIBS_windows := advapi32.lib psapi.lib, \

--- a/make/modules/java.security.jgss/Lib.gmk
+++ b/make/modules/java.security.jgss/Lib.gmk
@@ -33,7 +33,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJ2GSS, \
     NAME := j2gss, \
     OPTIMIZATION := LOW, \
     EXTRA_HEADER_DIRS := java.base:libjava, \
-    DISABLED_WARNINGS_gcc := undef, \
+    DISABLED_WARNINGS_gcc := undef unused-but-set-variable, \
     DISABLED_WARNINGS_clang := undef, \
     LIBS_unix := $(LIBDL), \
 ))

--- a/make/modules/jdk.crypto.cryptoki/Lib.gmk
+++ b/make/modules/jdk.crypto.cryptoki/Lib.gmk
@@ -33,6 +33,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJ2PKCS11, \
     NAME := j2pkcs11, \
     OPTIMIZATION := LOW, \
     EXTRA_HEADER_DIRS := java.base:libjava, \
+    DISABLED_WARNINGS_gcc_p11_md.c := unused-variable, \
     DISABLED_WARNINGS_clang_p11_util.c := format-nonliteral, \
     LIBS_unix := $(LIBDL), \
 ))

--- a/make/modules/jdk.hotspot.agent/Lib.gmk
+++ b/make/modules/jdk.hotspot.agent/Lib.gmk
@@ -59,10 +59,12 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBSAPROC, \
     OPTIMIZATION := HIGH, \
     EXTRA_HEADER_DIRS := java.base:libjvm, \
     DISABLED_WARNINGS_gcc := sign-compare, \
+    DISABLED_WARNINGS_gcc_LinuxDebuggerLocal.cpp := unused-variable, \
     DISABLED_WARNINGS_gcc_ps_core.c := pointer-arith, \
-    DISABLED_WARNINGS_clang_ps_core.c := pointer-arith, \
+    DISABLED_WARNINGS_gcc_symtab.c := unused-but-set-variable, \
     DISABLED_WARNINGS_clang := sign-compare, \
     DISABLED_WARNINGS_clang_libproc_impl.c := format-nonliteral, \
+    DISABLED_WARNINGS_clang_ps_core.c := pointer-arith, \
     DISABLED_WARNINGS_clang_sadis.c := format-nonliteral, \
     CFLAGS := $(LIBSAPROC_CFLAGS), \
     CXXFLAGS := $(LIBSAPROC_CFLAGS) $(LIBSAPROC_CXXFLAGS), \

--- a/make/modules/jdk.jdwp.agent/Lib.gmk
+++ b/make/modules/jdk.jdwp.agent/Lib.gmk
@@ -52,7 +52,10 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBJDWP, \
     NAME := jdwp, \
     OPTIMIZATION := LOW, \
     CFLAGS := -DJDWP_LOGGING, \
+    DISABLED_WARNINGS_gcc_eventFilter.c := unused-variable, \
     DISABLED_WARNINGS_gcc_SDE.c := unused-function, \
+    DISABLED_WARNINGS_gcc_threadControl.c := unused-but-set-variable unused-variable, \
+    DISABLED_WARNINGS_gcc_utf_util.c := unused-but-set-variable, \
     DISABLED_WARNINGS_clang_error_messages.c := format-nonliteral, \
     DISABLED_WARNINGS_clang_EventRequestImpl.c := self-assign, \
     DISABLED_WARNINGS_clang_inStream.c := sometimes-uninitialized, \

--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -89,6 +89,7 @@ ifeq ($(call isTargetOs, linux), true)
       EXCLUDE_FILES := LinuxLauncher.c LinuxPackage.c, \
       LINK_TYPE := C++, \
       OPTIMIZATION := LOW, \
+      DISABLED_WARNINGS_gcc_Log.cpp := unused-const-variable, \
       DISABLED_WARNINGS_clang_JvmLauncherLib.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_tstrings.cpp := format-nonliteral, \
       LD_SET_ORIGIN := false, \

--- a/make/modules/jdk.management/Lib.gmk
+++ b/make/modules/jdk.management/Lib.gmk
@@ -44,6 +44,7 @@ endif
 $(eval $(call SetupJdkLibrary, BUILD_LIBMANAGEMENT_EXT, \
     NAME := management_ext, \
     OPTIMIZATION := $(LIBMANAGEMENT_EXT_OPTIMIZATION), \
+    DISABLED_WARNINGS_gcc_DiagnosticCommandImpl.c := unused-variable, \
     DISABLED_WARNINGS_clang_UnixOperatingSystem.c := format-nonliteral, \
     CFLAGS := $(LIBMANAGEMENT_EXT_CFLAGS), \
     JDK_LIBS := java.base:libjava java.base:libjvm, \


### PR DESCRIPTION
Currently, we issue -Wno-unused for all files in gcc, which is a rather big sledgehammer to get rid of some warnings that proliferate in a few areas of the build.

We should instead leave -Wunused turned on (as done by -Wall) and use a much more fine-grained approach to disabling specific warnings in specific files or libraries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339120](https://bugs.openjdk.org/browse/JDK-8339120): Use more fine-granular gcc unused warnings (**Bug** - P3)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20733/head:pull/20733` \
`$ git checkout pull/20733`

Update a local copy of the PR: \
`$ git checkout pull/20733` \
`$ git pull https://git.openjdk.org/jdk.git pull/20733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20733`

View PR using the GUI difftool: \
`$ git pr show -t 20733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20733.diff">https://git.openjdk.org/jdk/pull/20733.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20733#issuecomment-2313687282)