### PR TITLE
8339488: Extended NPE message doesn't handle CONSTANT_Dynamic

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeUtils.cpp
+++ b/src/hotspot/share/interpreter/bytecodeUtils.cpp
@@ -643,7 +643,7 @@ int ExceptionMessageBuilder::do_instruction(int bci) {
         }
       }
 
-      constantTag tag = cp->tag_at(cp_index);
+      constantTag tag = cp->constant_tag_at(cp_index);
       if (tag.is_klass()  || tag.is_unresolved_klass() ||
           tag.is_method() || tag.is_interface_method() ||
           tag.is_field()  || tag.is_string()) {

--- a/test/hotspot/jtreg/runtime/condy/CondyExtendedNullPointer.jasm
+++ b/test/hotspot/jtreg/runtime/condy/CondyExtendedNullPointer.jasm
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * This test generates an extended NullPointerException inside a method with
+ * a condy ldc. We add two ldc instructions and a pop around the real null
+ * value to stress the stack handling of the NPE message generator.
+ */
+class CondyExtendedNullPointer
+	version 55:0
+{
+
+static Field nullObject:"Ljava/lang/Object;";
+
+public static Method condy:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;)I"
+	stack 1 locals 3
+{
+		bipush	123;
+		ireturn;
+}
+
+public static Method main:"([Ljava/lang/String;)V"
+	stack 3 locals 1
+{
+		ldc	Dynamic REF_invokeStatic:CondyExtendedNullPointer.condy:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;)I":I:"I";
+		getstatic	Field nullObject:"Ljava/lang/Object;";
+		ldc	Dynamic REF_invokeStatic:CondyExtendedNullPointer.condy:"(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/Class;)I":I:"I";
+		pop;
+		invokevirtual   Method java/lang/Object.notify:"()V";
+		return;
+}
+
+} // end Class CondyExtendedNullPointer

--- a/test/hotspot/jtreg/runtime/condy/CondyExtendedNullPointerTest.java
+++ b/test/hotspot/jtreg/runtime/condy/CondyExtendedNullPointerTest.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 8339488
  * @summary Test extended NullPointerException message in method with CONSTANT_Dynamic.
- * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  * @library /test/lib
  * @compile CondyExtendedNullPointer.jasm
@@ -37,7 +36,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 
 public class CondyExtendedNullPointerTest {
     public static void main(String args[]) throws Throwable {
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xverify:all",
+        ProcessBuilder pb = ProcessTools.createTestJavaProcessBuilder("-Xverify:all",
                                                                              "CondyExtendedNullPointer");
         OutputAnalyzer oa = new OutputAnalyzer(pb.start());
         oa.shouldContain("Cannot invoke \"Object.notify()\" because \"CondyExtendedNullPointer.nullObject\" is null");

--- a/test/hotspot/jtreg/runtime/condy/CondyExtendedNullPointerTest.java
+++ b/test/hotspot/jtreg/runtime/condy/CondyExtendedNullPointerTest.java
@@ -34,7 +34,6 @@
 
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.lib.compiler.InMemoryJavaCompiler;
 
 public class CondyExtendedNullPointerTest {
     public static void main(String args[]) throws Throwable {

--- a/test/hotspot/jtreg/runtime/condy/CondyExtendedNullPointerTest.java
+++ b/test/hotspot/jtreg/runtime/condy/CondyExtendedNullPointerTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8339488
+ * @summary Test extended NullPointerException message in method with CONSTANT_Dynamic.
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @compile CondyExtendedNullPointer.jasm
+ * @run driver CondyExtendedNullPointerTest
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.compiler.InMemoryJavaCompiler;
+
+public class CondyExtendedNullPointerTest {
+    public static void main(String args[]) throws Throwable {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-Xverify:all",
+                                                                             "CondyExtendedNullPointer");
+        OutputAnalyzer oa = new OutputAnalyzer(pb.start());
+        oa.shouldContain("Cannot invoke \"Object.notify()\" because \"CondyExtendedNullPointer.nullObject\" is null");
+        oa.shouldHaveExitValue(1);
+    }
+}


### PR DESCRIPTION
Extended NPE messages require walking the bytecode in the method where it was created, and simulating the effect on the stack. `ldc` for dynamic constants is not handled, which can lead to assertion failures in debug builds, or incorrect NPE messages in release builds (possibly worse with the right conditions?).

Simply handle dynamic constants by figuring out their return type so we know how they will affect the stack.

The new test fails without the fix in both release and debug builds. In release, it fails because the NPE message is wrong: `Exception in thread "main" java.lang.NullPointerException: Cannot invoke "Object.notify()" because "`, and in debug builds it hits this assert:

```
#
# A fatal error has been detected by the Java Runtime Environment:
#
# Internal Error (<redacted>/src/hotspot/share/interpreter/bytecodeUtils.cpp:660), pid=12677, tid=12678
# assert(false) failed: Unexpected tag
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339488](https://bugs.openjdk.org/browse/JDK-8339488): Extended NPE message doesn't handle CONSTANT_Dynamic (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [9382a708](https://git.openjdk.org/jdk/pull/20889/files/9382a708b3196fedb2465b11129e0a9963d41305)
 * [Volker Simonis](https://openjdk.org/census#simonis) (@simonis - **Reviewer**) Review applies to [1cf82008](https://git.openjdk.org/jdk/pull/20889/files/1cf820088582b032d0735cc1816afd12f4896305)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**) Review applies to [9382a708](https://git.openjdk.org/jdk/pull/20889/files/9382a708b3196fedb2465b11129e0a9963d41305)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20889/head:pull/20889` \
`$ git checkout pull/20889`

Update a local copy of the PR: \
`$ git checkout pull/20889` \
`$ git pull https://git.openjdk.org/jdk.git pull/20889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20889`

View PR using the GUI difftool: \
`$ git pr show -t 20889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20889.diff">https://git.openjdk.org/jdk/pull/20889.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20889#issuecomment-2333852965)