### PR TITLE
8339627: Cleanup Unsafe.setMemory intrinsic code

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64_arraycopy.cpp
@@ -2627,7 +2627,6 @@ address StubGenerator::generate_unsafe_setmemory(const char *name,
 
     // Fill words
     {
-      Label L_wordsTail, L_wordsLoop, L_wordsTailLoop;
       UnsafeMemoryAccessMark umam(this, true, true);
 
       // At this point, we know the lower bit of size is zero and a
@@ -2641,7 +2640,6 @@ address StubGenerator::generate_unsafe_setmemory(const char *name,
 
     // Fill QUADWORDs
     {
-      Label L_qwordLoop, L_qwordsTail, L_qwordsTailLoop;
       UnsafeMemoryAccessMark umam(this, true, true);
 
       // At this point, we know the lower 3 bits of size are zero and a
@@ -2658,7 +2656,6 @@ address StubGenerator::generate_unsafe_setmemory(const char *name,
 
     // Fill DWORDs
     {
-      Label L_dwordLoop, L_dwordsTail, L_dwordsTailLoop;
       UnsafeMemoryAccessMark umam(this, true, true);
 
       // At this point, we know the lower 2 bits of size are zero and a

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -404,7 +404,7 @@ class StubRoutines: AllStatic {
 
   static address unsafe_setmemory()     { return _unsafe_setmemory; }
 
-  typedef void (*UnsafeSetMemoryStub)(const void* src, size_t count, char byte);
+  typedef void (*UnsafeSetMemoryStub)(void* dest, size_t count, char byte);
   static UnsafeSetMemoryStub UnsafeSetMemory_stub()         { return CAST_TO_FN_PTR(UnsafeSetMemoryStub,  _unsafe_setmemory); }
 
   static address generic_arraycopy()   { return _generic_arraycopy; }

--- a/src/hotspot/share/runtime/stubRoutines.hpp
+++ b/src/hotspot/share/runtime/stubRoutines.hpp
@@ -404,7 +404,7 @@ class StubRoutines: AllStatic {
 
   static address unsafe_setmemory()     { return _unsafe_setmemory; }
 
-  typedef void (*UnsafeSetMemoryStub)(void* dest, size_t count, char byte);
+  typedef void (*UnsafeSetMemoryStub)(void* dst, size_t count, char byte);
   static UnsafeSetMemoryStub UnsafeSetMemory_stub()         { return CAST_TO_FN_PTR(UnsafeSetMemoryStub,  _unsafe_setmemory); }
 
   static address generic_arraycopy()   { return _generic_arraycopy; }


### PR DESCRIPTION
Hi,

The code for the `Unsafe.setMemory` intrinsic has a few issues that this PR cleans up.

1. The labels are unused in x86-64 intrinsic
2. The function stub has an incorrect function prototype as it clearly manipulates the array so the array is not const, and we don't read the array so it probably shouldn't be called `src`. That's probably just an issue of `UnsafeArrayCopyStub` being copied and altered insufficiently.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339627](https://bugs.openjdk.org/browse/JDK-8339627): Cleanup Unsafe.setMemory intrinsic code (**Bug** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20873/head:pull/20873` \
`$ git checkout pull/20873`

Update a local copy of the PR: \
`$ git checkout pull/20873` \
`$ git pull https://git.openjdk.org/jdk.git pull/20873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20873`

View PR using the GUI difftool: \
`$ git pr show -t 20873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20873.diff">https://git.openjdk.org/jdk/pull/20873.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20873#issuecomment-2332320927)