### PR TITLE
8339313: JDK-8338888 broke 32-bit builds

### DIFF
--- a/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
+++ b/test/hotspot/jtreg/runtime/exceptionMsgs/NoClassDefFoundError/libNoClassDefFoundErrorTest.c
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef __LP64__
 
 JNIEXPORT void JNICALL
 Java_NoClassDefFoundErrorTest_callDefineClass(JNIEnv *env, jclass klass, jstring className) {
@@ -77,3 +78,5 @@ Java_NoClassDefFoundErrorTest_tryCallFindClass(JNIEnv *env, jclass klass) {
     }
     return JNI_FALSE;
 }
+
+#endif /* __LP64__ */


### PR DESCRIPTION
See JBS issue and comment history. GCC chokes on the native test code with bogus (AFAICS) fortify errors.

In any case, since this code should not be compiled for 32-bit anyway, I exclude it. Trivial?

Tested on x86 and x64. On x86, build succeeds, on x64 we still can run `runtime/exceptionMsgs/NoClassDefFoundError `successfully.

Ping @dholmes-ora

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339313](https://bugs.openjdk.org/browse/JDK-8339313): JDK-8338888 broke 32-bit builds (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20809/head:pull/20809` \
`$ git checkout pull/20809`

Update a local copy of the PR: \
`$ git checkout pull/20809` \
`$ git pull https://git.openjdk.org/jdk.git pull/20809/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20809`

View PR using the GUI difftool: \
`$ git pr show -t 20809`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20809.diff">https://git.openjdk.org/jdk/pull/20809.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20809#issuecomment-2324340019)