### PR TITLE
JDK-8339541: CSS rule is not specific enough

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -360,8 +360,11 @@ main {
     padding:10px 20px;
     position:relative;
 }
-section[id$=-description] :is(dl, ol, ul, p, div, blockquote, pre):last-child,
-section[id$=-description] :is(dl, ol, ul):last-child > :is(li, dd):last-child {
+/* Compensate for non-collapsing margins between element description and summary tables */
+div.horizontal-scroll > section[id$=-description] > :is(dl, ol, ul, p, div, blockquote, pre):last-child,
+div.horizontal-scroll > section[id$=-description] > :last-child > :is(li, dd):last-child,
+section.class-description > div.horizontal-scroll > :is(dl, ol, ul, p, div, blockquote, pre):last-child,
+section.class-description > div.horizontal-scroll > :last-child > :is(li, dd):last-child {
     margin-bottom:4px;
 }
 dl.notes > dt {


### PR DESCRIPTION
Please review a CSS fix for javadoc-generated API documentation to avoid a CSS being applied to elements it is not meant for. The rule in question was in JDK-8308659 when we added scrollable container `div` elements. Since elements with non-visible `overflow` prevent [margin collapse](https://www.joshwcomeau.com/css/rules-of-margin-collapse/), this changed the effective margin between some elements, namely between the element descriptions on module, package, and class pages and the subsequent lists/tables. 

The problem with the original version of this rule was that it was too generic, and therefore applied to various element within the element description, such as the last items in nessted lists, preview notices, and code snippets. The reason it was kept generic was that the order of the `section` element and the scrollable `div` element is different in module/package pages and class pages. 

The new version of the rule uses distinct selectors for module and package pages (the first two rules) and class pages (the second two rules), allowing us to use the child combinator (`>`) to only select direct descendents of the description containers. 

I also added a comment to explain the purpose of the rule. The fix was tested on Chrome, Firefox and Safari on macOS and Linux.