### PR TITLE
8340011: Simplify jdk.internal.classfile.impl.EntryMap

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/EntryMap.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/EntryMap.java
@@ -33,10 +33,10 @@ package jdk.internal.classfile.impl;
  * element is the hash and the second is the mapped index.  To look something up
  * in the map, provide a hash value and an index to map it to, and invoke
  * firstToken(hash).  This returns an opaque token that can be provided to
- * nextToken(hash, token) to get the next candidate, or to getElementByToken(token)
- * or getIndexByToken to get the mapped element or index.
+ * nextToken(hash, token) to get the next candidate, or to getIndexByToken to
+ * get the mapped element or index.
  */
-public abstract class EntryMap<T> {
+public final class EntryMap {
     public static final int NO_VALUE = -1;
 
     /**
@@ -77,8 +77,6 @@ public abstract class EntryMap<T> {
         data = new int[capacity * 2];
     }
 
-    protected abstract T fetchElement(int index);
-
     public int firstToken(int hash) {
         if (hash == 0)
             throw new IllegalArgumentException("hash must be nonzero");
@@ -108,10 +106,6 @@ public abstract class EntryMap<T> {
 
     public int getIndexByToken(int token) {
         return data[token + 1];
-    }
-
-    public T getElementByToken(int token) {
-        return fetchElement(data[token + 1]);
     }
 
     public void put(int hash, int index) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/SplitConstantPool.java
@@ -63,8 +63,8 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     private PoolEntry[] myEntries;
     private BootstrapMethodEntryImpl[] myBsmEntries;
     private boolean doneFullScan;
-    private EntryMap<PoolEntry> map;
-    private EntryMap<BootstrapMethodEntryImpl> bsmMap;
+    private EntryMap map;
+    private EntryMap bsmMap;
 
     public SplitConstantPool() {
         this.size = 1;
@@ -178,14 +178,10 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
         }
     }
 
-    private EntryMap<PoolEntry> map() {
+    private EntryMap map() {
         if (map == null) {
-            map = new EntryMap<>(Math.max(size, 1024), .75f) {
-                @Override
-                protected PoolEntry fetchElement(int index) {
-                    return entryByIndex(index);
-                }
-            };
+            map = new EntryMap(Math.max(size, 1024), .75f);
+
             // Doing a full scan here yields fall-off-the-cliff performance results,
             // especially if we only need a few entries that are already
             // inflated (such as attribute names).
@@ -220,14 +216,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
         doneFullScan = true;
     }
 
-    private EntryMap<BootstrapMethodEntryImpl> bsmMap() {
+    private EntryMap bsmMap() {
         if (bsmMap == null) {
-            bsmMap = new EntryMap<>(Math.max(bsmSize, 16), .75f) {
-                @Override
-                protected BootstrapMethodEntryImpl fetchElement(int index) {
-                    return bootstrapMethodEntry(index);
-                }
-            };
+            bsmMap = new EntryMap(Math.max(bsmSize, 16), .75f);
             for (int i=0; i<parentBsmSize; i++) {
                 BootstrapMethodEntryImpl bsm = parent.bootstrapMethodEntry(i);
                 bsmMap.put(bsm.hash, bsm.index);
@@ -268,9 +259,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
     private IntegerEntry findIntEntry(int val) {
         int hash = AbstractPoolEntry.hash1(TAG_INTEGER, Integer.hashCode(val));
-        EntryMap<PoolEntry> map = map();
+        EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
-            PoolEntry e = map.getElementByToken(token);
+            PoolEntry e = entryByIndex(map.getIndexByToken(token));
             if (e.tag() == TAG_INTEGER
                     && e instanceof AbstractPoolEntry.IntegerEntryImpl ce
                     && ce.intValue() == val)
@@ -285,9 +276,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
     private LongEntry findLongEntry(long val) {
         int hash = AbstractPoolEntry.hash1(TAG_LONG, Long.hashCode(val));
-        EntryMap<PoolEntry> map = map();
+        EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
-            PoolEntry e = map.getElementByToken(token);
+            PoolEntry e = entryByIndex(map.getIndexByToken(token));
             if (e.tag() == TAG_LONG
                     && e instanceof AbstractPoolEntry.LongEntryImpl ce
                     && ce.longValue() == val)
@@ -302,9 +293,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
     private FloatEntry findFloatEntry(float val) {
         int hash = AbstractPoolEntry.hash1(TAG_FLOAT, Float.hashCode(val));
-        EntryMap<PoolEntry> map = map();
+        EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
-            PoolEntry e = map.getElementByToken(token);
+            PoolEntry e = entryByIndex(map.getIndexByToken(token));
             if (e.tag() == TAG_FLOAT
                     && e instanceof AbstractPoolEntry.FloatEntryImpl ce
                     && ce.floatValue() == val)
@@ -319,9 +310,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
 
     private DoubleEntry findDoubleEntry(double val) {
         int hash = AbstractPoolEntry.hash1(TAG_DOUBLE, Double.hashCode(val));
-        EntryMap<PoolEntry> map = map();
+        EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
-            PoolEntry e = map.getElementByToken(token);
+            PoolEntry e = entryByIndex(map.getIndexByToken(token));
             if (e.tag() == TAG_DOUBLE
                     && e instanceof AbstractPoolEntry.DoubleEntryImpl ce
                     && ce.doubleValue() == val)
@@ -337,9 +328,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     private<T extends AbstractPoolEntry> AbstractPoolEntry findEntry(int tag, T ref1) {
         // invariant: canWriteDirect(ref1.constantPool())
         int hash = AbstractPoolEntry.hash1(tag, ref1.index());
-        EntryMap<PoolEntry> map = map();
+        EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
-            PoolEntry e = map.getElementByToken(token);
+            PoolEntry e = entryByIndex(map.getIndexByToken(token));
             if (e.tag() == tag
                 && e instanceof AbstractPoolEntry.AbstractRefEntry<?> re
                 && re.ref1 == ref1)
@@ -356,9 +347,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
             AbstractPoolEntry findEntry(int tag, T ref1, U ref2) {
         // invariant: canWriteDirect(ref1.constantPool()), canWriteDirect(ref2.constantPool())
         int hash = AbstractPoolEntry.hash2(tag, ref1.index(), ref2.index());
-        EntryMap<PoolEntry> map = map();
+        EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
-            PoolEntry e = map.getElementByToken(token);
+            PoolEntry e = entryByIndex(map.getIndexByToken(token));
             if (e.tag() == tag
                     && e instanceof AbstractPoolEntry.AbstractRefsEntry<?, ?> re
                     && re.ref1 == ref1
@@ -374,10 +365,10 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     }
 
     private AbstractPoolEntry.Utf8EntryImpl tryFindUtf8(int hash, String target) {
-        EntryMap<PoolEntry> map = map();
+        EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1;
              token = map.nextToken(hash, token)) {
-            PoolEntry e = map.getElementByToken(token);
+            PoolEntry e = entryByIndex(map.getIndexByToken(token));
             if (e.tag() == ClassFile.TAG_UTF8
                 && e instanceof AbstractPoolEntry.Utf8EntryImpl ce
                 && ce.hashCode() == hash
@@ -392,9 +383,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
     }
 
     private AbstractPoolEntry.Utf8EntryImpl tryFindUtf8(int hash, AbstractPoolEntry.Utf8EntryImpl target) {
-        EntryMap<PoolEntry> map = map();
+        EntryMap map = map();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
-            PoolEntry e = map.getElementByToken(token);
+            PoolEntry e = entryByIndex(map.getIndexByToken(token));
             if (e.tag() == ClassFile.TAG_UTF8
                 && e instanceof AbstractPoolEntry.Utf8EntryImpl ce
                 && target.equalsUtf8(ce))
@@ -513,9 +504,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
         }
 
         int hash = AbstractPoolEntry.hash2(TAG_METHODHANDLE, refKind, reference.index());
-        EntryMap<PoolEntry> map1 = map();
+        EntryMap map1 = map();
         for (int token = map1.firstToken(hash); token != -1; token = map1.nextToken(hash, token)) {
-            PoolEntry e = map1.getElementByToken(token);
+            PoolEntry e = entryByIndex(map1.getIndexByToken(token));
             if (e.tag() == TAG_METHODHANDLE
                 && e instanceof AbstractPoolEntry.MethodHandleEntryImpl ce
                 && ce.kind() == refKind && ce.reference() == reference)
@@ -539,9 +530,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
             nameAndType = nameAndTypeEntry(nameAndType.name(), nameAndType.type());
         int hash = AbstractPoolEntry.hash2(TAG_INVOKEDYNAMIC,
                 bootstrapMethodEntry.bsmIndex(), nameAndType.index());
-        EntryMap<PoolEntry> map1 = map();
+        EntryMap map1 = map();
         for (int token = map1.firstToken(hash); token != -1; token = map1.nextToken(hash, token)) {
-            PoolEntry e = map1.getElementByToken(token);
+            PoolEntry e = entryByIndex(map1.getIndexByToken(token));
             if (e.tag() == TAG_INVOKEDYNAMIC
                 && e instanceof AbstractPoolEntry.InvokeDynamicEntryImpl ce
                 && ce.bootstrap() == bootstrapMethodEntry && ce.nameAndType() == nameAndType)
@@ -570,9 +561,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
             nameAndType = nameAndTypeEntry(nameAndType.name(), nameAndType.type());
         int hash = AbstractPoolEntry.hash2(TAG_CONSTANTDYNAMIC,
                 bootstrapMethodEntry.bsmIndex(), nameAndType.index());
-        EntryMap<PoolEntry> map1 = map();
+        EntryMap map1 = map();
         for (int token = map1.firstToken(hash); token != -1; token = map1.nextToken(hash, token)) {
-            PoolEntry e = map1.getElementByToken(token);
+            PoolEntry e = entryByIndex(map1.getIndexByToken(token));
             if (e.tag() == TAG_CONSTANTDYNAMIC
                 && e instanceof AbstractPoolEntry.ConstantDynamicEntryImpl ce
                 && ce.bootstrap() == bootstrapMethodEntry && ce.nameAndType() == nameAndType)
@@ -640,9 +631,9 @@ public final class SplitConstantPool implements ConstantPoolBuilder {
         }
         AbstractPoolEntry.MethodHandleEntryImpl mre = (AbstractPoolEntry.MethodHandleEntryImpl) methodReference;
         int hash = BootstrapMethodEntryImpl.computeHashCode(mre, arguments);
-        EntryMap<BootstrapMethodEntryImpl> map = bsmMap();
+        EntryMap map = bsmMap();
         for (int token = map.firstToken(hash); token != -1; token = map.nextToken(hash, token)) {
-            BootstrapMethodEntryImpl e = map.getElementByToken(token);
+            BootstrapMethodEntryImpl e = bootstrapMethodEntry(map.getIndexByToken(token));
             if (e.bootstrapMethod() == mre && e.arguments().equals(arguments)) {
                 return e;
             }


### PR DESCRIPTION
Minor refactoring to avoid the need to define two anonymous classes that override `EntryMap`. Minor speed-up in interpreter, as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340011](https://bugs.openjdk.org/browse/JDK-8340011): Simplify jdk.internal.classfile.impl.EntryMap (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20966/head:pull/20966` \
`$ git checkout pull/20966`

Update a local copy of the PR: \
`$ git checkout pull/20966` \
`$ git pull https://git.openjdk.org/jdk.git pull/20966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20966`

View PR using the GUI difftool: \
`$ git pr show -t 20966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20966.diff">https://git.openjdk.org/jdk/pull/20966.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20966#issuecomment-2346299014)