### PR TITLE
8226933: [TEST_BUG]GTK L&F: There is no swatches or RGB tab in JColorChooser

### DIFF
--- a/test/jdk/javax/swing/JColorChooser/Test4887836.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4887836.java
@@ -54,9 +54,7 @@ public class Test4887836 {
         PassFailJFrame.builder()
                 .title("Test4759306")
                 .instructions(instructions)
-                .rows(5)
                 .columns(40)
-                .testTimeOut(5)
                 .testUI(Test4887836::createColorChooser)
                 .build()
                 .awaitAndCheck();

--- a/test/jdk/javax/swing/JColorChooser/Test4887836.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4887836.java
@@ -41,7 +41,7 @@ public class Test4887836 {
         String instructions = """
                                 If you do not see white area under the \"Swatches\" tab,
                                 then test passed, otherwise it failed.
-                                
+
                                 NOTE: There is no Swatches tab for GTK Look and Feel, Press Pass.""";
 
         PassFailJFrame.builder()

--- a/test/jdk/javax/swing/JColorChooser/Test4887836.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4887836.java
@@ -44,7 +44,6 @@ public class Test4887836 {
         // ColorChooser UI design is different for GTK L&F.
         // There is no Swatches tab available for GTK L&F, skip the testing.
         if (UIManager.getLookAndFeel().getName().contains("GTK")) {
-            System.out.println("Test skipped for " + UIManager.getLookAndFeel().getName());
             throw new SkippedException("Test not applicable for GTK L&F");
         }
 

--- a/test/jdk/javax/swing/JColorChooser/Test4887836.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4887836.java
@@ -26,10 +26,12 @@ import java.awt.Font;
 import javax.swing.JColorChooser;
 import javax.swing.UIManager;
 
+import jtreg.SkippedException;
+
 /*
  * @test
  * @bug 4887836
- * @library /java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers /test/lib
  * @build PassFailJFrame
  * @summary Checks for white area under the JColorChooser Swatch tab
  * @run main/manual Test4887836
@@ -38,11 +40,17 @@ import javax.swing.UIManager;
 public class Test4887836 {
 
     public static void main(String[] args) throws Exception {
+
+        // ColorChooser UI design is different for GTK L&F.
+        // There is no Swatches tab available for GTK L&F, skip the testing.
+        if (UIManager.getLookAndFeel().getName().contains("GTK")) {
+            System.out.println("Test skipped for " + UIManager.getLookAndFeel().getName());
+            throw new SkippedException("Test not applicable for GTK L&F");
+        }
+
         String instructions = """
                                 If you do not see white area under the \"Swatches\" tab,
-                                then test passed, otherwise it failed.
-
-                                NOTE: There is no Swatches tab for GTK Look and Feel, Press Pass.""";
+                                then test passed, otherwise it failed.""";
 
         PassFailJFrame.builder()
                 .title("Test4759306")

--- a/test/jdk/javax/swing/JColorChooser/Test4887836.java
+++ b/test/jdk/javax/swing/JColorChooser/Test4887836.java
@@ -40,14 +40,16 @@ public class Test4887836 {
     public static void main(String[] args) throws Exception {
         String instructions = """
                                 If you do not see white area under the \"Swatches\" tab,
-                                then test passed, otherwise it failed.""";
+                                then test passed, otherwise it failed.
+                                
+                                NOTE: There is no Swatches tab for GTK Look and Feel, Press Pass.""";
 
         PassFailJFrame.builder()
                 .title("Test4759306")
                 .instructions(instructions)
                 .rows(5)
                 .columns(40)
-                .testTimeOut(10)
+                .testTimeOut(5)
                 .testUI(Test4887836::createColorChooser)
                 .build()
                 .awaitAndCheck();

--- a/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
@@ -53,9 +53,7 @@ public class bug4419255 {
         PassFailJFrame.builder()
                 .title("bug4419255")
                 .instructions(instructions)
-                .rows(5)
                 .columns(40)
-                .testTimeOut(5)
                 .testUI(bug4419255::createColorChooser)
                 .build()
                 .awaitAndCheck();

--- a/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
@@ -43,7 +43,6 @@ public class bug4419255 {
         // ColorChooser UI design is different for GTK L&F.
         // There is no RGB tab available for GTK L&F, skip the testing.
         if (UIManager.getLookAndFeel().getName().contains("GTK")) {
-            System.out.println("Test skipped for " + UIManager.getLookAndFeel().getName());
             throw new SkippedException("Test not applicable for GTK L&F");
         }
         String instructions = """

--- a/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
@@ -62,7 +62,6 @@ public class bug4419255 {
     }
 
     private static JColorChooser createColorChooser() {
-        JColorChooser chooser = new JColorChooser(Color.BLUE);
-        return chooser;
+        return new JColorChooser(Color.BLUE);
     }
 }

--- a/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicSliderUI/bug4419255.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import javax.swing.JColorChooser;
+import javax.swing.UIManager;
+
+import jtreg.SkippedException;
+
+/*
+ * @test
+ * @bug 4419255
+ * @library /java/awt/regtesthelpers /test/lib
+ * @build PassFailJFrame
+ * @summary Tests if Metal Slider's thumb isn't clipped
+ * @run main/manual bug4419255
+ */
+
+public class bug4419255 {
+
+    public static void main(String[] args) throws Exception {
+
+        // ColorChooser UI design is different for GTK L&F.
+        // There is no RGB tab available for GTK L&F, skip the testing.
+        if (UIManager.getLookAndFeel().getName().contains("GTK")) {
+            System.out.println("Test skipped for " + UIManager.getLookAndFeel().getName());
+            throw new SkippedException("Test not applicable for GTK L&F");
+        }
+        String instructions = """
+                Choose RGB tab. If sliders' thumbs are painted correctly
+                (top is not clipped, black line is visible),
+                then test passed. Otherwise it failed.""";
+
+        PassFailJFrame.builder()
+                .title("bug4419255")
+                .instructions(instructions)
+                .rows(5)
+                .columns(40)
+                .testTimeOut(5)
+                .testUI(bug4419255::createColorChooser)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JColorChooser createColorChooser() {
+        JColorChooser chooser = new JColorChooser(Color.BLUE);
+        return chooser;
+    }
+}


### PR DESCRIPTION
There is no Swatches tab available for GTK Look and Feel due to the different ColorChooser UI design. Updated the test instructions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8226933](https://bugs.openjdk.org/browse/JDK-8226933): [TEST_BUG]GTK L&amp;F: There is no swatches or RGB tab in JColorChooser (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) Review applies to [677cb0e9](https://git.openjdk.org/jdk/pull/20867/files/677cb0e9452239dd8b026bf7abfeb96a76533161)
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**) Review applies to [56bb68d9](https://git.openjdk.org/jdk/pull/20867/files/56bb68d95bd0fbb39d5f0cdece4119def1601d1f)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20867/head:pull/20867` \
`$ git checkout pull/20867`

Update a local copy of the PR: \
`$ git checkout pull/20867` \
`$ git pull https://git.openjdk.org/jdk.git pull/20867/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20867`

View PR using the GUI difftool: \
`$ git pr show -t 20867`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20867.diff">https://git.openjdk.org/jdk/pull/20867.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20867#issuecomment-2333305306)