### PR TITLE
8334301: Errors in jpackage man page

### DIFF
--- a/src/jdk.jpackage/share/man/jpackage.1
+++ b/src/jdk.jpackage/share/man/jpackage.1
@@ -111,6 +111,16 @@ Path where generated output file is placed
 Defaults to the current working directory.
 .RE
 .TP
+\f[V]--resource-dir\f[R] \f[I]path\f[R]
+Path to override jpackage resources
+.RS
+.PP
+(absolute path or relative to the current directory)
+.PP
+Icons, template files, and other resources of jpackage can be
+over-ridden by adding replacement resources to this directory.
+.RE
+.TP
 \f[V]--temp\f[R] \f[I]directory\f[R]
 Path of a new or empty directory used to create temporary files
 .RS
@@ -207,9 +217,9 @@ of key, value pairs
 .PP
 The keys \[dq]module\[dq], \[dq]main-jar\[dq], \[dq]main-class\[dq],
 \[dq]description\[dq], \[dq]arguments\[dq], \[dq]java-options\[dq],
-\[dq]app-version\[dq], \[dq]icon\[dq], \[dq]launcher-as-service\[dq],
-\[dq]win-console\[dq], \[dq]win-shortcut\[dq], \[dq]win-menu\[dq],
-\[dq]linux-app-category\[dq], and \[dq]linux-shortcut\[dq] can be used.
+\[dq]icon\[dq], \[dq]launcher-as-service\[dq], \[dq]win-console\[dq],
+\[dq]win-shortcut\[dq], \[dq]win-menu\[dq], and \[dq]linux-shortcut\[dq]
+can be used.
 .PP
 These options are added to, or used to overwrite, the original command
 line options to build an additional alternative launcher.
@@ -260,7 +270,7 @@ When this option is specified, the main module will be linked in the
 Java runtime image.
 Either --module or --main-jar option can be specified but not both.
 .RE
-.SS Platform dependent option for creating the application launcher:
+.SS Platform dependent options for creating the application launcher:
 .SS Windows platform options (available only when running on Windows):
 .TP
 \f[V]--win-console\f[R]
@@ -355,16 +365,6 @@ Path to the license file
 .RS
 .PP
 (absolute path or relative to the current directory)
-.RE
-.TP
-\f[V]--resource-dir\f[R] \f[I]path\f[R]
-Path to override jpackage resources
-.RS
-.PP
-(absolute path or relative to the current directory)
-.PP
-Icons, template files, and other resources of jpackage can be
-over-ridden by adding replacement resources to this directory.
 .RE
 .TP
 \f[V]--runtime-image\f[R] \f[I]path\f[R]


### PR DESCRIPTION
Correct jpackage man errors

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334301](https://bugs.openjdk.org/browse/JDK-8334301): Errors in jpackage man page (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20969/head:pull/20969` \
`$ git checkout pull/20969`

Update a local copy of the PR: \
`$ git checkout pull/20969` \
`$ git pull https://git.openjdk.org/jdk.git pull/20969/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20969`

View PR using the GUI difftool: \
`$ git pr show -t 20969`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20969.diff">https://git.openjdk.org/jdk/pull/20969.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20969#issuecomment-2346729070)