### PR TITLE
8339148: Add os::active_physical_processor_count() API

### DIFF
--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -575,7 +575,7 @@ int CgroupSubsystem::active_processor_count() {
     return val;
   }
 
-  cpu_count = os::Linux::active_processor_count();
+  cpu_count = os::physical_active_processor_count();
   result = CgroupUtil::processor_count(contrl->controller(), cpu_count);
   // Update cached metric to avoid re-reading container settings too often
   cpu_limit->set_value(result, OSCONTAINER_CACHE_TIMEOUT);

--- a/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupSubsystem_linux.cpp
@@ -575,7 +575,7 @@ int CgroupSubsystem::active_processor_count() {
     return val;
   }
 
-  cpu_count = os::physical_active_processor_count();
+  cpu_count = os::active_physical_processor_count();
   result = CgroupUtil::processor_count(contrl->controller(), cpu_count);
   // Update cached metric to avoid re-reading container settings too often
   cpu_limit->set_value(result, OSCONTAINER_CACHE_TIMEOUT);

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -84,7 +84,7 @@ void OSContainer::init() {
     //  1.) On a physical Linux system without any limit
     //  2.) On a physical Linux system with a limit enforced by other means (like systemd slice)
     any_mem_cpu_limit_present = cgroup_subsystem->memory_limit_in_bytes() > 0 ||
-                                     os::Linux::active_processor_count() != cgroup_subsystem->active_processor_count();
+                                     os::physical_active_processor_count() != cgroup_subsystem->active_processor_count();
     if (any_mem_cpu_limit_present) {
       reason = " because either a cpu or a memory limit is present";
     } else {

--- a/src/hotspot/os/linux/osContainer_linux.cpp
+++ b/src/hotspot/os/linux/osContainer_linux.cpp
@@ -84,7 +84,7 @@ void OSContainer::init() {
     //  1.) On a physical Linux system without any limit
     //  2.) On a physical Linux system with a limit enforced by other means (like systemd slice)
     any_mem_cpu_limit_present = cgroup_subsystem->memory_limit_in_bytes() > 0 ||
-                                     os::physical_active_processor_count() != cgroup_subsystem->active_processor_count();
+                                     os::active_physical_processor_count() != cgroup_subsystem->active_processor_count();
     if (any_mem_cpu_limit_present) {
       reason = " because either a cpu or a memory limit is present";
     } else {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4829,7 +4829,9 @@ static int get_active_processor_count() {
   return cpu_count;
 }
 
-int os::Linux::active_processor_count() {
+// Return the active CPUs irrespective of the system being containerized
+// or not. Thus, this returns the host active cpus in a container.
+int os::pd_physical_active_processor_count() {
   return get_active_processor_count();
 }
 
@@ -4861,7 +4863,7 @@ int os::active_processor_count() {
     log_trace(os)("active_processor_count: determined by OSContainer: %d",
                    active_cpus);
   } else {
-    active_cpus = os::Linux::active_processor_count();
+    active_cpus = os::pd_physical_active_processor_count();
   }
 
   return active_cpus;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4831,7 +4831,7 @@ static int get_active_processor_count() {
 
 // Return the active CPUs irrespective of the system being containerized
 // or not. Thus, this returns the host active cpus in a container.
-int os::pd_physical_active_processor_count() {
+int os::pd_active_physical_processor_count() {
   return get_active_processor_count();
 }
 
@@ -4863,7 +4863,7 @@ int os::active_processor_count() {
     log_trace(os)("active_processor_count: determined by OSContainer: %d",
                    active_cpus);
   } else {
-    active_cpus = os::pd_physical_active_processor_count();
+    active_cpus = os::pd_active_physical_processor_count();
   }
 
   return active_cpus;

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -30,9 +30,7 @@
 // os::Linux defines the interface to Linux operating systems
 
 class os::Linux {
-  friend class CgroupSubsystem;
   friend class os;
-  friend class OSContainer;
 
   static int (*_pthread_getcpuclockid)(pthread_t, clockid_t *);
   static int (*_pthread_setname_np)(pthread_t, const char*);
@@ -58,7 +56,6 @@ class os::Linux {
   static julong available_memory();
   static julong free_memory();
 
-  static int active_processor_count();
 
   static void initialize_system_info();
 
@@ -256,6 +253,7 @@ class os::Linux {
   static void set_numa_interleave_bitmask(struct bitmask* ptr)     { _numa_interleave_bitmask = ptr ;   }
   static void set_numa_membind_bitmask(struct bitmask* ptr)        { _numa_membind_bitmask = ptr ;      }
   static int sched_getcpu_syscall(void);
+  static int active_processor_count();
 
   enum NumaAllocationPolicy{
     NotInitialized,

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -80,7 +80,6 @@
 
 #ifdef LINUX
 #include "osContainer_linux.hpp"
-#include "os_linux.hpp"
 #endif
 
 #ifndef _WINDOWS

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1860,9 +1860,9 @@ void os::initialize_initial_active_processor_count() {
   log_debug(os)("Initial active processor count set to %d" , _initial_active_processor_count);
 }
 
-int os::physical_active_processor_count() {
+int os::active_physical_processor_count() {
 #ifdef LINUX
-  return os::pd_physical_active_processor_count();
+  return os::pd_active_physical_processor_count();
 #else
   return os::active_processor_count();
 #endif

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -80,6 +80,7 @@
 
 #ifdef LINUX
 #include "osContainer_linux.hpp"
+#include "os_linux.hpp"
 #endif
 
 #ifndef _WINDOWS
@@ -1858,6 +1859,14 @@ void os::initialize_initial_active_processor_count() {
   assert(_initial_active_processor_count == 0, "Initial active processor count already set.");
   _initial_active_processor_count = active_processor_count();
   log_debug(os)("Initial active processor count set to %d" , _initial_active_processor_count);
+}
+
+int os::physical_active_processor_count() {
+#ifdef LINUX
+  return os::pd_physical_active_processor_count();
+#else
+  return os::active_processor_count();
+#endif
 }
 
 bool os::create_stack_guard_pages(char* addr, size_t bytes) {

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -254,7 +254,7 @@ class os: AllStatic {
   static void initialize_initial_active_processor_count();
 
   LINUX_ONLY(static void pd_init_container_support();)
-  LINUX_ONLY(static int pd_physical_active_processor_count();)
+  LINUX_ONLY(static int pd_active_physical_processor_count();)
 
  public:
   static void init(void);                      // Called before command line parsing
@@ -373,7 +373,7 @@ class os: AllStatic {
   // the same as active_processor_count() except on Linux where this
   // function also returns the physical CPUs instead of the containerized
   // value.
-  static int physical_active_processor_count();
+  static int active_physical_processor_count();
 
   // Give a name to the current thread.
   static void set_native_thread_name(const char *name);

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -254,6 +254,7 @@ class os: AllStatic {
   static void initialize_initial_active_processor_count();
 
   LINUX_ONLY(static void pd_init_container_support();)
+  LINUX_ONLY(static int pd_physical_active_processor_count();)
 
  public:
   static void init(void);                      // Called before command line parsing
@@ -367,6 +368,12 @@ class os: AllStatic {
     assert(_initial_active_processor_count > 0, "Initial active processor count not set yet.");
     return _initial_active_processor_count;
   }
+
+  // Returns the number of active CPUs of the physical system. It is
+  // the same as active_processor_count() except on Linux where this
+  // function also returns the physical CPUs instead of the containerized
+  // value.
+  static int physical_active_processor_count();
 
   // Give a name to the current thread.
   static void set_native_thread_name(const char *name);


### PR DESCRIPTION
Please review this rather trivial patch for adding `os::active_physical_processor_count()` function. It is useful to have that info on Linux for the container code which bounds the CPU limit above by that value. Also, the old `os::Linux::active_processor_count()` was protected and had a bit of a misleading name. As a bonus, we can get rid of some `friend class` smells.

**Testing**:
- [x] GHA
- [x] Container tests and cgroup gtests on linux x86_64

Thoughts?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8339148](https://bugs.openjdk.org/browse/JDK-8339148)

### Issue
 * [JDK-8339148](https://bugs.openjdk.org/browse/JDK-8339148): Make os::Linux::active_processor_count() public (**Enhancement** - P3) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20768/head:pull/20768` \
`$ git checkout pull/20768`

Update a local copy of the PR: \
`$ git checkout pull/20768` \
`$ git pull https://git.openjdk.org/jdk.git pull/20768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20768`

View PR using the GUI difftool: \
`$ git pr show -t 20768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20768.diff">https://git.openjdk.org/jdk/pull/20768.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20768#issuecomment-2318315683)