### PR TITLE
8225049: Bad -Xlog example in -Xlog:help, online documentation, JEP

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -4825,7 +4825,7 @@ level to a file called \f[V]gc.txt\f[R] with no decorations.
 The default configuration for all other messages at level
 \f[V]warning\f[R] is still in effect.
 .TP
-\f[V]-Xlog:gc=trace:file=gctrace.txt:uptimemillis,pids:filecount=5,filesize=1024\f[R]
+\f[V]-Xlog:gc=trace:file=gctrace.txt:uptimemillis,pid:filecount=5,filesize=1024\f[R]
 Logs messages tagged with the \f[V]gc\f[R] tag using the \f[V]trace\f[R]
 level to a rotating file set with 5 files with size 1 MB with the base
 name \f[V]gctrace.txt\f[R] and uses decorations \f[V]uptimemillis\f[R]


### PR DESCRIPTION
Can I get a review of this change which fixes a typo in the java spec documentation? 

As noted in the issue, the example used there `-Xlog:gc=trace:file=gctrace.txt:uptimemillis,pids:filecount=5,filesize=1024` doesn't work and instead of `pids`, it should have been `pid`.

The updated example in this PR now works fine with:
 ```console
java -Xlog:gc=trace:file=gctrace.txt:uptimemillis,pid:filecount=5,filesize=1024 -version
```
and the generated trace file contains the process id:
```console
[1ms][85757] MarkStackSize: 4096k  MarkStackSizeMax: 524288k
[5ms][85757] Using G1
[5ms][85757] ConcGCThreads: 2 offset 16
[5ms][85757] ParallelGCThreads: 8
[5ms][85757] Initialize mark stack with 4096 chunks, maximum 524288

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8225049](https://bugs.openjdk.org/browse/JDK-8225049): Bad -Xlog example in -Xlog:help, online documentation, JEP (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20934/head:pull/20934` \
`$ git checkout pull/20934`

Update a local copy of the PR: \
`$ git checkout pull/20934` \
`$ git pull https://git.openjdk.org/jdk.git pull/20934/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20934`

View PR using the GUI difftool: \
`$ git pr show -t 20934`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20934.diff">https://git.openjdk.org/jdk/pull/20934.diff</a>

</details>
