### PR TITLE
8339020: Remove unused HeapShared::calculate_oopmap

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -1644,30 +1644,6 @@ class FindEmbeddedNonNullPointers: public BasicOopIterateClosure {
 };
 #endif
 
-#ifndef PRODUCT
-ResourceBitMap HeapShared::calculate_oopmap(MemRegion region) {
-  size_t num_bits = region.byte_size() / (UseCompressedOops ? sizeof(narrowOop) : sizeof(oop));
-  ResourceBitMap oopmap(num_bits);
-
-  HeapWord* p   = region.start();
-  HeapWord* end = region.end();
-  FindEmbeddedNonNullPointers finder((void*)p, &oopmap);
-
-  int num_objs = 0;
-  while (p < end) {
-    oop o = cast_to_oop(p);
-    o->oop_iterate(&finder);
-    p += o->size();
-    ++ num_objs;
-  }
-
-  log_info(cds, heap)("calculate_oopmap: objects = %6d, oop fields = %7d (nulls = %7d)",
-                      num_objs, finder.num_total_oops(), finder.num_null_oops());
-  return oopmap;
-}
-
-#endif // !PRODUCT
-
 void HeapShared::count_allocation(size_t size) {
   _total_obj_count ++;
   _total_obj_size += size;

--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -371,9 +371,6 @@ private:
                                              KlassSubGraphInfo* subgraph_info,
                                              oop orig_obj);
 
-#ifndef PRODUCT
-  static ResourceBitMap calculate_oopmap(MemRegion region); // marks all the oop pointers
-#endif
   static void add_to_dumped_interned_strings(oop string);
 
   // Scratch objects for archiving Klass::java_mirror()


### PR DESCRIPTION
After JDK-8251330, `HeapShared::calculate_oopmap` is totally unused so this patch removes the method. Verified with tier1-4 tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339020](https://bugs.openjdk.org/browse/JDK-8339020): Remove unused HeapShared::calculate_oopmap (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20753/head:pull/20753` \
`$ git checkout pull/20753`

Update a local copy of the PR: \
`$ git checkout pull/20753` \
`$ git pull https://git.openjdk.org/jdk.git pull/20753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20753`

View PR using the GUI difftool: \
`$ git pr show -t 20753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20753.diff">https://git.openjdk.org/jdk/pull/20753.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20753#issuecomment-2317821836)