### PR TITLE
8340232: Optimize DataInputStream::readUTF

### DIFF
--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -579,17 +579,13 @@ loop:   while (true) {
     public static final String readUTF(DataInput in) throws IOException {
         int utflen = in.readUnsignedShort();
         byte[] bytearr;
-        char[] chararr;
         if (in instanceof DataInputStream dis) {
             if (dis.bytearr.length < utflen) {
                 dis.bytearr = new byte[utflen*2];
-                dis.chararr = new char[utflen*2];
             }
-            chararr = dis.chararr;
             bytearr = dis.bytearr;
         } else {
             bytearr = new byte[utflen];
-            chararr = new char[utflen];
         }
 
         int c, char2, char3;
@@ -600,6 +596,16 @@ loop:   while (true) {
         int ascii = JLA.countPositives(bytearr, 0, utflen);
         if (ascii == utflen) {
             return new String(bytearr, 0, utflen, StandardCharsets.ISO_8859_1);
+        }
+
+        char[] chararr;
+        if (in instanceof DataInputStream dis) {
+            if (dis.chararr.length < (utflen << 1)) {
+                dis.chararr = new char[utflen << 1];
+            }
+            chararr = dis.chararr;
+        } else {
+            chararr = new char[utflen];
         }
 
         if (ascii != 0) {

--- a/src/java.base/share/classes/java/io/DataInputStream.java
+++ b/src/java.base/share/classes/java/io/DataInputStream.java
@@ -584,10 +584,10 @@ loop:   while (true) {
                 bytearr = dis.bytearr;
             }
         }
-        boolean allocate = false;
+        boolean trusted = false;
         if (bytearr == null) {
             bytearr = new byte[utflen];
-            allocate = true;
+            trusted = true;
         }
 
         int c, char2, char3;
@@ -598,15 +598,16 @@ loop:   while (true) {
         int ascii = JLA.countPositives(bytearr, 0, utflen);
         if (ascii == utflen) {
             String str;
-            if (allocate) {
+            if (trusted) {
                 str = JLA.newStringNoRepl(bytearr, StandardCharsets.ISO_8859_1);
             } else {
                 str = new String(bytearr, 0, utflen, StandardCharsets.ISO_8859_1);
             }
             return str;
         }
-        if (allocate && in instanceof DataInputStream dis) {
+        if (trusted && in instanceof DataInputStream dis) {
             dis.bytearr = bytearr;
+            trusted = false;
         }
 
         char[] chararr;


### PR DESCRIPTION
Similar to ObjectInputStream, use JLA.countPositives and JLA.inflateBytesToChars to speed up readUTF

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8340232](https://bugs.openjdk.org/browse/JDK-8340232): Optimize DataInputStream::readUTF (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20903/head:pull/20903` \
`$ git checkout pull/20903`

Update a local copy of the PR: \
`$ git checkout pull/20903` \
`$ git pull https://git.openjdk.org/jdk.git pull/20903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20903`

View PR using the GUI difftool: \
`$ git pr show -t 20903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20903.diff">https://git.openjdk.org/jdk/pull/20903.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20903#issuecomment-2354434062)