### PR TITLE
8339347: keytool -importpass insists prompting the user even if there is no terminal

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1789,7 +1789,8 @@ public final class Main {
      */
     private char[] promptForCredential() throws Exception {
         // Handle password supplied via stdin
-        if (System.console() == null) {
+        Console console = System.console();
+        if (console == null || !console.isTerminal()) {
             char[] importPass = Password.readPassword(System.in);
             passwords.add(importPass);
             return importPass;

--- a/test/jdk/sun/security/tools/keytool/TestImportPass.java
+++ b/test/jdk/sun/security/tools/keytool/TestImportPass.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8339347
+ * @summary Test keytool -importpass with password input from System.in for
+ *          the non-terminal console
+ * @library /test/lib
+ * @run main TestImportPass
+ */
+
+import jdk.test.lib.SecurityTools;
+
+public class TestImportPass {
+    public static void main(String[] args) throws Throwable {
+        SecurityTools.setResponse("pass123", "pass123");
+        SecurityTools.keytool("-importpass -keystore ks.p12 -storepass changeit " +
+                "-storetype pkcs12 -alias newentry")
+                .shouldNotContain("Enter the password to be stored:")
+                .shouldHaveExitValue(0);
+
+        SecurityTools.keytool("-list -keystore ks.p12 -storepass changeit " +
+                "-v")
+                .shouldContain("Alias name: newentry")
+                .shouldHaveExitValue(0);
+    }
+}

--- a/test/jdk/sun/security/tools/keytool/TestImportPass.java
+++ b/test/jdk/sun/security/tools/keytool/TestImportPass.java
@@ -34,7 +34,7 @@ import jdk.test.lib.SecurityTools;
 
 public class TestImportPass {
     public static void main(String[] args) throws Throwable {
-        SecurityTools.setResponse("pass123", "pass123");
+        SecurityTools.setResponse("pass123");
         SecurityTools.keytool("-importpass -keystore ks.p12 -storepass changeit " +
                 "-storetype pkcs12 -alias newentry")
                 .shouldNotContain("Enter the password to be stored:")


### PR DESCRIPTION
Given the changes to the System.console() behavior, where it no longer returns null when a write pipe is connected to the Java process, keytool needs to be updated to determine whether an interactive terminal is attached.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8339347: keytool -importpass insists prompting the user even if there is no terminal`

### Issue
 * [JDK-8339347](https://bugs.openjdk.org/browse/JDK-8339347): keytool -importpass insists prompting the user even if there is no terminal (**Bug** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20855/head:pull/20855` \
`$ git checkout pull/20855`

Update a local copy of the PR: \
`$ git checkout pull/20855` \
`$ git pull https://git.openjdk.org/jdk.git pull/20855/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20855`

View PR using the GUI difftool: \
`$ git pr show -t 20855`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20855.diff">https://git.openjdk.org/jdk/pull/20855.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20855#issuecomment-2329488264)