### PR TITLE
8326616: tools/javac/patterns/Exhaustiveness.java intermittently Timeout signalled after 480 seconds

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -841,9 +841,18 @@ public class Flow {
                         return true;
                     }
                     if (!repeat) {
+                        //there may be situation like:
+                        //class B permits S1, S2
+                        //patterns: R(S1, B), R(S2, S2)
+                        //this might be joined to R(B, S2), as B could be rewritten to S2
+                        //but hashing in reduceNestedPatterns will not allow that
+                        //disable the use of hashing, and use subtyping in
+                        //reduceNestedPatterns to handle situations like this:
                         repeat = useHashes;
                         useHashes = false;
                     } else {
+                        //if a reduction happened, make sure hashing in reduceNestedPatterns
+                        //is enabled, as the hashing speeds up the process significantly:
                         useHashes = true;
                     }
                     patterns = updatedPatterns;
@@ -1024,7 +1033,8 @@ public class Flow {
          *            when false, the processing will be significantly slower,
          *            as pattern hashes cannot be used to speed up the matching process
          */
-        private Set<PatternDescription> reduceNestedPatterns(Set<PatternDescription> patterns, boolean useHashes) {
+        private Set<PatternDescription> reduceNestedPatterns(Set<PatternDescription> patterns,
+                                                             boolean useHashes) {
             /* implementation note:
              * finding a sub-set of patterns that only differ in a single
              * column is time-consuming task, so this method speeds it up by:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -1027,8 +1027,8 @@ public class Flow {
          * of patterns is replaced with a new set of patterns of the form:
          * $record($prefix$, $resultOfReduction, $suffix$)
          *
-         * useHashes: when true, patterns will be a subject to exact equivalence;
-         *            when false, two bindings patterns will be considered equivalent
+         * useHashes: when true, patterns will be subject to exact equivalence;
+         *            when false, two binding patterns will be considered equivalent
          *            if one of them is more generic than the other one;
          *            when false, the processing will be significantly slower,
          *            as pattern hashes cannot be used to speed up the matching process
@@ -1059,13 +1059,13 @@ public class Flow {
                      mismatchingCandidate < nestedPatternsCount;
                      mismatchingCandidate++) {
                     int mismatchingCandidateFin = mismatchingCandidate;
-                    var groupByHashes =
+                    var groupEquivalenceCandidates =
                             current
                              .stream()
                              //error recovery, ignore patterns with incorrect number of nested patterns:
                              .filter(pd -> pd.nested.length == nestedPatternsCount)
                              .collect(groupingBy(pd -> useHashes ? pd.hashCode(mismatchingCandidateFin) : 0));
-                    for (var candidates : groupByHashes.values()) {
+                    for (var candidates : groupEquivalenceCandidates.values()) {
                         var candidatesArr = candidates.toArray(RecordPattern[]::new);
 
                         for (int firstCandidate = 0;

--- a/test/langtools/ProblemList.txt
+++ b/test/langtools/ProblemList.txt
@@ -61,7 +61,6 @@ tools/javac/annotations/typeAnnotations/referenceinfos/Lambda.java              
 tools/javac/annotations/typeAnnotations/referenceinfos/NestedTypes.java         8057687    generic-all    emit correct byte code an attributes for type annotations
 tools/javac/warnings/suppress/TypeAnnotations.java                              8057683    generic-all    improve ordering of errors with type annotations
 tools/javac/modules/SourceInSymlinkTest.java                                    8180263    windows-all    fails when run on a subst drive
-tools/javac/patterns/Exhaustiveness.java 					8326616    generic-all    intermittently timeout
 
 ###########################################################################
 #


### PR DESCRIPTION
This patch revisits the fix for JDK-8325215 (PR: https://github.com/openjdk/jdk/pull/17949). The problem in that bug was along the following lines.

Consider this code:
```
    sealed interface B permits S1, S2 {}
    final class S1 implements B {}
    final class S2 implements B {}
    record R(B b, B s) {}
    private void test(R r) {
        switch (r) {
            case R(B _, S1 _) -> {}
            case R(S1 _, B _) -> {}
            case R(S2 _, S2 _) -> {}
        }
    }
```

The `switch` is exhaustive, but before the fix for JDK-8325215, javac considered it not exhaustive. If ` case R(S1 _, B _)` is preplaced with ` case R(S1 _, S2 _)`, javac will consider the `switch` to be exhaustive.

This problem is because to prove that the `switch` is exhaustive, it is necessary to merge `R(S1 _, B _)` and `R(S2 _, S2 _)` into `R(B _, S2 _)`, which then can be merged with `R(B _, S1 _)` to form `R(B _, B_)`, and then just `R _`, which means the `switch` is exhaustive.

But, before JDK-8325215, javac could merge `R(S1 _, B _)` and `R(S2 _, S2 _)` into `R(B _, S2 _)`, because it was looking at the two patterns, set the mismatching component to `0`, and was looking at the patterns in all other components, if they are precisely the same - but they are not, so javac failed to merge the patterns. Note that it is permitted to replace a type pattern with a more specific type pattern (i.e. replace `B _` with `S2 _`).

The solution in JDK-8325215 was to expand all type patterns in all the patterns in the set into their possible permitted subtypes. I.e. in the above case `R(S1 _, B _)` was expanded to `R(S1 _, B _)`, `R(S1 _, S1 _)` and `R(S1 _, S2 _)`. As a consequence, the merging could proceed, and javac would consider the `switch` to be exhaustive.

The problem with this solution is that it sometimes leads to a very big pattern set, which the javac then processes very slowly/too slowly.

The proposal alternate fix for the original problem proposed herein is to avoid the creation of the very big pattern set, and rather permit javac to merge `R(S1 _, B _)` and `R(S2 _, S2 _)`, because `B` is a supertype of (more general pattern than) `S2`. This is a bit tricky, as the code that searches for merge candidates is using hashes for the patterns, and the hashes speed up the search very significantly (and the use of the hashes is not compatible with the  use of the subtyping relation). So, the proposal is to use hashing when possible, and use the subtyping relation when no more patterns can be merged.

I ran the `Exhaustiveness` test many times with this change, without a timeout so far.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8326616](https://bugs.openjdk.org/browse/JDK-8326616): tools/javac/patterns/Exhaustiveness.java intermittently Timeout signalled after 480 seconds (**Bug** - P4)


### Reviewers
 * [Aggelos Biboudis](https://openjdk.org/census#abimpoudis) (@biboudis - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20836/head:pull/20836` \
`$ git checkout pull/20836`

Update a local copy of the PR: \
`$ git checkout pull/20836` \
`$ git pull https://git.openjdk.org/jdk.git pull/20836/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20836`

View PR using the GUI difftool: \
`$ git pr show -t 20836`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20836.diff">https://git.openjdk.org/jdk/pull/20836.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20836#issuecomment-2326414959)