### PR TITLE
8339480: Build static-jdk image with a statically linked launcher

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -452,6 +452,18 @@ $(eval $(call SetupTarget, legacy-jre-image, \
 $(eval $(call SetupTarget, symbols-image, \
     MAKEFILE := Images, \
     TARGET := symbols, \
+))
+
+$(eval $(call SetupTarget, static-launcher, \
+    MAKEFILE := StaticLibs, \
+    TARGET := static-launcher, \
+    DEPS := hotspot-server-static-libs static-libs, \
+))
+
+$(eval $(call SetupTarget, static-jdk-image, \
+    MAKEFILE := StaticLibs, \
+    TARGET := static-jdk-image, \
+    DEPS := static-exploded-image jdk-image, \
 ))
 
 $(eval $(call SetupTarget, static-libs-image, \
@@ -1082,9 +1094,9 @@ else
 
   symbols-image: $(LIBS_TARGETS) $(LAUNCHER_TARGETS)
 
-  static-libs-image: hotspot-static-libs $(STATIC_LIBS_TARGETS)
+  static-libs-image: hotspot-static-libs static-libs
 
-  static-libs-graal-image: $(STATIC_LIBS_TARGETS)
+  static-libs-graal-image: static-libs
 
   bootcycle-images: jdk-image
 
@@ -1250,6 +1262,8 @@ ifeq ($(call isTargetOs, macosx), true)
   legacy-images: mac-legacy-jre-bundle
 endif
 
+static-exploded-image: static-launcher exploded-image
+
 # These targets build the various documentation images
 docs-jdk-image: docs-jdk
 docs-javase-image: docs-javase
@@ -1292,7 +1306,7 @@ endif
 ################################################################################
 
 # all-images builds all our deliverables as images.
-all-images: product-images test-image all-docs-images
+all-images: product-images static-jdk-image test-image all-docs-images
 
 # all-bundles packages all our deliverables as tar.gz bundles.
 all-bundles: product-bundles test-bundles docs-bundles static-libs-bundles
@@ -1305,7 +1319,7 @@ ALL_TARGETS += buildtools hotspot hotspot-libs hotspot-static-libs \
     create-buildjdk docs-jdk-api docs-javase-api docs-reference-api docs-jdk \
     docs-javase docs-reference docs-javadoc mac-bundles product-images legacy-images \
     docs-image docs-javase-image docs-reference-image all-docs-images \
-    docs-bundles all-docs-bundles test-image all-images \
+    docs-bundles all-docs-bundles test-image all-images static-exploded-image \
     all-bundles
 
 ################################################################################

--- a/make/ModuleWrapper.gmk
+++ b/make/ModuleWrapper.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -44,6 +44,18 @@ TARGETS :=
 
 # Include the file being wrapped.
 include $(MAKEFILE_PREFIX).gmk
+
+ifeq ($(MAKEFILE_PREFIX), Lib)
+  ifneq ($($(MODULE)_JDK_LIBS), )
+    LIBLIST := $(SUPPORT_OUTPUTDIR)/modules_static-libs/$(MODULE)/module-libs.txt
+
+    $(LIBLIST): $(TARGETS)
+	$(call MakeDir, $(@D))
+	$(ECHO) $($(MODULE)_JDK_LIBS) > $@
+
+    TARGETS += $(LIBLIST)
+  endif
+endif
 
 # Setup copy rules from the modules directories to the jdk image directory.
 ifeq ($(call isTargetOs, windows), true)

--- a/make/StaticLibs.gmk
+++ b/make/StaticLibs.gmk
@@ -1,0 +1,184 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.  Oracle designates this
+# particular file as subject to the "Classpath" exception as provided
+# by Oracle in the LICENSE file that accompanied this code.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+default: all
+
+include $(SPEC)
+include MakeBase.gmk
+
+include CopyFiles.gmk
+include Modules.gmk
+include modules/LauncherCommon.gmk
+
+################################################################################
+#
+# Create the static java launcher
+#
+################################################################################
+
+STATIC_JDK_IMAGE_DIR := $(IMAGES_OUTPUTDIR)/static-jdk
+STATIC_LAUNCHER_OUTPUT_DIR := $(SUPPORT_OUTPUTDIR)/static-native/launcher
+HOTSPOT_STATIC_LIB_PATH := $(HOTSPOT_OUTPUTDIR)/*/libjvm/objs/static
+
+ifneq ($(word 2, $(wildcard $(HOTSPOT_STATIC_LIB_PATH))), )
+  $(error Cannot perform static linking when building more than one JVM library)
+endif
+
+# Find all modules with static libraries
+STATIC_LIB_MODULES := $(patsubst $(SUPPORT_OUTPUTDIR)/modules_static-libs/%, \
+    %, $(wildcard $(SUPPORT_OUTPUTDIR)/modules_static-libs/*))
+
+# Filter out known broken libraries. This is a temporary measure until
+# proper support for these libraries can be provided.
+ifeq ($(call isTargetOs, linux), true)
+  # libsplashscreen has a name conflict with libawt in the function
+  # BitmapToYXBandedRectangles, so we exclude it for now.
+  BROKEN_STATIC_LIBS += splashscreen
+else ifeq ($(call isTargetOs, macosx), true)
+  # libosxsecurity has a name conflict with libosxapp in the function
+  # JavaStringToNSString, so we exclude it for now.
+  BROKEN_STATIC_LIBS += osxsecurity
+else ifeq ($(call isTargetOs, windows), true)
+  # libsplashscreen has a name conflict with libawt in the function
+  # BitmapToYXBandedRectangles, so we exclude it for now.
+  BROKEN_STATIC_LIBS += splashscreen
+  # windowsaccessbridge-64 has multiple collisions and conflicts
+  BROKEN_STATIC_LIBS += windowsaccessbridge-64
+  # libsspi_bridge has name conflicts with sunmscapi
+  BROKEN_STATIC_LIBS += sspi_bridge
+  # These libs define DllMain which conflict with Hotspot
+  BROKEN_STATIC_LIBS += awt dt_shmem dt_socket javaaccessbridge
+  # These libs are dependent on any of the above disabled libs
+  BROKEN_STATIC_LIBS += fontmanager jawt lcms net nio
+endif
+
+$(foreach module, $(STATIC_LIB_MODULES), \
+    $(eval LIBS_$(module) := $(filter-out $(BROKEN_STATIC_LIBS), $(shell cat \
+    $(SUPPORT_OUTPUTDIR)/modules_static-libs/$(module)/module-libs.txt))) \
+)
+
+STATIC_LIB_FILES := $(foreach module, $(STATIC_LIB_MODULES), \
+    $(foreach lib, $(LIBS_$(module)), \
+    $(SUPPORT_OUTPUTDIR)/native/$(module)/lib$(lib)/static/$(LIBRARY_PREFIX)$(lib)$(STATIC_LIBRARY_SUFFIX)))
+
+# Add Hotspot
+STATIC_LIB_FILES += $(wildcard $(HOTSPOT_STATIC_LIB_PATH)/$(LIBRARY_PREFIX)jvm$(STATIC_LIBRARY_SUFFIX))
+
+# Figure out what external libraries are required to link these static JDK
+# libraries.
+LIB_FLAGS_FILES := $(addsuffix .lib-flags.txt, $(STATIC_LIB_FILES))
+
+# Gather the lib flags from all individual libraries. There are many duplicates,
+# so sort and just keep unique instances. On macOS, a common pattern is
+# "-framework FooFramework", so we must make sure we keep the two words together.
+EXTERNAL_LIBS := $(strip $(shell $(CAT) $(LIB_FLAGS_FILES) | \
+    $(SED) -e 's/-framework /-framework_/g' | $(TR) ' ' '\n' | $(SORT) -u | \
+    $(SED) -e 's/-framework_/-framework /g'))
+
+ifeq ($(call isTargetOs, macosx), true)
+  STATIC_LIBS := $(addprefix -force_load$(SPACE), $(STATIC_LIB_FILES))
+  STANDARD_LIBS += -lstdc++
+else ifeq ($(call isTargetOs, linux), true)
+  STATIC_LIBS := -Wl,--export-dynamic -Wl,--whole-archive $(STATIC_LIB_FILES) -Wl,--no-whole-archive
+  STANDARD_LIBS := -l:libstdc++.a
+else ifeq ($(call isTargetOs, windows), true)
+  STATIC_LIBS := $(addprefix -wholearchive:, $(STATIC_LIB_FILES))
+else
+  $(error Unsupported platform)
+endif
+
+$(eval $(call SetupBuildLauncher, java, \
+    CFLAGS := -DEXPAND_CLASSPATH_WILDCARDS -DENABLE_ARG_FILES, \
+    EXTRA_RCFLAGS := $(JAVA_RCFLAGS), \
+    VERSION_INFO_RESOURCE := $(JAVA_VERSION_INFO_RESOURCE), \
+    OPTIMIZATION := HIGH, \
+    STATIC_LAUNCHER := true, \
+    LDFLAGS := $(JAVASTATIC_LINK_LDFLAGS), \
+    LIBS := $(STATIC_LIBS) $(EXTERNAL_LIBS) $(STANDARD_LIBS), \
+    OUTPUT_DIR := $(STATIC_LAUNCHER_OUTPUT_DIR), \
+    OBJECT_DIR := $(STATIC_LAUNCHER_OUTPUT_DIR), \
+))
+
+TARGETS += $(java)
+
+JAVA_LAUNCHER := $(BUILD_LAUNCHER_java_TARGET)
+
+static-launcher: $(java)
+
+################################################################################
+#
+# Create the static-jdk image with the statically built java launcher
+#
+################################################################################
+
+# Until we get proper support in jlink for generating an image with static
+# builds, we need to create the image ourselves. We base it on a normal
+# dynamically linked JDK image.
+
+# All these files/dirs should be copied as-is
+JDK_IMAGE_COPY_FILES := $(addprefix $(JDK_IMAGE_DIR)/, conf demo include jmods \
+    legal man/man1/java.1 release README)
+
+# We need to copy some files from lib, but not the dynamic libraries themselves
+ALL_LIB_FILES := $(call FindFiles, $(JDK_IMAGE_DIR)/lib)
+
+# Remove all dynamic libraries from the list
+JDK_IMAGE_COPY_LIB_FILES := $(filter-out %$(SHARED_LIBRARY_SUFFIX), $(ALL_LIB_FILES))
+# Remove all debug files from the list
+ifeq ($(call isTargetOs, macosx), true)
+  JDK_IMAGE_COPY_LIB_FILES := $(call not-containing, .dSYM, $(JDK_IMAGE_COPY_LIB_FILES))
+else
+  JDK_IMAGE_COPY_LIB_FILES := $(filter-out %.debuginfo %.pdb %.map, $(JDK_IMAGE_COPY_LIB_FILES))
+endif
+
+static-jdk-info:
+	$(call LogWarn, Creating static-jdk image)
+
+$(eval $(call SetupCopyFiles, copy-from-jdk-image, \
+    SRC := $(JDK_IMAGE_DIR), \
+    DEST := $(STATIC_JDK_IMAGE_DIR), \
+    FILES := $(call FindFiles, $(JDK_IMAGE_COPY_FILES)) \
+        $(JDK_IMAGE_COPY_LIB_FILES), \
+))
+
+TARGETS += $(copy-from-jdk-image)
+
+$(copy-from-jdk-image): | static-jdk-info
+
+$(eval $(call SetupCopyFiles, copy-static-launcher, \
+    SRC := $(dir $(JAVA_LAUNCHER)), \
+    DEST := $(STATIC_JDK_IMAGE_DIR)/bin, \
+    FILES := $(JAVA_LAUNCHER), \
+))
+
+TARGETS += $(copy-static-launcher)
+
+static-jdk-image: $(copy-from-jdk-image) $(copy-static-launcher)
+
+TARGETS += static-jdk-image
+
+all: $(TARGETS)
+
+.PHONY: all static-launcher static-jdk-image

--- a/make/common/JdkNativeCompilation.gmk
+++ b/make/common/JdkNativeCompilation.gmk
@@ -303,6 +303,12 @@ define SetupJdkNativeCompilationBody
     $1_RC_FTYPE := 0x2L
   endif
 
+  ifneq ($$(MODULE), )
+    ifneq ($$($1_EXCLUDE_FROM_STATIC_LIBS), true)
+      $$(MODULE)_JDK_LIBS += $$($1_NAME)
+    endif
+  endif
+
   ifeq ($$($1_OUTPUT_DIR), )
     ifneq ($$(MODULE), )
       ifeq ($$($1_TYPE), STATIC_LIBRARY)

--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -62,6 +62,7 @@ JAVA_MANIFEST := $(TOPDIR)/src/java.base/windows/native/launcher/java.manifest
 # OPTIMIZATION   Override default optimization level (LOW)
 # OUTPUT_DIR   Override default output directory
 # VERSION_INFO_RESOURCE   Override default Windows resource file
+# STATIC_LAUNCHER   If true, will use settings for building a static launcher
 SetupBuildLauncher = $(NamedParamsMacroTemplate)
 define SetupBuildLauncherBody
   # Setup default values (unless overridden)
@@ -120,6 +121,15 @@ define SetupBuildLauncherBody
     $1_EXTRA_FILES += $(TOPDIR)/make/data/lsan/lsan_default_options.c
   endif
 
+  ifneq ($$($1_STATIC_LAUNCHER), true)
+      $1_JDK_LIBS := java.base:libjli
+      $1_JDK_LIBS_windows := java.base:libjava
+  else
+    ifneq ($(findstring $(TOOLCHAIN_TYPE), gcc clang), )
+      $1_LDFLAGS_FILTER_OUT := -Wl$(COMMA)--exclude-libs$(COMMA)ALL
+    endif
+  endif
+
   ##############################################################################
   ## Build launcher "$1"
   ##############################################################################
@@ -140,8 +150,9 @@ define SetupBuildLauncherBody
       LDFLAGS := $$($1_LDFLAGS), \
       LDFLAGS_linux := $$(call SET_EXECUTABLE_ORIGIN,/../lib), \
       LDFLAGS_macosx := $$(call SET_EXECUTABLE_ORIGIN,/../lib), \
-      JDK_LIBS := java.base:libjli, \
-      JDK_LIBS_windows := java.base:libjava, \
+      LDFLAGS_FILTER_OUT := $$($1_LDFLAGS_FILTER_OUT), \
+      JDK_LIBS := $$($1_JDK_LIBS), \
+      JDK_LIBS_windows := $$($1_JDK_LIBS_windows), \
       LIBS := $$($1_LIBS), \
       LIBS_unix := $(LIBZ_LIBS), \
       LIBS_linux := $(LIBDL) -lpthread, \
@@ -150,6 +161,7 @@ define SetupBuildLauncherBody
           -framework Cocoa \
           -framework Security, \
       OUTPUT_DIR := $$($1_OUTPUT_DIR), \
+      OBJECT_DIR := $$($1_OBJECT_DIR), \
       VERSIONINFO_RESOURCE := $$($1_VERSION_INFO_RESOURCE), \
       EXTRA_RCFLAGS := $$($1_EXTRA_RCFLAGS), \
       MANIFEST := $(JAVA_MANIFEST), \

--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -119,6 +119,7 @@ define CreateStaticLibrary
 	    $(if $$($1_LINK_OBJS_RELATIVE), $$(CD) $$(OUTPUTDIR) ; ) \
 	    $$($1_AR) $$(ARFLAGS) -r -cs $$($1_TARGET) \
 	        $$($1_AR_OBJ_ARG) $$($1_RES))
+	$$(ECHO) $$(strip $$($1_LIBS) $$($1_EXTRA_LIBS)) > $$($1_TARGET).lib-flags.txt
 endef
 
 ################################################################################

--- a/make/common/native/LinkMicrosoft.gmk
+++ b/make/common/native/LinkMicrosoft.gmk
@@ -54,7 +54,8 @@ define CreateStaticLibraryMicrosoft
 	$$(call MakeDir, $$($1_OUTPUT_DIR) $$($1_SYMBOLS_DIR))
 	$$(call ExecuteWithLog, $$($1_OBJECT_DIR)/$$($1_SAFE_NAME)_run_lib, \
 	    $$($1_LIB) -nologo $$(LIBFLAGS) -out:$$($1_TARGET) \
-	        $$($1_LD_OBJ_ARG) $$($1_RES))
+	        $$($1_LD_OBJ_ARG))
+	$$(ECHO) $$(strip $$($1_LIBS) $$($1_EXTRA_LIBS)) > $$($1_TARGET).lib-flags.txt
 endef
 
 ################################################################################

--- a/make/modules/java.desktop/lib/AwtLibraries.gmk
+++ b/make/modules/java.desktop/lib/AwtLibraries.gmk
@@ -172,10 +172,16 @@ ifeq ($(call isTargetOs, windows macosx), false)
   # static libraries cause linking errors due to duplicate symbols.
   LIBAWT_HEADLESS_STATIC_EXCLUDE_OBJS := systemScale.o
 
+  ifneq ($(ENABLE_HEADLESS_ONLY), true)
+    # We cannot link with both awt_headless and awt_xawt at the same time
+    LIBAWT_HEADLESS_EXCLUDE_FROM_STATIC_LIBS := true
+  endif
+
   $(eval $(call SetupJdkLibrary, BUILD_LIBAWT_HEADLESS, \
       NAME := awt_headless, \
       EXTRA_SRC := $(LIBAWT_HEADLESS_EXTRA_SRC), \
       EXCLUDES := medialib, \
+      EXCLUDE_FROM_STATIC_LIBS := $(LIBAWT_HEADLESS_EXCLUDE_FROM_STATIC_LIBS), \
       OPTIMIZATION := LOW, \
       CFLAGS := -DHEADLESS=true $(CUPS_CFLAGS) $(FONTCONFIG_CFLAGS) \
           $(X_CFLAGS), \
@@ -312,6 +318,8 @@ ifeq ($(call isTargetOs, macosx), true)
   LIBAWT_LWAWT_EXCLUDE_FILES := fontpath.c awt_Font.c X11Color.c
   LIBAWT_LWAWT_EXCLUDES := $(TOPDIR)/src/$(MODULE)/unix/native/common/awt/medialib
 
+  LIBAWT_LWAWT_STATIC_EXCLUDE_OBJS := systemScale.o
+
   $(eval $(call SetupJdkLibrary, BUILD_LIBAWT_LWAWT, \
       NAME := awt_lwawt, \
       EXTRA_SRC := $(LIBAWT_LWAWT_EXTRA_SRC), \
@@ -350,6 +358,7 @@ ifeq ($(call isTargetOs, macosx), true)
           -framework OpenGL \
           -framework QuartzCore \
           -framework Security, \
+      STATIC_LIB_EXCLUDE_OBJS := $(LIBAWT_LWAWT_STATIC_EXCLUDE_OBJS), \
   ))
 
   TARGETS += $(BUILD_LIBAWT_LWAWT)

--- a/make/modules/java.desktop/lib/ClientLibraries.gmk
+++ b/make/modules/java.desktop/lib/ClientLibraries.gmk
@@ -154,6 +154,15 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
 
   ifeq ($(USE_EXTERNAL_LIBJPEG), false)
     LIBSPLASHSCREEN_EXTRA_SRC += libjavajpeg
+    LIBSPLASHSCREEN_STATIC_LIB_EXCLUDE_OBJS += jcapimin.o jcapistd.o \
+        jccoefct.o jccolor.o jcdctmgr.o jchuff.o jcinit.o jcmainct.o \
+        jcmarker.o jcmaster.o jcomapi.o jcparam.o jcphuff.o jcprepct.o \
+        jcsample.o jctrans.o jdapimin.o jdapistd.o jdcoefct.o jdcolor.o \
+        jddctmgr.o jdhuff.o jdinput.o jdmainct.o jdmarker.o jdmaster.o \
+        jdmerge.o jdphuff.o jdpostct.o jdsample.o jdtrans.o jerror.o \
+        jfdctflt.o jfdctfst.o jfdctint.o jidctflt.o jidctfst.o jidctint.o \
+        jidctred.o jmemmgr.o jmemnobs.o jpegdecoder.o jquant1.o jquant2.o \
+        jutils.o
   endif
 
   ifeq ($(USE_EXTERNAL_LIBPNG), false)
@@ -164,6 +173,10 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
 
   ifeq ($(USE_EXTERNAL_LIBZ), false)
     LIBSPLASHSCREEN_EXTRA_SRC += java.base:libzip/zlib
+    LIBSPLASHSCREEN_STATIC_LIB_EXCLUDE_OBJS += Adler32.o compress.o CRC32.o \
+        deflate.o Deflater.o Inflater.o gzclose.o gzlib.o gzread.o gzwrite.o \
+        infback.o inffast.o inflate.o inftrees.o trees.o uncompr.o zadler32.o \
+        zcrc32.o zip_util.o zutil.o
   endif
 
   LIBSPLASHSCREEN_CFLAGS += -DSPLASHSCREEN -DPNG_NO_MMX_CODE \
@@ -205,6 +218,8 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
   else
     LIBSPLASHSCREEN_CFLAGS += -DWITH_X11 $(X_CFLAGS)
   endif
+
+  LIBSPLASHSCREEN_STATIC_LIB_EXCLUDE_OBJS += systemScale.o
 
   $(eval $(call SetupJdkLibrary, BUILD_LIBSPLASHSCREEN, \
       NAME := splashscreen, \
@@ -256,6 +271,7 @@ ifeq ($(ENABLE_HEADLESS_ONLY), false)
           -framework Security, \
       LIBS_aix := $(LIBDL) -liconv $(X_LIBS) -lX11 -lXext, \
       LIBS_windows := delayimp.lib gdi32.lib kernel32.lib user32.lib, \
+      STATIC_LIB_EXCLUDE_OBJS := $(LIBSPLASHSCREEN_STATIC_LIB_EXCLUDE_OBJS), \
   ))
 
   TARGETS += $(BUILD_LIBSPLASHSCREEN)

--- a/make/modules/jdk.accessibility/Lib.gmk
+++ b/make/modules/jdk.accessibility/Lib.gmk
@@ -82,6 +82,7 @@ ifeq ($(call isTargetOs, windows), true)
             user32.lib uuid.lib winspool.lib, \
         VERSIONINFO_RESOURCE := \
             $(ACCESSIBILITY_SRCDIR)/common/AccessBridgeStatusWindow.rc, \
+        STATIC_LIB_EXCLUDE_OBJS := AccessBridgeDebug.obj AccessBridgeMessages.obj, \
     )
 
     TARGETS += $$(BUILD_LIBWINDOWSACCESSBRIDGE$1)

--- a/make/modules/jdk.jpackage/Lib.gmk
+++ b/make/modules/jdk.jpackage/Lib.gmk
@@ -49,6 +49,7 @@ $(eval $(call SetupJdkExecutable, BUILD_JPACKAGEAPPLAUNCHER, \
     LINK_TYPE := $(JPACKAGEAPPLAUNCHER_LINK_TYPE), \
     OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
     SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/jpackageapplauncher, \
+    EXCLUDE_FROM_STATIC_LIBS := true, \
     SRC := applauncher, \
     EXTRA_SRC := common, \
     INCLUDE_FILES := $(JPACKAGEAPPLAUNCHER_INCLUDE_FILES), \
@@ -83,6 +84,7 @@ ifeq ($(call isTargetOs, linux), true)
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
       SYMBOLS_DIR := \
           $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libjpackageapplauncheraux, \
+      EXCLUDE_FROM_STATIC_LIBS := true, \
       SRC := libapplauncher, \
       EXTRA_SRC := \
           applauncher \
@@ -127,6 +129,7 @@ ifeq ($(call isTargetOs, windows), true)
       NAME := wixhelper, \
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
       SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/libwixhelper, \
+      EXCLUDE_FROM_STATIC_LIBS := true, \
       OPTIMIZATION := LOW, \
       EXTRA_SRC := common, \
       CXXFLAGS_FILTER_OUT := -MD, \
@@ -146,6 +149,7 @@ ifeq ($(call isTargetOs, windows), true)
       NAME := msiwrapper, \
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
       SYMBOLS_DIR := $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/msiwrapper, \
+      EXCLUDE_FROM_STATIC_LIBS := true, \
       EXTRA_SRC := common, \
       CXXFLAGS_FILTER_OUT := -MD, \
       CXXFLAGS_windows := -MT $(JPACKAGE_CXXFLAGS_windows), \
@@ -164,6 +168,7 @@ ifeq ($(call isTargetOs, windows), true)
       OUTPUT_DIR := $(JPACKAGE_OUTPUT_DIR), \
       SYMBOLS_DIR := \
           $(SUPPORT_OUTPUTDIR)/native/$(MODULE)/jpackageapplauncherw, \
+      EXCLUDE_FROM_STATIC_LIBS := true, \
       SRC := applauncher, \
       EXTRA_SRC := common, \
       OPTIMIZATION := LOW, \

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -571,6 +571,7 @@ void os::init_system_properties_values() {
 // Base path of extensions installed on the system.
 #define SYS_EXT_DIR     "/usr/java/packages"
 #define EXTENSIONS_DIR  "/lib/ext"
+#define JVM_LIB_NAME "libjvm.so"
 
   // Buffer that fits several snprintfs.
   // Note that the space for the colon and the trailing null are provided
@@ -585,22 +586,32 @@ void os::init_system_properties_values() {
     char *pslash;
     os::jvm_path(buf, bufsize);
 
-    // Found the full path to libjvm.so.
-    // Now cut the path to <java_home>/jre if we can.
+    // Found the full path to the binary. It is normally of this structure:
+    //   <jdk_path>/lib/<hotspot_variant>/libjvm.so
+    // but can also be like this for a statically linked binary:
+    //   <jdk_path>/bin/<executable>
     pslash = strrchr(buf, '/');
     if (pslash != nullptr) {
-      *pslash = '\0';            // Get rid of /libjvm.so.
-    }
-    pslash = strrchr(buf, '/');
-    if (pslash != nullptr) {
-      *pslash = '\0';            // Get rid of /{client|server|hotspot}.
+      if (strncmp(pslash + 1, JVM_LIB_NAME, strlen(JVM_LIB_NAME)) == 0) {
+        // Binary name is libjvm.so. Get rid of /libjvm.so.
+        *pslash = '\0';
+      }
+
+      // Get rid of /<hotspot_variant>, if binary is libjvm.so,
+      // or cut off /<executable>, if it is a statically linked binary.
+      pslash = strrchr(buf, '/');
+      if (pslash != nullptr) {
+        *pslash = '\0';
+      }
     }
     Arguments::set_dll_dir(buf);
 
+    // Get rid of /lib, if binary is libjvm.so,
+    // or cut off /bin, if it is a statically linked binary.
     if (pslash != nullptr) {
       pslash = strrchr(buf, '/');
       if (pslash != nullptr) {
-        *pslash = '\0';        // Get rid of /lib.
+        *pslash = '\0';
       }
     }
     Arguments::set_java_home(buf);

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -857,6 +857,12 @@ void os::dll_unload(void *lib) {
   LINUX_ONLY(os::free(l_pathdup));
 }
 
+void* os::lookup_function(const char* name) {
+  // This returns the global symbol in the main executable and its dependencies,
+  // as well as shared objects dynamically loaded with RTLD_GLOBAL flag.
+  return dlsym(RTLD_DEFAULT, name);
+}
+
 jlong os::lseek(int fd, jlong offset, int whence) {
   return (jlong) ::lseek(fd, offset, whence);
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -1403,6 +1403,12 @@ void* os::dll_lookup(void *lib, const char *name) {
   return ret;
 }
 
+void* os::lookup_function(const char* name) {
+  // This is needed only for static builds which are not supported on Windows
+  ShouldNotReachHere();
+  return nullptr; // Satisfy compiler
+}
+
 // Directory routines copied from src/win32/native/java/io/dirent_md.c
 //  * dirent_md.c       1.15 00/02/02
 //

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -949,6 +949,11 @@ void* ClassLoader::dll_lookup(void* lib, const char* name, const char* path) {
 
 void ClassLoader::load_java_library() {
   assert(CanonicalizeEntry == nullptr, "should not load java library twice");
+  if (is_vm_statically_linked()) {
+    CanonicalizeEntry = CAST_TO_FN_PTR(canonicalize_fn_t, os::lookup_function("JDK_Canonicalize"));
+    return;
+  }
+
   void *javalib_handle = os::native_java_library();
   if (javalib_handle == nullptr) {
     vm_exit_during_initialization("Unable to load java library", nullptr);
@@ -959,6 +964,15 @@ void ClassLoader::load_java_library() {
 
 void ClassLoader::load_jimage_library() {
   assert(JImageOpen == nullptr, "should not load jimage library twice");
+
+  if (is_vm_statically_linked()) {
+      JImageOpen = CAST_TO_FN_PTR(JImageOpen_t, os::lookup_function("JIMAGE_Open"));
+      JImageClose = CAST_TO_FN_PTR(JImageClose_t, os::lookup_function("JIMAGE_Close"));
+      JImageFindResource = CAST_TO_FN_PTR(JImageFindResource_t, os::lookup_function("JIMAGE_FindResource"));
+      JImageGetResource = CAST_TO_FN_PTR(JImageGetResource_t, os::lookup_function("JIMAGE_GetResource"));
+      return;
+    }
+
   char path[JVM_MAXPATHLEN];
   char ebuf[1024];
   void* handle = nullptr;

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -84,15 +84,20 @@ static verify_byte_codes_fn_t verify_byte_codes_fn() {
   if (_verify_byte_codes_fn != nullptr)
     return _verify_byte_codes_fn;
 
+  void *lib_handle = nullptr;
   // Load verify dll
-  char buffer[JVM_MAXPATHLEN];
-  char ebuf[1024];
-  if (!os::dll_locate_lib(buffer, sizeof(buffer), Arguments::get_dll_dir(), "verify"))
-    return nullptr; // Caller will throw VerifyError
+  if (is_vm_statically_linked()) {
+    lib_handle = os::get_default_process_handle();
+  } else {
+    char buffer[JVM_MAXPATHLEN];
+    char ebuf[1024];
+    if (!os::dll_locate_lib(buffer, sizeof(buffer), Arguments::get_dll_dir(), "verify"))
+      return nullptr; // Caller will throw VerifyError
 
-  void *lib_handle = os::dll_load(buffer, ebuf, sizeof(ebuf));
-  if (lib_handle == nullptr)
-    return nullptr; // Caller will throw VerifyError
+    lib_handle = os::dll_load(buffer, ebuf, sizeof(ebuf));
+    if (lib_handle == nullptr)
+      return nullptr; // Caller will throw VerifyError
+  }
 
   void *fn = os::dll_lookup(lib_handle, "VerifyClassForMajorVersion");
   if (fn == nullptr)

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -512,6 +512,11 @@ static void* _native_java_library = nullptr;
 
 void* os::native_java_library() {
   if (_native_java_library == nullptr) {
+    if (is_vm_statically_linked()) {
+      _native_java_library = get_default_process_handle();
+      return _native_java_library;
+    }
+
     char buffer[JVM_MAXPATHLEN];
     char ebuf[1024];
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -752,6 +752,9 @@ class os: AllStatic {
   // Unload library
   static void  dll_unload(void *lib);
 
+  // Lookup the named function. This is used by the static JDK.
+  static void* lookup_function(const char* name);
+
   // Callback for loaded module information
   // Input parameters:
   //    char*     module_file_name,

--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -369,29 +369,31 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     int  argc         = *pargc;
     char **argv       = *pargv;
 
-    /* Find out where the JRE is that we will be using. */
-    if (!GetJREPath(jrepath, so_jrepath, JNI_FALSE) ) {
-        JLI_ReportErrorMessage(JRE_ERROR1);
-        exit(2);
-    }
-    JLI_Snprintf(jvmcfg, so_jvmcfg, "%s%slib%sjvm.cfg",
-                 jrepath, FILESEP, FILESEP);
-    /* Find the specified JVM type */
-    if (ReadKnownVMs(jvmcfg, JNI_FALSE) < 1) {
-        JLI_ReportErrorMessage(CFG_ERROR7);
-        exit(1);
-    }
+    if (!JLI_IsStaticallyLinked()) {
+        /* Find out where the JRE is that we will be using. */
+        if (!GetJREPath(jrepath, so_jrepath, JNI_FALSE) ) {
+            JLI_ReportErrorMessage(JRE_ERROR1);
+            exit(2);
+        }
+        JLI_Snprintf(jvmcfg, so_jvmcfg, "%s%slib%sjvm.cfg",
+                    jrepath, FILESEP, FILESEP);
+        /* Find the specified JVM type */
+        if (ReadKnownVMs(jvmcfg, JNI_FALSE) < 1) {
+            JLI_ReportErrorMessage(CFG_ERROR7);
+            exit(1);
+        }
 
-    jvmpath[0] = '\0';
-    jvmtype = CheckJvmType(pargc, pargv, JNI_FALSE);
-    if (JLI_StrCmp(jvmtype, "ERROR") == 0) {
-        JLI_ReportErrorMessage(CFG_ERROR9);
-        exit(4);
-    }
+        jvmpath[0] = '\0';
+        jvmtype = CheckJvmType(pargc, pargv, JNI_FALSE);
+        if (JLI_StrCmp(jvmtype, "ERROR") == 0) {
+            JLI_ReportErrorMessage(CFG_ERROR9);
+            exit(4);
+        }
 
-    if (!GetJVMPath(jrepath, jvmtype, jvmpath, so_jvmpath)) {
-        JLI_ReportErrorMessage(CFG_ERROR8, jvmtype, jvmpath);
-        exit(4);
+        if (!GetJVMPath(jrepath, jvmtype, jvmpath, so_jvmpath)) {
+            JLI_ReportErrorMessage(CFG_ERROR8, jvmtype, jvmpath);
+            exit(4);
+        }
     }
 
     /*

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -296,6 +296,16 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
                            char jrepath[], jint so_jrepath,
                            char jvmpath[], jint so_jvmpath,
                            char jvmcfg[],  jint so_jvmcfg) {
+    /* Compute/set the name of the executable. This is needed for macOS. */
+    SetExecname(*pargv);
+
+    if (JLI_IsStaticallyLinked()) {
+        // With static builds, all JDK and VM natives are statically linked
+        // with the launcher executable. No need to manipulate LD_LIBRARY_PATH
+        // by adding <jdk_path>/lib and etc. The 'jrepath', 'jvmpath' and
+        // 'jvmcfg' are not used by the caller for static builds. Simply return.
+        return;
+    }
 
     char * jvmtype = NULL;
     char **argv = *pargv;
@@ -309,9 +319,6 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     char** newenvp = NULL; /* current environment */
     size_t new_runpath_size;
 #endif  /* SETENV_REQUIRED */
-
-    /* Compute/set the name of the executable */
-    SetExecname(*pargv);
 
     /* Check to see if the jvmpath exists */
     /* Find out where the JRE is that we will be using. */
@@ -338,6 +345,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
         JLI_ReportErrorMessage(CFG_ERROR8, jvmtype, jvmpath);
         exit(4);
     }
+
     /*
      * we seem to have everything we need, so without further ado
      * we return back, otherwise proceed to set the environment.
@@ -498,6 +506,10 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
     JLI_TraceLauncher("Attempt to get JRE path from launcher executable path\n");
 
     if (GetApplicationHome(path, pathsize)) {
+        if (JLI_IsStaticallyLinked()) {
+            return JNI_TRUE;
+        }
+
         /* Is JRE co-located with the application? */
         JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
         if (access(libjava, F_OK) == 0) {
@@ -539,11 +551,15 @@ LoadJavaVM(const char *jvmpath, InvocationFunctions *ifn)
 
     JLI_TraceLauncher("JVM path is %s\n", jvmpath);
 
-    libjvm = dlopen(jvmpath, RTLD_NOW + RTLD_GLOBAL);
-    if (libjvm == NULL) {
-        JLI_ReportErrorMessage(DLL_ERROR1, __LINE__);
-        JLI_ReportErrorMessage(DLL_ERROR2, jvmpath, dlerror());
-        return JNI_FALSE;
+    if (JLI_IsStaticallyLinked()) {
+        libjvm = dlopen(NULL, RTLD_NOW + RTLD_GLOBAL);
+    } else {
+        libjvm = dlopen(jvmpath, RTLD_NOW + RTLD_GLOBAL);
+        if (libjvm == NULL) {
+            JLI_ReportErrorMessage(DLL_ERROR1, __LINE__);
+            JLI_ReportErrorMessage(DLL_ERROR2, jvmpath, dlerror());
+            return JNI_FALSE;
+        }
     }
 
     ifn->CreateJavaVM = (CreateJavaVM_t)
@@ -620,22 +636,26 @@ void* SplashProcAddress(const char* name) {
         char jrePath[MAXPATHLEN];
         char splashPath[MAXPATHLEN];
 
-        if (!GetJREPath(jrePath, sizeof(jrePath), JNI_FALSE)) {
-            JLI_ReportErrorMessage(JRE_ERROR1);
-            return NULL;
-        }
-        ret = JLI_Snprintf(splashPath, sizeof(splashPath), "%s/lib/%s",
-                     jrePath, SPLASHSCREEN_SO);
+        if (JLI_IsStaticallyLinked()) {
+            hSplashLib = dlopen(NULL, RTLD_LAZY);
+        } else {
+            if (!GetJREPath(jrePath, sizeof(jrePath), JNI_FALSE)) {
+                JLI_ReportErrorMessage(JRE_ERROR1);
+                return NULL;
+            }
+            ret = JLI_Snprintf(splashPath, sizeof(splashPath), "%s/lib/%s",
+                        jrePath, SPLASHSCREEN_SO);
 
-        if (ret >= (int) sizeof(splashPath)) {
-            JLI_ReportErrorMessage(JRE_ERROR11);
-            return NULL;
+            if (ret >= (int) sizeof(splashPath)) {
+                JLI_ReportErrorMessage(JRE_ERROR11);
+                return NULL;
+            }
+            if (ret < 0) {
+                JLI_ReportErrorMessage(JRE_ERROR13);
+                return NULL;
+            }
+            hSplashLib = dlopen(splashPath, RTLD_LAZY | RTLD_GLOBAL);
         }
-        if (ret < 0) {
-            JLI_ReportErrorMessage(JRE_ERROR13);
-            return NULL;
-        }
-        hSplashLib = dlopen(splashPath, RTLD_LAZY | RTLD_GLOBAL);
         JLI_TraceLauncher("Info: loaded %s\n", splashPath);
     }
     if (hSplashLib) {

--- a/src/java.desktop/unix/native/libawt/awt/awt_LoadLibrary.c
+++ b/src/java.desktop/unix/native/libawt/awt/awt_LoadLibrary.c
@@ -132,7 +132,9 @@ AWT_OnLoad(JavaVM *vm, void *reserved)
     }
 #endif
 
-    if (!JVM_IsStaticallyLinked()) {
+    if (JVM_IsStaticallyLinked()) {
+        awtHandle = dlopen(NULL, RTLD_LAZY);
+    } else {
         /* Get address of this library and the directory containing it. */
         dladdr((void *)AWT_OnLoad, &dlinfo);
         realpath((char *)dlinfo.dli_fname, buf);


### PR DESCRIPTION
As a prerequisite for Hermetic Java, we need a statically linked `java` launcher. It should behave like the normal, dynamically linked `java` launcher, except that all JDK native libraries should be statically, not dynamically, linked.

This patch is the first step towards this goal. It will generate a `static-jdk` image with a statically linked launcher. This launcher is missing several native libs, however, and does therefore not behave like a proper dynamic java. One of the reasons for this is that local symbol hiding in static libraries are not implemented yet, which causes symbol clashes when linking all static libraries together. This will be addressed in an upcoming patch. 

All changes in the `src` directory are copied from, or inspired by, changes made in [the hermetic-java-runtime branch in Project Leyden](https://github.com/openjdk/leyden/tree/hermetic-java-runtime).