### PR TITLE
8339703: Problem list serviceability/sa/TestJhsdbJstackUpcall.java for generational ZGC

### DIFF
--- a/test/hotspot/jtreg/ProblemList-generational-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-generational-zgc.txt
@@ -92,6 +92,7 @@ serviceability/sa/TestIntConstant.java                        8307393   generic-
 serviceability/sa/TestJhsdbJstackLineNumbers.java             8307393   generic-all
 serviceability/sa/TestJhsdbJstackLock.java                    8307393   generic-all
 serviceability/sa/TestJhsdbJstackMixed.java                   8307393   generic-all
+serviceability/sa/TestJhsdbJstackUpcall.java                  8307393   generic-all
 serviceability/sa/TestJmapCore.java                           8307393   generic-all
 serviceability/sa/TestJmapCoreMetaspace.java                  8307393   generic-all
 serviceability/sa/TestObjectAlignment.java                    8307393   generic-all


### PR DESCRIPTION
This is a new SA test. We don't support SA with generational ZGC, so the test needs to be problem listed. 

I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339703](https://bugs.openjdk.org/browse/JDK-8339703): Problem list serviceability/sa/TestJhsdbJstackUpcall.java for generational ZGC (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20902/head:pull/20902` \
`$ git checkout pull/20902`

Update a local copy of the PR: \
`$ git checkout pull/20902` \
`$ git pull https://git.openjdk.org/jdk.git pull/20902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20902`

View PR using the GUI difftool: \
`$ git pr show -t 20902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20902.diff">https://git.openjdk.org/jdk/pull/20902.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20902#issuecomment-2336434137)