### PR TITLE
8340012: [C2] assert(KlassEncodingMetaspaceMax > pd) failed: change encoding max if new encoding after 8338526

### DIFF
--- a/src/hotspot/share/ci/ciKlass.hpp
+++ b/src/hotspot/share/ci/ciKlass.hpp
@@ -107,6 +107,10 @@ public:
     return false;
   }
 
+  bool is_in_encoding_range() {
+    return CompressedKlassPointers::is_in_encoding_range(get_Klass());
+  }
+
   // Attempt to get a klass using this ciKlass's loader.
   ciKlass* find_klass(ciSymbol* klass_name);
   // Note:  To find a class from its name string, use ciSymbol::make,

--- a/src/hotspot/share/oops/compressedKlass.inline.hpp
+++ b/src/hotspot/share/oops/compressedKlass.inline.hpp
@@ -51,7 +51,7 @@ inline narrowKlass CompressedKlassPointers::encode_not_null(Klass* v, address na
   assert(!is_null(v), "klass value can never be zero");
   assert(check_alignment(v), "Address not aligned");
   uint64_t pd = (uint64_t)(pointer_delta(v, narrow_base, 1));
-  assert(KlassEncodingMetaspaceMax > pd, "change encoding max if new encoding");
+  assert(KlassEncodingMetaspaceMax > pd, "change encoding max if new encoding (Klass " PTR_FORMAT ", Base " PTR_FORMAT ")", p2i(v), p2i(narrow_base));
   uint64_t result = pd >> shift;
   assert((result & CONST64(0xffffffff00000000)) == 0, "narrow klass pointer overflow");
   assert(decode_not_null((narrowKlass)result, narrow_base, shift) == v, "reversibility");

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3324,7 +3324,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
       bool is_klass = t->isa_klassptr() != nullptr;
 
       if ((is_oop   && Matcher::const_oop_prefer_decode()  ) ||
-          (is_klass && Matcher::const_klass_prefer_decode())) {
+          (is_klass && Matcher::const_klass_prefer_decode() && t->isa_klassptr()->exact_klass()->is_in_encoding_range())) {
         Node* nn = nullptr;
 
         int op = is_oop ? Op_ConN : Op_ConNKlass;


### PR DESCRIPTION
After JDK-8338526, the transformation can only be done if the Klass* is in the encoding range (also see JBS issue for more details). I've also enhanced the assertion message.