### PR TITLE
8256211: assert fired in java/net/httpclient/DependentPromiseActionsTest (infrequent)

### DIFF
--- a/test/jdk/java/net/httpclient/DependentPromiseActionsTest.java
+++ b/test/jdk/java/net/httpclient/DependentPromiseActionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/DependentPromiseActionsTest.java
+++ b/test/jdk/java/net/httpclient/DependentPromiseActionsTest.java
@@ -73,6 +73,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Flow;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiPredicate;
@@ -112,6 +113,7 @@ public class DependentPromiseActionsTest implements HttpServerAdapters {
     static volatile boolean tasksFailed;
     static final AtomicLong serverCount = new AtomicLong();
     static final AtomicLong clientCount = new AtomicLong();
+    static final AtomicInteger requestCount = new AtomicInteger();
     static final long start = System.nanoTime();
     public static String now() {
         long now = System.nanoTime() - start;
@@ -244,14 +246,17 @@ public class DependentPromiseActionsTest implements HttpServerAdapters {
     }
 
     @Test(dataProvider = "noStalls")
-    public void testNoStalls(String uri, boolean sameClient)
+    public void testNoStalls(String rootUri, boolean sameClient)
             throws Exception {
+        if (!FAILURES.isEmpty()) return;
         HttpClient client = null;
-        out.printf("%ntestNoStalls(%s, %b)%n", uri, sameClient);
+        out.printf("%ntestNoStalls(%s, %b)%n", rootUri, sameClient);
         for (int i=0; i< ITERATION_COUNT; i++) {
             if (!sameClient || client == null)
                 client = newHttpClient(sameClient);
 
+            String uri = rootUri + "/" + requestCount.incrementAndGet();
+            out.printf("\tsending request %s%n", uri);
             HttpRequest req = HttpRequest.newBuilder(URI.create(uri))
                     .build();
             BodyHandler<Stream<String>> handler =
@@ -331,6 +336,10 @@ public class DependentPromiseActionsTest implements HttpServerAdapters {
                                      SubscriberType subscriberType)
             throws Exception
     {
+        if (!FAILURES.isEmpty()) {
+            out.printf("%s: skipping test - previous failure detected%n", name);
+            return;
+        }
         out.printf("%n%s%s%n", now(), name);
         try {
             testDependent(uri, sameClient, handlers, finisher,
@@ -341,7 +350,7 @@ public class DependentPromiseActionsTest implements HttpServerAdapters {
         }
     }
 
-    private <T,U> void testDependent(String uri, boolean sameClient,
+    private <T,U> void testDependent(String rootUri, boolean sameClient,
                                      Supplier<BodyHandler<T>> handlers,
                                      Finisher finisher,
                                      Extractor<T> extractor,
@@ -354,6 +363,8 @@ public class DependentPromiseActionsTest implements HttpServerAdapters {
             if (!sameClient || client == null)
                 client = newHttpClient(sameClient);
 
+            String uri = rootUri + "/" + requestCount.incrementAndGet();
+            out.printf("\tsending request %s%n", uri);
             HttpRequest req = HttpRequest.
                     newBuilder(URI.create(uri))
                     .build();
@@ -363,7 +374,13 @@ public class DependentPromiseActionsTest implements HttpServerAdapters {
             System.out.println("try stalling in " + where);
             CompletableFuture<HttpResponse<T>> responseCF =
                     client.sendAsync(req, handler, promiseHandler);
-            assert subscriberType == SubscriberType.LAZZY || !responseCF.isDone();
+            // The body of the main response can be received before the body
+            // of the push promise handlers are received.
+            // The body of the main response doesn't stall, so the cf of
+            // the main response may be done here even for EAGER subscribers.
+            // We cannot make any assumption on the state of the main response
+            // cf here, so the only thing we can do is to call the finisher
+            // which will wait for them all.
             finisher.finish(where, responseCF, promiseHandler, extractor);
         }
     }


### PR DESCRIPTION
The fired assert appears to be too strong and can be safely removed. The test uses a "Staller" to stall the delivery of bytes to the body handlers. However, the stalling happens for the push promise response bodies, and there's no guarantee the main response body can't be fully completed before the push promise bodies start being delivered.

I have replaced the assert with a comment, and also updated the test to make it easier to parse logs and diagnose future issues.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8256211: assert fired in java/net/httpclient/DependentPromiseActionsTest (infrequent)`

### Issue
 * [JDK-8256211](https://bugs.openjdk.org/browse/JDK-8256211): assert fired in java/net/httpclient/DependentPromiseActionsTest (infrequent) (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20795/head:pull/20795` \
`$ git checkout pull/20795`

Update a local copy of the PR: \
`$ git checkout pull/20795` \
`$ git pull https://git.openjdk.org/jdk.git pull/20795/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20795`

View PR using the GUI difftool: \
`$ git pr show -t 20795`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20795.diff">https://git.openjdk.org/jdk/pull/20795.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20795#issuecomment-2321274502)