### PR TITLE
8339487: ProcessHandleImpl os_getChildren sysctl call - retry in case of ENOMEM and enhance exception message

### DIFF
--- a/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
+++ b/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
@@ -100,7 +100,7 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
     // Get buffer size needed to read all processes
     int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0};
     if (sysctl(mib, 4, NULL, &bufSize, NULL, 0) < 0) {
-        JNU_ThrowByNameWithLastError(env,
+        JNU_ThrowByNameWithMessageAndLastError(env,
             "java/lang/RuntimeException", "sysctl failed");
         return -1;
     }
@@ -114,8 +114,8 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
 
     // Read process info for all processes
     if (sysctl(mib, 4, buffer, &bufSize, NULL, 0) < 0) {
-        JNU_ThrowByNameWithLastError(env,
-            "java/lang/RuntimeException", "sysctl failed");
+        JNU_ThrowByNameWithMessageAndLastError(env,
+            "java/lang/RuntimeException", "sysctl failed to get info about all processes");
         free(buffer);
         return -1;
     }

--- a/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
+++ b/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
@@ -121,7 +121,7 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
 
         // Read process info for all processes
         errsysctl = sysctl(mib, 4, buffer, &bufSize, NULL, 0);
-    } while (errsysctl < 0 && maxRetries-- > 0);
+    } while (errsysctl < 0 && errno == ENOMEM && maxRetries-- > 0);
 
     if (errsysctl < 0) {
         JNU_ThrowByNameWithMessageAndLastError(env,

--- a/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
+++ b/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
@@ -97,23 +97,33 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
         }
     }
 
-    // Get buffer size needed to read all processes
-    int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0};
-    if (sysctl(mib, 4, NULL, &bufSize, NULL, 0) < 0) {
-        JNU_ThrowByNameWithMessageAndLastError(env,
-            "java/lang/RuntimeException", "sysctl failed");
-        return -1;
-    }
+    int errsysctl;
+    int maxRetries = 100;
+    void *buffer = NULL;
+    do {
+        int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0};
+        if (buffer != NULL) free(buffer);
+        // Get buffer size needed to read all processes
+        if (sysctl(mib, 4, NULL, &bufSize, NULL, 0) < 0) {
+            JNU_ThrowByNameWithMessageAndLastError(env,
+                "java/lang/RuntimeException", "sysctl failed");
+            return -1;
+        }
 
-    // Allocate buffer big enough for all processes
-    void *buffer = malloc(bufSize);
-    if (buffer == NULL) {
-        JNU_ThrowOutOfMemoryError(env, "malloc failed");
-        return -1;
-    }
+        // Allocate buffer big enough for all processes; add a little
+        // bit of space to be able to hold a few more proc infos
+        // for processes started rigth after the first sysctl call
+        buffer = malloc(bufSize + 4 * sizeof(struct kinfo_proc));
+        if (buffer == NULL) {
+            JNU_ThrowOutOfMemoryError(env, "malloc failed");
+            return -1;
+        }
 
-    // Read process info for all processes
-    if (sysctl(mib, 4, buffer, &bufSize, NULL, 0) < 0) {
+        // Read process info for all processes
+        errsysctl = sysctl(mib, 4, buffer, &bufSize, NULL, 0);
+    } while (errsysctl < 0 && maxRetries-- > 0);
+
+    if (errsysctl < 0) {
         JNU_ThrowByNameWithMessageAndLastError(env,
             "java/lang/RuntimeException", "sysctl failed to get info about all processes");
         free(buffer);

--- a/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
+++ b/src/java.base/macosx/native/libjava/ProcessHandleImpl_macosx.c
@@ -112,7 +112,7 @@ jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
 
         // Allocate buffer big enough for all processes; add a little
         // bit of space to be able to hold a few more proc infos
-        // for processes started rigth after the first sysctl call
+        // for processes started right after the first sysctl call
         buffer = malloc(bufSize + 4 * sizeof(struct kinfo_proc));
         if (buffer == NULL) {
             JNU_ThrowOutOfMemoryError(env, "malloc failed");

--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
@@ -528,7 +528,7 @@ jint unix_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
      * position integer as a filename.
      */
     if ((dir = opendir("/proc")) == NULL) {
-        JNU_ThrowByNameWithLastError(env,
+        JNU_ThrowByNameWithMessageAndLastError(env,
             "java/lang/RuntimeException", "Unable to open /proc");
         return -1;
     }


### PR DESCRIPTION
When running jtreg test java/lang/ProcessHandle/PermissionTest.java on macOS, a few times this error occurs :

java.lang.RuntimeException: Cannot allocate memory
       at java.base/java.lang.ProcessHandleImpl.getProcessPids0(Native Method)
       at java.base/java.lang.ProcessHandleImpl.children(ProcessHandleImpl.java:456)
       at java.base/java.lang.ProcessHandleImpl.children(ProcessHandleImpl.java:434)
       at PermissionTest.childrenWithPermission(PermissionTest.java:84)
       at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
       at java.base/java.lang.reflect.Method.invoke(Method.java:573)
       at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:132)
       at org.testng.internal.TestInvoker.invokeMethod(TestInvoker.java:599)
       at org.testng.internal.TestInvoker.invokeTestMethod(TestInvoker.java:174)
       at org.testng.internal.MethodRunner.runInSequence(MethodRunner.java:46)
       at org.testng.internal.TestInvoker$MethodInvocationAgent.invoke(TestInvoker.java:822)
       at org.testng.internal.TestInvoker.invokeTestMethods(TestInvoker.java:147)
       at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:146)
       at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:128)
       at java.base/java.util.ArrayList.forEach(ArrayList.java:1597)


Probably sysctl fails here, but it is not fully clear; it would help to change the exception so that the standard text is shown too in the exception message.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339487](https://bugs.openjdk.org/browse/JDK-8339487): ProcessHandleImpl os_getChildren sysctl call - retry in case of ENOMEM and enhance exception message (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) Review applies to [a9cd3b25](https://git.openjdk.org/jdk/pull/20839/files/a9cd3b25b993ec22f7c11098c4f6f5ec41690e09)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) Review applies to [afc423ad](https://git.openjdk.org/jdk/pull/20839/files/afc423ad745315c0c02ec54a3174dbb2eba9eab3)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20839/head:pull/20839` \
`$ git checkout pull/20839`

Update a local copy of the PR: \
`$ git checkout pull/20839` \
`$ git pull https://git.openjdk.org/jdk.git pull/20839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20839`

View PR using the GUI difftool: \
`$ git pr show -t 20839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20839.diff">https://git.openjdk.org/jdk/pull/20839.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20839#issuecomment-2326638067)