### PR TITLE
8339175: ProblemList runtime/interpreter/LastJsrTest.java on all platforms with Xcomp

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -51,3 +51,5 @@ vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 829
 vmTestbase/nsk/stress/thread/thread006.java 8321476 linux-all
 
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
+
+runtime/interpreter/LastJsrTest.java 8338924 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -119,7 +119,6 @@ runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/Thread/TestAlwaysPreTouchStacks.java 8335167 macosx-aarch64
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
-runtime/interpreter/LastJsrTest.java 8338924 linux-all
 
 
 applications/jcstress/copy.java 8229852 linux-all


### PR DESCRIPTION
A trivial fix to ProblemList runtime/interpreter/LastJsrTest.java on all platforms with Xcomp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339175](https://bugs.openjdk.org/browse/JDK-8339175): ProblemList runtime/interpreter/LastJsrTest.java on all platforms with Xcomp (**Sub-task** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20751/head:pull/20751` \
`$ git checkout pull/20751`

Update a local copy of the PR: \
`$ git checkout pull/20751` \
`$ git pull https://git.openjdk.org/jdk.git pull/20751/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20751`

View PR using the GUI difftool: \
`$ git pr show -t 20751`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20751.diff">https://git.openjdk.org/jdk/pull/20751.diff</a>

</details>
