### PR TITLE
8338916: Build warnings about overriding recipe for jvm-ldflags.txt

### DIFF
--- a/make/common/NativeCompilation.gmk
+++ b/make/common/NativeCompilation.gmk
@@ -292,6 +292,7 @@ define SetupBasicVariables
   $1_TARGET := $$($1_OUTPUT_DIR)/$$($1_BASENAME)
   $1_NOSUFFIX := $$($1_PREFIX)$$($1_NAME)
   $1_SAFE_NAME := $$(strip $$(subst /,_, $1))
+  $1_UNIQUE_NAME = $$($1_TYPE)_$$(subst /,_,$$(patsubst $$(OUTPUTDIR)/%/,%,$$(dir $$($1_OBJECT_DIR))))_$$($1_NOSUFFIX)
 endef
 
 ################################################################################

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -200,7 +200,7 @@ define CreateDynamicLibraryOrExecutable
         endif
 
   # This is for IDE integration purposes only, and is not normally generated
-  $1_LDFLAGS_FILE := $$(MAKESUPPORT_OUTPUTDIR)/compile-commands/$$($1_NAME)-ldflags.txt
+  $1_LDFLAGS_FILE := $$(MAKESUPPORT_OUTPUTDIR)/compile-commands/$$($1_UNIQUE_NAME)-ldflags.txt
 
   $1_ALL_LD_ARGS := $$($1_LDFLAGS) $$($1_EXTRA_LDFLAGS) $$($1_SYSROOT_LDFLAGS) \
       $$($1_LIBS) $$($1_EXTRA_LIBS)


### PR DESCRIPTION
From the bug report:

Users are reporting warnings like this:

lib/CompileGtest.gmk:84: warning: overriding recipe for target '/.../build/linux-x64/make-support/compile-commands/jvm-ldflags.txt'
lib/CompileJvm.gmk:166: warning: ignoring old recipe for target '/.../build/linux-x64/make-support/compile-commands/jvm-ldflags.txt'

I believe this is caused by [JDK-8338290](https://bugs.openjdk.org/browse/JDK-8338290), where the jvm-ldflags.txt target file isn't made unique enough.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338916](https://bugs.openjdk.org/browse/JDK-8338916): Build warnings about overriding recipe for jvm-ldflags.txt (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20819/head:pull/20819` \
`$ git checkout pull/20819`

Update a local copy of the PR: \
`$ git checkout pull/20819` \
`$ git pull https://git.openjdk.org/jdk.git pull/20819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20819`

View PR using the GUI difftool: \
`$ git pr show -t 20819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20819.diff">https://git.openjdk.org/jdk/pull/20819.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20819#issuecomment-2324653516)