### PR TITLE
8339696: Clarify modeling scope of javax.lang.model.element

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,9 +32,15 @@
  * The interfaces in this package do not model the structure of a
  * program inside a method body; for example there is no
  * representation of a {@code for} loop or {@code try}-{@code finally}
- * block.  However, the interfaces can model some structures only
- * appearing inside method bodies, such as local variables and
- * anonymous classes.
+ * block. Concretely, there is no model of the abstract syntax tree
+ * (AST) structure of a Java program.
+ * However, the interfaces can model some structures only
+ * appearing inside method bodies, such as {@linkplain ElementKind#LOCAL_VARIABLE local variables},
+ * {@linkplain NestingKind#ANONYMOUS anonymous classes}, and
+ * {@linkplain ElementKind#EXCEPTION_PARAMETER exception parameters}. 
+ * Therefore, these interfaces can be used by an AST API to model the
+ * declarations found in the method bodies of Java compilation units
+ * (JLS {@jls 7.3}).
  *
  * <p id="accurate_model">When used in the context of annotation
  * processing, an accurate model of the element being represented must

--- a/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
@@ -37,7 +37,7 @@
  * However, the interfaces can model some structures only
  * appearing inside method bodies, such as {@linkplain ElementKind#LOCAL_VARIABLE local variables},
  * {@linkplain NestingKind#ANONYMOUS anonymous classes}, and
- * {@linkplain ElementKind#EXCEPTION_PARAMETER exception parameters}. 
+ * {@linkplain ElementKind#EXCEPTION_PARAMETER exception parameters}.
  * Therefore, these interfaces can be used by an AST API to model the
  * declarations found in the method bodies of Java compilation units
  * (JLS {@jls 7.3}).

--- a/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
@@ -32,7 +32,7 @@
  * The interfaces in this package do not model the structure of a
  * program inside a method body; for example there is no
  * representation of a {@code for} loop or {@code try}-{@code finally}
- * block. Concretely, there is no model of the abstract syntax tree
+ * block. Concretely, there is no model of any abstract syntax tree
  * (AST) structure of a Java program.  However, the interfaces can
  * model some structures only appearing inside method bodies, such as
  * {@linkplain ElementKind#LOCAL_VARIABLE local variables},

--- a/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
@@ -33,9 +33,9 @@
  * program inside a method body; for example there is no
  * representation of a {@code for} loop or {@code try}-{@code finally}
  * block. Concretely, there is no model of the abstract syntax tree
- * (AST) structure of a Java program.
- * However, the interfaces can model some structures only
- * appearing inside method bodies, such as {@linkplain ElementKind#LOCAL_VARIABLE local variables},
+ * (AST) structure of a Java program.  However, the interfaces can
+ * model some structures only appearing inside method bodies, such as
+ * {@linkplain ElementKind#LOCAL_VARIABLE local variables},
  * {@linkplain NestingKind#ANONYMOUS anonymous classes}, and
  * {@linkplain ElementKind#EXCEPTION_PARAMETER exception parameters}.
  * Therefore, these interfaces can be used by an AST API to model the


### PR DESCRIPTION
Clarify that while javax.lang.model does not include an AST API, it is intended to be usable by an AST API.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339696](https://bugs.openjdk.org/browse/JDK-8339696): Clarify modeling scope of javax.lang.model.element (**Enhancement** - P4)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**) Review applies to [2c213737](https://git.openjdk.org/jdk/pull/20900/files/2c213737c92043e5eab9786404cb543c93ba1929)
 * @abdelhak-zaaim (no known openjdk.org user name / role) Review applies to [2c213737](https://git.openjdk.org/jdk/pull/20900/files/2c213737c92043e5eab9786404cb543c93ba1929)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**) Review applies to [2c213737](https://git.openjdk.org/jdk/pull/20900/files/2c213737c92043e5eab9786404cb543c93ba1929)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20900/head:pull/20900` \
`$ git checkout pull/20900`

Update a local copy of the PR: \
`$ git checkout pull/20900` \
`$ git pull https://git.openjdk.org/jdk.git pull/20900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20900`

View PR using the GUI difftool: \
`$ git pr show -t 20900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20900.diff">https://git.openjdk.org/jdk/pull/20900.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20900#issuecomment-2334903030)