### PR TITLE
8337422: spelling error in jlink documentation

### DIFF
--- a/src/jdk.jlink/share/man/jlink.1
+++ b/src/jdk.jlink/share/man/jlink.1
@@ -62,7 +62,7 @@ dependencies.
 .SH DESCRIPTION
 .PP
 The \f[V]jlink\f[R] tool links a set of modules, along with their
-transitive dependences, to create a custom runtime image.
+transitive dependencies, to create a custom runtime image.
 .PP
 \f[B]Note:\f[R]
 .PP


### PR DESCRIPTION
fixed spelling to be consistent with the rest of the man page.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8337422: spelling error in jlink documentation`

### Issue
 * [JDK-8337422](https://bugs.openjdk.org/browse/JDK-8337422): spelling error in jlink documentation (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20882/head:pull/20882` \
`$ git checkout pull/20882`

Update a local copy of the PR: \
`$ git checkout pull/20882` \
`$ git pull https://git.openjdk.org/jdk.git pull/20882/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20882`

View PR using the GUI difftool: \
`$ git pr show -t 20882`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20882.diff">https://git.openjdk.org/jdk/pull/20882.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20882#issuecomment-2333340990)