### PR TITLE
8339161: ZGC: Remove unused remembered sets

### DIFF
--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -248,8 +248,7 @@ void ZHeap::free_page(ZPage* page) {
   _page_table.remove(page);
 
   if (page->is_old()) {
-    page->verify_remset_cleared_current();
-    page->verify_remset_cleared_previous();
+    page->remset_delete();
   }
 
   // Free page
@@ -261,12 +260,10 @@ size_t ZHeap::free_empty_pages(const ZArray<ZPage*>* pages) {
   // Remove page table entries
   ZArrayIterator<ZPage*> iter(pages);
   for (ZPage* page; iter.next(&page);) {
-    if (page->is_old()) {
-      // The remset of pages should be clean when installed into the page
-      // cache.
-      page->remset_clear();
-    }
     _page_table.remove(page);
+    if (page->is_old()) {
+      page->remset_delete();
+    }
     freed += page->size();
   }
 

--- a/src/hotspot/share/gc/z/zPage.cpp
+++ b/src/hotspot/share/gc/z/zPage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,27 +78,16 @@ void ZPage::reset_seqnum() {
   Atomic::store(&_seqnum_other, ZGeneration::generation(_generation_id == ZGenerationId::young ? ZGenerationId::old : ZGenerationId::young)->seqnum());
 }
 
-void ZPage::remset_initialize() {
-  // Remsets should only be initialized once and only for old pages.
+void ZPage::remset_alloc() {
+  // Remsets should only be allocated/initialized once and only for old pages.
   assert(!_remembered_set.is_initialized(), "Should not be initialized");
   assert(is_old(), "Only old pages need a remset");
 
   _remembered_set.initialize(size());
 }
 
-void ZPage::remset_initialize_or_verify_cleared() {
-  assert(is_old(), "Only old pages need a remset");
-
-  if (_remembered_set.is_initialized()) {
-    verify_remset_cleared_current();
-    verify_remset_cleared_previous();
-  } else {
-    remset_initialize();
-  }
-}
-
-void ZPage::remset_clear() {
-  _remembered_set.clear_all();
+void ZPage::remset_delete() {
+  _remembered_set.delete_all();
 }
 
 void ZPage::reset(ZPageAge age) {
@@ -214,10 +203,6 @@ void ZPage::verify_remset_cleared_previous() const {
   if (ZVerifyRemembered && !is_remset_cleared_previous()) {
     fatal_msg(" previous remset bits should be cleared");
   }
-}
-
-void ZPage::clear_remset_current() {
-  _remembered_set.clear_current();
 }
 
 void ZPage::clear_remset_previous() {

--- a/src/hotspot/share/gc/z/zPage.cpp
+++ b/src/hotspot/share/gc/z/zPage.cpp
@@ -112,7 +112,6 @@ void ZPage::reset_top_for_allocation() {
 void ZPage::reset_type_and_size(ZPageType type) {
   _type = type;
   _livemap.resize(object_max_count());
-  _remembered_set.resize(size());
 }
 
 ZPage* ZPage::retype(ZPageType type) {

--- a/src/hotspot/share/gc/z/zPage.hpp
+++ b/src/hotspot/share/gc/z/zPage.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -155,9 +155,8 @@ public:
   void clear_remset_range_non_par_current(uintptr_t l_offset, size_t size);
   void swap_remset_bitmaps();
 
-  void remset_initialize();
-  void remset_initialize_or_verify_cleared();
-  void remset_clear();
+  void remset_alloc();
+  void remset_delete();
 
   ZBitMap::ReverseIterator remset_reverse_iterator_previous();
   BitMap::Iterator remset_iterator_limited_current(uintptr_t l_offset, size_t size);
@@ -182,7 +181,6 @@ public:
   void verify_remset_cleared_current() const;
   void verify_remset_cleared_previous() const;
 
-  void clear_remset_current();
   void clear_remset_previous();
 
   void* remset_current();

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -733,7 +733,7 @@ retry:
   page->reset_top_for_allocation();
   page->reset_livemap();
   if (age == ZPageAge::old) {
-    page->remset_initialize_or_verify_cleared();
+    page->remset_alloc();
   }
 
   // Update allocation statistics. Exclude gc relocations to avoid

--- a/src/hotspot/share/gc/z/zRememberedSet.cpp
+++ b/src/hotspot/share/gc/z/zRememberedSet.cpp
@@ -55,18 +55,10 @@ void ZRememberedSet::initialize(size_t page_size) {
   _bitmap[1].initialize(size_in_bits, true /* clear */);
 }
 
-void ZRememberedSet::resize(size_t page_size) {
-  // The bitmaps only need to be resized if remset has been
-  // initialized, and hence the bitmaps have been initialized.
-  if (is_initialized()) {
-    const BitMap::idx_t size_in_bits = to_bit_size(page_size);
-
-    // The bitmaps need to be cleared when free, but since this function is
-    // only used for shrinking the clear argument is correct but not crucial.
-    assert(size_in_bits <= _bitmap[0].size(), "Only used for shrinking");
-    _bitmap[0].resize(size_in_bits, true /* clear */);
-    _bitmap[1].resize(size_in_bits, true /* clear */);
-  }
+void ZRememberedSet::delete_all() {
+  assert(is_initialized(), "precondition");
+  _bitmap[0].resize(0);
+  _bitmap[1].resize(0);
 }
 
 bool ZRememberedSet::is_cleared_current() const {
@@ -75,10 +67,6 @@ bool ZRememberedSet::is_cleared_current() const {
 
 bool ZRememberedSet::is_cleared_previous() const {
   return previous()->is_empty();
-}
-
-void ZRememberedSet::delete_all() {
-  resize(0);
 }
 
 void ZRememberedSet::clear_previous() {

--- a/src/hotspot/share/gc/z/zRememberedSet.cpp
+++ b/src/hotspot/share/gc/z/zRememberedSet.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -77,13 +77,8 @@ bool ZRememberedSet::is_cleared_previous() const {
   return previous()->is_empty();
 }
 
-void ZRememberedSet::clear_all() {
-  _bitmap[0].clear_large();
-  _bitmap[1].clear_large();
-}
-
-void ZRememberedSet::clear_current() {
-  current()->clear_large();
+void ZRememberedSet::delete_all() {
+  resize(0);
 }
 
 void ZRememberedSet::clear_previous() {

--- a/src/hotspot/share/gc/z/zRememberedSet.hpp
+++ b/src/hotspot/share/gc/z/zRememberedSet.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,8 +133,7 @@ public:
   bool is_cleared_current() const;
   bool is_cleared_previous() const;
 
-  void clear_all();
-  void clear_current();
+  void delete_all();
   void clear_previous();
   void swap_remset_bitmaps();
 

--- a/src/hotspot/share/gc/z/zRememberedSet.hpp
+++ b/src/hotspot/share/gc/z/zRememberedSet.hpp
@@ -114,8 +114,7 @@ public:
 
   bool is_initialized() const;
   void initialize(size_t page_size);
-
-  void resize(size_t page_size);
+  void delete_all();
 
   bool at_current(uintptr_t offset) const;
   bool at_previous(uintptr_t offset) const;
@@ -133,7 +132,6 @@ public:
   bool is_cleared_current() const;
   bool is_cleared_previous() const;
 
-  void delete_all();
   void clear_previous();
   void swap_remset_bitmaps();
 


### PR DESCRIPTION
In ZGC, when a page becomes old it needs a remembered set (remset) which stores 2 bits per byte, a memory overhead of 3.125% (2/64) per page that stores an allocated remset.

When an old page is potentially freed and inserted in the page cache, it can later be re-used as a young page. In this case, the remset is still allocated even though the young page does not need it. This is especially noteworthy for long-running programs where pages are recycled for a long enough period to have a remset allocated for close to all pages.

The attached plot shows remset memory usage for pages that are "live" for a program that frequently recycles pages using a cache-mechanism. As remsets for young pages are unused, it should be considered wasted memory.

![remset_waste](https://github.com/user-attachments/assets/2a60948b-9297-4554-8fb4-d9f527855c33)

The alternative solution that I propose in this PR deletes/frees remsets when an old page is inserted into the page cache, to not wast ememory. This would mean that remsets are only stored for old pages that are in use. Pages that are not in use or are young, should not have an allocated remset. With this change, the line showing remset usage for young pages would disappear in the plot above and the total memory usage dictated by the number of "live" old pages.

Below is a performance measurement of initializing vs. clearing remsets in the same cache program mentioned above. When deleting remsets, freeing is made by GC threads so there is no latency impact for mutators. Initializing remsets is on average ~2.3x slower than clearing, but also uses 3.125% less memory for pages that do not need a remset. ~89% of the measured initializations are made by GC threads and the rest by mutator threads.

|              | min (ms) | max (ms) | mean (ms)  |
| ------------ | -------- | -------- | ---------- |
| remset init  | 0.000292 | 0.706    | 0.00258083 |
| remset clear | 0.000082 | 0.015    | 0.00111340 |

Tested with tiers 1-7 and local test making sure there are no remsets for young pages. SPECjbb2015 performance measurements show no statistically significant regression/improvement.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339161](https://bugs.openjdk.org/browse/JDK-8339161): ZGC: Remove unused remembered sets (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20947/head:pull/20947` \
`$ git checkout pull/20947`

Update a local copy of the PR: \
`$ git checkout pull/20947` \
`$ git pull https://git.openjdk.org/jdk.git pull/20947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20947`

View PR using the GUI difftool: \
`$ git pr show -t 20947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20947.diff">https://git.openjdk.org/jdk/pull/20947.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20947#issuecomment-2355684421)