### PR TITLE
8338123: Linker crash when building a downcall handle with many arguments in x64

### DIFF
--- a/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
+++ b/src/hotspot/cpu/x86/downcallLinker_x86_64.cpp
@@ -34,8 +34,8 @@
 
 #define __ _masm->
 
-static const int native_invoker_code_base_size = 512;
-static const int native_invoker_size_per_arg = 8;
+static const int native_invoker_code_base_size = 256;
+static const int native_invoker_size_per_arg = 16;
 
 RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
                                                 int num_args,

--- a/test/jdk/java/foreign/largestub/TestLargeStub.java
+++ b/test/jdk/java/foreign/largestub/TestLargeStub.java
@@ -43,11 +43,20 @@ public class TestLargeStub extends NativeTestHelper {
     ); // 16 byte struct triggers return buffer usage on SysV
 
     @Test
-    public void testDowncall() {
+    public void testDowncallDoubles() {
         // Link a handle with a large number of arguments, to try and overflow the code buffer
         Linker.nativeLinker().downcallHandle(
                 FunctionDescriptor.of(STRUCT_LL,
                         Stream.generate(() -> C_DOUBLE).limit(124).toArray(MemoryLayout[]::new)),
+                Linker.Option.captureCallState("errno"));
+    }
+
+    @Test
+    public void testDowncallInts() {
+        // Link a handle with a large number of arguments, to try and overflow the code buffer
+        Linker.nativeLinker().downcallHandle(
+                FunctionDescriptor.of(STRUCT_LL,
+                        Stream.generate(() -> C_INT).limit(248).toArray(MemoryLayout[]::new)),
                 Linker.Option.captureCallState("errno"));
     }
 

--- a/test/jdk/java/foreign/largestub/TestLargeStub.java
+++ b/test/jdk/java/foreign/largestub/TestLargeStub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,17 +25,21 @@
  * @test
  * @library ../
  * @modules java.base/jdk.internal.foreign
- * @run testng/othervm --enable-native-access=ALL-UNNAMED TestLargeStub
+ * @run junit/othervm --enable-native-access=ALL-UNNAMED TestLargeStub
  */
 
-import org.testng.annotations.Test;
-import org.testng.annotations.DataProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.lang.foreign.FunctionDescriptor;
 import java.lang.foreign.Linker;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.ValueLayout;
 import java.util.stream.Stream;
+
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 public class TestLargeStub extends NativeTestHelper {
 
@@ -47,7 +51,8 @@ public class TestLargeStub extends NativeTestHelper {
         C_LONG_LONG
     ); // 16 byte struct triggers return buffer usage on SysV
 
-    @Test(dataProvider="layouts")
+    @ParameterizedTest
+    @MethodSource("layouts")
     public void testDowncall(ValueLayout layout, int numSlots) {
         // Link a handle with a large number of arguments, to try and overflow the code buffer
         Linker.nativeLinker().downcallHandle(
@@ -67,7 +72,8 @@ public class TestLargeStub extends NativeTestHelper {
                 Linker.Option.critical(true));
     }
 
-    @Test(dataProvider="layouts")
+    @ParameterizedTest
+    @MethodSource("layouts")
     public void testUpcall(ValueLayout layout, int numSlots) {
         // Link a handle with a large number of arguments, to try and overflow the code buffer
         Linker.nativeLinker().downcallHandle(
@@ -75,13 +81,12 @@ public class TestLargeStub extends NativeTestHelper {
                         Stream.generate(() -> layout).limit(UPCALL_AVAILABLE_SLOTS / numSlots).toArray(MemoryLayout[]::new)));
     }
 
-    @DataProvider
-    public static Object[][] layouts() {
-        return new Object[][] {
-            { C_INT, 1 },
-            { C_LONG_LONG, 2 },
-            { C_FLOAT, 1 },
-            { C_DOUBLE, 2 }
-        };
+    private static Stream<Arguments> layouts() {
+        return Stream.of(
+            arguments(C_INT, 1),
+            arguments(C_LONG_LONG, 2),
+            arguments(C_FLOAT, 1),
+            arguments(C_DOUBLE, 2)
+        );
     }
 }


### PR DESCRIPTION
- Adjust downcall stub sizes based on latest version. (per method described in https://github.com/openjdk/jdk/pull/12908)
- Beef up test for large stubs to also cover this particular case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338123](https://bugs.openjdk.org/browse/JDK-8338123): Linker crash when building a downcall handle with many arguments in x64 (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20842/head:pull/20842` \
`$ git checkout pull/20842`

Update a local copy of the PR: \
`$ git checkout pull/20842` \
`$ git pull https://git.openjdk.org/jdk.git pull/20842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20842`

View PR using the GUI difftool: \
`$ git pr show -t 20842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20842.diff">https://git.openjdk.org/jdk/pull/20842.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20842#issuecomment-2328936723)