### PR TITLE
8339242: Fix overflow issues in AdlArena

### DIFF
--- a/src/hotspot/share/adlc/adlArena.cpp
+++ b/src/hotspot/share/adlc/adlArena.cpp
@@ -138,7 +138,8 @@ void *AdlArena::Acalloc( size_t items, size_t x ) {
 }
 
 //------------------------------realloc----------------------------------------
-size_t pointer_delta(const void *left, const void *right) {
+static size_t pointer_delta(const void *left, const void *right) {
+  assert(left >= right, "pointer delta underflow");
   return (uintptr_t)left - (uintptr_t)right;
 }
 

--- a/src/hotspot/share/adlc/adlArena.cpp
+++ b/src/hotspot/share/adlc/adlArena.cpp
@@ -130,7 +130,6 @@ void* AdlArena::grow( size_t x ) {
 //------------------------------calloc-----------------------------------------
 // Allocate zeroed storage in AdlArena
 void *AdlArena::Acalloc( size_t items, size_t x ) {
-  assert(items * x <= (size_t)1 << 31, "unreasonable arena allocation size");
   assert(items <= SIZE_MAX / x, "overflow");
   size_t z = items*x;   // Total size needed
   void *ptr = Amalloc(z);       // Get space
@@ -139,32 +138,25 @@ void *AdlArena::Acalloc( size_t items, size_t x ) {
 }
 
 //------------------------------realloc----------------------------------------
-// Offsets a pointer with saturation to prevent overflow.
-uintptr_t saturated_pointer_add(uintptr_t ptr, size_t size) {
-  if (ptr > UINTPTR_MAX - size) {
-    return UINTPTR_MAX;
-  }
-  return ptr + size;
+size_t pointer_delta(const void *left, const void *right) {
+  return (uintptr_t)left - (uintptr_t)right;
 }
 
 // Reallocate storage in AdlArena.
 void *AdlArena::Arealloc( void *old_ptr, size_t old_size, size_t new_size ) {
   char *c_old = (char*)old_ptr; // Handy name
-  // Stupid fast special case
-  if (new_size <= old_size) {     // Shrink in-place
-    if (c_old + old_size == _hwm) // Attempt to free the excess bytes
-      _hwm = c_old + new_size;    // Adjust hwm
+
+  // Reallocating the latest allocation?
+  if (c_old + old_size == _hwm) {
+    assert(_chunk->bottom() <= c_old, "invariant");
+
+    // Reallocate in place if it fits. Also handles shrinking
+    if (pointer_delta(_max, c_old) >= new_size) {
+      _hwm = c_old + new_size;
+      return c_old;
+    }
+  } else if (new_size <= old_size) { // Shrink in place
     return c_old;
-  }
-
-  uintptr_t new_hwm = saturated_pointer_add((uintptr_t)c_old, new_size);
-  // See if we can resize in-place
-  if ((c_old + old_size == _hwm) && // Adjusting recent thing
-      ((char *)new_hwm <= _max) &&  // Still fits where it sits
-      (new_hwm != UINTPTR_MAX)) {   // Did not overflow
-
-    _hwm = (char *)new_hwm; // Adjust hwm
-    return c_old;           // Return old pointer
   }
 
   // Oops, got to relocate guts

--- a/src/hotspot/share/adlc/adlArena.hpp
+++ b/src/hotspot/share/adlc/adlArena.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,8 +105,10 @@ public:
   // Fast allocate in the arena.  Common case is: pointer test + increment.
   void* Amalloc(size_t x) {
 #ifdef _LP64
+    assert(x <= SIZE_MAX - (8-1), "overflow");
     x = (x + (8-1)) & ((unsigned)(-8));
 #else
+    assert(x <= SIZE_MAX - (4-1), "overflow");
     x = (x + (4-1)) & ((unsigned)(-4));
 #endif
     if (_hwm + x > _max) {

--- a/src/hotspot/share/adlc/adlArena.hpp
+++ b/src/hotspot/share/adlc/adlArena.hpp
@@ -104,6 +104,7 @@ public:
 
   // Fast allocate in the arena.  Common case is: pointer test + increment.
   void* Amalloc(size_t x) {
+  assert(x <= (size_t)1 << 31, "unreasonable arena allocation size");
 #ifdef _LP64
     assert(x <= SIZE_MAX - (8-1), "overflow");
     x = (x + (8-1)) & ((unsigned)(-8));

--- a/src/hotspot/share/adlc/adlArena.hpp
+++ b/src/hotspot/share/adlc/adlArena.hpp
@@ -104,7 +104,6 @@ public:
 
   // Fast allocate in the arena.  Common case is: pointer test + increment.
   void* Amalloc(size_t x) {
-  assert(x <= (size_t)1 << 31, "unreasonable arena allocation size");
 #ifdef _LP64
     assert(x <= SIZE_MAX - (8-1), "overflow");
     x = (x + (8-1)) & ((unsigned)(-8));

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -311,14 +311,6 @@ void* Arena::grow(size_t x, AllocFailType alloc_failmode) {
   return result;
 }
 
-// Offsets a pointer with saturation to prevent overflow.
-uintptr_t saturated_pointer_add(uintptr_t ptr, size_t size) {
-  if (ptr > UINTPTR_MAX - size) {
-    return UINTPTR_MAX;
-  }
-  return ptr + size;
-}
-
 // Reallocate storage in Arena.
 void *Arena::Arealloc(void* old_ptr, size_t old_size, size_t new_size, AllocFailType alloc_failmode) {
   if (new_size == 0) {
@@ -330,22 +322,21 @@ void *Arena::Arealloc(void* old_ptr, size_t old_size, size_t new_size, AllocFail
     return Amalloc(new_size, alloc_failmode); // as with realloc(3), a null old ptr is equivalent to malloc(3)
   }
   char *c_old = (char*)old_ptr; // Handy name
-  // Stupid fast special case
-  if (new_size <= old_size) {     // Shrink in-place
-    if (c_old + old_size == _hwm) // Attempt to free the excess bytes
-      _hwm = c_old + new_size;    // Adjust hwm
-    return c_old;
-  }
 
-  // make sure that new_size is legal
+  // Make sure that new_size is legal
   size_t corrected_new_size = ARENA_ALIGN(new_size);
-  uintptr_t new_hwm = saturated_pointer_add((uintptr_t)c_old, corrected_new_size);
-  // See if we can resize in-place
-  if ((c_old + old_size == _hwm) && // Adjusting recent thing
-      ((char *)new_hwm <= _max) &&  // Still fits where it sits
-      (new_hwm != UINTPTR_MAX)) {   // Did not overflow
-    _hwm = (char *)new_hwm;         // Adjust hwm
-    return c_old;                   // Return old pointer
+
+  // Reallocating the latest allocation?
+  if (c_old + old_size == _hwm) {
+    assert(_chunk->bottom() <= c_old, "invariant");
+
+    // Reallocate in place if it fits. Also handles shrinking
+    if (pointer_delta(_max, c_old, 1) >= corrected_new_size) {
+      _hwm = c_old + corrected_new_size;
+      return c_old;
+    }
+  } else if (new_size <= old_size) { // Shrink in place
+    return c_old;
   }
 
   // Oops, got to relocate guts

--- a/src/hotspot/share/memory/arena.cpp
+++ b/src/hotspot/share/memory/arena.cpp
@@ -335,8 +335,8 @@ void *Arena::Arealloc(void* old_ptr, size_t old_size, size_t new_size, AllocFail
   size_t corrected_new_size = ARENA_ALIGN(new_size);
 
   // See if we can resize in-place
-  if( (c_old+old_size == _hwm) &&       // Adjusting recent thing
-      (c_old+corrected_new_size <= _max) ) {      // Still fits where it sits
+  if( (c_old+old_size == _hwm) &&                      // Adjusting recent thing
+      ((size_t)(_max-c_old) >= corrected_new_size) ) { // Still fits where it sits, safe from overflow
     _hwm = c_old+corrected_new_size;      // Adjust hwm
     return c_old;               // Return old pointer
   }

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -146,6 +146,7 @@ protected:
   // Fast allocate in the arena.  Common case aligns to the size of jlong which is 64 bits
   // on both 32 and 64 bit platforms. Required for atomic jlong operations on 32 bits.
   void* Amalloc(size_t x, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM) {
+    assert(x <= 2*G, "unreasonable arena allocation size");
     x = ARENA_ALIGN(x);  // note for 32 bits this should align _hwm as well.
     // Amalloc guarantees 64-bit alignment and we need to ensure that in case the preceding
     // allocation was AmallocWords. Only needed on 32-bit - on 64-bit Amalloc and AmallocWords are

--- a/src/hotspot/share/memory/arena.hpp
+++ b/src/hotspot/share/memory/arena.hpp
@@ -146,7 +146,6 @@ protected:
   // Fast allocate in the arena.  Common case aligns to the size of jlong which is 64 bits
   // on both 32 and 64 bit platforms. Required for atomic jlong operations on 32 bits.
   void* Amalloc(size_t x, AllocFailType alloc_failmode = AllocFailStrategy::EXIT_OOM) {
-    assert(x <= 2*G, "unreasonable arena allocation size");
     x = ARENA_ALIGN(x);  // note for 32 bits this should align _hwm as well.
     // Amalloc guarantees 64-bit alignment and we need to ensure that in case the preceding
     // allocation was AmallocWords. Only needed on 32-bit - on 64-bit Amalloc and AmallocWords are


### PR DESCRIPTION
Hi everyone,

This PR addresses an issue in `adlArena` where some allocations lack checks for overflow. This could potentially result in successful allocations when called with unrealistic values.

The fix includes:

- Adding assertions to check for potential overflow.
- Reordering some operations to guard against overflow.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339242](https://bugs.openjdk.org/browse/JDK-8339242): Fix overflow issues in AdlArena (**Bug** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20774/head:pull/20774` \
`$ git checkout pull/20774`

Update a local copy of the PR: \
`$ git checkout pull/20774` \
`$ git pull https://git.openjdk.org/jdk.git pull/20774/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20774`

View PR using the GUI difftool: \
`$ git pr show -t 20774`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20774.diff">https://git.openjdk.org/jdk/pull/20774.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20774#issuecomment-2320544733)