### PR TITLE
8339835: Replace usages of -mx and -ms in some client-libs tests

### DIFF
--- a/test/jdk/java/awt/Window/OwnedWindowsLeak/OwnedWindowsLeak.java
+++ b/test/jdk/java/awt/Window/OwnedWindowsLeak/OwnedWindowsLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
   @summary Tests that windows are removed from owner's child windows list
   @modules java.desktop/java.awt:open
   @author art: area=awt.toplevel
-  @run main/othervm -mx128m OwnedWindowsLeak
+  @run main/othervm -Xmx128m OwnedWindowsLeak
 */
 
 import java.awt.Frame;

--- a/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
+++ b/test/jdk/javax/print/PrintServiceLookup/FlushCustomClassLoader.java
@@ -36,7 +36,7 @@ import javax.print.PrintServiceLookup;
  * @summary Tests custom class loader cleanup
  * @library /javax/swing/regtesthelpers
  * @build Util
- * @run main/timeout=60/othervm -mx32m FlushCustomClassLoader
+ * @run main/timeout=60/othervm -Xmx32m FlushCustomClassLoader
  */
 public final class FlushCustomClassLoader {
 

--- a/test/jdk/javax/sound/sampled/Clip/AudioContentHandlers.java
+++ b/test/jdk/javax/sound/sampled/Clip/AudioContentHandlers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,7 @@ import static javax.sound.sampled.AudioFileFormat.Type.WAVE;
  * @test
  * @bug 8204454
  * @summary URL.getContent() should return AudioClip for supported formats
- * @run main/othervm -mx128m AudioContentHandlers
+ * @run main/othervm -Xmx128m AudioContentHandlers
  */
 public final class AudioContentHandlers {
 

--- a/test/jdk/javax/swing/JFileChooser/6396844/TwentyThousandTest.java
+++ b/test/jdk/javax/swing/JFileChooser/6396844/TwentyThousandTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,7 +30,7 @@
  * @library ../../regtesthelpers
  * @modules java.desktop/sun.java2d
  * @build Util
- * @run main/othervm/timeout=1000 -mx128m TwentyThousandTest
+ * @run main/othervm/timeout=1000 -Xmx128m TwentyThousandTest
  */
 
 import sun.java2d.Disposer;

--- a/test/jdk/javax/swing/JOptionPane/6464022/bug6464022.java
+++ b/test/jdk/javax/swing/JOptionPane/6464022/bug6464022.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  * @author Pavel Porvatov
  * @library ../../regtesthelpers
  * @build Util
- * @run main/othervm -mx128m bug6464022
+ * @run main/othervm -Xmx128m bug6464022
  */
 
 import javax.swing.*;

--- a/test/jdk/javax/swing/UIDefaults/6795356/bug6795356.java
+++ b/test/jdk/javax/swing/UIDefaults/6795356/bug6795356.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
  * @author Alexander Potochkin
  * @library ../../regtesthelpers
  * @build Util
- * @run main/othervm -mx128m bug6795356
+ * @run main/othervm -Xmx128m bug6795356
  */
 
 import java.lang.ref.WeakReference;

--- a/test/jdk/javax/swing/border/TestTitledBorderLeak.java
+++ b/test/jdk/javax/swing/border/TestTitledBorderLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import javax.swing.border.TitledBorder;
  * @summary Verifies TitledBorder's memory leak
  * @library /javax/swing/regtesthelpers
  * @build Util
- * @run main/timeout=60/othervm -mx32m TestTitledBorderLeak
+ * @run main/timeout=60/othervm -Xmx32m TestTitledBorderLeak
  */
 public final class TestTitledBorderLeak {
 

--- a/test/jdk/javax/swing/regtesthelpers/Util.java
+++ b/test/jdk/javax/swing/regtesthelpers/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,7 +82,7 @@ public class Util {
     /**
      * Fills the heap until OutOfMemoryError occurs. This method is useful for
      * WeakReferences removing. To minimize the amount of filled memory the
-     * test should provide reasonable heap size via -mx option.
+     * test should provide reasonable heap size via -Xmx option.
      */
     public static void generateOOME() {
         List<Object> bigLeak = new LinkedList<Object>();

--- a/test/jdk/sun/java2d/Disposer/TestDisposerLeak.java
+++ b/test/jdk/sun/java2d/Disposer/TestDisposerLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import sun.java2d.DisposerRecord;
  * @test
  * @bug 8129457
  * @summary Check Disposer disposes all objects without any memory leaks
- * @run main/othervm -mx128m TestDisposerLeak
+ * @run main/othervm -Xmx128m TestDisposerLeak
  * @modules java.desktop/sun.java2d
  */
 public final class TestDisposerLeak {

--- a/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
+++ b/test/jdk/sun/java2d/Disposer/TestDisposerRace.java
@@ -33,7 +33,7 @@ import sun.java2d.DisposerRecord;
  * @test
  * @bug 8289208
  * @summary Verifies Disposer robustness in a multi-threaded environment.
- * @run main/othervm -mx128m TestDisposerRace
+ * @run main/othervm -Xmx128m TestDisposerRace
  * @modules java.desktop/sun.java2d
  */
 public final class TestDisposerRace {

--- a/test/jdk/sun/java2d/marlin/CrashTest.java
+++ b/test/jdk/sun/java2d/marlin/CrashTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,9 +35,9 @@ import javax.imageio.ImageIO;
 /**
  * @test
  * @summary Simple crash rendering test using huge GeneralPaths with the Marlin renderer
- * @run main/othervm -mx512m CrashTest
+ * @run main/othervm -Xmx512m CrashTest
  * @ignore tests that take a long time and consumes 5Gb memory
- * @run main/othervm -ms4g -mx4g CrashTest -slow
+ * @run main/othervm -Xms4g -Xmx4g CrashTest -slow
 */
 public class CrashTest {
 


### PR DESCRIPTION
Can I please get a review of this test-only change which updates some client-libs tests to replace the usage of the outdated `-mx` and `-ms` java launcher options with `-Xmx`  and `-Xms`?

As noted in https://bugs.openjdk.org/browse/JDK-8339835, these outdated options will soon be deprecated for removal from the java launcher code.

tier testing in our CI is currently in progress with these changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339835](https://bugs.openjdk.org/browse/JDK-8339835): Replace usages of -mx and -ms in some client-libs tests (**Sub-task** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20931/head:pull/20931` \
`$ git checkout pull/20931`

Update a local copy of the PR: \
`$ git checkout pull/20931` \
`$ git pull https://git.openjdk.org/jdk.git pull/20931/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20931`

View PR using the GUI difftool: \
`$ git pr show -t 20931`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20931.diff">https://git.openjdk.org/jdk/pull/20931.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20931#issuecomment-2340225651)