### PR TITLE
8339167: Remove AbstractPoolEntry.PrimitiveEntry to reduce boxing overheads

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -1030,39 +1030,18 @@ public abstract sealed class AbstractPoolEntry {
 
     }
 
-    abstract static sealed class PrimitiveEntry<T extends ConstantDesc>
-            extends AbstractPoolEntry {
-        protected final T val;
+    public static final class IntegerEntryImpl extends AbstractPoolEntry implements IntegerEntry {
 
-        public PrimitiveEntry(ConstantPool constantPool, int tag, int index, T val) {
-            super(constantPool, tag, index, hash1(tag, val.hashCode()));
-            this.val = val;
-        }
-
-        public T value() {
-            return val;
-        }
-
-        public ConstantDesc constantValue() {
-            return value();
-        }
-
-        @Override
-        public String toString() {
-            return "" + tag() + value();
-        }
-    }
-
-    public static final class IntegerEntryImpl extends PrimitiveEntry<Integer>
-            implements IntegerEntry {
+        private final int val;
 
         IntegerEntryImpl(ConstantPool cpm, int index, int i) {
-            super(cpm, ClassFile.TAG_INTEGER, index, i);
+            super(cpm, ClassFile.TAG_INTEGER, index, hash1(ClassFile.TAG_INTEGER, Integer.hashCode(i)));
+            val = i;
         }
 
         @Override
         void writeTo(BufWriterImpl pool) {
-            pool.writeU1(tag);
+            pool.writeU1(ClassFile.TAG_INTEGER);
             pool.writeInt(val);
         }
 
@@ -1073,7 +1052,12 @@ public abstract sealed class AbstractPoolEntry {
 
         @Override
         public int intValue() {
-            return value();
+            return val;
+        }
+
+        @Override
+        public ConstantDesc constantValue() {
+            return val;
         }
 
         @Override
@@ -1086,11 +1070,14 @@ public abstract sealed class AbstractPoolEntry {
         }
     }
 
-    public static final class FloatEntryImpl extends PrimitiveEntry<Float>
+    public static final class FloatEntryImpl extends AbstractPoolEntry
             implements FloatEntry {
 
+        private final float val;
+
         FloatEntryImpl(ConstantPool cpm, int index, float f) {
-            super(cpm, ClassFile.TAG_FLOAT, index, f);
+            super(cpm, ClassFile.TAG_FLOAT, index, Float.hashCode(f));
+            val = f;
         }
 
         @Override
@@ -1106,7 +1093,12 @@ public abstract sealed class AbstractPoolEntry {
 
         @Override
         public float floatValue() {
-            return value();
+            return val;
+        }
+
+        @Override
+        public ConstantDesc constantValue() {
+            return val;
         }
 
         @Override
@@ -1119,10 +1111,13 @@ public abstract sealed class AbstractPoolEntry {
         }
     }
 
-    public static final class LongEntryImpl extends PrimitiveEntry<Long> implements LongEntry {
+    public static final class LongEntryImpl extends AbstractPoolEntry implements LongEntry {
+
+        private final long val;
 
         LongEntryImpl(ConstantPool cpm, int index, long l) {
-            super(cpm, ClassFile.TAG_LONG, index, l);
+            super(cpm, ClassFile.TAG_LONG, index, hash1(ClassFile.TAG_LONG, Long.hashCode(l)));
+            val = l;
         }
 
         @Override
@@ -1138,7 +1133,12 @@ public abstract sealed class AbstractPoolEntry {
 
         @Override
         public long longValue() {
-            return value();
+            return val;
+        }
+
+        @Override
+        public ConstantDesc constantValue() {
+            return val;
         }
 
         @Override
@@ -1151,10 +1151,13 @@ public abstract sealed class AbstractPoolEntry {
         }
     }
 
-    public static final class DoubleEntryImpl extends PrimitiveEntry<Double> implements DoubleEntry {
+    public static final class DoubleEntryImpl extends AbstractPoolEntry implements DoubleEntry {
+
+        private final double val;
 
         DoubleEntryImpl(ConstantPool cpm, int index, double d) {
-            super(cpm, ClassFile.TAG_DOUBLE, index, d);
+            super(cpm, ClassFile.TAG_DOUBLE, index, hash1(ClassFile.TAG_DOUBLE, Double.hashCode(d)));
+            val = d;
         }
 
         @Override
@@ -1170,7 +1173,12 @@ public abstract sealed class AbstractPoolEntry {
 
         @Override
         public double doubleValue() {
-            return value();
+            return val;
+        }
+
+        @Override
+        public ConstantDesc constantValue() {
+            return val;
         }
 
         @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -266,19 +266,70 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
         return bsm;
     }
 
-    private <T extends ConstantDesc> PoolEntry findPrimitiveEntry(int tag, T val) {
-        int hash = AbstractPoolEntry.hash1(tag, val.hashCode());
+    private IntegerEntry findIntEntry(int val) {
+        int hash = AbstractPoolEntry.hash1(TAG_INTEGER, Integer.hashCode(val));
         EntryMap<PoolEntry> map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
             PoolEntry e = map.getElementByToken(token);
-            if (e.tag() == tag
-                && e instanceof AbstractPoolEntry.PrimitiveEntry<?> ce
-                && ce.value().equals(val))
-                return e;
+            if (e.tag() == TAG_INTEGER
+                    && e instanceof AbstractPoolEntry.IntegerEntryImpl ce
+                    && ce.intValue() == val)
+                return ce;
         }
         if (!doneFullScan) {
             fullScan();
-            return findPrimitiveEntry(tag, val);
+            return findIntEntry(val);
+        }
+        return null;
+    }
+
+    private LongEntry findLongEntry(long val) {
+        int hash = AbstractPoolEntry.hash1(TAG_LONG, Long.hashCode(val));
+        EntryMap<PoolEntry> map = map();
+        for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
+            PoolEntry e = map.getElementByToken(token);
+            if (e.tag() == TAG_LONG
+                    && e instanceof AbstractPoolEntry.LongEntryImpl ce
+                    && ce.longValue() == val)
+                return ce;
+        }
+        if (!doneFullScan) {
+            fullScan();
+            return findLongEntry(val);
+        }
+        return null;
+    }
+
+    private FloatEntry findFloatEntry(float val) {
+        int hash = AbstractPoolEntry.hash1(TAG_FLOAT, Float.hashCode(val));
+        EntryMap<PoolEntry> map = map();
+        for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
+            PoolEntry e = map.getElementByToken(token);
+            if (e.tag() == TAG_FLOAT
+                    && e instanceof AbstractPoolEntry.FloatEntryImpl ce
+                    && ce.floatValue() == val)
+                return ce;
+        }
+        if (!doneFullScan) {
+            fullScan();
+            return findFloatEntry(val);
+        }
+        return null;
+    }
+
+    private DoubleEntry findDoubleEntry(double val) {
+        int hash = AbstractPoolEntry.hash1(TAG_DOUBLE, Double.hashCode(val));
+        EntryMap<PoolEntry> map = map();
+        for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
+            PoolEntry e = map.getElementByToken(token);
+            if (e.tag() == TAG_DOUBLE
+                    && e instanceof AbstractPoolEntry.DoubleEntryImpl ce
+                    && ce.doubleValue() == val)
+                return ce;
+        }
+        if (!doneFullScan) {
+            fullScan();
+            return findDoubleEntry(val);
         }
         return null;
     }
@@ -542,25 +593,25 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
     @Override
     public IntegerEntry intEntry(int value) {
-        var e = (IntegerEntry) findPrimitiveEntry(TAG_INTEGER, value);
+        var e = findIntEntry(value);
         return e == null ? internalAdd(new AbstractPoolEntry.IntegerEntryImpl(this, size, value)) : e;
     }
 
     @Override
     public FloatEntry floatEntry(float value) {
-        var e = (FloatEntry) findPrimitiveEntry(TAG_FLOAT, value);
+        var e = findFloatEntry(value);
         return e == null ? internalAdd(new AbstractPoolEntry.FloatEntryImpl(this, size, value)) : e;
     }
 
     @Override
     public LongEntry longEntry(long value) {
-        var e = (LongEntry) findPrimitiveEntry(TAG_LONG, value);
+        var e = findLongEntry(value);
         return e == null ? internalAdd(new AbstractPoolEntry.LongEntryImpl(this, size, value)) : e;
     }
 
     @Override
     public DoubleEntry doubleEntry(double value) {
-        var e = (DoubleEntry) findPrimitiveEntry(TAG_DOUBLE, value);
+        var e = findDoubleEntry(value);
         return e == null ? internalAdd(new AbstractPoolEntry.DoubleEntryImpl(this, size, value)) : e;
     }
 


### PR DESCRIPTION
Removing PrimitiveEntry reduces boxing/unboxing and removes a class. 