### PR TITLE
8339769: Incorrect error message during startup if working directory does not exist

### DIFF
--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,6 +113,7 @@ Java_jdk_internal_util_SystemProps_00024Raw_platformProperties(JNIEnv *env, jcla
 
     // Get the platform specific values
     sprops = GetJavaProperties(env);
+    JNU_CHECK_EXCEPTION_RETURN(env, NULL); // Checks working directory
     CHECK_NULL_RETURN(sprops, NULL);
 
     /*

--- a/src/java.base/share/native/libjava/System.c
+++ b/src/java.base/share/native/libjava/System.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -113,7 +113,6 @@ Java_jdk_internal_util_SystemProps_00024Raw_platformProperties(JNIEnv *env, jcla
 
     // Get the platform specific values
     sprops = GetJavaProperties(env);
-    JNU_CHECK_EXCEPTION_RETURN(env, NULL); // Checks working directory
     CHECK_NULL_RETURN(sprops, NULL);
 
     /*

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -521,11 +521,14 @@ GetJavaProperties(JNIEnv *env)
     {
         char buf[MAXPATHLEN];
         errno = 0;
-        if (getcwd(buf, sizeof(buf))  == NULL)
+        if (getcwd(buf, sizeof(buf))  == NULL) {
             JNU_ThrowByName(env, "java/lang/Error",
              "Properties init: Could not determine current working directory.");
-        else
+            return NULL;
+        }
+        else {
             sprops.user_dir = strdup(buf);
+        }
     }
 
     sprops.file_separator = "/";

--- a/src/java.base/unix/native/libjava/java_props_md.c
+++ b/src/java.base/unix/native/libjava/java_props_md.c
@@ -521,9 +521,9 @@ GetJavaProperties(JNIEnv *env)
     {
         char buf[MAXPATHLEN];
         errno = 0;
-        if (getcwd(buf, sizeof(buf))  == NULL) {
+        if (getcwd(buf, sizeof(buf)) == NULL) {
             JNU_ThrowByName(env, "java/lang/Error",
-             "Properties init: Could not determine current working directory.");
+            "Properties init: Could not determine current working directory.");
             return NULL;
         }
         else {


### PR DESCRIPTION
Please review this PR which restores the correct exception message when the current working directory can not be found during java startup in `initPhase1`.

Both MacOS and Linux are expected to fail with `java.lang.Error: Properties init: Could not determine current working directory` if the _user.dir_ system property cannot be initialized. Currently, MacOS now fails with `java.lang.InternalError: platform encoding not initialized` and Linux fails with  `java.lang.InternalError: null property: user.dir` which are both unexpected messages. 

In `System.c`, `Java_jdk_internal_util_SystemProps_00024Raw_platformProperties` calls `GetJavaProperties(JNIEnv *env)` which throws an internal error (with an appropriate message) for Unix platforms when the current working directory cannot be found. However, this exception is never checked and thus unexpected failures occur later. NULL should be returned after the exception is thrown, so that the initialization fails with the expected error when the return value is checked.

```
    // Get the platform specific values
    sprops = GetJavaProperties(env);
    CHECK_NULL_RETURN(sprops, NULL);
```

Testing done locally on both platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339769](https://bugs.openjdk.org/browse/JDK-8339769): Incorrect error message during startup if working directory does not exist (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**) Review applies to [c69216ee](https://git.openjdk.org/jdk/pull/20975/files/c69216ee75d9820f2109e99207f83a20b3ee4ef2)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [c69216ee](https://git.openjdk.org/jdk/pull/20975/files/c69216ee75d9820f2109e99207f83a20b3ee4ef2)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20975/head:pull/20975` \
`$ git checkout pull/20975`

Update a local copy of the PR: \
`$ git checkout pull/20975` \
`$ git pull https://git.openjdk.org/jdk.git pull/20975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20975`

View PR using the GUI difftool: \
`$ git pr show -t 20975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20975.diff">https://git.openjdk.org/jdk/pull/20975.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20975#issuecomment-2347321532)