### PR TITLE
8339579: ZGC: Race results in only one of two remembered sets being cleared

### DIFF
--- a/src/hotspot/share/gc/z/zRememberedSet.cpp
+++ b/src/hotspot/share/gc/z/zRememberedSet.cpp
@@ -78,8 +78,8 @@ bool ZRememberedSet::is_cleared_previous() const {
 }
 
 void ZRememberedSet::clear_all() {
-  clear_current();
-  clear_previous();
+  _bitmap[0].clear_large();
+  _bitmap[1].clear_large();
 }
 
 void ZRememberedSet::clear_current() {


### PR DESCRIPTION
https://github.com/openjdk/jdk/pull/20821 introduced a fix that skips clearing of a potential remembered set in the young collection in favor of doing it only in the old collection.

The code responsible for clearing the remset (`ZRememberedSet::clear_all()`) is dependent on the `_current` variable in ZRememberedSet not being altered in between the two "clear_*" calls in `ZRememberedSet::clear_all()`. If the remembered set is being cleared in the old collection, and successfully clears the current remset with `clear_current()`, a young collection might then flip/swap the current/previous remembered sets by changing the `_current` value in ZRememberedSet. This would mean that the call to `clear_previous()` would clean the same bitmap again, resulting in one of the two bitmaps not being cleared at all. This will later crash in an assert checking if both bitmaps are empty/clear when the page is being freed.

Code in question:
```c++
void ZRememberedSet::clear_all() {
  clear_current();
  clear_previous();
}
```

This PR makes sure that clearing is done independently of what the `_current` value is, by accessing the two bitmaps directly.

Tested with tier5, where the fails/crashes occured before this fix, and a reproducer of the crash as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339579](https://bugs.openjdk.org/browse/JDK-8339579): ZGC: Race results in only one of two remembered sets being cleared (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20869/head:pull/20869` \
`$ git checkout pull/20869`

Update a local copy of the PR: \
`$ git checkout pull/20869` \
`$ git pull https://git.openjdk.org/jdk.git pull/20869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20869`

View PR using the GUI difftool: \
`$ git pr show -t 20869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20869.diff">https://git.openjdk.org/jdk/pull/20869.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20869#issuecomment-2331387367)