### PR TITLE
8339419: [s390x] Problemlist compiler/c2/irTests/TestIfMinMax.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -53,7 +53,7 @@ compiler/loopopts/TestUnreachableInnerLoop.java 8288981 linux-s390x
 
 compiler/c2/Test8004741.java 8235801 generic-all
 compiler/c2/irTests/TestDuplicateBackedge.java 8318904 generic-all
-compiler/c2/irTests/TestIfMinMax.java linux-s390x
+compiler/c2/irTests/TestIfMinMax.java 8339220 linux-s390x
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 compiler/codecache/CheckLargePages.java 8332654 linux-x64

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -53,6 +53,7 @@ compiler/loopopts/TestUnreachableInnerLoop.java 8288981 linux-s390x
 
 compiler/c2/Test8004741.java 8235801 generic-all
 compiler/c2/irTests/TestDuplicateBackedge.java 8318904 generic-all
+compiler/c2/irTests/TestIfMinMax.java linux-s390x
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 compiler/codecache/CheckLargePages.java 8332654 linux-x64


### PR DESCRIPTION
TestIfMinMax.java is failing on s390x, for now I want to disable this test for s390x-platform. In future whenever the failure will be fixed with [JDK-8339220](https://bugs.openjdk.org/browse/JDK-8339220), changes done by this PR will be reverted.

I guess this is trivial patch and one review will be required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339419](https://bugs.openjdk.org/browse/JDK-8339419): [s390x] Problemlist compiler/c2/irTests/TestIfMinMax.java (**Sub-task** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20827/head:pull/20827` \
`$ git checkout pull/20827`

Update a local copy of the PR: \
`$ git checkout pull/20827` \
`$ git pull https://git.openjdk.org/jdk.git pull/20827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20827`

View PR using the GUI difftool: \
`$ git pr show -t 20827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20827.diff">https://git.openjdk.org/jdk/pull/20827.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20827#issuecomment-2325758660)