### PR TITLE
8299419: Thread.sleep(millis) may throw OOME

### DIFF
--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -457,18 +457,19 @@ public class Thread implements Runnable {
      * Called before sleeping to create a jdk.ThreadSleep event.
      */
     private static ThreadSleepEvent beforeSleep(long nanos) {
-        ThreadSleepEvent event = null;
-        if (ThreadSleepEvent.isTurnedOn()) {
-            try {
-                event = new ThreadSleepEvent();
+        try {
+            ThreadSleepEvent event = new ThreadSleepEvent();
+            if (event.isEnabled()) {
                 event.time = nanos;
                 event.begin();
-            } catch (OutOfMemoryError e) {
-                event = null;
+                return event;
             }
+        } catch (OutOfMemoryError e) {
+            // ignore
         }
-        return event;
+        return null;
     }
+
 
     /**
      * Called after sleeping to commit the jdk.ThreadSleep event.

--- a/src/java.base/share/classes/jdk/internal/event/ThreadSleepEvent.java
+++ b/src/java.base/share/classes/jdk/internal/event/ThreadSleepEvent.java
@@ -30,14 +30,5 @@ package jdk.internal.event;
  */
 
 public final class ThreadSleepEvent extends Event {
-    private static final ThreadSleepEvent EVENT = new ThreadSleepEvent();
-
-    /**
-     * Returns {@code true} if event is enabled, {@code false} otherwise.
-     */
-    public static boolean isTurnedOn() {
-        return EVENT.isEnabled();
-    }
-
     public long time;
 }

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.java
@@ -665,7 +665,6 @@ class SleepingThread extends BaseThread {
         // jdk.internal.event.ThreadSleepEvent not accessible
         expectedMethods.add("jdk.internal.event.ThreadSleepEvent.<clinit>");
         expectedMethods.add("jdk.internal.event.ThreadSleepEvent.isEnabled");
-        expectedMethods.add("jdk.internal.event.ThreadSleepEvent.isTurnedOn");
         expectedMethods.add(SleepingThread.class.getName() + ".run");
 
         switch (controller.invocationType) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/SleepingThread.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/SleepingThread.java
@@ -42,7 +42,6 @@ public class SleepingThread extends RecursiveMonitoringThread {
                 "java.lang.Thread.afterSleep",
                 "java.util.concurrent.TimeUnit.toNanos",
                 "jdk.internal.event.ThreadSleepEvent.<clinit>",
-                "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
                 "jdk.internal.event.ThreadSleepEvent.isEnabled",
                 "nsk.monitoring.share.thread.SleepingThread.runInside"
         };

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
@@ -151,7 +151,6 @@ public class strace001 {
                 "java.util.concurrent.TimeUnit.toNanos",
                 "jdk.internal.event.ThreadSleepEvent.<clinit>",
                 "jdk.internal.event.ThreadSleepEvent.<init>",
-                "jdk.internal.event.ThreadSleepEvent.isTurnedOn",
                 "jdk.internal.event.ThreadSleepEvent.isEnabled"
         };
 


### PR DESCRIPTION
This PR applies @AlanBateman's patch from the JBS issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8299419](https://bugs.openjdk.org/browse/JDK-8299419): Thread.sleep(millis) may throw OOME (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20923/head:pull/20923` \
`$ git checkout pull/20923`

Update a local copy of the PR: \
`$ git checkout pull/20923` \
`$ git pull https://git.openjdk.org/jdk.git pull/20923/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20923`

View PR using the GUI difftool: \
`$ git pr show -t 20923`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20923.diff">https://git.openjdk.org/jdk/pull/20923.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20923#issuecomment-2340021464)