### PR TITLE
8339097: Parallel: Compact GC to split array early for task stealing

### DIFF
--- a/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
+++ b/src/hotspot/share/gc/parallel/psCompactionManager.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,13 +117,17 @@ inline void follow_array_specialized(objArrayOop obj, int index, ParCompactionMa
   assert(beg_index < len || len == 0, "index too large");
 
   const size_t stride = MIN2(len - beg_index, (size_t)ObjArrayMarkingStride);
-  const size_t end_index = beg_index + stride;
+  size_t end_index = beg_index + stride;
   T* const base = (T*)obj->base();
   T* const beg = base + beg_index;
   T* const end = base + end_index;
 
-  if (end_index < len) {
-    cm->push_objarray(obj, end_index); // Push the continuation.
+  if (index == 0) {
+    // Breakup remaining and push to the task queue
+    while (end_index < len) {
+      cm->push_objarray(obj, end_index);
+      end_index += (size_t)ObjArrayMarkingStride;
+    }
   }
 
   // Push the non-null elements of the next stride on the marking stack.


### PR DESCRIPTION
Parallel Compact GC splits a large array in stripes during marking, so that other workers can steal the work.

Currently, it only splits a large array into two tasks, retains and pushes remaining into a task queue for task stealing, depends on next worker to further split the array if possible, that creates artificial dependency.

I would like purpose to have the first worker breaking up the array, to eliminate the dependency.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339097](https://bugs.openjdk.org/browse/JDK-8339097): Parallel: Compact GC to split array early for task stealing (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20745/head:pull/20745` \
`$ git checkout pull/20745`

Update a local copy of the PR: \
`$ git checkout pull/20745` \
`$ git pull https://git.openjdk.org/jdk.git pull/20745/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20745`

View PR using the GUI difftool: \
`$ git pr show -t 20745`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20745.diff">https://git.openjdk.org/jdk/pull/20745.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20745#issuecomment-2317721809)