### PR TITLE
8339492: StackMapDecoder::writeFrames makes lots of allocations

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapDecoder.java
@@ -113,26 +113,15 @@ public class StackMapDecoder {
                 return Integer.compare(dcb.labelToBci(o1.target()), dcb.labelToBci(o2.target()));
             }
         });
-        // count uniques
-        int cnt = 0;
+        b.writeU2(infos.length);
         for (var fr : infos) {
             int offset = dcb.labelToBci(fr.target());
-            if (offset > prevOffset) {
-                cnt ++;
-                prevOffset = offset;
+            if (offset == prevOffset) {
+                throw new IllegalArgumentException("Duplicated stack frame bytecode index: " + offset);
             }
-        }
-        // reset
-        prevOffset = -1;
-        b.writeU2(cnt);
-        for (var fr : infos) {
-            int offset = dcb.labelToBci(fr.target());
-            // skip duplicates
-            if (offset > prevOffset) {
-                writeFrame(buf, offset - prevOffset - 1, prevLocals, fr);
-                prevOffset = offset;
-                prevLocals = fr.locals();
-            }
+            writeFrame(buf, offset - prevOffset - 1, prevLocals, fr);
+            prevOffset = offset;
+            prevLocals = fr.locals();
         }
     }
 


### PR DESCRIPTION
Please review this change, which reduces the number of allocations in `StackMapDecoder::writeFrames` by using a sorted array instead of a `TreeMap<Integer, ...>` to sort and uniquify entries before writing. It also adds a validation missed by the original implementation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339492](https://bugs.openjdk.org/browse/JDK-8339492): StackMapDecoder::writeFrames makes lots of allocations (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20841/head:pull/20841` \
`$ git checkout pull/20841`

Update a local copy of the PR: \
`$ git checkout pull/20841` \
`$ git pull https://git.openjdk.org/jdk.git pull/20841/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20841`

View PR using the GUI difftool: \
`$ git pr show -t 20841`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20841.diff">https://git.openjdk.org/jdk/pull/20841.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20841#issuecomment-2326936693)