### PR TITLE
8335362: [Windows] Stack pointer increment in _cont_thaw stub can cause program to terminate with exit code 0xc0000005

### DIFF
--- a/src/hotspot/os/windows/os_windows.inline.hpp
+++ b/src/hotspot/os/windows/os_windows.inline.hpp
@@ -55,6 +55,9 @@ inline void os::map_stack_shadow_pages(address sp) {
     sp -= page_size;
     *sp = 0;
   }
+  StackOverflow* state = JavaThread::current()->stack_overflow_state();
+  assert(sp > state->shadow_zone_safe_limit(), "");
+  state->set_shadow_zone_growth_watermark(sp);
 }
 
 inline bool os::numa_has_group_homing()     { return false;  }

--- a/src/hotspot/os/windows/os_windows.inline.hpp
+++ b/src/hotspot/os/windows/os_windows.inline.hpp
@@ -49,6 +49,7 @@ inline void os::map_stack_shadow_pages(address sp) {
   // If we decrement stack pointer more than one page
   // the OS may not map an intervening page into our space
   // and may fault on a memory access to interior of our frame.
+  address original_sp = sp;
   const size_t page_size = os::vm_page_size();
   const size_t n_pages = StackOverflow::stack_shadow_zone_size() / page_size;
   for (size_t pages = 1; pages <= n_pages; pages++) {
@@ -56,8 +57,8 @@ inline void os::map_stack_shadow_pages(address sp) {
     *sp = 0;
   }
   StackOverflow* state = JavaThread::current()->stack_overflow_state();
-  assert(sp > state->shadow_zone_safe_limit(), "");
-  state->set_shadow_zone_growth_watermark(sp);
+  assert(original_sp > state->shadow_zone_safe_limit(), "");
+  state->set_shadow_zone_growth_watermark(original_sp);
 }
 
 inline bool os::numa_has_group_homing()     { return false;  }

--- a/src/hotspot/os/windows/os_windows.inline.hpp
+++ b/src/hotspot/os/windows/os_windows.inline.hpp
@@ -57,7 +57,8 @@ inline void os::map_stack_shadow_pages(address sp) {
     *sp = 0;
   }
   StackOverflow* state = JavaThread::current()->stack_overflow_state();
-  assert(original_sp > state->shadow_zone_safe_limit(), "");
+  assert(original_sp > state->shadow_zone_safe_limit(), "original_sp=" INTPTR_FORMAT ", "
+         "shadow_zone_safe_limit=" INTPTR_FORMAT, p2i(original_sp), p2i(state->shadow_zone_safe_limit()));
   state->set_shadow_zone_growth_watermark(original_sp);
 }
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -286,7 +286,7 @@ static void map_stack_pages(JavaThread* thread, size_t size, address sp) {
     size_t page_size = os::vm_page_size();
     address last_touched_page = watermark - StackOverflow::stack_shadow_zone_size();
     size_t pages_to_touch = align_up(watermark - new_sp, page_size) / page_size;
-    while (pages_to_touch--) {
+    while (pages_to_touch-- > 0) {
       last_touched_page -= page_size;
       *last_touched_page = 0;
     }

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -277,12 +277,31 @@ public:
   }
 };
 
+#ifdef _WINDOWS
+static void map_stack_pages(JavaThread* thread, size_t size, address sp) {
+  address new_sp = sp - size;
+  address watermark = thread->stack_overflow_state()->shadow_zone_growth_watermark();
+
+  if (new_sp < watermark) {
+    size_t page_size = os::vm_page_size();
+    address last_touched_page = watermark - StackOverflow::stack_shadow_zone_size();
+    size_t pages_to_touch = align_up(watermark - new_sp, page_size) / page_size;
+    while (pages_to_touch--) {
+      last_touched_page -= page_size;
+      *last_touched_page = 0;
+    }
+    thread->stack_overflow_state()->set_shadow_zone_growth_watermark(new_sp);
+  }
+}
+#endif
+
 static bool stack_overflow_check(JavaThread* thread, size_t size, address sp) {
   const size_t page_size = os::vm_page_size();
   if (size > page_size) {
     if (sp - size < thread->stack_overflow_state()->shadow_zone_safe_limit()) {
       return false;
     }
+    WINDOWS_ONLY(map_stack_pages(thread, size, sp));
   }
   return true;
 }

--- a/src/hotspot/share/runtime/stackOverflow.hpp
+++ b/src/hotspot/share/runtime/stackOverflow.hpp
@@ -293,6 +293,16 @@ class StackOverflow {
     return _shadow_zone_safe_limit;
   }
 
+  address shadow_zone_growth_watermark() const {
+    assert(_shadow_zone_growth_watermark != nullptr, "Don't call this before the field is initialized.");
+    return _shadow_zone_growth_watermark;
+  }
+
+  void set_shadow_zone_growth_watermark(address new_watermark) {
+    assert(_shadow_zone_growth_watermark != nullptr, "Don't call this before the field is initialized.");
+    _shadow_zone_growth_watermark = new_watermark;
+  }
+
   void create_stack_guard_pages();
   void remove_stack_guard_pages();
 

--- a/test/jdk/java/lang/Thread/virtual/BigStackChunk.java
+++ b/test/jdk/java/lang/Thread/virtual/BigStackChunk.java
@@ -44,7 +44,7 @@ class BigStackChunk {
         int i5 = i4 + 1;
         int i6 = i5 + 1;
         int i7 = i6 + 1;
-        long ll = 2*(long)i1;
+        long ll = 2 * (long)i1;
         float ff = ll + 1.2f;
         double dd = ff + 1.3D;
 

--- a/test/jdk/java/lang/Thread/virtual/BigStackChunk.java
+++ b/test/jdk/java/lang/Thread/virtual/BigStackChunk.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test id=default
+ * @bug 8335362
+ * @summary Test virtual thread usage with big stackChunks
+ * @requires vm.continuations
+ * @run junit/othervm BigStackChunk
+ */
+
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BigStackChunk {
+
+    void recurse(int cnt, ReentrantLock rlock) {
+        int i1 = cnt;
+        int i2 = i1 + 1;
+        int i3 = i2 + 1;
+        int i4 = i3 + 1;
+        int i5 = i4 + 1;
+        int i6 = i5 + 1;
+        int i7 = i6 + 1;
+        long ll = 2*(long)i1;
+        float ff = ll + 1.2f;
+        double dd = ff + 1.3D;
+
+        if (cnt > 0) {
+            recurse(cnt - 1, rlock);
+        } else {
+            rlock.lock();
+            rlock.unlock();
+        }
+    }
+
+    @Test
+    void bigStackChunkTest() throws Exception {
+        int VTHREAD_CNT = Runtime.getRuntime().availableProcessors();
+        ReentrantLock rlock = new ReentrantLock();
+        Thread[] vthreads = new Thread[VTHREAD_CNT];
+
+        rlock.lock();
+        for (int i = 0; i < VTHREAD_CNT; i++) {
+            vthreads[i] = Thread.ofVirtual().start(() -> {
+                // Set up things so that half of the carriers will commit lots of
+                // pages in the stack while running the mounted vthread and half
+                // will just commit very few ones.
+                if (Math.random() < 0.5) {
+                    recurse(300, rlock);
+                } else {
+                    recurse(1, rlock);
+                }
+            });
+        }
+        await(vthreads[0], Thread.State.WAITING);
+        // Now we expect that some vthread that recursed a lot is mounted on
+        // a carrier that previously run a vthread that didn't recurse at all.
+        rlock.unlock();
+
+        for (int i = 0; i < VTHREAD_CNT; i++) {
+            vthreads[i].join();
+        }
+    }
+
+    private void await(Thread thread, Thread.State expectedState) throws InterruptedException {
+        Thread.State state = thread.getState();
+        while (state != expectedState) {
+            assertTrue(state != Thread.State.TERMINATED, "Thread has terminated");
+            Thread.sleep(10);
+            state = thread.getState();
+        }
+    }
+}


### PR DESCRIPTION
Please review the following fix. In stub routine cont_thaw() we bump the stack pointer by the maximum size required to copy the frames currently stored in the top stackChunk. On Windows this increment of the stack pointer doesn't play nice with the way Windows sets up and manages stack pages. When a thread is created the stack is divided in 3 memory regions: regular committed pages, guard pages, reserved pages. The first pages are committed and the thread can read/write to them with no issues. The next pages(~2/3) are guard pages, which are committed but have the PAGE_GUARD attribute. When the thread tries to access a guard page the first time, the PAGE_GUARD attribute is removed and a new guard page from the reserved region is added. The rest of the stack are reserved pages and if we try to access it directly we get an EXCEPTION_ACCESS_VIOLATION (see bug for more details). So the problem is that we can bump the stack pointer too much and set it to point somewhere in the reserved region. When we then execute the call instruction for method thaw(), we get an EXCEPTION_ACCESS_VIOLATION exception, but because we cannot access the memory at the current stack pointer, we cannot call any method anymore, including the exception handler and the program terminates abruptly with exit code 0xc0000005.

The fix implemented is to bang the stack pages one by one to let the Windows page protection take over. This is what we already do in os::map_stack_shadow_pages() in JavaCalls::call_helper(), and also in interpreter (bang_stack_shadow_pages()) and compiler (generate_stack_overflow_check()) code. It's actually also the same mechanism that Windows routine _chkstk used by the compiler employs (see bug comments with assembly code).

I added new test BigStackChunk.java that reproduces the issue. The test fails without this fix and passes with it. I also tested the patch by running in mach5 tiers1-7.

Thanks,
Patricio

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335362](https://bugs.openjdk.org/browse/JDK-8335362): [Windows] Stack pointer increment in _cont_thaw stub can cause program to terminate with exit code 0xc0000005 (**Bug** - P3)


### Reviewers
 * [Frederic Parain](https://openjdk.org/census#fparain) (@fparain - **Reviewer**) Review applies to [1eda89a6](https://git.openjdk.org/jdk/pull/20862/files/1eda89a6145e66511bd3a5a1c1d0676ae2df5c61)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20862/head:pull/20862` \
`$ git checkout pull/20862`

Update a local copy of the PR: \
`$ git checkout pull/20862` \
`$ git pull https://git.openjdk.org/jdk.git pull/20862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20862`

View PR using the GUI difftool: \
`$ git pr show -t 20862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20862.diff">https://git.openjdk.org/jdk/pull/20862.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20862#issuecomment-2330209363)