### PR TITLE
8339970: Add error checking for empty jcmd filename arguments

### DIFF
--- a/src/hotspot/share/services/diagnosticArgument.cpp
+++ b/src/hotspot/share/services/diagnosticArgument.cpp
@@ -190,6 +190,11 @@ template <> void DCmdArgument<char*>::parse_value(const char* str,
   } else {
     // Use realloc as we may have a default set.
     if (strcmp(type(), "FILE") == 0) {
+      if (str == NULL || *str == 0) {
+        stringStream error_msg;
+        error_msg.print("Filename is empty or not specified. %s", str);
+        THROW_MSG(vmSymbols::java_lang_IllegalArgumentException(), error_msg.base());
+      }
       _value = REALLOC_C_HEAP_ARRAY(char, _value, JVM_MAXPATHLEN, mtInternal);
       if (!Arguments::copy_expand_pid(str, len, _value, JVM_MAXPATHLEN)) {
         stringStream error_msg;


### PR DESCRIPTION
This PR addresses #[8339970](https://bugs.openjdk.org/browse/JDK-8339970) by adding a test for empty filename ("-F" usually) arguments in jcmd invocations.

Currently there are five jcmd commands which provide filename options, and some of them test for empty arguments, while others just pass the empty string to, for example, "outputStream(filename)" and let the system handle the error.
While this works properly on Linux (an error message is passed back to jcmd and logged), it causes a VM crash on Windows and perhaps other platforms.

This PR adds a test in the common argument processing and removes the test where it is no longer required.

The test itself was contributed by @szaldana.

