### PR TITLE
8339387: ZGC: Synchronize medium page allocation

### DIFF
--- a/src/hotspot/share/gc/z/zObjectAllocator.cpp
+++ b/src/hotspot/share/gc/z/zObjectAllocator.cpp
@@ -143,7 +143,7 @@ zaddress ZObjectAllocator::alloc_object_in_medium_page(size_t size,
     // of the new page using a lock. This is to avoid having multiple
     // threads requesting a medium page from the page cache when we know
     // only one of the will succeed in installing the page at this layer.
-    ZLocker<ZConditionLock> locker(&_medium_page_alloc_lock);
+    ZLocker<ZLock> locker(&_medium_page_alloc_lock);
 
     // When holding the lock we can't allow the page allocator to stall,
     // which in the common case it won't. The page allocation is thus done

--- a/src/hotspot/share/gc/z/zObjectAllocator.hpp
+++ b/src/hotspot/share/gc/z/zObjectAllocator.hpp
@@ -58,9 +58,7 @@ private:
                                        size_t size,
                                        ZAllocationFlags flags);
 
-  zaddress alloc_object_in_medium_page(ZPageType page_type,
-                                       size_t page_size,
-                                       size_t size,
+  zaddress alloc_object_in_medium_page(size_t size,
                                        ZAllocationFlags flags);
 
   zaddress alloc_large_object(size_t size, ZAllocationFlags flags);

--- a/src/hotspot/share/gc/z/zObjectAllocator.hpp
+++ b/src/hotspot/share/gc/z/zObjectAllocator.hpp
@@ -42,7 +42,7 @@ private:
   ZPerCPU<size_t>    _undone;
   ZPerCPU<ZPage*>    _shared_small_page;
   ZContended<ZPage*> _shared_medium_page;
-  ZConditionLock     _medium_page_alloc_lock;
+  ZLock              _medium_page_alloc_lock;
 
   ZPage** shared_small_page_addr();
   ZPage* const* shared_small_page_addr() const;

--- a/src/hotspot/share/gc/z/zObjectAllocator.hpp
+++ b/src/hotspot/share/gc/z/zObjectAllocator.hpp
@@ -26,6 +26,7 @@
 
 #include "gc/z/zAddress.hpp"
 #include "gc/z/zAllocationFlags.hpp"
+#include "gc/z/zLock.hpp"
 #include "gc/z/zPageAge.hpp"
 #include "gc/z/zPageType.hpp"
 #include "gc/z/zValue.hpp"
@@ -39,8 +40,9 @@ private:
   const bool         _use_per_cpu_shared_small_pages;
   ZPerCPU<size_t>    _used;
   ZPerCPU<size_t>    _undone;
-  ZContended<ZPage*> _shared_medium_page;
   ZPerCPU<ZPage*>    _shared_small_page;
+  ZContended<ZPage*> _shared_medium_page;
+  ZConditionLock     _medium_page_alloc_lock;
 
   ZPage** shared_small_page_addr();
   ZPage* const* shared_small_page_addr() const;
@@ -56,10 +58,16 @@ private:
                                        size_t size,
                                        ZAllocationFlags flags);
 
+  zaddress alloc_object_in_medium_page(ZPageType page_type,
+                                       size_t page_size,
+                                       size_t size,
+                                       ZAllocationFlags flags);
+
   zaddress alloc_large_object(size_t size, ZAllocationFlags flags);
   zaddress alloc_medium_object(size_t size, ZAllocationFlags flags);
   zaddress alloc_small_object(size_t size, ZAllocationFlags flags);
   zaddress alloc_object(size_t size, ZAllocationFlags flags);
+  zaddress alloc_object_in_page_atomic(ZPage* page, size_t size);
 
 public:
   ZObjectAllocator(ZPageAge age);

--- a/src/hotspot/share/gc/z/zObjectAllocator.hpp
+++ b/src/hotspot/share/gc/z/zObjectAllocator.hpp
@@ -65,7 +65,6 @@ private:
   zaddress alloc_medium_object(size_t size, ZAllocationFlags flags);
   zaddress alloc_small_object(size_t size, ZAllocationFlags flags);
   zaddress alloc_object(size_t size, ZAllocationFlags flags);
-  zaddress alloc_object_in_page_atomic(ZPage* page, size_t size);
 
 public:
   ZObjectAllocator(ZPageAge age);


### PR DESCRIPTION
Please review this change to synchronize medium page allocations in ZGC.

**Summary**
In ZGC objects of a certain size class are allocated in medium sized pages. For each age there is a single medium page shared by all mutators. When this page gets full all thread that try to do a medium page allocation will try to allocate and install a new medium page, but only one will succeed. This can lead to a lot of unnecessary medium page allocation which in turn can lead to the unnecessary page cache flushing.

This change introduces synchronization to only a allow a single thread to allocate the medium page in the common case.  

**Testing**
* Functional testing through mach5 tier1-7 using ZGC
* Performance testing through aurora to verify no regression occur
* Manual testing to verify performance
* Manual testing to verify we avoid page cache flushing

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339387](https://bugs.openjdk.org/browse/JDK-8339387): ZGC: Synchronize medium page allocation (**Enhancement** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) Review applies to [66a9a238](https://git.openjdk.org/jdk/pull/20883/files/66a9a238d3157081fd8143843dea3a238a1c1061)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20883/head:pull/20883` \
`$ git checkout pull/20883`

Update a local copy of the PR: \
`$ git checkout pull/20883` \
`$ git pull https://git.openjdk.org/jdk.git pull/20883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20883`

View PR using the GUI difftool: \
`$ git pr show -t 20883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20883.diff">https://git.openjdk.org/jdk/pull/20883.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20883#issuecomment-2333411024)