### PR TITLE
8339711: ZipFile.Source.initCEN needlessly reads END header

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1184,6 +1184,8 @@ public class ZipFile implements ZipConstants, Closeable {
         // "META-INF/".length()
         private static final int META_INF_LEN = 9;
         private static final int[] EMPTY_META_VERSIONS = new int[0];
+        // CEN size is limited to the maximum array size in the JDK
+        private static final int MAX_CEN_SIZE = Integer.MAX_VALUE - 2;
 
         private final Key key;               // the key in files
         private final @Stable ZipCoder zc;   // ZIP coder used to decode/encode
@@ -1191,7 +1193,7 @@ public class ZipFile implements ZipConstants, Closeable {
         private int refs = 1;
 
         private RandomAccessFile zfile;      // zfile of the underlying ZIP file
-        private byte[] cen;                  // CEN & ENDHDR
+        private byte[] cen;                  // CEN
         private long locpos;                 // position of first LOC header (usually 0)
         private byte[] comment;              // ZIP file comment
                                              // list of meta entries in META-INF dir
@@ -1247,7 +1249,7 @@ public class ZipFile implements ZipConstants, Closeable {
             // should not exceed 65,535 bytes per the PKWare APP.NOTE
             // 4.4.10, 4.4.11, & 4.4.12.  Also check that current CEN header will
             // not exceed the length of the CEN array
-            if (headerSize > 0xFFFF || pos + headerSize > cen.length - ENDHDR) {
+            if (headerSize > 0xFFFF || pos + headerSize > cen.length) {
                 zerror("invalid CEN header (bad header size)");
             }
 
@@ -1300,7 +1302,7 @@ public class ZipFile implements ZipConstants, Closeable {
             }
             // CEN Offset where this Extra field ends
             int extraEndOffset = startingOffset + extraFieldLen;
-            if (extraEndOffset > cen.length - ENDHDR) {
+            if (extraEndOffset > cen.length) {
                 zerror("Invalid CEN header (extra data field size too long)");
             }
             int currentOffset = startingOffset;
@@ -1738,12 +1740,12 @@ public class ZipFile implements ZipConstants, Closeable {
                 if (locpos < 0) {
                     zerror("invalid END header (bad central directory offset)");
                 }
-                // read in the CEN and END
-                if (end.cenlen + ENDHDR >= Integer.MAX_VALUE) {
+                // read in the CEN
+                if (end.cenlen > MAX_CEN_SIZE) {
                     zerror("invalid END header (central directory size too large)");
                 }
-                cen = this.cen = new byte[(int)(end.cenlen + ENDHDR)];
-                if (readFullyAt(cen, 0, cen.length, cenpos) != end.cenlen + ENDHDR) {
+                cen = this.cen = new byte[(int)end.cenlen];
+                if (readFullyAt(cen, 0, cen.length, cenpos) != end.cenlen) {
                     zerror("read CEN tables failed");
                 }
                 this.total = end.centot;
@@ -1772,7 +1774,7 @@ public class ZipFile implements ZipConstants, Closeable {
             int idx = 0; // Index into the entries array
             int pos = 0;
             int entryPos = CENHDR;
-            int limit = cen.length - ENDHDR;
+            int limit = cen.length;
             manifestNum = 0;
             while (entryPos <= limit) {
                 if (idx >= entriesLength) {
@@ -1835,7 +1837,7 @@ public class ZipFile implements ZipConstants, Closeable {
             } else {
                 metaVersions = EMPTY_META_VERSIONS;
             }
-            if (pos + ENDHDR != cen.length) {
+            if (pos != cen.length) {
                 zerror("invalid CEN header (bad header size)");
             }
         }

--- a/test/jdk/java/util/zip/ZipFile/EndOfCenValidation.java
+++ b/test/jdk/java/util/zip/ZipFile/EndOfCenValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class EndOfCenValidation {
     private static final int ENDSIZ = ZipFile.ENDSIZ; // Offset of CEN size field within ENDHDR
     private static final int ENDOFF = ZipFile.ENDOFF; // Offset of CEN offset field within ENDHDR
     // Maximum allowed CEN size allowed by ZipFile
-    private static int MAX_CEN_SIZE = Integer.MAX_VALUE - ENDHDR - 1;
+    private static int MAX_CEN_SIZE = Integer.MAX_VALUE - 2;
 
     // Expected message when CEN size does not match file size
     private static final String INVALID_CEN_BAD_SIZE = "invalid END header (bad central directory size)";


### PR DESCRIPTION
Please review this small cleanup PR which updates `ZipFile.Source.initCEN` to not include the 22-byte `END` header when reading the `CEN` section of the ZIP file.

The reading of the END header was probably brought over from native code when this was brought over to Java in JDK 9 where it seems to have be memory mapped together with the CEN section. In the current JDK, the END header is unused. This needlessly complicates any code accessing the array which must account for the trailing END record when calculating the end of CEN position.

Additionally, the current enforcement of the maximum CEN size limit is currently off by one. It allows the construction of a byte array of size `Integer.MAX_VALUE - 1`, but this size is not supported by OpenJDK. Instead, the maximum CEN limit should be such that is does not exceed  `Integer.MAX_VALUE - 2`.

Testing:

The `EndOfCenValidation` test is updated to reject `Integer.MAX_VALUE - 1` as the new minumum rejected CEN size. 