### PR TITLE
8339309: unused-variable warnings happen in libfontmanager

### DIFF
--- a/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c
+++ b/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,7 +98,6 @@ JDKEXPORT int jdk_hb_shape(
      float devScale = 1.0f;
      if (getenv("HB_NODEVTX") != NULL) {
          float xPtSize = euclidianDistance(matrix[0], matrix[1]);
-         float yPtSize = euclidianDistance(matrix[2], matrix[3]);
          devScale = xPtSize / ptSize;
      }
 

--- a/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
+++ b/src/java.desktop/share/native/libfontmanager/freetypeScaler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -513,8 +513,6 @@ Java_sun_font_FreetypeFontScaler_createScalerContextNative(
     double dmat[4], ptsz;
     FTScalerContext *context =
             (FTScalerContext*) calloc(1, sizeof(FTScalerContext));
-    FTScalerInfo *scalerInfo =
-             (FTScalerInfo*) jlong_to_ptr(pScaler);
 
     if (context == NULL) {
         free(context);
@@ -1652,7 +1650,6 @@ Java_sun_font_FreetypeFontScaler_getGlyphPointNative(
         jlong pScaler, jint glyphCode, jint pointNumber) {
 
     FT_Outline* outline;
-    jobject point = NULL;
     jfloat x=0, y=0;
     FTScalerContext *context =
          (FTScalerContext*) jlong_to_ptr(pScalerContext);

--- a/src/java.desktop/unix/native/libfontmanager/X11FontScaler.c
+++ b/src/java.desktop/unix/native/libfontmanager/X11FontScaler.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -267,7 +267,6 @@ Java_sun_font_NativeFont_getGlyphAdvance
         xcs = AWTFontPerChar(xFont, glyphCode - context->minGlyph);
         advance = AWTCharAdvance(xcs);
     } else {
-        int direction, ascent, descent;
         AWTChar2b xChar;
 
         xChar.byte1 = (unsigned char) (glyphCode >> 8);


### PR DESCRIPTION
I saw following errors (warnings) when I tried to build OpenJDK on Fedora 40 with gcc-14.2.1-1.fc40.x86_64:

```
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c: In function ‘jdk_hb_shape’:
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c:101:16: error: unused variable ‘yPtSize’ [-Werror=unused-variable]
  101 | float yPtSize = euclidianDistance(matrix[2], matrix[3]);
      | ^~~~~~~
cc1: all warnings being treated as errors
* For target support_native_java.desktop_libfontmanager_X11FontScaler.o:
/home/ysuenaga/github-forked/jdk/src/java.desktop/unix/native/libfontmanager/X11FontScaler.c: In function ‘Java_sun_font_NativeFont_getGlyphAdvance’:
/home/ysuenaga/github-forked/jdk/src/java.desktop/unix/native/libfontmanager/X11FontScaler.c:270:32: error: unused variable ‘descent’ [-Werror=unused-variable]
  270 | int direction, ascent, descent;
      | ^~~~~~~
/home/ysuenaga/github-forked/jdk/src/java.desktop/unix/native/libfontmanager/X11FontScaler.c:270:24: error: unused variable ‘ascent’ [-Werror=unused-variable]
  270 | int direction, ascent, descent;
      | ^~~~~~
/home/ysuenaga/github-forked/jdk/src/java.desktop/unix/native/libfontmanager/X11FontScaler.c:270:13: error: unused variable ‘direction’ [-Werror=unused-variable]
  270 | int direction, ascent, descent;
      | ^~~~~~~~~
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libfontmanager/freetypeScaler.c: In function ‘Java_sun_font_FreetypeFontScaler_createScalerContextNative’:
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libfontmanager/freetypeScaler.c:516:19: error: unused variable ‘scalerInfo’ [-Werror=unused-variable]
  516 | FTScalerInfo *scalerInfo =
      | ^~~~~~~~~~
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libfontmanager/freetypeScaler.c: In function ‘Java_sun_font_FreetypeFontScaler_getGlyphPointNative’:
/home/ysuenaga/github-forked/jdk/src/java.desktop/share/native/libfontmanager/freetypeScaler.c:1655:13: error: unused variable ‘point’ [-Werror=unused-variable]
 1655 | jobject point = NULL;
      | ^~~~~
```