### PR TITLE
8339300: CollectorPolicy.young_scaled_initial_ergo_vm gtest fails on ppc64 based platforms

### DIFF
--- a/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
+++ b/test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp
@@ -67,7 +67,7 @@ class TestGenCollectorPolicy {
       MinHeapSize = 40 * M;
       FLAG_SET_ERGO(InitialHeapSize, 100 * M);
       FLAG_SET_ERGO(NewSize, 1 * M);
-      FLAG_SET_ERGO(MaxNewSize, 40 * M);
+      FLAG_SET_ERGO(MaxNewSize, 50 * M);
 
       ASSERT_NO_FATAL_FAILURE(setter1->execute());
 
@@ -196,7 +196,7 @@ TEST_OTHER_VM(CollectorPolicy, young_cmd) {
 
   // If NewSize is set on command line, but is larger than the min
   // heap size, it should only be used for initial young size.
-  TestGenCollectorPolicy::SetNewSizeCmd setter_large(40 * M);
-  TestGenCollectorPolicy::CheckYoungInitial checker_large(40 * M);
+  TestGenCollectorPolicy::SetNewSizeCmd setter_large(50 * M);
+  TestGenCollectorPolicy::CheckYoungInitial checker_large(50 * M);
   TestGenCollectorPolicy::TestWrapper::test(&setter_large, &checker_large);
 }


### PR DESCRIPTION
We currently fail in CollectorPolicy.young_scaled_initial_ergo_vm after [JDK-8258483](https://bugs.openjdk.org/browse/JDK-8258483) came in.
AIX / Linux ppc64le show this error :

[ RUN ] CollectorPolicy.young_scaled_initial_ergo_vm
test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp:122: Failure
Expected equality of these values:
  expected
    Which is: 44695552
  NewSize
    Which is: 41943040

test/hotspot/gtest/gc/shared/test_collectorPolicy.cpp:78: Failure
Expected: checker->execute() doesn't generate new fatal failures in the current thread.
  Actual: it does.

[ FAILED ] CollectorPolicy.young_scaled_initial_ergo_vm (0 ms)

So the decrease form 80M to 40M was too much for these platforms (they slightly differ in ergo/startup behavior).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339300](https://bugs.openjdk.org/browse/JDK-8339300): CollectorPolicy.young_scaled_initial_ergo_vm gtest fails on ppc64 based platforms (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20820/head:pull/20820` \
`$ git checkout pull/20820`

Update a local copy of the PR: \
`$ git checkout pull/20820` \
`$ git pull https://git.openjdk.org/jdk.git pull/20820/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20820`

View PR using the GUI difftool: \
`$ git pr show -t 20820`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20820.diff">https://git.openjdk.org/jdk/pull/20820.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20820#issuecomment-2324691805)