### PR TITLE
8339801: Add better test failure diagnostics to vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002.java
@@ -127,6 +127,7 @@ public class thrstartreq002 extends JDIBase {
             log2("debuggee launched");
         } catch ( Exception e ) {
             log3("ERROR: Exception : " + e);
+            e.printStackTrace(System.out);
             log2("       test cancelled");
             return FAILED;
         }
@@ -170,6 +171,7 @@ public class thrstartreq002 extends JDIBase {
                           vm.exit(PASS_BASE);
                       } catch ( Exception e ) {
                           log3("ERROR: Exception : " + e);
+                          e.printStackTrace(System.out);
                       }
                       break;
 
@@ -183,6 +185,7 @@ public class thrstartreq002 extends JDIBase {
                           }
                       } catch ( Exception e ) {
                           log3("ERROR: Exception : " + e);
+                          e.printStackTrace(System.out);
                       }
                       break;
             }
@@ -211,9 +214,11 @@ public class thrstartreq002 extends JDIBase {
             return 1;
         } catch ( VMDisconnectedException e ) {
             log3("ERROR: VMDisconnectedException : " + e);
+            e.printStackTrace(System.out);
             return 2;
         } catch ( Exception e ) {
             log3("ERROR: Exception : " + e);
+            e.printStackTrace(System.out);
             return 1;
         }
 


### PR DESCRIPTION
This test fails periodically. It only prints the exception message when it fails. It should print the entire stack trace so we have a better idea of why it is failing.

Testing: This test is not run until tier5 CI testing, so I'm running all tier5 svc tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339801](https://bugs.openjdk.org/browse/JDK-8339801): Add better test failure diagnostics to vmTestbase/nsk/jdi/EventRequestManager/threadStartRequests/thrstartreq002 (**Sub-task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20927/head:pull/20927` \
`$ git checkout pull/20927`

Update a local copy of the PR: \
`$ git checkout pull/20927` \
`$ git pull https://git.openjdk.org/jdk.git pull/20927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20927`

View PR using the GUI difftool: \
`$ git pr show -t 20927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20927.diff">https://git.openjdk.org/jdk/pull/20927.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20927#issuecomment-2339385139)