### PR TITLE
8339684: ResizeObserver callback interrupts smooth scrolling on Chrome

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/script.js.template
@@ -300,6 +300,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
     });
     var expanded = false;
     var windowWidth;
+    var bodyHeight;
     function collapse(e) {
         if (expanded) {
             mainnav.removeAttribute("style");
@@ -365,6 +366,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
     var scrollTimeoutNeeded;
     var prevHash;
     function initSectionData() {
+        bodyHeight = document.body.offsetHeight;
         sections = [{ id: "", top: 0 }].concat(Array.from(main.querySelectorAll("section[id], h2[id], h2 a[id], div[id]"))
             .filter((e) => {
                 return sidebar.querySelector("a[href=\"#" + encodeURI(e.getAttribute("id")) + "\"]") !== null
@@ -469,7 +471,7 @@ document.addEventListener("DOMContentLoaded", function(e) {
                 expand();
             }
         }
-        if (sections) {
+        if (sections && document.body.offsetHeight !== bodyHeight) {
             initSectionData();
             prevHash = null;
             handleScroll();


### PR DESCRIPTION
Please review a simple JavaScript change to avoid the `ResizeObserver` callback to interrupt smooth scrolling on Chrome browsers when an page with an anchor is loaded. Unfortunately, Chrome is susceptible to interrupt smooth scrolling if a script accesses the DOM while scrolling. Since the `ResizeObserver` callback is invoked when the page is loaded, Chrome failed to scroll to the element indicated by the anchor. This change causes the initial invocation of the callback to be ignored.

I have uploaded [sample docs built with this fix](https://cr.openjdk.org/~hannesw/8339684/api.00/) to be tested against the [unfixed docs](https://download.java.net/java/early_access/jdk24/docs/api/).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339684](https://bugs.openjdk.org/browse/JDK-8339684): ResizeObserver callback interrupts smooth scrolling on Chrome (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20935/head:pull/20935` \
`$ git checkout pull/20935`

Update a local copy of the PR: \
`$ git checkout pull/20935` \
`$ git pull https://git.openjdk.org/jdk.git pull/20935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20935`

View PR using the GUI difftool: \
`$ git pr show -t 20935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20935.diff">https://git.openjdk.org/jdk/pull/20935.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20935#issuecomment-2340843694)