### PR TITLE
8339154: Cleanups and JUnit conversion of test/jdk/java/util/zip/Available.java

### DIFF
--- a/test/jdk/java/util/zip/Available.java
+++ b/test/jdk/java/util/zip/Available.java
@@ -66,6 +66,7 @@ public class Available {
 
             // Second entry uses STORED method
             ZipEntry stored = new ZipEntry("stored.txt");
+            stored.setMethod(ZipEntry.STORED);
             stored.setSize(contents.length);
             CRC32 crc32 = new CRC32();
             crc32.update(contents);

--- a/test/jdk/java/util/zip/Available.java
+++ b/test/jdk/java/util/zip/Available.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,69 +22,160 @@
  */
 
 /* @test
-   @bug 4028605 4109069 4234207 4401122
-   @summary Make sure ZipInputStream/InflaterInputStream.available() will
-            return 0 after EOF has reached and 1 otherwise.
-   */
+ * @bug 4028605 4109069 4234207 4401122 8339154
+ * @summary Verify that ZipInputStream, InflaterInputStream, ZipFileInputStream,
+ *          ZipFileInflaterInputStream.available() return values according
+ *          to their specification or long-standing behavior
+ * @run junit Available
+ */
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.zip.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class Available {
 
-    public static void main(String[] args) throws Exception {
-        // 4028605 4109069 4234207
-        test1();
-        // test 4401122
-        test2();
+    // ZIP file produced in this test
+    private final Path zip = Path.of("available.jar");
+
+    /**
+     * Create the ZIP file used in this test, containing
+     * one deflated and one stored entry.
+     *
+     * @throws IOException if an unexpected error occurs
+     */
+    @BeforeEach
+    public void setup() throws IOException {
+        byte[] contents = "contents".repeat(10).getBytes(StandardCharsets.UTF_8);
+
+        try (ZipOutputStream zo = new ZipOutputStream(Files.newOutputStream(zip))) {
+            // First entry uses DEFLATE method
+            zo.putNextEntry(new ZipEntry("deflated.txt"));
+            zo.write(contents);
+
+            // Second entry uses STORED method
+            ZipEntry stored = new ZipEntry("stored.txt");
+            stored.setSize(contents.length);
+            CRC32 crc32 = new CRC32();
+            crc32.update(contents);
+            stored.setCrc(crc32.getValue());
+            zo.putNextEntry(stored);
+            zo.write(contents);
+        }
     }
 
-    private static void test1() throws Exception {
-        File f = new File(System.getProperty("test.src", "."), "input.jar");
+    /**
+     * Delete the ZIP file created by this test
+     *
+     * @throws IOException if an unexpected error occurs
+     */
+    @AfterEach
+    public void cleanup() throws IOException {
+        Files.deleteIfExists(zip);
+    }
 
-        // test ZipInputStream
-        try (FileInputStream fis = new FileInputStream(f);
-             ZipInputStream z = new ZipInputStream(fis))
-        {
+    /**
+     * Verify that ZipInputStream.available() returns 0 after EOF or
+     * closeEntry, otherwise 1, as specified in the API description.
+     * This tests 4028605 4109069 4234207
+     * @throws IOException if an unexpected error occurs
+     */
+    @Test
+    public void testZipInputStream() throws IOException {
+        try (InputStream in = Files.newInputStream(zip);
+             ZipInputStream z = new ZipInputStream(in)) {
             z.getNextEntry();
-            tryAvail(z);
+            assertEquals(1, z.available());
+            z.read();
+            assertEquals(1, z.available());
+            z.transferTo(OutputStream.nullOutputStream());
+            assertEquals(0, z.available(),
+                    "ZipInputStream.available() should return 0 after EOF");
         }
 
-        // test InflaterInputStream
-        try (ZipFile zfile = new ZipFile(f)) {
-            tryAvail(zfile.getInputStream(zfile.getEntry("Available.java")));
+        try (InputStream in = Files.newInputStream(zip);
+             ZipInputStream z = new ZipInputStream(in)) {
+            z.getNextEntry();
+            assertEquals(1, z.available());
+            z.read();
+            assertEquals(1, z.available());
+            z.closeEntry();
+            assertEquals(0, z.available(),
+                    "ZipInputStream.available() should return 0 after closeEntry");
         }
     }
 
-    static void tryAvail(InputStream in) throws Exception {
-        byte[] buf = new byte[1024];
-        int n;
-
-        while ((n = in.read(buf)) != -1);
-        if (in.available() != 0) {
-            throw new Exception("available should return 0 after EOF");
+    /**
+     * Verify that ZipFileInputStream.available() returns
+     * the number of remaining uncompressed bytes.
+     *
+     * This verifies unspecified, but long-standing behavior. See 4401122.
+     *
+     * @throws IOException if an unexpected error occurs
+     */
+    @Test
+    public void testZipFileInputStream() throws IOException {
+        try (ZipFile zfile = new ZipFile(zip.toFile())) {
+            assertRemainingUncompressedBytes(zfile, "stored.txt");
         }
     }
 
-    // To reproduce 4401122
-    private static void test2() throws Exception {
-        File f = new File(System.getProperty("test.src", "."), "input.jar");
-        try (ZipFile zf = new ZipFile(f)) {
-            InputStream in = zf.getInputStream(zf.getEntry("Available.java"));
+    /**
+     * Verify that ZipFileInflaterInputStream.available() returns
+     * the number of remaining uncompressed bytes.
+     *
+     * This verifies unspecified, but long-standing behavior. See 4401122.
+     *
+     * @throws IOException if an unexpected error occurs
+     */
+    @Test
+    public void testZipFileInflaterInputStream() throws IOException {
+        try (ZipFile zfile = new ZipFile(zip.toFile())) {
+            assertRemainingUncompressedBytes(zfile, "deflated.txt");
+        }
+    }
 
-            int initialAvailable = in.available();
+    /**
+     * Assert that calling available() on a an InputStream obtained
+     * from ZipFile.getInputStream for the given entry
+     * returns the number of remaining uncompressed bytes in the stream.
+     *
+     * @param zfile the ZipFile to read an entry from
+     * @param name the name of the entry to read
+     * @throws IOException if an unexpected error occurs
+     */
+    private void assertRemainingUncompressedBytes(ZipFile zfile, String name) throws IOException {
+        ZipEntry entry = zfile.getEntry(name);
+        InputStream in = zfile.getInputStream(entry);
+
+        int initialAvailable = in.available();
+
+        // Initally, the number of remaining uncompressed bytes is the entry size
+        assertEquals(entry.getSize(), in.available());
+
+        // Reading a single byte should decrement available by 1
+        in.read();
+        assertEquals(initialAvailable - 1, in.available(),
+                "Available not decremented");
+
+        // Read all bytes one by one
+        for (int i=0; i < initialAvailable-1; i++) {
             in.read();
-            if (in.available() != initialAvailable - 1)
-                throw new RuntimeException("Available not decremented.");
-            for(int j=0; j<initialAvailable-1; j++)
-                in.read();
-            if (in.available() != 0)
-                throw new RuntimeException();
-            in.close();
-            if (in.available() != 0)
-                throw new RuntimeException();
         }
-    }
 
+        // No remaining uncompressed bytes
+        assertEquals(0, in.available());
+
+        // available() should still return 0 after close
+        in.close();
+        assertEquals(0, in.available());
+    }
 }

--- a/test/jdk/java/util/zip/Available.java
+++ b/test/jdk/java/util/zip/Available.java
@@ -40,6 +40,7 @@ import java.nio.file.Path;
 import java.util.zip.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class Available {
 
@@ -90,8 +91,8 @@ public class Available {
      */
     @Test
     public void testZipInputStream() throws IOException {
-        try (InputStream in = Files.newInputStream(zip);
-             ZipInputStream z = new ZipInputStream(in)) {
+        try (InputStream in = Files.newInputStream(zip)) {
+            ZipInputStream z = new ZipInputStream(in);
             z.getNextEntry();
             assertEquals(1, z.available());
             z.read();
@@ -99,14 +100,15 @@ public class Available {
             z.transferTo(OutputStream.nullOutputStream());
             assertEquals(0, z.available(),
                     "ZipInputStream.available() should return 0 after EOF");
+
+            z.close();
+            assertThrows(IOException.class, () -> z.available(),
+                    "Expected an IOException when calling available on a closed stream");
         }
 
         try (InputStream in = Files.newInputStream(zip);
              ZipInputStream z = new ZipInputStream(in)) {
             z.getNextEntry();
-            assertEquals(1, z.available());
-            z.read();
-            assertEquals(1, z.available());
             z.closeEntry();
             assertEquals(0, z.available(),
                     "ZipInputStream.available() should return 0 after closeEntry");


### PR DESCRIPTION
Please review this test-only PR which addresses several issues with the `test/jdk/java/util/zip/Available.java` test:

* The test is converted to JUnit 5
* The test now creates its own test vector programmatically instead of relying on a binary `input.jar` test vector 
* Coverage is added for calling `available()` after calling `ZipInputStream.closeEntry`, as expected by the API specification for `ZipInputStream.available`
* Coverage is added for calling `available()` on a closed `ZipInputStream`
* Coverage is added for the unspecified, but long-standing behavior of `ZipFileInputStream.available()` (The InputStream returned for `STORED` entries)

Additionally, the test is split into multiple methods, adding javadoc comments for each of them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339154](https://bugs.openjdk.org/browse/JDK-8339154): Cleanups and JUnit conversion of test/jdk/java/util/zip/Available.java (**Enhancement** - P5)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20744/head:pull/20744` \
`$ git checkout pull/20744`

Update a local copy of the PR: \
`$ git checkout pull/20744` \
`$ git pull https://git.openjdk.org/jdk.git pull/20744/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20744`

View PR using the GUI difftool: \
`$ git pr show -t 20744`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20744.diff">https://git.openjdk.org/jdk/pull/20744.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20744#issuecomment-2315117266)