### PR TITLE
8339329: ConstantPoolBuilder#constantValueEntry method doc typo and clarifications

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/Attributes.java
+++ b/src/java.base/share/classes/java/lang/classfile/Attributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,6 +248,7 @@ public final class Attributes {
     /**
      * {@return Attribute mapper for the {@code ConstantValue} attribute}
      * @since 23
+     * @see java.lang.classfile.constantpool.ConstantPoolBuilder#constantValueEntry(java.lang.constant.ConstantDesc)
      */
     public static AttributeMapper<ConstantValueAttribute> constantValue() {
         return ConstantValueMapper.INSTANCE;

--- a/src/java.base/share/classes/java/lang/classfile/Attributes.java
+++ b/src/java.base/share/classes/java/lang/classfile/Attributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,7 +248,6 @@ public final class Attributes {
     /**
      * {@return Attribute mapper for the {@code ConstantValue} attribute}
      * @since 23
-     * @see java.lang.classfile.constantpool.ConstantPoolBuilder#constantValueEntry(java.lang.constant.ConstantDesc)
      */
     public static AttributeMapper<ConstantValueAttribute> constantValue() {
         return ConstantValueMapper.INSTANCE;

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -478,7 +478,7 @@ public sealed interface ConstantPoolBuilder
      * Integer, Long, Float, Double, or String constant}
      *
      * @param c the constant
-     * @see java.lang.classfile.Attributes#constantValue()
+     * @see ConstantValueEntry#constantValue()
      */
     default ConstantValueEntry constantValueEntry(ConstantDesc c) {
         if (c instanceof Integer i) return intEntry(i);

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -474,10 +474,13 @@ public sealed interface ConstantPoolBuilder
     }
 
     /**
-     * {@return A {@link ConstantValueEntry} descripbing the provided
+     * {@return A {@link ConstantValueEntry} describing the provided
      * Integer, Long, Float, Double, or String constant}
+     * The returned consant is suitable as a value for the
+     * {@code ConstantValue} attribute.
      *
      * @param c the constant
+     * @see java.lang.classfile.Attributes#constantValue()
      */
     default ConstantValueEntry constantValueEntry(ConstantDesc c) {
         if (c instanceof Integer i) return intEntry(i);

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -476,8 +476,6 @@ public sealed interface ConstantPoolBuilder
     /**
      * {@return A {@link ConstantValueEntry} describing the provided
      * Integer, Long, Float, Double, or String constant}
-     * The returned consant is suitable as a value for the
-     * {@code ConstantValue} attribute.
      *
      * @param c the constant
      * @see java.lang.classfile.Attributes#constantValue()

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantValueEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantValueEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ public sealed interface ConstantValueEntry extends LoadableConstantEntry
     /**
      * {@return the constant value}  The constant value will be an {@link Integer},
      * {@link Long}, {@link Float}, {@link Double}, or {@link String}.
+     *
+     * @see java.lang.classfile.Attributes#constantValue()
      */
     @Override
     ConstantDesc constantValue();

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantValueEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantValueEntry.java
@@ -24,13 +24,14 @@
  */
 package java.lang.classfile.constantpool;
 
+import java.lang.classfile.Attributes;
 import java.lang.constant.ConstantDesc;
 import jdk.internal.javac.PreviewFeature;
 
 /**
  * Models a constant pool entry that can be used as the constant in a
- * {@code ConstantValue} attribute; this includes the four primitive constant
- * types and {@linkplain String} constants.
+ * {@link Attributes#constantValue() ConstantValue} attribute; this includes the four
+ * primitive constant types and {@linkplain String} constants.
  *
  * @sealedGraph
  * @since 22
@@ -43,7 +44,7 @@ public sealed interface ConstantValueEntry extends LoadableConstantEntry
      * {@return the constant value}  The constant value will be an {@link Integer},
      * {@link Long}, {@link Float}, {@link Double}, or {@link String}.
      *
-     * @see java.lang.classfile.Attributes#constantValue()
+     * @see ConstantPoolBuilder#constantValueEntry(ConstantDesc)
      */
     @Override
     ConstantDesc constantValue();


### PR DESCRIPTION
Please review this small documentation change to ConstantPoolBuilder to fix a typo and clarify the usage of the `constantValueEntry` method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339329](https://bugs.openjdk.org/browse/JDK-8339329): ConstantPoolBuilder#constantValueEntry method doc typo and clarifications (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20796/head:pull/20796` \
`$ git checkout pull/20796`

Update a local copy of the PR: \
`$ git checkout pull/20796` \
`$ git pull https://git.openjdk.org/jdk.git pull/20796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20796`

View PR using the GUI difftool: \
`$ git pr show -t 20796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20796.diff">https://git.openjdk.org/jdk/pull/20796.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20796#issuecomment-2321569870)