### PR TITLE
8339371: jlink.log warning when building after JDK-8338404

### DIFF
--- a/make/InterimImage.gmk
+++ b/make/InterimImage.gmk
@@ -48,7 +48,8 @@ $(eval $(call SetupExecute, jlink_interim_image, \
     DEPS :=  $(JMODS) $(call DependOnVariable, INTERIM_MODULES_LIST), \
     OUTPUT_DIR := $(INTERIM_IMAGE_DIR), \
     SUPPORT_DIR := $(INTERIM_JLINK_SUPPORT_DIR), \
-    COMMAND := $(RM) -r $(INTERIM_IMAGE_DIR) && $(JLINK_TOOL) --output $(INTERIM_IMAGE_DIR) \
+    PRE_COMMAND := $(RM) -r $(INTERIM_IMAGE_DIR), \
+    COMMAND := $(JLINK_TOOL) --output $(INTERIM_IMAGE_DIR) \
         --disable-plugin generate-jli-classes \
         --add-modules $(INTERIM_MODULES_LIST), \
 ))

--- a/make/InterimImage.gmk
+++ b/make/InterimImage.gmk
@@ -27,12 +27,13 @@ default: all
 
 include $(SPEC)
 include MakeBase.gmk
+
+include Execute.gmk
 include Modules.gmk
 
 ################################################################################
 
-# Use this file inside the image as target for make rule
-JIMAGE_TARGET_FILE := bin/java$(EXECUTABLE_SUFFIX)
+INTERIM_JLINK_SUPPORT_DIR := $(SUPPORT_OUTPUTDIR)/interim-image-jlink
 
 INTERIM_MODULES_LIST := $(call CommaList, $(INTERIM_IMAGE_MODULES))
 
@@ -42,19 +43,17 @@ JLINK_TOOL := $(JLINK) -J-Djlink.debug=true \
     --module-path $(INTERIM_JMODS_DIR) \
     --endian $(OPENJDK_BUILD_CPU_ENDIAN)
 
-$(INTERIM_IMAGE_DIR)/$(JIMAGE_TARGET_FILE): $(JMODS) \
-    $(call DependOnVariable, INTERIM_MODULES_LIST)
-	$(call LogWarn, Creating interim jimage)
-	$(RM) -r $(INTERIM_IMAGE_DIR)
-	$(call MakeDir, $(INTERIM_IMAGE_DIR))
-	$(call ExecuteWithLog, $(INTERIM_IMAGE_DIR)/jlink, \
-	    $(JLINK_TOOL) \
-	    --output $(INTERIM_IMAGE_DIR) \
-	    --disable-plugin generate-jli-classes \
-	    --add-modules $(INTERIM_MODULES_LIST))
-	$(TOUCH) $@
+$(eval $(call SetupExecute, jlink_interim_image, \
+    WARN := Creating interim jimage, \
+    DEPS :=  $(JMODS) $(call DependOnVariable, INTERIM_MODULES_LIST), \
+    OUTPUT_DIR := $(INTERIM_IMAGE_DIR), \
+    SUPPORT_DIR := $(INTERIM_JLINK_SUPPORT_DIR), \
+    COMMAND := $(RM) -r $(INTERIM_IMAGE_DIR) && $(JLINK_TOOL) --output $(INTERIM_IMAGE_DIR) \
+        --disable-plugin generate-jli-classes \
+        --add-modules $(INTERIM_MODULES_LIST), \
+))
 
-TARGETS += $(INTERIM_IMAGE_DIR)/$(JIMAGE_TARGET_FILE)
+TARGETS += $(jlink_interim_image)
 
 ################################################################################
 


### PR DESCRIPTION
After JDK-8338404, the build produces warnings like:

/bin/tee: /localhome/git/jdk-CDR/build/linux-x64/support/interim-image/jlink.log: No such file or directory

Fix this by using a proper SetupExecute instead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339371](https://bugs.openjdk.org/browse/JDK-8339371): jlink.log warning when building after JDK-8338404 (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [725a74ff](https://git.openjdk.org/jdk/pull/20814/files/725a74ffa08eaeffd1c1fc4728038cd4e9f4529e)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20814/head:pull/20814` \
`$ git checkout pull/20814`

Update a local copy of the PR: \
`$ git checkout pull/20814` \
`$ git pull https://git.openjdk.org/jdk.git pull/20814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20814`

View PR using the GUI difftool: \
`$ git pr show -t 20814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20814.diff">https://git.openjdk.org/jdk/pull/20814.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20814#issuecomment-2324633296)