### PR TITLE
8339619: ProblemList runtime/cds/appcds/jvmti/dumpingWithAgent/DumpingWithJavaAgent.java

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -118,6 +118,7 @@ runtime/ErrorHandling/TestDwarf.java#checkDecoder 8305489 linux-all
 runtime/ErrorHandling/MachCodeFramesInErrorFile.java 8313315 linux-ppc64le
 runtime/Thread/TestAlwaysPreTouchStacks.java 8335167 macosx-aarch64
 runtime/cds/appcds/customLoader/HelloCustom_JFR.java 8241075 linux-all,windows-x64
+runtime/cds/appcds/jvmti/dumpingWithAgent/DumpingWithJavaAgent.java 8339575 generic-all
 
 applications/jcstress/copy.java 8229852 linux-all
 


### PR DESCRIPTION
A trivial fix to ProblemList runtime/cds/appcds/jvmti/dumpingWithAgent/DumpingWithJavaAgent.java.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339619](https://bugs.openjdk.org/browse/JDK-8339619): ProblemList runtime/cds/appcds/jvmti/dumpingWithAgent/DumpingWithJavaAgent.java (**Sub-task** - P2)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20871/head:pull/20871` \
`$ git checkout pull/20871`

Update a local copy of the PR: \
`$ git checkout pull/20871` \
`$ git pull https://git.openjdk.org/jdk.git pull/20871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20871`

View PR using the GUI difftool: \
`$ git pr show -t 20871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20871.diff">https://git.openjdk.org/jdk/pull/20871.diff</a>

</details>
