### PR TITLE
8335870: Doclet should default @since of classes with no @since information to that of the enclosing package

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testSinceTag/TestSinceTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSinceTag/TestSinceTag.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug      7180906 8026567 8239804 8324342 8332039
+ * @bug      7180906 8026567 8239804 8324342 8332039 8335870
  * @summary  Test to make sure that the since tag works correctly
  * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -185,6 +185,42 @@ public class TestSinceTag extends JavadocTester {
                     <dl class="notes">
                     <dt>Since:</dt>
                     <dd>99 <a href="C.html" title="class in p"><code>C</code></a></dd>""");
+
+    }
+
+    @Test
+    public void testSinceInfer_Package(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                          /**
+                           * package p
+                           * @since 24
+                           */
+                        package p;
+                         """,
+                         """
+                        package p;
+                        /**
+                         * Class C.
+                         */
+                         public class C {
+                             public class Nested { }
+                         }""");
+        javadoc("-d", base.resolve("api").toString(),
+                "-sourcepath", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+        checkOutput("p/C.html", true,
+                """
+                        <dl class="notes">
+                        <dt>Since:</dt>
+                        <dd>24</dd>""");
+
+        checkOutput("p/C.Nested.html", true,
+                """
+                        <dl class="notes">
+                        <dt>Since:</dt>
+                        <dd>24</dd>""");
 
     }
 }


### PR DESCRIPTION
Please review this change to default the value of `@since` to that of the immediately enclosing package if a class doesn't have the `@since` tag.

For nested classes, you still need to recursively look for the package so I had to add an extra check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8335870](https://bugs.openjdk.org/browse/JDK-8335870): Doclet should default @<!---->since of classes with no @<!---->since information to that of the enclosing package (**Enhancement** - P4)
 * [JDK-8335871](https://bugs.openjdk.org/browse/JDK-8335871): Doclet should default @<!---->since of classes with no @<!---->since information to that of the enclosing package (**CSR**) (Withdrawn)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20918/head:pull/20918` \
`$ git checkout pull/20918`

Update a local copy of the PR: \
`$ git checkout pull/20918` \
`$ git pull https://git.openjdk.org/jdk.git pull/20918/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20918`

View PR using the GUI difftool: \
`$ git pr show -t 20918`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20918.diff">https://git.openjdk.org/jdk/pull/20918.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20918#issuecomment-2338543526)