### PR TITLE
8306679: com/sun/jdi/InterruptHangTest.java asserts with -Xcomp -Dmain.wrapper=Virtual options

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -2043,7 +2043,7 @@ NOINLINE intptr_t* ThawBase::thaw_slow(stackChunkOop chunk, bool return_barrier)
 
   assert(_cont.chunk_invariant(), "");
 
-  JVMTI_ONLY(if (!return_barrier) invalidate_jvmti_stack(_thread));
+  JVMTI_ONLY(invalidate_jvmti_stack(_thread));
 
   _thread->set_cont_fastpath(_fastpath);
 

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -29,4 +29,3 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java          8146623 generic-all
 java/lang/management/MemoryMXBean/CollectionUsageThreshold.java 8318668 generic-all
-com/sun/jdi/InterruptHangTest.java                              8306679,8043571 generic-all

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -29,3 +29,4 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java          8146623 generic-all
 java/lang/management/MemoryMXBean/CollectionUsageThreshold.java 8318668 generic-all
+com/sun/jdi/InterruptHangTest.java                              8043571 generic-all


### PR DESCRIPTION
The test is failing with virtual threads because the `cur_stack_depth()` of a virtual thread executed in `interp_only` mode is invalidated conditionally in the `ThawBase::thaw_slow()`:
```JVMTI_ONLY(if (!return_barrier) invalidate_jvmti_stack(_thread));```

It has to be invalidated unconditionally instead:
```JVMTI_ONLY(invalidate_jvmti_stack(_thread));```

Testing:
 - ran the test `com/sun/jdi/InterruptHangTest.java` locally and with mach5
 - the mach5 tiers 1-6 all passed

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8306679](https://bugs.openjdk.org/browse/JDK-8306679): com/sun/jdi/InterruptHangTest.java asserts with -Xcomp -Dmain.wrapper=Virtual options (**Bug** - P3)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) Review applies to [3f40efef](https://git.openjdk.org/jdk/pull/20943/files/3f40efefe6dff6e56b53e1bdae0a482129bceda4)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20943/head:pull/20943` \
`$ git checkout pull/20943`

Update a local copy of the PR: \
`$ git checkout pull/20943` \
`$ git pull https://git.openjdk.org/jdk.git pull/20943/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20943`

View PR using the GUI difftool: \
`$ git pr show -t 20943`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20943.diff">https://git.openjdk.org/jdk/pull/20943.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20943#issuecomment-2342519080)