### PR TITLE
8338708: Don't create/destroy debug agent cmdQueueLock for each connection

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/debugLoop.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,9 @@ debugLoop_run(void)
     /* Initialize all statics */
     /* We may be starting a new connection after an error */
     cmdQueue = NULL;
-    cmdQueueLock = debugMonitorCreate("JDWP Command Queue Lock");
+    if (cmdQueueLock == NULL) {
+      cmdQueueLock = debugMonitorCreate("JDWP Command Queue Lock");
+    }
     transportError = JNI_FALSE;
 
     shouldListen = JNI_TRUE;
@@ -190,7 +192,6 @@ debugLoop_run(void)
      * be trying to send.
      */
     transport_close();
-    debugMonitorDestroy(cmdQueueLock);
 
     /* Reset for a new connection to this VM if it's still alive */
     if ( ! gdata->vmDead ) {

--- a/test/jdk/com/sun/jdi/ReattachStressTest.java
+++ b/test/jdk/com/sun/jdi/ReattachStressTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+
+import jdk.test.lib.process.ProcessTools;
+
+import com.sun.jdi.Bootstrap;
+import com.sun.jdi.VirtualMachine;
+import com.sun.jdi.connect.AttachingConnector;
+import com.sun.jdi.connect.Connector;
+import com.sun.jdi.connect.IllegalConnectorArgumentsException;
+
+/**
+ * @test
+ * @bug 8338708
+ * @summary Stress test for reattaching to a debuggee
+ * @library /test/lib
+ * @modules jdk.jdi
+ * @run driver ProcessAttachTest
+ */
+
+class ReattachStressTestTarg {
+    public static void main(String args[]) throws Exception {
+        System.out.println("Debuggee started");
+        while (true) {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+            }
+        }
+    }
+}
+
+public class ReattachStressTest {
+    public static void main(String[] args) throws Exception {
+        System.out.println("Test 1: Debuggee start with suspend=n");
+        runTest("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n");
+
+        System.out.println("Test 2: Debuggee start with suspend=y");
+        runTest("-agentlib:jdwp=transport=dt_socket,server=y,suspend=y");
+    }
+
+    private static void runTest(String jdwpArg) throws Exception {
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder(
+                jdwpArg,
+                "ReattachStressTestTarg");
+        Process p = null;
+        try {
+            p = pb.start();
+
+            // Read the first character of output to make sure we've waited until the
+            // debuggee is ready. This will be the debug agent's "Listening..." message.
+            InputStream is = p.getInputStream();
+            is.read();
+
+            // Attach a debugger
+            tryDebug(p.pid(), is);
+        } finally {
+            p.destroyForcibly();
+        }
+    }
+
+    private static void tryDebug(long pid, InputStream is) throws IOException,
+            IllegalConnectorArgumentsException {
+        // Get the ProcessAttachingConnector, which can attach using the pid of the debuggee.
+        AttachingConnector ac = Bootstrap.virtualMachineManager().attachingConnectors()
+                .stream()
+                .filter(c -> c.name().equals("com.sun.jdi.ProcessAttach"))
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("Unable to locate ProcessAttachingConnector"));
+
+        // Set the connector's "pid" argument to the pid of the debuggee.
+        Map<String, Connector.Argument> args = ac.defaultArguments();
+        Connector.StringArgument arg = (Connector.StringArgument) args.get("pid");
+        arg.setValue("" + pid);
+
+        // Loop that will repeatedly attach and detach from the same debuggee.
+        for (int i = 0; i < 500; i++) {
+            System.out.println(i + ": Debugger is attaching to: " + pid + " ...");
+
+            // Attach to the debuggee.
+            VirtualMachine vm = ac.attach(args);
+
+            // Drain remaining "Listening..." output.  Otherwise too much
+            // output will buffer up and the debuggee may block until it is cleared.
+            while (is.available() > 0) {
+                is.read();
+            }
+            
+            // We've attached. Do some things that will send JDWP commands.
+            System.out.println("Attached!");
+            System.out.println("JVM name: " + vm.name());
+            System.out.println("Num threads: " + vm.allThreads().size());
+            
+            // We're all done with this debugger connection.
+            vm.dispose();
+
+            // Wait for first char of next "Listening..." output.
+            is.read();
+        }
+        System.out.println("Debugger done.");
+    }
+}

--- a/test/jdk/com/sun/jdi/ReattachStressTest.java
+++ b/test/jdk/com/sun/jdi/ReattachStressTest.java
@@ -94,7 +94,7 @@ public class ReattachStressTest {
 
         // Set the connector's "pid" argument to the pid of the debuggee.
         Map<String, Connector.Argument> args = ac.defaultArguments();
-        Connector.StringArgument arg = (Connector.StringArgument) args.get("pid");
+        Connector.StringArgument arg = (Connector.StringArgument)args.get("pid");
         arg.setValue("" + pid);
 
         // Loop that will repeatedly attach and detach from the same debuggee.

--- a/test/jdk/com/sun/jdi/ReattachStressTest.java
+++ b/test/jdk/com/sun/jdi/ReattachStressTest.java
@@ -109,12 +109,12 @@ public class ReattachStressTest {
             while (is.available() > 0) {
                 is.read();
             }
-            
+
             // We've attached. Do some things that will send JDWP commands.
             System.out.println("Attached!");
             System.out.println("JVM name: " + vm.name());
             System.out.println("Num threads: " + vm.allThreads().size());
-            
+
             // We're all done with this debugger connection.
             vm.dispose();
 


### PR DESCRIPTION
Only allocate the cmdQueueLock once rather than allocate each time there is a new connection (and destroy when the connection is terminated).

Currently each time there is a new debug agent connection established, the cmdQueueLock is allocated. It is then destroyed when the connection is dropped, only to be recreated on the next connection. I looked closely at the use of this lock, and what happens when the connection is dropped, and I can't see any reason to create and then dispose of cmdQueueLock for each connection. Of the 18 debug agent raw monitors, this is the only one that gets destroyed and recreated. The other 17 stick around for the next connection. I'd like to get rid of this reallocation in order to support static initialization of all the debug agent raw monitors on startup. This will be done as part of the ranked monitor support ([JDK-8328866](https://bugs.openjdk.org/browse/JDK-8328866)).

As part of the testing for this change, I put an assert in place when we try to create cmdQueueLock for the 2nd time. I ran all our debugger tests, and unfortunately none of them failed. This means we don't currently test attaching to the debug agent more than once in any of our tests, so I did two things to better test out this change. The first was to write a test that attaches numerous times in sequence, and the 2nd was to manually attach and reattach using jdb. At the same time I stepped through the debug agent code in gdb just to help better understand the setup and use of cmdQueueLock. I didn't see anything that gave me concern about making this change.

Tested by running all jdi, jdwp, and jdb tests on all supported platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338708](https://bugs.openjdk.org/browse/JDK-8338708): Don't create/destroy debug agent cmdQueueLock for each connection (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) Review applies to [0ac33045](https://git.openjdk.org/jdk/pull/20755/files/0ac330450b845cf8a50745dfb0f6371bf9c09358)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20755/head:pull/20755` \
`$ git checkout pull/20755`

Update a local copy of the PR: \
`$ git checkout pull/20755` \
`$ git pull https://git.openjdk.org/jdk.git pull/20755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20755`

View PR using the GUI difftool: \
`$ git pr show -t 20755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20755.diff">https://git.openjdk.org/jdk/pull/20755.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20755#issuecomment-2316314876)