### PR TITLE
8335734: Test sun/java2d/Disposer/TestDisposerRace.java fails with OOME in unexpected location

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedLongSynchronizer.java
@@ -1327,6 +1327,8 @@ public abstract class AbstractQueuedLongSynchronizer
                         rejected = true;
                     } catch (InterruptedException ie) {
                         interrupted = true;
+                    } catch (Error | RuntimeException ex) {
+                        // Spurious errors, keep trying
                     }
                 } else
                     Thread.onSpinWait();    // awoke while enqueuing
@@ -1374,6 +1376,8 @@ public abstract class AbstractQueuedLongSynchronizer
                         rejected = true;
                     } catch (InterruptedException ie) {
                         interrupted = true;
+                    } catch (Error | RuntimeException ex) {
+                        // Spurious errors, keep trying
                     }
                 } else
                     Thread.onSpinWait();    // awoke while enqueuing

--- a/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
+++ b/src/java.base/share/classes/java/util/concurrent/locks/AbstractQueuedSynchronizer.java
@@ -516,7 +516,9 @@ public abstract class AbstractQueuedSynchronizer
         }
 
         public final boolean block() {
-            while (!isReleasable()) LockSupport.park();
+            while (!isReleasable()) {
+                LockSupport.park();
+            }
             return true;
         }
     }
@@ -1706,6 +1708,8 @@ public abstract class AbstractQueuedSynchronizer
                         rejected = true;
                     } catch (InterruptedException ie) {
                         interrupted = true;
+                    } catch (Error | RuntimeException ex) {
+                        // Spurious errors, keep trying
                     }
                 } else
                     Thread.onSpinWait();    // awoke while enqueuing
@@ -1753,6 +1757,8 @@ public abstract class AbstractQueuedSynchronizer
                         rejected = true;
                     } catch (InterruptedException ie) {
                         interrupted = true;
+                    } catch (Error | RuntimeException ex) {
+                        // Spurious errors, keep trying
                     }
                 } else
                     Thread.onSpinWait();    // awoke while enqueuing

--- a/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
+++ b/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
@@ -94,6 +94,7 @@ public final class TestDisposerRace {
                         Thread.sleep(1); // Give GC a little chance to run
                         break;
                     } catch (OutOfMemoryError | InterruptedException ignored2) {
+                        System.gc(); // If we can't even sleep, ask the GC for assistance
                         continue;
                     }
                 }
@@ -112,6 +113,7 @@ public final class TestDisposerRace {
                         Thread.sleep(1); // Give GC a little chance to run
                         break;
                     } catch (OutOfMemoryError | InterruptedException ignored2) {
+                        System.gc(); // If we can't even sleep, ask the GC for assistance
                         continue;
                     }
                 }
@@ -150,6 +152,7 @@ public final class TestDisposerRace {
                 Thread.sleep(2000); // Give GC a little chance to run
                 break;
             } catch (OutOfMemoryError | InterruptedException ignored2) {
+                System.gc(); // If we can't even sleep, ask the GC for assistance
                 continue;
             }
         }

--- a/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
+++ b/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
@@ -89,22 +89,32 @@ public final class TestDisposerRace {
             try {
                 return allocator.get();
             } catch (OutOfMemoryError ignored1) {
-                try {
-                    Thread.sleep(1); // Give GC a little chance to run
-                } catch (InterruptedException ignored2) {}
+                for (;;) {
+                    try {
+                        Thread.sleep(1); // Give GC a little chance to run
+                        break;
+                    } catch (OutOfMemoryError | InterruptedException ignored2) {
+                        continue;
+                    }
+                }
             }
         }
     }
 
     private static <E extends Exception> void retryOnOOME(ThrowingRunnable<E> tr) throws E {
-        for(;;) {
+        for (;;) {
             try {
                 tr.run();
                 break;
             } catch (OutOfMemoryError ignored1) {
-                try {
-                    Thread.sleep(1); // Give GC a little chance to run
-                } catch (InterruptedException ignored2) {}
+                for (;;) {
+                    try {
+                        Thread.sleep(1); // Give GC a little chance to run
+                        break;
+                    } catch (OutOfMemoryError | InterruptedException ignored2) {
+                        continue;
+                    }
+                }
             }
         }
     }
@@ -135,9 +145,14 @@ public final class TestDisposerRace {
     }
 
     private static void giveGCAChance() {
-        try {
-            Thread.sleep(2000);
-        } catch (InterruptedException ignored) {}
+        for (;;) {
+            try {
+                Thread.sleep(2000); // Give GC a little chance to run
+                break;
+            } catch (OutOfMemoryError | InterruptedException ignored2) {
+                continue;
+            }
+        }
     }
 
     private static void generateOOME() throws Exception {


### PR DESCRIPTION
So I ran the TestDisposerRace.java ~110k times and still got an OOME, but this time from within AWT EventQueue:

```
java.lang.OutOfMemoryError: Java heap space
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:714)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
STATUS:Failed.`main' threw exception: java.lang.OutOfMemoryError: Java heap space
```

(Note that the OOM is when trying to allocate a PrivilegedAction)

I guess the bit question is how robust against executing under OOM we can reasonably make it?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335734](https://bugs.openjdk.org/browse/JDK-8335734): Test sun/java2d/Disposer/TestDisposerRace.java fails with OOME in unexpected location (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20891/head:pull/20891` \
`$ git checkout pull/20891`

Update a local copy of the PR: \
`$ git checkout pull/20891` \
`$ git pull https://git.openjdk.org/jdk.git pull/20891/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20891`

View PR using the GUI difftool: \
`$ git pr show -t 20891`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20891.diff">https://git.openjdk.org/jdk/pull/20891.diff</a>

</details>
