### PR TITLE
8339640: Reduce construction overheads in StringConcatFactory$InlineHiddenClassStrategy

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1242,7 +1242,7 @@ public final class StringConcatFactory {
             lookup = STR_LOOKUP;
             final MethodType concatArgs = erasedArgs(args);
 
-            // 1 argment use built-in method
+            // 1 argument use built-in method
             if (args.parameterCount() == 1) {
                 Object concat1 = JLA.stringConcat1(constants);
                 var handle = lookup.findVirtual(concat1.getClass(), METHOD_NAME, concatArgs);
@@ -1254,7 +1254,7 @@ public final class StringConcatFactory {
                 MethodHandlePair handlePair = weakConstructorHandle.get();
                 if (handlePair != null) {
                     try {
-                        var instance = handlePair.constructor.invoke(constants);
+                        var instance = handlePair.constructor.invokeBasic(constants);
                         return handlePair.concatenator.bindTo(instance);
                     } catch (Throwable e) {
                         throw new StringConcatException("Exception while utilizing the hidden class", e);
@@ -1331,10 +1331,10 @@ public final class StringConcatFactory {
                 var hiddenClass = lookup.makeHiddenClassDefiner(CLASS_NAME, classBytes, Set.of(), DUMPER)
                                         .defineClass(true, null);
                 var constructor = lookup.findConstructor(hiddenClass, CONSTRUCTOR_METHOD_TYPE);
-                var concat      = lookup.findVirtual(hiddenClass, METHOD_NAME, concatArgs);
-                CACHE.put(concatArgs, new SoftReference<>(new MethodHandlePair(constructor, concat)));
-                var instance = hiddenClass.cast(constructor.invoke(constants));
-                return concat.bindTo(instance);
+                var concatenator = lookup.findVirtual(hiddenClass, METHOD_NAME, concatArgs);
+                CACHE.put(concatArgs, new SoftReference<>(new MethodHandlePair(constructor, concatenator)));
+                var instance = constructor.invokeBasic(constants);
+                return concatenator.bindTo(instance);
             } catch (Throwable e) {
                 throw new StringConcatException("Exception while spinning the class", e);
             }

--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1254,7 +1254,7 @@ public final class StringConcatFactory {
                 MethodHandlePair handlePair = weakConstructorHandle.get();
                 if (handlePair != null) {
                     try {
-                        var instance = handlePair.constructor.invokeBasic(constants);
+                        var instance = handlePair.constructor.invokeBasic((Object)constants);
                         return handlePair.concatenator.bindTo(instance);
                     } catch (Throwable e) {
                         throw new StringConcatException("Exception while utilizing the hidden class", e);
@@ -1333,7 +1333,7 @@ public final class StringConcatFactory {
                 var constructor = lookup.findConstructor(hiddenClass, CONSTRUCTOR_METHOD_TYPE);
                 var concatenator = lookup.findVirtual(hiddenClass, METHOD_NAME, concatArgs);
                 CACHE.put(concatArgs, new SoftReference<>(new MethodHandlePair(constructor, concatenator)));
-                var instance = constructor.invokeBasic(constants);
+                var instance = constructor.invokeBasic((Object)constants);
                 return concatenator.bindTo(instance);
             } catch (Throwable e) {
                 throw new StringConcatException("Exception while spinning the class", e);


### PR DESCRIPTION
Using the trusted `invokeBasic` method streamlines invokers and avoids spinning up of some type conversion handles. This reduces classes generated in a few scalability stress tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339640](https://bugs.openjdk.org/browse/JDK-8339640): Reduce construction overheads in StringConcatFactory$InlineHiddenClassStrategy (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20884/head:pull/20884` \
`$ git checkout pull/20884`

Update a local copy of the PR: \
`$ git checkout pull/20884` \
`$ git pull https://git.openjdk.org/jdk.git pull/20884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20884`

View PR using the GUI difftool: \
`$ git pr show -t 20884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20884.diff">https://git.openjdk.org/jdk/pull/20884.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20884#issuecomment-2333450504)