### PR TITLE
8339548: GHA: RISC-V: Use Debian snapshot archive for bootstrap

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -84,7 +84,7 @@ jobs:
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64
-            debian-repository: https://httpredir.debian.org/debian/
+            debian-repository: https://snapshot.debian.org/archive/debian/20240228T034848Z/
             debian-version: sid
             tolerate-sysroot-errors: true
 


### PR DESCRIPTION
Debian "sid" or "unstable" (https://httpredir.debian.org/debian) that we use for debootstrapping RISC-V breaks very often. Currently, the GHA linux-cross-build for RISC-V would not continue and is simply skipped when this debootstrap for "sid" repos fails. (See [JDK-8326960](https://bugs.openjdk.org/browse/JDK-8326960) for more details). This is affecting GHA linux-cross-build for RISC-V for quite some time. As a result, we failed to catch some early build issues.

But I don't think we need to catch up with the latest Debian "unstable" for our GHA verification purpose. So one way would be using some older but working Debian shapshot [1] [2] for our purpose. I find the most recent usable shapshot is https://snapshot.debian.org/archive/debian/20240228T034848Z/. We can switch back to more stable Debian repo once it graduates.

[1] https://snapshot.debian.org/
[2] https://lists.debian.org/debian-snapshot/

Testing:
- [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339548](https://bugs.openjdk.org/browse/JDK-8339548): GHA: RISC-V: Use Debian snapshot archive for bootstrap (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20853/head:pull/20853` \
`$ git checkout pull/20853`

Update a local copy of the PR: \
`$ git checkout pull/20853` \
`$ git pull https://git.openjdk.org/jdk.git pull/20853/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20853`

View PR using the GUI difftool: \
`$ git pr show -t 20853`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20853.diff">https://git.openjdk.org/jdk/pull/20853.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20853#issuecomment-2329354654)