### PR TITLE
8003887: File.getCanonicalFile() does not resolve symlinks on MS Windows

### DIFF
--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -491,7 +491,13 @@ final class WinNTFileSystem extends FileSystem {
             return "" + ((char) (c-32)) + ':' + '\\';
         }
         String canonicalPath = canonicalize0(path);
-        return getFinalPath(canonicalPath);
+        String finalPath = null;
+        try {
+            finalPath = getFinalPath(canonicalPath);
+        } catch (IOException ignored) {
+            finalPath = canonicalPath;
+        }
+        return finalPath;
     }
 
     private native String canonicalize0(String path)

--- a/src/java.base/windows/classes/java/io/WinNTFileSystem.java
+++ b/src/java.base/windows/classes/java/io/WinNTFileSystem.java
@@ -490,10 +490,18 @@ final class WinNTFileSystem extends FileSystem {
                 return path;
             return "" + ((char) (c-32)) + ':' + '\\';
         }
-        return canonicalize0(path);
+        String canonicalPath = canonicalize0(path);
+        return getFinalPath(canonicalPath);
     }
 
     private native String canonicalize0(String path)
+            throws IOException;
+
+    private String getFinalPath(String path) throws IOException {
+        return getFinalPath0(path);
+    }
+
+    private native String getFinalPath0(String path)
             throws IOException;
 
 

--- a/src/java.base/windows/native/libjava/WinNTFileSystem_md.c
+++ b/src/java.base/windows/native/libjava/WinNTFileSystem_md.c
@@ -344,7 +344,7 @@ Java_java_io_WinNTFileSystem_getFinalPath0(JNIEnv* env, jobject this, jstring pa
     } END_UNICODE_STRING(env, path);
 
     if (rv == NULL && !(*env)->ExceptionCheck(env)) {
-        JNU_ThrowIOExceptionWithLastError(env, "Bad pathname"); // XXX message?
+        JNU_ThrowIOExceptionWithLastError(env, "Bad pathname");
     }
 
     return rv;

--- a/src/java.base/windows/native/libjava/WinNTFileSystem_md.c
+++ b/src/java.base/windows/native/libjava/WinNTFileSystem_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,31 +46,15 @@ static struct {
     jfieldID path;
 } ids;
 
-/**
- * GetFinalPathNameByHandle is available on Windows Vista and newer
- */
-typedef BOOL (WINAPI* GetFinalPathNameByHandleProc) (HANDLE, LPWSTR, DWORD, DWORD);
-static GetFinalPathNameByHandleProc GetFinalPathNameByHandle_func;
-
 JNIEXPORT void JNICALL
 Java_java_io_WinNTFileSystem_initIDs(JNIEnv *env, jclass cls)
 {
-    HMODULE handle;
     jclass fileClass;
 
     fileClass = (*env)->FindClass(env, "java/io/File");
     CHECK_NULL(fileClass);
     ids.path = (*env)->GetFieldID(env, fileClass, "path", "Ljava/lang/String;");
     CHECK_NULL(ids.path);
-
-    // GetFinalPathNameByHandle requires Windows Vista or newer
-    if (GetModuleHandleExW((GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
-                            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT),
-                           (LPCWSTR)&CreateFileW, &handle) != 0)
-    {
-        GetFinalPathNameByHandle_func = (GetFinalPathNameByHandleProc)
-            GetProcAddress(handle, "GetFinalPathNameByHandleW");
-    }
 }
 
 /* -- Path operations -- */
@@ -87,10 +71,6 @@ static WCHAR* getFinalPath(JNIEnv *env, const WCHAR *path)
     HANDLE h;
     WCHAR *result;
     DWORD error;
-
-    /* Need Windows Vista or newer to get the final path */
-    if (GetFinalPathNameByHandle_func == NULL)
-        return NULL;
 
     h = CreateFileW(path,
                     FILE_READ_ATTRIBUTES,
@@ -109,13 +89,13 @@ static WCHAR* getFinalPath(JNIEnv *env, const WCHAR *path)
      */
     result = (WCHAR*)malloc(MAX_PATH * sizeof(WCHAR));
     if (result != NULL) {
-        DWORD len = (*GetFinalPathNameByHandle_func)(h, result, MAX_PATH, 0);
+        DWORD len = GetFinalPathNameByHandleW(h, result, MAX_PATH, 0);
         if (len >= MAX_PATH) {
             /* retry with a buffer of the right size */
             WCHAR* newResult = (WCHAR*)realloc(result, (len+1) * sizeof(WCHAR));
             if (newResult != NULL) {
                 result = newResult;
-                len = (*GetFinalPathNameByHandle_func)(h, result, len, 0);
+                len = GetFinalPathNameByHandleW(h, result, len, 0);
             } else {
                 len = 0;
                 JNU_ThrowOutOfMemoryError(env, "native memory allocation failed");
@@ -348,6 +328,22 @@ Java_java_io_WinNTFileSystem_canonicalizeWithPrefix0(JNIEnv *env, jobject this,
     if (rv == NULL && !(*env)->ExceptionCheck(env)) {
         JNU_ThrowIOExceptionWithLastError(env, "Bad pathname");
     }
+    return rv;
+}
+
+JNIEXPORT jstring JNICALL
+Java_java_io_WinNTFileSystem_getFinalPath0(JNIEnv* env, jobject this, jstring pathname) {
+    jstring rv = NULL;
+
+    WITH_UNICODE_STRING(env, pathname, path) {
+        WCHAR* finalPath = getFinalPath(env, path);
+        rv = (*env)->NewString(env, finalPath, (jsize)wcslen(finalPath));
+    } END_UNICODE_STRING(env, path);
+
+    if (rv == NULL && !(*env)->ExceptionCheck(env)) {
+        JNU_ThrowIOExceptionWithLastError(env, "Bad pathname"); // XXX message?
+    }
+
     return rv;
 }
 

--- a/src/java.base/windows/native/libjava/WinNTFileSystem_md.c
+++ b/src/java.base/windows/native/libjava/WinNTFileSystem_md.c
@@ -337,7 +337,10 @@ Java_java_io_WinNTFileSystem_getFinalPath0(JNIEnv* env, jobject this, jstring pa
 
     WITH_UNICODE_STRING(env, pathname, path) {
         WCHAR* finalPath = getFinalPath(env, path);
-        rv = (*env)->NewString(env, finalPath, (jsize)wcslen(finalPath));
+        if (finalPath != NULL) {
+            rv = (*env)->NewString(env, finalPath, (jsize)wcslen(finalPath));
+            free(finalPath);
+        }
     } END_UNICODE_STRING(env, path);
 
     if (rv == NULL && !(*env)->ExceptionCheck(env)) {


### PR DESCRIPTION
Return the final path derived from the string returned by `canonicalize0()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8003887](https://bugs.openjdk.org/browse/JDK-8003887): File.getCanonicalFile() does not resolve symlinks on MS Windows (**Enhancement** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20801/head:pull/20801` \
`$ git checkout pull/20801`

Update a local copy of the PR: \
`$ git checkout pull/20801` \
`$ git pull https://git.openjdk.org/jdk.git pull/20801/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20801`

View PR using the GUI difftool: \
`$ git pr show -t 20801`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20801.diff">https://git.openjdk.org/jdk/pull/20801.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20801#issuecomment-2322335602)