### PR TITLE
8338891: HotSpotDiagnosticsMXBean missing @since tag

### DIFF
--- a/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
@@ -47,6 +47,8 @@ import java.lang.management.PlatformManagedObject;
  * {@code null} unless it's stated otherwise.
  *
  * @see java.lang.management.ManagementFactory#getPlatformMXBeans(Class)
+ *
+ * @since 1.6
  */
 public interface HotSpotDiagnosticMXBean extends PlatformManagedObject {
     /**


### PR DESCRIPTION
Trivial "since" tag addition in javadoc: since 1.6

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338891](https://bugs.openjdk.org/browse/JDK-8338891): HotSpotDiagnosticsMXBean missing @<!---->since tag (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20823/head:pull/20823` \
`$ git checkout pull/20823`

Update a local copy of the PR: \
`$ git checkout pull/20823` \
`$ git pull https://git.openjdk.org/jdk.git pull/20823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20823`

View PR using the GUI difftool: \
`$ git pr show -t 20823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20823.diff">https://git.openjdk.org/jdk/pull/20823.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20823#issuecomment-2325032557)