### PR TITLE
8339800: Prefer invokeBasic in BootstrapMethodInvokers

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
+++ b/src/java.base/share/classes/java/lang/invoke/BootstrapMethodInvoker.java
@@ -99,7 +99,7 @@ final class BootstrapMethodInvoker {
                 // with empty constant arguments?
                 if (isStringConcatFactoryBSM(bootstrapMethod.type())) {
                     result = (CallSite)bootstrapMethod
-                            .invokeExact(caller, name, (MethodType)type,
+                            .invokeBasic(caller, name, (MethodType)type,
                                          (String)info, new Object[0]);
                 } else {
                     info = maybeReBox(info);
@@ -131,23 +131,23 @@ final class BootstrapMethodInvoker {
                 MethodType bsmType = bootstrapMethod.type();
                 if (isLambdaMetafactoryIndyBSM(bsmType) && argv.length == 3) {
                     result = (CallSite)bootstrapMethod
-                            .invokeExact(caller, name, (MethodType)type, (MethodType)argv[0],
+                            .invokeBasic(caller, name, (MethodType)type, (MethodType)argv[0],
                                     (MethodHandle)argv[1], (MethodType)argv[2]);
                 } else if (isLambdaMetafactoryCondyBSM(bsmType) && argv.length == 3) {
                     result = bootstrapMethod
-                            .invokeExact(caller, name, (Class<?>)type, (MethodType)argv[0],
+                            .invokeBasic(caller, name, (Class<?>)type, (MethodType)argv[0],
                                     (MethodHandle)argv[1], (MethodType)argv[2]);
                 } else if (isStringConcatFactoryBSM(bsmType) && argv.length >= 1) {
                     String recipe = (String)argv[0];
                     Object[] shiftedArgs = Arrays.copyOfRange(argv, 1, argv.length);
                     maybeReBoxElements(shiftedArgs);
-                    result = (CallSite)bootstrapMethod.invokeExact(caller, name, (MethodType)type, recipe, shiftedArgs);
+                    result = (CallSite)bootstrapMethod.invokeBasic(caller, name, (MethodType)type, recipe, shiftedArgs);
                 } else if (isLambdaMetafactoryAltMetafactoryBSM(bsmType)) {
                     maybeReBoxElements(argv);
-                    result = (CallSite)bootstrapMethod.invokeExact(caller, name, (MethodType)type, argv);
+                    result = (CallSite)bootstrapMethod.invokeBasic(caller, name, (MethodType)type, argv);
                 } else if (isObjectMethodsBootstrapBSM(bsmType)) {
                     MethodHandle[] mhs = Arrays.copyOfRange(argv, 2, argv.length, MethodHandle[].class);
-                    result = bootstrapMethod.invokeExact(caller, name, (TypeDescriptor)type, (Class<?>)argv[0], (String)argv[1], mhs);
+                    result = bootstrapMethod.invokeBasic(caller, name, (TypeDescriptor)type, (Class<?>)argv[0], (String)argv[1], mhs);
                 } else {
                     maybeReBoxElements(argv);
                     if (type instanceof Class<?> c) {


### PR DESCRIPTION
Switching to `invokeBasic` for type-checked invokes in `BootstrapMethodInvokers` instead of `invokeExact` avoids some `MethodHandleNatives.linkMethod` calls during bootstrap. This brings a tiny but measurable once-per-bootstrap method win. Both before and after we lean on the static casts in BootstrapMethodInvokers to sanitize against type mismatches.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339800](https://bugs.openjdk.org/browse/JDK-8339800): Prefer invokeBasic in BootstrapMethodInvokers (**Sub-task** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20926/head:pull/20926` \
`$ git checkout pull/20926`

Update a local copy of the PR: \
`$ git checkout pull/20926` \
`$ git pull https://git.openjdk.org/jdk.git pull/20926/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20926`

View PR using the GUI difftool: \
`$ git pr show -t 20926`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20926.diff">https://git.openjdk.org/jdk/pull/20926.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20926#issuecomment-2339352228)