### PR TITLE
8339366: [jittester] Make it possible to generate tests without execution

### DIFF
--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ByteCodeGenerator.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ByteCodeGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,16 +47,17 @@ class ByteCodeGenerator extends TestsGenerator {
     }
 
     @Override
-    public void accept(IRNode mainClass, IRNode privateClasses) {
-        generateClassFiles(mainClass, privateClasses);
-        generateSeparateJtregHeader(mainClass);
+    public void accept(IRTreeGenerator.Test test) {
+        IRNode mainClass = test.mainClass();
+        generateClassFiles(mainClass, test.privateClasses());
+        generateSeparateJtregHeader(test.seed(), mainClass);
         compilePrinter();
         generateGoldenOut(mainClass.getName());
     }
 
-    private void generateSeparateJtregHeader(IRNode mainClass) {
+    private void generateSeparateJtregHeader(long seed, IRNode mainClass) {
         String mainClassName = mainClass.getName();
-        writeFile(generatorDir, mainClassName + ".java", getJtregHeader(mainClassName));
+        writeFile(generatorDir, mainClassName + ".java", getJtregHeader(mainClassName, seed));
     }
 
     private void generateClassFiles(IRNode mainClass, IRNode privateClasses) {
@@ -92,6 +93,19 @@ class ByteCodeGenerator extends TestsGenerator {
             Files.write(generatorDir.resolve(fileName), bytecode);
         } catch (IOException ex) {
             ex.printStackTrace();
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        ProductionParams.initializeFromCmdline(args);
+        IRTreeGenerator.initializeWithProductionParams();
+
+        ByteCodeGenerator generator = new ByteCodeGenerator();
+
+        for (String mainClass : ProductionParams.mainClassNames.value()) {
+            var test = IRTreeGenerator.generateIRTree(mainClass);
+            generator.generateClassFiles(test.mainClass(), test.privateClasses());
+            generator.generateSeparateJtregHeader(test.seed(), test.mainClass());
         }
     }
 }

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/IRTreeGenerator.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/IRTreeGenerator.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.jittester;
+
+import jdk.test.lib.jittester.factories.IRNodeBuilder;
+import jdk.test.lib.jittester.types.TypeKlass;
+import jdk.test.lib.jittester.utils.FixedTrees;
+import jdk.test.lib.jittester.utils.PseudoRandom;
+
+/**
+ * Generates IR trees for fuzzy test classes.
+ */
+public class IRTreeGenerator {
+
+    /**
+     * Generated Test - main and private classes trees along with random seed used for generation.
+     */
+    public record Test (long seed, IRNode mainClass, IRNode privateClasses) {};
+
+    /**
+     * Generates IR trees for main and private classes.
+     *
+     * @param name main class name
+     * @return a pair (main class; private classes)
+     */
+    public static Test generateIRTree(String name) {
+        long seed = PseudoRandom.getCurrentSeed();
+        ProductionLimiter.resetTimer();
+        //NB: SymbolTable is a widely-used singleton, hence all the locking.
+        SymbolTable.removeAll();
+        TypeList.removeAll();
+
+        IRNodeBuilder builder = new IRNodeBuilder()
+                .setPrefix(name)
+                .setName(name)
+                .setLevel(0);
+
+        Long complexityLimit = ProductionParams.complexityLimit.value();
+        IRNode privateClasses = null;
+        if (!ProductionParams.disableClasses.value()) {
+            long privateClassComlexity = (long) (complexityLimit * PseudoRandom.random());
+            try {
+                privateClasses = builder.setComplexityLimit(privateClassComlexity)
+                        .getClassDefinitionBlockFactory()
+                        .produce();
+            } catch (ProductionFailedException ex) {
+                ex.printStackTrace(System.out);
+            }
+        }
+        long mainClassComplexity = (long) (complexityLimit * PseudoRandom.random());
+        IRNode mainClass = null;
+        try {
+            mainClass = builder.setComplexityLimit(mainClassComplexity)
+                    .getMainKlassFactory()
+                    .produce();
+            TypeKlass aClass = new TypeKlass(name);
+            mainClass.getChild(1).addChild(FixedTrees.generateMainOrExecuteMethod(aClass, true));
+            mainClass.getChild(1).addChild(FixedTrees.generateMainOrExecuteMethod(aClass, false));
+        } catch (ProductionFailedException ex) {
+            ex.printStackTrace(System.out);
+        }
+        return new Test(seed, mainClass, privateClasses);
+    }
+
+    /**
+     * Initializes the generator from ProductionParams static class.
+     */
+    public static void initializeWithProductionParams() {
+        TypesParser.parseTypesAndMethods(ProductionParams.classesFile.value(),
+                ProductionParams.excludeMethodsFile.value());
+        if (ProductionParams.specificSeed.isSet()) {
+            PseudoRandom.setCurrentSeed(ProductionParams.specificSeed.value());
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/ProductionParams.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,15 @@
 
 package jdk.test.lib.jittester;
 
+import java.util.List;
+
 import jdk.test.lib.jittester.utils.OptionResolver;
 import jdk.test.lib.jittester.utils.OptionResolver.Option;
+import jdk.test.lib.jittester.utils.PseudoRandom;
 
 public class ProductionParams {
 
+    public static Option<List<String>> mainClassNames = null;
     public static Option<Integer> productionLimit = null;
     public static Option<Integer> productionLimitSeconds = null;
     public static Option<Integer> dataMemberLimit = null;
@@ -72,6 +76,7 @@ public class ProductionParams {
     // workaraound: to reduce chance throwing ArrayIndexOutOfBoundsException
     public static Option<Integer> chanceExpressionIndex = null;
     public static Option<String> testbaseDir = null;
+    public static Option<String> tempDir = null;
     public static Option<Integer> numberOfTests = null;
     public static Option<String> seed = null;
     public static Option<Long> specificSeed = null;
@@ -81,6 +86,7 @@ public class ProductionParams {
     public static Option<String> generatorsFactories = null;
 
     public static void register(OptionResolver optionResolver) {
+        mainClassNames = optionResolver.addRepeatingOption('k', "main-class", "", "Main class name");
         productionLimit = optionResolver.addIntegerOption('l', "production-limit", 100, "Limit on steps in the production of an expression");
         productionLimitSeconds = optionResolver.addIntegerOption("production-limit-seconds", 600, "Limit the time a test generation may take");
         dataMemberLimit = optionResolver.addIntegerOption('v', "data-member-limit", 10, "Upper limit on data members");
@@ -124,6 +130,7 @@ public class ProductionParams {
         enableFinalizers = optionResolver.addBooleanOption("enable-finalizers", "Enable finalizers (for stress testing)");
         chanceExpressionIndex = optionResolver.addIntegerOption("chance-expression-index", 0, "A non negative decimal integer used to restrict chane of generating expression in array index while creating or accessing by index");
         testbaseDir = optionResolver.addStringOption("testbase-dir", ".", "Testbase dir");
+        tempDir = optionResolver.addStringOption("temp-dir", ".", "Temp dir path");
         numberOfTests = optionResolver.addIntegerOption('n', "number-of-tests", 0, "Number of test classes to generate");
         seed = optionResolver.addStringOption("seed", "", "Random seed");
         specificSeed = optionResolver.addLongOption('z', "specificSeed", 0L, "A seed to be set for specific test generation(regular seed still needed for initialization)");
@@ -131,5 +138,19 @@ public class ProductionParams {
         excludeMethodsFile = optionResolver.addStringOption('r', "exclude-methods-file", "conf/exclude.methods.lst", "File to read excluded methods from");
         generators = optionResolver.addStringOption("generators", "", "Comma-separated list of generator names");
         generatorsFactories = optionResolver.addStringOption("generatorsFactories", "", "Comma-separated list of generators factories class names");
+    }
+
+    /**
+     * Initializes from the given command-line args
+     *
+     * @param args command-line arguments to use for initialization
+     */
+    public static void initializeFromCmdline(String[] args) {
+        OptionResolver parser = new OptionResolver();
+        Option<String> propertyFileOpt = parser.addStringOption('p', "property-file",
+                "conf/default.properties", "File to read properties from");
+        ProductionParams.register(parser);
+        parser.parse(args, propertyFileOpt);
+        PseudoRandom.reset(ProductionParams.seed.value());
     }
 }

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TestsGenerator.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/TestsGenerator.java
@@ -30,13 +30,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import jdk.test.lib.jittester.types.TypeKlass;
-import jdk.test.lib.jittester.utils.PseudoRandom;
 
-public abstract class TestsGenerator implements BiConsumer<IRNode, IRNode> {
+public abstract class TestsGenerator implements Consumer<IRTreeGenerator.Test> {
     private static final int DEFAULT_JTREG_TIMEOUT = 120;
     protected static final String JAVA_BIN = getJavaPath();
     protected static final String JAVAC = Paths.get(JAVA_BIN, "javac").toString();
@@ -121,9 +120,9 @@ public abstract class TestsGenerator implements BiConsumer<IRNode, IRNode> {
         }
     }
 
-    protected String getJtregHeader(String mainClassName) {
+    protected String getJtregHeader(String mainClassName, long seed) {
         String synopsis = "seed = '" + ProductionParams.seed.value() + "'"
-                + ", specificSeed = '" + PseudoRandom.getCurrentSeed() + "'";
+                + ", specificSeed = '" + seed + "'";
         StringBuilder header = new StringBuilder();
         header.append("/*\n * @test\n * @summary ")
               .append(synopsis)

--- a/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/utils/OptionResolver.java
+++ b/test/hotspot/jtreg/testlibrary/jittester/src/jdk/test/lib/jittester/utils/OptionResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -156,6 +156,12 @@ public class OptionResolver {
         return addBooleanOption(null, name, false, description);
     }
 
+    public Option<List<String>> addRepeatingOption(Character key, String name, String defaultValue, String description) {
+        final Option<List<String>> option = new RepeatingOption(key, name, defaultValue, description);
+        register(option);
+        return option;
+    }
+
     private void register(Option<?> option) {
         if (options.put("--" + option.longName, option) != null) {
             throw new RuntimeException("Option is already registered for key " + option.longName);
@@ -261,6 +267,20 @@ public class OptionResolver {
         public Boolean parseFromString(String arg) {
             //null and empty value is considered true, as option is flag and value could be absent
             return arg == null || "".equals(arg) || "1".equalsIgnoreCase(arg) || "true".equalsIgnoreCase(arg);
+        }
+    }
+
+    private class RepeatingOption extends Option<List<String>> {
+        List<String> accumulated = new ArrayList<String>();
+
+        RepeatingOption(Character s, String l, String v, String d) {
+            super(s, l, List.of(v), d);
+        }
+
+        @Override
+        public List<String> parseFromString(String arg) {
+            accumulated.add(arg);
+            return accumulated;
         }
     }
 


### PR DESCRIPTION
This PR:

1. Extracts IR tree generation from execution (left in the Automatic) into a dedicated class IRTreeGenerator;
2. Introduces a generation result record (named IRTreeGenerator.Test). The record contains main and private classes along with the random seed used for their generation;
3. Creates CLI-wrapper classes for Java and ByteCode generators to allow generation-only execution;
4. Add a repeating option to the configuration - to make it possible to specify several main class names.

Sample usage:
```bash
java -cp build/classes --add-opens java.base/java.util=ALL-UNNAMED \
      jdk.test.lib.jittester.JavaCodeGenerator \
      -k Test_0 -k Test_1 -k Test_10
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339366](https://bugs.openjdk.org/browse/JDK-8339366): [jittester] Make it possible to generate tests without execution (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20806/head:pull/20806` \
`$ git checkout pull/20806`

Update a local copy of the PR: \
`$ git checkout pull/20806` \
`$ git pull https://git.openjdk.org/jdk.git pull/20806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20806`

View PR using the GUI difftool: \
`$ git pr show -t 20806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20806.diff">https://git.openjdk.org/jdk/pull/20806.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20806#issuecomment-2324043805)