### PR TITLE
8339196: Optimize BufWriterImpl#writeU1/U2/Int/Long

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -91,17 +91,26 @@ public final class BufWriterImpl implements BufWriter {
 
     @Override
     public void writeU1(int x) {
-        writeIntBytes(1, x);
+        reserveSpace(1);
+        elems[offset++] = (byte) x;
     }
 
     @Override
     public void writeU2(int x) {
-        writeIntBytes(2, x);
+        reserveSpace(2);
+        elems[offset    ] = (byte) (x >> 8);
+        elems[offset + 1] = (byte) x;
+        offset += 2;
     }
 
     @Override
     public void writeInt(int x) {
-        writeIntBytes(4, x);
+        reserveSpace(4);
+        elems[offset    ] = (byte) (x >> 24);
+        elems[offset + 1] = (byte) (x >> 16);
+        elems[offset + 2] = (byte) (x >> 8);
+        elems[offset + 3] = (byte)  x;
+        offset += 4;
     }
 
     @Override
@@ -111,7 +120,16 @@ public final class BufWriterImpl implements BufWriter {
 
     @Override
     public void writeLong(long x) {
-        writeIntBytes(8, x);
+        reserveSpace(8);
+        elems[offset    ] = (byte) (x >> 56);
+        elems[offset + 1] = (byte) (x >> 48);
+        elems[offset + 2] = (byte) (x >> 40);
+        elems[offset + 3] = (byte) (x >> 32);
+        elems[offset + 4] = (byte) (x >> 24);
+        elems[offset + 5] = (byte) (x >> 16);
+        elems[offset + 6] = (byte) (x >> 8);
+        elems[offset + 7] = (byte)  x;
+        offset += 8;
     }
 
     @Override
@@ -153,13 +171,18 @@ public final class BufWriterImpl implements BufWriter {
 
     @Override
     public void reserveSpace(int freeBytes) {
-        if (offset + freeBytes > elems.length) {
-            int newsize = elems.length * 2;
-            while (offset + freeBytes > newsize) {
-                newsize *= 2;
-            }
-            elems = Arrays.copyOf(elems, newsize);
+        int minCapacity = offset + freeBytes;
+        if (minCapacity > elems.length) {
+            grow(minCapacity);
         }
+    }
+
+    private void grow(int minCapacity) {
+        int newsize = elems.length * 2;
+        while (minCapacity > newsize) {
+            newsize *= 2;
+        }
+        elems = Arrays.copyOf(elems, newsize);
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufWriterImpl.java
@@ -98,19 +98,23 @@ public final class BufWriterImpl implements BufWriter {
     @Override
     public void writeU2(int x) {
         reserveSpace(2);
+        byte[] elems = this.elems;
+        int offset = this.offset;
         elems[offset    ] = (byte) (x >> 8);
         elems[offset + 1] = (byte) x;
-        offset += 2;
+        this.offset = offset + 2;
     }
 
     @Override
     public void writeInt(int x) {
         reserveSpace(4);
+        byte[] elems = this.elems;
+        int offset = this.offset;
         elems[offset    ] = (byte) (x >> 24);
         elems[offset + 1] = (byte) (x >> 16);
         elems[offset + 2] = (byte) (x >> 8);
         elems[offset + 3] = (byte)  x;
-        offset += 4;
+        this.offset = offset + 4;
     }
 
     @Override
@@ -121,6 +125,8 @@ public final class BufWriterImpl implements BufWriter {
     @Override
     public void writeLong(long x) {
         reserveSpace(8);
+        byte[] elems = this.elems;
+        int offset = this.offset;
         elems[offset    ] = (byte) (x >> 56);
         elems[offset + 1] = (byte) (x >> 48);
         elems[offset + 2] = (byte) (x >> 40);
@@ -129,7 +135,7 @@ public final class BufWriterImpl implements BufWriter {
         elems[offset + 5] = (byte) (x >> 16);
         elems[offset + 6] = (byte) (x >> 8);
         elems[offset + 7] = (byte)  x;
-        offset += 8;
+        this.offset = offset + 8;
     }
 
     @Override


### PR DESCRIPTION
A small optimization makes BufWriterImpl's writeU1/U2/Int/Long methods more C2-friendly and improves performance.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339196](https://bugs.openjdk.org/browse/JDK-8339196): Optimize BufWriterImpl#writeU1/U2/Int/Long (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20748/head:pull/20748` \
`$ git checkout pull/20748`

Update a local copy of the PR: \
`$ git checkout pull/20748` \
`$ git pull https://git.openjdk.org/jdk.git pull/20748/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20748`

View PR using the GUI difftool: \
`$ git pr show -t 20748`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20748.diff">https://git.openjdk.org/jdk/pull/20748.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20748#issuecomment-2316156730)