### PR TITLE
8339874: Avoid duplicate checking of trailing slash in ZipFile.getZipEntry

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -158,13 +158,6 @@ class ZipCoder {
         return hsh;
     }
 
-    boolean hasTrailingSlash(byte[] a, int end) {
-        byte[] slashBytes = slashBytes();
-        return end >= slashBytes.length &&
-            Arrays.mismatch(a, end - slashBytes.length, end, slashBytes, 0, slashBytes.length) == -1;
-    }
-
-    private byte[] slashBytes;
     private final Charset cs;
     protected CharsetDecoder dec;
     private CharsetEncoder enc;
@@ -189,23 +182,6 @@ class ZipCoder {
               .onUnmappableCharacter(CodingErrorAction.REPORT);
         }
         return enc;
-    }
-
-    // This method produces an array with the bytes that will correspond to a
-    // trailing '/' in the chosen character encoding.
-    //
-    // While in most charsets a trailing slash will be encoded as the byte
-    // value of '/', this does not hold in the general case. E.g., in charsets
-    // such as UTF-16 and UTF-32 it will be represented by a sequence of 2 or 4
-    // bytes, respectively.
-    private byte[] slashBytes() {
-        if (slashBytes == null) {
-            // Take into account charsets that produce a BOM, e.g., UTF-16
-            byte[] slash = "/".getBytes(cs);
-            byte[] doubleSlash = "//".getBytes(cs);
-            slashBytes = Arrays.copyOfRange(doubleSlash, slash.length, doubleSlash.length);
-        }
-        return slashBytes;
     }
 
     /**
@@ -297,8 +273,7 @@ class ZipCoder {
             return h;
         }
 
-        @Override
-        boolean hasTrailingSlash(byte[] a, int end) {
+        private boolean hasTrailingSlash(byte[] a, int end) {
             return end > 0 && a[end - 1] == '/';
         }
 

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -158,7 +158,7 @@ class ZipCoder {
         return hsh;
     }
 
-    protected boolean hasTrailingSlash(byte[] a, int end) {
+    boolean hasTrailingSlash(byte[] a, int end) {
         byte[] slashBytes = slashBytes();
         return end >= slashBytes.length &&
             Arrays.mismatch(a, end - slashBytes.length, end, slashBytes, 0, slashBytes.length) == -1;
@@ -298,7 +298,7 @@ class ZipCoder {
         }
 
         @Override
-        protected boolean hasTrailingSlash(byte[] a, int end) {
+        boolean hasTrailingSlash(byte[] a, int end) {
             return end > 0 && a[end - 1] == '/';
         }
 

--- a/src/java.base/share/classes/java/util/zip/ZipCoder.java
+++ b/src/java.base/share/classes/java/util/zip/ZipCoder.java
@@ -158,7 +158,7 @@ class ZipCoder {
         return hsh;
     }
 
-    boolean hasTrailingSlash(byte[] a, int end) {
+    protected boolean hasTrailingSlash(byte[] a, int end) {
         byte[] slashBytes = slashBytes();
         return end >= slashBytes.length &&
             Arrays.mismatch(a, end - slashBytes.length, end, slashBytes, 0, slashBytes.length) == -1;
@@ -298,7 +298,7 @@ class ZipCoder {
         }
 
         @Override
-        boolean hasTrailingSlash(byte[] a, int end) {
+        protected boolean hasTrailingSlash(byte[] a, int end) {
             return end > 0 && a[end - 1] == '/';
         }
 

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -347,6 +347,9 @@ public class ZipFile implements ZipConstants, Closeable {
         ZipEntry entry = null;
         synchronized (this) {
             ensureOpen();
+            // Look up the name and CEN header position of the entry.
+            // The resolved name may include a trailing slash.
+            // See Source::getEntryPos for details.
             EntryPos pos = res.zsrc.getEntryPos(name, true);
             if (pos != null) {
                 entry = getZipEntry(pos.name, pos.pos);

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -349,7 +349,7 @@ public class ZipFile implements ZipConstants, Closeable {
             ensureOpen();
             EntryPos pos = res.zsrc.getEntryPos(name, true);
             if (pos != null) {
-                entry = getZipEntry(pos);
+                entry = getZipEntry(pos.name, pos.pos);
             }
         }
         return entry;
@@ -546,7 +546,7 @@ public class ZipFile implements ZipConstants, Closeable {
                 }
                 // each "entry" has 3 ints in table entries
                 int pos = res.zsrc.getEntryPos(i++ * 3);
-                return (T)getZipEntry(new EntryPos(getEntryName(pos), pos));
+                return (T)getZipEntry(getEntryName(pos), pos);
             }
         }
 
@@ -618,7 +618,7 @@ public class ZipFile implements ZipConstants, Closeable {
         synchronized (this) {
             ensureOpen();
             return StreamSupport.stream(new EntrySpliterator<>(0, res.zsrc.total,
-                pos -> getZipEntry(new EntryPos(getEntryName(pos), pos))), false);
+                pos -> getZipEntry(getEntryName(pos), pos)), false);
        }
     }
 
@@ -661,7 +661,7 @@ public class ZipFile implements ZipConstants, Closeable {
         synchronized (this) {
             ensureOpen();
             return StreamSupport.stream(new EntrySpliterator<>(0, res.zsrc.total,
-                pos -> (JarEntry)getZipEntry(new EntryPos(getEntryName(pos), pos))), false);
+                pos -> (JarEntry)getZipEntry(getEntryName(pos), pos)), false);
         }
     }
 
@@ -669,9 +669,7 @@ public class ZipFile implements ZipConstants, Closeable {
     private int lastEntryPos;
 
     /* Check ensureOpen() before invoking this method */
-    private ZipEntry getZipEntry(EntryPos entryPos) {
-        String name = entryPos.name;
-        int pos  = entryPos.pos;
+    private ZipEntry getZipEntry(String name, int pos) {
         byte[] cen = res.zsrc.cen;
         ZipEntry e = this instanceof JarFile jarFile
                 ? Source.JUJA.entryFor(jarFile, name)

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -676,26 +676,25 @@ public class ZipFile implements ZipConstants, Closeable {
                 : new ZipEntry(name);
 
         e.flag = CENFLG(cen, pos);
-        e.method = CENHOW(cen, pos);
         e.xdostime = CENTIM(cen, pos);
         e.crc = CENCRC(cen, pos);
-        e.csize = CENSIZ(cen, pos);
         e.size = CENLEN(cen, pos);
+        e.csize = CENSIZ(cen, pos);
+        e.method = CENHOW(cen, pos);
         if (CENVEM_FA(cen, pos) == FILE_ATTRIBUTES_UNIX) {
             // read all bits in this field, including sym link attributes
             e.externalFileAttributes = CENATX_PERMS(cen, pos) & 0xFFFF;
         }
 
+        int nlen = CENNAM(cen, pos);
         int elen = CENEXT(cen, pos);
         int clen = CENCOM(cen, pos);
 
         if (elen != 0) {
-            int nlen = CENNAM(cen, pos);
             int start = pos + CENHDR + nlen;
             e.setExtra0(Arrays.copyOfRange(cen, start, start + elen), true, false);
         }
         if (clen != 0) {
-            int nlen = CENNAM(cen, pos);
             int start = pos + CENHDR + nlen + elen;
             ZipCoder zc = res.zsrc.zipCoderForPos(pos);
             e.comment = zc.toString(cen, start, clen);

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1885,7 +1885,7 @@ public class ZipFile implements ZipConstants, Closeable {
             // Reaching this point means we did not find "name".
             // Return the position of "name/" if we found it
             if (dirPos != -1) {
-                return new EntryPos(name +"/", dirPos);
+                return new EntryPos(name + "/", dirPos);
             }
             // No entry found
             return null;

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -347,9 +347,9 @@ public class ZipFile implements ZipConstants, Closeable {
         ZipEntry entry = null;
         synchronized (this) {
             ensureOpen();
-            int pos = res.zsrc.getEntryPos(name, true);
-            if (pos != -1) {
-                entry = getZipEntry(name, pos);
+            EntryPos pos = res.zsrc.getEntryPos(name, true);
+            if (pos != null) {
+                entry = getZipEntry(pos);
             }
         }
         return entry;
@@ -387,7 +387,12 @@ public class ZipFile implements ZipConstants, Closeable {
             if (Objects.equals(lastEntryName, entry.name)) {
                 pos = lastEntryPos;
             } else {
-                pos = zsrc.getEntryPos(entry.name, false);
+                EntryPos entryPos = zsrc.getEntryPos(entry.name, false);
+                if (entryPos != null) {
+                    pos = entryPos.pos;
+                } else {
+                    pos = -1;
+                }
             }
             if (pos == -1) {
                 return null;
@@ -540,7 +545,8 @@ public class ZipFile implements ZipConstants, Closeable {
                     throw new NoSuchElementException();
                 }
                 // each "entry" has 3 ints in table entries
-                return (T)getZipEntry(null, res.zsrc.getEntryPos(i++ * 3));
+                int pos = res.zsrc.getEntryPos(i++ * 3);
+                return (T)getZipEntry(new EntryPos(getEntryName(pos), pos));
             }
         }
 
@@ -612,7 +618,7 @@ public class ZipFile implements ZipConstants, Closeable {
         synchronized (this) {
             ensureOpen();
             return StreamSupport.stream(new EntrySpliterator<>(0, res.zsrc.total,
-                pos -> getZipEntry(null, pos)), false);
+                pos -> getZipEntry(new EntryPos(getEntryName(pos), pos))), false);
        }
     }
 
@@ -655,7 +661,7 @@ public class ZipFile implements ZipConstants, Closeable {
         synchronized (this) {
             ensureOpen();
             return StreamSupport.stream(new EntrySpliterator<>(0, res.zsrc.total,
-                pos -> (JarEntry)getZipEntry(null, pos)), false);
+                pos -> (JarEntry)getZipEntry(new EntryPos(getEntryName(pos), pos))), false);
         }
     }
 
@@ -663,49 +669,37 @@ public class ZipFile implements ZipConstants, Closeable {
     private int lastEntryPos;
 
     /* Check ensureOpen() before invoking this method */
-    private ZipEntry getZipEntry(String name, int pos) {
+    private ZipEntry getZipEntry(EntryPos entryPos) {
+        String name = entryPos.name;
+        int pos  = entryPos.pos;
         byte[] cen = res.zsrc.cen;
-        int nlen = CENNAM(cen, pos);
-        int elen = CENEXT(cen, pos);
-        int clen = CENCOM(cen, pos);
+        ZipEntry e = this instanceof JarFile jarFile
+                ? Source.JUJA.entryFor(jarFile, name)
+                : new ZipEntry(name);
 
-        ZipCoder zc = res.zsrc.zipCoderForPos(pos);
-        if (name != null) {
-            // only need to check for mismatch of trailing slash
-            if (nlen > 0 &&
-                !name.isEmpty() &&
-                zc.hasTrailingSlash(cen, pos + CENHDR + nlen) &&
-                !name.endsWith("/"))
-            {
-                name += '/';
-            }
-        } else {
-            // invoked from iterator, use the entry name stored in cen
-            name = zc.toString(cen, pos + CENHDR, nlen);
-        }
-        ZipEntry e;
-        if (this instanceof JarFile) {
-            e = Source.JUJA.entryFor((JarFile)this, name);
-        } else {
-            e = new ZipEntry(name);
-        }
         e.flag = CENFLG(cen, pos);
+        e.method = CENHOW(cen, pos);
         e.xdostime = CENTIM(cen, pos);
         e.crc = CENCRC(cen, pos);
-        e.size = CENLEN(cen, pos);
         e.csize = CENSIZ(cen, pos);
-        e.method = CENHOW(cen, pos);
+        e.size = CENLEN(cen, pos);
         if (CENVEM_FA(cen, pos) == FILE_ATTRIBUTES_UNIX) {
             // read all bits in this field, including sym link attributes
             e.externalFileAttributes = CENATX_PERMS(cen, pos) & 0xFFFF;
         }
 
+        int elen = CENEXT(cen, pos);
+        int clen = CENCOM(cen, pos);
+
         if (elen != 0) {
+            int nlen = CENNAM(cen, pos);
             int start = pos + CENHDR + nlen;
             e.setExtra0(Arrays.copyOfRange(cen, start, start + elen), true, false);
         }
         if (clen != 0) {
+            int nlen = CENNAM(cen, pos);
             int start = pos + CENHDR + nlen + elen;
+            ZipCoder zc = res.zsrc.zipCoderForPos(pos);
             e.comment = zc.toString(cen, start, clen);
         }
         lastEntryName = e.name;
@@ -1176,6 +1170,8 @@ public class ZipFile implements ZipConstants, Closeable {
              }
         );
     }
+    // Represents the resolved name and position of a CEN record
+    static record EntryPos(String name, int pos) {}
 
     private static class Source {
         // While this is only used from ZipFile, defining it there would cause
@@ -1849,12 +1845,12 @@ public class ZipFile implements ZipConstants, Closeable {
         }
 
         /*
-         * Returns the {@code pos} of the ZIP cen entry corresponding to the
-         * specified entry name, or -1 if not found.
+         * Returns the resolved name and position of the ZIP cen entry corresponding
+         *  to the specified entry name, or {@code null} if not found.
          */
-        private int getEntryPos(String name, boolean addSlash) {
+        private EntryPos getEntryPos(String name, boolean addSlash) {
             if (total == 0) {
-                return -1;
+                return null;
             }
 
             int hsh = ZipCoder.hash(name);
@@ -1877,7 +1873,7 @@ public class ZipFile implements ZipConstants, Closeable {
                     switch (zc.compare(name, cen, noff, nlen, addSlash)) {
                         case EXACT_MATCH:
                             // We found an exact match for "name"
-                            return pos;
+                            return new EntryPos(name, pos);
                         case DIRECTORY_MATCH:
                             // We found the directory "name/"
                             // Track its position, then continue the search for "name"
@@ -1892,10 +1888,10 @@ public class ZipFile implements ZipConstants, Closeable {
             // Reaching this point means we did not find "name".
             // Return the position of "name/" if we found it
             if (dirPos != -1) {
-                return dirPos;
+                return new EntryPos(name +"/", dirPos);
             }
             // No entry found
-            return -1;
+            return null;
         }
 
         private ZipCoder zipCoderForPos(int pos) {


### PR DESCRIPTION
Please review this PR which speeds up `ZipFile.getZipEntry` by removing slash-checking logic which is already taking place during lookup in `ZipFile.Source.getEntryPos`. 

`ZipFile.Source.getEntryPos` includes logic to match a lookup for "name" against a directory entry "name/" (with a trailing slash). However, only the CEN position is currently returned, so `ZipFile.getZipEntry` needs to re-read the name from the CEN and determine if a trailing slash needs to be appended to the name of the returned `ZipEntry`.

By letting `ZipFile.Source.getEntryPos` return the resolved name along with the CEN position (in a new record `EntryPos`), `ZipFile.getZipEntry` can now instead use the already resolved name. 

Since `ZipFile.getZipEntry` now has the name, CEN header fields can now be read in bulk, separate from the allocation of the `ZipEntry`. This reordering is unlocked by the other changes in this PR and can alone explain a lot of the performance gains, probably because of better cache use.

This results in a nice ~18% speedup in the `ZipFileGetEntry.getEntryHit` micro:

Baseline:

```
Benchmark                    (size)  Mode  Cnt   Score   Error  Units
ZipFileGetEntry.getEntryHit     512  avgt   15  63.713 ? 2.645  ns/op
ZipFileGetEntry.getEntryHit    1024  avgt   15  67.405 ? 1.474  ns/op
```

PR:

```
Benchmark                    (size)  Mode  Cnt   Score   Error  Units
ZipFileGetEntry.getEntryHit     512  avgt   15  52.027 ? 2.669  ns/op
ZipFileGetEntry.getEntryHit    1024  avgt   15  55.211 ? 1.169  ns/op
```
The changes in this PR makes `UTF8ZipCoder.compare` the only caller of `ZipCoder.hasTrailingSlash`, so this method is made private and the implementation in the base class retired.

This purely a cleanup and optimization PR, no functional tests are changed or added.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339874](https://bugs.openjdk.org/browse/JDK-8339874): Avoid duplicate checking of trailing slash in ZipFile.getZipEntry (**Enhancement** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20939/head:pull/20939` \
`$ git checkout pull/20939`

Update a local copy of the PR: \
`$ git checkout pull/20939` \
`$ git pull https://git.openjdk.org/jdk.git pull/20939/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20939`

View PR using the GUI difftool: \
`$ git pr show -t 20939`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20939.diff">https://git.openjdk.org/jdk/pull/20939.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20939#issuecomment-2341788416)