### PR TITLE
8236073/8204088: Introduce CurrentMaxExpansionSize and SoftMaxHeapSize into G1GC

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1149,7 +1149,6 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
   log_debug(gc, ergo, heap, ahs)(
       "Expanded the heap by %i regions, wanted to expand by %i regions",
       expanded_by, regions_to_expand);
-  }
 
   return true;
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1137,11 +1137,6 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
       "B expansion amount: " SIZE_FORMAT "B",
       expand_bytes, aligned_expand_bytes);
 
-  log_debug(gc, ergo, heap)(
-    "SoftMaxHeapSize value: " SIZE_FORMAT, SoftMaxHeapSize);
-  log_debug(gc, ergo, heap)(
-    "CurrentMaxExpansionSize value: " SIZE_FORMAT, CurrentMaxExpansionSize);
-
   if (is_maximal_no_gc()) {
     log_debug(gc, ergo, heap)("Did not expand the heap (heap already fully expanded)");
     return false;

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1085,16 +1085,17 @@ HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
 
 bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_workers, double* expand_time_ms) {
   // Save temporary value to mitigate race conditions in case
-  // CurrentMaxExpansionSize is overwritten during the lifetime of this
+  // CurrentMaxHeapSize is overwritten during the lifetime of this
   // function. It is still possible for the timing of the write to override a
-  // more recent CurrentMaxExpansionSize value, but this is tolerable for one
+  // more recent CurrentMaxHeapSize value, but this is tolerable for one
   // iteration.
   const size_t current_max_expansion_size = CurrentMaxHeapSize - capacity();
   log_debug(ahs)("expand() of size: " SIZE_FORMAT
                  " called with SoftMaxHeapSize: " SIZE_FORMAT
-                 "B, CurrentMaxExpansionSize: " SIZE_FORMAT
+                 "B, CurrentMaxHeapSize" SIZE_FORMAT
+                 "B, current_max_expansion_size: " SIZE_FORMAT
                  "B, and current heap size: " SIZE_FORMAT "B.",
-                 expand_bytes, SoftMaxHeapSize, current_max_expansion_size,
+                 expand_bytes, SoftMaxHeapSize, CurrentMaxHeapSize, current_max_expansion_size,
                  capacity());
   size_t aligned_expand_bytes = ReservedSpace::page_align_size_up(expand_bytes);
   aligned_expand_bytes = align_up(aligned_expand_bytes, G1HeapRegion::GrainBytes);

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1070,7 +1070,8 @@ HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
     _verifier->verify_region_sets_optional();
     HeapWord* result = attempt_allocation_at_safepoint(
         word_size, false /* expect_null_mutator_alloc_region */);
-    if (result != nullptr) {
+    // if (result != nullptr) {
+    if (true) {
       return result;
     }
     // If the allocation fails and AHS is enabled, we force the allocation.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -942,7 +942,7 @@ void G1CollectedHeap::resize_heap_if_necessary_ahs(bool record_expand_time) {
   if (bytes_to_change > 0) {
     log_info(ahs)(
         "Attempt heap expansion via ahs resize. "
-        "Expand bytes: " SIZE_FORMAT "B Capacity: " SIZE_FORMAT
+        "Expand bytes: " INT64_FORMAT "B Capacity: " SIZE_FORMAT
         "B occupancy: " SIZE_FORMAT "B live: " SIZE_FORMAT
         "B SoftMaxHeapSize: " SIZE_FORMAT "B",
         bytes_to_change, heap_capacity, heap_occupancy, used(),

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -353,12 +353,55 @@ HeapWord* G1CollectedHeap::humongous_obj_allocate(size_t word_size) {
     // Policy: We could not find enough regions for the humongous object in the
     // free list. Look through the heap to find a mix of free and uncommitted regions.
     // If so, expand the heap and allocate the humongous object.
-    humongous_start = _hrm.expand_and_allocate_humongous(obj_regions);
+
+    // If AHS is enabled, check to see if AHS allows for expansion.
+    // Save temporary value to prevent race conditions in case
+    // CurrentMaxExpansionSize is overridden during the lifetime of this
+    // function.
+    const size_t current_max_expansion_size = CurrentMaxExpansionSize;
+    bool can_expand = true;
+    if (current_max_expansion_size > 0) {
+      size_t aligned_current_max_expansion_size =
+          ReservedSpace::page_align_size_down(current_max_expansion_size);
+      aligned_current_max_expansion_size = align_down(
+          aligned_current_max_expansion_size, G1HeapRegion::GrainBytes);
+      const uint max_regions_to_expand =
+          (uint)(aligned_current_max_expansion_size / G1HeapRegion::GrainBytes);
+
+      // If AHS says that an expansion of the requested size cannot be
+      // completed for the humongous object, we should not expand.
+      if (obj_regions > max_regions_to_expand) {
+        log_debug(gc, ergo, heap, ahs)(
+            "Did not expand with humongous allocation of size: %u "
+            "regions, due to CurrentMaxExpansionSize: " SIZE_FORMAT
+            "B, which corresponds to %u regions.",
+            obj_regions, current_max_expansion_size, max_regions_to_expand);
+        can_expand = false;
+      }
+    }
+
+    if (can_expand) {
+        humongous_start = _hrm.expand_and_allocate_humongous(obj_regions);
+    }
+
     if (humongous_start != nullptr) {
       // We managed to find a region by expanding the heap.
-      log_debug(gc, ergo, heap)("Heap expansion (humongous allocation request). Allocation request: " SIZE_FORMAT "B",
-                                word_size * HeapWordSize);
+      log_debug(gc, ergo, heap, ahs)("Heap expansion (humongous allocation request). Allocation request: " SIZE_FORMAT "B",
+                                 word_size * HeapWordSize);
       policy()->record_new_heap_size(num_regions());
+      if (current_max_expansion_size > 0) {
+        assert(current_max_expansion_size >=
+                   obj_regions * G1HeapRegion::GrainBytes, "sanity");
+        const size_t new_current_max_expansion_size =
+            current_max_expansion_size - (obj_regions * G1HeapRegion::GrainBytes);
+        // In a very rare case, it's possible that CurrentMaxExpansionSize is
+        // exactly equal to the amount of spaces we want to expand. To prevent
+        // this from happening, we bound the minimum value of
+        // CurrentMaxExpansionSize by 1, since a 0-value is interpreted as AHS
+        // being disabled.
+        CurrentMaxExpansionSize =
+            MAX2(new_current_max_expansion_size, static_cast<size_t>(1));
+      }
     } else {
       // Policy: Potentially trigger a defragmentation GC.
     }
@@ -774,7 +817,7 @@ void G1CollectedHeap::prepare_for_mutator_after_full_collection() {
   assert(num_free_regions() == 0, "we should not have added any free regions");
   rebuild_region_sets(false /* free_list_only */);
   abort_refinement();
-  resize_heap_if_necessary();
+  resize_heap_if_necessary(false);
   uncommit_regions_if_necessary();
 
   // Rebuild the code root lists for each region
@@ -862,7 +905,15 @@ bool G1CollectedHeap::upgrade_to_full_collection() {
   return success;
 }
 
-void G1CollectedHeap::resize_heap_if_necessary() {
+void G1CollectedHeap::resize_heap_if_necessary(bool record_expand_time) {
+  if (SoftMaxHeapSize == 0) {
+    resize_heap_if_necessary_non_ahs();
+  } else {
+    resize_heap_if_necessary_ahs(record_expand_time);
+  }
+}
+
+void G1CollectedHeap::resize_heap_if_necessary_non_ahs() {
   assert_at_safepoint_on_vm_thread();
 
   bool should_expand;
@@ -874,6 +925,40 @@ void G1CollectedHeap::resize_heap_if_necessary() {
     expand(resize_amount, _workers);
   } else {
     shrink(resize_amount);
+  }
+}
+
+void G1CollectedHeap::resize_heap_if_necessary_ahs(bool record_expand_time) {
+  assert(SoftMaxHeapSize > 0,
+         "Unexpected call to resize_heap_if_necessary_ahs() when "
+         "SoftMaxHeapSize not set!");
+
+  const size_t heap_capacity = capacity();
+  const size_t heap_occupancy =
+      heap_capacity -
+      unused_committed_regions_in_bytes();
+  const int64_t bytes_to_change = _heap_sizing_policy->resize_amount_ahs();
+
+  if (bytes_to_change > 0) {
+    log_info(ahs)(
+        "Attempt heap expansion via ahs resize. "
+        "Expand bytes: " SIZE_FORMAT "B Capacity: " SIZE_FORMAT
+        "B occupancy: " SIZE_FORMAT "B live: " SIZE_FORMAT
+        "B SoftMaxHeapSize: " SIZE_FORMAT "B",
+        bytes_to_change, heap_capacity, heap_occupancy, used(),
+        SoftMaxHeapSize);
+    double expand_ms = 0.0;
+    expand(bytes_to_change, _workers, &expand_ms);
+    if (record_expand_time) {
+      policy()->phase_times()->record_expand_heap_time(expand_ms);
+    }
+  } else if (bytes_to_change < 0) {
+    log_info(ahs)(
+        "Attempt heap shrinking via ahs resize. "
+        "Capacity: " SIZE_FORMAT "B occupancy: " SIZE_FORMAT
+        "B live: " SIZE_FORMAT "B SoftMaxHeapSize: " SIZE_FORMAT "B",
+        heap_capacity, heap_occupancy, used(), SoftMaxHeapSize);
+    shrink(-bytes_to_change);
   }
 }
 
@@ -983,18 +1068,74 @@ HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
   if (expand(expand_bytes, _workers)) {
     _hrm.verify_optional();
     _verifier->verify_region_sets_optional();
-    return attempt_allocation_at_safepoint(word_size,
-                                           false /* expect_null_mutator_alloc_region */);
+    HeapWord* result = attempt_allocation_at_safepoint(
+        word_size, false /* expect_null_mutator_alloc_region */);
+    if (result != nullptr) {
+      return result;
+    }
+    // If the allocation fails and AHS is enabled, we force the allocation.
+    // This is because we don't want the failed allocation attempt to make this
+    // function return nullptr, which can result in a premature Java OOM. With
+    // AHS enabled, we should only return nullptr if even after all attempts we
+    // still cannot successfully allocate.
+    // Note that since humongous objects go through a different code path in
+    // attempt_allocation_at_safepoint(), we don't need to handle that case
+    // here.
+    if (SoftMaxHeapSize > 0 && !is_humongous(word_size)) {
+      result = _allocator->attempt_allocation_locked(word_size);
+      if (result != nullptr) {
+        return result;
+      } else {
+        log_debug(ahs)(
+            "Forced allocation attempt under AHS failed - returning nullptr.");
+      }
+    }
   }
   return nullptr;
 }
 
 bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_workers, double* expand_time_ms) {
+  // Save temporary value to mitigate race conditions in case
+  // CurrentMaxExpansionSize is overwritten during the lifetime of this
+  // function. It is still possible for the timing of the write to override a
+  // more recent CurrentMaxExpansionSize value, but this is tolerable for one
+  // iteration.
+  const size_t current_max_expansion_size = CurrentMaxExpansionSize;
+  log_debug(ahs)("expand() of size: " SIZE_FORMAT
+                 " called with SoftMaxHeapSize: " SIZE_FORMAT
+                 "B, CurrentMaxExpansionSize: " SIZE_FORMAT
+                 "B, and current heap size: " SIZE_FORMAT "B.",
+                 expand_bytes, SoftMaxHeapSize, current_max_expansion_size,
+                 capacity());
   size_t aligned_expand_bytes = ReservedSpace::page_align_size_up(expand_bytes);
   aligned_expand_bytes = align_up(aligned_expand_bytes, G1HeapRegion::GrainBytes);
 
-  log_debug(gc, ergo, heap)("Expand the heap. requested expansion amount: " SIZE_FORMAT "B expansion amount: " SIZE_FORMAT "B",
-                            expand_bytes, aligned_expand_bytes);
+  // Make sure we are not expanding too much if there is not much space left in
+  // the container.
+  if (current_max_expansion_size > 0) {
+    size_t aligned_max_expand_bytes =
+        ReservedSpace::page_align_size_down(current_max_expansion_size);
+    aligned_max_expand_bytes =
+        align_down(aligned_max_expand_bytes, G1HeapRegion::GrainBytes);
+    log_debug(ahs)("CMESize flag value: " SIZE_FORMAT
+                   "B. After alignment: " SIZE_FORMAT "B.",
+                   current_max_expansion_size, aligned_max_expand_bytes);
+    if (aligned_expand_bytes > aligned_max_expand_bytes) {
+      log_debug(ahs)(
+          "Wanted to expand by: " SIZE_FORMAT
+          ", but limited by (aligned) CMESize, which is: " SIZE_FORMAT,
+          aligned_expand_bytes, aligned_max_expand_bytes);
+      aligned_expand_bytes = aligned_max_expand_bytes;
+    }
+    if (aligned_max_expand_bytes == 0) {
+      return false;
+    }
+  }
+
+  log_debug(gc, ergo, heap)(
+      "Expand the heap. requested expansion amount: " SIZE_FORMAT
+      "B expansion amount: " SIZE_FORMAT "B",
+      expand_bytes, aligned_expand_bytes);
 
   if (is_maximal_no_gc()) {
     log_debug(gc, ergo, heap)("Did not expand the heap (heap already fully expanded)");
@@ -1015,6 +1156,14 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
   size_t actual_expand_bytes = expanded_by * G1HeapRegion::GrainBytes;
   assert(actual_expand_bytes <= aligned_expand_bytes, "post-condition");
   policy()->record_new_heap_size(num_regions());
+
+  log_debug(gc, ergo, heap, ahs)(
+      "Expanded the heap by %i regions, wanted to expand by %i regions",
+      expanded_by, regions_to_expand);
+  if (current_max_expansion_size > 0) {
+    CurrentMaxExpansionSize =
+        current_max_expansion_size - actual_expand_bytes;
+  }
 
   return true;
 }
@@ -2375,7 +2524,19 @@ void G1CollectedHeap::verify_after_young_collection(G1HeapVerifier::G1VerifyType
 }
 
 void G1CollectedHeap::expand_heap_after_young_collection(){
-  size_t expand_bytes = _heap_sizing_policy->young_collection_expansion_amount();
+  int64_t expand_bytes;
+  if (SoftMaxHeapSize == 0) {
+    expand_bytes = _heap_sizing_policy->young_collection_expansion_amount();
+  } else {
+    expand_bytes = _heap_sizing_policy->resize_amount_ahs();
+    log_trace(ahs)(
+        "expand_heap_after_young_collection() with AHS enabled suggests an "
+        "expansion of size: " INT64_FORMAT
+        ", with a current heap size of: " SIZE_FORMAT
+        ", and a SoftMaxHeapSize of size: " SIZE_FORMAT
+        ". We only expand if the suggested expansion is positive.",
+        expand_bytes, capacity(), SoftMaxHeapSize);
+  }
   if (expand_bytes > 0) {
     // No need for an ergo logging here,
     // expansion_amount() does this when it returns a value > 0.

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -1070,8 +1070,7 @@ HeapWord* G1CollectedHeap::expand_and_allocate(size_t word_size) {
     _verifier->verify_region_sets_optional();
     HeapWord* result = attempt_allocation_at_safepoint(
         word_size, false /* expect_null_mutator_alloc_region */);
-    // if (result != nullptr) {
-    if (true) {
+    if (result != nullptr) {
       return result;
     }
     // If the allocation fails and AHS is enabled, we force the allocation.
@@ -1137,6 +1136,11 @@ bool G1CollectedHeap::expand(size_t expand_bytes, WorkerThreads* pretouch_worker
       "Expand the heap. requested expansion amount: " SIZE_FORMAT
       "B expansion amount: " SIZE_FORMAT "B",
       expand_bytes, aligned_expand_bytes);
+
+  log_debug(gc, ergo, heap)(
+    "SoftMaxHeapSize value: " SIZE_FORMAT, SoftMaxHeapSize);
+  log_debug(gc, ergo, heap)(
+    "CurrentMaxExpansionSize value: " SIZE_FORMAT, CurrentMaxExpansionSize);
 
   if (is_maximal_no_gc()) {
     log_debug(gc, ergo, heap)("Did not expand the heap (heap already fully expanded)");

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.hpp
@@ -559,7 +559,7 @@ public:
   void pin_object(JavaThread* thread, oop obj) override;
   void unpin_object(JavaThread* thread, oop obj) override;
 
-  void resize_heap_if_necessary();
+  void resize_heap_if_necessary(bool record_expand_time);
 
   // Check if there is memory to uncommit and if so schedule a task to do it.
   void uncommit_regions_if_necessary();
@@ -724,6 +724,11 @@ private:
   // (Rounds down to a G1HeapRegion boundary.)
   void shrink(size_t shrink_bytes);
   void shrink_helper(size_t expand_bytes);
+
+  // Helper functions for `resize_heap_if_necessary()`, depending on whether
+  // Adaptable Heap Sizing is active or not.
+  void resize_heap_if_necessary_non_ahs();
+  void resize_heap_if_necessary_ahs(bool record_expand_time);
 
   // Schedule the VM operation that will do an evacuation pause to
   // satisfy an allocation request of word_size. *succeeded will

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -1458,7 +1458,7 @@ void G1ConcurrentMark::remark() {
     // GC pause.
     _g1h->increment_total_collections();
 
-    _g1h->resize_heap_if_necessary();
+    _g1h->resize_heap_if_necessary(false);
     _g1h->uncommit_regions_if_necessary();
 
     compute_new_sizes();

--- a/src/hotspot/share/gc/g1/g1HeapSizingPolicy.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapSizingPolicy.hpp
@@ -52,6 +52,11 @@ class G1HeapSizingPolicy: public CHeapObj<mtGC> {
   G1HeapSizingPolicy(const G1CollectedHeap* g1h, const G1Analytics* analytics);
 public:
 
+  // Use Adaptable Heap Sizing to determine an appropriate amount to expand
+  // or shrink by. Return a positive value to indicate a suggested expansion,
+  // and a negative value to indicate a suggested shrinking.
+  virtual int64_t resize_amount_ahs();
+
   // If an expansion would be appropriate, because recent GC overhead had
   // exceeded the desired limit, return an amount to expand by.
   size_t young_collection_expansion_amount();

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -160,6 +160,8 @@ void GCArguments::initialize_heap_flags_and_sizes() {
     }
   }
 
+  // We exclude G1GC from this override, as we rely on the default value of 0
+  // for SoftMaxHeapSize to mean that Adaptable Heap Sizing is disabled.
   if (FLAG_IS_DEFAULT(SoftMaxHeapSize) && !UseG1GC) {
     FLAG_SET_ERGO(SoftMaxHeapSize, MaxHeapSize);
   }

--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -160,7 +160,7 @@ void GCArguments::initialize_heap_flags_and_sizes() {
     }
   }
 
-  if (FLAG_IS_DEFAULT(SoftMaxHeapSize)) {
+  if (FLAG_IS_DEFAULT(SoftMaxHeapSize) && !UseG1GC) {
     FLAG_SET_ERGO(SoftMaxHeapSize, MaxHeapSize);
   }
 

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -538,7 +538,7 @@
                                                                             \
   product(size_t, CurrentMaxHeapSize, 0, MANAGEABLE,                        \
           "This flag is set by Adaptable Heap Sizing as the maximum size "  \
-          "of the heap can , based on container usage and limits.")         \                                 \
+          "of the heap can , based on container usage and limits.")         \
                                                                             \
   product(size_t, NewSize, ScaleForWordSize(1*M),                           \
           "Initial new generation size (in bytes)")                         \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -536,10 +536,9 @@
           "Soft limit for maximum heap size (in bytes)")                    \
           constraint(SoftMaxHeapSizeConstraintFunc,AfterMemoryInit)         \
                                                                             \
-  product(size_t, CurrentMaxExpansionSize, 0, MANAGEABLE,                   \
-          "Google-only: This flag is set by the Adaptable Heap Sizing "     \
-          "thread as the maximum amount the heap can expand by, based "     \
-          "on container usage and limits.")                                 \
+  product(size_t, CurrentMaxHeapSize, 0, MANAGEABLE,                        \
+          "This flag is set by Adaptable Heap Sizing as the maximum size "  \
+          "of the heap can , based on container usage and limits.")         \                                 \
                                                                             \
   product(size_t, NewSize, ScaleForWordSize(1*M),                           \
           "Initial new generation size (in bytes)")                         \

--- a/src/hotspot/share/gc/shared/gc_globals.hpp
+++ b/src/hotspot/share/gc/shared/gc_globals.hpp
@@ -536,6 +536,11 @@
           "Soft limit for maximum heap size (in bytes)")                    \
           constraint(SoftMaxHeapSizeConstraintFunc,AfterMemoryInit)         \
                                                                             \
+  product(size_t, CurrentMaxExpansionSize, 0, MANAGEABLE,                   \
+          "Google-only: This flag is set by the Adaptable Heap Sizing "     \
+          "thread as the maximum amount the heap can expand by, based "     \
+          "on container usage and limits.")                                 \
+                                                                            \
   product(size_t, NewSize, ScaleForWordSize(1*M),                           \
           "Initial new generation size (in bytes)")                         \
           constraint(NewSizeConstraintFunc,AfterErgo)                       \

--- a/src/hotspot/share/logging/logTag.hpp
+++ b/src/hotspot/share/logging/logTag.hpp
@@ -36,6 +36,7 @@ class outputStream;
 #define LOG_TAG_LIST \
   LOG_TAG(add) \
   LOG_TAG(age) \
+  LOG_TAG(ahs) /* Logging for debugging Adaptable Heap Sizing */ \
   LOG_TAG(alloc) \
   LOG_TAG(annotation) \
   LOG_TAG(arguments) \

--- a/test/hotspot/jtreg/gc/arguments/TestSoftMaxHeapSizeFlag.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSoftMaxHeapSizeFlag.java
@@ -25,6 +25,8 @@ package gc.arguments;
 
 /*
  * @test TestSoftMaxHeapSizeFlag
+ * @requires vm.gc != "G1"
+ * @requires vm.gc != "null"
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management


### PR DESCRIPTION
This PR upstreams Google's internal changes to the JVM to make Adaptable Heap Sizing work for G1 GC.

As is, this PR alone should be a no-op, since we default the values of these flags to 0, and when these flags are set to 0,  there should be no behavior changes in the JVM. 

A PR which actually introduces logic to calculate and set these flags can be introduced later.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ Found copyright format issue for oracle in [test/jdk/javax/swing/JFileChooser/6738668/bug6738668.java]

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20783/head:pull/20783` \
`$ git checkout pull/20783`

Update a local copy of the PR: \
`$ git checkout pull/20783` \
`$ git pull https://git.openjdk.org/jdk.git pull/20783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20783`

View PR using the GUI difftool: \
`$ git pr show -t 20783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20783.diff">https://git.openjdk.org/jdk/pull/20783.diff</a>

</details>
