### PR TITLE
8339710: Avoid initializing AccessFlag related classes in write-only cases

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
@@ -25,8 +25,10 @@
 
 package jdk.internal.classfile.impl;
 
+import java.lang.constant.ClassDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
+import java.lang.reflect.AccessFlag;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -83,17 +85,38 @@ public final class DirectClassBuilder
     }
 
     @Override
+    public ClassBuilder withFlags(int flags) {
+        setFlags(flags);
+        return this;
+    }
+
+    @Override
+    public ClassBuilder withField(String name,
+                                  ClassDesc descriptor,
+                                  int flags) {
+        return withField(new DirectFieldBuilder(constantPool, context,
+                constantPool.utf8Entry(name), constantPool.utf8Entry(descriptor), flags, null));
+    }
+
+    @Override
+    public ClassBuilder withField(Utf8Entry name,
+                                  Utf8Entry descriptor,
+                                  int flags) {
+        return withField(new DirectFieldBuilder(constantPool, context, name, descriptor, flags, null));
+    }
+
+    @Override
     public ClassBuilder withField(Utf8Entry name,
                                   Utf8Entry descriptor,
                                   Consumer<? super FieldBuilder> handler) {
-        return withField(new DirectFieldBuilder(constantPool, context, name, descriptor, null)
+        return withField(new DirectFieldBuilder(constantPool, context, name, descriptor, 0, null)
                                  .run(handler));
     }
 
     @Override
     public ClassBuilder transformField(FieldModel field, FieldTransform transform) {
         DirectFieldBuilder builder = new DirectFieldBuilder(constantPool, context, field.fieldName(),
-                                                            field.fieldType(), field);
+                                                            field.fieldType(), 0, field);
         builder.transform(field, transform);
         return withField(builder);
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectFieldBuilder.java
@@ -68,6 +68,12 @@ public final class DirectFieldBuilder
         return this;
     }
 
+    @Override
+    public FieldBuilder withFlags(int flags) {
+        setFlags(flags);
+        return this;
+    }
+
     void setFlags(int flags) {
         this.flags = flags;
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectFieldBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectFieldBuilder.java
@@ -44,12 +44,13 @@ public final class DirectFieldBuilder
                               ClassFileImpl context,
                               Utf8Entry name,
                               Utf8Entry type,
+                              int flags,
                               FieldModel original) {
         super(constantPool, context);
         setOriginal(original);
         this.name = name;
         this.desc = type;
-        this.flags = 0;
+        this.flags = flags;
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectMethodBuilder.java
@@ -61,6 +61,12 @@ public final class DirectMethodBuilder
         this.flags = flags;
     }
 
+    @Override
+    public MethodBuilder withFlags(int flags) {
+        setFlags(flags);
+        return this;
+    }
+
     void setFlags(int flags) {
         boolean wasStatic = (this.flags & ClassFile.ACC_STATIC) != 0;
         boolean isStatic = (flags & ClassFile.ACC_STATIC) != 0;


### PR DESCRIPTION
This PR reduces number of classes loaded on a minimal lambda bootstrapping test by 4 by avoiding the need to pull in some AccessFlag classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339710](https://bugs.openjdk.org/browse/JDK-8339710): Avoid initializing AccessFlag related classes in write-only cases (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20904/head:pull/20904` \
`$ git checkout pull/20904`

Update a local copy of the PR: \
`$ git checkout pull/20904` \
`$ git pull https://git.openjdk.org/jdk.git pull/20904/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20904`

View PR using the GUI difftool: \
`$ git pr show -t 20904`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20904.diff">https://git.openjdk.org/jdk/pull/20904.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20904#issuecomment-2336684875)