### PR TITLE
8338525: Leading and trailing code blocks by indentation

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -295,6 +295,7 @@ public class DocCommentParser {
                         markdown.update();
                         if (markdown.isIndentedCodeBlock()) {
                             markdown.skipLine();
+                            lastNonWhite = bp - 1; // don't include newline or EOF
                         }
                     }
                 }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -496,7 +496,7 @@ public class DocCommentParser {
         markdown.update();
         if (markdown.isIndentedCodeBlock()) {
             markdown.skipLine();
-            lastNonWhite = bp - 1; // no not include newline or EOF
+            lastNonWhite = bp - 1; // do not include newline or EOF
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -286,17 +286,17 @@ public class DocCommentParser {
         int depth = 1;                  // only used when phase is INLINE
         int pos = bp;                   // only used when phase is INLINE
 
+        if (textKind == DocTree.Kind.MARKDOWN) {
+            initMarkdownLine();
+        }
+
         loop:
         while (bp < buflen) {
             switch (ch) {
                 case '\n', '\r' -> {
                     nextChar();
                     if (textKind == DocTree.Kind.MARKDOWN) {
-                        markdown.update();
-                        if (markdown.isIndentedCodeBlock()) {
-                            markdown.skipLine();
-                            lastNonWhite = bp - 1; // don't include newline or EOF
-                        }
+                        initMarkdownLine();
                     }
                 }
 
@@ -487,6 +487,17 @@ public class DocCommentParser {
             textStart = bp;
         lastNonWhite = bp;
         nextChar();
+    }
+
+    void initMarkdownLine() {
+        if (textStart == -1) {
+            textStart = bp;
+        }
+        markdown.update();
+        if (markdown.isIndentedCodeBlock()) {
+            markdown.skipLine();
+            lastNonWhite = bp - 1; // no not include newline or EOF
+        }
     }
 
     private IllegalStateException unknownTextKind(DocTree.Kind textKind) {

--- a/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownCodeBlocks.java
+++ b/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownCodeBlocks.java
@@ -486,4 +486,61 @@ public class TestMarkdownCodeBlocks extends JavadocTester {
                     <dd><code><a href="NullPointerException.html" title="class in p">NullPointerException</a></code> - if other is <code>null</code></dd>
                     </dl>""");
     }
+
+    @Test
+    public void testLeadingCodeBlock(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p;
+                    ///     Leading code block
+                    /// Lorum ipsum.
+                    public class C { }
+                    """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "--no-platform-links",
+                "--source-path", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        // check first sentence is empty in package summary file
+        checkOutput("p/package-summary.html", true,
+                """
+                    <div class="col-first even-row-color class-summary class-summary-tab2"><a href="C.html" title="class in p">C</a></div>
+                    <div class="col-last even-row-color class-summary class-summary-tab2">&nbsp;</div>""");
+
+        checkOutput("p/C.html", true,
+                """
+                    <div class="block"><pre><code>Leading code block
+                    </code></pre>
+                    <p>Lorum ipsum.</p>""");
+
+    }
+
+    @Test
+    public void testTrailingCodeBlock(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p;
+                    /// Lorum ipsum.
+                    ///
+                    ///     Trailing code block
+                    public class C { }
+                    """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "--no-platform-links",
+                "--source-path", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("p/C.html", true,
+                """
+                    <div class="block"><p>Lorum ipsum.</p>
+                    <pre><code>Trailing code block
+                    </code></pre>
+                    </div>""");
+    }
 }

--- a/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownCodeBlocks.java
+++ b/test/langtools/jdk/javadoc/doclet/testMarkdown/TestMarkdownCodeBlocks.java
@@ -543,4 +543,50 @@ public class TestMarkdownCodeBlocks extends JavadocTester {
                     </code></pre>
                     </div>""");
     }
+
+    // this example is derived from the test case in JDK-8338525
+    @Test
+    public void testLeadingTrailingCodeBlockWithAnnotations(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    package p;
+                    public class C {
+                        ///     @Override
+                        ///     void m() {}
+                        ///
+                        /// Plain text
+                        ///
+                        ///     @Override
+                        ///     void m() {}
+                        public void m() {}
+                    }""");
+
+        javadoc("-d", base.resolve("api").toString(),
+                "--no-platform-links",
+                "--source-path", src.toString(),
+                "p");
+        checkExit(Exit.OK);
+
+        checkOutput("p/C.html", true,
+                """
+                    <div class="col-first even-row-color method-summary-table method-summary-table-tab2 \
+                    method-summary-table-tab4"><code>void</code></div>
+                    <div class="col-second even-row-color method-summary-table method-summary-table-tab2 \
+                    method-summary-table-tab4"><code><a href="#m()" class="member-name-link">m</a>()</code></div>
+                    <div class="col-last even-row-color method-summary-table method-summary-table-tab2 \
+                    method-summary-table-tab4">&nbsp;</div>""",
+                """
+                    <div class="member-signature"><span class="modifiers">public</span>&nbsp;\
+                    <span class="return-type">void</span>&nbsp;<span class="element-name">m</span>()</div>
+                    <div class="block"><pre><code>@Override
+                    void m() {}
+                    </code></pre>
+                    <p>Plain text</p>
+                    <pre><code>@Override
+                    void m() {}
+                    </code></pre>
+                    </div>""");
+
+    }
 }

--- a/test/langtools/tools/javac/doctree/DocCommentTester.java
+++ b/test/langtools/tools/javac/doctree/DocCommentTester.java
@@ -1043,8 +1043,9 @@ public class DocCommentTester {
                     .replaceAll("(\\{@value\\s+[^}]+)\\s+(})", "$1$2");
         }
 
+        // See comment in MarkdownTest for explanation of dummy and Override
         String normalizeFragment(String s) {
-            return s.replaceAll("\n[ \t]+@(?!([@*]|dummy))", "\n@");
+            return s.replaceAll("\n[ \t]+@(?!([@*]|(dummy|Override)))", "\n@");
         }
 
         int copyLiteral(String s, int start, StringBuilder sb) {

--- a/test/langtools/tools/javac/doctree/MarkdownTest.java
+++ b/test/langtools/tools/javac/doctree/MarkdownTest.java
@@ -411,6 +411,32 @@ DocComment[DOC_COMMENT, pos:0
 ]
 */
 
+    ///     Indented Code Block
+    /// Lorum ipsum.
+    void indentedCodeBlock_leading() { }
+/*
+DocComment[DOC_COMMENT, pos:0
+  firstSentence: empty
+  body: 1
+    RawText[MARKDOWN, pos:0, ____Indented_Code_Block|Lorum_ipsum.]
+  block tags: empty
+]
+*/
+
+    /// Lorum ipsum.
+    ///
+    ///     Indented Code Block
+    void indentedCodeBlock_trailing() { }
+/*
+DocComment[DOC_COMMENT, pos:0
+  firstSentence: 1
+    RawText[MARKDOWN, pos:0, Lorum_ipsum.]
+  body: 1
+    RawText[MARKDOWN, pos:18, Indented_Code_Block]
+  block tags: empty
+]
+*/
+
     ///123.
     ///
     ///```

--- a/test/langtools/tools/javac/doctree/MarkdownTest.java
+++ b/test/langtools/tools/javac/doctree/MarkdownTest.java
@@ -40,6 +40,7 @@
  * In the tests for code spans and code blocks, "@dummy" is used as a dummy inline
  * or block tag to verify that it is skipped as part of the code span or code block.
  * In other words, "@dummy" should appear as a literal part of the Markdown content.
+ * ("@Override" is also treated the same way, as a commonly found annotation.)
  * Conversely, standard tags are used to verify that a fragment of text is not being
  * skipped as a code span or code block. In other words, they should be recognized as tags
  * and not skipped as part of any Markdown content.
@@ -635,6 +636,25 @@ DocComment[DOC_COMMENT, pos:0
     RawText[MARKDOWN, pos:0, Indented_by_8.]
   body: 1
     RawText[MARKDOWN, pos:19, *_list||____code_block||done.]
+  block tags: empty
+]
+*/
+
+// The following test case is derived from the test case in JDK-8338525.
+
+    ///     @Override
+    ///     void m() { }
+    ///
+    /// Plain text
+    ///
+    ///     @Override
+    ///     void m() { }
+    void leadingTrailingCodeBlocksWithAnnos() { }
+/*
+DocComment[DOC_COMMENT, pos:0
+  firstSentence: empty
+  body: 1
+    RawText[MARKDOWN, pos:0, ____@Override|____void_m()_{_}||...||____@Override|____void_m()_{_}]
   block tags: empty
 ]
 */


### PR DESCRIPTION
Please review these changes to correct the handling of leading and trailing indented code blocks in a doc comment.

There are two separate issues here: one for leading indented code blocks and one for trailing indented code blocks.

1. Leading indented code blocks: the code to detect the first sentence of a doc comment is modified to detect whether the comment begins with an indented code block. If it does, the first sentence is deemed to be empty, and the body of the doc comment begins with the code block.
2. Trailing indented code blocks: the content of the indented code block is marked as significant by updating `lastNonWhite`, which will cause the content to be recorded (not dropped) if the code block is followed by EOF.

For both cases, simple `DocTree` AST-level tests are provided, as well as full `JavadocTester` tests, that test the end-user view of the generated docs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338525](https://bugs.openjdk.org/browse/JDK-8338525): Leading and trailing code blocks by indentation (**Bug** - P3)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**) Review applies to [02f10326](https://git.openjdk.org/jdk/pull/20956/files/02f10326b0a63c4e294e8529e1ba48689112463e)
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20956/head:pull/20956` \
`$ git checkout pull/20956`

Update a local copy of the PR: \
`$ git checkout pull/20956` \
`$ git pull https://git.openjdk.org/jdk.git pull/20956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20956`

View PR using the GUI difftool: \
`$ git pr show -t 20956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20956.diff">https://git.openjdk.org/jdk/pull/20956.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20956#issuecomment-2344827321)