### PR TITLE
8338716: Re-visit "interrupt handling" in jdk.internal.loader.Resource

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/Resource.java
+++ b/src/java.base/share/classes/jdk/internal/loader/Resource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package jdk.internal.loader;
 import java.io.EOFException;
 import java.net.URL;
 import java.io.IOException;
-import java.io.InterruptedIOException;
 import java.io.InputStream;
 import java.security.CodeSigner;
 import java.util.jar.Manifest;
@@ -87,24 +86,7 @@ public abstract class Resource {
         // Get stream before content length so that a FileNotFoundException
         // can propagate upwards without being caught too early
         InputStream in = cachedInputStream();
-
-        // This code has been uglified to protect against interrupts.
-        // Even if a thread has been interrupted when loading resources,
-        // the IO should not abort, so must carefully retry, failing only
-        // if the retry leads to some other IO exception.
-
-        boolean isInterrupted = Thread.interrupted();
-        int len;
-        for (;;) {
-            try {
-                len = getContentLength();
-                break;
-            } catch (InterruptedIOException iioe) {
-                Thread.interrupted();
-                isInterrupted = true;
-            }
-        }
-
+        int len = getContentLength();
         try {
             b = new byte[0];
             if (len == -1) len = Integer.MAX_VALUE;
@@ -121,13 +103,7 @@ public abstract class Resource {
                 } else {
                     bytesToRead = b.length - pos;
                 }
-                int cc = 0;
-                try {
-                    cc = in.read(b, pos, bytesToRead);
-                } catch (InterruptedIOException iioe) {
-                    Thread.interrupted();
-                    isInterrupted = true;
-                }
+                int cc = in.read(b, pos, bytesToRead);
                 if (cc < 0) {
                     if (len != Integer.MAX_VALUE) {
                         throw new EOFException("Detect premature EOF");
@@ -143,13 +119,7 @@ public abstract class Resource {
         } finally {
             try {
                 in.close();
-            } catch (InterruptedIOException iioe) {
-                isInterrupted = true;
             } catch (IOException ignore) {}
-
-            if (isInterrupted) {
-                Thread.currentThread().interrupt();
-            }
         }
         return b;
     }

--- a/src/java.base/share/classes/jdk/internal/loader/Resource.java
+++ b/src/java.base/share/classes/jdk/internal/loader/Resource.java
@@ -86,8 +86,8 @@ public abstract class Resource {
         // Get stream before content length so that a FileNotFoundException
         // can propagate upwards without being caught too early
         InputStream in = cachedInputStream();
-        int len = getContentLength();
         try {
+            int len = getContentLength();
             b = new byte[0];
             if (len == -1) len = Integer.MAX_VALUE;
             int pos = 0;


### PR DESCRIPTION
The InterruptibleIO feature (which was only on Solaris) was removed some time ago. See [JDK-4385444](https://bugs.openjdk.org/browse/JDK-4385444).

Vestiges of it remain in jdk.internal.loader.Resource.getBytes(), and should be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338716](https://bugs.openjdk.org/browse/JDK-8338716): Re-visit "interrupt handling" in jdk.internal.loader.Resource (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20736/head:pull/20736` \
`$ git checkout pull/20736`

Update a local copy of the PR: \
`$ git checkout pull/20736` \
`$ git pull https://git.openjdk.org/jdk.git pull/20736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20736`

View PR using the GUI difftool: \
`$ git pr show -t 20736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20736.diff">https://git.openjdk.org/jdk/pull/20736.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20736#issuecomment-2313654502)