### PR TITLE
8339687: Rearrange reachabilityFence()s in jdk.test.lib.util.ForceGC

### DIFF
--- a/test/lib/jdk/test/lib/util/ForceGC.java
+++ b/test/lib/jdk/test/lib/util/ForceGC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,9 +78,8 @@ public class ForceGC {
         ReferenceQueue<Object> queue = new ReferenceQueue<>();
         Object obj = new Object();
         PhantomReference<Object> ref = new PhantomReference<>(obj, queue);
-        obj = null;
         Reference.reachabilityFence(obj);
-        Reference.reachabilityFence(ref);
+        obj = null;
 
         int retries = (int)(timeout / 200);
         for (; retries >= 0; retries--) {
@@ -100,6 +99,7 @@ public class ForceGC {
                 // ignore, the loop will try again
             }
         }
+        Reference.reachabilityFence(ref);
 
         return booleanSupplier.getAsBoolean();
     }


### PR DESCRIPTION
From the bug description:
ForceGC would be improved by moving the Reference.reachabilityFence() calls for 'obj' and 'ref'.

Reference.reachabilityFence(obj) is currently placed after 'obj' has been set to null, so effectively does nothing. It should occur before obj = null;

For Reference.reachabilityFence(ref): 'ref' is a PhantomReference to 'obj', and is registered with 'queue'. ForceGC.waitFor() later remove()s the reference from the queue, as an indication that some GC and reference processing has taken place (hopefully causing the BooleanSupplier to return true).

The code expects the PhantomReference to be cleared and be put on the queue. But recall that a Reference refers to its queue, and not the other way around. If a Reference becomes unreachable and is garbage collected, it will never be enqueued.

I argue that the VM/GC could determine that 'ref' is not used by waitFor() and collect it before the call to queue.remove(). Moving Reference.reachabilityFence(ref) after the for() loop would prevent this scenario.

While this is only a very minor deficiency in ForceGC, I believe it would be good to ensure that the code behaves as expected.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339687](https://bugs.openjdk.org/browse/JDK-8339687): Rearrange reachabilityFence()s in jdk.test.lib.util.ForceGC (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) Review applies to [862d4da2](https://git.openjdk.org/jdk/pull/20898/files/862d4da2dc38c3f003768ae27c94e5ff632af1b9)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20898/head:pull/20898` \
`$ git checkout pull/20898`

Update a local copy of the PR: \
`$ git checkout pull/20898` \
`$ git pull https://git.openjdk.org/jdk.git pull/20898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20898`

View PR using the GUI difftool: \
`$ git pr show -t 20898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20898.diff">https://git.openjdk.org/jdk/pull/20898.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20898#issuecomment-2334733549)