### PR TITLE
8339927: Man page update for deprecating jhsdb debugd for removal

### DIFF
--- a/src/jdk.hotspot.agent/share/man/jhsdb.1
+++ b/src/jdk.hotspot.agent/share/man/jhsdb.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -43,6 +43,10 @@ jhsdb - attach to a Java process or launch a postmortem debugger to
 analyze the content of a core dump from a crashed Java Virtual Machine
 (JVM)
 .SH SYNOPSIS
+.PP
+\f[B]WARNING:\f[R] The \f[V]debugd\f[R] subcommand and
+\f[V]--connect\f[R] options are deprecated.
+They will be removed in a future release.
 .PP
 \f[V]jhsdb\f[R] \f[V]clhsdb\f[R] [\f[V]--pid\f[R] \f[I]pid\f[R] |
 \f[V]--exe\f[R] \f[I]executable\f[R] \f[V]--core\f[R]


### PR DESCRIPTION
Man page update to warn of deprecation of the jshdb debug subcommand and --connect option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339927](https://bugs.openjdk.org/browse/JDK-8339927): Man page update for deprecating jhsdb debugd for removal (**Enhancement** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20946/head:pull/20946` \
`$ git checkout pull/20946`

Update a local copy of the PR: \
`$ git checkout pull/20946` \
`$ git pull https://git.openjdk.org/jdk.git pull/20946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20946`

View PR using the GUI difftool: \
`$ git pr show -t 20946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20946.diff">https://git.openjdk.org/jdk/pull/20946.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20946#issuecomment-2343473509)