### PR TITLE
8339298: Remove unused function declaration poll_for_safepoint

### DIFF
--- a/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/c1_LIRAssembler_aarch64.hpp
@@ -60,8 +60,6 @@ friend class ArrayCopyStub;
   void casw(Register addr, Register newval, Register cmpval);
   void casl(Register addr, Register newval, Register cmpval);
 
-  void poll_for_safepoint(relocInfo::relocType rtype, CodeEmitInfo* info = nullptr);
-
   static const int max_tableswitches = 20;
   struct tableswitch switches[max_tableswitches];
   int tableswitch_count;

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
@@ -62,8 +62,6 @@ private:
   void caswu(Register addr, Register newval, Register cmpval);
   void casl(Register addr, Register newval, Register cmpval);
 
-  void poll_for_safepoint(relocInfo::relocType rtype, CodeEmitInfo* info = nullptr);
-
   void deoptimize_trap(CodeEmitInfo *info);
 
   enum {


### PR DESCRIPTION
Hi, I noticed that there are two unused function declarations here, in the historical version they were used without UseCompilerSafepoints, now the unused UseCompilerSafepoints have been removed, but the function declarations may have forgotten to be removed.

### Testing
- [x] release & fastdebug build OK on linux-aarch64
- [x] release & fastdebug build OK on linux-riscv64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339298](https://bugs.openjdk.org/browse/JDK-8339298): Remove unused function declaration poll_for_safepoint (**Enhancement** - P5)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20785/head:pull/20785` \
`$ git checkout pull/20785`

Update a local copy of the PR: \
`$ git checkout pull/20785` \
`$ git pull https://git.openjdk.org/jdk.git pull/20785/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20785`

View PR using the GUI difftool: \
`$ git pr show -t 20785`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20785.diff">https://git.openjdk.org/jdk/pull/20785.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20785#issuecomment-2320290290)