### PR TITLE
8339399: ZGC: Remove unnecessary page reset when splitting pages

### DIFF
--- a/src/hotspot/share/gc/z/zPage.hpp
+++ b/src/hotspot/share/gc/z/zPage.hpp
@@ -44,8 +44,6 @@ enum class ZPageResetType {
   // Page was not selected for relocation, all objects
   // stayed, but the page aged.
   FlipAging,
-  // The page was split and needs to be reset
-  Splitting,
 };
 
 class ZPage : public CHeapObj<mtGC> {


### PR DESCRIPTION
There is no use-case where it is necessary to reset the same page after splitting and thus the reset should be removed.

Tested with tiers 1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339399](https://bugs.openjdk.org/browse/JDK-8339399): ZGC: Remove unnecessary page reset when splitting pages (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20824/head:pull/20824` \
`$ git checkout pull/20824`

Update a local copy of the PR: \
`$ git checkout pull/20824` \
`$ git pull https://git.openjdk.org/jdk.git pull/20824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20824`

View PR using the GUI difftool: \
`$ git pr show -t 20824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20824.diff">https://git.openjdk.org/jdk/pull/20824.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20824#issuecomment-2325060349)