### PR TITLE
8338626: ClassLoaderExt::process_jar_manifest() should allow / separator on Windows

### DIFF
--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -213,6 +213,12 @@ void ClassLoaderExt::process_jar_manifest(JavaThread* current, ClassPathEntry* e
     char sep = os::file_separator()[0];
     const char* dir_name = entry->name();
     const char* dir_tail = strrchr(dir_name, sep);
+#ifdef _WINDOWS
+    // On Windows, we also support forward slash as the file separator for Class-Path: attribute.
+    if (dir_tail == nullptr) {
+      dir_tail = strrchr(dir_name, '/');
+    }
+#endif
     int dir_len;
     if (dir_tail == nullptr) {
       dir_len = 0;

--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -214,9 +214,12 @@ void ClassLoaderExt::process_jar_manifest(JavaThread* current, ClassPathEntry* e
     const char* dir_name = entry->name();
     const char* dir_tail = strrchr(dir_name, sep);
 #ifdef _WINDOWS
-    // On Windows, we also support forward slash as the file separator for Class-Path: attribute.
+    // On Windows, we also support forward slash as the file separator when locating entries in the Class-Path: attribute.
+    const char* dir_tail2 = strrchr(dir_name, '/');
     if (dir_tail == nullptr) {
-      dir_tail = strrchr(dir_name, '/');
+      dir_tail = dir_tail2;
+    } else if (dir_tail2 != nullptr && dir_tail2 > dir_tail) {
+      dir_tail = dir_tail2;
     }
 #endif
     int dir_len;

--- a/src/hotspot/share/classfile/classLoaderExt.cpp
+++ b/src/hotspot/share/classfile/classLoaderExt.cpp
@@ -214,7 +214,7 @@ void ClassLoaderExt::process_jar_manifest(JavaThread* current, ClassPathEntry* e
     const char* dir_name = entry->name();
     const char* dir_tail = strrchr(dir_name, sep);
 #ifdef _WINDOWS
-    // On Windows, we also support forward slash as the file separator when locating entries in the Class-Path: attribute.
+    // On Windows, we also support forward slash as the file separator when locating entries in the classpath entry.
     const char* dir_tail2 = strrchr(dir_name, '/');
     if (dir_tail == nullptr) {
       dir_tail = dir_tail2;

--- a/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttr.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttr.java
@@ -84,7 +84,8 @@ public class ClassPathAttr {
             output.shouldMatch("checking shared classpath entry: .*cpattr3.jar");
           });
 
-      // Test handling of forward slash ('/') file separator for Class-Path attribute on Windows.
+      // Test handling of forward slash ('/') file separator when locating entries
+      // in the classpath entry on Windows.
       // Skip the following test when CDS dynamic dump is enabled due to some
       // issue when converting a relative path to real path.
       if (Platform.isWindows() && !CDSTestUtils.DYNAMIC_DUMP) {

--- a/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttr.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/ClassPathAttr.java
@@ -85,7 +85,9 @@ public class ClassPathAttr {
           });
 
       // Test handling of forward slash ('/') file separator for Class-Path attribute on Windows.
-      if (Platform.isWindows()) {
+      // Skip the following test when CDS dynamic dump is enabled due to some
+      // issue when converting a relative path to real path.
+      if (Platform.isWindows() && !CDSTestUtils.DYNAMIC_DUMP) {
           // Test with relative path
           // Find the index to the dir before the jar file.
           int idx = jar1.lastIndexOf(File.separator);
@@ -98,13 +100,13 @@ public class ClassPathAttr {
 
           OutputAnalyzer out = TestCommon.testDump(jarDir, newCp, classlist, "-Xlog:class+path=info");
           if (i == 1) {
-              out.shouldContain("opened: 0/cpattr1.jar"); // first jar on -cp
+              out.shouldMatch("opened:.*cpattr1.jar"); // first jar on -cp
           } else {
               // first jar on -cp with long Class-Path: attribute
-              out.shouldContain("opened: 0/cpattr1_long.jar");
+              out.shouldMatch("opened:.*cpattr1_long.jar");
           }
           // one of the jar in the Class-Path: attribute of cpattr1.jar
-          out.shouldContain("opened: 0/cpattr2.jar");
+          out.shouldMatch("opened:.*cpattr2.jar");
 
           TestCommon.runWithRelativePath(
               jarDir.replace("\\", "/"),
@@ -131,13 +133,13 @@ public class ClassPathAttr {
               newCp = jar1Name + File.pathSeparator + jar4Name;
               out = TestCommon.testDump(jarDir, newCp, classlist, "-Xlog:class+path=info");
               if (i == 1) {
-                  out.shouldContain("opened: scratch\\0/cpattr1.jar"); // first jar on -cp
+                  out.shouldMatch("opened:.*cpattr1.jar"); // first jar on -cp
               } else {
                   // first jar on -cp with long Class-Path: attribute
-                  out.shouldContain("opened: scratch\\0/cpattr1_long.jar");
+                  out.shouldMatch("opened:.*cpattr1_long.jar");
               }
               // one of the jar in the Class-Path: attribute of cpattr1.jar
-              out.shouldContain("opened: scratch\\0/cpattr2.jar");
+              out.shouldMatch("opened:.*cpattr2.jar");
 
               TestCommon.runWithRelativePath(
                   jarDir.replace("\\", "/"),


### PR DESCRIPTION
On Windows, we can use '/' as the file separator in the classpath but not in the `Class-Path:` attribute.
This patch is to enable the use of '/' as the file separator in the `Class-Path:`attribute on Windows.

Passed tiers 1 - 3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338626](https://bugs.openjdk.org/browse/JDK-8338626): ClassLoaderExt::process_jar_manifest() should allow / separator on Windows (**Bug** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**) Review applies to [335a0aae](https://git.openjdk.org/jdk/pull/20924/files/335a0aae6d85873a475bee0bc696ad32ad572788)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20924/head:pull/20924` \
`$ git checkout pull/20924`

Update a local copy of the PR: \
`$ git checkout pull/20924` \
`$ git pull https://git.openjdk.org/jdk.git pull/20924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20924`

View PR using the GUI difftool: \
`$ git pr show -t 20924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20924.diff">https://git.openjdk.org/jdk/pull/20924.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20924#issuecomment-2339067422)