### PR TITLE
8338817: Wrong indent in API docs for java.lang.management.ManagementFactory

### DIFF
--- a/src/java.management/share/classes/java/lang/management/ManagementFactory.java
+++ b/src/java.management/share/classes/java/lang/management/ManagementFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -95,7 +95,6 @@ import sun.management.spi.PlatformMBeanProvider.PlatformComponent;
  * <p>
  * An application can access a platform MXBean in the following ways:
  * <h3>1. Direct access to an MXBean interface</h3>
- * <blockquote>
  * <ul>
  *     <li>Get an MXBean instance by calling the
  *         {@link #getPlatformMXBean(Class) getPlatformMXBean} or
@@ -130,7 +129,6 @@ import sun.management.spi.PlatformMBeanProvider.PlatformComponent;
  *         for details.
  *        </li>
  * </ul>
- * </blockquote>
  *
  * <p>
  * The {@link #getPlatformManagementInterfaces getPlatformManagementInterfaces}


### PR DESCRIPTION
Trivial change.
Javadoc has a misplaced and unnecessary blockquote tag which cuts across two sections.  Removing this fixes the odd indent.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338817](https://bugs.openjdk.org/browse/JDK-8338817): Wrong indent in API docs for java.lang.management.ManagementFactory (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20813/head:pull/20813` \
`$ git checkout pull/20813`

Update a local copy of the PR: \
`$ git checkout pull/20813` \
`$ git pull https://git.openjdk.org/jdk.git pull/20813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20813`

View PR using the GUI difftool: \
`$ git pr show -t 20813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20813.diff">https://git.openjdk.org/jdk/pull/20813.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20813#issuecomment-2324571690)