### PR TITLE
8339574: Behavior of File.is{Directory,File,Hidden} is not documented with respect to symlinks

### DIFF
--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -81,7 +81,7 @@ import jdk.internal.util.StaticProperty;
  *
  * <p> Unless otherwise noted,
  * <a href= "../../java/nio/file/package-summary.html#links">symbolic links</a>
- * are transparent to the constructors and methods of this class, whether they
+ * are automatically redirected to the <i>target</i> of the link, whether they
  * are provided by a pathname string or via a {@code File} object.
  *
  * <p> The <em>parent</em> of an abstract pathname may be obtained by invoking

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -142,6 +142,12 @@ import jdk.internal.util.StaticProperty;
  * additional file operations, file attributes, and I/O exceptions to help
  * diagnose errors when an operation on a file fails.
  *
+ * <h2>Operations on Symbolic Links</h2>
+ *
+ * <p> Unless otherwise noted,
+ * <a href= "../../java/nio/file/package-summary.html#links">symbolic links</a>
+ * are transparent to {@code File} operations.
+ *
  * @since   1.0
  */
 
@@ -838,8 +844,7 @@ public class File
 
     /**
      * Tests whether the file denoted by this abstract pathname is a
-     * directory.  Symbolic links are followed and the file attribute of the
-     * final target of the link is read.
+     * directory.
      *
      * <p> Where it is required to distinguish an I/O exception from the case
      * that the file is not a directory, or where several attributes of the
@@ -873,8 +878,6 @@ public class File
      * file.  A file is <em>normal</em> if it is not a directory and, in
      * addition, satisfies other system-dependent criteria.  Any non-directory
      * file created by a Java application is guaranteed to be a normal file.
-     * Symbolic links are followed and the file attribute of the final target
-     * of the link is read.
      *
      * <p> Where it is required to distinguish an I/O exception from the case
      * that the file is not a normal file, or where several attributes of the
@@ -906,11 +909,17 @@ public class File
     /**
      * Tests whether the file named by this abstract pathname is a hidden
      * file.  The exact definition of <em>hidden</em> is system-dependent.  On
-     * UNIX systems, a file or symbolic link is considered to be hidden if its
-     * name begins with a period character ({@code '.'}).  On Microsoft Windows
-     * systems, a file is considered to be hidden if it has been marked as such
-     * in the filesystem, and a symbolic link to be hidden if its final target
-     * is so marked in the filesystem.
+     * UNIX systems, a file is considered to be hidden if its name begins with
+     * a period character ({@code '.'}).  On Microsoft Windows systems, a file
+     * is considered to be hidden if it has been marked as such in the
+     * filesystem.
+     *
+     *
+     * @implNote
+     * If the file is a symbolic link, then on UNIX system it is considered to
+     * be hidden if the name of the link itself, not that of its target, begins
+     * with a period character.  On Windows systems, a symbolic link is
+     * considered hidden if its target is so marked in the filesystem.
      *
      * @return  {@code true} if and only if the file denoted by this
      *          abstract pathname is hidden according to the conventions of the
@@ -1053,7 +1062,8 @@ public class File
     /**
      * Deletes the file or directory denoted by this abstract pathname.  If
      * this pathname denotes a directory, then the directory must be empty in
-     * order to be deleted.
+     * order to be deleted.  If this pathname denotes a symbolic link, then the
+     * link itself, not its target, will be deleted.
      *
      * <p> Note that the {@link java.nio.file.Files} class defines the {@link
      * java.nio.file.Files#delete(Path) delete} method to throw an {@link IOException}
@@ -1426,7 +1436,9 @@ public class File
     }
 
     /**
-     * Renames the file denoted by this abstract pathname.
+     * Renames the file denoted by this abstract pathname.  If this pathname
+     * denotes a symbolic link, then the link itself, not its target, will be
+     * renamed.
      *
      * <p> Many aspects of the behavior of this method are inherently
      * platform-dependent: The rename operation might not be able to move a

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -1091,6 +1091,8 @@ public class File
     /**
      * Requests that the file or directory denoted by this abstract
      * pathname be deleted when the virtual machine terminates.
+     * If this pathname denotes a symbolic link, then the
+     * link itself, not its target, will be deleted.
      * Files (or directories) are deleted in the reverse order that
      * they are registered. Invoking this method to delete a file or
      * directory that is already registered for deletion has no effect.

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -838,7 +838,8 @@ public class File
 
     /**
      * Tests whether the file denoted by this abstract pathname is a
-     * directory.
+     * directory.  Symbolic links are followed and the file attribute of the
+     * final target of the link is read.
      *
      * <p> Where it is required to distinguish an I/O exception from the case
      * that the file is not a directory, or where several attributes of the
@@ -872,6 +873,8 @@ public class File
      * file.  A file is <em>normal</em> if it is not a directory and, in
      * addition, satisfies other system-dependent criteria.  Any non-directory
      * file created by a Java application is guaranteed to be a normal file.
+     * Symbolic links are followed and the file attribute of the final target
+     * of the link is read.
      *
      * <p> Where it is required to distinguish an I/O exception from the case
      * that the file is not a normal file, or where several attributes of the
@@ -903,9 +906,11 @@ public class File
     /**
      * Tests whether the file named by this abstract pathname is a hidden
      * file.  The exact definition of <em>hidden</em> is system-dependent.  On
-     * UNIX systems, a file is considered to be hidden if its name begins with
-     * a period character ({@code '.'}).  On Microsoft Windows systems, a file is
-     * considered to be hidden if it has been marked as such in the filesystem.
+     * UNIX systems, a file or symbolic link is considered to be hidden if its
+     * name begins with a period character ({@code '.'}).  On Microsoft Windows
+     * systems, a file is considered to be hidden if it has been marked as such
+     * in the filesystem, and a symbolic link to be hidden if its final target
+     * is so marked in the filesystem.
      *
      * @return  {@code true} if and only if the file denoted by this
      *          abstract pathname is hidden according to the conventions of the

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -79,8 +79,7 @@ import jdk.internal.util.StaticProperty;
  * {@code user.dir}, and is typically the directory in which the Java
  * virtual machine was invoked.
  *
- * <p> Unless otherwise noted,
- * <a href= "../../java/nio/file/package-summary.html#links">symbolic links</a>
+ * <p> Unless otherwise noted, {@linkplain java.nio.file##links symbolic links}
  * are automatically redirected to the <i>target</i> of the link, whether they
  * are provided by a pathname string or via a {@code File} object.
  *

--- a/src/java.base/share/classes/java/io/File.java
+++ b/src/java.base/share/classes/java/io/File.java
@@ -79,6 +79,11 @@ import jdk.internal.util.StaticProperty;
  * {@code user.dir}, and is typically the directory in which the Java
  * virtual machine was invoked.
  *
+ * <p> Unless otherwise noted,
+ * <a href= "../../java/nio/file/package-summary.html#links">symbolic links</a>
+ * are transparent to the constructors and methods of this class, whether they
+ * are provided by a pathname string or via a {@code File} object.
+ *
  * <p> The <em>parent</em> of an abstract pathname may be obtained by invoking
  * the {@link #getParent} method of this class and consists of the pathname's
  * prefix and each name in the pathname's name sequence except for the last.
@@ -141,12 +146,6 @@ import jdk.internal.util.StaticProperty;
  * java.nio.file.Files} class to provide more efficient and extensive access to
  * additional file operations, file attributes, and I/O exceptions to help
  * diagnose errors when an operation on a file fails.
- *
- * <h2>Operations on Symbolic Links</h2>
- *
- * <p> Unless otherwise noted,
- * <a href= "../../java/nio/file/package-summary.html#links">symbolic links</a>
- * are transparent to {@code File} operations.
  *
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -42,8 +42,8 @@ import sun.nio.ch.FileChannelImpl;
  *
  * <p>
  * <a href= "../../java/nio/file/package-summary.html#links">Symbolic links</a>
- * are transparent to the constructors of this class, whether they are provided
- * by a pathname string or via a {@code File} object.
+ * are automatically redirected to the <i>target</i> of the link, whether they
+ * are provided by a pathname string or via a {@code File} object.
  *
  * @apiNote
  * The {@link #close} method should be called to release resources used by this

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -40,6 +40,11 @@ import sun.nio.ch.FileChannelImpl;
  * such as image data. For reading streams of characters, consider using
  * {@code FileReader}.
  *
+ * <p>
+ * <a href= "../../java/nio/file/package-summary.html#links">Symbolic links</a>
+ * are transparent to the constructors of this class, whether they are provided
+ * by a pathname string or via a {@code File} object.
+ *
  * @apiNote
  * The {@link #close} method should be called to release resources used by this
  * stream, either directly, or with the {@code try}-with-resources statement.

--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -40,11 +40,6 @@ import sun.nio.ch.FileChannelImpl;
  * such as image data. For reading streams of characters, consider using
  * {@code FileReader}.
  *
- * <p>
- * <a href= "../../java/nio/file/package-summary.html#links">Symbolic links</a>
- * are automatically redirected to the <i>target</i> of the link, whether they
- * are provided by a pathname string or via a {@code File} object.
- *
  * @apiNote
  * The {@link #close} method should be called to release resources used by this
  * stream, either directly, or with the {@code try}-with-resources statement.
@@ -90,7 +85,9 @@ public class FileInputStream extends InputStream
      * Creates a {@code FileInputStream} by
      * opening a connection to an actual file,
      * the file named by the path name {@code name}
-     * in the file system.  A new {@code FileDescriptor}
+     * in the file system.  {@linkplain java.nio.file##links Symbolic links}
+     * are automatically redirected to the <i>target</i> of the link.
+     * A new {@code FileDescriptor}
      * object is created to represent this file
      * connection.
      * <p>
@@ -122,6 +119,8 @@ public class FileInputStream extends InputStream
      * opening a connection to an actual file,
      * the file named by the {@code File}
      * object {@code file} in the file system.
+     * {@linkplain java.nio.file##links Symbolic links}
+     * are automatically redirected to the <i>target</i> of the link.
      * A new {@code FileDescriptor} object
      * is created to represent this file connection.
      * <p>

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -45,11 +45,6 @@ import sun.nio.ch.FileChannelImpl;
  * such as image data. For writing streams of characters, consider using
  * {@code FileWriter}.
  *
- * <p>
- * <a href= "../../java/nio/file/package-summary.html#links">Symbolic links</a>
- * are automatically redirected to the <i>target</i> of the link, whether they
- * are provided by a pathname string or via a {@code File} object.
- *
  * @apiNote
  * The {@link #close} method should be called to release resources used by this
  * stream, either directly, or with the {@code try}-with-resources statement.
@@ -102,7 +97,10 @@ public class FileOutputStream extends OutputStream
 
     /**
      * Creates a file output stream to write to the file with the
-     * specified name. A new {@code FileDescriptor} object is
+     * specified name. {@linkplain java.nio.file##links Symbolic links}
+     * are automatically redirected to the <i>target</i> of the link.
+     * If the file or link target exists, then it will be truncated.
+     * A new {@code FileDescriptor} object is
      * created to represent this file connection.
      * <p>
      * First, if there is a security manager, its {@code checkWrite}
@@ -131,8 +129,12 @@ public class FileOutputStream extends OutputStream
 
     /**
      * Creates a file output stream to write to the file with the specified
-     * name.  If the second argument is {@code true}, then
-     * bytes will be written to the end of the file rather than the beginning.
+     * name.  {@linkplain java.nio.file##links Symbolic links}
+     * are automatically redirected to the <i>target</i> of the link.
+     * If the second argument is {@code true}, then
+     * bytes will be written to the end of the file or link target rather than
+     * the beginning; if {@code false}, the file or link target will be
+     * truncated if it exists.
      * A new {@code FileDescriptor} object is created to represent this
      * file connection.
      * <p>
@@ -163,8 +165,11 @@ public class FileOutputStream extends OutputStream
 
     /**
      * Creates a file output stream to write to the file represented by
-     * the specified {@code File} object. A new
-     * {@code FileDescriptor} object is created to represent this
+     * the specified {@code File} object.
+     * {@linkplain java.nio.file##links Symbolic links}
+     * are automatically redirected to the <i>target</i> of the link.
+     * If the file or link target exists, then it will be truncated.
+     * A new {@code FileDescriptor} object is created to represent this
      * file connection.
      * <p>
      * First, if there is a security manager, its {@code checkWrite}
@@ -192,9 +197,13 @@ public class FileOutputStream extends OutputStream
 
     /**
      * Creates a file output stream to write to the file represented by
-     * the specified {@code File} object. If the second argument is
+     * the specified {@code File} object.
+     * {@linkplain java.nio.file##links Symbolic links}
+     * are automatically redirected to the <i>target</i> of the link.
+     * If the second argument is
      * {@code true}, then bytes will be written to the end of the file
-     * rather than the beginning. A new {@code FileDescriptor} object is
+     * rather than the beginning; if {@code false}, the file or link target
+     * will be truncated if it exists. A new {@code FileDescriptor} object is
      * created to represent this file connection.
      * <p>
      * First, if there is a security manager, its {@code checkWrite}

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -47,8 +47,8 @@ import sun.nio.ch.FileChannelImpl;
  *
  * <p>
  * <a href= "../../java/nio/file/package-summary.html#links">Symbolic links</a>
- * are transparent to the constructors of this class, whether they are provided
- * by a pathname string or via a {@code File} object.
+ * are automatically redirected to the <i>target</i> of the link, whether they
+ * are provided by a pathname string or via a {@code File} object.
  *
  * @apiNote
  * The {@link #close} method should be called to release resources used by this

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -45,6 +45,11 @@ import sun.nio.ch.FileChannelImpl;
  * such as image data. For writing streams of characters, consider using
  * {@code FileWriter}.
  *
+ * <p>
+ * <a href= "../../java/nio/file/package-summary.html#links">Symbolic links</a>
+ * are transparent to the constructors of this class, whether they are provided
+ * by a pathname string or via a {@code File} object.
+ *
  * @apiNote
  * The {@link #close} method should be called to release resources used by this
  * stream, either directly, or with the {@code try}-with-resources statement.

--- a/src/java.base/share/classes/java/io/FileOutputStream.java
+++ b/src/java.base/share/classes/java/io/FileOutputStream.java
@@ -97,9 +97,9 @@ public class FileOutputStream extends OutputStream
 
     /**
      * Creates a file output stream to write to the file with the
-     * specified name. {@linkplain java.nio.file##links Symbolic links}
+     * specified name. If the file exists, it is truncated, otherwise a
+     * new file is created. {@linkplain java.nio.file##links Symbolic links}
      * are automatically redirected to the <i>target</i> of the link.
-     * If the file or link target exists, then it will be truncated.
      * A new {@code FileDescriptor} object is
      * created to represent this file connection.
      * <p>
@@ -129,12 +129,11 @@ public class FileOutputStream extends OutputStream
 
     /**
      * Creates a file output stream to write to the file with the specified
-     * name.  {@linkplain java.nio.file##links Symbolic links}
+     * name. If the file exists, it is truncated unless the second
+     * argument is {@code true}, in which case bytes will be written to the
+     * end of the file rather than the beginning. If the file does not exist,
+     * it is created. {@linkplain java.nio.file##links Symbolic links}
      * are automatically redirected to the <i>target</i> of the link.
-     * If the second argument is {@code true}, then
-     * bytes will be written to the end of the file or link target rather than
-     * the beginning; if {@code false}, the file or link target will be
-     * truncated if it exists.
      * A new {@code FileDescriptor} object is created to represent this
      * file connection.
      * <p>
@@ -166,11 +165,11 @@ public class FileOutputStream extends OutputStream
     /**
      * Creates a file output stream to write to the file represented by
      * the specified {@code File} object.
-     * {@linkplain java.nio.file##links Symbolic links}
+     * If the file exists, it is truncated, otherwise a
+     * new file is created. {@linkplain java.nio.file##links Symbolic links}
      * are automatically redirected to the <i>target</i> of the link.
-     * If the file or link target exists, then it will be truncated.
-     * A new {@code FileDescriptor} object is created to represent this
-     * file connection.
+     * A new {@code FileDescriptor} object is
+     * created to represent this file connection.
      * <p>
      * First, if there is a security manager, its {@code checkWrite}
      * method is called with the path represented by the {@code file}
@@ -198,13 +197,13 @@ public class FileOutputStream extends OutputStream
     /**
      * Creates a file output stream to write to the file represented by
      * the specified {@code File} object.
-     * {@linkplain java.nio.file##links Symbolic links}
+     * If the file exists, it is truncated unless the second
+     * argument is {@code true}, in which case bytes will be written to the
+     * end of the file rather than the beginning. If the file does not exist,
+     * it is created. {@linkplain java.nio.file##links Symbolic links}
      * are automatically redirected to the <i>target</i> of the link.
-     * If the second argument is
-     * {@code true}, then bytes will be written to the end of the file
-     * rather than the beginning; if {@code false}, the file or link target
-     * will be truncated if it exists. A new {@code FileDescriptor} object is
-     * created to represent this file connection.
+     * A new {@code FileDescriptor} object is created to represent this
+     * file connection.
      * <p>
      * First, if there is a security manager, its {@code checkWrite}
      * method is called with the path represented by the {@code file}

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -59,6 +59,11 @@ import sun.nio.ch.FileChannelImpl;
  * than {@code EOFException} is thrown. In particular, an
  * {@code IOException} may be thrown if the stream has been closed.
  *
+ * <p>
+ * <a href= "../../java/nio/file/package-summary.html#links">Symbolic links</a>
+ * are transparent to the constructors of this class, whether they are provided
+ * by a pathname string or via a {@code File} object.
+ *
  * @since   1.0
  */
 

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -61,8 +61,8 @@ import sun.nio.ch.FileChannelImpl;
  *
  * <p>
  * <a href= "../../java/nio/file/package-summary.html#links">Symbolic links</a>
- * are transparent to the constructors of this class, whether they are provided
- * by a pathname string or via a {@code File} object.
+ * are automatically redirected to the <i>target</i> of the link, whether they
+ * are provided by a pathname string or via a {@code File} object.
  *
  * @since   1.0
  */

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -101,11 +101,11 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
 
     /**
      * Creates a random access file stream to read from, and optionally
-     * to write to, a file with the specified pathname.
+     * to write to, a file with the specified pathname. If the file exists
+     * it is opened; if it does not exist and write mode is specified, a
+     * new file is created.
      * {@linkplain java.nio.file##links Symbolic links}
      * are automatically redirected to the <i>target</i> of the link.
-     * If the access mode specifies writing and the file or link target exists,
-     * then it will be truncated.
      * A new {@link FileDescriptor} object is created to represent the
      * connection to the file.
      *
@@ -150,13 +150,14 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
     }
 
     /**
-     * Creates a random access file stream to read from, and optionally to
-     * write to, the file specified by the {@link File} argument.
+     * Creates a random access file stream to read from, and optionally
+     * to write to, the file specified by the {@link File} argument. If
+     * the file exists it is opened; if it does not exist and write mode
+     * is specified, a new file is created.
      * {@linkplain java.nio.file##links Symbolic links}
      * are automatically redirected to the <i>target</i> of the link.
-     * If the access mode specifies writing and the file or link target exists,
-     * then it will be truncated. A new {@link
-     * FileDescriptor} object is created to represent this file connection.
+     * A new {@link FileDescriptor} object is created to represent the
+     * connection to the file.
      *
      * <p>The <a id="mode">{@code mode}</a> argument specifies the access mode
      * in which the file is to be opened.  The permitted values and their

--- a/src/java.base/share/classes/java/io/RandomAccessFile.java
+++ b/src/java.base/share/classes/java/io/RandomAccessFile.java
@@ -59,11 +59,6 @@ import sun.nio.ch.FileChannelImpl;
  * than {@code EOFException} is thrown. In particular, an
  * {@code IOException} may be thrown if the stream has been closed.
  *
- * <p>
- * <a href= "../../java/nio/file/package-summary.html#links">Symbolic links</a>
- * are automatically redirected to the <i>target</i> of the link, whether they
- * are provided by a pathname string or via a {@code File} object.
- *
  * @since   1.0
  */
 
@@ -106,8 +101,12 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
 
     /**
      * Creates a random access file stream to read from, and optionally
-     * to write to, a file with the specified pathname. A new
-     * {@link FileDescriptor} object is created to represent the
+     * to write to, a file with the specified pathname.
+     * {@linkplain java.nio.file##links Symbolic links}
+     * are automatically redirected to the <i>target</i> of the link.
+     * If the access mode specifies writing and the file or link target exists,
+     * then it will be truncated.
+     * A new {@link FileDescriptor} object is created to represent the
      * connection to the file.
      *
      * <p> The {@code mode} argument specifies the access mode with which the
@@ -152,7 +151,11 @@ public class RandomAccessFile implements DataOutput, DataInput, Closeable {
 
     /**
      * Creates a random access file stream to read from, and optionally to
-     * write to, the file specified by the {@link File} argument.  A new {@link
+     * write to, the file specified by the {@link File} argument.
+     * {@linkplain java.nio.file##links Symbolic links}
+     * are automatically redirected to the <i>target</i> of the link.
+     * If the access mode specifies writing and the file or link target exists,
+     * then it will be truncated. A new {@link
      * FileDescriptor} object is created to represent this file connection.
      *
      * <p>The <a id="mode">{@code mode}</a> argument specifies the access mode


### PR DESCRIPTION
Make explicit how the `java.io.File` methods `isDirectory`, `isFile`, and `isHidden` behave when the `File` represents a symbolic link.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8339868](https://bugs.openjdk.org/browse/JDK-8339868) to be approved

### Issues
 * [JDK-8339574](https://bugs.openjdk.org/browse/JDK-8339574): Behavior of File.is{Directory,File,Hidden} is not documented with respect to symlinks (**Bug** - P4)
 * [JDK-8339868](https://bugs.openjdk.org/browse/JDK-8339868): Behavior of File.is{Directory,File,Hidden} is not documented with respect to symlinks (**CSR**)


### Reviewers
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [a6c21681](https://git.openjdk.org/jdk/pull/20878/files/a6c216812ec9824696481834e2a20ca73b831a68)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20878/head:pull/20878` \
`$ git checkout pull/20878`

Update a local copy of the PR: \
`$ git checkout pull/20878` \
`$ git pull https://git.openjdk.org/jdk.git pull/20878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20878`

View PR using the GUI difftool: \
`$ git pr show -t 20878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20878.diff">https://git.openjdk.org/jdk/pull/20878.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20878#issuecomment-2332636671)