### PR TITLE
8339233: Test javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java#id failed: Button renderings are different after window resize

### DIFF
--- a/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
+++ b/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
@@ -125,9 +125,6 @@ public class SwingButtonResizeTestWithOpenGL {
 
         try {
             robot = new Robot();
-            robot.setAutoWaitForIdle(true);
-            robot.setAutoDelay(200);
-
             if (focusGainedLatch.await(3, TimeUnit.SECONDS)) {
                 System.out.println("Button focus gained...");
             } else {
@@ -193,7 +190,7 @@ public class SwingButtonResizeTestWithOpenGL {
     private BufferedImage getButtonImage() {
         try {
             robot.waitForIdle();
-            robot.delay(500);
+            robot.delay(1000);
 
             AtomicReference<Point> buttonLocRef = new AtomicReference<>();
             SwingUtilities.invokeAndWait(
@@ -210,10 +207,7 @@ public class SwingButtonResizeTestWithOpenGL {
     }
 
     private void disposeFrame() {
-        if (frame != null) {
-            frame.dispose();
-            frame = null;
-        }
+        frame.dispose();
     }
 
     // Save BufferedImage to PNG file

--- a/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
+++ b/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
@@ -99,6 +99,7 @@ public class SwingButtonResizeTestWithOpenGL {
         frame.setLocation(200, 200);
         frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
         button.setPreferredSize(new Dimension(300, 300));
+        button.setFocusPainted(false);
         button.addFocusListener(new FocusAdapter() {
             public void focusGained(FocusEvent fe) {
                 focusGainedLatch.countDown();

--- a/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
+++ b/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
@@ -125,6 +125,8 @@ public class SwingButtonResizeTestWithOpenGL {
 
         try {
             robot = new Robot();
+            robot.waitForIdle();
+            robot.delay(1000);
             if (focusGainedLatch.await(3, TimeUnit.SECONDS)) {
                 System.out.println("Button focus gained...");
             } else {
@@ -140,7 +142,6 @@ public class SwingButtonResizeTestWithOpenGL {
             // some platforms may not support maximize frame
             if (frame.getToolkit().isFrameStateSupported(
                     JFrame.MAXIMIZED_BOTH)) {
-                robot.waitForIdle();
                 // maximize frame from normal size
                 frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
                 System.out.println("Frame is maximized");
@@ -151,7 +152,8 @@ public class SwingButtonResizeTestWithOpenGL {
                     System.out.println("Frame is back to normal");
                     // resize from maximum size to normal
                     frame.setExtendedState(JFrame.NORMAL);
-
+                    robot.waitForIdle();
+                    robot.delay(100);
                     // capture image of JButton after resize
                     System.out.println(
                             "Getting image of JButton after resize..image2");
@@ -191,7 +193,7 @@ public class SwingButtonResizeTestWithOpenGL {
     private BufferedImage getButtonImage() {
         try {
             robot.waitForIdle();
-            robot.delay(1000);
+            robot.delay(500);
 
             AtomicReference<Point> buttonLocRef = new AtomicReference<>();
             SwingUtilities.invokeAndWait(

--- a/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
+++ b/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
@@ -145,6 +145,7 @@ public class SwingButtonResizeTestWithOpenGL {
                 frame.setExtendedState(JFrame.MAXIMIZED_BOTH);
                 System.out.println("Frame is maximized");
                 robot.waitForIdle();
+                robot.delay(100);
 
                 if (frame.getToolkit().isFrameStateSupported(JFrame.NORMAL)) {
                     System.out.println("Frame is back to normal");

--- a/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
+++ b/test/jdk/javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java
@@ -210,7 +210,9 @@ public class SwingButtonResizeTestWithOpenGL {
     }
 
     private void disposeFrame() {
-        frame.dispose();
+        if(frame != null) {
+            frame.dispose();
+        }
     }
 
     // Save BufferedImage to PNG file


### PR DESCRIPTION
This is a highly intermittent failure, and it failed only once in CI on a particular windows machine and passed on all other runs. 

Failure reason:
When the button was displayed for the first time, the focus rectangle drawn on the button text(Button A) was not seen(failure images attached in the bug).

Fix:
To stabilize the test, I have added a line -> button.setFocusPainted(false), so that the focus rectangle will not be painted

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339233](https://bugs.openjdk.org/browse/JDK-8339233): Test javax/swing/JButton/SwingButtonResizeTestWithOpenGL.java#id failed: Button renderings are different after window resize (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20777/head:pull/20777` \
`$ git checkout pull/20777`

Update a local copy of the PR: \
`$ git checkout pull/20777` \
`$ git pull https://git.openjdk.org/jdk.git pull/20777/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20777`

View PR using the GUI difftool: \
`$ git pr show -t 20777`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20777.diff">https://git.openjdk.org/jdk/pull/20777.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20777#issuecomment-2318674195)