### PR TITLE
8339731: java.desktop/share/classes/javax/swing/text/html/default.css typo in margin settings

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/default.css
+++ b/src/java.desktop/share/classes/javax/swing/text/html/default.css
@@ -102,7 +102,7 @@ dd {margin-left-ltr: 40;
     margin-bottom: 0}
 
 dd p {margin-left: 0;
-    margin-rigth: 0;
+    margin-right: 0;
     margin-top: 0;
     margin-bottom: 0}
 


### PR DESCRIPTION
java.desktop/share/classes/javax/swing/text/html/default.css:105: margin-rigth: 0;

seems to be a typo (must be right).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339731](https://bugs.openjdk.org/browse/JDK-8339731): java.desktop/share/classes/javax/swing/text/html/default.css typo in margin settings (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20915/head:pull/20915` \
`$ git checkout pull/20915`

Update a local copy of the PR: \
`$ git checkout pull/20915` \
`$ git pull https://git.openjdk.org/jdk.git pull/20915/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20915`

View PR using the GUI difftool: \
`$ git pr show -t 20915`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20915.diff">https://git.openjdk.org/jdk/pull/20915.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20915#issuecomment-2338147699)