### PR TITLE
8339943: Frame not disposed in java/awt/dnd/DropActionChangeTest.java

### DIFF
--- a/test/jdk/java/awt/dnd/DropActionChangeTest.java
+++ b/test/jdk/java/awt/dnd/DropActionChangeTest.java
@@ -72,7 +72,7 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
     static final int MOUSE_RELEASE_TIMEOUT = 2000;
 
     public static void main(String[] args) throws Exception {
-        EventQueue.invokeAndWait(()->test = new DropActionChangeTest());
+        EventQueue.invokeAndWait(() -> test = new DropActionChangeTest());
         EventQueue.invokeAndWait(test::init);
         try {
             test.start();
@@ -101,8 +101,8 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
                         "drop action=" + e.getDropAction());
                 if (e.getDropAction() != DnDConstants.ACTION_MOVE) {
                     System.err.println("FAILURE: wrong drop action:"
-                                       + e.getDropAction()+", It should be "
-                                       +DnDConstants.ACTION_MOVE);
+                                       + e.getDropAction() + ", It should be "
+                                       + DnDConstants.ACTION_MOVE);
                     failed = true;
                 }
                 synchronized (LOCK) {
@@ -138,6 +138,15 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
         new DropTarget(panel, dtl);
 
         frame.setVisible(true);
+    }
+
+    private static void disposeFrame() {
+        if (frame != null) {
+            frame.dispose();
+        }
+        if (test != null) {
+            test.dispose();
+        }
     }
 
     public void start() {
@@ -191,24 +200,18 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
 
         System.err.println("Test passed!");
     }
-    private static void disposeFrame() {
-        if(frame != null) {
-            frame.dispose();
-        }
-        if(test != null) {
-            test.dispose();
-        }
-    }
+
     private static void captureScreen(String str) {
         try {
             final Rectangle screenBounds = new Rectangle(
                     Toolkit.getDefaultToolkit().getScreenSize());
-            ImageIO.write(robot.createScreenCapture(screenBounds),
-                          "png", new File(str+"Failure_Screen.png"));
+            ImageIO.write(robot.createScreenCapture(screenBounds), "png",
+                          new File(str + "Failure_Screen.png"));
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
+
     public void reset() {
         clickedComponent = null;
     }
@@ -251,7 +254,7 @@ class Util {
     }
 
     public static void doDrag(Robot robot, Point startPoint, Point endPoint) {
-        robot.waitForIdle();
+       robot.waitForIdle();
        for (Point p = new Point(startPoint); !p.equals(endPoint);
                 p.translate(Util.sign(endPoint.x - p.x),
                             Util.sign(endPoint.y - p.y))) {

--- a/test/jdk/java/awt/dnd/DropActionChangeTest.java
+++ b/test/jdk/java/awt/dnd/DropActionChangeTest.java
@@ -21,17 +21,17 @@
  * questions.
  */
 
-import javax.swing.JFrame;
 import java.awt.AWTEvent;
 import java.awt.Component;
 import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Panel;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.dnd.DnDConstants;
-import java.awt.dnd.DragGestureEvent;
 import java.awt.dnd.DragGestureListener;
 import java.awt.dnd.DragSource;
 import java.awt.dnd.DragSourceAdapter;
@@ -43,9 +43,13 @@ import java.awt.dnd.DropTargetDragEvent;
 import java.awt.dnd.DropTargetDropEvent;
 import java.awt.dnd.DropTargetListener;
 import java.awt.event.AWTEventListener;
-import java.awt.event.MouseEvent;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.io.File;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.imageio.ImageIO;
+import javax.swing.JFrame;
 
 /*
   @test
@@ -56,28 +60,24 @@ import java.awt.event.KeyEvent;
 */
 
 public class DropActionChangeTest extends JFrame implements AWTEventListener {
-    Robot robot;
-    Frame frame;
+    private static Robot robot;
+    private static Frame frame;
+    private static DropActionChangeTest test;
     Panel panel;
     private volatile boolean failed;
     private volatile boolean dropEnd;
     private volatile Component clickedComponent;
     private final Object LOCK = new Object();
-    static final int FRAME_ACTIVATION_TIMEOUT = 3000;
     static final int DROP_COMPLETION_TIMEOUT = 5000;
     static final int MOUSE_RELEASE_TIMEOUT = 2000;
 
     public static void main(String[] args) throws Exception {
-        DropActionChangeTest test = new DropActionChangeTest();
+        test = new DropActionChangeTest();
         EventQueue.invokeAndWait(test::init);
         try {
             test.start();
         } finally {
-            EventQueue.invokeAndWait(() -> {
-                if (test.frame != null) {
-                    test.frame.dispose();
-                }
-            });
+            EventQueue.invokeAndWait(DropActionChangeTest::disposeFrame);
         }
     }
 
@@ -100,7 +100,9 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
                 System.err.println("DragSourseListener.dragDropEnd(): " +
                         "drop action=" + e.getDropAction());
                 if (e.getDropAction() != DnDConstants.ACTION_MOVE) {
-                    System.err.println("FAILURE: wrong drop action:" + e.getDropAction());
+                    System.err.println("FAILURE: wrong drop action:"
+                                       + e.getDropAction()+", It should be "
+                                       +DnDConstants.ACTION_MOVE);
                     failed = true;
                 }
                 synchronized (LOCK) {
@@ -110,11 +112,7 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
             }
         };
 
-        DragGestureListener dgl = new DragGestureListener() {
-            public void dragGestureRecognized(DragGestureEvent dge) {
-                dge.startDrag(null, new StringSelection("test"), dsl);
-            }
-        };
+        DragGestureListener dgl = dge -> dge.startDrag(null, new StringSelection("test"), dsl);
 
         new DragSource().createDefaultDragGestureRecognizer(panel,
                 DnDConstants.ACTION_COPY_OR_MOVE, dgl);
@@ -145,8 +143,11 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
     public void start() {
         try {
             robot = new Robot();
+            robot.setAutoDelay(100);
 
-            Point startPoint = panel.getLocationOnScreen();
+            AtomicReference<Point> startPointRef = new AtomicReference<>();
+            EventQueue.invokeAndWait(()-> startPointRef.set(panel.getLocationOnScreen()));
+            Point startPoint = startPointRef.get();
             startPoint.translate(50, 50);
 
             if (!pointInComponent(robot, startPoint, panel)) {
@@ -163,14 +164,15 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
             synchronized (LOCK) {
                 robot.keyPress(KeyEvent.VK_CONTROL);
                 robot.mouseMove(startPoint.x, startPoint.y);
-                robot.mousePress(InputEvent.BUTTON1_MASK);
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
                 Util.doDrag(robot, startPoint, medPoint);
                 robot.keyRelease(KeyEvent.VK_CONTROL);
                 Util.doDrag(robot, medPoint, endPoint);
-                robot.mouseRelease(InputEvent.BUTTON1_MASK);
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
                 LOCK.wait(DROP_COMPLETION_TIMEOUT);
             }
             if (!dropEnd) {
+                captureScreen();
                 System.err.println("DragSourseListener.dragDropEnd() was not called, returning");
                 return;
             }
@@ -179,12 +181,30 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
         }
 
         if (failed) {
-            throw new RuntimeException("wrong drop action!");
+            captureScreen();
+            throw new RuntimeException("Wrong drop action!");
         }
 
-        System.err.println("test passed!");
+        System.err.println("Test passed!");
     }
-
+    private static void disposeFrame() {
+        if(frame != null) {
+            frame.dispose();
+        }
+        if(test != null) {
+            test.dispose();
+        }
+    }
+    private static void captureScreen() {
+        try {
+            final Rectangle screenBounds = new Rectangle(
+                    Toolkit.getDefaultToolkit().getScreenSize());
+            ImageIO.write(robot.createScreenCapture(screenBounds),
+                          "png", new File("Failure_Screen.png"));
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
     public void reset() {
         clickedComponent = null;
     }
@@ -203,9 +223,9 @@ public class DropActionChangeTest extends JFrame implements AWTEventListener {
         robot.waitForIdle();
         reset();
         robot.mouseMove(p.x, p.y);
-        robot.mousePress(InputEvent.BUTTON1_MASK);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
         synchronized (LOCK) {
-            robot.mouseRelease(InputEvent.BUTTON1_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             LOCK.wait(MOUSE_RELEASE_TIMEOUT);
         }
 


### PR DESCRIPTION
Stabilized the test by disposing the frame at the end, adding an auto delay,  called panel.getLocationOnScreen() in invokeAndWait(), formatting changes, etc
And for better debugging, added captureScreen() for failure cases.

Testing:
Tested using mach5 in all available platforms and attached the link in bug as a comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339943](https://bugs.openjdk.org/browse/JDK-8339943): Frame not disposed in java/awt/dnd/DropActionChangeTest.java (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**) Review applies to [6238ba9b](https://git.openjdk.org/jdk/pull/20951/files/6238ba9b23db8f4c0805c9c3ea00ff28638595a8)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20951/head:pull/20951` \
`$ git checkout pull/20951`

Update a local copy of the PR: \
`$ git checkout pull/20951` \
`$ git pull https://git.openjdk.org/jdk.git pull/20951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20951`

View PR using the GUI difftool: \
`$ git pr show -t 20951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20951.diff">https://git.openjdk.org/jdk/pull/20951.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20951#issuecomment-2343882679)