### PR TITLE
8339148: Make os::Linux::active_processor_count() public

### DIFF
--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -30,9 +30,7 @@
 // os::Linux defines the interface to Linux operating systems
 
 class os::Linux {
-  friend class CgroupSubsystem;
   friend class os;
-  friend class OSContainer;
 
   static int (*_pthread_getcpuclockid)(pthread_t, clockid_t *);
   static int (*_pthread_setname_np)(pthread_t, const char*);
@@ -58,7 +56,6 @@ class os::Linux {
   static julong available_memory();
   static julong free_memory();
 
-  static int active_processor_count();
 
   static void initialize_system_info();
 
@@ -93,6 +90,7 @@ class os::Linux {
     bool     has_steal_ticks;
   };
 
+  static int active_processor_count();
   static void kernel_version(long* major, long* minor);
 
   // which_logical_cpu=-1 returns accumulated ticks for all cpus.


### PR DESCRIPTION
Please review this Linux-only change which makes `os::Linux::active_processor_count()` public (from currently protected). This allows us to clean up some `friend class` usages and will also make some container related patches less clunky.

Testing:
- [ ] GHA
- [x] Container tests on linux x86

Thoughts?