### PR TITLE
8339307: jhsdb jstack could not trace FFM upcall frame

### DIFF
--- a/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/upcallLinker_aarch64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2019, 2022, Arm Limited. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -330,7 +330,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
     = UpcallStub::create(name,
                          &buffer,
                          receiver,
-                         in_ByteSize(frame_data_offset));
+                         in_ByteSize(frame_data_offset),
+                         /*
+                          * frame size should be in words,
+                          * and also should include both saved FP and return address
+                          */
+                         (frame_size / wordSize) + 2);
   if (blob == nullptr) {
     return nullptr;
   }

--- a/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
+++ b/src/hotspot/cpu/ppc/upcallLinker_ppc.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -338,7 +338,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
     = UpcallStub::create(name,
                          &buffer,
                          receiver,
-                         in_ByteSize(frame_data_offset));
+                         in_ByteSize(frame_data_offset),
+                         /*
+                          * frame size should be in words,
+                          * and also should include the frame
+                          */
+                         (frame_size / wordSize) + 1);
   if (blob == nullptr) {
     return nullptr;
   }

--- a/src/hotspot/cpu/riscv/upcallLinker_riscv.cpp
+++ b/src/hotspot/cpu/riscv/upcallLinker_riscv.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2023, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -350,7 +350,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
     = UpcallStub::create(name,
                          &buffer,
                          receiver,
-                         in_ByteSize(frame_data_offset));
+                         in_ByteSize(frame_data_offset),
+                         /*
+                          * frame size should be in words,
+                          * and also should include both saved FP and return address
+                          */
+                         (frame_size / wordSize) + 2);
   if (blob == nullptr) {
     return nullptr;
   }

--- a/src/hotspot/cpu/s390/upcallLinker_s390.cpp
+++ b/src/hotspot/cpu/s390/upcallLinker_s390.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2020, 2024, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -285,7 +285,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
     = UpcallStub::create(name,
                          &buffer,
                          receiver,
-                         in_ByteSize(frame_data_offset));
+                         in_ByteSize(frame_data_offset),
+                         /*
+                          * frame size should be in words,
+                          * and also should include return address
+                          */
+                         (frame_size / wordSize) + 1);
   if (blob == nullptr) {
     return nullptr;
   }

--- a/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/upcallLinker_x86_64.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -389,7 +389,12 @@ address UpcallLinker::make_upcall_stub(jobject receiver, Method* entry,
     = UpcallStub::create(name,
                          &buffer,
                          receiver,
-                         in_ByteSize(frame_data_offset));
+                         in_ByteSize(frame_data_offset),
+                         /*
+                          * frame size should be in words,
+                          * and also should include both saved FP and return address
+                          */
+                         (frame_size / wordSize) + 2);
   if (blob == nullptr) {
     return nullptr;
   }

--- a/src/hotspot/share/code/codeBlob.cpp
+++ b/src/hotspot/share/code/codeBlob.cpp
@@ -593,9 +593,9 @@ SafepointBlob* SafepointBlob::create(
 //----------------------------------------------------------------------------------------------------
 // Implementation of UpcallStub
 
-UpcallStub::UpcallStub(const char* name, CodeBuffer* cb, int size, jobject receiver, ByteSize frame_data_offset) :
+UpcallStub::UpcallStub(const char* name, CodeBuffer* cb, int size, jobject receiver, ByteSize frame_data_offset, int frame_size) :
   RuntimeBlob(name, CodeBlobKind::Upcall, cb, size, sizeof(UpcallStub),
-              CodeOffsets::frame_never_safe, 0 /* no frame size */,
+              CodeOffsets::frame_never_safe, frame_size,
               /* oop maps = */ nullptr, /* caller must gc arguments = */ false),
   _receiver(receiver),
   _frame_data_offset(frame_data_offset)
@@ -607,14 +607,14 @@ void* UpcallStub::operator new(size_t s, unsigned size) throw() {
   return CodeCache::allocate(size, CodeBlobType::NonNMethod);
 }
 
-UpcallStub* UpcallStub::create(const char* name, CodeBuffer* cb, jobject receiver, ByteSize frame_data_offset) {
+UpcallStub* UpcallStub::create(const char* name, CodeBuffer* cb, jobject receiver, ByteSize frame_data_offset, int frame_size) {
   ThreadInVMfromUnknown __tiv;  // get to VM state in case we block on CodeCache_lock
 
   UpcallStub* blob = nullptr;
   unsigned int size = CodeBlob::allocation_size(cb, sizeof(UpcallStub));
   {
     MutexLocker mu(CodeCache_lock, Mutex::_no_safepoint_check_flag);
-    blob = new (size) UpcallStub(name, cb, size, receiver, frame_data_offset);
+    blob = new (size) UpcallStub(name, cb, size, receiver, frame_data_offset, frame_size);
   }
   if (blob == nullptr) {
     return nullptr; // caller must handle this

--- a/src/hotspot/share/code/codeBlob.hpp
+++ b/src/hotspot/share/code/codeBlob.hpp
@@ -600,7 +600,7 @@ class UpcallStub: public RuntimeBlob {
   jobject _receiver;
   ByteSize _frame_data_offset;
 
-  UpcallStub(const char* name, CodeBuffer* cb, int size, jobject receiver, ByteSize frame_data_offset);
+  UpcallStub(const char* name, CodeBuffer* cb, int size, jobject receiver, ByteSize frame_data_offset, int frame_size);
 
   void* operator new(size_t s, unsigned size) throw();
 
@@ -615,7 +615,7 @@ class UpcallStub: public RuntimeBlob {
   FrameData* frame_data_for_frame(const frame& frame) const;
  public:
   // Creation
-  static UpcallStub* create(const char* name, CodeBuffer* cb, jobject receiver, ByteSize frame_data_offset);
+  static UpcallStub* create(const char* name, CodeBuffer* cb, jobject receiver, ByteSize frame_data_offset, int frame_size);
 
   static void free(UpcallStub* blob);
 

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1306,6 +1306,7 @@
   declare_type(nmethod,                  CodeBlob)                        \
   declare_type(RuntimeStub,              RuntimeBlob)                     \
   declare_type(SingletonBlob,            RuntimeBlob)                     \
+  declare_type(UpcallStub,               RuntimeBlob)                     \
   declare_type(SafepointBlob,            SingletonBlob)                   \
   declare_type(DeoptimizationBlob,       SingletonBlob)                   \
   declare_c2_type(ExceptionBlob,         SingletonBlob)                   \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeBlob.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeBlob.java
@@ -143,6 +143,8 @@ public class CodeBlob extends VMObject {
 
   public boolean isRuntimeStub()        { return false; }
 
+  public boolean isUpcallStub()         { return false; }
+
   public boolean isDeoptimizationStub() { return false; }
 
   public boolean isUncommonTrapStub()   { return false; }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeCache.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/CodeCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,6 +60,7 @@ public class CodeCache {
     virtualConstructor.addMapping("AdapterBlob", AdapterBlob.class);
     virtualConstructor.addMapping("MethodHandlesAdapterBlob", MethodHandlesAdapterBlob.class);
     virtualConstructor.addMapping("VtableBlob", VtableBlob.class);
+    virtualConstructor.addMapping("UpcallStub", UpcallStub.class);
     virtualConstructor.addMapping("SafepointBlob", SafepointBlob.class);
     virtualConstructor.addMapping("DeoptimizationBlob", DeoptimizationBlob.class);
     if (VM.getVM().isServerCompiler()) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/UpcallStub.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/UpcallStub.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.code;
+
+import java.util.*;
+import sun.jvm.hotspot.debugger.*;
+import sun.jvm.hotspot.runtime.*;
+import sun.jvm.hotspot.types.*;
+import sun.jvm.hotspot.utilities.Observable;
+import sun.jvm.hotspot.utilities.Observer;
+
+public class UpcallStub extends RuntimeBlob {
+  static {
+    VM.registerVMInitializedObserver(new Observer() {
+        public void update(Observable o, Object data) {
+          initialize(VM.getVM().getTypeDataBase());
+        }
+      });
+  }
+
+  private static void initialize(TypeDataBase db) {
+    Type type = db.lookupType("UpcallStub");
+
+    // FIXME: add any needed fields
+  }
+
+  public UpcallStub(Address addr) {
+    super(addr);
+  }
+
+  public boolean isUpcallStub()      { return true; }
+}

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/UpcallStub.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/code/UpcallStub.java
@@ -42,8 +42,6 @@ public class UpcallStub extends RuntimeBlob {
 
   private static void initialize(TypeDataBase db) {
     Type type = db.lookupType("UpcallStub");
-
-    // FIXME: add any needed fields
   }
 
   public UpcallStub(Address addr) {

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithFFMUpcall.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithFFMUpcall.java
@@ -62,7 +62,7 @@ public class LingeredAppWithFFMUpcall extends LingeredApp {
             long upcallAddr = createFunctionPointerForUpcall();
             (new Thread(() -> callJNI(upcallAddr), THREAD_NAME)).start();
             LingeredApp.main(args);
-        } catch(Exception e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithFFMUpcall.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithFFMUpcall.java
@@ -42,7 +42,7 @@ public class LingeredAppWithFFMUpcall extends LingeredApp {
     public static void upcall() {
         try {
             Thread.sleep(600000);  // 10 min
-        } catch(InterruptedException e) {
+        } catch (InterruptedException e) {
             // Ignore
         }
     }

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithFFMUpcall.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithFFMUpcall.java
@@ -58,7 +58,7 @@ public class LingeredAppWithFFMUpcall extends LingeredApp {
     public static native void callJNI(long upcallAddr);
 
     public static void main(String[] args) {
-        try{
+        try {
             long upcallAddr = createFunctionPointerForUpcall();
             (new Thread(() -> callJNI(upcallAddr), THREAD_NAME)).start();
             LingeredApp.main(args);

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithFFMUpcall.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithFFMUpcall.java
@@ -1,0 +1,69 @@
+
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.Utils;
+
+public class LingeredAppWithFFMUpcall extends LingeredApp {
+
+    public static final String THREAD_NAME = "Upcall thread";
+
+    static {
+        System.loadLibrary("upcall");
+    }
+
+    public static void upcall() {
+        try {
+            Thread.sleep(600000);  // 10 min
+        } catch(InterruptedException e) {
+            // Ignore
+        }
+    }
+
+    public static long createFunctionPointerForUpcall() throws NoSuchMethodException, IllegalAccessException {
+        var mh = MethodHandles.lookup()
+                              .findStatic(LingeredAppWithFFMUpcall.class, "upcall", MethodType.methodType(void.class));
+        var stub = Linker.nativeLinker()
+                         .upcallStub(mh, FunctionDescriptor.ofVoid(), Arena.global());
+        return stub.address();
+    }
+
+    public static native void callJNI(long upcallAddr);
+
+    public static void main(String[] args) {
+        try{
+            long upcallAddr = createFunctionPointerForUpcall();
+            (new Thread(() -> callJNI(upcallAddr), THREAD_NAME)).start();
+            LingeredApp.main(args);
+        } catch(Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackUpcall.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackUpcall.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.SA.SATestUtils;
+import jdk.test.lib.Utils;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
+
+/**
+ * @test
+ * @bug 8339307
+ * @requires vm.hasSA
+ * @library /test/lib
+ * @run driver TestJhsdbJstackUpcall
+ */
+public class TestJhsdbJstackUpcall {
+
+    private static final int MAX_ITERATIONS = 20;
+
+    /*
+     * Test should focus JNI call (caller of upcall) because the frame
+     * prior to the upcall cannot be obtained if some exception happens
+     * in during to process upcall.
+     */
+    private static boolean isJNIFrame(List<String> lines) {
+        return lines.stream()
+                    .anyMatch(s -> s.startsWith(" - LingeredAppWithFFMUpcall.callJNI"));
+    }
+
+    private static void runJstackInLoop(LingeredApp app) throws Exception {
+        for (int i = 0; i < MAX_ITERATIONS; i++) {
+            JDKToolLauncher launcher = JDKToolLauncher
+                    .createUsingTestJDK("jhsdb");
+            launcher.addVMArgs(Utils.getTestJavaOpts());
+            launcher.addToolArg("jstack");
+            launcher.addToolArg("--pid");
+            launcher.addToolArg(Long.toString(app.getPid()));
+
+            ProcessBuilder pb = SATestUtils.createProcessBuilder(launcher);
+            Process jhsdb = pb.start();
+            OutputAnalyzer out = new OutputAnalyzer(jhsdb);
+
+            jhsdb.waitFor();
+
+            System.out.println(out.getStdout());
+            System.err.println(out.getStderr());
+
+            out.shouldContain(LingeredAppWithFFMUpcall.THREAD_NAME);
+            if (isJNIFrame(out.asLines())) {
+                System.out.println("DEBUG: Test triggered interesting condition.");
+                out.shouldNotContain("sun.jvm.hotspot.types.WrongTypeException");
+                System.out.println("DEBUG: Test PASSED.");
+                return; // If we've reached here, all is well.
+            }
+            System.out.println("DEBUG: Iteration: " + (i + 1)
+                                 + " - Test didn't trigger interesting condition.");
+            out.shouldNotContain("sun.jvm.hotspot.types.WrongTypeException");
+        }
+        throw new IllegalStateException("Could not find expected frame");
+    }
+
+    public static void main(String... args) throws Exception {
+        SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
+        LingeredApp app = null;
+
+        try {
+            // Needed for LingeredApp to be able to resolve native library.
+            String libPath = System.getProperty("java.library.path");
+            String[] vmArgs = (libPath != null)
+                ? Utils.prependTestJavaOpts("-Djava.library.path=" + libPath)
+                : Utils.getTestJavaOpts();
+
+            app = new LingeredAppWithFFMUpcall();
+            LingeredApp.startAppExactJvmOpts(app, vmArgs);
+            System.out.println("Started LingeredApp with pid " + app.getPid());
+            runJstackInLoop(app);
+            System.out.println("Test Completed");
+        } catch (Throwable e) {
+            e.printStackTrace();
+            throw e;
+        } finally {
+            LingeredApp.stopApp(app);
+        }
+    }
+}

--- a/test/hotspot/jtreg/serviceability/sa/libupcall.c
+++ b/test/hotspot/jtreg/serviceability/sa/libupcall.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include <jni.h>
+
+typedef void (*upcall_func)(void);
+
+JNIEXPORT void JNICALL
+Java_LingeredAppWithFFMUpcall_callJNI(JNIEnv *env, jclass cls, jlong upcallAddr) {
+  upcall_func upcall = (upcall_func)upcallAddr;
+  upcall();
+}


### PR DESCRIPTION
I attempted to check stack trace in the core generated by [SEGV example in upcall](https://github.com/YaSuenag/garakuta/blob/841452d9176dab1ddbb552009c180530eb81190b/NativeSEGV/ffm/upcall/src/main/java/com/yasuenag/garakuta/nativesegv/upcall/Main.java) with `jhsdb jstack`, however it failed with following exception.

```
Error occurred during stack walking:
java.lang.RuntimeException: Couldn't deduce type of CodeBlob @0x00007fa04c265990 for PC=0x00007fa04c265aa6
        at jdk.hotspot.agent/sun.jvm.hotspot.code.CodeCache.findBlobUnsafe(CodeCache.java:124)
        at jdk.hotspot.agent/sun.jvm.hotspot.code.CodeCache.findBlob(CodeCache.java:83)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Frame.cb(Frame.java:119)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.x86.X86Frame.adjustUnextendedSP(X86Frame.java:334)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.x86.X86Frame.initFrame(X86Frame.java:137)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.x86.X86Frame.<init>(X86Frame.java:163)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.x86.X86Frame.senderForInterpreterFrame(X86Frame.java:361)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.x86.X86Frame.sender(X86Frame.java:281)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Frame.sender(Frame.java:207)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.Frame.realSender(Frame.java:212)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.VFrame.sender(VFrame.java:120)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.VFrame.javaSender(VFrame.java:144)
        at jdk.hotspot.agent/sun.jvm.hotspot.tools.StackTrace.run(StackTrace.java:81)
        at jdk.hotspot.agent/sun.jvm.hotspot.tools.StackTrace.run(StackTrace.java:45)
        at jdk.hotspot.agent/sun.jvm.hotspot.tools.JStack.run(JStack.java:67)
        at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.startInternal(Tool.java:278)
        at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.start(Tool.java:241)
        at jdk.hotspot.agent/sun.jvm.hotspot.tools.Tool.execute(Tool.java:134)
        at jdk.hotspot.agent/sun.jvm.hotspot.tools.JStack.runWithArgs(JStack.java:90)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.runJSTACK(SALauncher.java:302)
        at jdk.hotspot.agent/sun.jvm.hotspot.SALauncher.main(SALauncher.java:500)
Caused by: sun.jvm.hotspot.types.WrongTypeException: No suitable match for type of address 0x00007fa04c265990 (nearest symbol is _ZTV10UpcallStub)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.InstanceConstructor.newWrongTypeException(InstanceConstructor.java:62)
        at jdk.hotspot.agent/sun.jvm.hotspot.runtime.VirtualConstructor.instantiateWrapperFor(VirtualConstructor.java:80)
        at jdk.hotspot.agent/sun.jvm.hotspot.code.CodeCache.findBlobUnsafe(CodeCache.java:107)
```

FFM upcall would use `UpcallStub` to call Java code from native, however frame size of the stub would be set to zero implicitly. It should be set to valid size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8339307: jhsdb jstack could not trace FFM upcall frame`

### Issue
 * [JDK-8339307](https://bugs.openjdk.org/browse/JDK-8339307): jhsdb jstack could not trace FFM upcall frame (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20789/head:pull/20789` \
`$ git checkout pull/20789`

Update a local copy of the PR: \
`$ git checkout pull/20789` \
`$ git pull https://git.openjdk.org/jdk.git pull/20789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20789`

View PR using the GUI difftool: \
`$ git pr show -t 20789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20789.diff">https://git.openjdk.org/jdk/pull/20789.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20789#issuecomment-2320623210)