### PR TITLE
8306085: [JVMCI] expose pre-allocated exception objects to JVMCI

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -63,6 +63,7 @@ import jdk.vm.ci.code.InstalledCode;
 import jdk.vm.ci.common.InitTimer;
 import jdk.vm.ci.common.JVMCIError;
 import jdk.vm.ci.common.NativeImageReinitialize;
+import jdk.vm.ci.meta.JavaConstant;
 import jdk.vm.ci.meta.JavaKind;
 import jdk.vm.ci.meta.JavaType;
 import jdk.vm.ci.meta.ResolvedJavaField;
@@ -1490,5 +1491,19 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         writeDebugOutput(messageBytes, 0, messageBytes.length, true, true);
         exitHotSpot(status);
         throw JVMCIError.shouldNotReachHere();
+    }
+
+    /**
+     * Gets a preallocated exception object of type {@code type} that can be used to implement
+     * {@code OmitStackTraceInFastThrow}.
+     *
+     * @param type the type of the preallocated exception object
+     * @param throwingMethod if non-null, the caller is requesting the object to implement
+     *            {@code OmitStackTraceInFastThrow} in the compiled code for {@code throwingMethod}
+     * @return the pre-allocated object or null if no such pre-allocated object is available or must
+     *            not be used for a hot throw site in {@code throwingMethod}
+     */
+    public <T extends Throwable> JavaConstant getPreallocatedExceptionObject(Class<T> type, ResolvedJavaMethod throwingMethod) {
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Issue
 * [JDK-8306085](https://bugs.openjdk.org/browse/JDK-8306085): [JVMCI] expose pre-allocated exception objects to JVMCI (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20802/head:pull/20802` \
`$ git checkout pull/20802`

Update a local copy of the PR: \
`$ git checkout pull/20802` \
`$ git pull https://git.openjdk.org/jdk.git pull/20802/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20802`

View PR using the GUI difftool: \
`$ git pr show -t 20802`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20802.diff">https://git.openjdk.org/jdk/pull/20802.diff</a>

</details>
