### PR TITLE
8305489: runtime/ErrorHandling/TestDwarf.java fails in some Linux configurations after JDK-8303805

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -115,7 +115,6 @@ runtime/os/TestTracePageSizes.java#Parallel 8267460 linux-aarch64
 runtime/os/TestTracePageSizes.java#Serial 8267460 linux-aarch64
 runtime/ErrorHandling/CreateCoredumpOnCrash.java 8267433 macosx-x64
 runtime/StackGuardPages/TestStackGuardPagesNative.java 8303612 linux-all
-runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/Thread/TestAlwaysPreTouchStacks.java 8335167 macosx-aarch64
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64


### PR DESCRIPTION
We've decided to clean up `TestDwarf.java` and remove the configuration checking the decoder which is not reliably working. I cleaned the problemlist entry as well. The removed parts can be re-added again if the decoder is fixed at some point.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8305489](https://bugs.openjdk.org/browse/JDK-8305489): runtime/ErrorHandling/TestDwarf.java fails in some Linux configurations after JDK-8303805 (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20811/head:pull/20811` \
`$ git checkout pull/20811`

Update a local copy of the PR: \
`$ git checkout pull/20811` \
`$ git pull https://git.openjdk.org/jdk.git pull/20811/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20811`

View PR using the GUI difftool: \
`$ git pr show -t 20811`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20811.diff">https://git.openjdk.org/jdk/pull/20811.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20811#issuecomment-2324409917)