### PR TITLE
8339918: Remove checks for outdated -t -tm -Xfuture -checksource -cs -noasyncgc options from the launcher

### DIFF
--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -141,9 +141,6 @@ java.launcher.X.usage=\n\
 \    -Xcomp            forces compilation of methods on first invocation\n\
 \    -Xdebug           does nothing; deprecated for removal in a future release.\n\
 \    -Xdiag            show additional diagnostic messages\n\
-\    -Xfuture          enable strictest checks, anticipating future default.\n\
-\                      This option is deprecated and may be removed in a\n\
-\                      future release.\n\
 \    -Xint             interpreted mode execution only\n\
 \    -Xinternalversion\n\
 \                      displays more detailed JVM version information than the\n\

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -3914,6 +3914,16 @@ of objects reachable from the old generation space into the young
 generation space.
 To disable GC of the young generation before each full GC, specify the
 option \f[V]-XX:-ScavengeBeforeFullGC\f[R].
+.TP
+\f[V]-Xfuture\f[R]
+Enables strict class-file format checks that enforce close conformance
+to the class-file format specification.
+Developers should use this flag when developing new code.
+Stricter checks may become the default in future releases.
+.RS
+.PP
+Use the option \f[V]-Xverify:all\f[R] instead.
+.RE
 .PP
 For the lists and descriptions of options removed in previous releases
 see the \f[I]Removed Java Options\f[R] section in:

--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -3749,12 +3749,6 @@ future JDK release.
 They\[aq]re still accepted and acted upon, but a warning is issued when
 they\[aq]re used.
 .TP
-\f[V]-Xfuture\f[R]
-Enables strict class-file format checks that enforce close conformance
-to the class-file format specification.
-Developers should use this flag when developing new code.
-Stricter checks may become the default in future releases.
-.TP
 \f[V]-Xloggc:\f[R]\f[I]filename\f[R]
 Sets the file to which verbose GC events information should be
 redirected for logging.

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1464,17 +1464,10 @@ ParseArguments(int *pargc, char ***pargv,
             return JNI_FALSE;
         } else if (JLI_StrCmp(arg, "-verbosegc") == 0) {
             AddOption("-verbose:gc", NULL);
-        } else if (JLI_StrCmp(arg, "-t") == 0) {
-            AddOption("-Xt", NULL);
-        } else if (JLI_StrCmp(arg, "-tm") == 0) {
-            AddOption("-Xtm", NULL);
         } else if (JLI_StrCmp(arg, "-debug") == 0) {
             JLI_ReportErrorMessage(ARG_DEPRECATED, "-debug");
         } else if (JLI_StrCmp(arg, "-noclassgc") == 0) {
             AddOption("-Xnoclassgc", NULL);
-        } else if (JLI_StrCmp(arg, "-Xfuture") == 0) {
-            JLI_ReportErrorMessage(ARG_DEPRECATED, "-Xfuture");
-            AddOption("-Xverify:all", NULL);
         } else if (JLI_StrCmp(arg, "-verify") == 0) {
             AddOption("-Xverify:all", NULL);
         } else if (JLI_StrCmp(arg, "-verifyremote") == 0) {
@@ -1493,11 +1486,6 @@ ParseArguments(int *pargc, char ***pargv,
             char *tmp = JLI_MemAlloc(tmpSize);
             snprintf(tmp, tmpSize, "-X%s", arg + 1); /* skip '-' */
             AddOption(tmp, NULL);
-        } else if (JLI_StrCmp(arg, "-checksource") == 0 ||
-                   JLI_StrCmp(arg, "-cs") == 0 ||
-                   JLI_StrCmp(arg, "-noasyncgc") == 0) {
-            /* No longer supported */
-            JLI_ReportErrorMessage(ARG_WARN, arg);
         } else if (JLI_StrCCmp(arg, "-splash:") == 0) {
             ; /* Ignore machine independent options already handled */
         } else if (JLI_StrCmp(arg, "--disable-@files") == 0) {

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -988,7 +988,7 @@ public class TTY implements EventNotifier {
                    token.startsWith("-X") ||
                    // Old-style options (These should remain in place as long as
                    //  the standard VM accepts them)
-                   token.equals("-noasyncgc") || token.equals("-prof") ||
+                   token.equals("-prof") ||
                    token.equals("-verify") ||
                    token.equals("-verifyremote") ||
                    token.equals("-verbosegc") ||

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -980,7 +980,6 @@ public class TTY implements EventNotifier {
                 return;
             } else if (
                    // Standard VM options passed on
-                   token.equals("-v") || token.startsWith("-v:") ||  // -v[:...]
                    token.startsWith("-verbose") ||                  // -verbose[:...]
                    token.startsWith("-D") ||
                    // -classpath handled below
@@ -988,7 +987,6 @@ public class TTY implements EventNotifier {
                    token.startsWith("-X") ||
                    // Old-style options (These should remain in place as long as
                    //  the standard VM accepts them)
-                   token.equals("-prof") ||
                    token.equals("-verify") ||
                    token.equals("-verifyremote") ||
                    token.equals("-verbosegc") ||

--- a/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/example/debug/tty/TTY.java
@@ -989,9 +989,7 @@ public class TTY implements EventNotifier {
                    //  the standard VM accepts them)
                    token.equals("-verify") ||
                    token.equals("-verifyremote") ||
-                   token.equals("-verbosegc") ||
-                   token.startsWith("-ms") || token.startsWith("-mx") ||
-                   token.startsWith("-ss") || token.startsWith("-oss") ) {
+                   token.equals("-verbosegc")) {
 
                 javaArgs = addArgument(javaArgs, token);
             } else if (token.startsWith("-R")) {


### PR DESCRIPTION
Can I please get a review for this change which cleans up the `java` launcher to remove checks/support for outdated options?

As noted in https://bugs.openjdk.org/browse/JDK-8339918, these 6 options have been outdated and unsupported for several releases now. 2 of them even throw an error currently. The change in this PR removes the code which had specific checks for these options and will now consider these options just like any other unknown option to the launcher.

tier1, tier2 and tier3 testing passed with these changes. Higher tier testing is in progress.

Would this change require a CSR?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8339928](https://bugs.openjdk.org/browse/JDK-8339928) to be approved

### Issues
 * [JDK-8339918](https://bugs.openjdk.org/browse/JDK-8339918): Remove checks for outdated -t -tm -Xfuture -checksource -cs -noasyncgc options from the launcher (**Sub-task** - P4)
 * [JDK-8339928](https://bugs.openjdk.org/browse/JDK-8339928): Remove checks for outdated -t -tm -Xfuture -checksource -cs -noasyncgc options from the launcher (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20945/head:pull/20945` \
`$ git checkout pull/20945`

Update a local copy of the PR: \
`$ git checkout pull/20945` \
`$ git pull https://git.openjdk.org/jdk.git pull/20945/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20945`

View PR using the GUI difftool: \
`$ git pr show -t 20945`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20945.diff">https://git.openjdk.org/jdk/pull/20945.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20945#issuecomment-2343175664)