### PR TITLE
8339592: Simplify and remove unused code in ObjectMethods.<clinit>

### DIFF
--- a/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
+++ b/src/java.base/share/classes/java/lang/runtime/ObjectMethods.java
@@ -31,8 +31,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.StringConcatFactory;
 import java.lang.invoke.TypeDescriptor;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -56,20 +54,14 @@ public class ObjectMethods {
 
     private static final int MAX_STRING_CONCAT_SLOTS = 20;
 
-    private static final MethodType DESCRIPTOR_MT = MethodType.methodType(MethodType.class);
-    private static final MethodType NAMES_MT = MethodType.methodType(List.class);
-    private static final MethodHandle FALSE = MethodHandles.constant(boolean.class, false);
+    private static final MethodHandle FALSE = MethodHandles.zero(boolean.class);
     private static final MethodHandle TRUE = MethodHandles.constant(boolean.class, true);
-    private static final MethodHandle ZERO = MethodHandles.constant(int.class, 0);
+    private static final MethodHandle ZERO = MethodHandles.zero(int.class);
     private static final MethodHandle CLASS_IS_INSTANCE;
-    private static final MethodHandle OBJECT_EQUALS;
     private static final MethodHandle OBJECTS_EQUALS;
     private static final MethodHandle OBJECTS_HASHCODE;
     private static final MethodHandle OBJECTS_TOSTRING;
     private static final MethodHandle OBJECT_EQ;
-    private static final MethodHandle OBJECT_HASHCODE;
-    private static final MethodHandle OBJECT_TO_STRING;
-    private static final MethodHandle STRING_FORMAT;
     private static final MethodHandle HASH_COMBINER;
 
     private static final HashMap<Class<?>, MethodHandle> primitiveEquals = new HashMap<>();
@@ -82,21 +74,8 @@ public class ObjectMethods {
             MethodHandles.Lookup publicLookup = MethodHandles.publicLookup();
             MethodHandles.Lookup lookup = MethodHandles.lookup();
 
-            @SuppressWarnings("removal")
-            ClassLoader loader = AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
-                @Override public ClassLoader run() { return ClassLoader.getPlatformClassLoader(); }
-            });
-
             CLASS_IS_INSTANCE = publicLookup.findVirtual(Class.class, "isInstance",
                                                          MethodType.methodType(boolean.class, Object.class));
-            OBJECT_EQUALS = publicLookup.findVirtual(Object.class, "equals",
-                                                     MethodType.methodType(boolean.class, Object.class));
-            OBJECT_HASHCODE = publicLookup.findVirtual(Object.class, "hashCode",
-                                                       MethodType.fromMethodDescriptorString("()I", loader));
-            OBJECT_TO_STRING = publicLookup.findVirtual(Object.class, "toString",
-                                                        MethodType.methodType(String.class));
-            STRING_FORMAT = publicLookup.findStatic(String.class, "format",
-                                                    MethodType.methodType(String.class, String.class, Object[].class));
             OBJECTS_EQUALS = publicLookup.findStatic(Objects.class, "equals",
                                                      MethodType.methodType(boolean.class, Object.class, Object.class));
             OBJECTS_HASHCODE = publicLookup.findStatic(Objects.class, "hashCode",
@@ -107,41 +86,41 @@ public class ObjectMethods {
             OBJECT_EQ = lookup.findStatic(OBJECT_METHODS_CLASS, "eq",
                                           MethodType.methodType(boolean.class, Object.class, Object.class));
             HASH_COMBINER = lookup.findStatic(OBJECT_METHODS_CLASS, "hashCombiner",
-                                              MethodType.fromMethodDescriptorString("(II)I", loader));
+                                              MethodType.methodType(int.class, int.class, int.class));
 
             primitiveEquals.put(byte.class, lookup.findStatic(OBJECT_METHODS_CLASS, "eq",
-                                                              MethodType.fromMethodDescriptorString("(BB)Z", loader)));
+                                                              MethodType.methodType(boolean.class, byte.class, byte.class)));
             primitiveEquals.put(short.class, lookup.findStatic(OBJECT_METHODS_CLASS, "eq",
-                                                               MethodType.fromMethodDescriptorString("(SS)Z", loader)));
+                                                               MethodType.methodType(boolean.class, short.class, short.class)));
             primitiveEquals.put(char.class, lookup.findStatic(OBJECT_METHODS_CLASS, "eq",
-                                                              MethodType.fromMethodDescriptorString("(CC)Z", loader)));
+                                                              MethodType.methodType(boolean.class, char.class, char.class)));
             primitiveEquals.put(int.class, lookup.findStatic(OBJECT_METHODS_CLASS, "eq",
-                                                             MethodType.fromMethodDescriptorString("(II)Z", loader)));
+                                                             MethodType.methodType(boolean.class, int.class, int.class)));
             primitiveEquals.put(long.class, lookup.findStatic(OBJECT_METHODS_CLASS, "eq",
-                                                              MethodType.fromMethodDescriptorString("(JJ)Z", loader)));
+                                                              MethodType.methodType(boolean.class, long.class, long.class)));
             primitiveEquals.put(float.class, lookup.findStatic(OBJECT_METHODS_CLASS, "eq",
-                                                               MethodType.fromMethodDescriptorString("(FF)Z", loader)));
+                                                               MethodType.methodType(boolean.class, float.class, float.class)));
             primitiveEquals.put(double.class, lookup.findStatic(OBJECT_METHODS_CLASS, "eq",
-                                                                MethodType.fromMethodDescriptorString("(DD)Z", loader)));
+                                                                MethodType.methodType(boolean.class, double.class, double.class)));
             primitiveEquals.put(boolean.class, lookup.findStatic(OBJECT_METHODS_CLASS, "eq",
-                                                                 MethodType.fromMethodDescriptorString("(ZZ)Z", loader)));
+                                                                 MethodType.methodType(boolean.class, boolean.class, boolean.class)));
 
             primitiveHashers.put(byte.class, lookup.findStatic(Byte.class, "hashCode",
-                                                               MethodType.fromMethodDescriptorString("(B)I", loader)));
+                                                               MethodType.methodType(int.class, byte.class)));
             primitiveHashers.put(short.class, lookup.findStatic(Short.class, "hashCode",
-                                                                MethodType.fromMethodDescriptorString("(S)I", loader)));
+                                                                MethodType.methodType(int.class, short.class)));
             primitiveHashers.put(char.class, lookup.findStatic(Character.class, "hashCode",
-                                                               MethodType.fromMethodDescriptorString("(C)I", loader)));
+                                                               MethodType.methodType(int.class, char.class)));
             primitiveHashers.put(int.class, lookup.findStatic(Integer.class, "hashCode",
-                                                              MethodType.fromMethodDescriptorString("(I)I", loader)));
+                                                              MethodType.methodType(int.class, int.class)));
             primitiveHashers.put(long.class, lookup.findStatic(Long.class, "hashCode",
-                                                               MethodType.fromMethodDescriptorString("(J)I", loader)));
+                                                               MethodType.methodType(int.class, long.class)));
             primitiveHashers.put(float.class, lookup.findStatic(Float.class, "hashCode",
-                                                                MethodType.fromMethodDescriptorString("(F)I", loader)));
+                                                                MethodType.methodType(int.class, float.class)));
             primitiveHashers.put(double.class, lookup.findStatic(Double.class, "hashCode",
-                                                                 MethodType.fromMethodDescriptorString("(D)I", loader)));
+                                                                 MethodType.methodType(int.class, double.class)));
             primitiveHashers.put(boolean.class, lookup.findStatic(Boolean.class, "hashCode",
-                                                                  MethodType.fromMethodDescriptorString("(Z)I", loader)));
+                                                                  MethodType.methodType(int.class, boolean.class)));
 
             primitiveToString.put(byte.class, lookup.findStatic(Byte.class, "toString",
                                                                 MethodType.methodType(String.class, byte.class)));


### PR DESCRIPTION
A few trivial(?) cleanups to `java.lang.runtime.ObjectMethods`:
- Avoid `MethodType.fromMethodDescriptorString` which needs a classloader
- Use `MethodHandles.zero`
- Remove unused static `MethodHandles` and `MethodTypes`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339592](https://bugs.openjdk.org/browse/JDK-8339592): Simplify and remove unused code in ObjectMethods.&lt;clinit&gt; (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20866/head:pull/20866` \
`$ git checkout pull/20866`

Update a local copy of the PR: \
`$ git checkout pull/20866` \
`$ git pull https://git.openjdk.org/jdk.git pull/20866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20866`

View PR using the GUI difftool: \
`$ git pr show -t 20866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20866.diff">https://git.openjdk.org/jdk/pull/20866.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20866#issuecomment-2330918408)