### PR TITLE
8338404: Cross-compilation to different endianness fails after JDK-8318913

### DIFF
--- a/make/CreateJmods.gmk
+++ b/make/CreateJmods.gmk
@@ -230,11 +230,17 @@ ifeq ($(INTERIM_JMOD), true)
   # to compress them at all.
   JMOD_FLAGS += --compress zip-0
 
+  JMOD_TARGET_OS := $(OPENJDK_BUILD_OS)
+  ifeq ($(JMOD_TARGET_OS), macosx)
+    JMOD_TARGET_OS := macos
+  endif
+
   JMOD_TARGET_CPU := $(OPENJDK_BUILD_CPU)
   ifeq ($(JMOD_TARGET_CPU), x86_64)
     JMOD_TARGET_CPU := amd64
   endif
-  JMOD_TARGET_PLATFORM := $(OPENJDK_BUILD_OS)-$(JMOD_TARGET_CPU)
+
+  JMOD_TARGET_PLATFORM := $(JMOD_TARGET_OS)-$(JMOD_TARGET_CPU)
 else
   JMOD_FLAGS += --compress $(JMOD_COMPRESS)
   JMOD_TARGET_PLATFORM := $(OPENJDK_MODULE_TARGET_PLATFORM)

--- a/make/CreateJmods.gmk
+++ b/make/CreateJmods.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -229,8 +229,15 @@ ifeq ($(INTERIM_JMOD), true)
   # Interim JMODs are not shipped anywhere, so there is no reason
   # to compress them at all.
   JMOD_FLAGS += --compress zip-0
+
+  JMOD_TARGET_CPU := $(OPENJDK_BUILD_CPU)
+  ifeq ($(JMOD_TARGET_CPU), x86_64)
+    JMOD_TARGET_CPU := amd64
+  endif
+  JMOD_TARGET_PLATFORM := $(OPENJDK_BUILD_OS)-$(JMOD_TARGET_CPU)
 else
   JMOD_FLAGS += --compress $(JMOD_COMPRESS)
+  JMOD_TARGET_PLATFORM := $(OPENJDK_MODULE_TARGET_PLATFORM)
 endif
 
 # Create jmods in the support dir and then move them into place to keep the
@@ -242,7 +249,7 @@ $(eval $(call SetupExecute, create_$(JMOD_FILE), \
     SUPPORT_DIR := $(JMODS_SUPPORT_DIR), \
     PRE_COMMAND := $(RM) $(JMODS_DIR)/$(JMOD_FILE) $(JMODS_SUPPORT_DIR)/$(JMOD_FILE), \
     COMMAND := $(JMOD) $(JMOD_SMALL_FLAGS) create --module-version $(VERSION_SHORT) \
-        --target-platform '$(OPENJDK_MODULE_TARGET_PLATFORM)' \
+        --target-platform '$(JMOD_TARGET_PLATFORM)' \
         --module-path $(JMODS_DIR) $(JMOD_FLAGS) \
         --date $(SOURCE_DATE_ISO_8601) \
         $(JMODS_SUPPORT_DIR)/$(JMOD_FILE), \

--- a/make/InterimImage.gmk
+++ b/make/InterimImage.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -46,10 +46,12 @@ $(INTERIM_IMAGE_DIR)/$(JIMAGE_TARGET_FILE): $(JMODS) \
     $(call DependOnVariable, INTERIM_MODULES_LIST)
 	$(call LogWarn, Creating interim jimage)
 	$(RM) -r $(INTERIM_IMAGE_DIR)
-	$(JLINK_TOOL) \
+	$(call MakeDir, $(INTERIM_IMAGE_DIR))
+	$(call ExecuteWithLog, $(INTERIM_IMAGE_DIR)/jlink, \
+	    $(JLINK_TOOL) \
 	    --output $(INTERIM_IMAGE_DIR) \
 	    --disable-plugin generate-jli-classes \
-	    --add-modules $(INTERIM_MODULES_LIST)
+	    --add-modules $(INTERIM_MODULES_LIST))
 	$(TOUCH) $@
 
 TARGETS += $(INTERIM_IMAGE_DIR)/$(JIMAGE_TARGET_FILE)


### PR DESCRIPTION
From the bug report:

After JDK-8318913, trying to cross-compile to a different endian target than the build host is using, will cause the interim image generation to fail:

```
[buildjdk] Creating interim jimage
Error: specified --endian LITTLE_ENDIAN does not match endianness of target platform linux-s390
java.io.IOException: specified --endian LITTLE_ENDIAN does not match endianness of target platform linux-s390
        at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.createImageProvider(JlinkTask.java:574)
        at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.createImage(JlinkTask.java:410)
        at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.run(JlinkTask.java:285)
        at jdk.jlink/jdk.tools.jlink.internal.Main.run(Main.java:56)
        at jdk.jlink/jdk.tools.jlink.internal.Main.main(Main.java:34)
InterimImage.gmk:47: recipe for target '/localhome/git/jdk-BAR/build/linux-s390x/support/interim-image/bin/java' failed
```

This has only been spotted when cross-compiling from x64 to s390x, but it seems to be a general endianness problem.

---

In fact, it was technically a problem with how we generate all interim images, but apparently the platform mistake did not affect jlink apart from when cross-compiling and the endianness was off.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338404](https://bugs.openjdk.org/browse/JDK-8338404): Cross-compilation to different endianness fails after JDK-8318913 (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20750/head:pull/20750` \
`$ git checkout pull/20750`

Update a local copy of the PR: \
`$ git checkout pull/20750` \
`$ git pull https://git.openjdk.org/jdk.git pull/20750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20750`

View PR using the GUI difftool: \
`$ git pr show -t 20750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20750.diff">https://git.openjdk.org/jdk/pull/20750.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20750#issuecomment-2318039237)