### PR TITLE
8339876: Move constant symbol caches to Utf8EntryImpl

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/Annotation.java
+++ b/src/java.base/share/classes/java/lang/classfile/Annotation.java
@@ -34,6 +34,8 @@ import jdk.internal.classfile.impl.TemporaryConstantPool;
 
 import java.lang.constant.ClassDesc;
 import java.util.List;
+
+import jdk.internal.classfile.impl.Util;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -78,7 +80,7 @@ public sealed interface Annotation
      * {@return the annotation interface, as a symbolic descriptor}
      */
     default ClassDesc classSymbol() {
-        return ClassDesc.ofDescriptor(className().stringValue());
+        return Util.fieldTypeSymbol(className());
     }
 
     /**
@@ -115,7 +117,7 @@ public sealed interface Annotation
      */
     static Annotation of(ClassDesc annotationClass,
                          List<AnnotationElement> elements) {
-        return of(TemporaryConstantPool.INSTANCE.utf8Entry(annotationClass.descriptorString()), elements);
+        return of(TemporaryConstantPool.INSTANCE.utf8Entry(annotationClass), elements);
     }
 
     /**
@@ -125,6 +127,6 @@ public sealed interface Annotation
      */
     static Annotation of(ClassDesc annotationClass,
                          AnnotationElement... elements) {
-        return of(TemporaryConstantPool.INSTANCE.utf8Entry(annotationClass.descriptorString()), elements);
+        return of(TemporaryConstantPool.INSTANCE.utf8Entry(annotationClass), elements);
     }
 }

--- a/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
+++ b/src/java.base/share/classes/java/lang/classfile/AnnotationValue.java
@@ -38,6 +38,8 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.Constable;
 import java.util.ArrayList;
 import java.util.List;
+
+import jdk.internal.classfile.impl.Util;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -405,7 +407,7 @@ public sealed interface AnnotationValue {
 
         /** {@return the class descriptor} */
         default ClassDesc classSymbol() {
-            return ClassDesc.ofDescriptor(className().stringValue());
+            return Util.fieldTypeSymbol(className());
         }
     }
 
@@ -423,7 +425,7 @@ public sealed interface AnnotationValue {
 
         /** {@return the enum class descriptor} */
         default ClassDesc classSymbol() {
-            return ClassDesc.ofDescriptor(className().stringValue());
+            return Util.fieldTypeSymbol(className());
         }
 
         /** {@return the enum constant name} */
@@ -452,7 +454,7 @@ public sealed interface AnnotationValue {
      * @param constantName the name of the enum constant
      */
     static OfEnum ofEnum(ClassDesc className, String constantName) {
-        return ofEnum(TemporaryConstantPool.INSTANCE.utf8Entry(className.descriptorString()),
+        return ofEnum(TemporaryConstantPool.INSTANCE.utf8Entry(className),
                       TemporaryConstantPool.INSTANCE.utf8Entry(constantName));
     }
 
@@ -469,7 +471,7 @@ public sealed interface AnnotationValue {
      * @param className the descriptor of the class
      */
     static OfClass ofClass(ClassDesc className) {
-        return ofClass(TemporaryConstantPool.INSTANCE.utf8Entry(className.descriptorString()));
+        return ofClass(TemporaryConstantPool.INSTANCE.utf8Entry(className));
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/ClassBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassBuilder.java
@@ -194,7 +194,9 @@ public sealed interface ClassBuilder
     default ClassBuilder withField(String name,
                                    ClassDesc descriptor,
                                    int flags) {
-        return withField(name, descriptor, Util.buildingFlags(flags));
+        return withField(constantPool().utf8Entry(name),
+                         constantPool().utf8Entry(descriptor),
+                         flags);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/CodeBuilder.java
@@ -769,7 +769,7 @@ public sealed interface CodeBuilder
     default CodeBuilder localVariable(int slot, String name, ClassDesc descriptor, Label startScope, Label endScope) {
         return localVariable(slot,
                              constantPool().utf8Entry(name),
-                             constantPool().utf8Entry(descriptor.descriptorString()),
+                             constantPool().utf8Entry(descriptor),
                              startScope, endScope);
     }
 

--- a/src/java.base/share/classes/java/lang/classfile/FieldModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/FieldModel.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BufferedFieldBuilder;
 import jdk.internal.classfile.impl.FieldImpl;
+import jdk.internal.classfile.impl.Util;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -59,6 +60,6 @@ public sealed interface FieldModel
 
     /** {@return the field descriptor of this field, as a symbolic descriptor} */
     default ClassDesc fieldTypeSymbol() {
-        return ClassDesc.ofDescriptor(fieldType().stringValue());
+        return Util.fieldTypeSymbol(fieldType());
     }
 }

--- a/src/java.base/share/classes/java/lang/classfile/MethodModel.java
+++ b/src/java.base/share/classes/java/lang/classfile/MethodModel.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BufferedMethodBuilder;
 import jdk.internal.classfile.impl.MethodImpl;
+import jdk.internal.classfile.impl.Util;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -59,7 +60,7 @@ public sealed interface MethodModel
 
     /** {@return the method descriptor of this method, as a symbolic descriptor} */
     default MethodTypeDesc methodTypeSymbol() {
-        return MethodTypeDesc.ofDescriptor(methodType().stringValue());
+        return Util.methodTypeSymbol(methodType());
     }
 
     /** {@return the body of this method, if there is one} */

--- a/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/LocalVariableInfo.java
@@ -28,6 +28,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundLocalVariable;
 import jdk.internal.classfile.impl.UnboundAttribute;
+import jdk.internal.classfile.impl.Util;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -65,7 +66,7 @@ public sealed interface LocalVariableInfo
      * {@return the field descriptor of the local variable}
      */
     default ClassDesc typeSymbol() {
-        return ClassDesc.ofDescriptor(type().stringValue());
+        return Util.fieldTypeSymbol(type());
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/attribute/RecordComponentInfo.java
+++ b/src/java.base/share/classes/java/lang/classfile/attribute/RecordComponentInfo.java
@@ -33,6 +33,7 @@ import java.lang.classfile.constantpool.Utf8Entry;
 import jdk.internal.classfile.impl.BoundRecordComponentInfo;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
 import jdk.internal.classfile.impl.UnboundAttribute;
+import jdk.internal.classfile.impl.Util;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -58,7 +59,7 @@ public sealed interface RecordComponentInfo
      * {@return the field descriptor of this component, as a {@linkplain ClassDesc}}
      */
     default ClassDesc descriptorSymbol() {
-        return ClassDesc.ofDescriptor(descriptor().stringValue());
+        return Util.fieldTypeSymbol(descriptor());
     }
 
     /**
@@ -95,7 +96,7 @@ public sealed interface RecordComponentInfo
                                   ClassDesc descriptor,
                                   List<Attribute<?>> attributes) {
         return new UnboundAttribute.UnboundRecordComponentInfo(TemporaryConstantPool.INSTANCE.utf8Entry(name),
-                                                               TemporaryConstantPool.INSTANCE.utf8Entry(descriptor.descriptorString()),
+                                                               TemporaryConstantPool.INSTANCE.utf8Entry(descriptor),
                                                                attributes);
     }
 

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantPoolBuilder.java
@@ -223,9 +223,7 @@ public sealed interface ConstantPoolBuilder
      * @param type the symbolic descriptor for a field type
      */
     default NameAndTypeEntry nameAndTypeEntry(String name, ClassDesc type) {
-        var ret = (NameAndTypeEntryImpl)nameAndTypeEntry(utf8Entry(name), utf8Entry(type.descriptorString()));
-        ret.typeSym = type;
-        return ret;
+        return nameAndTypeEntry(utf8Entry(name), utf8Entry(type));
     }
 
     /**
@@ -238,9 +236,7 @@ public sealed interface ConstantPoolBuilder
      * @param type the symbolic descriptor for a method type
      */
     default NameAndTypeEntry nameAndTypeEntry(String name, MethodTypeDesc type) {
-        var ret = (NameAndTypeEntryImpl)nameAndTypeEntry(utf8Entry(name), utf8Entry(type.descriptorString()));
-        ret.typeSym = type;
-        return ret;
+        return nameAndTypeEntry(utf8Entry(name), utf8Entry(type));
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariable.java
+++ b/src/java.base/share/classes/java/lang/classfile/instruction/LocalVariable.java
@@ -36,6 +36,7 @@ import java.lang.constant.ClassDesc;
 import jdk.internal.classfile.impl.AbstractPseudoInstruction;
 import jdk.internal.classfile.impl.BoundLocalVariable;
 import jdk.internal.classfile.impl.TemporaryConstantPool;
+import jdk.internal.classfile.impl.Util;
 import jdk.internal.javac.PreviewFeature;
 
 /**
@@ -70,7 +71,7 @@ public sealed interface LocalVariable extends PseudoInstruction
      * {@return the local variable type, as a symbolic descriptor}
      */
     default ClassDesc typeSymbol() {
-        return ClassDesc.ofDescriptor(type().stringValue());
+        return Util.fieldTypeSymbol(type());
     }
 
     /**
@@ -109,7 +110,7 @@ public sealed interface LocalVariable extends PseudoInstruction
     static LocalVariable of(int slot, String name, ClassDesc descriptor, Label startScope, Label endScope) {
         return of(slot,
                   TemporaryConstantPool.INSTANCE.utf8Entry(name),
-                  TemporaryConstantPool.INSTANCE.utf8Entry(descriptor.descriptorString()),
+                  TemporaryConstantPool.INSTANCE.utf8Entry(descriptor),
                   startScope, endScope);
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BoundLocalVariable.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BoundLocalVariable.java
@@ -46,7 +46,7 @@ public final class BoundLocalVariable
 
     @Override
     public ClassDesc typeSymbol() {
-        return ClassDesc.ofDescriptor(type().stringValue());
+        return Util.fieldTypeSymbol(type());
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BufferedMethodBuilder.java
@@ -53,7 +53,6 @@ public final class BufferedMethodBuilder
     private AccessFlags flags;
     private final MethodModel original;
     private int[] parameterSlots;
-    MethodTypeDesc mDesc;
 
     public BufferedMethodBuilder(SplitConstantPool constantPool,
                                  ClassFileImpl context,
@@ -102,14 +101,7 @@ public final class BufferedMethodBuilder
 
     @Override
     public MethodTypeDesc methodTypeSymbol() {
-        if (mDesc == null) {
-            if (original instanceof MethodInfo mi) {
-                mDesc = mi.methodTypeSymbol();
-            } else {
-                mDesc = MethodTypeDesc.ofDescriptor(methodType().stringValue());
-            }
-        }
-        return mDesc;
+        return Util.methodTypeSymbol(methodType());
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/ChainedClassBuilder.java
@@ -80,15 +80,6 @@ public final class ChainedClassBuilder
     }
 
     @Override
-    public ClassBuilder withMethod(String name, MethodTypeDesc descriptor, int flags, Consumer<? super MethodBuilder> handler) {
-        var mb = new BufferedMethodBuilder(terminal.constantPool, terminal.context,
-                constantPool().utf8Entry(name), constantPool().utf8Entry(descriptor), flags, null);
-        mb.mDesc = descriptor;
-        consumer.accept(mb.run(handler).toModel());
-        return this;
-    }
-
-    @Override
     public ClassBuilder transformMethod(MethodModel method, MethodTransform transform) {
         BufferedMethodBuilder builder = new BufferedMethodBuilder(terminal.constantPool, terminal.context,
                                                                   method.methodName(), method.methodType(), method.flags().flagsMask(), method);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectClassBuilder.java
@@ -91,14 +91,6 @@ public final class DirectClassBuilder
     }
 
     @Override
-    public ClassBuilder withField(String name,
-                                  ClassDesc descriptor,
-                                  int flags) {
-        return withField(new DirectFieldBuilder(constantPool, context,
-                constantPool.utf8Entry(name), constantPool.utf8Entry(descriptor), flags, null));
-    }
-
-    @Override
     public ClassBuilder withField(Utf8Entry name,
                                   Utf8Entry descriptor,
                                   int flags) {
@@ -128,13 +120,6 @@ public final class DirectClassBuilder
                                    Consumer<? super MethodBuilder> handler) {
         return withMethod(new DirectMethodBuilder(constantPool, context, name, descriptor, flags, null)
                                   .run(handler));
-    }
-
-    @Override
-    public ClassBuilder withMethod(String name, MethodTypeDesc descriptor, int flags, Consumer<? super MethodBuilder> handler) {
-        var method = new DirectMethodBuilder(constantPool, context, constantPool.utf8Entry(name), constantPool.utf8Entry(descriptor), flags, null);
-        method.mDesc = descriptor;
-        return withMethod(method.run(handler));
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectMethodBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectMethodBuilder.java
@@ -46,7 +46,6 @@ public final class DirectMethodBuilder
     final Utf8Entry desc;
     int flags;
     int[] parameterSlots;
-    MethodTypeDesc mDesc;
 
     public DirectMethodBuilder(SplitConstantPool constantPool,
                                ClassFileImpl context,
@@ -87,14 +86,7 @@ public final class DirectMethodBuilder
 
     @Override
     public MethodTypeDesc methodTypeSymbol() {
-        if (mDesc == null) {
-            if (original instanceof MethodInfo mi) {
-                mDesc = mi.methodTypeSymbol();
-            } else {
-                mDesc = MethodTypeDesc.ofDescriptor(methodType().stringValue());
-            }
-        }
-        return mDesc;
+        return Util.methodTypeSymbol(methodType());
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/MethodImpl.java
@@ -41,7 +41,6 @@ public final class MethodImpl
     private final int startPos, endPos, attributesPos;
     private List<Attribute<?>> attributes;
     private int[] parameterSlots;
-    private MethodTypeDesc mDesc;
 
     public MethodImpl(ClassReader reader, int startPos, int endPos, int attrStart) {
         this.reader = reader;
@@ -75,10 +74,7 @@ public final class MethodImpl
 
     @Override
     public MethodTypeDesc methodTypeSymbol() {
-        if (mDesc == null) {
-            mDesc = MethodTypeDesc.ofDescriptor(methodType().stringValue());
-        }
-        return mDesc;
+        return Util.methodTypeSymbol(methodType());
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -24,7 +24,7 @@
  */
 package jdk.internal.classfile.impl;
 
-import java.lang.constant.ConstantDesc;
+import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.Arrays;
 import java.util.List;
@@ -408,6 +408,20 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     }
 
     @Override
+    public Utf8Entry utf8Entry(ClassDesc desc) {
+        var utf8 = utf8Entry(desc.descriptorString());
+        utf8.typeSym = desc;
+        return utf8;
+    }
+
+    @Override
+    public Utf8Entry utf8Entry(MethodTypeDesc desc) {
+        var utf8 = utf8Entry(desc.descriptorString());
+        utf8.typeSym = desc;
+        return utf8;
+    }
+
+    @Override
     public AbstractPoolEntry.Utf8EntryImpl utf8Entry(String s) {
         int hash = AbstractPoolEntry.hashString(s.hashCode());
         var ce = tryFindUtf8(hash, s);
@@ -489,9 +503,7 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
     @Override
     public MethodTypeEntry methodTypeEntry(MethodTypeDesc descriptor) {
-        var ret = (AbstractPoolEntry.MethodTypeEntryImpl)methodTypeEntry(utf8Entry(descriptor.descriptorString()));
-        ret.sym = descriptor;
-        return ret;
+        return methodTypeEntry(utf8Entry(descriptor));
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -30,6 +30,7 @@ import java.lang.classfile.FieldBuilder;
 import java.lang.classfile.MethodBuilder;
 import java.lang.classfile.PseudoInstruction;
 import java.lang.classfile.constantpool.PoolEntry;
+import java.lang.classfile.constantpool.Utf8Entry;
 import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.AbstractList;
@@ -220,12 +221,20 @@ public class Util {
         return (flag.mask() & flagsMask) == flag.mask() && flag.locations().contains(location);
     }
 
+    public static ClassDesc fieldTypeSymbol(Utf8Entry utf8) {
+        return ((AbstractPoolEntry.Utf8EntryImpl) utf8).fieldTypeSymbol();
+    }
+
+    public static MethodTypeDesc methodTypeSymbol(Utf8Entry utf8) {
+        return ((AbstractPoolEntry.Utf8EntryImpl) utf8).methodTypeSymbol();
+    }
+
     public static ClassDesc fieldTypeSymbol(NameAndTypeEntry nat) {
-        return ((AbstractPoolEntry.NameAndTypeEntryImpl)nat).fieldTypeSymbol();
+        return fieldTypeSymbol(nat.type());
     }
 
     public static MethodTypeDesc methodTypeSymbol(NameAndTypeEntry nat) {
-        return ((AbstractPoolEntry.NameAndTypeEntryImpl)nat).methodTypeSymbol();
+        return methodTypeSymbol(nat.type());
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
Some type descriptors are validated against generic utf8 entries, such as field or method types; we can cache a type descriptor wrapping the content of the utf8 entry if this entry is ever used as a type descriptor.

This patch is more of a code cleanup; it is performance neutral.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339876](https://bugs.openjdk.org/browse/JDK-8339876): Move constant symbol caches to Utf8EntryImpl (**Sub-task** - P4)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20957/head:pull/20957` \
`$ git checkout pull/20957`

Update a local copy of the PR: \
`$ git checkout pull/20957` \
`$ git pull https://git.openjdk.org/jdk.git pull/20957/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20957`

View PR using the GUI difftool: \
`$ git pr show -t 20957`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20957.diff">https://git.openjdk.org/jdk/pull/20957.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20957#issuecomment-2344972916)