### PR TITLE
8339852: Fix typos in java.compiler documentation

### DIFF
--- a/src/java.compiler/share/classes/javax/annotation/processing/AbstractProcessor.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/AbstractProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,7 +157,7 @@ public abstract class AbstractProcessor implements Processor {
      *
      * @implSpec
      * Initializes the processor with the processing environment by
-     * setting the {@code processingEnv} field to the value of the
+     * setting the {@link #processingEnv} field to the value of the
      * {@code processingEnv} argument.  An {@code
      * IllegalStateException} will be thrown if this method is called
      * more than once on the same object.

--- a/src/java.compiler/share/classes/javax/annotation/processing/Processor.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/Processor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -195,7 +195,7 @@ import javax.lang.model.SourceVersion;
  * processors can operate on files.
  *
  * @apiNote Implementors of this interface may find it convenient
- * to extend {@link AbstractProcessor} rather than implementing this
+ * to extend {@link AbstractProcessor} rather than implement this
  * interface directly.
  *
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
+++ b/src/java.compiler/share/classes/javax/annotation/processing/RoundEnvironment.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -146,7 +146,7 @@ public interface RoundEnvironment {
      * processing. The set of annotation interfaces present in the runtime
      * context may differ from the set of annotation interfaces present in
      * the context of annotation processing in a particular
-     * environmental configuration. If an runtime annotation interface is
+     * environmental configuration. If a runtime annotation interface is
      * not present in the annotation processing context, the situation
      * is not treated as an error and no elements are found for that
      * annotation interface.
@@ -173,7 +173,7 @@ public interface RoundEnvironment {
      * processing. The set of annotation interfaces present in the runtime
      * context may differ from the set of annotation interfaces present in
      * the context of annotation processing in a particular
-     * environmental configuration. If an runtime annotation interface is
+     * environmental configuration. If a runtime annotation interface is
      * not present in the annotation processing context, the situation
      * is not treated as an error and no elements are found for that
      * annotation interface.

--- a/src/java.compiler/share/classes/javax/lang/model/AnnotatedConstruct.java
+++ b/src/java.compiler/share/classes/javax/lang/model/AnnotatedConstruct.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,14 +45,14 @@ import javax.lang.model.type.*;
  * <em>type annotation</em>.
  *
  * The terms <em>directly present</em>, <em>present</em>,
- * <em>indirectly present</em>, and <em>associated </em> are used
+ * <em>indirectly present</em>, and <em>associated</em> are used
  * throughout this interface to describe precisely which annotations,
  * either declaration annotations or type annotations, are returned by
  * the methods in this interface.
  *
  * <p>In the definitions below, an annotation <i>A</i> has an
  * annotation interface <i>AI</i>. If <i>AI</i> is a repeatable annotation
- * interface, the type of the containing annotation is <i>AIC</i>.
+ * interface, the type of the container annotation is <i>AIC</i>.
  *
  * <p>Annotation <i>A</i> is <em>directly present</em> on a construct
  * <i>C</i> if either:
@@ -78,7 +78,7 @@ import javax.lang.model.type.*;
  * Specification</cite> (JLS {@jls 8.10.1}).
  *
  * If there are multiple annotations of type <i>AI</i> present on
- * <i>C</i>, then if <i>AI</i> is repeatable annotation interface, an
+ * <i>C</i>, then if <i>AI</i> is a repeatable annotation interface, an
  * annotation of type <i>AIC</i> is {@linkplain javax.lang.model.util.Elements#getOrigin(AnnotatedConstruct, AnnotationMirror) implicitly declared} on <i>C</i>.
  * <li> A representation of <i>A</i> appears in the executable output
  * for <i>C</i>, such as the {@code RuntimeVisibleAnnotations} (JVMS {@jvms 4.7.16}) or
@@ -189,10 +189,11 @@ public interface AnnotatedConstruct {
     <A extends Annotation> A getAnnotation(Class<A> annotationType);
 
     /**
-     * Returns annotations that are <em>associated</em> with this construct.
+     * Returns annotations of the specified type that are <em>associated</em>
+     * with this construct.
      *
-     * If there are no annotations associated with this construct, the
-     * return value is an array of length 0.
+     * If there are no annotations of the specified type associated with this
+     * construct, the return value is an array of length 0.
      *
      * The order of annotations which are directly or indirectly
      * present on a construct <i>C</i> is computed as if indirectly present

--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -202,7 +202,7 @@ public enum SourceVersion {
      * @see <a href="https://openjdk.org/jeps/213">
      * JEP 213: Milling Project Coin</a>
      */
-     RELEASE_9,
+    RELEASE_9,
 
     /**
      * The version introduced by the Java Platform, Standard Edition
@@ -470,7 +470,7 @@ public enum SourceVersion {
      *
      * @apiNote This method is included alongside {@link latest} to
      * allow identification of situations where the language model API
-     * is running on a platform version different than the latest
+     * is running on a platform version different from the latest
      * version modeled by the API. One way that sort of situation can
      * occur is if an IDE or similar tool is using the API to model
      * source version <i>N</i> while running on platform version
@@ -496,8 +496,7 @@ public enum SourceVersion {
      * followed only by characters for which {@link
      * Character#isJavaIdentifierPart(int)} returns {@code true}.
      * This pattern matches regular identifiers, keywords, contextual
-     * keywords, and the literals {@code "true"},
-     * {@code "false"}, {@code "null"}.
+     * keywords, boolean literals, and the null literal.
      *
      * The method returns {@code false} for all other strings.
      *
@@ -591,13 +590,13 @@ public enum SourceVersion {
 
     /**
      * Returns whether or not {@code s} is a keyword, boolean literal,
-     * or null literal in the latest source version.
+     * or the null literal in the latest source version.
      * This method returns {@code false} for <i>contextual
      * keywords</i>.
      *
      * @param s the string to check
-     * @return {@code true} if {@code s} is a keyword, or boolean
-     * literal, or null literal, {@code false} otherwise.
+     * @return {@code true} if {@code s} is a keyword, boolean
+     * literal, or the null literal, {@code false} otherwise.
      * @jls 3.9 Keywords
      * @jls 3.10.3 Boolean Literals
      * @jls 3.10.8 The Null Literal
@@ -608,14 +607,14 @@ public enum SourceVersion {
 
     /**
      * Returns whether or not {@code s} is a keyword, boolean literal,
-     * or null literal in the given source version.
+     * or the null literal in the given source version.
      * This method returns {@code false} for <i>contextual
      * keywords</i>.
      *
      * @param s the string to check
      * @param version the version to use
-     * @return {@code true} if {@code s} is a keyword, or boolean
-     * literal, or null literal, {@code false} otherwise.
+     * @return {@code true} if {@code s} is a keyword, boolean
+     * literal, or the null literal, {@code false} otherwise.
      * @jls 3.9 Keywords
      * @jls 3.10.3 Boolean Literals
      * @jls 3.10.8 The Null Literal

--- a/src/java.compiler/share/classes/javax/lang/model/element/AnnotationMirror.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/AnnotationMirror.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,7 @@ public interface AnnotationMirror {
 
     /**
      * Returns the values of this annotation's elements.
-     * This is returned in the form of a map that associates elements
+     * These are returned in the form of a map that associates elements
      * with their corresponding values.
      * Only those elements with values explicitly present in the
      * annotation are included, not those that are implicitly assuming

--- a/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/ExecutableElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import javax.lang.model.type.*;
  * elements.
  * Annotation interface elements are methods restricted to have no
  * formal parameters, no type parameters, and no {@code throws}
- * clause, among other restrictions; see JLS {@jls 9.6.1} for details
+ * clause, among other restrictions; see JLS {@jls 9.6.1} for details.
  *
  * @see ExecutableType
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/TypeElement.java
@@ -58,14 +58,14 @@ import javax.lang.model.util.*;
  * javax.lang.model.util.Elements#getFileObjectOf(Element) reference
  * representation} (either source code or executable output). Multiple
  * classes and interfaces can share the same reference representation
- * backing construct. For example, multiple classes and interface can
- * be declared in the same source file, including, but are not limited
+ * backing construct. For example, multiple classes and interfaces can
+ * be declared in the same source file, including, but not limited
  * to:
  * <ul>
  * <li> a {@linkplain NestingKind#TOP_LEVEL top-level} class or
  * interface and auxiliary classes and interfaces
  * <li>a top-level class or interface and {@linkplain
- * NestingKind#isNested() nested class and interfaces} within it
+ * NestingKind#isNested() nested classes and interfaces} within it
  * </ul>
  * <p>In the context of annotation processing, a type element can
  * be:

--- a/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
+++ b/src/java.compiler/share/classes/javax/lang/model/element/package-info.java
@@ -30,7 +30,7 @@
  * elements, the declared entities that make up a program.  Elements
  * include classes, interfaces, methods, constructors, and fields.
  * The interfaces in this package do not model the structure of a
- * program inside a method body; for example there is no
+ * program inside a method body; for example, there is no
  * representation of a {@code for} loop or {@code try}-{@code finally}
  * block. Concretely, there is no model of any abstract syntax tree
  * (AST) structure of a Java program.  However, the interfaces can
@@ -84,7 +84,7 @@
  * javax.lang.model.util.Elements#isBridge(ExecutableElement)
  * bridge methods} used in implementing covariant returns, are
  * translation artifacts strictly outside of this model. However, when
- * operating on class files, it is helpful be able to operate on such
+ * operating on class files, it is helpful to be able to operate on such
  * elements, screening them out when appropriate.
  *
  * <p>During annotation processing, operating on incomplete or

--- a/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Elements.java
@@ -56,11 +56,11 @@ public interface Elements {
      * <ul>
      *     <li>find non-empty packages with the given name returned by
      *         {@link #getPackageElement(ModuleElement, CharSequence)},
-     *         where the provided ModuleSymbol is any
+     *         where the provided ModuleElement is any
      *         {@linkplain java.lang.module##root-modules root module},
      *     </li>
      *     <li>if the above yields an empty list, search
-     *         {@link #getAllModuleElements() all modules} for observable
+     *         {@linkplain #getAllModuleElements() all modules} for observable
      *         packages with the given name
      *     </li>
      * </ul>
@@ -143,11 +143,11 @@ public interface Elements {
      * <ul>
      *     <li>find type elements with the given name returned by
      *         {@link #getTypeElement(ModuleElement, CharSequence)},
-     *         where the provided ModuleSymbol is any
+     *         where the provided ModuleElement is any
      *         {@linkplain java.lang.module##root-modules root module},
      *     </li>
      *     <li>if the above yields an empty list, search
-     *         {@link #getAllModuleElements() all modules} for observable
+     *         {@linkplain #getAllModuleElements() all modules} for observable
      *         type elements with the given name
      *     </li>
      * </ul>
@@ -617,7 +617,7 @@ public interface Elements {
 
     /**
      * Returns all members of a type element, whether inherited or
-     * declared directly.  For a class the result also includes its
+     * declared directly.  For a class, the result also includes its
      * constructors, but not local or anonymous classes.
      *
      * @apiNote Elements of certain kinds can be isolated using
@@ -878,10 +878,10 @@ public interface Elements {
      * accessor.
      *
      * @implSpec The default implementation of this method checks if the element
-     * enclosing the accessor has kind {@link ElementKind#RECORD RECORD} if that is
-     * the case, then all the record components on the accessor's enclosing element
-     * are retrieved by invoking {@link ElementFilter#recordComponentsIn(Iterable)}.
-     * If the accessor of at least one of the record components retrieved happen to
+     * enclosing the accessor has kind {@link ElementKind#RECORD RECORD}, if that is
+     * the case, then all the record components of the accessor's enclosing element
+     * are isolated by invoking {@link ElementFilter#recordComponentsIn(Iterable)}.
+     * If the accessor of at least one of the record components retrieved happens to
      * be equal to the accessor passed as a parameter to this method, then that
      * record component is returned, in any other case {@code null} is returned.
      *

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -40,7 +40,7 @@ import javax.lang.model.type.*;
  * ExecutableType Executable types} and the pseudo-types for
  * {@linkplain TypeKind#PACKAGE packages} and {@linkplain
  * TypeKind#MODULE modules} are generally out of scope for these
- * methods. One or more out of scope arguments will typically result
+ * methods. One or more out-of-scope arguments will typically result
  * in a method throwing an {@link IllegalArgumentException}.
  *
  * <p>Where a method returns a type mirror or a collection of type
@@ -165,7 +165,7 @@ public interface Types {
      * the direct supertypes of a type mirror representing {@code
      * java.lang.Object}.
      *
-     * Annotations on the direct super types are preserved.
+     * Annotations on the direct supertypes are preserved.
      *
      * @param t  the type being examined
      * @return the direct supertypes, or an empty list if none
@@ -318,7 +318,7 @@ public interface Types {
      * Annotations on the type arguments are preserved.
      *
      * <p> If the containing type is a parameterized type,
-     * the number of type arguments must equal the
+     * the number of type arguments must be equal to the
      * number of {@code typeElem}'s formal type parameters.
      * If it is not parameterized or if it is {@code null}, this method is
      * equivalent to {@code getDeclaredType(typeElem, typeArgs)}.
@@ -354,7 +354,7 @@ public interface Types {
     /**
      * {@return a type mirror equivalent to the argument, but with no annotations}
      * If the type mirror is a composite type, such as an array type
-     * or a wildcard type, any constitute types, such as the
+     * or a wildcard type, any constituent types, such as the
      * component type of an array and the type of the bounds of a
      * wildcard type, also have no annotations, recursively.
      *

--- a/src/java.compiler/share/classes/javax/tools/ForwardingFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import java.util.Objects;
  * additional fields and methods.
  *
  * <p>Unless stated otherwise, references in this class to "<em>this file object</em>"
- * should be interpreted as referring indirectly to the {@link #fileObject delegate file object}.
+ * should be interpreted as referring indirectly to the {@linkplain #fileObject delegate file object}.
  *
  * @param <F> the kind of file object forwarded to by this object
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javax.tools.JavaFileObject.Kind;
  * additional fields and methods.
  *
  * <p>Unless stated otherwise, references in this class to "<em>this file manager</em>"
- * should be interpreted as referring indirectly to the {@link #fileManager delegate file manager}.
+ * should be interpreted as referring indirectly to the {@linkplain #fileManager delegate file manager}.
  *
  * @param <M> the kind of file manager forwarded to by this object
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileObject.java
+++ b/src/java.compiler/share/classes/javax/tools/ForwardingJavaFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import javax.lang.model.element.NestingKind;
  * additional fields and methods.
  *
  * <p>Unless stated otherwise, references in this class to "<em>this file object</em>"
- * should be interpreted as referring indirectly to the {@link #fileObject delegate file object}.
+ * should be interpreted as referring indirectly to the {@linkplain #fileObject delegate file object}.
  *
  * @param <F> the kind of file object forwarded to by this object
  * @since 1.6

--- a/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/JavaFileManager.java
@@ -52,7 +52,7 @@ import static javax.tools.JavaFileObject.Kind;
  *
  * <p>Some methods in this interface use class names.  Such class
  * names must be given in the Java Virtual Machine internal form of
- * fully qualified class and interface names.  For convenience '.'
+ * fully qualified class and interface names.  For convenience, '.'
  * and '/' are interchangeable.  The internal form is defined in
  * chapter four of
  * <cite>The Java Virtual Machine Specification</cite>.
@@ -239,7 +239,7 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
     String inferBinaryName(Location location, JavaFileObject file);
 
     /**
-     * Compares two file objects and return true if they represent the
+     * Compares two file objects and returns true if they represent the
      * same underlying object.
      *
      * @param a a file object
@@ -255,7 +255,7 @@ public interface JavaFileManager extends Closeable, Flushable, OptionChecker {
 
     /**
      * Handles one option.  If {@code current} is an option to this
-     * file manager it will consume any arguments to that option from
+     * file manager, it will consume any arguments to that option from
      * {@code remaining} and return true, otherwise return false.
      *
      * @param current current option

--- a/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -142,7 +142,7 @@ import java.util.List;
  * </ul>
  *
  * <p>All implementations of this interface must support Path objects representing
- * files in the {@linkplain java.nio.file.FileSystems#getDefault() default file system.}
+ * files in the {@linkplain java.nio.file.FileSystems#getDefault() default file system}.
  * It is recommended that implementations should support Path objects from any filesystem.</p>
  *
  *

--- a/src/java.compiler/share/classes/javax/tools/ToolProvider.java
+++ b/src/java.compiler/share/classes/javax/tools/ToolProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -90,8 +90,8 @@ public class ToolProvider {
      * @implSpec This implementation always returns {@code null}.
      * @deprecated This method is subject to removal in a future version of
      * Java SE.
-     * Use the {@link java.util.spi.ToolProvider system tool provider} or
-     * {@link java.util.ServiceLoader service loader} mechanisms to
+     * Use the {@linkplain java.util.spi.ToolProvider system tool provider} or
+     * {@linkplain java.util.ServiceLoader service loader} mechanisms to
      * locate system tools as well as user-installed tools.
      * @return a class loader, or {@code null}
      */


### PR DESCRIPTION
Please review this PR to fix typos and formatting issue. Some typos are trivial, others relate to domain-specific vocabulary.