### PR TITLE
8321935: Define the term 'standard doclet'

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/doclet/StandardDoclet.java
@@ -36,7 +36,10 @@ import jdk.javadoc.internal.doclets.formats.html.HtmlDoclet;
 
 /**
  * This doclet generates HTML-formatted documentation for the specified modules,
- * packages and types.
+ * packages and types. It is the doclet that is used by the
+ * <a href="{@docRoot}/../specs/man/javadoc.html"><em>javadoc</em></a> tool
+ * and the {@linkplain javax.tools.ToolProvider#getSystemDocumentationTool
+ * system documentation tool} when no other doclet is specified to be used.
  *
  * <h2><a id="user-defined-taglets">User-Defined Taglets</a></h2>
  *


### PR DESCRIPTION
Please review this doc-only fix to indicate that the `StandardDoclet` class is the one used by default by the _javadoc_ tool.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8321935](https://bugs.openjdk.org/browse/JDK-8321935): Define the term 'standard doclet' (**Enhancement** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20952/head:pull/20952` \
`$ git checkout pull/20952`

Update a local copy of the PR: \
`$ git checkout pull/20952` \
`$ git pull https://git.openjdk.org/jdk.git pull/20952/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20952`

View PR using the GUI difftool: \
`$ git pr show -t 20952`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20952.diff">https://git.openjdk.org/jdk/pull/20952.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20952#issuecomment-2344357057)