### PR TITLE
8339733: C2: some nodes can have incorrect control after do_range_check()

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3154,7 +3154,7 @@ void PhaseIdealLoop::ensure_node_and_inputs_are_above_pre_end(CountedLoopEndNode
     Node* n = wq.at(i);
     assert(is_dominator(compute_early_ctrl(n, get_ctrl(n)), pre_end), "node pinned on loop exit test?");
     set_ctrl(n, control);
-    for (uint j = 0; j < n->req(); ++j) {
+    for (uint j = 0; j < n->req(); j++) {
       Node* in = n->in(j);
       if (in != nullptr && has_ctrl(in) && !is_dominator(get_ctrl(in), pre_end)) {
         wq.push(in);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2920,7 +2920,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
         continue;
       }
 
-      Node *offset_ctrl = get_ctrl(offset);
+      Node* offset_ctrl = get_ctrl(offset);
       if (loop->is_member(get_loop(offset_ctrl))) {
         continue;               // Offset is not really loop invariant
       }

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3135,8 +3135,8 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
   // new main_limit can push Bool/Cmp nodes down (when one of the eliminated condition has parameters that are not loop
   // invariant in the pre loop.
   set_ctrl(opqzm, new_limit_ctrl);
-  set_ctrl(iffm->in(1), new_limit_ctrl);
   set_ctrl(iffm->in(1)->in(1), new_limit_ctrl);
+  set_ctrl(iffm->in(1), new_limit_ctrl);
 }
 
 // Adjust control for node and its inputs (and inputs of its inputs) to be above the pre end

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -3091,8 +3091,8 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
   // new pre_limit can push Bool/Cmp/Opaque nodes down (when one of the eliminated condition has parameters that are not
   // loop invariant in the pre loop.
   set_ctrl(pre_opaq, new_limit_ctrl);
-  set_ctrl(pre_end->in(1), new_limit_ctrl);
   set_ctrl(pre_end->cmp_node(), new_limit_ctrl);
+  set_ctrl(pre_end->in(1), new_limit_ctrl);
 
   _igvn.replace_input_of(pre_opaq, 1, pre_limit);
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2891,7 +2891,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
       Node *limit  = cmp->in(2);
       int scale_con= 1;        // Assume trip counter not scaled
 
-      Node *limit_ctrl = get_ctrl(limit);
+      Node* limit_ctrl = get_ctrl(limit);
       if (loop->is_member(get_loop(limit_ctrl))) {
         // Compare might have operands swapped; commute them
         b_test = b_test.commute();

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1185,6 +1185,7 @@ public:
   Node *dom_lca_internal( Node *n1, Node *n2 ) const;
 
   Node* dominated_node(Node* c1, Node* c2) {
+    assert(is_dominator(c1, c2) || is_dominator(c2, c1), "nodes must be related");
     return is_dominator(c1, c2) ? c2 : c1;
   }
 
@@ -1794,7 +1795,7 @@ public:
 
   void pin_array_access_nodes_dependent_on(Node* ctrl);
 
-  void ensure_node_and_inputs_are_above_pre_end(CountedLoopEndNode* pre_end, Node* node, Node*& control);
+  Node* ensure_node_and_inputs_are_above_pre_end(CountedLoopEndNode* pre_end, Node* node);
 };
 
 

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1184,6 +1184,15 @@ public:
   }
   Node *dom_lca_internal( Node *n1, Node *n2 ) const;
 
+  Node* dominated_node(Node* c1, Node* c2) {
+    return is_dominator(c1, c2) ? c2 : c1;
+  }
+
+  // Return control node that's dominated by the 2 others
+  Node* dominated_node(Node* c1, Node* c2, Node* c3) {
+    return dominated_node(c1, dominated_node(c2, c3));
+  }
+
   // Build and verify the loop tree without modifying the graph.  This
   // is useful to verify that all inputs properly dominate their uses.
   static void verify(PhaseIterGVN& igvn) {
@@ -1784,6 +1793,8 @@ public:
   bool can_move_to_inner_loop(Node* n, LoopNode* n_loop, Node* x);
 
   void pin_array_access_nodes_dependent_on(Node* ctrl);
+
+  void ensure_node_and_inputs_are_above_pre_end(CountedLoopEndNode* pre_end, Node* node, Node*& control);
 };
 
 


### PR DESCRIPTION
PhaseIdealLoop::do_range_check() sets the control of the new pre and
main limits to be the entry control of the pre loop but it eliminates
all conditions whose parameters are invariant in the main loop. Most
of the time they are also invariant in the pre loop but that's not
guaranteed. It does happen sometimes that those parameters are pinned
in the pre loop. In that case, PhaseIdealLoop::do_range_check() sets
wrong controls.

This doesn't cause any issue today AFAICT.

Also, this seems to be a typo in PhaseIdealLoop::insert_pre_post_loops():

```
pre_head->in(0)
```

is `pre_head`. I fixed that one too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339733](https://bugs.openjdk.org/browse/JDK-8339733): C2: some nodes can have incorrect control after do_range_check() (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20908/head:pull/20908` \
`$ git checkout pull/20908`

Update a local copy of the PR: \
`$ git checkout pull/20908` \
`$ git pull https://git.openjdk.org/jdk.git pull/20908/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20908`

View PR using the GUI difftool: \
`$ git pr show -t 20908`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20908.diff">https://git.openjdk.org/jdk/pull/20908.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20908#issuecomment-2337470440)