### PR TITLE
8339238: Update to use jtreg 7.5.1

### DIFF
--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: openjdk/jtreg
-        ref: jtreg-${{ steps.version.outputs.value }}
+        ref: master
         path: jtreg/src
       if: (steps.get-cached.outputs.cache-hit != 'true')
 

--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023, 2025, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: openjdk/jtreg
-        ref: master
+        ref: jtreg-${{ steps.version.outputs.value }}
         path: jtreg/src
       if: (steps.get-cached.outputs.cache-hit != 'true')
 

--- a/make/autoconf/lib-tests.m4
+++ b/make/autoconf/lib-tests.m4
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 ################################################################################
 
 # Minimum supported versions
-JTREG_MINIMUM_VERSION=7.4
+JTREG_MINIMUM_VERSION=7.5.1
 GTEST_MINIMUM_VERSION=1.14.0
 
 ################################################################################

--- a/make/conf/github-actions.conf
+++ b/make/conf/github-actions.conf
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 # Versions and download locations for dependencies used by GitHub Actions (GHA)
 
 GTEST_VERSION=1.14.0
-JTREG_VERSION=7.4+1
+JTREG_VERSION=7.5.1+1
 
 LINUX_X64_BOOT_JDK_EXT=tar.gz
 LINUX_X64_BOOT_JDK_URL=https://download.java.net/java/GA/jdk23/3c5b90190c68498b986a97f276efd28a/37/GPL/openjdk-23_linux-x64_bin.tar.gz

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1186,9 +1186,9 @@ var getJibProfilesDependencies = function (input, common) {
         jtreg: {
             server: "jpg",
             product: "jtreg",
-            version: "7.6",
-            build_number: "ci/7",
-            file: "bundles/jtreg-7.6+1.zip",
+            version: "7.5.1",
+            build_number: "1",
+            file: "bundles/jtreg-7.5.1+1.zip",
             environment_name: "JT_HOME",
             environment_path: input.get("jtreg", "home_path") + "/bin",
             configure_args: "--with-jtreg=" + input.get("jtreg", "home_path"),

--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1186,9 +1186,9 @@ var getJibProfilesDependencies = function (input, common) {
         jtreg: {
             server: "jpg",
             product: "jtreg",
-            version: "7.4",
-            build_number: "1",
-            file: "bundles/jtreg-7.4+1.zip",
+            version: "7.6",
+            build_number: "ci/7",
+            file: "bundles/jtreg-7.6+1.zip",
             environment_name: "JT_HOME",
             environment_path: input.get("jtreg", "home_path") + "/bin",
             configure_args: "--with-jtreg=" + input.get("jtreg", "home_path"),

--- a/test/docs/TEST.ROOT
+++ b/test/docs/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2024, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Use new module options
 useNewOptions=true

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -95,7 +95,7 @@ requires.properties= \
     jlink.packagedModules
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../../ notation to reach them

--- a/test/jaxp/TEST.ROOT
+++ b/test/jaxp/TEST.ROOT
@@ -23,7 +23,7 @@ modules=java.xml
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -114,7 +114,7 @@ requires.properties= \
     jlink.packagedModules
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them

--- a/test/langtools/TEST.ROOT
+++ b/test/langtools/TEST.ROOT
@@ -15,7 +15,7 @@ keys=intermittent randomness needs-src needs-src-jdk_javadoc
 groups=TEST.groups
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Use new module options
 useNewOptions=true

--- a/test/lib-test/TEST.ROOT
+++ b/test/lib-test/TEST.ROOT
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2020, 2025, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
 keys=randomness
 
 # Minimum jtreg version
-requiredVersion=7.4+1
+requiredVersion=7.5.1+1
 
 # Path to libraries in the topmost test directory. This is needed so @library
 # does not need ../../ notation to reach them


### PR DESCRIPTION
Please review the change to update to using jtreg 7.5.1.

The primary change is to the `jib-profiles.js` file, which specifies the version of jtreg to use, for those systems that rely on this file. In addition, the `requiredVersion` has been updated in the various `TEST.ROOT` files.

Tested with tier 1 — tier 8.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339238](https://bugs.openjdk.org/browse/JDK-8339238): Update to use jtreg 7.5.1 (**Enhancement** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20766/head:pull/20766` \
`$ git checkout pull/20766`

Update a local copy of the PR: \
`$ git checkout pull/20766` \
`$ git pull https://git.openjdk.org/jdk.git pull/20766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20766`

View PR using the GUI difftool: \
`$ git pr show -t 20766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20766.diff">https://git.openjdk.org/jdk/pull/20766.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20766#issuecomment-2651056594)
</details>
