### PR TITLE
8339126: JNI exception pending in Inflater.c

### DIFF
--- a/src/java.base/share/native/libzip/Inflater.c
+++ b/src/java.base/share/native/libzip/Inflater.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,8 +49,8 @@ JNIEXPORT void JNICALL
 Java_java_util_zip_Inflater_initIDs(JNIEnv *env, jclass cls)
 {
     inputConsumedID = (*env)->GetFieldID(env, cls, "inputConsumed", "I");
-    outputConsumedID = (*env)->GetFieldID(env, cls, "outputConsumed", "I");
     CHECK_NULL(inputConsumedID);
+    outputConsumedID = (*env)->GetFieldID(env, cls, "outputConsumed", "I");
     CHECK_NULL(outputConsumedID);
 }
 


### PR DESCRIPTION
This PR addresses the JNI pending exception in Inflater.c, under `Java_java_util_zip_Inflater_initIDs`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339126](https://bugs.openjdk.org/browse/JDK-8339126): JNI exception pending in Inflater.c (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20735/head:pull/20735` \
`$ git checkout pull/20735`

Update a local copy of the PR: \
`$ git checkout pull/20735` \
`$ git pull https://git.openjdk.org/jdk.git pull/20735/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20735`

View PR using the GUI difftool: \
`$ git pr show -t 20735`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20735.diff">https://git.openjdk.org/jdk/pull/20735.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20735#issuecomment-2313620476)