### PR TITLE
8339701: Test TestPinCaseWithCFLH.java fails with -Xcomp

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/TestPinCaseWithCFLH/TestPinCaseWithCFLH.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/TestPinCaseWithCFLH/TestPinCaseWithCFLH.java
@@ -37,9 +37,9 @@ import jdk.test.lib.thread.VThreadPinner;
  * @build jdk.test.lib.Utils
  * @run driver jdk.test.lib.util.JavaAgentBuilder
  *             TestPinCaseWithCFLH TestPinCaseWithCFLH.jar
- * @run main/othervm/timeout=100  -Djdk.virtualThreadScheduler.maxPoolSize=1
+ * @run main/othervm/timeout=100 -Djdk.virtualThreadScheduler.maxPoolSize=1
  *       -Djdk.tracePinnedThreads=full --enable-native-access=ALL-UNNAMED
- *       -javaagent:TestPinCaseWithCFLH.jar TestPinCaseWithCFLH
+ *       -javaagent:TestPinCaseWithCFLH.jar -XX:+BackgroundCompilation TestPinCaseWithCFLH
  */
 public class TestPinCaseWithCFLH {
 


### PR DESCRIPTION
Hi all,
  The newly added testcase `serviceability/jvmti/vthread/TestPinCaseWithCFLH/TestPinCaseWithCFLH.java` fails with `-Xcomp` jvm option. The jvm option `-Xcomp` will make `BackgroundCompilation` false. In this test, disable `BackgroundCompilation` will make `instrumentation` in `premain` throw `java.util.MissingResourceException` in some test  environments. If I add `Thread.sleep(1000)` or `System.gc();` before `instrumentation.addTransformer`, this test also passed with `-Xcomp`.
   So, I think it's necessary add `-XX:+BackgroundCompilation` option for this test to make this test more robustness, to make this test run passed with `-Xcomp` option.
  Test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339701](https://bugs.openjdk.org/browse/JDK-8339701): Test TestPinCaseWithCFLH.java fails with -Xcomp (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20906/head:pull/20906` \
`$ git checkout pull/20906`

Update a local copy of the PR: \
`$ git checkout pull/20906` \
`$ git pull https://git.openjdk.org/jdk.git pull/20906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20906`

View PR using the GUI difftool: \
`$ git pr show -t 20906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20906.diff">https://git.openjdk.org/jdk/pull/20906.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20906#issuecomment-2336729033)
</details>
