### PR TITLE
8339411: [PPC64] cmpxchgw/h/b doesn't handle external Label

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -1737,7 +1737,7 @@ void MacroAssembler::cmpxchg_generic(ConditionRegister flag, Register dest_curre
 
   cmpxchg_loop_body(flag, dest_current_value, compare_value, exchange_value, addr_base, tmp1, tmp2,
                     retry, failed, cmpxchgx_hint, size);
-  if (!weak || use_result_reg) {
+  if (!weak || use_result_reg || failed_ext) {
     if (UseStaticBranchPredictionInCompareAndSwapPPC64) {
       bne_predict_not_taken(CCR0, weak ? failed : retry); // StXcx_ sets CCR0.
     } else {


### PR DESCRIPTION
I had forgotten to copy one line from the cmpxchgd in [JDK-8338814](https://bugs.openjdk.org/browse/JDK-8338814) (https://github.com/openjdk/jdk/commit/2edf574f62837678e621e1dfdd8d8a77dbe17ad6).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339411](https://bugs.openjdk.org/browse/JDK-8339411): [PPC64] cmpxchgw/h/b doesn't handle external Label (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20826/head:pull/20826` \
`$ git checkout pull/20826`

Update a local copy of the PR: \
`$ git checkout pull/20826` \
`$ git pull https://git.openjdk.org/jdk.git pull/20826/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20826`

View PR using the GUI difftool: \
`$ git pr show -t 20826`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20826.diff">https://git.openjdk.org/jdk/pull/20826.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20826#issuecomment-2325293539)