### PR TITLE
8340009: Improve the output from assert_different_registers

### DIFF
--- a/src/hotspot/share/asm/register.hpp
+++ b/src/hotspot/share/asm/register.hpp
@@ -276,19 +276,23 @@ inline constexpr bool different_registers(R first_register, Rx... more_registers
 }
 
 template<typename R, typename... Rx>
-inline void assert_different_registers(R first_register, Rx... more_registers) {
+inline void assert_different_registers_impl(const char* file, int line, R first_register, Rx... more_registers) {
 #ifdef ASSERT
   if (!different_registers(first_register, more_registers...)) {
     const R regs[] = { first_register, more_registers... };
     // Find a duplicate entry.
     for (size_t i = 0; i < ARRAY_SIZE(regs) - 1; ++i) {
       for (size_t j = i + 1; j < ARRAY_SIZE(regs); ++j) {
-        assert(!regs[i]->is_valid() || regs[i] != regs[j],
-               "Multiple uses of register: %s", regs[i]->name());
+        if (regs[i]->is_valid()) {
+          assert_with_file_and_line(regs[i] != regs[j], file, line, "regs[%zu] and regs[%zu] are both: %s",
+              i, j, regs[i]->name());
+        }
       }
     }
   }
 #endif
 }
+
+#define assert_different_registers(...) assert_different_registers_impl(__FILE__, __LINE__, __VA_ARGS__)
 
 #endif // SHARE_ASM_REGISTER_HPP

--- a/src/hotspot/share/utilities/debug.hpp
+++ b/src/hotspot/share/utilities/debug.hpp
@@ -139,22 +139,25 @@ public:
 
 // assertions
 #ifndef ASSERT
+#define vmassert_with_file_and_line(p, file, line, ...)
 #define vmassert(p, ...)
 #else
 // Note: message says "assert" rather than "vmassert" for backward
 // compatibility with tools that parse/match the message text.
 // Note: The signature is vmassert(p, format, ...), but the solaris
 // compiler can't handle an empty ellipsis in a macro without a warning.
-#define vmassert(p, ...)                                                       \
-do {                                                                           \
-  if (! VMASSERT_CHECK_PASSED(p)) {                                            \
-    TOUCH_ASSERT_POISON;                                                       \
-    report_vm_error(__FILE__, __LINE__, "assert(" #p ") failed", __VA_ARGS__); \
-  }                                                                            \
+#define vmassert_with_file_and_line(p, file, line, ...)                \
+do {                                                                   \
+  if (! VMASSERT_CHECK_PASSED(p)) {                                    \
+    TOUCH_ASSERT_POISON;                                               \
+    report_vm_error(file, line, "assert(" #p ") failed", __VA_ARGS__); \
+  }                                                                    \
 } while (0)
+#define vmassert(p, ...) vmassert_with_file_and_line(p, __FILE__, __LINE__, __VA_ARGS__)
 #endif
 
 // For backward compatibility.
+#define assert_with_file_and_line(p, file, line, ...) vmassert_with_file_and_line(p, file, line, __VA_ARGS__)
 #define assert(p, ...) vmassert(p, __VA_ARGS__)
 
 #define precond(p)   assert(p, "precond")


### PR DESCRIPTION
`assert_different_registers` is a mechanism we use to ensure that we don't use the same register in different variables. When the assert triggers it is not immediately clear where and why the assert failed.

For example, if I introduce an intentional violation:
```
diff --git a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
index fde868a64b3..551878ac09d 100644
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -1188,7 +1188,8 @@ void MacroAssembler::lookup_interface_method(Register recv_klass,
                                              Register scan_temp,
                                              Label& L_no_such_interface,
                          bool return_method) {
-  assert_different_registers(recv_klass, intf_klass, scan_temp);
+  Register joker = intf_klass;
+  assert_different_registers(recv_klass, intf_klass, scan_temp, joker);
   assert_different_registers(method_result, intf_klass, scan_temp);
   assert(recv_klass != method_result || !return_method,
      "recv_klass can be destroyed when method isn't needed");
```
I get this error message:
```
#  Internal Error (src/hotspot/share/asm/register.hpp:287), pid=42568, tid=9731
#  assert(!regs[i]->is_valid() || regs[i] != regs[j]) failed: Multiple uses of register: c_rarg0
```
The indicated file and line number refers to the `assert_different_registers` implementation and not the offending call site. More over, it's unclear from the assert which of the four variables contain the same register.

I'd like to propose a few changes:
1) That we report the indices of the conflicting registers
2) That we report the correct file and line number
3) That we hide the is_valid() check to lower the noise in the output. Not strictly necessary, but I think it looks nicer.

After these suggestions we'll get error messages that look like this:
```
#  Internal Error (src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp:1187), pid=59065, tid=8963
#  assert(regs[i] != regs[j]) failed: regs[1] and regs[3] are both: c_rarg0
```
Which makes it easy to see that variables 1 and 3 are conflicting and by looking at the indicated file and line, it is clear that it is `intf_klass` and `joker` that are the offending variables.

There might be a way to use more macros to propagate the variable names, but I propose that we start with this incremental improvement.