### PR TITLE
8339850: Restore the interrupt status in FileSystemPreferences.lockFile()

### DIFF
--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -957,6 +957,8 @@ class FileSystemPreferences extends AbstractPreferences {
             try {
                 Thread.sleep(sleepTime);
             } catch(InterruptedException e) {
+                // Don't lose the interrupt.
+                Thread.currentThread().interrupt();
                 checkLockFile0ErrorCode(errorCode);
                 return false;
             }


### PR DESCRIPTION
FIleSystemPreferences.lockFile() catches an InterruptedException and just returns false, forgetting to re-interrupt the current thread. This leaves the caller with no way to observe that the thread was interrupted. This change restores the interrupted status on the current thread before returning.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8339850](https://bugs.openjdk.org/browse/JDK-8339850): Restore the interrupt status in FileSystemPreferences.lockFile() (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Daniel Jeliński](https://openjdk.org/census#djelinski) (@djelinski - **Reviewer**)
 * [Vyom Tewari](https://openjdk.org/census#vtewari) (@vyommani - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20938/head:pull/20938` \
`$ git checkout pull/20938`

Update a local copy of the PR: \
`$ git checkout pull/20938` \
`$ git pull https://git.openjdk.org/jdk.git pull/20938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20938`

View PR using the GUI difftool: \
`$ git pr show -t 20938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20938.diff">https://git.openjdk.org/jdk/pull/20938.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20938#issuecomment-2341457114)