### PR TITLE
8339799: Reduce work done in j.l.invoke bytecode generators

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -158,7 +158,6 @@ import sun.invoke.util.Wrapper;
         implMethodName = implInfo.getName();
         implMethodDesc = methodDesc(implInfo.getMethodType());
         constructorType = factoryType.changeReturnType(Void.TYPE);
-        constructorTypeDesc = methodDesc(constructorType);
         lambdaClassName = lambdaClassName(targetClass);
         lambdaClassEntry = pool.classEntry(ReferenceClassDescImpl.ofValidated(ConstantUtils.concat("L", lambdaClassName, ";")));
         // If the target class invokes a protected method inherited from a
@@ -184,6 +183,7 @@ import sun.invoke.util.Wrapper;
             argNames = EMPTY_STRING_ARRAY;
             argDescs = EMPTY_CLASSDESC_ARRAY;
         }
+        constructorTypeDesc = MethodTypeDescImpl.ofValidated(CD_void, argDescs);
     }
 
     private static String lambdaClassName(Class<?> targetClass) {
@@ -192,7 +192,7 @@ import sun.invoke.util.Wrapper;
             // use the original class name
             name = name.replace('/', '_');
         }
-        return name.replace('.', '/') + "$$Lambda";
+        return name.replace('.', '/').concat("$$Lambda");
     }
 
     /**
@@ -222,7 +222,7 @@ import sun.invoke.util.Wrapper;
                 MethodHandle mh = caller.findConstructor(innerClass, constructorType);
                 if (factoryType.parameterCount() == 0) {
                     // In the case of a non-capturing lambda, we optimize linkage by pre-computing a single instance
-                    Object inst = mh.asType(methodType(Object.class)).invokeExact();
+                    Object inst = mh.invokeBasic();
                     return new ConstantCallSite(MethodHandles.constant(interfaceClass, inst));
                 } else {
                     return new ConstantCallSite(mh.asType(factoryType));

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -98,7 +98,7 @@ import sun.invoke.util.Wrapper;
     private final ClassDesc[] argDescs;              // Type descriptors for the constructor arguments
     private final String lambdaClassName;            // Generated name for the generated class "X$$Lambda$1"
     private final ConstantPoolBuilder pool = ConstantPoolBuilder.of();
-    private final ClassEntry lambdaClassEntry;       // Type descriptor for the generated class "X$$Lambda$1"
+    private final ClassEntry lambdaClassEntry;       // Class entry for the generated class "X$$Lambda$1"
     private final boolean useImplMethodHandle;       // use MethodHandle invocation instead of symbolic bytecode invocation
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -32,6 +32,8 @@ import sun.invoke.util.Wrapper;
 import java.lang.classfile.*;
 import java.lang.classfile.attribute.RuntimeVisibleAnnotationsAttribute;
 import java.lang.classfile.attribute.SourceFileAttribute;
+import java.lang.classfile.constantpool.ClassEntry;
+import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.FieldRefEntry;
 import java.lang.classfile.instruction.SwitchCase;
 import java.lang.constant.ClassDesc;
@@ -93,7 +95,8 @@ class InvokerBytecodeGenerator {
     /** Name of new class */
     private final String name;
     private final String className;
-    private final ClassDesc classDesc;
+    private final ConstantPoolBuilder pool = ConstantPoolBuilder.of();
+    private final ClassEntry classEntry;
 
     private final LambdaForm lambdaForm;
     private final String     invokerName;
@@ -131,7 +134,7 @@ class InvokerBytecodeGenerator {
         this.name = name;
         this.className = CLASS_PREFIX.concat(name);
         validateInternalClassName(name);
-        this.classDesc = ReferenceClassDescImpl.ofValidated(concat("L", className, ";"));
+        this.classEntry = pool.classEntry(ReferenceClassDescImpl.ofValidated(concat("L", className, ";")));
         this.lambdaForm = lambdaForm;
         this.invokerName = invokerName;
         this.invokerType = invokerType;
@@ -212,7 +215,7 @@ class InvokerBytecodeGenerator {
         } else {
             name = "_D_" + classData.size();
         }
-        var field = cfb.constantPool().fieldRefEntry(classDesc, name, desc);
+        var field = pool.fieldRefEntry(classEntry, pool.nameAndTypeEntry(name, desc));
         classData.add(new ClassData(field, arg));
         return field;
     }
@@ -243,7 +246,7 @@ class InvokerBytecodeGenerator {
      */
     private byte[] classFileSetup(Consumer<? super ClassBuilder> config) {
         try {
-            return ClassFile.of().build(classDesc, new Consumer<>() {
+            return ClassFile.of().build(classEntry, pool, new Consumer<>() {
                 @Override
                 public void accept(ClassBuilder clb) {
                     clb.withFlags(ACC_FINAL | ACC_SUPER)
@@ -293,14 +296,14 @@ class InvokerBytecodeGenerator {
      * <clinit> to initialize the static final fields with the live class data
      * LambdaForms can't use condy due to bootstrapping issue.
      */
-    static void clinit(ClassBuilder clb, ClassDesc classDesc, List<ClassData> classData) {
+    static void clinit(ClassBuilder clb, ClassEntry classEntry, List<ClassData> classData) {
         if (classData.isEmpty())
             return;
 
         clb.withMethodBody(CLASS_INIT_NAME, MTD_void, ACC_STATIC, new Consumer<>() {
             @Override
             public void accept(CodeBuilder cob) {
-                cob.loadConstant(classDesc)
+                cob.ldc(classEntry)
                    .invokestatic(CD_MethodHandles, "classData", MTD_Object_Class);
                 int size = classData.size();
                 if (size == 1) {
@@ -534,7 +537,7 @@ class InvokerBytecodeGenerator {
             @Override
             public void accept(ClassBuilder clb) {
                 addMethod(clb, true);
-                clinit(clb, classDesc, classData);
+                clinit(clb, classEntry, classData);
                 bogusMethod(clb, lambdaForm);
             }
         });
@@ -1551,7 +1554,7 @@ class InvokerBytecodeGenerator {
                         });
                     }
                 });
-                clinit(clb, classDesc, classData);
+                clinit(clb, classEntry, classData);
                 bogusMethod(clb, invokerType);
             }
         });
@@ -1627,7 +1630,7 @@ class InvokerBytecodeGenerator {
                         });
                     }
                 });
-                clinit(clb, classDesc, classData);
+                clinit(clb, classEntry, classData);
                 bogusMethod(clb, dstType);
             }
         });


### PR DESCRIPTION
Misc improvements to InnerClassLambdaMetafactory and InvokerBytecodeGenerator:
- Define `ClassEntry` early, use it when profitable (there are some warts in the API where using `ce.name(), ce.type()` in a few places means we drop the link to the `ClassDesc` which will then be re-spun in later - should be revisited)
- Use `mh.invokeBasic()` for zero-arg non-capturing lambda constructor calls(!) 
- Narrow name validation to the name passed in
- We were calling `classDesc` twice per factoryType argument, refactored to reuse `argDescs`. 

Interpreter instrumentation sees 1.5% less bytecode executed on netty startup tests, -2.5% on minimal lambda test. Part of the https://bugs.openjdk.org/browse/JDK-8338542 ClassFile API startup work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339799](https://bugs.openjdk.org/browse/JDK-8339799): Reduce work done in j.l.invoke bytecode generators (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20925/head:pull/20925` \
`$ git checkout pull/20925`

Update a local copy of the PR: \
`$ git checkout pull/20925` \
`$ git pull https://git.openjdk.org/jdk.git pull/20925/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20925`

View PR using the GUI difftool: \
`$ git pr show -t 20925`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20925.diff">https://git.openjdk.org/jdk/pull/20925.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20925#issuecomment-2339296599)