### PR TITLE
8339149: jfr_flush_event_writer - return value type mismatch

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -113,7 +113,7 @@ jobject JNICALL jfr_get_event_writer(JNIEnv* env, jclass jvm);
 
 jobject JNICALL jfr_new_event_writer(JNIEnv* env, jclass jvm);
 
-jboolean JNICALL jfr_event_writer_flush(JNIEnv* env, jclass jvm, jobject writer, jint used_size, jint requested_size);
+void JNICALL jfr_event_writer_flush(JNIEnv* env, jclass jvm, jobject writer, jint used_size, jint requested_size);
 
 jlong JNICALL jfr_commit(JNIEnv* env, jclass cls, jlong next_position);
 void JNICALL jfr_flush(JNIEnv* env, jclass jvm);


### PR DESCRIPTION
Very small adjustment to the function signature.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339149](https://bugs.openjdk.org/browse/JDK-8339149): jfr_flush_event_writer - return value type mismatch (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20742/head:pull/20742` \
`$ git checkout pull/20742`

Update a local copy of the PR: \
`$ git checkout pull/20742` \
`$ git pull https://git.openjdk.org/jdk.git pull/20742/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20742`

View PR using the GUI difftool: \
`$ git pr show -t 20742`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20742.diff">https://git.openjdk.org/jdk/pull/20742.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20742#issuecomment-2314831379)