### PR TITLE
8339364: AIX build fails: various unused variable and function warnings

### DIFF
--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -181,8 +181,11 @@ ifeq ($(call isTargetOs, windows macosx), false)
           $(X_CFLAGS), \
       EXTRA_HEADER_DIRS := $(LIBAWT_HEADLESS_EXTRA_HEADER_DIRS), \
       DISABLED_WARNINGS_gcc := unused-variable, \
+      DISABLED_WARNINGS_clang := unused-variable, \
       DISABLED_WARNINGS_gcc_X11Renderer.c := unused-function, \
       DISABLED_WARNINGS_gcc_X11SurfaceData.c := unused-function, \
+      DISABLED_WARNINGS_clang_X11Renderer.c := unused-function, \
+      DISABLED_WARNINGS_clang_X11SurfaceData.c := unused-function, \
       JDK_LIBS := libawt java.base:libjava, \
       LIBS_linux := $(LIBDL) $(LIBM), \
       STATIC_LIB_EXCLUDE_OBJS := $(LIBAWT_HEADLESS_STATIC_EXCLUDE_OBJS), \
@@ -238,6 +241,7 @@ ifeq ($(call isTargetOs, windows macosx)+$(ENABLE_HEADLESS_ONLY), false+false)
       CFLAGS := -DXAWT -DXAWT_HACK $(LIBAWT_XAWT_CFLAGS) \
           $(FONTCONFIG_CFLAGS) $(CUPS_CFLAGS) $(X_CFLAGS), \
       DISABLED_WARNINGS_gcc := int-to-pointer-cast unused-variable, \
+      DISABLED_WARNINGS_clang := unused-variable, \
       DISABLED_WARNINGS_gcc_awt_Taskbar.c := parentheses, \
       DISABLED_WARNINGS_gcc_GLXSurfaceData.c := unused-function, \
       DISABLED_WARNINGS_gcc_gtk3_interface.c := parentheses type-limits \
@@ -256,20 +260,22 @@ ifeq ($(call isTargetOs, windows macosx)+$(ENABLE_HEADLESS_ONLY), false+false)
       DISABLED_WARNINGS_gcc_XToolkit.c := unused-result, \
       DISABLED_WARNINGS_gcc_XWindow.c := unused-function, \
       DISABLED_WARNINGS_clang_awt_Taskbar.c := parentheses, \
-      DISABLED_WARNINGS_clang_gtk3_interface.c := parentheses, \
+      DISABLED_WARNINGS_clang_gtk3_interface.c := unused-function parentheses, \
+      DISABLED_WARNINGS_clang_GLXSurfaceData.c := unused-function, \
       DISABLED_WARNINGS_clang_OGLBufImgOps.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_OGLPaints.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_screencast_pipewire.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_sun_awt_X11_GtkFileDialogPeer.c := parentheses, \
+      DISABLED_WARNINGS_clang_XWindow.c := unused-function, \
       DISABLED_WARNINGS_clang_aix := deprecated-non-prototype, \
       DISABLED_WARNINGS_clang_aix_awt_Taskbar.c := parentheses, \
       DISABLED_WARNINGS_clang_aix_OGLPaints.c := format-nonliteral, \
       DISABLED_WARNINGS_clang_aix_OGLBufImgOps.c := format-nonliteral, \
-      DISABLED_WARNINGS_clang_aix_gtk3_interface.c := parentheses \
+      DISABLED_WARNINGS_clang_aix_gtk3_interface.c := unused-function parentheses \
           logical-op-parentheses, \
       DISABLED_WARNINGS_clang_aix_sun_awt_X11_GtkFileDialogPeer.c := \
           parentheses, \
-      DISABLED_WARNINGS_clang_aix_awt_InputMethod.c := sign-compare, \
+      DISABLED_WARNINGS_clang_aix_awt_InputMethod.c := unused-function sign-compare, \
       JDK_LIBS := libawt java.base:libjava, \
       LIBS_unix := $(LIBDL) $(LIBM) $(X_LIBS) -lX11 -lXext -lXi -lXrender \
           -lXtst, \

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
@@ -661,11 +661,8 @@ pid_t unix_getParentPidAndTimings(JNIEnv *env, pid_t pid,
 
 void unix_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
     psinfo_t psinfo;
-    char fn[32];
-    char exePath[PATH_MAX];
     char prargs[PRARGSZ + 1];
     jstring cmdexe = NULL;
-    int ret;
 
     /*
      * Now try to open /proc/%d/psinfo

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -41,8 +41,6 @@
 #include "TimeZone_md.h"
 #include "path_util.h"
 
-static char *isFileIdentical(char* buf, size_t size, char *pathname);
-
 #define fileopen        fopen
 #define filegets        fgets
 #define fileclose       fclose
@@ -61,6 +59,8 @@ static const char popularZones[][4] = {"UTC", "GMT"};
 
 #if defined(_AIX)
 static const char *ETC_ENVIRONMENT_FILE = "/etc/environment";
+#else
+static char *isFileIdentical(char* buf, size_t size, char *pathname);
 #endif
 
 #if defined(__linux__) || defined(MACOSX)

--- a/src/java.base/unix/native/libjava/TimeZone_md.c
+++ b/src/java.base/unix/native/libjava/TimeZone_md.c
@@ -57,13 +57,8 @@ static const char *DEFAULT_ZONEINFO_FILE = "/usr/share/lib/zoneinfo/localtime";
 
 static const char popularZones[][4] = {"UTC", "GMT"};
 
-#if defined(_AIX)
-static const char *ETC_ENVIRONMENT_FILE = "/etc/environment";
-#else
-static char *isFileIdentical(char* buf, size_t size, char *pathname);
-#endif
-
 #if defined(__linux__) || defined(MACOSX)
+static char *isFileIdentical(char* buf, size_t size, char *pathname);
 
 /*
  * remove repeated path separators ('/') in the given 'path'.
@@ -356,6 +351,7 @@ getPlatformTimeZoneID()
 }
 
 #elif defined(_AIX)
+static const char *ETC_ENVIRONMENT_FILE = "/etc/environment";
 
 static char *
 getPlatformTimeZoneID()

--- a/src/java.desktop/aix/native/libawt_xawt/awt/awt_InputMethod.c
+++ b/src/java.desktop/aix/native/libawt_xawt/awt/awt_InputMethod.c
@@ -493,9 +493,6 @@ static StatusWindow *createStatusWindow(Window parent) {
     XWindowAttributes xwa;
     XWindowAttributes xxwa;
     /* Variable for XCreateFontSet()*/
-    char **mclr;
-    int  mccr = 0;
-    char *dsr;
     unsigned long bg, fg, light, dim;
     int x, y, off_x, off_y, xx, yy;
     unsigned int w, h, bw, depth;

--- a/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
+++ b/src/java.desktop/unix/native/common/awt/CUPSfuncs.c
@@ -202,7 +202,6 @@ Java_sun_print_CUPSPrinter_getCupsDefaultPrinter(JNIEnv *env,
     cups_dest_t *dests;
     char *defaultPrinter = NULL;
     int num_dests = j2d_cupsGetDests(&dests);
-    int i = 0;
     cups_dest_t *dest = j2d_cupsGetDest(NULL, NULL, num_dests, dests);
     if (dest != NULL) {
         defaultPrinter = dest->name;

--- a/src/java.desktop/unix/native/common/awt/X11Color.c
+++ b/src/java.desktop/unix/native/common/awt/X11Color.c
@@ -1233,8 +1233,8 @@ awt_allocate_systemrgbcolors (jint *rgbColors, int num_colors,
                               AwtGraphicsConfigDataPtr awtData) {
     for (int i = 0; i < num_colors; i++)
         alloc_col (awt_display, awtData->awt_cmap, red (rgbColors [i]),
-                     green (rgbColors [i]), blue (rgbColors [i]), -1,
-                     awtData);
+                   green (rgbColors [i]), blue (rgbColors [i]), -1,
+                   awtData);
 }
 
 int

--- a/src/java.desktop/unix/native/common/awt/X11Color.c
+++ b/src/java.desktop/unix/native/common/awt/X11Color.c
@@ -338,7 +338,7 @@ awt_allocate_colors(AwtGraphicsConfigDataPtr awt_data)
     unsigned char reds[256], greens[256], blues[256];
     int indices[256];
     Colormap cm;
-    int i, j, k, cmapsize, nfree, depth, bpp;
+    int i, k, cmapsize, nfree, depth, bpp;
     int allocatedColorsNum, unavailableColorsNum;
     XPixmapFormatValues *pPFV;
     int numpfv;
@@ -878,7 +878,6 @@ awt_allocate_colors(AwtGraphicsConfigDataPtr awt_data)
 
 jobject getColorSpace(JNIEnv* env, jint csID) {
     jclass clazz;
-    jobject cspaceL;
     jmethodID mid;
 
     clazz = (*env)->FindClass(env,"java/awt/color/ColorSpace");
@@ -1033,7 +1032,6 @@ jobject awtJNI_GetColorModel(JNIEnv *env, AwtGraphicsConfigDataPtr aData)
         jobject validBits = NULL;
         ColorEntry *c;
         int i, allocAllGray, b, allvalid, paletteSize;
-        jlong pData;
 
         if (aData->awt_visInfo.depth == 12) {
             paletteSize = MAX_PALETTE12_SIZE;
@@ -1233,11 +1231,10 @@ jobject awtJNI_GetColorModel(JNIEnv *env, AwtGraphicsConfigDataPtr aData)
 void
 awt_allocate_systemrgbcolors (jint *rgbColors, int num_colors,
                               AwtGraphicsConfigDataPtr awtData) {
-    int i, pixel;
-    for (i = 0; i < num_colors; i++)
-        pixel = alloc_col (awt_display, awtData->awt_cmap, red (rgbColors [i]),
-                           green (rgbColors [i]), blue (rgbColors [i]), -1,
-                           awtData);
+    for (int i = 0; i < num_colors; i++)
+        alloc_col (awt_display, awtData->awt_cmap, red (rgbColors [i]),
+                     green (rgbColors [i]), blue (rgbColors [i]), -1,
+                     awtData);
 }
 
 int

--- a/src/java.desktop/unix/native/common/awt/fontpath.c
+++ b/src/java.desktop/unix/native/common/awt/fontpath.c
@@ -100,7 +100,6 @@ typedef struct {
 jboolean isDisplayLocal(JNIEnv *env) {
     static jboolean isLocal = False;
     static jboolean isLocalSet = False;
-    jboolean ret;
 
     if (! isLocalSet) {
       jclass geCls = (*env)->FindClass(env, "java/awt/GraphicsEnvironment");
@@ -134,7 +133,7 @@ jboolean isDisplayLocal(JNIEnv *env) {
 static char **getX11FontPath ()
 {
     char **x11Path, **fontdirs;
-    int i, pos, slen, nPaths, numDirs;
+    int i, pos, slen, nPaths;
 
     x11Path = XGetFontPath (awt_display, &nPaths);
 
@@ -533,7 +532,6 @@ static char **getFontConfigLocations() {
 
     char **fontdirs;
     int numdirs = 0;
-    FcInitLoadConfigFuncType FcInitLoadConfig;
     FcPatternBuildFuncType FcPatternBuild;
     FcObjectSetFuncType FcObjectSetBuild;
     FcFontListFuncType FcFontList;
@@ -543,14 +541,10 @@ static char **getFontConfigLocations() {
     FcObjectSetDestroyFuncType FcObjectSetDestroy;
     FcFontSetDestroyFuncType FcFontSetDestroy;
 
-    FcConfig *fontconfig;
     FcPattern *pattern;
     FcObjectSet *objset;
     FcFontSet *fontSet;
-    FcStrList *strList;
-    FcChar8 *str;
-    int i, f, found, len=0;
-    char **fontPath;
+    int i, f, found;
 
     void* libfontconfig = openFontConfig();
 

--- a/src/java.desktop/unix/native/common/java2d/x11/X11FontScaler_md.c
+++ b/src/java.desktop/unix/native/common/java2d/x11/X11FontScaler_md.c
@@ -43,8 +43,6 @@
 
 static GC pixmapGC = 0;
 static Pixmap pixmap = 0;
-static Atom psAtom = 0;
-static Atom fullNameAtom = 0;
 static int pixmapWidth = 0;
 static int pixmapHeight = 0;
 
@@ -127,9 +125,9 @@ JNIEXPORT int JNICALL AWTCountFonts(char* xlfd) {
 }
 
 JNIEXPORT void JNICALL AWTLoadFont(char* name, AWTFont *pReturn) {
-    JNIEnv *env;
     *pReturn = NULL;
 #ifndef HEADLESS
+    JNIEnv *env;
     FONT_AWT_LOCK();
     *pReturn = (AWTFont)XLoadQueryFont(awt_display, name);
     AWT_UNLOCK();
@@ -268,7 +266,7 @@ JNIEXPORT jlong JNICALL AWTFontGenerateImage(AWTFont pFont, AWTChar2b* xChar) {
     XCharStruct xcs;
     XImage *ximage;
     int h, i, j, nbytes;
-    unsigned char *srcRow, *dstRow, *dstByte;
+    unsigned char *srcRow, *dstRow;
     int wholeByteCount, remainingBitsCount;
     unsigned int imageSize;
     JNIEnv *env;

--- a/src/java.desktop/unix/native/common/java2d/x11/X11Renderer.c
+++ b/src/java.desktop/unix/native/common/java2d/x11/X11Renderer.c
@@ -571,7 +571,6 @@ Java_sun_java2d_x11_X11Renderer_XDoPath
 #ifndef HEADLESS
     X11SDOps *xsdo = (X11SDOps *) pXSData;
     jarray typesArray;
-    jobject pointArray;
     jarray coordsArray;
     jint numTypes;
     jint fillRule;

--- a/src/java.desktop/unix/native/common/java2d/x11/X11SurfaceData.c
+++ b/src/java.desktop/unix/native/common/java2d/x11/X11SurfaceData.c
@@ -882,11 +882,9 @@ static void X11SD_GetRasInfo(JNIEnv *env,
     } else
 #endif /* MITSHM */
     if (xpriv->lockType == X11SD_LOCK_BY_XIMAGE) {
-        int x, y, w, h;
+        int x, y;
         x = pRasInfo->bounds.x1;
         y = pRasInfo->bounds.y1;
-        w = pRasInfo->bounds.x2 - x;
-        h = pRasInfo->bounds.y2 - y;
 
         xpriv->img = X11SD_GetImage(env, xsdo, &pRasInfo->bounds, lockFlags);
         if (xpriv->img) {

--- a/src/java.desktop/unix/native/common/java2d/x11/X11TextRenderer_md.c
+++ b/src/java.desktop/unix/native/common/java2d/x11/X11TextRenderer_md.c
@@ -213,7 +213,7 @@ AWTDrawGlyphList(JNIEnv *env, jobject xtr,
     XImage *theImage;
     Pixmap thePixmap;
     XGCValues xgcv;
-    int scan, screen;
+    int screen;
     AwtGraphicsConfigDataPtr cData;
     X11SDOps *xsdo = (X11SDOps *)jlong_to_ptr(dstData);
     jint cx1, cy1, cx2, cy2;
@@ -235,8 +235,6 @@ AWTDrawGlyphList(JNIEnv *env, jobject xtr,
     theImage = cData->monoImage;
     thePixmap = cData->monoPixmap;
     theGC = cData->monoPixmapGC;
-
-    scan = theImage->bytes_per_line;
 
     xgcv.fill_style = FillStippled;
     xgcv.stipple = thePixmap;

--- a/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/awt_GraphicsEnv.c
@@ -304,7 +304,6 @@ getAllConfigs (JNIEnv *env, int screen, AwtScreenDataPtr screenDataPtr) {
     AwtGraphicsConfigDataPtr *graphicsConfigs;
     AwtGraphicsConfigDataPtr defaultConfig;
     int ind;
-    char errmsg[128];
     int xinawareScreen;
     void* xrenderLibHandle = NULL;
     XRenderFindVisualFormatFunc* xrenderFindVisualFormat = NULL;
@@ -722,7 +721,6 @@ awt_init_Display(JNIEnv *env, jobject this)
     jclass klass;
     Display *dpy;
     char errmsg[128];
-    int i;
 
     if (awt_display) {
         return awt_display;
@@ -872,7 +870,6 @@ extern int mitShmPermissionMask;
 void TryInitMITShm(JNIEnv *env, jint *shmExt, jint *shmPixmaps) {
     XShmSegmentInfo shminfo;
     int XShmMajor, XShmMinor;
-    int a, b, c;
 
     AWT_LOCK();
     if (canUseShmExt != UNSET_MITSHM) {
@@ -1154,7 +1151,7 @@ JNIEnv *env, jobject this, jint visualNum, jint screen)
 
     AwtGraphicsConfigData *adata = NULL;
     AwtScreenData asd = x11Screens[screen];
-    int i, n;
+    int i;
     int depth;
     XImage * tempImage;
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/multiVis.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/multiVis.c
@@ -793,8 +793,6 @@ static list_ptr make_region_list(Display *disp, Window win, XRectangle *bbox,
     XRectangle          clip;
     int                 image_only;
 
-    int                 count=0 ;
-
     *hasNonDefault = False;
     XUnionRectWithRegion( bbox, bbox_region, bbox_region);
     XGetWindowAttributes( disp, win, &win_attrs);
@@ -823,8 +821,6 @@ static list_ptr make_region_list(Display *disp, Window win, XRectangle *bbox,
                                         malloc( sizeof( image_region_type)))) {
                     return (list_ptr) NULL;
                 }
-                count++;
-
                 new_reg->visible_region = XCreateRegion();
                 new_reg->win            = base_src->win;
                 new_reg->vis            = base_src->vis;

--- a/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
+++ b/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
@@ -209,7 +209,7 @@ FreeColors(Display * display, Screen * screen, int numColors,
 }
 
 static void SplashCenter(Splash * splash) {
-    Atom type, atom, actual_type;
+    Atom atom, actual_type;
     int status, actual_format;
     unsigned long nitems, bytes_after;
     CARD16 *prop = NULL;
@@ -251,8 +251,6 @@ static void SplashUpdateSizeHints(Splash * splash) {
 
 void
 SplashCreateWindow(Splash * splash) {
-    XSizeHints sizeHints;
-
     XSetWindowAttributes attr;
 
     attr.backing_store = NotUseful;
@@ -740,11 +738,10 @@ void
 SplashCreateThread(Splash * splash) {
     pthread_t thr;
     pthread_attr_t attr;
-    int rc;
 
     int rslt = pthread_attr_init(&attr);
     if (rslt != 0) return;
-    rc = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
     pthread_attr_destroy(&attr);
 }
 


### PR DESCRIPTION
We get a couple of warnings as errors on AIX because of unused variables or functions , for example :
/priv/jenkins/client-home/workspace/openjdk-jdk-dev-aix_ppc64-opt/jdk/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c:665:10: error: unused variable 'exePath' [-Werror,-Wunused-variable]
    char exePath[PATH_MAX];
         ^
/priv/jenkins/client-home/workspace/openjdk-jdk-dev-aix_ppc64-opt/jdk/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c:668:9: error: unused variable 'ret' [-Werror,-Wunused-variable]
    int ret;
        ^
/priv/jenkins/client-home/workspace/openjdk-jdk-dev-aix_ppc64-opt/jdk/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c:664:10: error: unused variable 'fn' [-Werror,-Wunused-variable]
    char fn[32];
         ^

This seems to be related to the recent make changes
8339156: Use more fine-granular clang unused warnings
https://bugs.openjdk.org/browse/JDK-8339156
(we use clang too on AIX)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339364](https://bugs.openjdk.org/browse/JDK-8339364): AIX build fails: various unused variable and function warnings (**Bug** - P2)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) Review applies to [0fca9ee0](https://git.openjdk.org/jdk/pull/20812/files/0fca9ee01d6c2d2d772877ae2c0aa17237cf2331)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer) Review applies to [0fca9ee0](https://git.openjdk.org/jdk/pull/20812/files/0fca9ee01d6c2d2d772877ae2c0aa17237cf2331)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20812/head:pull/20812` \
`$ git checkout pull/20812`

Update a local copy of the PR: \
`$ git checkout pull/20812` \
`$ git pull https://git.openjdk.org/jdk.git pull/20812/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20812`

View PR using the GUI difftool: \
`$ git pr show -t 20812`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20812.diff">https://git.openjdk.org/jdk/pull/20812.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20812#issuecomment-2324558838)