### PR TITLE
8339356: Test javax/net/ssl/SSLSocket/Tls13PacketSize.java failed with java.net.SocketException: An established connection was aborted by the software in your host machine

### DIFF
--- a/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
+++ b/test/jdk/javax/net/ssl/templates/SSLSocketTemplate.java
@@ -168,7 +168,7 @@ public class SSLSocketTemplate extends SSLContextTemplate {
     /*
      * What's the server address?  null means binding to the wildcard.
      */
-    protected volatile InetAddress serverAddress = null;
+    protected volatile InetAddress serverAddress = InetAddress.getLoopbackAddress();
 
     /*
      * Define the server side of the test.
@@ -178,12 +178,8 @@ public class SSLSocketTemplate extends SSLContextTemplate {
         SSLContext context = createServerSSLContext();
         SSLServerSocketFactory sslssf = context.getServerSocketFactory();
         InetAddress serverAddress = this.serverAddress;
-        SSLServerSocket sslServerSocket = serverAddress == null ?
-                (SSLServerSocket)sslssf.createServerSocket(serverPort)
-                : (SSLServerSocket)sslssf.createServerSocket();
-        if (serverAddress != null) {
-            sslServerSocket.bind(new InetSocketAddress(serverAddress, serverPort));
-        }
+        SSLServerSocket sslServerSocket = (SSLServerSocket)sslssf
+                .createServerSocket(serverPort, 0, serverAddress);
         configureServerSocket(sslServerSocket);
         serverPort = sslServerSocket.getLocalPort();
 
@@ -271,10 +267,7 @@ public class SSLSocketTemplate extends SSLContextTemplate {
         try (SSLSocket sslSocket = (SSLSocket)sslsf.createSocket()) {
             try {
                 configureClientSocket(sslSocket);
-                InetAddress serverAddress = this.serverAddress;
-                InetSocketAddress connectAddress = serverAddress == null
-                        ? new InetSocketAddress(InetAddress.getLoopbackAddress(), serverPort)
-                        : new InetSocketAddress(serverAddress, serverPort);
+                InetSocketAddress connectAddress = new InetSocketAddress(serverAddress, serverPort);
                 sslSocket.connect(connectAddress, 15000);
             } catch (IOException ioe) {
                 // The server side may be impacted by naughty test cases or


### PR DESCRIPTION
In this short PR, I updated the TLS server socket to use the host's loopback address by default. When necessary, tests are able to set a specific interface on which to listen to connections.