### PR TITLE
8339540: Unify include requirements for PlatformMonitor/Mutex constructors/destructors

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -5741,11 +5741,23 @@ void Parker::unpark() {
   SetEvent(_ParkHandle);
 }
 
+// Platform Mutex/Monitor implementation
+
+PlatformMutex::PlatformMutex() {
+  InitializeCriticalSection(&_mutex);
+}
+
 PlatformMutex::~PlatformMutex() {
   DeleteCriticalSection(&_mutex);
 }
 
-// Platform Monitor implementation
+PlatformMonitor::PlatformMonitor() {
+  InitializeConditionVariable(&_cond);
+}
+
+PlatformMonitor::~PlatformMonitor() {
+  // There is no DeleteConditionVariable API
+}
 
 // Must already be locked
 int PlatformMonitor::wait(uint64_t millis) {

--- a/src/hotspot/os/windows/os_windows.inline.hpp
+++ b/src/hotspot/os/windows/os_windows.inline.hpp
@@ -61,18 +61,6 @@ inline bool os::numa_has_group_homing()     { return false;  }
 
 // Platform Mutex/Monitor implementation
 
-inline PlatformMutex::PlatformMutex() {
-  InitializeCriticalSection(&_mutex);
-}
-
-inline PlatformMonitor::PlatformMonitor() {
-  InitializeConditionVariable(&_cond);
-}
-
-inline PlatformMonitor::~PlatformMonitor() {
-  // There is no DeleteConditionVariable API
-}
-
 inline void PlatformMutex::lock() {
   EnterCriticalSection(&_mutex);
 }


### PR DESCRIPTION
Today, if you write code that, potentially implicitly, calls the `PlatformMonitor` destructor you need to include `os.inline.hpp` to get it to compile on Windows but you don't need to do that for "posix" platforms.

That's because the destructor is located in `os_posix.cpp` for "posix" and in `os_windows.inline.hpp` for Windows.

This leads to the situation that you can get everything to compile on Linux, just for it to fail linking when you later build it on Windows. I propose that we simplify this and move the constructors and destructors to the cpp files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339540](https://bugs.openjdk.org/browse/JDK-8339540): Unify include requirements for PlatformMonitor/Mutex constructors/destructors (**Enhancement** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20851/head:pull/20851` \
`$ git checkout pull/20851`

Update a local copy of the PR: \
`$ git checkout pull/20851` \
`$ git pull https://git.openjdk.org/jdk.git pull/20851/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20851`

View PR using the GUI difftool: \
`$ git pr show -t 20851`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20851.diff">https://git.openjdk.org/jdk/pull/20851.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20851#issuecomment-2329102341)