### PR TITLE
8326027: [TEST_BUG]Comparing buffered images  of white background frame fails in Mac

### DIFF
--- a/test/jdk/javax/swing/JFrame/JFrameBackgroundRefreshTest.java
+++ b/test/jdk/javax/swing/JFrame/JFrameBackgroundRefreshTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import javax.swing.SwingUtilities;
  * @key headful
  * @bug 8187759
  * @summary Test to check if JFrame background is refreshed in Linux.
- * @requires (os.family == "linux")
+ * @requires (os.family == "linux" | os.family == "mac")
  * @run main JFrameBackgroundRefreshTest
  */
 
@@ -59,6 +59,7 @@ public class JFrameBackgroundRefreshTest {
     private static Point frameLocation;
     private static int frameCenterX, frameCenterY, awayX, awayY;
     private static int imageCenterX, imageCenterY;
+    private static final int TOLERANCE = 10;
 
     public static void main(String[] args) throws Exception {
         try {
@@ -136,15 +137,21 @@ public class JFrameBackgroundRefreshTest {
     }
 
     private static boolean compareImages(BufferedImage bufferedImage) {
-        int sampleRGB = bufferedImage.getRGB(0,0);
+        Color firstPixel = new Color(bufferedImage.getRGB(0,0));
         for (int x = 0; x < bufferedImage.getWidth(); x++) {
             for (int y = 0; y < bufferedImage.getHeight(); y++) {
-                if (bufferedImage.getRGB(x, y) != sampleRGB) {
+                if (!compareColor(firstPixel, new Color(bufferedImage.getRGB(x, y)))) {
                     return false;
                 }
             }
         }
         return true;
+    }
+
+    private static boolean compareColor(Color c1, Color c2) {
+        return Math.abs(c1.getRed() - c2.getRed()) < TOLERANCE &&
+                Math.abs(c1.getGreen() - c2.getGreen()) < TOLERANCE &&
+                Math.abs(c1.getBlue() - c2.getBlue()) < TOLERANCE;
     }
 
     public static void initialize() throws Exception {


### PR DESCRIPTION
On analysis of captured image, it is observed that there are few pixels which vary slightly w.r.t to expected color. Hence tolerance is included in color comparison. 
Tested in mach5 multiple time and its green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8326027](https://bugs.openjdk.org/browse/JDK-8326027)

### Issue
 * [JDK-8326027](https://bugs.openjdk.org/browse/JDK-8326027): [TEST_BUG] Comparing screenshots of frame with white background fails in Mac (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20760/head:pull/20760` \
`$ git checkout pull/20760`

Update a local copy of the PR: \
`$ git checkout pull/20760` \
`$ git pull https://git.openjdk.org/jdk.git pull/20760/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20760`

View PR using the GUI difftool: \
`$ git pr show -t 20760`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20760.diff">https://git.openjdk.org/jdk/pull/20760.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20760#issuecomment-2316704867)
</details>
