### PR TITLE
8339742: Refactor ClassFileImpl to allow loading Option classes lazily

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractDirectBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractDirectBuilder.java
@@ -51,7 +51,7 @@ public class AbstractDirectBuilder<M> {
     }
 
     public void writeAttribute(Attribute<?> a) {
-        if (Util.isAttributeAllowed(a, context.attributesProcessingOption())) {
+        if (Util.isAttributeAllowed(a, context)) {
             attributes.withAttribute(a);
         }
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ClassReaderImpl.java
@@ -82,7 +82,7 @@ public final class ClassReaderImpl
         this.buffer = classfileBytes;
         this.classfileLength = classfileBytes.length;
         this.context = context;
-        this.attributeMapper = this.context.attributeMapperOption().attributeMapper();
+        this.attributeMapper = this.context.attributeMapper();
         if (classfileLength < 4 || readInt(0) != 0xCAFEBABE) {
             throw new IllegalArgumentException("Bad magic number");
         }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/CodeImpl.java
@@ -122,7 +122,7 @@ public final class CodeImpl
         if (!inflated) {
             if (labels == null)
                 labels = new LabelImpl[codeLength + 1];
-            if (classReader.context().lineNumbersOption() == ClassFile.LineNumbersOption.PASS_LINE_NUMBERS)
+            if (classReader.context().passLineNumbers())
                 inflateLineNumbers();
             inflateJumpTargets();
             inflateTypeAnnotations();
@@ -167,7 +167,7 @@ public final class CodeImpl
         inflateMetadata();
         boolean doLineNumbers = (lineNumbers != null);
         generateCatchTargets(consumer);
-        if (classReader.context().debugElementsOption() == ClassFile.DebugElementsOption.PASS_DEBUG)
+        if (classReader.context().passDebugElements())
             generateDebugElements(consumer);
         for (int pos=codeStart; pos<codeEnd; ) {
             if (labels[pos - codeStart] != null)

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -103,7 +103,7 @@ public final class DirectCodeBuilder
             handler.accept(cb = new DirectCodeBuilder(methodInfo, constantPool, context, original, false));
             cb.buildContent();
         } catch (LabelOverflowException loe) {
-            if (context.shortJumpsOption() == ClassFile.ShortJumpsOption.FIX_SHORT_JUMPS) {
+            if (context.fixShortJumps()) {
                 handler.accept(cb = new DirectCodeBuilder(methodInfo, constantPool, context, original, true));
                 cb.buildContent();
             }
@@ -122,7 +122,7 @@ public final class DirectCodeBuilder
         setOriginal(original);
         this.methodInfo = methodInfo;
         this.transformFwdJumps = transformFwdJumps;
-        this.transformBackJumps = context.shortJumpsOption() == ClassFile.ShortJumpsOption.FIX_SHORT_JUMPS;
+        this.transformBackJumps = context.fixShortJumps();
         bytecodesBufWriter = (original instanceof CodeImpl cai) ? new BufWriterImpl(constantPool, context, cai.codeLength())
                 : new BufWriterImpl(constantPool, context);
         this.startLabel = new LabelImpl(this, 0);
@@ -195,7 +195,7 @@ public final class DirectCodeBuilder
             int endPc = labelToBci(h.tryEnd());
             int handlerPc = labelToBci(h.handler());
             if (startPc == -1 || endPc == -1 || handlerPc == -1) {
-                if (context.deadLabelsOption() == ClassFile.DeadLabelsOption.DROP_DEAD_LABELS) {
+                if (context.dropDeadLabels()) {
                     handlersSize--;
                 } else {
                     throw new IllegalArgumentException("Unbound label in exception handler");
@@ -219,7 +219,7 @@ public final class DirectCodeBuilder
         // Backfill branches for which Label didn't have position yet
         processDeferredLabels();
 
-        if (context.debugElementsOption() == ClassFile.DebugElementsOption.PASS_DEBUG) {
+        if (context.passDebugElements()) {
             if (!characterRanges.isEmpty()) {
                 Attribute<?> a = new UnboundAttribute.AdHocAttribute<>(Attributes.characterRangeTable()) {
 
@@ -232,7 +232,7 @@ public final class DirectCodeBuilder
                             var start = labelToBci(cr.startScope());
                             var end = labelToBci(cr.endScope());
                             if (start == -1 || end == -1) {
-                                if (context.deadLabelsOption() == ClassFile.DeadLabelsOption.DROP_DEAD_LABELS) {
+                                if (context.dropDeadLabels()) {
                                     crSize--;
                                 } else {
                                     throw new IllegalArgumentException("Unbound label in character range");
@@ -261,7 +261,7 @@ public final class DirectCodeBuilder
                         b.writeU2(lvSize);
                         for (LocalVariable l : localVariables) {
                             if (!Util.writeLocalVariable(b, l)) {
-                                if (context.deadLabelsOption() == ClassFile.DeadLabelsOption.DROP_DEAD_LABELS) {
+                                if (context.dropDeadLabels()) {
                                     lvSize--;
                                 } else {
                                     throw new IllegalArgumentException("Unbound label in local variable type");
@@ -284,7 +284,7 @@ public final class DirectCodeBuilder
                         b.writeU2(localVariableTypes.size());
                         for (LocalVariableType l : localVariableTypes) {
                             if (!Util.writeLocalVariable(b, l)) {
-                                if (context.deadLabelsOption() == ClassFile.DeadLabelsOption.DROP_DEAD_LABELS) {
+                                if (context.dropDeadLabels()) {
                                     lvtSize--;
                                 } else {
                                     throw new IllegalArgumentException("Unbound label in local variable type");
@@ -357,24 +357,21 @@ public final class DirectCodeBuilder
                 }
 
                 if (codeAndExceptionsMatch(codeLength)) {
-                    switch (context.stackMapsOption()) {
-                        case STACK_MAPS_WHEN_REQUIRED -> {
-                            attributes.withAttribute(original.findAttribute(Attributes.stackMapTable()).orElse(null));
-                            writeCounters(true, buf);
-                        }
-                        case GENERATE_STACK_MAPS ->
-                            generateStackMaps(buf);
-                        case DROP_STACK_MAPS ->
-                            writeCounters(true, buf);
+                    if (context.stackMapsWhenRequired()) {
+                        attributes.withAttribute(original.findAttribute(Attributes.stackMapTable()).orElse(null));
+                        writeCounters(true, buf);
+                    } else if (context.generateStackMaps()) {
+                        generateStackMaps(buf);
+                    } else if (context.dropStackMaps()) {
+                        writeCounters(true, buf);
                     }
                 } else {
-                    switch (context.stackMapsOption()) {
-                        case STACK_MAPS_WHEN_REQUIRED ->
-                            tryGenerateStackMaps(false, buf);
-                        case GENERATE_STACK_MAPS ->
-                            generateStackMaps(buf);
-                        case DROP_STACK_MAPS ->
-                            writeCounters(false, buf);
+                    if (context.stackMapsWhenRequired()) {
+                        tryGenerateStackMaps(false, buf);
+                    } else if (context.generateStackMaps()) {
+                        generateStackMaps(buf);
+                    } else if (context.dropStackMaps()) {
+                        writeCounters(false, buf);
                     }
                 }
 

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -235,9 +235,9 @@ public final class StackMapGenerator {
         this.labelContext = labelContext;
         this.handlers = handlers;
         this.rawHandlers = new ArrayList<>(handlers.size());
-        this.classHierarchy = new ClassHierarchyImpl(context.classHierarchyResolverOption().classHierarchyResolver());
-        this.patchDeadCode = context.deadCodeOption() == ClassFile.DeadCodeOption.PATCH_DEAD_CODE;
-        this.filterDeadLabels = context.deadLabelsOption() == ClassFile.DeadLabelsOption.DROP_DEAD_LABELS;
+        this.classHierarchy = new ClassHierarchyImpl(context.classHierarchyResolver());
+        this.patchDeadCode = context.patchDeadCode();
+        this.filterDeadLabels = context.dropDeadLabels();
         this.currentFrame = new Frame(classHierarchy);
         generate();
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -102,9 +102,9 @@ public class Util {
     private static final int ATTRIBUTE_STABILITY_COUNT = AttributeMapper.AttributeStability.values().length;
 
     public static boolean isAttributeAllowed(final Attribute<?> attr,
-                                             final ClassFile.AttributesProcessingOption processingOption) {
+                                             final ClassFileImpl context) {
         return attr instanceof BoundAttribute
-                ? ATTRIBUTE_STABILITY_COUNT - attr.attributeMapper().stability().ordinal() > processingOption.ordinal()
+                ? ATTRIBUTE_STABILITY_COUNT - attr.attributeMapper().stability().ordinal() > context.attributesProcessingOption().ordinal()
                 : true;
     }
 


### PR DESCRIPTION
Refactor ClassFileImpl so that Option classes are not eagerly loaded.

- Reduces number of classes loaded on various startup tests (typically 15 classes less)
- Reduces size of the default CDS archive by ~30Kb

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339742](https://bugs.openjdk.org/browse/JDK-8339742): Refactor ClassFileImpl to allow loading Option classes lazily (**Sub-task** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20911/head:pull/20911` \
`$ git checkout pull/20911`

Update a local copy of the PR: \
`$ git checkout pull/20911` \
`$ git pull https://git.openjdk.org/jdk.git pull/20911/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20911`

View PR using the GUI difftool: \
`$ git pr show -t 20911`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20911.diff">https://git.openjdk.org/jdk/pull/20911.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20911#issuecomment-2337844912)