### PR TITLE
8339698: x86 unused andw/orw/xorw/addw encoding could be removed

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1633,6 +1633,7 @@ void Assembler::andb(Address dst, Register src) {
 }
 
 void Assembler::andw(Register dst, Register src) {
+  emit_int8(0x66);
   (void)prefix_and_encode(dst->encoding(), src->encoding());
   emit_arith(0x23, 0xC0, dst, src);
 }
@@ -4230,6 +4231,7 @@ void Assembler::notl(Register dst) {
 }
 
 void Assembler::orw(Register dst, Register src) {
+  emit_int8(0x66);
   (void)prefix_and_encode(dst->encoding(), src->encoding());
   emit_arith(0x0B, 0xC0, dst, src);
 }
@@ -6803,6 +6805,7 @@ void Assembler::xorb(Address dst, Register src) {
 }
 
 void Assembler::xorw(Register dst, Register src) {
+  emit_int8(0x66);
   (void)prefix_and_encode(dst->encoding(), src->encoding());
   emit_arith(0x33, 0xC0, dst, src);
 }

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -1405,12 +1405,6 @@ void Assembler::addb(Register dst, int imm8) {
   emit_arith_b(0x80, 0xC0, dst, imm8);
 }
 
-void Assembler::addw(Register dst, Register src) {
-  emit_int8(0x66);
-  (void)prefix_and_encode(dst->encoding(), src->encoding());
-  emit_arith(0x03, 0xC0, dst, src);
-}
-
 void Assembler::addw(Address dst, int imm16) {
   InstructionMark im(this);
   emit_int8(0x66);
@@ -1630,12 +1624,6 @@ void Assembler::andb(Address dst, Register src) {
   prefix(dst, src, true);
   emit_int8(0x20);
   emit_operand(src, dst, 0);
-}
-
-void Assembler::andw(Register dst, Register src) {
-  emit_int8(0x66);
-  (void)prefix_and_encode(dst->encoding(), src->encoding());
-  emit_arith(0x23, 0xC0, dst, src);
 }
 
 void Assembler::andl(Address dst, int32_t imm32) {
@@ -4230,12 +4218,6 @@ void Assembler::notl(Register dst) {
   emit_int16((unsigned char)0xF7, (0xD0 | encode));
 }
 
-void Assembler::orw(Register dst, Register src) {
-  emit_int8(0x66);
-  (void)prefix_and_encode(dst->encoding(), src->encoding());
-  emit_arith(0x0B, 0xC0, dst, src);
-}
-
 void Assembler::orl(Address dst, int32_t imm32) {
   InstructionMark im(this);
   prefix(dst);
@@ -6802,12 +6784,6 @@ void Assembler::xorb(Address dst, Register src) {
   prefix(dst, src, true);
   emit_int8(0x30);
   emit_operand(src, dst, 0);
-}
-
-void Assembler::xorw(Register dst, Register src) {
-  emit_int8(0x66);
-  (void)prefix_and_encode(dst->encoding(), src->encoding());
-  emit_arith(0x33, 0xC0, dst, src);
 }
 
 void Assembler::xorw(Register dst, Address src) {

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1068,7 +1068,6 @@ private:
   void addb(Address dst, int imm8);
   void addb(Address dst, Register src);
   void addb(Register dst, int imm8);
-  void addw(Register dst, Register src);
   void addw(Address dst, int imm16);
   void addw(Address dst, Register src);
 
@@ -1120,7 +1119,6 @@ private:
   void vaesdec(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
   void vaesdeclast(XMMRegister dst, XMMRegister nds, XMMRegister src, int vector_len);
 
-  void andw(Register dst, Register src);
   void andb(Address dst, Register src);
 
   void andl(Address  dst, int32_t imm32);
@@ -1824,8 +1822,6 @@ private:
 #endif
   void btq(Register dst, Register src);
 
-  void orw(Register dst, Register src);
-
   void orl(Address dst, int32_t imm32);
   void orl(Register dst, int32_t imm32);
   void orl(Register dst, Address src);
@@ -2342,7 +2338,6 @@ private:
 
   void xorb(Address dst, Register src);
   void xorb(Register dst, Address src);
-  void xorw(Register dst, Register src);
   void xorw(Register dst, Address src);
 
   void xorq(Register dst, Address src);


### PR DESCRIPTION
x86 andw/orw/xorw(Register, Register) encoding is missing 0x66 prefix. These instructions along with addw(Register, Register) are unused and so removed.

Best Regards,
Sandhya

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339698](https://bugs.openjdk.org/browse/JDK-8339698): x86 unused andw/orw/xorw/addw encoding could be removed (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20901/head:pull/20901` \
`$ git checkout pull/20901`

Update a local copy of the PR: \
`$ git checkout pull/20901` \
`$ git pull https://git.openjdk.org/jdk.git pull/20901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20901`

View PR using the GUI difftool: \
`$ git pr show -t 20901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20901.diff">https://git.openjdk.org/jdk/pull/20901.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20901#issuecomment-2335002389)