### PR TITLE
8314842: zgc/genzgc tests ignore vm flags

### DIFF
--- a/test/hotspot/jtreg/gc/x/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/x/TestAllocateHeapAt.java
@@ -41,7 +41,7 @@ public class TestAllocateHeapAt {
         final String heapBackingFile = "Heap Backing File: " + directory;
         final String failedToCreateFile = "Failed to create file " + directory;
 
-        ProcessTools.executeLimitedTestJava(
+        ProcessTools.executeTestJava(
             "-XX:+UseZGC",
             "-XX:-ZGenerational",
             "-Xlog:gc*",

--- a/test/hotspot/jtreg/gc/x/TestPageCacheFlush.java
+++ b/test/hotspot/jtreg/gc/x/TestPageCacheFlush.java
@@ -68,7 +68,7 @@ public class TestPageCacheFlush {
     }
 
     public static void main(String[] args) throws Exception {
-        ProcessTools.executeLimitedTestJava(
+        ProcessTools.executeTestJava(
             "-XX:+UseZGC",
             "-XX:-ZGenerational",
             "-Xms128M",

--- a/test/hotspot/jtreg/gc/x/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/x/TestSmallHeap.java
@@ -53,7 +53,7 @@ public class TestSmallHeap {
 
     public static void main(String[] args) throws Exception {
         for (var maxCapacity: args) {
-            ProcessTools.executeLimitedTestJava(
+            ProcessTools.executeTestJava(
                 "-XX:+UseZGC",
                 "-XX:-ZGenerational",
                 "-Xlog:gc,gc+init,gc+reloc,gc+heap",

--- a/test/hotspot/jtreg/gc/z/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/z/TestAllocateHeapAt.java
@@ -41,7 +41,7 @@ public class TestAllocateHeapAt {
         final String heapBackingFile = "Heap Backing File: " + directory;
         final String failedToCreateFile = "Failed to create file " + directory;
 
-        ProcessTools.executeLimitedTestJava(
+        ProcessTools.executeTestJava(
             "-XX:+UseZGC",
             "-XX:+ZGenerational",
             "-Xlog:gc*",

--- a/test/hotspot/jtreg/gc/z/TestPageCacheFlush.java
+++ b/test/hotspot/jtreg/gc/z/TestPageCacheFlush.java
@@ -68,7 +68,7 @@ public class TestPageCacheFlush {
     }
 
     public static void main(String[] args) throws Exception {
-        ProcessTools.executeLimitedTestJava(
+        ProcessTools.executeTestJava(
             "-XX:+UseZGC",
             "-XX:+ZGenerational",
             "-Xms128M",

--- a/test/hotspot/jtreg/gc/z/TestSmallHeap.java
+++ b/test/hotspot/jtreg/gc/z/TestSmallHeap.java
@@ -53,7 +53,7 @@ public class TestSmallHeap {
 
     public static void main(String[] args) throws Exception {
         for (var maxCapacity: args) {
-            ProcessTools.executeLimitedTestJava(
+            ProcessTools.executeTestJava(
                 "-XX:+UseZGC",
                 "-XX:+ZGenerational",
                 "-Xlog:gc,gc+init,gc+reloc,gc+heap",


### PR DESCRIPTION
Change some ZGC tests to propagate requested vm flags.

I tested this by manually passing in various flags to jtreg. I also ran tier1-5 on Linux.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8314842](https://bugs.openjdk.org/browse/JDK-8314842): zgc/genzgc tests ignore vm flags (**Sub-task** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20963/head:pull/20963` \
`$ git checkout pull/20963`

Update a local copy of the PR: \
`$ git checkout pull/20963` \
`$ git pull https://git.openjdk.org/jdk.git pull/20963/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20963`

View PR using the GUI difftool: \
`$ git pr show -t 20963`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20963.diff">https://git.openjdk.org/jdk/pull/20963.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20963#issuecomment-2345764445)