### PR TITLE
8339369: G1: TestVerificationInConcurrentCycle.java fails with "Missing rem set entry" when using "-XX:G1RSetUpdatingPauseTimePercent=0 -XX:G1UpdateBufferSize=2"

### DIFF
--- a/src/hotspot/share/gc/g1/g1FullCollector.cpp
+++ b/src/hotspot/share/gc/g1/g1FullCollector.cpp
@@ -172,7 +172,6 @@ public:
 
   bool do_heap_region(G1HeapRegion* hr) {
     hr->prepare_for_full_gc();
-    hr->uninstall_group_cardset();
     G1CollectedHeap::heap()->prepare_region_for_full_compaction(hr);
     _collector->before_marking_update_attribute_table(hr);
     return false;

--- a/src/hotspot/share/gc/g1/g1FullGCResetMetadataTask.cpp
+++ b/src/hotspot/share/gc/g1/g1FullGCResetMetadataTask.cpp
@@ -37,6 +37,8 @@ void G1FullGCResetMetadataTask::G1ResetMetadataClosure::reset_region_metadata(G1
 }
 
 bool G1FullGCResetMetadataTask::G1ResetMetadataClosure::do_heap_region(G1HeapRegion* hr) {
+  hr->uninstall_group_cardset();
+
   uint const region_idx = hr->hrm_index();
   if (!_collector->is_compaction_target(region_idx)) {
     assert(!hr->is_free(), "all free regions should be compaction targets");


### PR DESCRIPTION
Please review this patch to reset the per region cardsets in the later phases of the full-gc.  This ensures that Remset verification can proceed without considering whether the cardsets are combined or not.

Testing: passes test in the cited in the bug report and Tiers 1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339369](https://bugs.openjdk.org/browse/JDK-8339369): G1: TestVerificationInConcurrentCycle.java fails with "Missing rem set entry" when using "-XX:G1RSetUpdatingPauseTimePercent=0 -XX:G1UpdateBufferSize=2" (**Bug** - P2)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20835/head:pull/20835` \
`$ git checkout pull/20835`

Update a local copy of the PR: \
`$ git checkout pull/20835` \
`$ git pull https://git.openjdk.org/jdk.git pull/20835/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20835`

View PR using the GUI difftool: \
`$ git pr show -t 20835`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20835.diff">https://git.openjdk.org/jdk/pull/20835.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20835#issuecomment-2326596376)