### PR TITLE
8339834: Replace usages of -mx and -ms in some tests

### DIFF
--- a/src/java.base/share/classes/sun/security/util/Cache.java
+++ b/src/java.base/share/classes/sun/security/util/Cache.java
@@ -59,7 +59,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * However, note that because of the way SoftReferences are implemented in
  * HotSpot at the moment, this may not work perfectly as it clears them fairly
  * eagerly. Performance may be improved if the Java heap size is set to larger
- * value using e.g. java -ms64M -mx128M foo.Test
+ * value using e.g. java -Xms64M -Xmx128M foo.Test
  *
  * Cache sizing: the memory cache is implemented on top of a LinkedHashMap.
  * In its current implementation, the number of buckets (NOT entries) in

--- a/test/hotspot/jtreg/resourcehogs/compiler/intrinsics/string/TestStringIntrinsics2LargeArray.java
+++ b/test/hotspot/jtreg/resourcehogs/compiler/intrinsics/string/TestStringIntrinsics2LargeArray.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -35,7 +35,7 @@
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  *
  * @run main/othervm
- *        -mx8G
+ *        -Xmx8G
  *        -Xbootclasspath/a:.
  *        -Xmixed
  *        -XX:+UnlockDiagnosticVMOptions

--- a/test/jdk/java/beans/Introspector/8159696/UnloadClassBeanInfo.java
+++ b/test/jdk/java/beans/Introspector/8159696/UnloadClassBeanInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@ import java.util.Arrays;
  * @bug 8159696
  * @library /javax/swing/regtesthelpers
  * @compile ./stub/Stub.java
- * @run main/othervm -mx32M UnloadClassBeanInfo
+ * @run main/othervm -Xmx32M UnloadClassBeanInfo
  */
 public class UnloadClassBeanInfo {
 

--- a/test/jdk/java/beans/Introspector/Test5102804.java
+++ b/test/jdk/java/beans/Introspector/Test5102804.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 5102804
  * @summary Tests memory leak
  * @author Sergey Malenkov
- * @run main/othervm -ms16m -mx16m Test5102804
+ * @run main/othervm -Xms16m -Xmx16m Test5102804
  */
 
 import java.beans.BeanInfo;

--- a/test/jdk/java/beans/Introspector/Test5102804.java
+++ b/test/jdk/java/beans/Introspector/Test5102804.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 5102804
  * @summary Tests memory leak
- * @author Sergey Malenkov
  * @run main/othervm -Xms16m -Xmx16m Test5102804
  */
 

--- a/test/jdk/java/beans/Introspector/Test8027905.java
+++ b/test/jdk/java/beans/Introspector/Test8027905.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@ import java.beans.PropertyDescriptor;
  * @bug 8027905
  * @summary Tests that GC does not affect a property type
  * @author Sergey Malenkov
- * @run main/othervm -mx16m Test8027905
+ * @run main/othervm -Xmx16m Test8027905
  */
 
 public class Test8027905 {

--- a/test/jdk/java/beans/Introspector/Test8027905.java
+++ b/test/jdk/java/beans/Introspector/Test8027905.java
@@ -27,7 +27,6 @@ import java.beans.PropertyDescriptor;
  * @test
  * @bug 8027905
  * @summary Tests that GC does not affect a property type
- * @author Sergey Malenkov
  * @run main/othervm -Xmx16m Test8027905
  */
 

--- a/test/jdk/java/beans/XMLEncoder/Test4646747.java
+++ b/test/jdk/java/beans/XMLEncoder/Test4646747.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @bug 4646747
  * @summary Tests that persistence delegate is correct after memory stress
  * @author Mark Davidson
- * @run main/othervm -ms16m -mx16m Test4646747
+ * @run main/othervm -Xms16m -Xmx16m Test4646747
  */
 
 import java.beans.DefaultPersistenceDelegate;

--- a/test/jdk/java/beans/XMLEncoder/Test4646747.java
+++ b/test/jdk/java/beans/XMLEncoder/Test4646747.java
@@ -25,7 +25,6 @@
  * @test
  * @bug 4646747
  * @summary Tests that persistence delegate is correct after memory stress
- * @author Mark Davidson
  * @run main/othervm -Xms16m -Xmx16m Test4646747
  */
 

--- a/test/jdk/java/lang/ref/SoftReference/Pin.java
+++ b/test/jdk/java/lang/ref/SoftReference/Pin.java
@@ -25,8 +25,6 @@
  * @bug 4076287
  * @summary Invoking get on a SoftReference shouldn't pin the referent
  * @run main/othervm -Xms16m -Xmx16m Pin
- * @author Peter Jones
- * @author Mark Reinhold
  */
 
 

--- a/test/jdk/java/lang/ref/SoftReference/Pin.java
+++ b/test/jdk/java/lang/ref/SoftReference/Pin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,7 @@
 /* @test
  * @bug 4076287
  * @summary Invoking get on a SoftReference shouldn't pin the referent
- * @run main/othervm -ms16m -mx16m Pin
+ * @run main/othervm -Xms16m -Xmx16m Pin
  * @author Peter Jones
  * @author Mark Reinhold
  */

--- a/test/jdk/java/nio/Buffer/Chew.java
+++ b/test/jdk/java/nio/Buffer/Chew.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @summary Ensure that direct memory can be unreserved
  *          as the reserving thread sleeps
  *
- * @run main/othervm -mx16M Chew
+ * @run main/othervm -Xmx16M Chew
  */
 
 import java.nio.*;

--- a/test/jdk/tools/jimage/JImageToolTest.java
+++ b/test/jdk/tools/jimage/JImageToolTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import jdk.test.lib.process.ProcessTools;
 public class JImageToolTest {
     private static void jimage(String... jimageArgs) throws Exception {
         ArrayList<String> args = new ArrayList<>();
-        args.add("-ms64m");
+        args.add("-Xms64m");
         args.add("jdk.tools.jimage.Main");
         args.addAll(Arrays.asList(jimageArgs));
 


### PR DESCRIPTION
Can I please get a review of this trivial change which replaces the usages of `-mx` and `-ms` to `-Xmx` and `-Xms` in tests and in one code comment?

As noted in https://bugs.openjdk.org/browse/JDK-8339834, these options are outdated and support for them will soon be deprecated and removed as part of https://bugs.openjdk.org/browse/JDK-8286851.

There are some more tests remaining in client-libs area which too require a similar change. I'll be creating a separate JBS issue and PR for that.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339834](https://bugs.openjdk.org/browse/JDK-8339834): Replace usages of -mx and -ms in some tests (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [8214fdb5](https://git.openjdk.org/jdk/pull/20930/files/8214fdb52eef14255b200f7a8fb419973c6070eb)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20930/head:pull/20930` \
`$ git checkout pull/20930`

Update a local copy of the PR: \
`$ git checkout pull/20930` \
`$ git pull https://git.openjdk.org/jdk.git pull/20930/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20930`

View PR using the GUI difftool: \
`$ git pr show -t 20930`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20930.diff">https://git.openjdk.org/jdk/pull/20930.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20930#issuecomment-2340196239)