### PR TITLE
8339166: java/lang/String/concat/HiddenClassUnloading.java fails on AIX and Linux ppc64le after JDK-8336856

### DIFF
--- a/test/jdk/java/lang/String/concat/HiddenClassUnloading.java
+++ b/test/jdk/java/lang/String/concat/HiddenClassUnloading.java
@@ -43,7 +43,7 @@ public class HiddenClassUnloading {
 
         long initUnloadedClassCount = ManagementFactory.getClassLoadingMXBean().getUnloadedClassCount();
 
-        for (int i = 0; i < 2000; i++) {
+        for (int i = 0; i < 12000; i++) {
             int radix = types.length;
             String str = Integer.toString(i, radix);
             int length = str.length();


### PR DESCRIPTION
We see HiddenClassUnloading.java failing on the ppc64 based platforms. On AIX it seems to fail always; Linux ppc64le sometimes.
Failure output :
java.lang.RuntimeException: unloadedClassCount is zero
at HiddenClassUnloading.main(HiddenClassUnloading.java:66)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:573)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1575)

Ergonomics sets on these platforms the heap to 32M (even with the -Xmx8M -Xms8M settings), see the Xlog UL output

```
[0.045s][info ][gc,init ] Heap Min Capacity: 32M
[0.045s][info ][gc,init ] Heap Initial Capacity: 32M
[0.045s][info ][gc,init ] Heap Max Capacity: 32M
```

So we need more iterations in the test to trigger the class unloading.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339166](https://bugs.openjdk.org/browse/JDK-8339166): java/lang/String/concat/HiddenClassUnloading.java fails on AIX and Linux ppc64le after JDK-8336856 (**Bug** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20771/head:pull/20771` \
`$ git checkout pull/20771`

Update a local copy of the PR: \
`$ git checkout pull/20771` \
`$ git pull https://git.openjdk.org/jdk.git pull/20771/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20771`

View PR using the GUI difftool: \
`$ git pr show -t 20771`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20771.diff">https://git.openjdk.org/jdk/pull/20771.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20771#issuecomment-2317755520)