### PR TITLE
8339384: Unintentional IOException in jdk.jdi module when JDWP end of stream occurs

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/TargetVM.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/TargetVM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/TargetVM.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/TargetVM.java
@@ -123,8 +123,9 @@ public class TargetVM implements Runnable {
                 byte b[] = connection.readPacket();
                 if (b.length == 0) {
                     done = true;
+                } else {
+                    p = Packet.fromByteArray(b);
                 }
-                p = Packet.fromByteArray(b);
             } catch (IOException e) {
                 done = true;
             }


### PR DESCRIPTION
A logic error in the block of code in com.sun.tools.jdi.TargetVM is fixed by putting fromByteArray() method within else statement to prevent invoking it when the array b is empty. See issue: [JDK-8339384](https://bugs.openjdk.org/browse/JDK-8339384)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339384](https://bugs.openjdk.org/browse/JDK-8339384): Unintentional IOException in jdk.jdi module when JDWP end of stream occurs (**Bug** - P5)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) Review applies to [bc244adb](https://git.openjdk.org/jdk/pull/20815/files/bc244adbe8307664af9291c8da4c5142ed1aeeee)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20815/head:pull/20815` \
`$ git checkout pull/20815`

Update a local copy of the PR: \
`$ git checkout pull/20815` \
`$ git pull https://git.openjdk.org/jdk.git pull/20815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20815`

View PR using the GUI difftool: \
`$ git pr show -t 20815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20815.diff">https://git.openjdk.org/jdk/pull/20815.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20815#issuecomment-2324640518)