### PR TITLE
8339401: Optimize ClassFile load and store instructions

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
@@ -56,83 +56,125 @@ public class BytecodeHelpers {
 
     public static Opcode loadOpcode(TypeKind tk, int slot) {
         return switch (tk) {
-            case INT, SHORT, BYTE, CHAR, BOOLEAN -> switch (slot) {
-                case 0 -> Opcode.ILOAD_0;
-                case 1 -> Opcode.ILOAD_1;
-                case 2 -> Opcode.ILOAD_2;
-                case 3 -> Opcode.ILOAD_3;
-                default -> (slot < 256) ? Opcode.ILOAD : Opcode.ILOAD_W;
-            };
-            case LONG -> switch (slot) {
-                case 0 -> Opcode.LLOAD_0;
-                case 1 -> Opcode.LLOAD_1;
-                case 2 -> Opcode.LLOAD_2;
-                case 3 -> Opcode.LLOAD_3;
-                default -> (slot < 256) ? Opcode.LLOAD : Opcode.LLOAD_W;
-            };
-            case DOUBLE -> switch (slot) {
-                case 0 -> Opcode.DLOAD_0;
-                case 1 -> Opcode.DLOAD_1;
-                case 2 -> Opcode.DLOAD_2;
-                case 3 -> Opcode.DLOAD_3;
-                default -> (slot < 256) ? Opcode.DLOAD : Opcode.DLOAD_W;
-            };
-            case FLOAT -> switch (slot) {
-                case 0 -> Opcode.FLOAD_0;
-                case 1 -> Opcode.FLOAD_1;
-                case 2 -> Opcode.FLOAD_2;
-                case 3 -> Opcode.FLOAD_3;
-                default -> (slot < 256) ? Opcode.FLOAD : Opcode.FLOAD_W;
-            };
-            case REFERENCE -> switch (slot) {
-                case 0 -> Opcode.ALOAD_0;
-                case 1 -> Opcode.ALOAD_1;
-                case 2 -> Opcode.ALOAD_2;
-                case 3 -> Opcode.ALOAD_3;
-                default -> (slot < 256) ? Opcode.ALOAD : Opcode.ALOAD_W;
-            };
-            case VOID -> throw new IllegalArgumentException("void");
+            case INT, SHORT, BYTE, CHAR, BOOLEAN
+                           -> iload(slot);
+            case LONG      -> lload(slot);
+            case DOUBLE    -> dload(slot);
+            case FLOAT     -> fload(slot);
+            case REFERENCE -> aload(slot);
+            case VOID      -> throw new IllegalArgumentException("void");
+        };
+    }
+
+    public static Opcode aload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.ALOAD_0;
+            case 1 -> Opcode.ALOAD_1;
+            case 2 -> Opcode.ALOAD_2;
+            case 3 -> Opcode.ALOAD_3;
+            default -> (slot < 256) ? Opcode.ALOAD : Opcode.ALOAD_W;
+        };
+    }
+
+    public static Opcode fload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.FLOAD_0;
+            case 1 -> Opcode.FLOAD_1;
+            case 2 -> Opcode.FLOAD_2;
+            case 3 -> Opcode.FLOAD_3;
+            default -> (slot < 256) ? Opcode.FLOAD : Opcode.FLOAD_W;
+        };
+    }
+
+    public static Opcode dload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.DLOAD_0;
+            case 1 -> Opcode.DLOAD_1;
+            case 2 -> Opcode.DLOAD_2;
+            case 3 -> Opcode.DLOAD_3;
+            default -> (slot < 256) ? Opcode.DLOAD : Opcode.DLOAD_W;
+        };
+    }
+
+    public static Opcode lload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.LLOAD_0;
+            case 1 -> Opcode.LLOAD_1;
+            case 2 -> Opcode.LLOAD_2;
+            case 3 -> Opcode.LLOAD_3;
+            default -> (slot < 256) ? Opcode.LLOAD : Opcode.LLOAD_W;
+        };
+    }
+
+    public static Opcode iload(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.ILOAD_0;
+            case 1 -> Opcode.ILOAD_1;
+            case 2 -> Opcode.ILOAD_2;
+            case 3 -> Opcode.ILOAD_3;
+            default -> (slot < 256) ? Opcode.ILOAD : Opcode.ILOAD_W;
         };
     }
 
     public static Opcode storeOpcode(TypeKind tk, int slot) {
         return switch (tk) {
-            case INT, SHORT, BYTE, CHAR, BOOLEAN -> switch (slot) {
-                case 0 -> Opcode.ISTORE_0;
-                case 1 -> Opcode.ISTORE_1;
-                case 2 -> Opcode.ISTORE_2;
-                case 3 -> Opcode.ISTORE_3;
-                default -> (slot < 256) ? Opcode.ISTORE : Opcode.ISTORE_W;
-            };
-            case LONG -> switch (slot) {
-                case 0 -> Opcode.LSTORE_0;
-                case 1 -> Opcode.LSTORE_1;
-                case 2 -> Opcode.LSTORE_2;
-                case 3 -> Opcode.LSTORE_3;
-                default -> (slot < 256) ? Opcode.LSTORE : Opcode.LSTORE_W;
-            };
-            case DOUBLE -> switch (slot) {
-                case 0 -> Opcode.DSTORE_0;
-                case 1 -> Opcode.DSTORE_1;
-                case 2 -> Opcode.DSTORE_2;
-                case 3 -> Opcode.DSTORE_3;
-                default -> (slot < 256) ? Opcode.DSTORE : Opcode.DSTORE_W;
-            };
-            case FLOAT -> switch (slot) {
-                case 0 -> Opcode.FSTORE_0;
-                case 1 -> Opcode.FSTORE_1;
-                case 2 -> Opcode.FSTORE_2;
-                case 3 -> Opcode.FSTORE_3;
-                default -> (slot < 256) ? Opcode.FSTORE : Opcode.FSTORE_W;
-            };
-            case REFERENCE -> switch (slot) {
-                case 0 -> Opcode.ASTORE_0;
-                case 1 -> Opcode.ASTORE_1;
-                case 2 -> Opcode.ASTORE_2;
-                case 3 -> Opcode.ASTORE_3;
-                default -> (slot < 256) ? Opcode.ASTORE : Opcode.ASTORE_W;
-            };
-            case VOID -> throw new IllegalArgumentException("void");
+            case INT, SHORT, BYTE, CHAR, BOOLEAN
+                           -> istore(slot);
+            case LONG      -> lstore(slot);
+            case DOUBLE    -> dstore(slot);
+            case FLOAT     -> fstore(slot);
+            case REFERENCE -> astore(slot);
+            case VOID      -> throw new IllegalArgumentException("void");
+        };
+    }
+
+    public static Opcode astore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.ASTORE_0;
+            case 1 -> Opcode.ASTORE_1;
+            case 2 -> Opcode.ASTORE_2;
+            case 3 -> Opcode.ASTORE_3;
+            default -> (slot < 256) ? Opcode.ASTORE : Opcode.ASTORE_W;
+        };
+    }
+
+    public static Opcode fstore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.FSTORE_0;
+            case 1 -> Opcode.FSTORE_1;
+            case 2 -> Opcode.FSTORE_2;
+            case 3 -> Opcode.FSTORE_3;
+            default -> (slot < 256) ? Opcode.FSTORE : Opcode.FSTORE_W;
+        };
+    }
+
+    public static Opcode dstore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.DSTORE_0;
+            case 1 -> Opcode.DSTORE_1;
+            case 2 -> Opcode.DSTORE_2;
+            case 3 -> Opcode.DSTORE_3;
+            default -> (slot < 256) ? Opcode.DSTORE : Opcode.DSTORE_W;
+        };
+    }
+
+    public static Opcode lstore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.LSTORE_0;
+            case 1 -> Opcode.LSTORE_1;
+            case 2 -> Opcode.LSTORE_2;
+            case 3 -> Opcode.LSTORE_3;
+            default -> (slot < 256) ? Opcode.LSTORE : Opcode.LSTORE_W;
+        };
+    }
+
+    public static Opcode istore(int slot) {
+        return switch (slot) {
+            case 0 -> Opcode.ISTORE_0;
+            case 1 -> Opcode.ISTORE_1;
+            case 2 -> Opcode.ISTORE_2;
+            case 3 -> Opcode.ISTORE_3;
+            default -> (slot < 256) ? Opcode.ISTORE : Opcode.ISTORE_W;
         };
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -859,6 +859,12 @@ public final class DirectCodeBuilder
     }
 
     @Override
+    public CodeBuilder aload(int slot) {
+        writeLocalVar(BytecodeHelpers.aload(slot), slot);
+        return this;
+    }
+
+    @Override
     public CodeBuilder anewarray(ClassEntry entry) {
         writeNewReferenceArray(entry);
         return this;
@@ -867,6 +873,12 @@ public final class DirectCodeBuilder
     @Override
     public CodeBuilder arraylength() {
         writeBytecode(ARRAYLENGTH);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder astore(int slot) {
+        writeLocalVar(BytecodeHelpers.astore(slot), slot);
         return this;
     }
 
@@ -944,6 +956,12 @@ public final class DirectCodeBuilder
     }
 
     @Override
+    public CodeBuilder dload(int slot) {
+        writeLocalVar(BytecodeHelpers.dload(slot), slot);
+        return this;
+    }
+
+    @Override
     public CodeBuilder dmul() {
         writeBytecode(DMUL);
         return this;
@@ -958,6 +976,12 @@ public final class DirectCodeBuilder
     @Override
     public CodeBuilder drem() {
         writeBytecode(DREM);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder dstore(int slot) {
+        writeLocalVar(BytecodeHelpers.dstore(slot), slot);
         return this;
     }
 
@@ -1064,6 +1088,12 @@ public final class DirectCodeBuilder
     }
 
     @Override
+    public CodeBuilder fload(int slot) {
+        writeLocalVar(BytecodeHelpers.fload(slot), slot);
+        return this;
+    }
+
+    @Override
     public CodeBuilder fmul() {
         writeBytecode(FMUL);
         return this;
@@ -1078,6 +1108,12 @@ public final class DirectCodeBuilder
     @Override
     public CodeBuilder frem() {
         writeBytecode(FREM);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder fstore(int slot) {
+        writeLocalVar(BytecodeHelpers.fstore(slot), slot);
         return this;
     }
 
@@ -1189,64 +1225,9 @@ public final class DirectCodeBuilder
         return this;
     }
 
-
     @Override
     public CodeBuilder iload(int slot) {
         writeLocalVar(BytecodeHelpers.iload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder lload(int slot) {
-        writeLocalVar(BytecodeHelpers.lload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder fload(int slot) {
-        writeLocalVar(BytecodeHelpers.fload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder dload(int slot) {
-        writeLocalVar(BytecodeHelpers.dload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder aload(int slot) {
-        writeLocalVar(BytecodeHelpers.aload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder istore(int slot) {
-        writeLocalVar(BytecodeHelpers.istore(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder lstore(int slot) {
-        writeLocalVar(BytecodeHelpers.lstore(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder fstore(int slot) {
-        writeLocalVar(BytecodeHelpers.fstore(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder dstore(int slot) {
-        writeLocalVar(BytecodeHelpers.dstore(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder astore(int slot) {
-        writeLocalVar(BytecodeHelpers.astore(slot), slot);
         return this;
     }
 
@@ -1335,6 +1316,12 @@ public final class DirectCodeBuilder
     }
 
     @Override
+    public CodeBuilder istore(int slot) {
+        writeLocalVar(BytecodeHelpers.istore(slot), slot);
+        return this;
+    }
+
+    @Override
     public CodeBuilder isub() {
         writeBytecode(ISUB);
         return this;
@@ -1419,6 +1406,12 @@ public final class DirectCodeBuilder
     }
 
     @Override
+    public CodeBuilder lload(int slot) {
+        writeLocalVar(BytecodeHelpers.lload(slot), slot);
+        return this;
+    }
+
+    @Override
     public CodeBuilder lmul() {
         writeBytecode(LMUL);
         return this;
@@ -1451,6 +1444,12 @@ public final class DirectCodeBuilder
     @Override
     public CodeBuilder lshr() {
         writeBytecode(LSHR);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder lstore(int slot) {
+        writeLocalVar(BytecodeHelpers.lstore(slot), slot);
         return this;
     }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -1189,6 +1189,67 @@ public final class DirectCodeBuilder
         return this;
     }
 
+
+    @Override
+    public CodeBuilder iload(int slot) {
+        writeLocalVar(BytecodeHelpers.iload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder lload(int slot) {
+        writeLocalVar(BytecodeHelpers.lload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder fload(int slot) {
+        writeLocalVar(BytecodeHelpers.fload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder dload(int slot) {
+        writeLocalVar(BytecodeHelpers.dload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder aload(int slot) {
+        writeLocalVar(BytecodeHelpers.aload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder istore(int slot) {
+        writeLocalVar(BytecodeHelpers.istore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder lstore(int slot) {
+        writeLocalVar(BytecodeHelpers.lstore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder fstore(int slot) {
+        writeLocalVar(BytecodeHelpers.fstore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder dstore(int slot) {
+        writeLocalVar(BytecodeHelpers.dstore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder astore(int slot) {
+        writeLocalVar(BytecodeHelpers.astore(slot), slot);
+        return this;
+    }
+
     @Override
     public CodeBuilder imul() {
         writeBytecode(IMUL);
@@ -1472,66 +1533,6 @@ public final class DirectCodeBuilder
     @Override
     public CodeBuilder tableswitch(int low, int high, Label defaultTarget, List<SwitchCase> cases) {
         writeTableSwitch(low, high, defaultTarget, cases);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder iload(int slot) {
-        writeLocalVar(BytecodeHelpers.iload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder lload(int slot) {
-        writeLocalVar(BytecodeHelpers.lload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder fload(int slot) {
-        writeLocalVar(BytecodeHelpers.fload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder dload(int slot) {
-        writeLocalVar(BytecodeHelpers.dload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder aload(int slot) {
-        writeLocalVar(BytecodeHelpers.aload(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder istore(int slot) {
-        writeLocalVar(BytecodeHelpers.istore(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder lstore(int slot) {
-        writeLocalVar(BytecodeHelpers.lstore(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder fstore(int slot) {
-        writeLocalVar(BytecodeHelpers.fstore(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder dstore(int slot) {
-        writeLocalVar(BytecodeHelpers.dstore(slot), slot);
-        return this;
-    }
-
-    @Override
-    public CodeBuilder astore(int slot) {
-        writeLocalVar(BytecodeHelpers.astore(slot), slot);
         return this;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -63,6 +63,8 @@ import java.util.function.Function;
 
 import static java.lang.classfile.Opcode.*;
 
+import static jdk.internal.classfile.impl.BytecodeHelpers.*;
+
 public final class DirectCodeBuilder
         extends AbstractDirectBuilder<CodeModel>
         implements TerminalCodeBuilder {
@@ -1469,6 +1471,66 @@ public final class DirectCodeBuilder
     @Override
     public CodeBuilder tableswitch(int low, int high, Label defaultTarget, List<SwitchCase> cases) {
         writeTableSwitch(low, high, defaultTarget, cases);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder iload(int slot) {
+        writeLocalVar(BytecodeHelpers.iload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder lload(int slot) {
+        writeLocalVar(BytecodeHelpers.lload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder fload(int slot) {
+        writeLocalVar(BytecodeHelpers.fload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder dload(int slot) {
+        writeLocalVar(BytecodeHelpers.dload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder aload(int slot) {
+        writeLocalVar(BytecodeHelpers.aload(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder istore(int slot) {
+        writeLocalVar(BytecodeHelpers.istore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder lstore(int slot) {
+        writeLocalVar(BytecodeHelpers.lstore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder fstore(int slot) {
+        writeLocalVar(BytecodeHelpers.fstore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder dstore(int slot) {
+        writeLocalVar(BytecodeHelpers.dstore(slot), slot);
+        return this;
+    }
+
+    @Override
+    public CodeBuilder astore(int slot) {
+        writeLocalVar(BytecodeHelpers.astore(slot), slot);
         return this;
     }
 }


### PR DESCRIPTION
BytecodeHelpers' loadOpcode and storeOpcode are large methods with code size greater than 325, break it into multiple small methods and call them directly in DirectCodeBuilder

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339401](https://bugs.openjdk.org/browse/JDK-8339401): Optimize ClassFile load and store instructions (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20739/head:pull/20739` \
`$ git checkout pull/20739`

Update a local copy of the PR: \
`$ git checkout pull/20739` \
`$ git pull https://git.openjdk.org/jdk.git pull/20739/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20739`

View PR using the GUI difftool: \
`$ git pr show -t 20739`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20739.diff">https://git.openjdk.org/jdk/pull/20739.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20739#issuecomment-2324848153)