### PR TITLE
8339163: ZGC: Race in clearing of remembered sets

### DIFF
--- a/src/hotspot/share/gc/z/zRemembered.cpp
+++ b/src/hotspot/share/gc/z/zRemembered.cpp
@@ -125,7 +125,7 @@ bool ZRemembered::should_scan_page(ZPage* page) const {
   return false;
 }
 
-bool ZRemembered::scan_page(ZPage* page) const {
+bool ZRemembered::scan_page_and_clear_remset(ZPage* page) const {
   const bool can_trust_live_bits =
       page->is_relocatable() && !ZGeneration::old()->is_phase_mark();
 
@@ -149,6 +149,20 @@ bool ZRemembered::scan_page(ZPage* page) const {
   } else {
     page->log_msg(" (scan_page_remembered_dead)");
     // All objects are dead - do nothing
+  }
+
+  if (ZVerifyRemembered) {
+    // Make sure self healing of pointers is ordered before clearing of
+    // the previous bits so that ZVerify::after_scan can detect missing
+    // remset entries accurately.
+    OrderAccess::storestore();
+  }
+
+  // If we have consumed the remset entries above we also clear them.
+  // The exception is if the page is completely empty/garbage, where we don't
+  // want to race with an old collection modifying the remset as well.
+  if (!can_trust_live_bits || page->is_marked()) {
+    page->clear_remset_previous();
   }
 
   return result;
@@ -500,16 +514,7 @@ public:
       if (page != nullptr) {
         if (_remembered->should_scan_page(page)) {
           // Visit all entries pointing into young gen
-          bool found_roots = _remembered->scan_page(page);
-
-          // ... and as a side-effect clear the previous entries
-          if (ZVerifyRemembered) {
-            // Make sure self healing of pointers is ordered before clearing of
-            // the previous bits so that ZVerify::after_scan can detect missing
-            // remset entries accurately.
-            OrderAccess::storestore();
-          }
-          page->clear_remset_previous();
+          bool found_roots = _remembered->scan_page_and_clear_remset(page);
 
           if (found_roots && !left_marking) {
             // Follow remembered set when possible

--- a/src/hotspot/share/gc/z/zRemembered.hpp
+++ b/src/hotspot/share/gc/z/zRemembered.hpp
@@ -73,7 +73,7 @@ private:
 
   bool should_scan_page(ZPage* page) const;
 
-  bool scan_page(ZPage* page) const;
+  bool scan_page_and_clear_remset(ZPage* page) const;
   bool scan_forwarding(ZForwarding* forwarding, void* context) const;
 
 public:


### PR DESCRIPTION
When a young collection is in the "concurrent mark" phase and is scanning remembered sets (remsets) to find roots into the young gen it "consumes" the remset when it is finished by clearing it (using memset).

At the same time, an old collection might find a completely empty/garbage page that it will insert into the page cache. Before inserting into the page cache, the page's remset is cleared (using memset).

These two operations might interfere, resulting in both threads clearing the memory simultaneously.

This race was found in connection to https://bugs.openjdk.org/browse/JDK-8339161 where I experimented replacing some clears of remsets with free's and got a crash on Windows from memset when operating on free'd memory.

This patch makes sure that remsets are only cleared in the "concurrent mark" phase if not already handled by an old collection.

Tested with tiers 1-3 and with a local test that crashes if both threads handle the remset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339163](https://bugs.openjdk.org/browse/JDK-8339163): ZGC: Race in clearing of remembered sets (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20821/head:pull/20821` \
`$ git checkout pull/20821`

Update a local copy of the PR: \
`$ git checkout pull/20821` \
`$ git pull https://git.openjdk.org/jdk.git pull/20821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20821`

View PR using the GUI difftool: \
`$ git pr show -t 20821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20821.diff">https://git.openjdk.org/jdk/pull/20821.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20821#issuecomment-2324736381)