### PR TITLE
8339727: Open source several AWT focus tests - series 1

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -133,6 +133,9 @@ java/awt/Focus/MouseClickRequestFocusRaceTest/MouseClickRequestFocusRaceTest.jav
 java/awt/Focus/NoAutotransferToDisabledCompTest/NoAutotransferToDisabledCompTest.java 7152980 macosx-all
 java/awt/Focus/ToFrontFocusTest/ToFrontFocus.java 7156130 linux-all
 java/awt/Focus/WrongKeyTypedConsumedTest/WrongKeyTypedConsumedTest.java 8169096 macosx-all
+java/awt/Focus/TestDisabledAutoTransfer.java 8159871 macosx-all,windows-all
+java/awt/Focus/TestDisabledAutoTransferSwing.java 6962362 windows-all
+java/awt/Focus/ActivateOnProperAppContextTest.java 8136516 macosx-all
 java/awt/EventQueue/6980209/bug6980209.java 8198615 macosx-all
 java/awt/grab/EmbeddedFrameTest1/EmbeddedFrameTest1.java 7080150 macosx-all
 java/awt/event/InputEvent/EventWhenTest/EventWhenTest.java 8168646 generic-all

--- a/test/jdk/java/awt/Focus/ActivateOnProperAppContextTest.java
+++ b/test/jdk/java/awt/Focus/ActivateOnProperAppContextTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+* @test
+* @bug 6385277
+* @key headful
+* @summary   Tests that activation happens on correct AppContext.
+* @modules java.desktop/sun.awt
+* @run main ActivateOnProperAppContextTest
+*/
+
+import sun.awt.AppContext;
+import sun.awt.SunToolkit;
+
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Cursor;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.InputEvent;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ActivateOnProperAppContextTest {
+    static Robot robot;
+    SunToolkit toolkit;
+
+    ThreadGroup threadGroup = new ThreadGroup("Test_Thread_Group");
+    AppContext appContext;
+    Frame frame;
+    volatile boolean passed = true;
+    AtomicBoolean cond = new AtomicBoolean(false);
+
+    public static void main(String[] args) throws Exception {
+        ActivateOnProperAppContextTest app = new ActivateOnProperAppContextTest();
+        robot = new Robot();
+        app.start();
+    }
+
+    public void start() {
+        toolkit = (SunToolkit)Toolkit.getDefaultToolkit();
+
+        Runnable runnable = new Runnable() {
+                public void run() {
+                    test();
+
+                    synchronized (cond) {
+                        cond.set(true);
+                        cond.notifyAll();
+                    }
+                }
+            };
+
+        Thread thread = new Thread(threadGroup, runnable, "Test Thread");
+
+        synchronized (cond) {
+
+            thread.start();
+
+            while (!cond.get()) {
+                try {
+                    cond.wait();
+                } catch (InterruptedException ie) {
+                    ie.printStackTrace();
+                }
+            }
+        }
+
+        if (passed) {
+            System.out.println("Test passed.");
+        } else {
+            throw new TestFailedException("Test failed!");
+        }
+    }
+
+    void test() {
+        appContext = SunToolkit.createNewAppContext();
+        System.out.println("Created new AppContext: " + appContext);
+
+        frame = new Frame("ActivateOnProperAppContextTest Frame") {
+                public boolean isActive() {
+                    verifyAppContext("Frame.isActive()");
+                    return super.isActive();
+                }
+                public boolean isFocused() {
+                    verifyAppContext("Frame.isFocused()");
+                    return super.isFocused();
+                }
+                public boolean isFocusable() {
+                    verifyAppContext("Frame.isFocusable()");
+                    return super.isFocusable();
+                }
+                public Window getOwner() {
+                    verifyAppContext("Frame.getOwner()");
+                    return super.getOwner();
+                }
+                public boolean isEnabled() {
+                    verifyAppContext("Frame.isEnabled()");
+                    return super.isEnabled();
+                }
+                public boolean isVisible() {
+                    verifyAppContext("Frame.isVisible()");
+                    return super.isVisible();
+                }
+                public Container getParent() {
+                    verifyAppContext("Frame.getParent()");
+                    return super.getParent();
+                }
+                public Cursor getCursor() {
+                    verifyAppContext("Frame.getCursor()");
+                    return super.getCursor();
+                }
+                public Point getLocation() {
+                    verifyAppContext("Frame.getLocation()");
+                    return super.getLocation();
+                }
+                public Point getLocationOnScreen() {
+                    verifyAppContext("Frame.getLocationOnScreen()");
+                    return super.getLocationOnScreen();
+                }
+            };
+        Window window = new Window(frame) {
+                public boolean isFocused() {
+                    verifyAppContext("Window.isFocused()");
+                    return super.isFocused();
+                }
+                public boolean isFocusable() {
+                    verifyAppContext("Window.isFocusable()");
+                    return super.isFocusable();
+                }
+                public Window getOwner() {
+                    verifyAppContext("Window.getOwner()");
+                    return super.getOwner();
+                }
+                public boolean isEnabled() {
+                    verifyAppContext("Window.isEnabled()");
+                    return super.isEnabled();
+                }
+                public boolean isVisible() {
+                    verifyAppContext("Window.isVisible()");
+                    return super.isVisible();
+                }
+                public Container getParent() {
+                    verifyAppContext("Window.getParent()");
+                    return super.getParent();
+                }
+                public Cursor getCursor() {
+                    verifyAppContext("Window.getCursor()");
+                    return super.getCursor();
+                }
+                public Point getLocation() {
+                    verifyAppContext("Window.getLocation()");
+                    return super.getLocation();
+                }
+                public Point getLocationOnScreen() {
+                    verifyAppContext("Window.getLocationOnScreen()");
+                    return super.getLocationOnScreen();
+                }
+            };
+        Button button = new Button("button");
+        Label label = new Label("label");
+
+        window.setLayout(new FlowLayout());
+        window.add(button);
+        window.add(label);
+        window.setLocation(800, 0);
+        window.pack();
+        window.setVisible(true);
+
+        frame.setBounds(800, 100, 100, 50);
+        frame.setVisible(true);
+
+        toolkit.realSync();
+
+        /*
+         * When the label is clicked in the window some of
+         * the owner's public method get called.
+         */
+        clickOn(label);
+    }
+
+    void verifyAppContext(String methodName) {
+        AppContext ac = AppContext.getAppContext();
+        println(methodName + " called on AppContext: " + ac);
+
+        if (ac != appContext) {
+            passed = false;
+            System.err.println("Test failed: " + methodName + " is called on wrong AppContext!");
+            Thread.dumpStack();
+        }
+    }
+
+    void clickOn(Component c) {
+        Point p = c.getLocationOnScreen();
+        Dimension d = c.getSize();
+
+        robot.mouseMove(p.x + (int)(d.getWidth()/2), p.y + (int)(d.getHeight()/2));
+
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(20);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+
+        toolkit.realSync();
+    }
+
+    void println(final String msg) {
+        SunToolkit.executeOnEventHandlerThread(frame, new Runnable() {
+                public void run() {
+                    System.out.println(msg);
+                }
+            });
+    }
+}
+
+class TestFailedException extends RuntimeException {
+    TestFailedException(String msg) {
+        super(msg);
+    }
+}

--- a/test/jdk/java/awt/Focus/KillFocusTest.java
+++ b/test/jdk/java/awt/Focus/KillFocusTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 4402942
+ * @summary After deactivation and activation of frame, focus should be restored correctlty
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual KillFocusTest
+*/
+
+import java.awt.Frame;
+import java.awt.TextField;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+
+public class KillFocusTest {
+
+    private static final String INSTRUCTIONS = """
+         After starting the test you should see \"Test Frame\"
+         with the \"Click me\" text field.
+         Click on this text field and try to type something in it.
+         Make sure that the field receives focus and you can enter text in it.
+         Click on any non-java window.
+         Click on \"Click me\" text field to return focus to it
+         If the caret is in the text field and you are able to type
+         in it then press pass else press fail.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("KillFocusTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(KillFocusTest::createTestUI)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+
+        Frame frame = new Frame("KillFocusTest Frame");
+        TextField textField = new TextField("Click me", 10);
+        textField.addFocusListener(new FocusListener() {
+            public void focusGained(FocusEvent fe) {
+                PassFailJFrame.log("Focus gained");
+            }
+            public void focusLost(FocusEvent fe) {
+                PassFailJFrame.log("Focus lost");
+            }
+        });
+        frame.add(textField);
+        frame.setSize(200, 100);
+        return frame;
+    }
+
+
+}
+

--- a/test/jdk/java/awt/Focus/TestDisabledAutoTransfer.java
+++ b/test/jdk/java/awt/Focus/TestDisabledAutoTransfer.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 6180261
+ * @summary Test that auto-transfer doesn't happen when there are pending focus requests
+ * @key headful
+ * @run main TestDisabledAutoTransfer
+*/
+
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+import java.awt.event.InputEvent;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TestDisabledAutoTransfer {
+    static Frame frame;
+    static Robot robot;
+    Button b1;
+    Button desired;
+    AtomicBoolean focused = new AtomicBoolean();
+    ActionListener mover;
+    volatile Point loc;
+    volatile Dimension dim;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        try {
+            TestDisabledAutoTransfer test = new TestDisabledAutoTransfer();
+            test.createTestUI();
+            robot.waitForIdle();
+            robot.delay(1000);
+            test.doTest();
+        } finally {
+            if (frame != null) {
+                frame.dispose();
+            }
+        }
+    }
+
+    public void createTestUI() {
+        frame = new Frame("TestDisabledAutoTransfer");
+        frame.setLayout(new FlowLayout());
+        desired = new Button("Desired");
+        FocusAdapter watcher = new FocusAdapter() {
+                public void focusGained(FocusEvent e) {
+                    synchronized(focused) {
+                        focused.set(true);
+                    }
+                }
+            };
+        b1 = new Button("Press to disable");
+        mover = new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                desired.requestFocus();
+                    ((Component)e.getSource()).setEnabled(false);
+                }
+            };
+        b1.addFocusListener(watcher);
+        desired.addFocusListener(watcher);
+        frame.add(b1);
+        Button misc = new Button("Next");
+        frame.add(misc);
+        misc.addFocusListener(watcher);
+        frame.add(desired);
+        frame.setSize (200, 200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.validate();
+
+    }
+
+    public void doTest() {
+
+        loc = b1.getLocationOnScreen();
+        dim = b1.getSize();
+        robot.mouseMove(loc.x + dim.width / 2, loc.y + dim.height / 2);
+        robot.waitForIdle();
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        b1.requestFocus();
+
+        try {
+            synchronized(focused) {
+                if (!focused.get()) {
+                    focused.wait(1000);
+                }
+            }
+        } catch (InterruptedException ie) {
+            throw new RuntimeException("Test was interrupted");
+        }
+
+        if (!focused.get()) {
+            throw new RuntimeException("b1 didn't get focus");
+        }
+        focused.set(false);
+
+        b1.addActionListener(mover);
+        robot.mouseMove(loc.x + dim.width / 2, loc.y + dim.height / 2);
+        robot.waitForIdle();
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+
+        try {
+            synchronized(focused) {
+                if (!focused.get()) {
+                    focused.wait(1000);
+                }
+            }
+        } catch (InterruptedException ie) {
+            throw new RuntimeException("Test was interrupted");
+        }
+
+        if (!focused.get()) {
+            throw new RuntimeException("none got focus");
+        }
+
+        if (!desired.isFocusOwner()) {
+            throw new RuntimeException("desired didn't get focus");
+        }
+    }
+
+}
+

--- a/test/jdk/java/awt/Focus/TestDisabledAutoTransfer.java
+++ b/test/jdk/java/awt/Focus/TestDisabledAutoTransfer.java
@@ -93,7 +93,7 @@ public class TestDisabledAutoTransfer {
         frame.add(misc);
         misc.addFocusListener(watcher);
         frame.add(desired);
-        frame.setSize (200, 200);
+        frame.setSize(200, 200);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
         frame.validate();

--- a/test/jdk/java/awt/Focus/TestDisabledAutoTransferSwing.java
+++ b/test/jdk/java/awt/Focus/TestDisabledAutoTransferSwing.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 6180261
+ * @summary Test that auto-transfer doesn't happen when there are pending focus requests
+ * @key headful
+ * @run main TestDisabledAutoTransferSwing
+*/
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FlowLayout;
+import java.awt.Point;
+import java.awt.Robot;
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.FocusAdapter;
+import java.awt.event.FocusEvent;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class TestDisabledAutoTransferSwing {
+    static JFrame frame;
+    static Robot robot;
+    JButton b1;
+    JButton desired;
+    AtomicBoolean focused = new AtomicBoolean();
+    ActionListener mover;
+    volatile Point loc;
+    volatile Dimension dim;
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+        try {
+            TestDisabledAutoTransferSwing test = new TestDisabledAutoTransferSwing();
+            SwingUtilities.invokeAndWait(() -> {
+                test.createTestUI();
+            });
+            robot.waitForIdle();
+            robot.delay(1000);
+            test.doTest();
+        } finally {
+            SwingUtilities.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    public void createTestUI() {
+        frame = new JFrame("TestDisabledAutoTransferSwing");
+        frame.setLayout (new FlowLayout ());
+        desired = new JButton("Desired");
+        FocusAdapter watcher = new FocusAdapter() {
+                public void focusGained(FocusEvent e) {
+                    synchronized(focused) {
+                        focused.set(true);
+                    }
+                }
+            };
+        b1 = new JButton("Press to disable");
+        mover = new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    desired.requestFocus();
+                    ((Component)e.getSource()).setEnabled(false);
+                }
+            };
+        b1.addFocusListener(watcher);
+        desired.addFocusListener(watcher);
+        frame.add(b1);
+        JButton misc = new JButton("Next");
+        frame.add(misc);
+        misc.addFocusListener(watcher);
+        frame.add(desired);
+        frame.setSize (200,200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+        frame.validate();
+
+    }
+
+    public void doTest() throws Exception {
+
+        SwingUtilities.invokeAndWait(() -> {
+            loc = b1.getLocationOnScreen();
+            dim = b1.getSize();
+        });
+        robot.mouseMove(loc.x + dim.width / 2, loc.y + dim.height / 2);
+        robot.waitForIdle();
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+        SwingUtilities.invokeAndWait(() -> {
+            b1.requestFocus();
+        });
+
+        try {
+            synchronized(focused) {
+                if (!focused.get()) {
+                    focused.wait(2000);
+                }
+            }
+        } catch (InterruptedException ie) {
+            throw new RuntimeException("Test was interrupted");
+        }
+
+        if (!focused.get()) {
+            throw new RuntimeException("b1 didn't get focus");
+        }
+        focused.set(false);
+
+        SwingUtilities.invokeAndWait(() -> {
+            b1.addActionListener(mover);
+        });
+        robot.mouseMove(loc.x + dim.width / 2, loc.y + dim.height / 2);
+        robot.waitForIdle();
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.waitForIdle();
+
+        try {
+            synchronized(focused) {
+                if (!focused.get()) {
+                    focused.wait(2000);
+                }
+            }
+        } catch (InterruptedException ie) {
+            throw new RuntimeException("Test was interrupted");
+        }
+
+        if (!focused.get()) {
+            throw new RuntimeException("none got focus");
+        }
+
+        if (!desired.isFocusOwner()) {
+            throw new RuntimeException("desired didn't get focus");
+        }
+    }
+
+}

--- a/test/jdk/java/awt/Focus/TestDisabledAutoTransferSwing.java
+++ b/test/jdk/java/awt/Focus/TestDisabledAutoTransferSwing.java
@@ -97,7 +97,7 @@ public class TestDisabledAutoTransferSwing {
         frame.add(misc);
         misc.addFocusListener(watcher);
         frame.add(desired);
-        frame.setSize (200,200);
+        frame.setSize(200, 200);
         frame.setLocationRelativeTo(null);
         frame.setVisible(true);
         frame.validate();


### PR DESCRIPTION
Open source few AWT focus tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339727](https://bugs.openjdk.org/browse/JDK-8339727): Open source several AWT focus tests - series 1 (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20961/head:pull/20961` \
`$ git checkout pull/20961`

Update a local copy of the PR: \
`$ git checkout pull/20961` \
`$ git pull https://git.openjdk.org/jdk.git pull/20961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20961`

View PR using the GUI difftool: \
`$ git pr show -t 20961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20961.diff">https://git.openjdk.org/jdk/pull/20961.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20961#issuecomment-2345335121)