### PR TITLE
8339368: Switch targets are not inflated in CodeModel if no StackMap

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
@@ -258,6 +258,14 @@ public final class CodeImpl
                     switch (i) {
                         case BranchInstruction br -> br.target();
                         case DiscontinuedInstruction.JsrInstruction jsr -> jsr.target();
+                        case LookupSwitchInstruction ls -> {
+                            ls.defaultTarget();
+                            ls.cases();
+                        }
+                        case TableSwitchInstruction ts -> {
+                            ts.defaultTarget();
+                            ts.cases();
+                        }
                         default -> {}
                     }
                     pos += i.sizeInBytes();

--- a/test/jdk/jdk/classfile/OneToOneTest.java
+++ b/test/jdk/jdk/classfile/OneToOneTest.java
@@ -24,16 +24,11 @@
 /*
  * @test
  * @summary Testing ClassFile class writing and reading.
+ * @bug 8339368
  * @run junit OneToOneTest
  */
 import java.lang.constant.ClassDesc;
-
-import static java.lang.classfile.ClassFile.ACC_PUBLIC;
-import static java.lang.classfile.ClassFile.ACC_STATIC;
-import static java.lang.constant.ConstantDescs.*;
 import java.lang.constant.MethodTypeDesc;
-import java.util.List;
-
 import java.lang.reflect.AccessFlag;
 import java.lang.classfile.ClassModel;
 import java.lang.classfile.ClassFile;
@@ -41,22 +36,20 @@ import java.lang.classfile.Instruction;
 import java.lang.classfile.Label;
 import java.lang.classfile.MethodModel;
 import java.lang.classfile.attribute.SourceFileAttribute;
-import static org.junit.jupiter.api.Assertions.*;
+import java.lang.classfile.instruction.*;
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
-import java.lang.classfile.instruction.ConstantInstruction;
-import java.lang.classfile.instruction.StoreInstruction;
-import java.lang.classfile.instruction.BranchInstruction;
-import java.lang.classfile.instruction.LoadInstruction;
-import java.lang.classfile.instruction.OperatorInstruction;
-import java.lang.classfile.instruction.FieldInstruction;
-import java.lang.classfile.instruction.InvokeInstruction;
-
+import static java.lang.classfile.ClassFile.ACC_PUBLIC;
+import static java.lang.classfile.ClassFile.ACC_STATIC;
+import static java.lang.classfile.Opcode.*;
+import static java.lang.constant.ConstantDescs.*;
 import static helpers.TestConstants.CD_PrintStream;
 import static helpers.TestConstants.CD_System;
 import static helpers.TestConstants.MTD_INT_VOID;
 import static helpers.TestConstants.MTD_VOID;
-import static java.lang.classfile.Opcode.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 class OneToOneTest {
 
@@ -155,5 +148,37 @@ class OneToOneTest {
             }
         }
         assertTrue(found);
+    }
+
+    @Test
+    void testJava5ClassWriteRead() {
+        MethodModel mm = ClassFile.of().parse(ClassFile.of().build(ClassDesc.of("MyClass"), clb -> clb
+                .withVersion(ClassFile.JAVA_5_VERSION, 0)
+                .withMethodBody("switches", MTD_void, ACC_STATIC, cob -> {
+                    Label l1 = cob.newLabel(), l2 = cob.newLabel(), l3 = cob.newLabel(), l4 = cob.newLabel();
+                    cob.iconst_0()
+                       .tableswitch(l1, List.of(SwitchCase.of(0, l2)))
+                       .labelBinding(l1)
+                       .nop()
+                       .labelBinding(l2)
+                       .iconst_0()
+                       .lookupswitch(l3, List.of(SwitchCase.of(0, l4)))
+                       .labelBinding(l3)
+                       .nop()
+                       .labelBinding(l4)
+                       .return_();
+                }))).methods().getFirst();
+        var it = mm.code().orElseThrow().iterator();
+        while (!(it.next() instanceof ConstantInstruction));
+        assertTrue(it.next() instanceof TableSwitchInstruction tsi
+                   && it.next() instanceof LabelTarget lt1 && lt1.label().equals(tsi.defaultTarget())
+                   && it.next() instanceof NopInstruction
+                   && it.next() instanceof LabelTarget lt2 && lt2.label().equals(tsi.cases().getFirst().target())
+                   && it.next() instanceof ConstantInstruction
+                   && it.next() instanceof LookupSwitchInstruction lsi
+                   && it.next() instanceof LabelTarget lt3 && lt3.label().equals(lsi.defaultTarget())
+                   && it.next() instanceof NopInstruction
+                   && it.next() instanceof LabelTarget lt4 && lt4.label().equals(lsi.cases().getFirst().target()),
+                () -> mm.code().get().elementList().toString());
     }
 }


### PR DESCRIPTION
ClassFile API use an alternate labels inflation method for class versions < 50 (where StackMapTable attribute is optional).
The alternate method missed label inflation of lookup switch and table switch instructions.
This patch fixes the label inflation method for for class versions < 50 and adds relevant test.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339368](https://bugs.openjdk.org/browse/JDK-8339368): Switch targets are not inflated in CodeModel if no StackMap (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20810/head:pull/20810` \
`$ git checkout pull/20810`

Update a local copy of the PR: \
`$ git checkout pull/20810` \
`$ git pull https://git.openjdk.org/jdk.git pull/20810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20810`

View PR using the GUI difftool: \
`$ git pr show -t 20810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20810.diff">https://git.openjdk.org/jdk/pull/20810.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20810#issuecomment-2324345937)