### PR TITLE
8339648: ZGC: Division by zero in rule_major_allocation_rate

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -488,7 +488,8 @@ static bool rule_major_allocation_rate(const ZDirectorStats& stats) {
 
   // Calculate the GC cost for each reclaimed byte
   const double current_young_gc_time_per_bytes_freed = double(young_gc_time) / double(reclaimed_per_young_gc);
-  const double current_old_gc_time_per_bytes_freed = reclaimed_per_old_gc == 0 ? std::numeric_limits<double>::infinity() : double(old_gc_time) / double(reclaimed_per_old_gc);
+  const double current_old_gc_time_per_bytes_freed = ((reclaimed_per_old_gc == 0) ? (std::numeric_limits<double>::infinity())
+                                                                                  : (double(old_gc_time) / double(reclaimed_per_old_gc)));
 
   // Calculate extra time per young collection inflicted by *not* doing an
   // old collection that frees up memory in the old generation.

--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -488,7 +488,6 @@ static bool rule_major_allocation_rate(const ZDirectorStats& stats) {
 
   // Calculate the GC cost for each reclaimed byte
   const double current_young_gc_time_per_bytes_freed = double(young_gc_time) / double(reclaimed_per_young_gc);
-  const double current_old_gc_time_per_bytes_freed = double(old_gc_time) / double(reclaimed_per_old_gc);
 
   // Calculate extra time per young collection inflicted by *not* doing an
   // old collection that frees up memory in the old generation.
@@ -518,7 +517,11 @@ static bool rule_major_allocation_rate(const ZDirectorStats& stats) {
 
   // If the garbage is cheaper to reap in the old generation, then it makes sense
   // to upgrade minor collections to major collections.
-  const bool old_garbage_is_cheaper = current_old_gc_time_per_bytes_freed < current_young_gc_time_per_bytes_freed;
+  bool old_garbage_is_cheaper = true;
+  if (reclaimed_per_old_gc != 0) {
+    const double current_old_gc_time_per_bytes_freed = double(old_gc_time) / double(reclaimed_per_old_gc);
+    old_garbage_is_cheaper = current_old_gc_time_per_bytes_freed < current_young_gc_time_per_bytes_freed;
+  }
 
   return can_amortize_time_cost || old_garbage_is_cheaper || is_major_urgent(stats);
 }

--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -488,8 +488,8 @@ static bool rule_major_allocation_rate(const ZDirectorStats& stats) {
 
   // Calculate the GC cost for each reclaimed byte
   const double current_young_gc_time_per_bytes_freed = double(young_gc_time) / double(reclaimed_per_young_gc);
-  const double current_old_gc_time_per_bytes_freed = ((reclaimed_per_old_gc == 0) ? (std::numeric_limits<double>::infinity())
-                                                                                  : (double(old_gc_time) / double(reclaimed_per_old_gc)));
+  const double current_old_gc_time_per_bytes_freed = reclaimed_per_old_gc == 0 ? std::numeric_limits<double>::infinity()
+                                                                               : (double(old_gc_time) / double(reclaimed_per_old_gc));
 
   // Calculate extra time per young collection inflicted by *not* doing an
   // old collection that frees up memory in the old generation.

--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -488,6 +488,7 @@ static bool rule_major_allocation_rate(const ZDirectorStats& stats) {
 
   // Calculate the GC cost for each reclaimed byte
   const double current_young_gc_time_per_bytes_freed = double(young_gc_time) / double(reclaimed_per_young_gc);
+  const double current_old_gc_time_per_bytes_freed = reclaimed_per_old_gc == 0 ? std::numeric_limits<double>::infinity() : double(old_gc_time) / double(reclaimed_per_old_gc);
 
   // Calculate extra time per young collection inflicted by *not* doing an
   // old collection that frees up memory in the old generation.
@@ -517,11 +518,7 @@ static bool rule_major_allocation_rate(const ZDirectorStats& stats) {
 
   // If the garbage is cheaper to reap in the old generation, then it makes sense
   // to upgrade minor collections to major collections.
-  bool old_garbage_is_cheaper = true;
-  if (reclaimed_per_old_gc != 0) {
-    const double current_old_gc_time_per_bytes_freed = double(old_gc_time) / double(reclaimed_per_old_gc);
-    old_garbage_is_cheaper = current_old_gc_time_per_bytes_freed < current_young_gc_time_per_bytes_freed;
-  }
+  const bool old_garbage_is_cheaper = current_old_gc_time_per_bytes_freed < current_young_gc_time_per_bytes_freed;
 
   return can_amortize_time_cost || old_garbage_is_cheaper || is_major_urgent(stats);
 }


### PR DESCRIPTION
The HS jtreg test gc/stringdedup/TestStringDeduplicationAgeThreshold_ZGenerational
shows this error when running with ubsan enabled 

src/hotspot/share/gc/z/zDirector.cpp:491:74: runtime error: division by zero
    #0 0x7f09886401d4 in rule_major_allocation_rate src/hotspot/share/gc/z/zDirector.cpp:491
    #1 0x7f09886401d4 in start_gc src/hotspot/share/gc/z/zDirector.cpp:822
    #2 0x7f09886401d4 in ZDirector::run_thread() src/hotspot/share/gc/z/zDirector.cpp:912
    #3 0x7f098c1404e8 in ZThread::run_service() src/hotspot/share/gc/z/zThread.cpp:29
    #4 0x7f09897cac19 in ConcurrentGCThread::run() src/hotspot/share/gc/shared/concurrentGCThread.cpp:48
    #5 0x7f098bb46b0a in Thread::call_run() src/hotspot/share/runtime/thread.cpp:225
    #6 0x7f098b1a9881 in thread_native_entry src/hotspot/os/linux/os_linux.cpp:858

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339648](https://bugs.openjdk.org/browse/JDK-8339648): ZGC: Division by zero in rule_major_allocation_rate (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**) Review applies to [21fe3ca7](https://git.openjdk.org/jdk/pull/20888/files/21fe3ca7355b47e16b342ae8952dbec2d9d93012)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20888/head:pull/20888` \
`$ git checkout pull/20888`

Update a local copy of the PR: \
`$ git checkout pull/20888` \
`$ git pull https://git.openjdk.org/jdk.git pull/20888/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20888`

View PR using the GUI difftool: \
`$ git pr show -t 20888`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20888.diff">https://git.openjdk.org/jdk/pull/20888.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20888#issuecomment-2333764260)