### PR TITLE
8339237: RISC-V: Builds fail after JDK-8339120

### DIFF
--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -223,8 +223,6 @@ StubFrame::~StubFrame() {
 
 #define __ sasm->
 
-const int float_regs_as_doubles_size_in_slots = pd_nof_fpu_regs_frame_map * 2;
-
 // Stack layout for saving/restoring  all the registers needed during a runtime
 // call (this includes deoptimization)
 // Note: note that users of this frame may well have arguments to some runtime


### PR DESCRIPTION
Encountered this build warning/error when doing a native build on linux-riscv64 platform with GCC-13. We can simply remove float_regs_as_doubles_size_in_slots in file c1_Runtime1_riscv.cpp as it is not used anywhere.

### Testing
- [x] release & fastdebug build OK on linux-riscv64 after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339237](https://bugs.openjdk.org/browse/JDK-8339237): RISC-V: Builds fail after JDK-8339120 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20765/head:pull/20765` \
`$ git checkout pull/20765`

Update a local copy of the PR: \
`$ git checkout pull/20765` \
`$ git pull https://git.openjdk.org/jdk.git pull/20765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20765`

View PR using the GUI difftool: \
`$ git pr show -t 20765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20765.diff">https://git.openjdk.org/jdk/pull/20765.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20765#issuecomment-2317326924)