### PR TITLE
8339714: Delete tedious bool type define

### DIFF
--- a/src/java.base/unix/native/libjsig/jsig.c
+++ b/src/java.base/unix/native/libjsig/jsig.c
@@ -42,14 +42,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#if (__STDC_VERSION__ >= 199901L)
-  #include <stdbool.h>
-#else
-  #define bool int
-  #define true 1
-  #define false 0
-#endif
+#include <stdbool.h>
 
 #define MAX_SIGNALS NSIG
 

--- a/src/utils/hsdis/binutils/hsdis-binutils.c
+++ b/src/utils/hsdis/binutils/hsdis-binutils.c
@@ -61,14 +61,10 @@
 
 #include <bfd.h>
 #include <dis-asm.h>
+#include <stdbool.h>
 
 #include "hsdis.h"
 
-#ifndef bool
-#define bool int
-#define true 1
-#define false 0
-#endif /*bool*/
 
 /* short names for stuff in hsdis.h */
 typedef decode_instructions_event_callback_ftype  event_callback_t;


### PR DESCRIPTION
Hi all,
  This PR delete tedious bool type define in `src/java.base/unix/native/libjsig/jsig.c` and `src/utils/hsdis/binutils/hsdis-binutils.c`. After JEP 347([JDK-8246032](https://bugs.openjdk.org/browse/JDK-8246032)), I think we can "#include <stdbool.h>" to use bool type directly, like [string.h](https://github.com/openjdk/jdk/blob/master/src/java.desktop/unix/native/libpipewire/include/spa/utils/string.h#L13) do.
  Make code more concision, the risk is quite low.

Additional testing:

- [x] Local build with --with-hsdis=binutils --with-binutils=$HOME/software/binutils
- [x] Jtreg tests(include tier1/tier2/tier3 etc.) on linux x64
- [x] Jtreg tests(include tier1/tier2/tier3 etc.) on linux aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339714](https://bugs.openjdk.org/browse/JDK-8339714): Delete tedious bool type define (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20909/head:pull/20909` \
`$ git checkout pull/20909`

Update a local copy of the PR: \
`$ git checkout pull/20909` \
`$ git pull https://git.openjdk.org/jdk.git pull/20909/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20909`

View PR using the GUI difftool: \
`$ git pr show -t 20909`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20909.diff">https://git.openjdk.org/jdk/pull/20909.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20909#issuecomment-2337666734)