### PR TITLE
8339954: Print JVMCI names with the Compiler.{perfmap,codelist,CodeHeap_Analytics} diagnostic commands

### DIFF
--- a/src/hotspot/share/code/codeCache.cpp
+++ b/src/hotspot/share/code/codeCache.cpp
@@ -1767,9 +1767,13 @@ void CodeCache::print_codelist(outputStream* st) {
     nmethod* nm = iter.method();
     ResourceMark rm;
     char* method_name = nm->method()->name_and_sig_as_C_string();
-    st->print_cr("%d %d %d %s [" INTPTR_FORMAT ", " INTPTR_FORMAT " - " INTPTR_FORMAT "]",
+    const char* jvmci_name = nullptr;
+#if INCLUDE_JVMCI
+    jvmci_name = nm->jvmci_name();
+#endif
+    st->print_cr("%d %d %d %s%s%s [" INTPTR_FORMAT ", " INTPTR_FORMAT " - " INTPTR_FORMAT "]",
                  nm->compile_id(), nm->comp_level(), nm->get_state(),
-                 method_name,
+                 method_name, jvmci_name ? " jvmci_name=" : "", jvmci_name ? jvmci_name : "",
                  (intptr_t)nm->header_begin(), (intptr_t)nm->code_begin(), (intptr_t)nm->code_end());
   }
 }
@@ -1811,12 +1815,20 @@ void CodeCache::write_perf_map(const char* filename, outputStream* st) {
   while (iter.next()) {
     CodeBlob *cb = iter.method();
     ResourceMark rm;
-    const char* method_name =
-      cb->is_nmethod() ? cb->as_nmethod()->method()->external_name()
-                       : cb->name();
-    fs.print_cr(INTPTR_FORMAT " " INTPTR_FORMAT " %s",
+    const char* method_name = nullptr;
+    const char* jvmci_name = nullptr;
+    if (cb->is_nmethod()) {
+      nmethod* nm = cb->as_nmethod();
+      method_name = nm->method()->external_name();
+#if INCLUDE_JVMCI
+      jvmci_name = nm->jvmci_name();
+#endif
+    } else {
+      method_name = cb->name();
+    }
+    fs.print_cr(INTPTR_FORMAT " " INTPTR_FORMAT " %s%s%s",
                 (intptr_t)cb->code_begin(), (intptr_t)cb->code_size(),
-                method_name);
+                method_name, jvmci_name ? " jvmci_name=" : "", jvmci_name ? jvmci_name : "");
   }
 }
 #endif // LINUX

--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -740,7 +740,7 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
             if (jvmci_name != nullptr) {
               size_t size = ::strlen(blob_name) + ::strlen(" jvmci_name=") + ::strlen(jvmci_name) + 1;
               char* new_blob_name = (char*)os::malloc(size, mtInternal);
-              ::sprintf(new_blob_name, "%s jvmci_name=%s", blob_name, jvmci_name);
+              os::snprintf(new_blob_name, size, "%s jvmci_name=%s", blob_name, jvmci_name);
               os::free((void*)blob_name);
               blob_name = new_blob_name;
             }

--- a/src/hotspot/share/code/codeHeapState.cpp
+++ b/src/hotspot/share/code/codeHeapState.cpp
@@ -735,7 +735,16 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
             } else {
               blob_name = os::strdup(cb->name());
             }
-
+#if INCLUDE_JVMCI
+            const char* jvmci_name = nm->jvmci_name();
+            if (jvmci_name != nullptr) {
+              size_t size = ::strlen(blob_name) + ::strlen(" jvmci_name=") + ::strlen(jvmci_name) + 1;
+              char* new_blob_name = (char*)os::malloc(size, mtInternal);
+              ::sprintf(new_blob_name, "%s jvmci_name=%s", blob_name, jvmci_name);
+              os::free((void*)blob_name);
+              blob_name = new_blob_name;
+            }
+#endif
             nm_size    = nm->total_size();
             compile_id = nm->compile_id();
             comp_lvl   = (CompLevel)(nm->comp_level());
@@ -2184,6 +2193,12 @@ void CodeHeapState::print_names(outputStream* out, CodeHeap* heap) {
             ast->print("%s.", classNameS);
             ast->print("%s", methNameS);
             ast->print("%s", methSigS);
+#if INCLUDE_JVMCI
+            const char* jvmci_name = nm->jvmci_name();
+            if (jvmci_name != nullptr) {
+              ast->print(" jvmci_name=%s", jvmci_name);
+            }
+#endif
           } else {
             ast->print("%s", blob_name);
           }


### PR DESCRIPTION
The diagnostic commands `Compiler.codelist`, `Compiler.CodeHeap_Analytics` and `Compiler.perfmap` are handy for analyzing the CodeCache or creating a symbol file for the perf tool. However, with the Truffle framework which uses the GraalVM compiler in "hosted" mode, we can end up with hundreds if not thousands of nmethods which are all linked to the same Java method (most prominently `com.oracle.truffle.runtime.OptimizedCallTarget.profiledPERoot()`). All these nmethods are currently indistinguishable by the two aforementioned diagnostic commands.

But nmethods compiled by the GraalVM compiler have a special "JVMCI name" attached to them, which in the case of Truffle corresponds to the guest language function name. Printing this "JVMCI name" in addition to the true Java method name makes it easier to distinguish various nmethods compiled by Truffle or other frameworks which use the GraalVM compiler in hosted mode.

For the `Compiler.perfmap` command, it should be mentioned that the format of the created perfmap file is specified here:
https://github.com/torvalds/linux/blob/master/tools/perf/Documentation/jit-interface.txt

It only mandates that each line starts with a start and size number in hex and interprets the whole rest of the line (which can even include special characters) as a "symbolname". Taking into account that we already today produce "symbol names" as different as "`throw_range_check_failed Runtime1 stub`", "`Signature Handler Temp Buffer`", "`I2C/C2I adapters`" or "`boolean java.lang.invoke.VarHandleInts$FieldInstanceReadWrite.compareAndSet(java.lang.invoke.VarHandle, java.lang.Object, int, int)`", adding a potential jvmci suffix like "jvmci_name=myFancyJSFunction()#2" to some methods will not cause any compatibility issues.

..and the output of `Compiler.CodeHeap_Analytics` is unparsable anyway :)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339954](https://bugs.openjdk.org/browse/JDK-8339954): Print JVMCI names with the Compiler.{perfmap,codelist,CodeHeap_Analytics} diagnostic commands (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20954/head:pull/20954` \
`$ git checkout pull/20954`

Update a local copy of the PR: \
`$ git checkout pull/20954` \
`$ git pull https://git.openjdk.org/jdk.git pull/20954/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20954`

View PR using the GUI difftool: \
`$ git pr show -t 20954`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20954.diff">https://git.openjdk.org/jdk/pull/20954.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20954#issuecomment-2344440383)