### PR TITLE
8339332: Clean up the java launcher code

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -87,10 +87,6 @@ struct NSAppArgs {
  * The vm selection options are not passed to the running
  * virtual machine; they must be screened out by the launcher.
  *
- * The version specification (if any) is processed first by the
- * platform independent routine SelectVersion.  This may result in
- * the exec of the specified launcher version.
- *
  * Now, in most cases,the launcher will dlopen the target libjvm.so. All
  * required libraries are loaded by the runtime linker, using the known paths
  * baked into the shared libraries at compile time. Therefore,

--- a/src/java.base/share/classes/jdk/internal/misc/MethodFinder.java
+++ b/src/java.base/share/classes/jdk/internal/misc/MethodFinder.java
@@ -98,7 +98,11 @@ public class MethodFinder {
         if (Modifier.isAbstract(mods) ||
                 mainMethod.getReturnType() != void.class ||
                 (isPreview && Modifier.isPrivate(mods)) ||
-                (!isPreview && !Modifier.isStatic(mods))) {
+                (!isPreview &&
+                        (!Modifier.isStatic(mods)
+                                || !Modifier.isPublic(mods)
+                                || mainMethod.getParameterCount() != 1)
+                )) {
             return null;
         }
 

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -239,7 +239,6 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
 {
     int mode = LM_UNKNOWN;
     char *what = NULL;
-    char *main_class = NULL;
     int ret;
     InvocationFunctions ifn;
     jlong start = 0, end = 0;

--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -51,23 +51,20 @@
 #define CURRENT_DATA_MODEL (CHAR_BIT * sizeof(void*))
 
 /*
- * The following environment variable is used to influence the behavior
- * of the jre exec'd through the SelectVersion routine.  The command line
- * options which specify the version are not passed to the exec'd version,
- * because that jre may be an older version which wouldn't recognize them.
- * This environment variable is known to this (and later) version and serves
- * to suppress the version selection code.  This is not only for efficiency,
- * but also for correctness, since any command line options have been
- * removed which would cause any value found in the manifest to be used.
- * This would be incorrect because the command line options are defined
- * to take precedence.
- *
- * The value associated with this environment variable is the MainClass
- * name from within the executable jar file (if any). This is strictly a
- * performance enhancement to avoid re-reading the jar file manifest.
- *
+ * Older versions of java launcher used to support JRE version selection.
+ * Specifically, the java launcher in JDK 1.8 can be used to launch a java
+ * application using a different java runtime (older, newer or same version JRE
+ * installed at a different location) than the one the launcher belongs to. That support
+ * was discontinued starting Java 9.
+ * However, java launcher in JDK 1.8 can still be launched with JRE version selection
+ * options to launch higher versioned java runtimes, including the current
+ * JDK version. When it does that, this environment variable is set by
+ * the Java 1.8 launcher. The value of this environment variable is the Main-Class name from
+ * within the executable jar file (if any).
+ * The java launcher in the current version of the JDK doesn't use this environment variable
+ * in any way other than merely using it for debug logging.
  */
-#define ENV_ENTRY "_JAVA_VERSION_SET"
+#define MAIN_CLASS_ENV_ENTRY "_JAVA_VERSION_SET"
 
 #define SPLASH_FILE_ENV_ENTRY "_JAVA_SPLASH_FILE"
 #define SPLASH_JAR_ENV_ENTRY "_JAVA_SPLASH_JAR"

--- a/src/java.base/share/native/libjli/manifest_info.h
+++ b/src/java.base/share/native/libjli/manifest_info.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -161,32 +161,13 @@ typedef struct zentry { /* Zip file entry */
 } zentry;
 
 /*
- * Information returned from the Manifest file by the ParseManifest() routine.
- * Certainly (much) more could be returned, but this is the information
- * currently of interest to the C based Java utilities (particularly the
- * Java launcher).
- */
-typedef struct manifest_info {  /* Interesting fields from the Manifest */
-    char        *manifest_version;      /* Manifest-Version string */
-    char        *main_class;            /* Main-Class entry */
-    char        *jre_version;           /* Appropriate J2SE release spec */
-    char        jre_restrict_search;    /* Restricted JRE search */
-    char        *splashscreen_image_file_name; /* splashscreen image file */
-} manifest_info;
-
-/*
  * Attribute closure to provide to manifest_iterate.
  */
 typedef void (*attribute_closure)(const char *name, const char *value,
         void *user_data);
 
-/*
- * Function prototypes.
- */
-int     JLI_ParseManifest(char *jarfile, manifest_info *info);
 void    *JLI_JarUnpackFile(const char *jarfile, const char *filename,
                 int *size);
-void    JLI_FreeManifest(void);
 
 JNIEXPORT int JNICALL
 JLI_ManifestIterate(const char *jarfile, attribute_closure ac,

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -713,14 +713,13 @@ JVMInit(InvocationFunctions* ifn, jlong threadStackSize,
         int argc, char **argv,
         int mode, char *what, int ret)
 {
-    ShowSplashScreen();
     return ContinueInNewThread(ifn, threadStackSize, argc, argv, mode, what, ret);
 }
 
 void
 PostJVMInit(JNIEnv *env, jclass mainClass, JavaVM *vm)
 {
-    // stubbed out for windows and *nixes.
+    ShowSplashScreen();
 }
 
 void

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -60,10 +60,6 @@
  * The vm selection options are not passed to the running
  * virtual machine; they must be screened out by the launcher.
  *
- * The version specification (if any) is processed first by the
- * platform independent routine SelectVersion.  This may result in
- * the exec of the specified launcher version.
- *
  * Previously the launcher modified the LD_LIBRARY_PATH appropriately for the
  * desired data model path, regardless if data models matched or not. The
  * launcher subsequently exec'ed the desired executable, in order to make the

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -918,14 +918,13 @@ JVMInit(InvocationFunctions* ifn, jlong threadStackSize,
         int argc, char **argv,
         int mode, char *what, int ret)
 {
-    ShowSplashScreen();
     return ContinueInNewThread(ifn, threadStackSize, argc, argv, mode, what, ret);
 }
 
 void
 PostJVMInit(JNIEnv *env, jclass mainClass, JavaVM *vm)
 {
-    // stubbed out for windows and *nixes.
+    ShowSplashScreen();
 }
 
 void

--- a/test/jdk/tools/launcher/MultipleJRERemoved.java
+++ b/test/jdk/tools/launcher/MultipleJRERemoved.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,8 +112,18 @@ public class MultipleJRERemoved extends TestHelper {
         TestResult tr = doExec(cmd.toArray(new String[cmd.size()]));
         tr.checkNegative();
         tr.isNotZeroOutput();
-        errorMessages.forEach(tr::contains);
-
+        boolean foundAnyExpectedErrMsgs = false;
+        for (String errMsg : errorMessages) {
+            if (tr.contains(errMsg)) {
+                foundAnyExpectedErrMsgs = true;
+                break;
+            }
+        }
+        if (!foundAnyExpectedErrMsgs) {
+            errorMessages.forEach((errMsg) -> {
+                tr.appendError("string <" + errMsg + "> not found");
+            });
+        }
         if (!tr.testStatus) {
             System.out.println(tr);
             throw new RuntimeException("test case: failed\n" + cmd);

--- a/test/jdk/tools/launcher/Zip64ExecutableJarTest.java
+++ b/test/jdk/tools/launcher/Zip64ExecutableJarTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.FileOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.jar.Attributes;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+import java.util.jar.Manifest;
+import java.util.zip.CRC32;
+
+import jdk.test.lib.compiler.CompilerUtils;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+import org.junit.jupiter.api.Test;
+import static java.util.zip.ZipEntry.STORED;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/*
+ * @test
+ * @bug 8328995
+ * @summary verifies that java -jar can launch a zip64 jar file
+ * @library /test/lib
+ * @build jdk.test.lib.process.ProcessTools jdk.test.lib.compiler.CompilerUtils
+ * @run junit Zip64ExecutableJarTest
+ */
+public class Zip64ExecutableJarTest {
+    // size in bytes to trigger representing ZIP entries as ZIP64 in the CEN
+    private static final long ZIP64_SIZE_MAGICVAL = 0xFFFFFFFFL;
+    private static final Path SCRATCH_DIR = Path.of(".");
+    private static final String MAIN_CLASS = "foo.Bar";
+    private static final String MAIN_CLASS_CONTENT = """
+            package foo;
+            public class Bar {
+                public static void main(final String[] args) throws Exception {
+                    System.out.println("hello world from " + Bar.class.getName());
+                }
+            }
+            """;
+
+    /*
+     * Creates a ZIP64 executable JAR file and verifies that "java -jar" against
+     * that file correctly launches the application class.
+     */
+    @Test
+    public void testLaunchZip64() throws Exception {
+        final Path mainClassFile = compileMainClass();
+        final Path zip64JarFile = createZip64Jar(mainClassFile);
+        System.out.println("created zip64 jar at " + zip64JarFile);
+        // java -jar <jar>
+        final OutputAnalyzer oa = ProcessTools.executeTestJava("-jar",
+                zip64JarFile.toAbsolutePath().toString());
+        oa.shouldHaveExitValue(0);
+        oa.shouldContain("hello world from " + MAIN_CLASS);
+    }
+
+    /*
+     * Compile the application class that will be packaged into the JAR file.
+     */
+    private static Path compileMainClass() throws Exception {
+        // create foo/Bar.java
+        final Path javaSrcDir = Files.createTempDirectory(SCRATCH_DIR, "8328995-java-src-");
+        final Path javaSrcFile = javaSrcDir.resolve("foo").resolve("Bar.java");
+        Files.createDirectories(javaSrcFile.getParent());
+        Files.writeString(javaSrcFile, MAIN_CLASS_CONTENT);
+        // compile foo/Bar.java into a classes dir
+        final Path classesDir = Files.createTempDirectory(SCRATCH_DIR, "8328995-classes-");
+        final boolean compiled = CompilerUtils.compile(javaSrcFile, classesDir);
+        assertTrue(compiled, "failed to compile " + javaSrcFile);
+        final Path mainClassFile = classesDir.resolve("foo").resolve("Bar.class");
+        assertTrue(Files.isRegularFile(mainClassFile), "missing compiled class file at "
+                + mainClassFile);
+        return mainClassFile;
+    }
+
+    /*
+     * Create the ZIP64 JAR file
+     */
+    private static Path createZip64Jar(final Path mainClassFile) throws Exception {
+        final Path jarFile = Files.createTempFile(SCRATCH_DIR, "8328995-", ".jar");
+        try (final SparseOutputStream sos =
+                     new SparseOutputStream(new FileOutputStream(jarFile.toFile()));
+             final JarOutputStream jaros = new JarOutputStream(sos)) {
+            // aad an entry with a large size so that ZipOutputStream
+            // creates ZIP64 data while writing the CEN
+            forceCreateLargeZip64Entry(jaros);
+            // now that the large entry has been written as sparse holes, we now
+            // switch to writing the actual bytes for the rest of the entries
+            sos.sparse = false;
+            // add the main class
+            final JarEntry mainClassEntry = new JarEntry(MAIN_CLASS.replace('.', '/') + ".class");
+            jaros.putNextEntry(mainClassEntry);
+            jaros.write(Files.readAllBytes(mainClassFile));
+            jaros.closeEntry();
+            // finally add the META-INF/MANIFEST.MF
+            final Manifest manifest = new Manifest();
+            final Attributes mainAttributes = manifest.getMainAttributes();
+            mainAttributes.putValue("Manifest-Version", "1.0");
+            mainAttributes.putValue("Main-Class", MAIN_CLASS);
+            final JarEntry manifestEntry = new JarEntry("META-INF/MANIFEST.MF");
+            jaros.putNextEntry(manifestEntry);
+            manifest.write(jaros);
+            jaros.closeEntry();
+        }
+        return jarFile;
+    }
+
+    private static void forceCreateLargeZip64Entry(final JarOutputStream jaros) throws IOException {
+        final JarEntry entry = new JarEntry("entry-1");
+        entry.setMethod(STORED); // no need to deflate, we want the entry to be large sized
+        entry.setSize(ZIP64_SIZE_MAGICVAL);
+        // start with a dummy value, we will update it once the entry content is written
+        entry.setCrc(0);
+        jaros.putNextEntry(entry);
+        long numWritten = 0;
+        final byte[] entryContent = new byte[102400];
+        final CRC32 crc = new CRC32();
+        // keep writing the entry content till we reach the
+        // desired size that represents a zip64 entry
+        while (numWritten < ZIP64_SIZE_MAGICVAL) {
+            final long remaining = ZIP64_SIZE_MAGICVAL - numWritten;
+            final int len = remaining < entryContent.length
+                    ? (int) remaining
+                    : entryContent.length;
+            jaros.write(entryContent, 0, len);
+            numWritten += len;
+            crc.update(entryContent, 0, len);
+        }
+        entry.setCrc(crc.getValue()); // update the CRC in the entry
+        jaros.closeEntry();
+    }
+
+    /*
+     * An OutputStream which writes holes through its write() methods, until it is
+     * instructed to write the actual bytes. This implementation allows us to create large
+     * ZIP files without actually consuming large disk space.
+     * Instances of this class should be passed directly to the ZipOutputStream/JarOutputStream
+     * constructor, without any buffering, to allow for the implementation to correctly keep
+     * track of when to and when not to write holes.
+     */
+    private static class SparseOutputStream extends FilterOutputStream {
+        private final FileChannel channel;
+        private boolean sparse = true; // if true then contents will be written as sparse holes
+        private long position;
+
+        public SparseOutputStream(FileOutputStream fos) {
+            super(fos);
+            this.channel = fos.getChannel();
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            position += len;
+            if (sparse) {
+                channel.position(position);
+            } else {
+                // regular write
+                out.write(b, off, len);
+            }
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            position++;
+            if (sparse) {
+                channel.position(position);
+            } else {
+                // regular write
+                out.write(b);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can I please get a review of this change which cleans up the code in the `java` launcher? The original motivation for the change was to prevent the `java` launcher's C code from parsing a jar's manifest when launching an application through `java -jar foo.jar`. The jar parsing code in C currently doesn't have the same level of robustness and features as what's available in the Java side implementation of `Zip/JarFile` API in `java.util.zip`. Among them, one is the lack of ZIP64 support in the launcher's jar parsing code. That issue was noticed in https://bugs.openjdk.org/browse/JDK-8328995 and a PR (https://github.com/openjdk/jdk/pull/18479) was proposed to enhance this C code in the launcher to support ZIP64 jar files. Even before the proposed changes in that PR, there already were a few concerns about long term maintainability of the jar parsing code in the launcher given that it duplicates what we already do in the Java side implementation, so adding new C code here isn't preferable.

The change in this current PR removes the part where the launcher's C code was parsing the jar's manifest file to identify "Main-Class" and "SplashScreen-Image" attributes from the manifest of the jar that was being launched. This was being done in the C code to support a long outdated "JRE selection" feature (mJRE https://bugs.openjdk.org/browse/JDK-8058407) which required it to parse the jar's manifest. After that feature was removed, the sole reason the jar's manifest was continued to be parsed in this launcher code was for convenience.

With the changes proposed in this PR, the launcher will use the jar parsing C code only if the jar has a "SplashScreen-Image" in its manifest. The number of such jars, based on an experiment against a large corpus of jar files, is very minimal (we found just 26 jars in around 900K odd jar files with a "SplashScreen-Image"). The updated code in this PR also delegates the identification of the "SplashScreen-Image" attribute to the java code (in `LauncherHelper`) thus removing the need to parse the manifest in C code. The only time the C code will now do the jar parsing is to display a splash screen image (if any is present) from the jar file. I think even that can be avoided, but I haven't experimented with it and I would like to pursue that separately in future, instead of this PR.

Finally, a few of the utility functions that were introduced in the launcher C code in a recent JEP to support "Implicitly Declared Classes and Instance Main Methods" have been instead moved into the Java code (in `LauncherHelper`) to simplify the launcher.

With these changes, tier testing of tier1 through tier8 has passed without issues. A new jtreg test has been added in this PR which reproduces the issue noted in https://bugs.openjdk.org/browse/JDK-8328995 and verifies the fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8339332](https://bugs.openjdk.org/browse/JDK-8339332): Clean up the java launcher code (**Bug** - P4)
 * [JDK-8328995](https://bugs.openjdk.org/browse/JDK-8328995): Launcher can't open jar files where the offset of the manifest is &gt;4GB (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20929/head:pull/20929` \
`$ git checkout pull/20929`

Update a local copy of the PR: \
`$ git checkout pull/20929` \
`$ git pull https://git.openjdk.org/jdk.git pull/20929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20929`

View PR using the GUI difftool: \
`$ git pr show -t 20929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20929.diff">https://git.openjdk.org/jdk/pull/20929.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20929#issuecomment-2345307344)