### PR TITLE
8338971: IGV: Add incrementally inlined method name to phase name

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -5196,7 +5196,14 @@ void Compile::print_method(CompilerPhaseType cpt, int level, Node* n) {
     ss.print(" %d", iter);
   }
   if (n != nullptr) {
-    ss.print(": %d %s ", n->_idx, NodeClassNames[n->Opcode()]);
+    ss.print(": %d %s", n->_idx, NodeClassNames[n->Opcode()]);
+    if (n->is_CallJava()) {
+      CallJavaNode* call = n->as_CallJava();
+      if (call->method() != nullptr) {
+        ss.print(" -");
+        call->method()->print_short_name(&ss);
+      }
+    }
   }
 
   const char* name = ss.as_string();

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -5197,11 +5197,17 @@ void Compile::print_method(CompilerPhaseType cpt, int level, Node* n) {
   }
   if (n != nullptr) {
     ss.print(": %d %s", n->_idx, NodeClassNames[n->Opcode()]);
-    if (n->is_CallJava()) {
-      CallJavaNode* call = n->as_CallJava();
-      if (call->method() != nullptr) {
-        ss.print(" -");
-        call->method()->print_short_name(&ss);
+    if (n->is_Call()) {
+      CallNode* call = n->as_Call();
+      if (call->_name != nullptr) {
+        // E.g. uncommon traps etc.
+        ss.print(" - %s", call->_name);
+      } else if (call->is_CallJava()) {
+        CallJavaNode* call_java = call->as_CallJava();
+        if (call_java->method() != nullptr) {
+          ss.print(" -");
+          call_java->method()->print_short_name(&ss);
+        }
       }
     }
   }


### PR DESCRIPTION
This patch adds the method name to the incremental inlining step dumps in IGV which improves debugging issues involving incremental inlining:

```
static void test() {
    method1();
    method2();
    method3();
}

static void method1() {}
static void method2() {}
static void method3() {}
```
Run with `-XX:+AlwaysIncrementalInline` and IGV print level >=3:

Before patch:
![image](https://github.com/user-attachments/assets/a3a1ab32-e7b3-4ccb-8ab2-a75d2b5b6912)

After patch:
![image](https://github.com/user-attachments/assets/8100a2fe-1670-4687-b8b8-c8053fbaa7d7)

The patch just prints the method name if we call `print_method()` with `n` being a call node which, AFAICT, only happens for the incremental inlining step. However, even if we call it with another phase at some point, I don't think it hurts to also dump the method name there.

#### Testing
- Manually verifying change in IGV
- Building IGV which runs its unit tests
- Sanity run with a hello world program with `-Xcomp -XX:+AlwaysIncrementalInline -XX:+PrintIdealGraph -XX:PrintIdealGraphLevel=3 -XX:PrintIdealGraphFile=graph.xml`

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338971](https://bugs.openjdk.org/browse/JDK-8338971): IGV: Add incrementally inlined method name to phase name (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [24cefa31](https://git.openjdk.org/jdk/pull/20834/files/24cefa31d34abc0ddf58e59ca3b9648d96cbb5d9)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20834/head:pull/20834` \
`$ git checkout pull/20834`

Update a local copy of the PR: \
`$ git checkout pull/20834` \
`$ git pull https://git.openjdk.org/jdk.git pull/20834/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20834`

View PR using the GUI difftool: \
`$ git pr show -t 20834`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20834.diff">https://git.openjdk.org/jdk/pull/20834.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20834#issuecomment-2326318902)