### PR TITLE
8339241: Optimize LambdaForm#basicType(Class)

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -196,7 +196,16 @@ class LambdaForm {
             };
         }
         static BasicType basicType(Class<?> type) {
-            return basicType(Wrapper.basicTypeChar(type));
+            if (type == int.class
+             || type == short.class
+             || type == byte.class
+             || type == char.class
+             || type == boolean.class) return I_TYPE;
+            if (type == long.class   ) return J_TYPE;
+            if (type == float.class  ) return F_TYPE;
+            if (type == double.class ) return D_TYPE;
+            if (type == void.class   ) return V_TYPE;
+            else                       return L_TYPE;
         }
         static int[] basicTypeOrds(BasicType[] types) {
             if (types == null) {

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -196,16 +196,12 @@ class LambdaForm {
             };
         }
         static BasicType basicType(Class<?> type) {
-            if (type == int.class
-             || type == short.class
-             || type == byte.class
-             || type == char.class
-             || type == boolean.class) return I_TYPE;
-            if (type == long.class   ) return J_TYPE;
-            if (type == float.class  ) return F_TYPE;
-            if (type == double.class ) return D_TYPE;
-            if (type == void.class   ) return V_TYPE;
-            else                       return L_TYPE;
+            if (!type.isPrimitive() ) return L_TYPE;
+            if (type == long.class  ) return J_TYPE;
+            if (type == float.class ) return F_TYPE;
+            if (type == double.class) return D_TYPE;
+            if (type == void.class  ) return V_TYPE;
+            else                      return I_TYPE; // int, short, byte, char, boolean
         }
         static int[] basicTypeOrds(BasicType[] types) {
             if (types == null) {

--- a/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
+++ b/src/java.base/share/classes/java/lang/invoke/LambdaForm.java
@@ -196,12 +196,16 @@ class LambdaForm {
             };
         }
         static BasicType basicType(Class<?> type) {
-            if (!type.isPrimitive() ) return L_TYPE;
-            if (type == long.class  ) return J_TYPE;
-            if (type == float.class ) return F_TYPE;
-            if (type == double.class) return D_TYPE;
-            if (type == void.class  ) return V_TYPE;
-            else                      return I_TYPE; // int, short, byte, char, boolean
+            if (type == int.class
+             || type == short.class
+             || type == byte.class
+             || type == char.class
+             || type == boolean.class) return I_TYPE;
+            if (type == long.class   ) return J_TYPE;
+            if (type == float.class  ) return F_TYPE;
+            if (type == double.class ) return D_TYPE;
+            if (type == void.class   ) return V_TYPE;
+            else                       return L_TYPE;
         }
         static int[] basicTypeOrds(BasicType[] types) {
             if (types == null) {


### PR DESCRIPTION
A small optimization to simplify the implementation logic of LambdaForm$BasicType#basicType method can reduce the call stack and reduce the overall bytecode size.

Below is the compiler log

* baseline
```
 @ 1   java.lang.invoke.LambdaForm$BasicType::basicType (8 bytes)   inline
   @ 1   sun.invoke.util.Wrapper::basicTypeChar (18 bytes)   inline
     @ 1   java.lang.Class::isPrimitive (0 bytes)   intrinsic
     @ 11   sun.invoke.util.Wrapper::forPrimitiveType (122 bytes)   failed to inline: callee is too large
     @ 14   sun.invoke.util.Wrapper::basicTypeChar (5 bytes)   inline
```

* current
```
java.lang.invoke.LambdaForm$BasicType::basicType (87 bytes)   failed to inline: callee is too large
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339241](https://bugs.openjdk.org/browse/JDK-8339241): Optimize LambdaForm#basicType(Class) (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20759/head:pull/20759` \
`$ git checkout pull/20759`

Update a local copy of the PR: \
`$ git checkout pull/20759` \
`$ git pull https://git.openjdk.org/jdk.git pull/20759/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20759`

View PR using the GUI difftool: \
`$ git pr show -t 20759`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20759.diff">https://git.openjdk.org/jdk/pull/20759.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20759#issuecomment-2317437281)