### PR TITLE
8339466: Enumerate shared stubs and define static fields and names via declarations

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2567,9 +2567,7 @@ uint SharedRuntime::out_preserve_stack_slots() {
 // and setup oopmap.
 //
 SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
-  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= SharedStubId::polling_page_return_handler_id),
-         "expected a polling page stub id");
+  assert(is_polling_page_id(id), "expected a polling page stub id");
 
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
@@ -2698,9 +2696,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 //
 RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= SharedStubId::wrong_method_id &&
-          id <= SharedStubId::resolve_static_call_id),
-         "expected a resolve blob id");
+  assert(is_resolve_id(id), "expected a resolve stub id");
 
   // allocate space for the code
   ResourceMark rm;
@@ -2798,9 +2794,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 // caller saved registers were assumed volatile in the compiler.
 
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
-  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
-          id <= SharedStubId::throw_delayed_StackOverflowError_id),
-         "expected a throw stub id");
+  assert(is_throw_id(id), "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
 

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2570,7 +2570,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
           id <= sharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
-         
+
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
   OopMap* map;
@@ -2803,7 +2803,7 @@ RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address ru
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
-  
+
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
   // the compilers are responsible for supplying a continuation point

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2181,7 +2181,7 @@ void SharedRuntime::generate_deopt_blob() {
     pad += 512; // Increase the buffer size when compiling for JVMCI
   }
 #endif
-  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2048+pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words;
@@ -2574,7 +2574,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   OopMap* map;
 
   // Allocate space for the code.  Setup code generation tools.
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
@@ -2701,7 +2701,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
   // allocate space for the code
   ResourceMark rm;
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   MacroAssembler* masm                = new MacroAssembler(&buffer);
 
@@ -2796,7 +2796,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
   assert(is_throw_id(id), "expected a throw stub id");
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
 
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
@@ -2906,7 +2906,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
@@ -2945,7 +2945,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
   int insts_size = 1024;
   int locs_size = 64;
 
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2181,7 +2181,8 @@ void SharedRuntime::generate_deopt_blob() {
     pad += 512; // Increase the buffer size when compiling for JVMCI
   }
 #endif
-  CodeBuffer buffer("deopt_blob", 2048+pad, 1024);
+  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  CodeBuffer buffer(name, 2048+pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words;
   OopMap* map = nullptr;
@@ -2565,20 +2566,25 @@ uint SharedRuntime::out_preserve_stack_slots() {
 // Generate a special Compile2Runtime blob that saves all registers,
 // and setup oopmap.
 //
-SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_type) {
+SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
+  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= sharedStubId::polling_page_return_handler_id),
+         "expected a polling page stub id");
+         
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
   OopMap* map;
 
   // Allocate space for the code.  Setup code generation tools.
-  CodeBuffer buffer("handler_blob", 2048, 1024);
+  const char *name = SharedRuntime::stub_name(id);
+  CodeBuffer buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
   address start   = __ pc();
   address call_pc = nullptr;
   int frame_size_in_words;
-  bool cause_return = (poll_type == POLL_AT_RETURN);
-  RegisterSaver reg_save(poll_type == POLL_AT_VECTOR_LOOP /* save_vectors */);
+  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
+  RegisterSaver reg_save(id == sharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
 
   // When the signal occurred, the LR was either signed and stored on the stack (in which
   // case it will be restored from the stack before being used) or unsigned and not stored
@@ -2690,12 +2696,16 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const char* name) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
+  assert((id >= sharedStubId::wrong_method_id &&
+          id <= sharedStubId::resolve_static_call_id),
+         "expected a resolve blob id");
 
   // allocate space for the code
   ResourceMark rm;
 
+  const char *name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   MacroAssembler* masm                = new MacroAssembler(&buffer);
 
@@ -2787,7 +2797,13 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
 // otherwise assume that stack unwinding will be initiated, so
 // caller saved registers were assumed volatile in the compiler.
 
-RuntimeStub* SharedRuntime::generate_throw_exception(const char* name, address runtime_entry) {
+RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
+  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
+          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+         "expected a throw stub id");
+
+  const char *name = SharedRuntime::stub_name(id);
+  
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
   // the compilers are responsible for supplying a continuation point
@@ -2896,7 +2912,8 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  CodeBuffer code("jfr_write_checkpoint", insts_size, locs_size);
+  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_write_checkpoint_id);
+  CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
 
@@ -2915,7 +2932,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
   oop_maps->add_gc_map(the_pc - start, map);
 
   RuntimeStub* stub = // codeBlob framesize is in words (not VMRegImpl::slot_size)
-    RuntimeStub::new_runtime_stub("jfr_write_checkpoint", &code, frame_complete,
+    RuntimeStub::new_runtime_stub(name, &code, frame_complete,
                                   (framesize >> (LogBytesPerWord - LogBytesPerInt)),
                                   oop_maps, false);
   return stub;
@@ -2934,7 +2951,8 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
   int insts_size = 1024;
   int locs_size = 64;
 
-  CodeBuffer code("jfr_return_lease", insts_size, locs_size);
+  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_return_lease_id);
+  CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
 
@@ -2953,7 +2971,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
   oop_maps->add_gc_map(the_pc - start, map);
 
   RuntimeStub* stub = // codeBlob framesize is in words (not VMRegImpl::slot_size)
-    RuntimeStub::new_runtime_stub("jfr_return_lease", &code, frame_complete,
+    RuntimeStub::new_runtime_stub(name, &code, frame_complete,
                                   (framesize >> (LogBytesPerWord - LogBytesPerInt)),
                                   oop_maps, false);
   return stub;

--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -2181,7 +2181,7 @@ void SharedRuntime::generate_deopt_blob() {
     pad += 512; // Increase the buffer size when compiling for JVMCI
   }
 #endif
-  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2048+pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words;
@@ -2566,9 +2566,9 @@ uint SharedRuntime::out_preserve_stack_slots() {
 // Generate a special Compile2Runtime blob that saves all registers,
 // and setup oopmap.
 //
-SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
-  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= sharedStubId::polling_page_return_handler_id),
+SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
+  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= SharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
 
   ResourceMark rm;
@@ -2583,8 +2583,8 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   address start   = __ pc();
   address call_pc = nullptr;
   int frame_size_in_words;
-  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
-  RegisterSaver reg_save(id == sharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
+  bool cause_return = (id == SharedStubId::polling_page_return_handler_id);
+  RegisterSaver reg_save(id == SharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
 
   // When the signal occurred, the LR was either signed and stored on the stack (in which
   // case it will be restored from the stack before being used) or unsigned and not stored
@@ -2696,10 +2696,10 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= sharedStubId::wrong_method_id &&
-          id <= sharedStubId::resolve_static_call_id),
+  assert((id >= SharedStubId::wrong_method_id &&
+          id <= SharedStubId::resolve_static_call_id),
          "expected a resolve blob id");
 
   // allocate space for the code
@@ -2797,9 +2797,9 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address desti
 // otherwise assume that stack unwinding will be initiated, so
 // caller saved registers were assumed volatile in the compiler.
 
-RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
-  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
-          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
+  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
+          id <= SharedStubId::throw_delayed_StackOverflowError_id),
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
@@ -2912,7 +2912,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_write_checkpoint_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
@@ -2951,7 +2951,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
   int insts_size = 1024;
   int locs_size = 64;
 
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_return_lease_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);

--- a/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
+++ b/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
@@ -1604,9 +1604,7 @@ void SharedRuntime::generate_deopt_blob() {
 //
 SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= SharedStubId::polling_page_return_handler_id),
-         "expected a polling page stub id");
+  assert(is_polling_page_id(id), "expected a polling page stub id");
 
   ResourceMark rm;
   const char *name = SharedRuntime::stub_name(id);
@@ -1678,9 +1676,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 
 RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert(StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= SharedStubId::wrong_method_id &&
-          id <= SharedStubId::resolve_static_call_id),
-         "expected a resolve blob id");
+  assert(is_resolve_id(id), "expected a resolve stub id");
 
   ResourceMark rm;
   const char *name = SharedRuntime::stub_name(id);
@@ -1743,9 +1739,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 // the current activation. Fabricates an exception oop and initiates normal
 // exception dispatching in this frame.
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
-  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
-          id <= SharedStubId::throw_delayed_StackOverflowError_id),
-         "expected a throw stub id");
+  assert(is_throw_id(id), "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
 

--- a/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
+++ b/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
@@ -1607,7 +1607,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
           id <= sharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
-         
+
   ResourceMark rm;
   const char *name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 256, 256);

--- a/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
+++ b/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
@@ -1360,7 +1360,7 @@ uint SharedRuntime::out_preserve_stack_slots() {
 //------------------------------generate_deopt_blob----------------------------
 void SharedRuntime::generate_deopt_blob() {
   ResourceMark rm;
-  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 1024, 1024);
   int frame_size_in_words;
   OopMapSet* oop_maps;
@@ -1607,7 +1607,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   assert(is_polling_page_id(id), "expected a polling page stub id");
 
   ResourceMark rm;
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 256, 256);
   int frame_size_words;
   OopMapSet* oop_maps;
@@ -1679,7 +1679,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
   assert(is_resolve_id(id), "expected a resolve stub id");
 
   ResourceMark rm;
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   int frame_size_words;
   OopMapSet *oop_maps;
@@ -1741,7 +1741,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
   assert(is_throw_id(id), "expected a throw stub id");
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
 
   int insts_size = 128;
   int locs_size  = 32;
@@ -1802,7 +1802,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
     framesize // inclusive of return address
   };
 
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, 512, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
 
@@ -1846,7 +1846,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
     framesize // inclusive of return address
   };
 
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, 512, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
 

--- a/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
+++ b/src/hotspot/cpu/arm/sharedRuntime_arm.cpp
@@ -1360,7 +1360,7 @@ uint SharedRuntime::out_preserve_stack_slots() {
 //------------------------------generate_deopt_blob----------------------------
 void SharedRuntime::generate_deopt_blob() {
   ResourceMark rm;
-  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 1024, 1024);
   int frame_size_in_words;
   OopMapSet* oop_maps;
@@ -1602,10 +1602,10 @@ void SharedRuntime::generate_deopt_blob() {
 // setup oopmap, and calls safepoint code to stop the compiled code for
 // a safepoint.
 //
-SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
+SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= sharedStubId::polling_page_return_handler_id),
+  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= SharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
 
   ResourceMark rm;
@@ -1614,7 +1614,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   int frame_size_words;
   OopMapSet* oop_maps;
 
-  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
+  bool cause_return = (id == SharedStubId::polling_page_return_handler_id);
 
   MacroAssembler* masm = new MacroAssembler(&buffer);
   address start = __ pc();
@@ -1676,10 +1676,10 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   return SafepointBlob::create(&buffer, oop_maps, frame_size_words);
 }
 
-RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert(StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= sharedStubId::wrong_method_id &&
-          id <= sharedStubId::resolve_static_call_id),
+  assert((id >= SharedStubId::wrong_method_id &&
+          id <= SharedStubId::resolve_static_call_id),
          "expected a resolve blob id");
 
   ResourceMark rm;
@@ -1742,9 +1742,9 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address desti
 // Continuation point for throwing of implicit exceptions that are not handled in
 // the current activation. Fabricates an exception oop and initiates normal
 // exception dispatching in this frame.
-RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
-  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
-          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
+  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
+          id <= SharedStubId::throw_delayed_StackOverflowError_id),
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
@@ -1808,7 +1808,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
     framesize // inclusive of return address
   };
 
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_write_checkpoint_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, 512, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
 
@@ -1852,7 +1852,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
     framesize // inclusive of return address
   };
 
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_return_lease_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, 512, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
 

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -3218,7 +3218,6 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
           id <= sharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
-         
 
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2862,7 +2862,7 @@ void SharedRuntime::generate_deopt_blob() {
   ResourceMark rm;
   // Setup code generation tools
   const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
-  CodeBuffer buffer(, 2048, 1024);
+  CodeBuffer buffer(name, 2048, 1024);
   InterpreterMacroAssembler* masm = new InterpreterMacroAssembler(&buffer);
   Label exec_mode_initialized;
   int frame_size_in_words;
@@ -3435,7 +3435,13 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address desti
 // Note: the routine set_pc_not_at_call_for_caller in
 // SharedRuntime.cpp requires that this code be generated into a
 // RuntimeStub.
-RuntimeStub* SharedRuntime::generate_throw_exception(const char* name, address runtime_entry) {
+RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
+  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
+          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+         "expected a throw stub id");
+
+  const char *name = SharedRuntime::stub_name(id);
+
   ResourceMark rm;
   const char* timer_msg = "SharedRuntime generate_throw_exception";
   TraceTime timer(timer_msg, TRACETIME_LOG(Info, startuptime));

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -3215,9 +3215,7 @@ void OptoRuntime::generate_uncommon_trap_blob() {
 SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr,
          "must be generated before");
-  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= SharedStubId::polling_page_return_handler_id),
-         "expected a polling page stub id");
+  assert(is_polling_page_id(id), "expected a polling page stub id");
 
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
@@ -3330,9 +3328,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 // must do any gc of the args.
 //
 RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
-  assert((id >= SharedStubId::wrong_method_id &&
-          id <= SharedStubId::resolve_static_call_id),
-         "expected a resolve blob id");
+  assert(is_resolve_id(id), "expected a resolve stub id");
 
   // allocate space for the code
   ResourceMark rm;
@@ -3436,9 +3432,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 // SharedRuntime.cpp requires that this code be generated into a
 // RuntimeStub.
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
-  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
-          id <= SharedStubId::throw_delayed_StackOverflowError_id),
-         "expected a throw stub id");
+  assert(is_throw_id(id), "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
 

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -3438,7 +3438,7 @@ RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address ru
 
   ResourceMark rm;
   const char* timer_msg = "SharedRuntime generate_throw_exception";
-  TraceTime timer(timer_msg, TRACETIME_LOG(shInfo, startuptime));
+  TraceTime timer(timer_msg, TRACETIME_LOG(Info, startuptime));
 
   CodeBuffer code(name, 1024 DEBUG_ONLY(+ 512), 0);
   MacroAssembler* masm = new MacroAssembler(&code);

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2861,7 +2861,7 @@ void SharedRuntime::generate_deopt_blob() {
   // Allocate space for the code
   ResourceMark rm;
   // Setup code generation tools
-  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2048, 1024);
   InterpreterMacroAssembler* masm = new InterpreterMacroAssembler(&buffer);
   Label exec_mode_initialized;
@@ -3212,11 +3212,11 @@ void OptoRuntime::generate_uncommon_trap_blob() {
 #endif // COMPILER2
 
 // Generate a special Compile2Runtime blob that saves all registers, and setup oopmap.
-SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
+SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr,
          "must be generated before");
-  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= sharedStubId::polling_page_return_handler_id),
+  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= SharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
 
   ResourceMark rm;
@@ -3232,7 +3232,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   int frame_size_in_bytes = 0;
 
   RegisterSaver::ReturnPCLocation return_pc_location;
-  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
+  bool cause_return = (id == SharedStubId::polling_page_return_handler_id);
   if (cause_return) {
     // Nothing to do here. The frame has already been popped in MachEpilogNode.
     // Register LR already contains the return pc.
@@ -3242,7 +3242,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
     return_pc_location = RegisterSaver::return_pc_is_thread_saved_exception_pc;
   }
 
-  bool save_vectors = (id == sharedStubId::polling_page_vectors_safepoint_handler_id);
+  bool save_vectors = (id == SharedStubId::polling_page_vectors_safepoint_handler_id);
 
   // Save registers, fpu state, and flags. Set R31 = return pc.
   map = RegisterSaver::push_frame_reg_args_and_save_live_registers(masm,
@@ -3329,9 +3329,9 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
-  assert((id >= sharedStubId::wrong_method_id &&
-          id <= sharedStubId::resolve_static_call_id),
+RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
+  assert((id >= SharedStubId::wrong_method_id &&
+          id <= SharedStubId::resolve_static_call_id),
          "expected a resolve blob id");
 
   // allocate space for the code
@@ -3435,9 +3435,9 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address desti
 // Note: the routine set_pc_not_at_call_for_caller in
 // SharedRuntime.cpp requires that this code be generated into a
 // RuntimeStub.
-RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
-  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
-          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
+  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
+          id <= SharedStubId::throw_delayed_StackOverflowError_id),
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
@@ -3764,7 +3764,7 @@ void SharedRuntime::montgomery_square(jint *a_ints, jint *n_ints,
 // It returns a jobject handle to the event writer.
 // The handle is dereferenced and the return value is the event writer oop.
 RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_write_checkpoint_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, 512, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
 
@@ -3801,7 +3801,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
 // For c2: call to return a leased buffer.
 RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_return_lease_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, 512, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
 

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2861,7 +2861,7 @@ void SharedRuntime::generate_deopt_blob() {
   // Allocate space for the code
   ResourceMark rm;
   // Setup code generation tools
-  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2048, 1024);
   InterpreterMacroAssembler* masm = new InterpreterMacroAssembler(&buffer);
   Label exec_mode_initialized;
@@ -3222,7 +3222,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   OopMap* map;
 
   // Allocate space for the code. Setup code generation tools.
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
@@ -3333,7 +3333,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
   // allocate space for the code
   ResourceMark rm;
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
@@ -3434,11 +3434,11 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
   assert(is_throw_id(id), "expected a throw stub id");
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
 
   ResourceMark rm;
   const char* timer_msg = "SharedRuntime generate_throw_exception";
-  TraceTime timer(timer_msg, TRACETIME_LOG(Info, startuptime));
+  TraceTime timer(timer_msg, TRACETIME_LOG(shInfo, startuptime));
 
   CodeBuffer code(name, 1024 DEBUG_ONLY(+ 512), 0);
   MacroAssembler* masm = new MacroAssembler(&code);
@@ -3758,7 +3758,7 @@ void SharedRuntime::montgomery_square(jint *a_ints, jint *n_ints,
 // It returns a jobject handle to the event writer.
 // The handle is dereferenced and the return value is the event writer oop.
 RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, 512, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
 
@@ -3795,7 +3795,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
 // For c2: call to return a leased buffer.
 RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, 512, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
 

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2440,7 +2440,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
           id <= sharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
-         
+
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
   assert_cond(oop_maps != nullptr);
@@ -2667,7 +2667,7 @@ RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address ru
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
-  
+
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
   // the compilers are responsible for supplying a continuation point

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2447,7 +2447,8 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   OopMap* map = nullptr;
 
   // Allocate space for the code.  Setup code generation tools.
-  CodeBuffer buffer("handler_blob", 2048, 1024);
+  const char *name = SharedRuntime::stub_name(id);
+  CodeBuffer buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   assert_cond(masm != nullptr);
 
@@ -2455,7 +2456,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   address call_pc = nullptr;
   int frame_size_in_words = -1;
   bool cause_return = (id == SharedStubId::polling_page_return_handler_id);
-  RegisterSaver reg_save(id == SharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
+  RegisterSaver reg_saver(id == SharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
 
   // Save Integer and Float registers.
   map = reg_saver.save_live_registers(masm, 0, &frame_size_in_words);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2057,7 +2057,7 @@ void SharedRuntime::generate_deopt_blob() {
     pad += 512; // Increase the buffer size when compiling for JVMCI
   }
 #endif
-  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2048 + pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words = -1;
@@ -2445,7 +2445,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   OopMap* map = nullptr;
 
   // Allocate space for the code.  Setup code generation tools.
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   assert_cond(masm != nullptr);
@@ -2567,7 +2567,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
   // allocate space for the code
   ResourceMark rm;
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   assert_cond(masm != nullptr);
@@ -2661,7 +2661,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
   assert(is_throw_id(id), "expected a throw stub id");
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
 
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
@@ -2769,7 +2769,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
@@ -2808,7 +2808,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2437,9 +2437,7 @@ uint SharedRuntime::out_preserve_stack_slots() {
 // and setup oopmap.
 //
 SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
-  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= SharedStubId::polling_page_return_handler_id),
-         "expected a polling page stub id");
+  assert(is_polling_page_id(id), "expected a polling page stub id");
 
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
@@ -2564,9 +2562,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 //
 RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert(StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= SharedStubId::wrong_method_id &&
-          id <= SharedStubId::resolve_static_call_id),
-         "expected a resolve blob id");
+  assert(is_resolve_id(id), "expected a resolve stub id");
 
   // allocate space for the code
   ResourceMark rm;
@@ -2663,9 +2659,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 // caller saved registers were assumed volatile in the compiler.
 
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
-  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
-          id <= SharedStubId::throw_delayed_StackOverflowError_id),
-         "expected a throw stub id");
+  assert(is_throw_id(id), "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
 

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2057,7 +2057,7 @@ void SharedRuntime::generate_deopt_blob() {
     pad += 512; // Increase the buffer size when compiling for JVMCI
   }
 #endif
-  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2048 + pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words = -1;
@@ -2436,9 +2436,9 @@ uint SharedRuntime::out_preserve_stack_slots() {
 // Generate a special Compile2Runtime blob that saves all registers,
 // and setup oopmap.
 //
-SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
-  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= sharedStubId::polling_page_return_handler_id),
+SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
+  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= SharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
 
   ResourceMark rm;
@@ -2454,8 +2454,8 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   address start   = __ pc();
   address call_pc = nullptr;
   int frame_size_in_words = -1;
-  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
-  RegisterSaver reg_save(id == sharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
+  bool cause_return = (id == SharedStubId::polling_page_return_handler_id);
+  RegisterSaver reg_save(id == SharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
 
   // Save Integer and Float registers.
   map = reg_saver.save_live_registers(masm, 0, &frame_size_in_words);
@@ -2561,10 +2561,10 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert(StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= sharedStubId::wrong_method_id &&
-          id <= sharedStubId::resolve_static_call_id),
+  assert((id >= SharedStubId::wrong_method_id &&
+          id <= SharedStubId::resolve_static_call_id),
          "expected a resolve blob id");
 
   // allocate space for the code
@@ -2661,9 +2661,9 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address desti
 // otherwise assume that stack unwinding will be initiated, so
 // caller saved registers were assumed volatile in the compiler.
 
-RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
-  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
-          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
+  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
+          id <= SharedStubId::throw_delayed_StackOverflowError_id),
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
@@ -2774,7 +2774,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_write_checkpoint_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
@@ -2813,7 +2813,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_return_lease_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -2838,9 +2838,7 @@ void OptoRuntime::generate_uncommon_trap_blob() {
 SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr,
          "must be generated before");
-  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= SharedStubId::polling_page_return_handler_id),
-         "expected a polling page stub id");
+  assert(is_polling_page_id(id), "expected a polling page stub id");
 
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
@@ -2942,9 +2940,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 //
 RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= SharedStubId::wrong_method_id &&
-          id <= SharedStubId::resolve_static_call_id),
-         "expected a resolve blob id");
+  assert(is_resolve_id(id), "expected a resolve stub id");
 
   // allocate space for the code
   ResourceMark rm;
@@ -3042,9 +3038,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 // RuntimeStub.
 
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
-  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
-          id <= SharedStubId::throw_delayed_StackOverflowError_id),
-         "expected a throw stub id");
+  assert(is_throw_id(id), "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
 

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -2488,7 +2488,7 @@ void SharedRuntime::generate_deopt_blob() {
   // Allocate space for the code.
   ResourceMark rm;
   // Setup code generation tools.
-  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2048, 1024);
   InterpreterMacroAssembler* masm = new InterpreterMacroAssembler(&buffer);
   Label exec_mode_initialized;
@@ -2845,7 +2845,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   OopMap* map;
 
   // Allocate space for the code. Setup code generation tools.
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
@@ -2945,7 +2945,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
   // allocate space for the code
   ResourceMark rm;
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   MacroAssembler* masm                = new MacroAssembler(&buffer);
 
@@ -3040,7 +3040,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
   assert(is_throw_id(id), "expected a throw stub id");
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
 
   int insts_size = 256;
   int locs_size  = 0;

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -2488,7 +2488,7 @@ void SharedRuntime::generate_deopt_blob() {
   // Allocate space for the code.
   ResourceMark rm;
   // Setup code generation tools.
-  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2048, 1024);
   InterpreterMacroAssembler* masm = new InterpreterMacroAssembler(&buffer);
   Label exec_mode_initialized;
@@ -2835,11 +2835,11 @@ void OptoRuntime::generate_uncommon_trap_blob() {
 //
 // Generate a special Compile2Runtime blob that saves all registers,
 // and setup oopmap.
-SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
+SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr,
          "must be generated before");
-  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= sharedStubId::polling_page_return_handler_id),
+  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= SharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
 
   ResourceMark rm;
@@ -2855,7 +2855,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   address call_pc = nullptr;
   int frame_size_in_bytes;
 
-  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
+  bool cause_return = (id == SharedStubId::polling_page_return_handler_id);
   // Make room for return address (or push it again)
   if (!cause_return) {
     __ z_lg(Z_R14, Address(Z_thread, JavaThread::saved_exception_pc_offset()));
@@ -2940,10 +2940,10 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= sharedStubId::wrong_method_id &&
-          id <= sharedStubId::resolve_static_call_id),
+  assert((id >= SharedStubId::wrong_method_id &&
+          id <= SharedStubId::resolve_static_call_id),
          "expected a resolve blob id");
 
   // allocate space for the code
@@ -3041,9 +3041,9 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address desti
 // SharedRuntime.cpp requires that this code be generated into a
 // RuntimeStub.
 
-RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
-  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
-          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
+  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
+          id <= SharedStubId::throw_delayed_StackOverflowError_id),
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -2488,7 +2488,8 @@ void SharedRuntime::generate_deopt_blob() {
   // Allocate space for the code.
   ResourceMark rm;
   // Setup code generation tools.
-  CodeBuffer buffer("deopt_blob", 2048, 1024);
+  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  CodeBuffer buffer(name, 2048, 1024);
   InterpreterMacroAssembler* masm = new InterpreterMacroAssembler(&buffer);
   Label exec_mode_initialized;
   OopMap* map = nullptr;
@@ -2834,23 +2835,27 @@ void OptoRuntime::generate_uncommon_trap_blob() {
 //
 // Generate a special Compile2Runtime blob that saves all registers,
 // and setup oopmap.
-SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_type) {
+SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr,
          "must be generated before");
+  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= sharedStubId::polling_page_return_handler_id),
+         "expected a polling page stub id");
 
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
   OopMap* map;
 
   // Allocate space for the code. Setup code generation tools.
-  CodeBuffer buffer("handler_blob", 2048, 1024);
+  const char *name = SharedRuntime::stub_name(id);
+  CodeBuffer buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
   unsigned int start_off = __ offset();
   address call_pc = nullptr;
   int frame_size_in_bytes;
 
-  bool cause_return = (poll_type == POLL_AT_RETURN);
+  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
   // Make room for return address (or push it again)
   if (!cause_return) {
     __ z_lg(Z_R14, Address(Z_thread, JavaThread::saved_exception_pc_offset()));
@@ -2935,12 +2940,16 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const char* name) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
+  assert((id >= sharedStubId::wrong_method_id &&
+          id <= sharedStubId::resolve_static_call_id),
+         "expected a resolve blob id");
 
   // allocate space for the code
   ResourceMark rm;
 
+  const char *name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   MacroAssembler* masm                = new MacroAssembler(&buffer);
 
@@ -3032,7 +3041,12 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
 // SharedRuntime.cpp requires that this code be generated into a
 // RuntimeStub.
 
-RuntimeStub* SharedRuntime::generate_throw_exception(const char* name, address runtime_entry) {
+RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
+  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
+          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+         "expected a throw stub id");
+
+  const char *name = SharedRuntime::stub_name(id);
 
   int insts_size = 256;
   int locs_size  = 0;

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2062,7 +2062,7 @@ void SharedRuntime::generate_deopt_blob() {
   ResourceMark rm;
   // setup code generation tools
   // note: the buffer code size must account for StackShadowPages=50
-  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer   buffer(name, 1536, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words;
@@ -2419,7 +2419,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 
   // allocate space for the code
   // setup code generation tools
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer   buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
@@ -2566,7 +2566,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
   // allocate space for the code
   ResourceMark rm;
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   MacroAssembler* masm                = new MacroAssembler(&buffer);
 
@@ -2670,7 +2670,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
   assert(is_throw_id(id), "expected a throw stub id");
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
 
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
@@ -2784,7 +2784,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
@@ -2826,7 +2826,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2411,9 +2411,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   int frame_size_in_words;
 
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= SharedStubId::polling_page_return_handler_id),
-         "expected a polling page stub id");
+  assert(is_polling_page_id(id), "expected a polling page stub id");
 
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
@@ -2563,9 +2561,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 //
 RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= SharedStubId::wrong_method_id &&
-          id <= SharedStubId::resolve_static_call_id),
-         "expected a resolve blob id");
+  assert(is_resolve_id(id), "expected a resolve stub id");
 
   // allocate space for the code
   ResourceMark rm;
@@ -2672,9 +2668,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
   // either at call sites or otherwise assume that stack unwinding will be initiated,
   // so caller saved registers were assumed volatile in the compiler.
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
-  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
-          id <= SharedStubId::throw_delayed_StackOverflowError_id),
-         "expected a throw stub id");
+  assert(is_throw_id(id), "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2429,7 +2429,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   address start   = __ pc();
   address call_pc = nullptr;
   bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
-  bool svae_vectors = (id == sharedStubId::polling_page_vectors_safepoint_handler_id);
+  bool save_vectors = (id == sharedStubId::polling_page_vectors_safepoint_handler_id);
 
   // If cause_return is true we are at a poll_return and there is
   // the return address on the stack to the caller on the nmethod

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2062,7 +2062,8 @@ void SharedRuntime::generate_deopt_blob() {
   ResourceMark rm;
   // setup code generation tools
   // note: the buffer code size must account for StackShadowPages=50
-  CodeBuffer   buffer("deopt_blob", 1536, 1024);
+  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  CodeBuffer   buffer(name, 1536, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words;
   OopMap* map = nullptr;
@@ -2403,13 +2404,16 @@ void SharedRuntime::generate_deopt_blob() {
 // setup oopmap, and calls safepoint code to stop the compiled code for
 // a safepoint.
 //
-SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_type) {
+SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
 
   // Account for thread arg in our frame
   const int additional_words = 1;
   int frame_size_in_words;
 
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
+  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= sharedStubId::polling_page_return_handler_id),
+         "expected a polling page stub id");
 
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
@@ -2417,14 +2421,15 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
 
   // allocate space for the code
   // setup code generation tools
-  CodeBuffer   buffer("handler_blob", 2048, 1024);
+  const char *name = SharedRuntime::stub_name(id);
+  CodeBuffer   buffer(name, 2048, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
   const Register java_thread = rdi; // callee-saved for VC++
   address start   = __ pc();
   address call_pc = nullptr;
-  bool cause_return = (poll_type == POLL_AT_RETURN);
-  bool save_vectors = (poll_type == POLL_AT_VECTOR_LOOP);
+  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
+  RegisterSaver reg_save(id == sharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
 
   // If cause_return is true we are at a poll_return and there is
   // the return address on the stack to the caller on the nmethod
@@ -2556,12 +2561,16 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const char* name) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
+  assert((id >= sharedStubId::wrong_method_id &&
+          id <= sharedStubId::resolve_static_call_id),
+         "expected a resolve blob id");
 
   // allocate space for the code
   ResourceMark rm;
 
+  const char *name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1000, 512);
   MacroAssembler* masm                = new MacroAssembler(&buffer);
 
@@ -2662,7 +2671,12 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
   // exceptions (e.g., NullPointerException or AbstractMethodError on entry) are
   // either at call sites or otherwise assume that stack unwinding will be initiated,
   // so caller saved registers were assumed volatile in the compiler.
-RuntimeStub* SharedRuntime::generate_throw_exception(const char* name, address runtime_entry) {
+RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
+  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
+          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+         "expected a throw stub id");
+
+  const char *name = SharedRuntime::stub_name(id);
 
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
@@ -2776,7 +2790,8 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  CodeBuffer code("jfr_write_checkpoint", insts_size, locs_size);
+  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_write_checkpoint_id);
+  CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
 
@@ -2795,7 +2810,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
   oop_maps->add_gc_map(the_pc - start, map);
 
   RuntimeStub* stub = // codeBlob framesize is in words (not VMRegImpl::slot_size)
-    RuntimeStub::new_runtime_stub("jfr_write_checkpoint", &code, frame_complete,
+    RuntimeStub::new_runtime_stub(name, &code, frame_complete,
                                   (framesize >> (LogBytesPerWord - LogBytesPerInt)),
                                   oop_maps, false);
   return stub;
@@ -2817,7 +2832,8 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  CodeBuffer code("jfr_return_lease", insts_size, locs_size);
+  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_return_lease_id);
+  CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
 
@@ -2835,7 +2851,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
   oop_maps->add_gc_map(the_pc - start, map);
 
   RuntimeStub* stub = // codeBlob framesize is in words (not VMRegImpl::slot_size)
-    RuntimeStub::new_runtime_stub("jfr_return_lease", &code, frame_complete,
+    RuntimeStub::new_runtime_stub(name, &code, frame_complete,
                                   (framesize >> (LogBytesPerWord - LogBytesPerInt)),
                                   oop_maps, false);
   return stub;

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2062,7 +2062,7 @@ void SharedRuntime::generate_deopt_blob() {
   ResourceMark rm;
   // setup code generation tools
   // note: the buffer code size must account for StackShadowPages=50
-  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer   buffer(name, 1536, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words;
@@ -2404,15 +2404,15 @@ void SharedRuntime::generate_deopt_blob() {
 // setup oopmap, and calls safepoint code to stop the compiled code for
 // a safepoint.
 //
-SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
+SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
 
   // Account for thread arg in our frame
   const int additional_words = 1;
   int frame_size_in_words;
 
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= sharedStubId::polling_page_return_handler_id),
+  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= SharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
 
   ResourceMark rm;
@@ -2428,8 +2428,8 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   const Register java_thread = rdi; // callee-saved for VC++
   address start   = __ pc();
   address call_pc = nullptr;
-  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
-  bool save_vectors = (id == sharedStubId::polling_page_vectors_safepoint_handler_id);
+  bool cause_return = (id == SharedStubId::polling_page_return_handler_id);
+  bool save_vectors = (id == SharedStubId::polling_page_vectors_safepoint_handler_id);
 
   // If cause_return is true we are at a poll_return and there is
   // the return address on the stack to the caller on the nmethod
@@ -2561,10 +2561,10 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= sharedStubId::wrong_method_id &&
-          id <= sharedStubId::resolve_static_call_id),
+  assert((id >= SharedStubId::wrong_method_id &&
+          id <= SharedStubId::resolve_static_call_id),
          "expected a resolve blob id");
 
   // allocate space for the code
@@ -2671,9 +2671,9 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address desti
   // exceptions (e.g., NullPointerException or AbstractMethodError on entry) are
   // either at call sites or otherwise assume that stack unwinding will be initiated,
   // so caller saved registers were assumed volatile in the compiler.
-RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
-  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
-          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
+  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
+          id <= SharedStubId::throw_delayed_StackOverflowError_id),
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
@@ -2790,7 +2790,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_write_checkpoint_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);
@@ -2832,7 +2832,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
 
   int insts_size = 1024;
   int locs_size = 64;
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_return_lease_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, insts_size, locs_size);
   OopMapSet* oop_maps = new OopMapSet();
   MacroAssembler* masm = new MacroAssembler(&code);

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -2429,7 +2429,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   address start   = __ pc();
   address call_pc = nullptr;
   bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
-  RegisterSaver reg_save(id == sharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
+  bool svae_vectors = (id == sharedStubId::polling_page_vectors_safepoint_handler_id);
 
   // If cause_return is true we are at a poll_return and there is
   // the return address on the stack to the caller on the nmethod

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2985,9 +2985,7 @@ void SharedRuntime::generate_deopt_blob() {
 SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr,
          "must be generated before");
-  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= SharedStubId::polling_page_return_handler_id),
-         "expected a polling page stub id");
+  assert(is_polling_page_id(id), "expected a polling page stub id");
 
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
@@ -3147,9 +3145,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
 //
 RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= SharedStubId::wrong_method_id &&
-          id <= SharedStubId::resolve_static_call_id),
-         "expected a resolve blob id");
+  assert(is_resolve_id(id), "expected a resolve stub id");
 
   // allocate space for the code
   ResourceMark rm;
@@ -3242,9 +3238,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 // otherwise assume that stack unwinding will be initiated, so
 // caller saved registers were assumed volatile in the compiler.
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
-  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
-          id <= SharedStubId::throw_delayed_StackOverflowError_id),
-         "expected a throw stub id");
+  assert(is_throw_id(id), "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2623,7 +2623,7 @@ void SharedRuntime::generate_deopt_blob() {
     pad += 512; // Increase the buffer size when compiling for JVMCI
   }
 #endif
-  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2560+pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words;
@@ -2982,11 +2982,11 @@ void SharedRuntime::generate_deopt_blob() {
 // Generate a special Compile2Runtime blob that saves all registers,
 // and setup oopmap.
 //
-SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
+SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr,
          "must be generated before");
-  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
-          id <= sharedStubId::polling_page_return_handler_id),
+  assert((id >= SharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= SharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
 
   ResourceMark rm;
@@ -3001,8 +3001,8 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   address start   = __ pc();
   address call_pc = nullptr;
   int frame_size_in_words;
-  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
-  bool save_wide_vectors = (id == sharedStubId::polling_page_vectors_safepoint_handler_id);
+  bool cause_return = (id == SharedStubId::polling_page_return_handler_id);
+  bool save_wide_vectors = (id == SharedStubId::polling_page_vectors_safepoint_handler_id);
 
   // Make room for return address (or push it again)
   if (!cause_return) {
@@ -3145,10 +3145,10 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
-  assert((id >= sharedStubId::wrong_method_id &&
-          id <= sharedStubId::resolve_static_call_id),
+  assert((id >= SharedStubId::wrong_method_id &&
+          id <= SharedStubId::resolve_static_call_id),
          "expected a resolve blob id");
 
   // allocate space for the code
@@ -3241,9 +3241,9 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address desti
 // AbstractMethodError on entry) are either at call sites or
 // otherwise assume that stack unwinding will be initiated, so
 // caller saved registers were assumed volatile in the compiler.
-RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
-  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
-          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
+  assert((id >= SharedStubId::throw_AbstractMethodError_id &&
+          id <= SharedStubId::throw_delayed_StackOverflowError_id),
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
@@ -3606,7 +3606,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
     framesize // inclusive of return address
   };
 
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_write_checkpoint_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, 1024, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
   address start = __ pc();
@@ -3651,7 +3651,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
     framesize // inclusive of return address
   };
 
-  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_return_lease_id);
+  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, 1024, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
   address start = __ pc();

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2623,7 +2623,7 @@ void SharedRuntime::generate_deopt_blob() {
     pad += 512; // Increase the buffer size when compiling for JVMCI
   }
 #endif
-  const char *name = SharedRuntime::stub_name(SharedStubId::deopt_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::deopt_id);
   CodeBuffer buffer(name, 2560+pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words;
@@ -2992,7 +2992,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
   OopMap* map;
 
   // Allocate space for the code.  Setup code generation tools.
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 2348, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
@@ -3150,7 +3150,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
   // allocate space for the code
   ResourceMark rm;
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1552, 512);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
@@ -3240,7 +3240,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address desti
 RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
   assert(is_throw_id(id), "expected a throw stub id");
 
-  const char *name = SharedRuntime::stub_name(id);
+  const char* name = SharedRuntime::stub_name(id);
 
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
@@ -3600,7 +3600,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
     framesize // inclusive of return address
   };
 
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_write_checkpoint_id);
   CodeBuffer code(name, 1024, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
   address start = __ pc();
@@ -3645,7 +3645,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
     framesize // inclusive of return address
   };
 
-  const char *name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
+  const char* name = SharedRuntime::stub_name(SharedStubId::jfr_return_lease_id);
   CodeBuffer code(name, 1024, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
   address start = __ pc();

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2988,7 +2988,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
           id <= sharedStubId::polling_page_return_handler_id),
          "expected a polling page stub id");
-         
+
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
   OopMap* map;
@@ -3002,7 +3002,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address cal
   address call_pc = nullptr;
   int frame_size_in_words;
   bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
-  RegisterSaver reg_save(id == sharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
+  bool save_wide_vectors = (id == sharedStubId::polling_page_vectors_safepoint_handler_id);
 
   // Make room for return address (or push it again)
   if (!cause_return) {
@@ -3247,7 +3247,7 @@ RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address ru
          "expected a throw stub id");
 
   const char *name = SharedRuntime::stub_name(id);
-  
+
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
   // the compilers are responsible for supplying a continuation point

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2623,7 +2623,8 @@ void SharedRuntime::generate_deopt_blob() {
     pad += 512; // Increase the buffer size when compiling for JVMCI
   }
 #endif
-  CodeBuffer buffer("deopt_blob", 2560+pad, 1024);
+  const char *name = SharedRuntime::stub_name(sharedStubId::deopt_id);
+  CodeBuffer buffer(name, 2560+pad, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
   int frame_size_in_words;
   OopMap* map = nullptr;
@@ -2981,23 +2982,27 @@ void SharedRuntime::generate_deopt_blob() {
 // Generate a special Compile2Runtime blob that saves all registers,
 // and setup oopmap.
 //
-SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_type) {
+SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
   assert(StubRoutines::forward_exception_entry() != nullptr,
          "must be generated before");
-
+  assert((id >= sharedStubId::polling_page_vectors_safepoint_handler_id ||
+          id <= sharedStubId::polling_page_return_handler_id),
+         "expected a polling page stub id");
+         
   ResourceMark rm;
   OopMapSet *oop_maps = new OopMapSet();
   OopMap* map;
 
   // Allocate space for the code.  Setup code generation tools.
-  CodeBuffer buffer("handler_blob", 2348, 1024);
+  const char *name = SharedRuntime::stub_name(id);
+  CodeBuffer buffer(name, 2348, 1024);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
   address start   = __ pc();
   address call_pc = nullptr;
   int frame_size_in_words;
-  bool cause_return = (poll_type == POLL_AT_RETURN);
-  bool save_wide_vectors = (poll_type == POLL_AT_VECTOR_LOOP);
+  bool cause_return = (id == sharedStubId::polling_page_return_handler_id);
+  RegisterSaver reg_save(id == sharedStubId::polling_page_vectors_safepoint_handler_id /* save_vectors */);
 
   // Make room for return address (or push it again)
   if (!cause_return) {
@@ -3140,12 +3145,16 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
 // but since this is generic code we don't know what they are and the caller
 // must do any gc of the args.
 //
-RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const char* name) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
   assert (StubRoutines::forward_exception_entry() != nullptr, "must be generated before");
+  assert((id >= sharedStubId::wrong_method_id &&
+          id <= sharedStubId::resolve_static_call_id),
+         "expected a resolve blob id");
 
   // allocate space for the code
   ResourceMark rm;
 
+  const char *name = SharedRuntime::stub_name(id);
   CodeBuffer buffer(name, 1552, 512);
   MacroAssembler* masm = new MacroAssembler(&buffer);
 
@@ -3232,7 +3241,13 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
 // AbstractMethodError on entry) are either at call sites or
 // otherwise assume that stack unwinding will be initiated, so
 // caller saved registers were assumed volatile in the compiler.
-RuntimeStub* SharedRuntime::generate_throw_exception(const char* name, address runtime_entry) {
+RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
+  assert((id >= sharedStubId::throw_AbstractMethodError_id &&
+          id <= sharedStubId::throw_delayed_StackOverflowError_id),
+         "expected a throw stub id");
+
+  const char *name = SharedRuntime::stub_name(id);
+  
   // Information about frame layout at time of blocking runtime call.
   // Note that we only have to preserve callee-saved registers since
   // the compilers are responsible for supplying a continuation point
@@ -3591,7 +3606,8 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
     framesize // inclusive of return address
   };
 
-  CodeBuffer code("jfr_write_checkpoint", 1024, 64);
+  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_write_checkpoint_id);
+  CodeBuffer code(name, 1024, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
   address start = __ pc();
 
@@ -3616,7 +3632,7 @@ RuntimeStub* SharedRuntime::generate_jfr_write_checkpoint() {
   oop_maps->add_gc_map(frame_complete, map);
 
   RuntimeStub* stub =
-    RuntimeStub::new_runtime_stub(code.name(),
+    RuntimeStub::new_runtime_stub(name,
                                   &code,
                                   frame_complete,
                                   (framesize >> (LogBytesPerWord - LogBytesPerInt)),
@@ -3635,7 +3651,8 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
     framesize // inclusive of return address
   };
 
-  CodeBuffer code("jfr_return_lease", 1024, 64);
+  const char *name = SharedRuntime::stub_name(sharedStubId::jfr_return_lease_id);
+  CodeBuffer code(name, 1024, 64);
   MacroAssembler* masm = new MacroAssembler(&code);
   address start = __ pc();
 
@@ -3657,7 +3674,7 @@ RuntimeStub* SharedRuntime::generate_jfr_return_lease() {
   oop_maps->add_gc_map(frame_complete, map);
 
   RuntimeStub* stub =
-    RuntimeStub::new_runtime_stub(code.name(),
+    RuntimeStub::new_runtime_stub(name,
                                   &code,
                                   frame_complete,
                                   (framesize >> (LogBytesPerWord - LogBytesPerInt)),

--- a/src/hotspot/cpu/zero/sharedRuntime_zero.cpp
+++ b/src/hotspot/cpu/zero/sharedRuntime_zero.cpp
@@ -105,15 +105,15 @@ void SharedRuntime::generate_deopt_blob() {
   _deopt_blob = generate_empty_deopt_blob();
 }
 
-SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_type) {
+SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
   return generate_empty_safepoint_blob();
 }
 
-RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const char* name) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
   return generate_empty_runtime_stub();
 }
 
-RuntimeStub* SharedRuntime::generate_throw_exception(const char* name, address runtime_entry) {
+RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
   return generate_empty_runtime_stub();
 }
 

--- a/src/hotspot/cpu/zero/sharedRuntime_zero.cpp
+++ b/src/hotspot/cpu/zero/sharedRuntime_zero.cpp
@@ -105,15 +105,15 @@ void SharedRuntime::generate_deopt_blob() {
   _deopt_blob = generate_empty_deopt_blob();
 }
 
-SafepointBlob* SharedRuntime::generate_handler_blob(sharedStubId id, address call_ptr) {
+SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address call_ptr) {
   return generate_empty_safepoint_blob();
 }
 
-RuntimeStub* SharedRuntime::generate_resolve_blob(sharedStubId id, address destination) {
+RuntimeStub* SharedRuntime::generate_resolve_blob(SharedStubId id, address destination) {
   return generate_empty_runtime_stub();
 }
 
-RuntimeStub* SharedRuntime::generate_throw_exception(sharedStubId id, address runtime_entry) {
+RuntimeStub* SharedRuntime::generate_throw_exception(SharedStubId id, address runtime_entry) {
   return generate_empty_runtime_stub();
 }
 

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -109,44 +109,44 @@ const char *SharedRuntime::_stub_names[] = {
 void SharedRuntime::generate_initial_stubs() {
   // Build this early so it's available for the interpreter.
   _throw_StackOverflowError_blob =
-    generate_throw_exception(sharedStubId::throw_StackOverflowError_id,
+    generate_throw_exception(SharedStubId::throw_StackOverflowError_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_StackOverflowError));
 }
 
 void SharedRuntime::generate_stubs() {
   _wrong_method_blob =
-    generate_resolve_blob(sharedStubId::wrong_method_id,
+    generate_resolve_blob(SharedStubId::wrong_method_id,
                           CAST_FROM_FN_PTR(address, SharedRuntime::handle_wrong_method));
   _wrong_method_abstract_blob =
-    generate_resolve_blob(sharedStubId::wrong_method_abstract_id,
+    generate_resolve_blob(SharedStubId::wrong_method_abstract_id,
                           CAST_FROM_FN_PTR(address, SharedRuntime::handle_wrong_method_abstract));
   _ic_miss_blob =
-    generate_resolve_blob(sharedStubId::ic_miss_id,
+    generate_resolve_blob(SharedStubId::ic_miss_id,
                           CAST_FROM_FN_PTR(address, SharedRuntime::handle_wrong_method_ic_miss));
   _resolve_opt_virtual_call_blob =
-    generate_resolve_blob(sharedStubId::resolve_opt_virtual_call_id,
+    generate_resolve_blob(SharedStubId::resolve_opt_virtual_call_id,
                           CAST_FROM_FN_PTR(address, SharedRuntime::resolve_opt_virtual_call_C));
   _resolve_virtual_call_blob =
-    generate_resolve_blob(sharedStubId::resolve_virtual_call_id,
+    generate_resolve_blob(SharedStubId::resolve_virtual_call_id,
                           CAST_FROM_FN_PTR(address, SharedRuntime::resolve_virtual_call_C));
   _resolve_static_call_blob =
-    generate_resolve_blob(sharedStubId::resolve_static_call_id,
+    generate_resolve_blob(SharedStubId::resolve_static_call_id,
                           CAST_FROM_FN_PTR(address, SharedRuntime::resolve_static_call_C));
 
   _throw_delayed_StackOverflowError_blob =
-    generate_throw_exception(sharedStubId::throw_delayed_StackOverflowError_id,
+    generate_throw_exception(SharedStubId::throw_delayed_StackOverflowError_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_delayed_StackOverflowError));
 
   _throw_AbstractMethodError_blob =
-    generate_throw_exception(sharedStubId::throw_AbstractMethodError_id,
+    generate_throw_exception(SharedStubId::throw_AbstractMethodError_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_AbstractMethodError));
 
   _throw_IncompatibleClassChangeError_blob =
-    generate_throw_exception(sharedStubId::throw_IncompatibleClassChangeError_id,
+    generate_throw_exception(SharedStubId::throw_IncompatibleClassChangeError_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_IncompatibleClassChangeError));
 
   _throw_NullPointerException_at_call_blob =
-    generate_throw_exception(sharedStubId::throw_NullPointerException_at_call_id,
+    generate_throw_exception(SharedStubId::throw_NullPointerException_at_call_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_NullPointerException_at_call));
 
   AdapterHandlerLibrary::initialize();
@@ -156,15 +156,15 @@ void SharedRuntime::generate_stubs() {
   bool support_wide = is_wide_vector(MaxVectorSize);
   if (support_wide) {
     _polling_page_vectors_safepoint_handler_blob =
-      generate_handler_blob(sharedStubId::polling_page_vectors_safepoint_handler_id,
+      generate_handler_blob(SharedStubId::polling_page_vectors_safepoint_handler_id,
                             CAST_FROM_FN_PTR(address, SafepointSynchronize::handle_polling_page_exception));
   }
 #endif // COMPILER2_OR_JVMCI
   _polling_page_safepoint_handler_blob =
-    generate_handler_blob(sharedStubId::polling_page_safepoint_handler_id,
+    generate_handler_blob(SharedStubId::polling_page_safepoint_handler_id,
                           CAST_FROM_FN_PTR(address, SafepointSynchronize::handle_polling_page_exception));
   _polling_page_return_handler_blob =
-    generate_handler_blob(sharedStubId::polling_page_return_handler_id,
+    generate_handler_blob(SharedStubId::polling_page_return_handler_id,
                           CAST_FROM_FN_PTR(address, SafepointSynchronize::handle_polling_page_exception));
 
   generate_deopt_blob();

--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -92,61 +92,61 @@
 // Shared runtime stub routines reside in their own unique blob with a
 // single entry point
 
-RuntimeStub*        SharedRuntime::_wrong_method_blob;
-RuntimeStub*        SharedRuntime::_wrong_method_abstract_blob;
-RuntimeStub*        SharedRuntime::_ic_miss_blob;
-RuntimeStub*        SharedRuntime::_resolve_opt_virtual_call_blob;
-RuntimeStub*        SharedRuntime::_resolve_virtual_call_blob;
-RuntimeStub*        SharedRuntime::_resolve_static_call_blob;
 
-DeoptimizationBlob* SharedRuntime::_deopt_blob;
-SafepointBlob*      SharedRuntime::_polling_page_vectors_safepoint_handler_blob;
-SafepointBlob*      SharedRuntime::_polling_page_safepoint_handler_blob;
-SafepointBlob*      SharedRuntime::_polling_page_return_handler_blob;
-
-RuntimeStub*        SharedRuntime::_throw_AbstractMethodError_blob;
-RuntimeStub*        SharedRuntime::_throw_IncompatibleClassChangeError_blob;
-RuntimeStub*        SharedRuntime::_throw_NullPointerException_at_call_blob;
-RuntimeStub*        SharedRuntime::_throw_StackOverflowError_blob;
-RuntimeStub*        SharedRuntime::_throw_delayed_StackOverflowError_blob;
-
-#if INCLUDE_JFR
-RuntimeStub*        SharedRuntime::_jfr_write_checkpoint_blob = nullptr;
-RuntimeStub*        SharedRuntime::_jfr_return_lease_blob = nullptr;
-#endif
+#define SHARED_STUB_FIELD_DEFINE(name, type) \
+  type        SharedRuntime::BLOB_FIELD_NAME(name);
+  SHARED_STUBS_DO(SHARED_STUB_FIELD_DEFINE)
+#undef SHARED_STUB_FIELD_DEFINE
 
 nmethod*            SharedRuntime::_cont_doYield_stub;
+
+#define SHARED_STUB_NAME_DECLARE(name, type) "Shared Runtime " # name "_blob",
+const char *SharedRuntime::_stub_names[] = {
+  SHARED_STUBS_DO(SHARED_STUB_NAME_DECLARE)
+};
 
 //----------------------------generate_stubs-----------------------------------
 void SharedRuntime::generate_initial_stubs() {
   // Build this early so it's available for the interpreter.
   _throw_StackOverflowError_blob =
-    generate_throw_exception("StackOverflowError throw_exception",
+    generate_throw_exception(sharedStubId::throw_StackOverflowError_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_StackOverflowError));
 }
 
 void SharedRuntime::generate_stubs() {
-  _wrong_method_blob                   = generate_resolve_blob(CAST_FROM_FN_PTR(address, SharedRuntime::handle_wrong_method),          "wrong_method_stub");
-  _wrong_method_abstract_blob          = generate_resolve_blob(CAST_FROM_FN_PTR(address, SharedRuntime::handle_wrong_method_abstract), "wrong_method_abstract_stub");
-  _ic_miss_blob                        = generate_resolve_blob(CAST_FROM_FN_PTR(address, SharedRuntime::handle_wrong_method_ic_miss),  "ic_miss_stub");
-  _resolve_opt_virtual_call_blob       = generate_resolve_blob(CAST_FROM_FN_PTR(address, SharedRuntime::resolve_opt_virtual_call_C),   "resolve_opt_virtual_call");
-  _resolve_virtual_call_blob           = generate_resolve_blob(CAST_FROM_FN_PTR(address, SharedRuntime::resolve_virtual_call_C),       "resolve_virtual_call");
-  _resolve_static_call_blob            = generate_resolve_blob(CAST_FROM_FN_PTR(address, SharedRuntime::resolve_static_call_C),        "resolve_static_call");
+  _wrong_method_blob =
+    generate_resolve_blob(sharedStubId::wrong_method_id,
+                          CAST_FROM_FN_PTR(address, SharedRuntime::handle_wrong_method));
+  _wrong_method_abstract_blob =
+    generate_resolve_blob(sharedStubId::wrong_method_abstract_id,
+                          CAST_FROM_FN_PTR(address, SharedRuntime::handle_wrong_method_abstract));
+  _ic_miss_blob =
+    generate_resolve_blob(sharedStubId::ic_miss_id,
+                          CAST_FROM_FN_PTR(address, SharedRuntime::handle_wrong_method_ic_miss));
+  _resolve_opt_virtual_call_blob =
+    generate_resolve_blob(sharedStubId::resolve_opt_virtual_call_id,
+                          CAST_FROM_FN_PTR(address, SharedRuntime::resolve_opt_virtual_call_C));
+  _resolve_virtual_call_blob =
+    generate_resolve_blob(sharedStubId::resolve_virtual_call_id,
+                          CAST_FROM_FN_PTR(address, SharedRuntime::resolve_virtual_call_C));
+  _resolve_static_call_blob =
+    generate_resolve_blob(sharedStubId::resolve_static_call_id,
+                          CAST_FROM_FN_PTR(address, SharedRuntime::resolve_static_call_C));
 
   _throw_delayed_StackOverflowError_blob =
-    generate_throw_exception("delayed StackOverflowError throw_exception",
+    generate_throw_exception(sharedStubId::throw_delayed_StackOverflowError_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_delayed_StackOverflowError));
 
   _throw_AbstractMethodError_blob =
-    generate_throw_exception("AbstractMethodError throw_exception",
+    generate_throw_exception(sharedStubId::throw_AbstractMethodError_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_AbstractMethodError));
 
   _throw_IncompatibleClassChangeError_blob =
-    generate_throw_exception("IncompatibleClassChangeError throw_exception",
+    generate_throw_exception(sharedStubId::throw_IncompatibleClassChangeError_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_IncompatibleClassChangeError));
 
   _throw_NullPointerException_at_call_blob =
-    generate_throw_exception("NullPointerException at call throw_exception",
+    generate_throw_exception(sharedStubId::throw_NullPointerException_at_call_id,
                              CAST_FROM_FN_PTR(address, SharedRuntime::throw_NullPointerException_at_call));
 
   AdapterHandlerLibrary::initialize();
@@ -155,11 +155,17 @@ void SharedRuntime::generate_stubs() {
   // Vectors are generated only by C2 and JVMCI.
   bool support_wide = is_wide_vector(MaxVectorSize);
   if (support_wide) {
-    _polling_page_vectors_safepoint_handler_blob = generate_handler_blob(CAST_FROM_FN_PTR(address, SafepointSynchronize::handle_polling_page_exception), POLL_AT_VECTOR_LOOP);
+    _polling_page_vectors_safepoint_handler_blob =
+      generate_handler_blob(sharedStubId::polling_page_vectors_safepoint_handler_id,
+                            CAST_FROM_FN_PTR(address, SafepointSynchronize::handle_polling_page_exception));
   }
 #endif // COMPILER2_OR_JVMCI
-  _polling_page_safepoint_handler_blob = generate_handler_blob(CAST_FROM_FN_PTR(address, SafepointSynchronize::handle_polling_page_exception), POLL_AT_LOOP);
-  _polling_page_return_handler_blob    = generate_handler_blob(CAST_FROM_FN_PTR(address, SafepointSynchronize::handle_polling_page_exception), POLL_AT_RETURN);
+  _polling_page_safepoint_handler_blob =
+    generate_handler_blob(sharedStubId::polling_page_safepoint_handler_id,
+                          CAST_FROM_FN_PTR(address, SafepointSynchronize::handle_polling_page_exception));
+  _polling_page_return_handler_blob =
+    generate_handler_blob(sharedStubId::polling_page_return_handler_id,
+                          CAST_FROM_FN_PTR(address, SafepointSynchronize::handle_polling_page_exception));
 
   generate_deopt_blob();
 }

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -43,10 +43,10 @@ class vframeStream;
 // Java exceptions), locking/unlocking mechanisms, statistical
 // information, etc.
 
-// define sharedStubId enum tags: wrong_method_id, etc
+// define SharedStubId enum tags: wrong_method_id, etc
 
 #define SHARED_STUB_ID_ENUM_DECLARE(name, type) STUB_ID_NAME(name),
-enum class sharedStubId :int {
+enum class SharedStubId :int {
   NO_STUBID = -1,
   SHARED_STUBS_DO(SHARED_STUB_ID_ENUM_DECLARE)
   NUM_STUBIDS
@@ -64,25 +64,25 @@ class SharedRuntime: AllStatic {
 #undef SHARED_STUB_FIELD_DECLARE
 
 #ifndef PRODUCT
-  static bool is_resolve_id(sharedStubId id) {
-    return (id == sharedStubId::wrong_method_id ||
-            id == sharedStubId::wrong_method_abstract_id ||
-            id == sharedStubId::ic_miss_id ||
-            id == sharedStubId::resolve_opt_virtual_call_id ||
-            id == sharedStubId::resolve_virtual_call_id ||
-            id == sharedStubId::resolve_static_call_id);
+  static bool is_resolve_id(SharedStubId id) {
+    return (id == SharedStubId::wrong_method_id ||
+            id == SharedStubId::wrong_method_abstract_id ||
+            id == SharedStubId::ic_miss_id ||
+            id == SharedStubId::resolve_opt_virtual_call_id ||
+            id == SharedStubId::resolve_virtual_call_id ||
+            id == SharedStubId::resolve_static_call_id);
   }
-  static bool is_polling_page_id(sharedStubId id) {
-    return (id == sharedStubId::polling_page_vectors_safepoint_handler_id ||
-            id == sharedStubId::polling_page_safepoint_handler_id ||
-            id == sharedStubId::polling_page_return_handler_id);
+  static bool is_polling_page_id(SharedStubId id) {
+    return (id == SharedStubId::polling_page_vectors_safepoint_handler_id ||
+            id == SharedStubId::polling_page_safepoint_handler_id ||
+            id == SharedStubId::polling_page_return_handler_id);
   }
-  static bool is_throw_id(sharedStubId id) {
-    return (id == sharedStubId::throw_AbstractMethodError_id ||
-            id == sharedStubId::throw_IncompatibleClassChangeError_id ||
-            id == sharedStubId::throw_NullPointerException_at_call_id ||
-            id == sharedStubId::throw_StackOverflowError_id ||
-            id == sharedStubId::throw_delayed_StackOverflowError_id);
+  static bool is_throw_id(SharedStubId id) {
+    return (id == SharedStubId::throw_AbstractMethodError_id ||
+            id == SharedStubId::throw_IncompatibleClassChangeError_id ||
+            id == SharedStubId::throw_NullPointerException_at_call_id ||
+            id == SharedStubId::throw_StackOverflowError_id ||
+            id == SharedStubId::throw_delayed_StackOverflowError_id);
   }
 #endif
 
@@ -92,7 +92,7 @@ class SharedRuntime: AllStatic {
   // counterpart the continuation do_enter method.
   static nmethod*            _cont_doYield_stub;
 
-  // Stub names indexed by sharedStubId
+  // Stub names indexed by SharedStubId
   static const char *_stub_names[];
 
 #ifndef PRODUCT
@@ -101,9 +101,9 @@ class SharedRuntime: AllStatic {
 #endif // !PRODUCT
 
  private:
-  static SafepointBlob* generate_handler_blob(sharedStubId id, address call_ptr);
-  static RuntimeStub*   generate_resolve_blob(sharedStubId id, address destination);
-  static RuntimeStub*   generate_throw_exception(sharedStubId id, address runtime_entry);
+  static SafepointBlob* generate_handler_blob(SharedStubId id, address call_ptr);
+  static RuntimeStub*   generate_resolve_blob(SharedStubId id, address destination);
+  static RuntimeStub*   generate_throw_exception(SharedStubId id, address runtime_entry);
  public:
   static void generate_initial_stubs(void);
   static void generate_stubs(void);
@@ -117,8 +117,8 @@ class SharedRuntime: AllStatic {
   static RuntimeStub* generate_jfr_return_lease();
 #endif
 
-  static const char *stub_name(sharedStubId id) {
-    assert(id > sharedStubId::NO_STUBID && id < sharedStubId::NUM_STUBIDS, "stub id out of range");
+  static const char *stub_name(SharedStubId id) {
+    assert(id > SharedStubId::NO_STUBID && id < SharedStubId::NUM_STUBIDS, "stub id out of range");
     return _stub_names[(int)id];
   }
 

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -63,6 +63,29 @@ class SharedRuntime: AllStatic {
   SHARED_STUBS_DO(SHARED_STUB_FIELD_DECLARE)
 #undef SHARED_STUB_FIELD_DECLARE
 
+#ifndef PRODUCT
+  static bool is_resolve_id(sharedStubId id) {
+    return (id == sharedStubId::wrong_method_id ||
+            id == sharedStubId::wrong_method_abstract_id ||
+            id == sharedStubId::ic_miss_id ||
+            id == sharedStubId::resolve_opt_virtual_call_id ||
+            id == sharedStubId::resolve_virtual_call_id ||
+            id == sharedStubId::resolve_static_call_id);
+  }
+  static bool is_polling_page_id(sharedStubId id) {
+    return (id == sharedStubId::polling_page_vectors_safepoint_handler_id ||
+            id == sharedStubId::polling_page_safepoint_handler_id ||
+            id == sharedStubId::polling_page_return_handler_id);
+  }
+  static bool is_throw_id(sharedStubId id) {
+    return (id == sharedStubId::throw_AbstractMethodError_id ||
+            id == sharedStubId::throw_IncompatibleClassChangeError_id ||
+            id == sharedStubId::throw_NullPointerException_at_call_id ||
+            id == sharedStubId::throw_StackOverflowError_id ||
+            id == sharedStubId::throw_delayed_StackOverflowError_id);
+  }
+#endif
+
   // cont_doYieldStub is not yet folded into the general model for
   // shared stub/blob handling. It is actually a specially generated
   // native wrapper for a specific native method, as also is it's
@@ -71,6 +94,7 @@ class SharedRuntime: AllStatic {
 
   // Stub names indexed by sharedStubId
   static const char *_stub_names[];
+
 #ifndef PRODUCT
   // Counters
   static int64_t _nof_megamorphic_calls;         // total # of megamorphic calls (through vtable)

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -30,6 +30,7 @@
 #include "interpreter/linkResolver.hpp"
 #include "memory/allStatic.hpp"
 #include "memory/resourceArea.hpp"
+#include "runtime/stubDeclarations.hpp"
 #include "utilities/macros.hpp"
 
 class AdapterHandlerEntry;
@@ -42,48 +43,43 @@ class vframeStream;
 // Java exceptions), locking/unlocking mechanisms, statistical
 // information, etc.
 
+// define sharedStubId enum tags: wrong_method_id, etc
+
+#define SHARED_STUB_ID_ENUM_DECLARE(name, type) STUB_ID_NAME(name),
+enum class sharedStubId :int {
+  NO_STUBID = -1,
+  SHARED_STUBS_DO(SHARED_STUB_ID_ENUM_DECLARE)
+  NUM_STUBIDS
+};
+#undef SHARED_STUB_ID_ENUM_DECLARE
+
 class SharedRuntime: AllStatic {
   friend class VMStructs;
 
  private:
-  // Shared stub locations
+  // Declare shared stub fields
+#define SHARED_STUB_FIELD_DECLARE(name, type) \
+  static type        BLOB_FIELD_NAME(name);
+  SHARED_STUBS_DO(SHARED_STUB_FIELD_DECLARE)
+#undef SHARED_STUB_FIELD_DECLARE
 
-  static RuntimeStub*        _wrong_method_blob;
-  static RuntimeStub*        _wrong_method_abstract_blob;
-  static RuntimeStub*        _ic_miss_blob;
-  static RuntimeStub*        _resolve_opt_virtual_call_blob;
-  static RuntimeStub*        _resolve_virtual_call_blob;
-  static RuntimeStub*        _resolve_static_call_blob;
-
-  static DeoptimizationBlob* _deopt_blob;
-
-  static SafepointBlob*      _polling_page_vectors_safepoint_handler_blob;
-  static SafepointBlob*      _polling_page_safepoint_handler_blob;
-  static SafepointBlob*      _polling_page_return_handler_blob;
-
+  // cont_doYieldStub is not yet folded into the general model for
+  // shared stub/blob handling. It is actually a specially generated
+  // native wrapper for a specific native method, as also is it's
+  // counterpart the continuation do_enter method.
   static nmethod*            _cont_doYield_stub;
 
-  static RuntimeStub*        _throw_AbstractMethodError_blob;
-  static RuntimeStub*        _throw_IncompatibleClassChangeError_blob;
-  static RuntimeStub*        _throw_NullPointerException_at_call_blob;
-  static RuntimeStub*        _throw_StackOverflowError_blob;
-  static RuntimeStub*        _throw_delayed_StackOverflowError_blob;
-
-#if INCLUDE_JFR
-  static RuntimeStub*        _jfr_write_checkpoint_blob;
-  static RuntimeStub*        _jfr_return_lease_blob;
-#endif
-
+  // Stub names indexed by sharedStubId
+  static const char *_stub_names[];
 #ifndef PRODUCT
   // Counters
   static int64_t _nof_megamorphic_calls;         // total # of megamorphic calls (through vtable)
 #endif // !PRODUCT
 
  private:
-  enum { POLL_AT_RETURN,  POLL_AT_LOOP, POLL_AT_VECTOR_LOOP };
-  static SafepointBlob* generate_handler_blob(address call_ptr, int poll_type);
-  static RuntimeStub*   generate_resolve_blob(address destination, const char* name);
-  static RuntimeStub*   generate_throw_exception(const char* name, address runtime_entry);
+  static SafepointBlob* generate_handler_blob(sharedStubId id, address call_ptr);
+  static RuntimeStub*   generate_resolve_blob(sharedStubId id, address destination);
+  static RuntimeStub*   generate_throw_exception(sharedStubId id, address runtime_entry);
  public:
   static void generate_initial_stubs(void);
   static void generate_stubs(void);
@@ -96,6 +92,11 @@ class SharedRuntime: AllStatic {
   // For c2: call to runtime to return a buffer lease.
   static RuntimeStub* generate_jfr_return_lease();
 #endif
+
+  static const char *stub_name(sharedStubId id) {
+    assert(id > sharedStubId::NO_STUBID && id < sharedStubId::NUM_STUBIDS, "stub id out of range");
+    return _stub_names[(int)id];
+  }
 
   // max bytes for each dtrace string parameter
   enum { max_dtrace_string_size = 256 };

--- a/src/hotspot/share/runtime/sharedRuntime.hpp
+++ b/src/hotspot/share/runtime/sharedRuntime.hpp
@@ -63,7 +63,7 @@ class SharedRuntime: AllStatic {
   SHARED_STUBS_DO(SHARED_STUB_FIELD_DECLARE)
 #undef SHARED_STUB_FIELD_DECLARE
 
-#ifndef PRODUCT
+#ifdef ASSERT
   static bool is_resolve_id(SharedStubId id) {
     return (id == SharedStubId::wrong_method_id ||
             id == SharedStubId::wrong_method_abstract_id ||

--- a/src/hotspot/share/runtime/stubDeclarations.hpp
+++ b/src/hotspot/share/runtime/stubDeclarations.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -23,8 +23,8 @@
  *
  */
 
-#ifndef SHARE_RUNTIME_SHAREDRUNTIME_ID_HPP
-#define SHARE_RUNTIME_SHAREDRUNTIME_ID_HPP
+#ifndef SHARE_RUNTIME_STUBDECLARATIONS_HPP
+#define SHARE_RUNTIME_STUBDECLARATIONS_HPP
 
 #include "utilities/macros.hpp"
 
@@ -38,121 +38,37 @@
 // same order to allow id values to be range checked
 
 #if INCLUDE_JFR
-// template(name, type)
-#define SHARED_JFR_STUBS_DO(template)                                  \
-  template(jfr_write_checkpoint, RuntimeStub*)                         \
-  template(jfr_return_lease, RuntimeStub*)                             \
+// do_blob(name, type)
+#define SHARED_JFR_STUBS_DO(do_blob)                                   \
+  do_blob(jfr_write_checkpoint, RuntimeStub*)                          \
+  do_blob(jfr_return_lease, RuntimeStub*)                              \
 
 #else
-#define SHARED_JFR_STUBS_DO(TEMPLATE)
+#define SHARED_JFR_STUBS_DO(do_blob)
 #endif
 
-// template(name, type)
-#define SHARED_STUBS_DO(template)                                      \
-  template(deopt, DeoptimizationBlob*)                                 \
+// do_blob(name, type)
+#define SHARED_STUBS_DO(do_blob)                                       \
+  do_blob(deopt, DeoptimizationBlob*)                                  \
   /* resolve stubs */                                                  \
-  template(wrong_method, RuntimeStub*)                                 \
-  template(wrong_method_abstract, RuntimeStub*)                        \
-  template(ic_miss, RuntimeStub*)                                      \
-  template(resolve_opt_virtual_call, RuntimeStub*)                     \
-  template(resolve_virtual_call, RuntimeStub*)                         \
-  template(resolve_static_call, RuntimeStub*)                          \
+  do_blob(wrong_method, RuntimeStub*)                                  \
+  do_blob(wrong_method_abstract, RuntimeStub*)                         \
+  do_blob(ic_miss, RuntimeStub*)                                       \
+  do_blob(resolve_opt_virtual_call, RuntimeStub*)                      \
+  do_blob(resolve_virtual_call, RuntimeStub*)                          \
+  do_blob(resolve_static_call, RuntimeStub*)                           \
   /* handler stubs */                                                  \
-  template(polling_page_vectors_safepoint_handler, SafepointBlob*)     \
-  template(polling_page_safepoint_handler, SafepointBlob*)             \
-  template(polling_page_return_handler, SafepointBlob*)                \
+  do_blob(polling_page_vectors_safepoint_handler, SafepointBlob*)      \
+  do_blob(polling_page_safepoint_handler, SafepointBlob*)              \
+  do_blob(polling_page_return_handler, SafepointBlob*)                 \
   /* throw stubs */                                                    \
-  template(throw_AbstractMethodError, RuntimeStub*)                    \
-  template(throw_IncompatibleClassChangeError, RuntimeStub*)           \
-  template(throw_NullPointerException_at_call, RuntimeStub*)           \
-  template(throw_StackOverflowError, RuntimeStub*)                     \
-  template(throw_delayed_StackOverflowError, RuntimeStub*)             \
+  do_blob(throw_AbstractMethodError, RuntimeStub*)                     \
+  do_blob(throw_IncompatibleClassChangeError, RuntimeStub*)            \
+  do_blob(throw_NullPointerException_at_call, RuntimeStub*)            \
+  do_blob(throw_StackOverflowError, RuntimeStub*)                      \
+  do_blob(throw_delayed_StackOverflowError, RuntimeStub*)              \
   /* other stubs */                                                    \
-  SHARED_JFR_STUBS_DO(template)                                        \
-
-// C1 stubs are always generated in a generic CodeBlob
-
-#ifdef COMPILER1
-// template(name)
-#define C1_STUBS_DO(template)                                          \
-  template(dtrace_object_alloc)                                        \
-  template(unwind_exception)                                           \
-  template(forward_exception)                                          \
-  template(throw_range_check_failed)       /* throws ArrayIndexOutOfBoundsException */ \
-  template(throw_index_exception)          /* throws IndexOutOfBoundsException */ \
-  template(throw_div0_exception)                                       \
-  template(throw_null_pointer_exception)                               \
-  template(register_finalizer)                                         \
-  template(new_instance)                                               \
-  template(fast_new_instance)                                          \
-  template(fast_new_instance_init_check)                               \
-  template(new_type_array)                                             \
-  template(new_object_array)                                           \
-  template(new_multi_array)                                            \
-  template(handle_exception_nofpu)         /* optimized version that does not preserve fpu registers */ \
-  template(handle_exception)                                           \
-  template(handle_exception_from_callee)                               \
-  template(throw_array_store_exception)                                \
-  template(throw_class_cast_exception)                                 \
-  template(throw_incompatible_class_change_error)                      \
-  template(slow_subtype_check)                                         \
-  template(monitorenter)                                               \
-  template(monitorenter_nofpu)             /* optimized version that does not preserve fpu registers */ \
-  template(monitorexit)                                                \
-  template(monitorexit_nofpu)              /* optimized version that does not preserve fpu registers */ \
-  template(deoptimize)                                                 \
-  template(access_field_patching)                                      \
-  template(load_klass_patching)                                        \
-  template(load_mirror_patching)                                       \
-  template(load_appendix_patching)                                     \
-  template(fpu2long_stub)                                              \
-  template(counter_overflow)                                           \
-  template(predicate_failed_trap)                                      \
-
-#else
-#define C1_STUBS_DO(template)
-#endif
-
-// Opto stubs can have different blob types and may include some JVMTI
-// stubs
-
-#ifdef COMPILER2
-// template(name, type)
-#if INCLUDE_JVMTI
-#define OPTO_JVMTI_STUBS_DO(template)                                  \
-  template(notify_jvmti_vthread_start, address)                        \
-  template(notify_jvmti_vthread_end, address)                          \
-  template(notify_jvmti_vthread_mount, address)                        \
-  template(notify_jvmti_vthread_unmount, address)                      \
-
-#else
-#define OPTO_JVMTI_STUBS_DO(template)
-#endif // INCLUDE_JVMTI
-
-#define OPTO_STUBS_DO(template)                                        \
-  template(uncommon_trap, UncommonTrapBlob*)                           \
-  template(exception, ExceptionBlob*)                                  \
-  template(new_instance_Java, address)                                 \
-  template(new_array_Java, address)                                    \
-  template(new_array_nozero_Java, address)                             \
-  template(multianewarray2_Java, address)                              \
-  template(multianewarray3_Java, address)                              \
-  template(multianewarray4_Java, address)                              \
-  template(multianewarray5_Java, address)                              \
-  template(multianewarrayN_Java, address)                              \
-  template(complete_monitor_locking_Java, address)                     \
-  template(complete_monitor_locking_C , address)                       \
-  template(monitor_notify_Java, address)                               \
-  template(monitor_notifyAll_Java, address)                            \
-  template(rethrow_Java, address)                                      \
-  template(slow_arraycopy_Java, address)                               \
-  template(register_finalizer_Java, address)                           \
-  template(class_init_barrier_Java, address)                           \
-  OPTO_JVMTI_STUBS_DO(template)                                        \
-
-#else
-#define OPTO_STUBS_DO(template)
-#endif
+  SHARED_JFR_STUBS_DO(do_blob)                                         \
 
 // generate a stub id enum tag from a name
 
@@ -166,5 +82,5 @@
 
 #define BLOB_FIELD_NAME(base) _##base##_blob
 
-#endif // SHARE_RUNTIME_SHAREDRUNTIME_ID_HPP
+#endif // SHARE_RUNTIME_STUBDECLARATIONS_HPP
 

--- a/src/hotspot/share/runtime/stubDeclarations.hpp
+++ b/src/hotspot/share/runtime/stubDeclarations.hpp
@@ -44,7 +44,7 @@
   template(jfr_return_lease, RuntimeStub*)                             \
 
 #else
-#define SHARED_JFR_STUBS_DO(TEMPLATE) 
+#define SHARED_JFR_STUBS_DO(TEMPLATE)
 #endif
 
 // template(name, type)

--- a/src/hotspot/share/runtime/stubDeclarations.hpp
+++ b/src/hotspot/share/runtime/stubDeclarations.hpp
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2024, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef SHARE_RUNTIME_SHAREDRUNTIME_ID_HPP
+#define SHARE_RUNTIME_SHAREDRUNTIME_ID_HPP
+
+#include "utilities/macros.hpp"
+
+// macros for generating definitions and declarations for shared, c1
+// and opto blob fields and associated stub ids
+
+// Different shared stubs can have different blob types and may
+// include some JFR stubs
+//
+// n.b resolve, handler and throw stubs must remain grouped in the
+// same order to allow id values to be range checked
+
+#if INCLUDE_JFR
+// template(name, type)
+#define SHARED_JFR_STUBS_DO(template)                                  \
+  template(jfr_write_checkpoint, RuntimeStub*)                         \
+  template(jfr_return_lease, RuntimeStub*)                             \
+
+#else
+#define SHARED_JFR_STUBS_DO(TEMPLATE) 
+#endif
+
+// template(name, type)
+#define SHARED_STUBS_DO(template)                                      \
+  template(deopt, DeoptimizationBlob*)                                 \
+  /* resolve stubs */                                                  \
+  template(wrong_method, RuntimeStub*)                                 \
+  template(wrong_method_abstract, RuntimeStub*)                        \
+  template(ic_miss, RuntimeStub*)                                      \
+  template(resolve_opt_virtual_call, RuntimeStub*)                     \
+  template(resolve_virtual_call, RuntimeStub*)                         \
+  template(resolve_static_call, RuntimeStub*)                          \
+  /* handler stubs */                                                  \
+  template(polling_page_vectors_safepoint_handler, SafepointBlob*)     \
+  template(polling_page_safepoint_handler, SafepointBlob*)             \
+  template(polling_page_return_handler, SafepointBlob*)                \
+  /* throw stubs */                                                    \
+  template(throw_AbstractMethodError, RuntimeStub*)                    \
+  template(throw_IncompatibleClassChangeError, RuntimeStub*)           \
+  template(throw_NullPointerException_at_call, RuntimeStub*)           \
+  template(throw_StackOverflowError, RuntimeStub*)                     \
+  template(throw_delayed_StackOverflowError, RuntimeStub*)             \
+  /* other stubs */                                                    \
+  SHARED_JFR_STUBS_DO(template)                                        \
+
+// C1 stubs are always generated in a generic CodeBlob
+
+#ifdef COMPILER1
+// template(name)
+#define C1_STUBS_DO(template)                                          \
+  template(dtrace_object_alloc)                                        \
+  template(unwind_exception)                                           \
+  template(forward_exception)                                          \
+  template(throw_range_check_failed)       /* throws ArrayIndexOutOfBoundsException */ \
+  template(throw_index_exception)          /* throws IndexOutOfBoundsException */ \
+  template(throw_div0_exception)                                       \
+  template(throw_null_pointer_exception)                               \
+  template(register_finalizer)                                         \
+  template(new_instance)                                               \
+  template(fast_new_instance)                                          \
+  template(fast_new_instance_init_check)                               \
+  template(new_type_array)                                             \
+  template(new_object_array)                                           \
+  template(new_multi_array)                                            \
+  template(handle_exception_nofpu)         /* optimized version that does not preserve fpu registers */ \
+  template(handle_exception)                                           \
+  template(handle_exception_from_callee)                               \
+  template(throw_array_store_exception)                                \
+  template(throw_class_cast_exception)                                 \
+  template(throw_incompatible_class_change_error)                      \
+  template(slow_subtype_check)                                         \
+  template(monitorenter)                                               \
+  template(monitorenter_nofpu)             /* optimized version that does not preserve fpu registers */ \
+  template(monitorexit)                                                \
+  template(monitorexit_nofpu)              /* optimized version that does not preserve fpu registers */ \
+  template(deoptimize)                                                 \
+  template(access_field_patching)                                      \
+  template(load_klass_patching)                                        \
+  template(load_mirror_patching)                                       \
+  template(load_appendix_patching)                                     \
+  template(fpu2long_stub)                                              \
+  template(counter_overflow)                                           \
+  template(predicate_failed_trap)                                      \
+
+#else
+#define C1_STUBS_DO(template)
+#endif
+
+// Opto stubs can have different blob types and may include some JVMTI
+// stubs
+
+#ifdef COMPILER2
+// template(name, type)
+#if INCLUDE_JVMTI
+#define OPTO_JVMTI_STUBS_DO(template)                                  \
+  template(notify_jvmti_vthread_start, address)                        \
+  template(notify_jvmti_vthread_end, address)                          \
+  template(notify_jvmti_vthread_mount, address)                        \
+  template(notify_jvmti_vthread_unmount, address)                      \
+
+#else
+#define OPTO_JVMTI_STUBS_DO(template)
+#endif // INCLUDE_JVMTI
+
+#define OPTO_STUBS_DO(template)                                        \
+  template(uncommon_trap, UncommonTrapBlob*)                           \
+  template(exception, ExceptionBlob*)                                  \
+  template(new_instance_Java, address)                                 \
+  template(new_array_Java, address)                                    \
+  template(new_array_nozero_Java, address)                             \
+  template(multianewarray2_Java, address)                              \
+  template(multianewarray3_Java, address)                              \
+  template(multianewarray4_Java, address)                              \
+  template(multianewarray5_Java, address)                              \
+  template(multianewarrayN_Java, address)                              \
+  template(complete_monitor_locking_Java, address)                     \
+  template(complete_monitor_locking_C , address)                       \
+  template(monitor_notify_Java, address)                               \
+  template(monitor_notifyAll_Java, address)                            \
+  template(rethrow_Java, address)                                      \
+  template(slow_arraycopy_Java, address)                               \
+  template(register_finalizer_Java, address)                           \
+  template(class_init_barrier_Java, address)                           \
+  OPTO_JVMTI_STUBS_DO(template)                                        \
+
+#else
+#define OPTO_STUBS_DO(template)
+#endif
+
+// generate a stub id enum tag from a name
+
+#define STUB_ID_NAME(base) base##_id
+
+// generate a blob id enum tag from a name
+
+#define BLOB_ID_NAME(base) base##_id
+
+// generate a blob field name
+
+#define BLOB_FIELD_NAME(base) _##base##_blob
+
+#endif // SHARE_RUNTIME_SHAREDRUNTIME_ID_HPP
+


### PR DESCRIPTION
Systematize handling of SharedRuntime stubs. Generate enum ids, static fields and names from declarations using template macros. Systematically reference stubs and stub names using ids.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339466](https://bugs.openjdk.org/browse/JDK-8339466): Enumerate shared stubs and define static fields and names via declarations (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20832/head:pull/20832` \
`$ git checkout pull/20832`

Update a local copy of the PR: \
`$ git checkout pull/20832` \
`$ git pull https://git.openjdk.org/jdk.git pull/20832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20832`

View PR using the GUI difftool: \
`$ git pr show -t 20832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20832.diff">https://git.openjdk.org/jdk/pull/20832.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20832#issuecomment-2326144962)