### PR TITLE
8339875: MethodTypeDesc to reuse descriptor string from MethodType

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
+++ b/src/java.base/share/classes/java/lang/constant/ConstantDescs.java
@@ -24,6 +24,7 @@
  */
 package java.lang.constant;
 
+import jdk.internal.constant.ConstantUtils;
 import jdk.internal.constant.MethodTypeDescImpl;
 import jdk.internal.constant.PrimitiveClassDescImpl;
 import jdk.internal.constant.ReferenceClassDescImpl;
@@ -328,7 +329,7 @@ public final class ConstantDescs {
      *
      * @since 21
      */
-    public static final MethodTypeDesc MTD_void = MethodTypeDesc.of(CD_void);
+    public static final MethodTypeDesc MTD_void = MethodTypeDescImpl.ofValidated("()V", CD_void, ConstantUtils.EMPTY_CLASSDESC);
 
     static final DirectMethodHandleDesc MHD_METHODHANDLE_ASTYPE
             = MethodHandleDesc.ofMethod(Kind.VIRTUAL, CD_MethodHandle, "asType",

--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -982,6 +982,6 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
         for (int i = 0; i < params.length; i++) {
             params[i] = classDesc(mt.parameterType(i));
         }
-        return MethodTypeDescImpl.ofValidated(mt.descriptorString(), classDesc(mt.returnType()), params);
+        return mt.sharedStringDesc(classDesc(mt.returnType()), params);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
+++ b/src/java.base/share/classes/java/lang/invoke/ClassSpecializer.java
@@ -982,6 +982,6 @@ abstract class ClassSpecializer<T,K,S extends ClassSpecializer<T,K,S>.SpeciesDat
         for (int i = 0; i < params.length; i++) {
             params[i] = classDesc(mt.parameterType(i));
         }
-        return MethodTypeDescImpl.ofValidated(classDesc(mt.returnType()), params);
+        return MethodTypeDescImpl.ofValidated(mt.descriptorString(), classDesc(mt.returnType()), params);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -567,6 +567,6 @@ import sun.invoke.util.Wrapper;
         for (int i = 0; i < params.length; i++) {
             params[i] = classDesc(mt.parameterType(i));
         }
-        return MethodTypeDescImpl.ofValidated(classDesc(mt.returnType()), params);
+        return MethodTypeDescImpl.ofValidated(mt.descriptorString(), classDesc(mt.returnType()), params);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -567,6 +567,6 @@ import sun.invoke.util.Wrapper;
         for (int i = 0; i < params.length; i++) {
             params[i] = classDesc(mt.parameterType(i));
         }
-        return MethodTypeDescImpl.ofValidated(mt.descriptorString(), classDesc(mt.returnType()), params);
+        return mt.sharedStringDesc(classDesc(mt.returnType()), params);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1670,6 +1670,6 @@ class InvokerBytecodeGenerator {
         for (int i = 0; i < params.length; i++) {
             params[i] = classDesc(mt.parameterType(i));
         }
-        return MethodTypeDescImpl.ofValidated(classDesc(mt.returnType()), params);
+        return MethodTypeDescImpl.ofValidated(mt.descriptorString(), classDesc(mt.returnType()), params);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1670,6 +1670,6 @@ class InvokerBytecodeGenerator {
         for (int i = 0; i < params.length; i++) {
             params[i] = classDesc(mt.parameterType(i));
         }
-        return MethodTypeDescImpl.ofValidated(mt.descriptorString(), classDesc(mt.returnType()), params);
+        return mt.sharedStringDesc(classDesc(mt.returnType()), params);
     }
 }

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1271,9 +1271,19 @@ class MethodType
         return toMethodDescriptorString();
     }
 
-    /*non-public*/
-    static String toFieldDescriptorString(Class<?> cls) {
-        return BytecodeDescriptor.unparse(cls);
+    /**
+     * Creates a method type descriptor derived from this one, evaluating the
+     * descriptor string eagerly and caching it in both objects.
+     */
+    MethodTypeDesc sharedStringDesc(ClassDesc returnType, ClassDesc[] parameterTypes) {
+        MethodTypeDesc ret;
+        var md = this.methodDescriptor;
+        if (md == null) {
+            ret = MethodTypeDescImpl.ofValidated(returnType, parameterTypes);
+            this.methodDescriptor = ret.descriptorString();
+            return ret;
+        }
+        return MethodTypeDescImpl.ofValidated(md, returnType, parameterTypes);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/invoke/MethodType.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,22 +28,18 @@ package java.lang.invoke;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.Constable;
 import java.lang.constant.MethodTypeDesc;
-import java.lang.ref.Reference;
-import java.lang.ref.ReferenceQueue;
-import java.lang.ref.WeakReference;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.function.Supplier;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.StringJoiner;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.stream.Stream;
 
+import jdk.internal.constant.ConstantUtils;
+import jdk.internal.constant.MethodTypeDescImpl;
 import jdk.internal.util.ReferencedKeySet;
 import jdk.internal.util.ReferenceKey;
 import jdk.internal.vm.annotation.Stable;
@@ -1296,7 +1292,7 @@ class MethodType
             return Optional.empty();
 
         if (parameterCount() == 0)
-            return Optional.of(MethodTypeDesc.of(retDesc.get()));
+            return Optional.of(MethodTypeDescImpl.ofValidated(methodDescriptor, retDesc.get(), ConstantUtils.EMPTY_CLASSDESC));
 
         var params = new ClassDesc[parameterCount()];
         for (int i = 0; i < params.length; i++) {
@@ -1305,7 +1301,7 @@ class MethodType
                 return Optional.empty();
             params[i] = paramDesc.get();
         }
-        return Optional.of(MethodTypeDesc.of(retDesc.get(), params));
+        return Optional.of(MethodTypeDescImpl.ofValidated(methodDescriptor, retDesc.get(), params));
     }
 
     //--- Serialization.

--- a/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
@@ -100,13 +100,13 @@ public final class ConstantUtils {
     public static MethodTypeDesc methodTypeDesc(MethodType type) {
         var returnDesc = classDesc(type.returnType());
         if (type.parameterCount() == 0) {
-            return MethodTypeDescImpl.ofValidated(type.descriptorString(), returnDesc, EMPTY_CLASSDESC);
+            return MethodTypeDescImpl.ofValidated(returnDesc, EMPTY_CLASSDESC);
         }
         var paramDescs = new ClassDesc[type.parameterCount()];
         for (int i = 0; i < type.parameterCount(); i++) {
             paramDescs[i] = classDesc(type.parameterType(i));
         }
-        return MethodTypeDescImpl.ofValidated(type.descriptorString(), returnDesc, paramDescs);
+        return MethodTypeDescImpl.ofValidated(returnDesc, paramDescs);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
@@ -31,8 +31,6 @@ import java.lang.constant.ConstantDesc;
 import java.lang.constant.ConstantDescs;
 import java.lang.constant.MethodTypeDesc;
 import java.lang.invoke.MethodType;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import jdk.internal.access.JavaLangAccess;
@@ -102,13 +100,13 @@ public final class ConstantUtils {
     public static MethodTypeDesc methodTypeDesc(MethodType type) {
         var returnDesc = classDesc(type.returnType());
         if (type.parameterCount() == 0) {
-            return MethodTypeDescImpl.ofValidated(returnDesc, EMPTY_CLASSDESC);
+            return MethodTypeDescImpl.ofValidated(type.descriptorString(), returnDesc, EMPTY_CLASSDESC);
         }
         var paramDescs = new ClassDesc[type.parameterCount()];
         for (int i = 0; i < type.parameterCount(); i++) {
             paramDescs[i] = classDesc(type.parameterType(i));
         }
-        return MethodTypeDescImpl.ofValidated(returnDesc, paramDescs);
+        return MethodTypeDescImpl.ofValidated(type.descriptorString(), returnDesc, paramDescs);
     }
 
     /**


### PR DESCRIPTION
A micro-optimization by sharing compatible String objects from MethodType (which itself is already deduplicated in a cache) to the generated MethodTypeDesc. This very slightly improves hashing performance by avoiding some string creation, hashing, and fast path equality via identity.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339875](https://bugs.openjdk.org/browse/JDK-8339875): MethodTypeDesc to reuse descriptor string from MethodType (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20942/head:pull/20942` \
`$ git checkout pull/20942`

Update a local copy of the PR: \
`$ git checkout pull/20942` \
`$ git pull https://git.openjdk.org/jdk.git pull/20942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20942`

View PR using the GUI difftool: \
`$ git pr show -t 20942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20942.diff">https://git.openjdk.org/jdk/pull/20942.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20942#issuecomment-2342333667)