### PR TITLE
8338711: Implement any outcomes of JDK-8300691: final variables in for loop headers should accept updates

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Preview.java
@@ -211,6 +211,7 @@ public class Preview {
             case FLEXIBLE_CONSTRUCTORS -> true;
             case PRIMITIVE_PATTERNS -> true;
             case MODULE_IMPORTS -> true;
+            case FINAL_FOR_LOOP_VARIABLES -> true;
             //Note: this is a backdoor which allows to optionally treat all features as 'preview' (for testing).
             //When real preview features will be added, this method can be implemented to return 'true'
             //for those selected features, and 'false' for all the others.

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Source.java
@@ -262,6 +262,7 @@ public enum Source {
         PRIMITIVE_PATTERNS(JDK23, Fragments.FeaturePrimitivePatterns, DiagKind.PLURAL),
         FLEXIBLE_CONSTRUCTORS(JDK22, Fragments.FeatureFlexibleConstructors, DiagKind.NORMAL),
         MODULE_IMPORTS(JDK23, Fragments.FeatureModuleImports, DiagKind.PLURAL),
+        FINAL_FOR_LOOP_VARIABLES(JDK24, Fragments.FeatureFinalForLoopVariables, DiagKind.NORMAL),
         ;
 
         enum DiagKind {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1790,9 +1790,10 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
 
         public void setLazyConstValue(final Env<AttrContext> env,
                                       final Attr attr,
-                                      final JCVariableDecl variable)
+                                      final JCVariableDecl variable,
+                                      final boolean forceNonConstant)
         {
-            setData((Callable<Object>)() -> attr.attribLazyConstantValue(env, variable, type));
+            setData((Callable<Object>)() -> attr.attribLazyConstantValue(env, variable, type, forceNonConstant));
         }
 
         /**

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/AttrContext.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/AttrContext.java
@@ -25,10 +25,14 @@
 
 package com.sun.tools.javac.comp;
 
+import java.util.Set;
+
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCVariableDecl;
 import com.sun.tools.javac.util.*;
 import com.sun.tools.javac.code.*;
 import com.sun.tools.javac.code.Scope.WriteableScope;
+import com.sun.tools.javac.code.Symbol.VarSymbol;
 import com.sun.tools.javac.comp.DeferredAttr.AttributionMode;
 
 /** Contains information specific to the attribute and enter
@@ -126,6 +130,16 @@ public class AttrContext {
      */
     JCTree preferredTreeForDiagnostics;
 
+    /** Variable declarations we want to prevent from being assigned constant values.
+     *  This is used when scanning for() inits to implement final for() loop variables.
+     */
+    Set<JCVariableDecl> nonConstantVarDecls;
+
+    /** Variables that may be assigned even though they are already initialized and final.
+     *  This is used when scanning for() steps to implement final for() loop variables.
+     */
+    Set<VarSymbol> assignableFinalVars;
+
     /** Duplicate this context, replacing scope field and copying all others.
      */
     AttrContext dup(WriteableScope scope) {
@@ -149,6 +163,8 @@ public class AttrContext {
         info.preferredTreeForDiagnostics = preferredTreeForDiagnostics;
         info.visitingServiceImplementation = visitingServiceImplementation;
         info.allowProtectedAccess = allowProtectedAccess;
+        info.nonConstantVarDecls = nonConstantVarDecls;
+        info.assignableFinalVars = assignableFinalVars;
         return info;
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
@@ -301,7 +301,8 @@ public class MemberEnter extends JCTree.Visitor {
                 needsLazyConstValue(tree.init)) {
                 Env<AttrContext> initEnv = getInitEnv(tree, env);
                 initEnv.info.enclVar = v;
-                v.setLazyConstValue(initEnv(tree, initEnv), attr, tree);
+                boolean forceNonConstant = env.info.nonConstantVarDecls != null && env.info.nonConstantVarDecls.contains(tree);
+                v.setLazyConstValue(initEnv(tree, initEnv), attr, tree, forceNonConstant);
             }
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/compiler.properties
@@ -3235,6 +3235,9 @@ compiler.misc.feature.implicit.classes=\
 compiler.misc.feature.flexible.constructors=\
     flexible constructors
 
+compiler.misc.feature.final.for.loop.variables=\
+    final for() loop variables
+
 compiler.misc.feature.module.imports=\
     module imports
 

--- a/test/langtools/tools/javac/diags/examples/FeatureFinalForLoopVariables.java
+++ b/test/langtools/tools/javac/diags/examples/FeatureFinalForLoopVariables.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+ // key: compiler.misc.feature.final.for.loop.variables
+ // key: compiler.warn.preview.feature.use
+ // options: --enable-preview -source ${jdk.version} -Xlint:preview
+
+class FeatureFinalForLoopVariables {
+    FeatureFinalForLoopVariables() {
+        for (final int i = 0; i < 3; i++)
+            ;
+    }
+}

--- a/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsBadAssign.java
+++ b/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsBadAssign.java
@@ -1,0 +1,32 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8338711
+ * @summary Test final for() loop variable support doesn't permit illegal stuff
+ * @compile/fail/ref=FinalLoopVarsBadAssign.out -XDrawDiagnostics FinalLoopVarsBadAssign.java
+ * @enablePreview
+ */
+
+import java.util.function.*;
+
+public class FinalLoopVarsBadAssign {
+
+    // Test: final for() loop variable may not be mutated in the init block
+    {
+        for (final int i = 0, j = ++i;              // error: cannot assign a value to final variable i
+          i < 3;
+          i++)
+            System.out.println(i);
+    }
+
+    // Test: final for() loop variable may not be mutated in the condition
+    {
+        for (final int i = 0; ++i < 3; i++)         // error: cannot assign a value to final variable i
+            System.out.println(i);
+    }
+
+    // Test: final for() loop variable may not be mutated in the body
+    {
+        for (final int i = 0; i < 3; i++)
+            i *= 2;                                 // error: cannot assign a value to final variable i
+    }
+}

--- a/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsBadAssign.out
+++ b/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsBadAssign.out
@@ -1,0 +1,6 @@
+FinalLoopVarsBadAssign.java:15:37: compiler.err.cant.assign.val.to.var: final, i
+FinalLoopVarsBadAssign.java:23:33: compiler.err.cant.assign.val.to.var: final, i
+FinalLoopVarsBadAssign.java:30:13: compiler.err.cant.assign.val.to.var: final, i
+- compiler.note.preview.filename: FinalLoopVarsBadAssign.java, DEFAULT
+- compiler.note.preview.recompile
+3 errors

--- a/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsConstValue.java
+++ b/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsConstValue.java
@@ -1,0 +1,40 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8338711
+ * @summary Test final for() loop variable support doesn't permit illegal stuff
+ * @compile/fail/ref=FinalLoopVarsConstValue.out -XDrawDiagnostics FinalLoopVarsConstValue.java
+ * @enablePreview
+ */
+
+import java.util.function.*;
+
+public class FinalLoopVarsConstValue {
+
+    // Test: a final for() loop variable that's not mutated has a constant value
+    {
+        for (final int i = 0; i != 0; /* no change */)
+            System.out.println("impossible");   // error: unreachable statement
+        System.out.println("ok");
+    }
+
+    // Test: a final for() loop variable that's not mutated has a constant value
+    {
+        for (final int i = 0; i == 0; /* no change */)
+            System.out.println("ok");
+        System.out.println("impossible");       // error: unreachable statement
+    }
+
+    // Test: weird nesting doesn't confuse the analysis logic
+    {
+        for (final int i = 0, j = new IntSupplier() {
+                                    public int getAsInt() {
+                                        for (int i = 0; i < 3; i++)     // mutate a different "i" here
+                                            System.out.println(i++);
+                                        return 0;
+                                    }
+                                  }.getAsInt();
+          i != 0;
+          /* no change */)
+            System.out.println("impossible");   // error: unreachable statement
+    }
+}

--- a/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsConstValue.out
+++ b/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsConstValue.out
@@ -1,0 +1,4 @@
+FinalLoopVarsConstValue.java:16:13: compiler.err.unreachable.stmt
+FinalLoopVarsConstValue.java:24:9: compiler.err.unreachable.stmt
+FinalLoopVarsConstValue.java:38:13: compiler.err.unreachable.stmt
+3 errors

--- a/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsEffectivelyFinal.java
+++ b/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsEffectivelyFinal.java
@@ -1,0 +1,20 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8338711
+ * @summary Test final for() loop variable support doesn't permit illegal stuff
+ * @compile/fail/ref=FinalLoopVarsEffectivelyFinal.out -XDrawDiagnostics FinalLoopVarsEffectivelyFinal.java
+ * @enablePreview
+ */
+
+import java.util.function.*;
+
+public class FinalLoopVarsEffectivelyFinal {
+
+    // Test: non-final for() loop variable modified in body is not effectively final
+    {
+        for (int i = 0; i < 3; i++) {
+            i *= 2;
+            ((Runnable)() -> System.out.println(i)).run();      // error: ...must be final or effectively final
+        }
+    }
+}

--- a/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsEffectivelyFinal.out
+++ b/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsEffectivelyFinal.out
@@ -1,0 +1,2 @@
+FinalLoopVarsEffectivelyFinal.java:17:49: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
+1 error

--- a/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsTest.java
+++ b/test/langtools/tools/javac/finalLoopVars/FinalLoopVarsTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8338711
+ * @summary Test final for() loop variables may be mutated in the step, etc.
+ * @enablePreview
+ */
+
+import java.util.function.*;
+
+public class FinalLoopVarsTest {
+
+    // Test: a final loop variable can be mutated in the step
+    public static int test1() {
+        int total = 0;
+        for (final int i = 0; i < 3; i++)
+            total += i;
+        return total;
+    }
+
+    // Test: a final loop variable can be captured by a lambda in the body
+    public static int test2() {
+        int total = 0;
+        for (final int i = 0; i < 3; i++) {
+            IntSupplier s = () -> i;
+            total += s.getAsInt();
+        }
+        return total;
+    }
+
+    // Test: a non-final loop variable can be captured by a lambda in the body
+    public static int test3() {
+        int total = 0;
+        for (int i = 0; i < 3; i++) {
+            IntSupplier s = () -> i;
+            total += s.getAsInt();
+        }
+        return total;
+    }
+
+    // Test: step mutations can appear in nested expressions
+    public static int test4() {
+        int total = 0;
+        for (final int i = 0;
+          i < 3;
+          i = switch (0) { default -> ++i; })
+            total += i;
+        return total;
+    }
+
+    // Test: mutated final loop variables do not have constant values
+    public static int test5() {
+        int total = 0;
+        int max = 0;
+        for (final int i = 0; i == 0; max = ++i)
+            total += i;
+        return max * 10 + total;        // this statement is reachable
+    }
+
+    // Test: mutated final loop variables do not have constant values
+    public static int test6() {
+        int total = 0;
+        int max = 0;
+        for (final int i = 0; i != 0; max = ++i)
+            total += i;                 // this statement is reachable
+        return max * 10 + total;
+    }
+
+    // Test: weird nesting doesn't confuse the analysis logic
+    public static int test7() {
+        int total = 0;
+        for (final int i = 0;
+          i < 3;
+          i++, new Object() {{
+                                for (int i = 0; i < 3; i++)
+                                    i *= 2;
+                            }})
+            total += i;
+        return total;
+    }
+
+    // Test: final loop variables without initializers don't change
+    public static int test8() {
+        int total = 0;
+        for (final int i; true; i++) {
+            total++;
+            break;
+        }
+        return total;
+    }
+
+    public static void main(String[] args) {
+        verify(test1(), 3);
+        verify(test2(), 3);
+        verify(test3(), 3);
+        verify(test4(), 3);
+        verify(test5(), 10);
+        verify(test6(), 0);
+        verify(test7(), 3);
+        verify(test8(), 1);
+    }
+
+    public static void verify(int actual, int expected) {
+        if (actual != expected)
+            throw new AssertionError(String.format("expected %d but got %d", expected, actual));
+    }
+}


### PR DESCRIPTION
JDK-8300691 describes a language feature making the following changes to variables declared in a basic `for()` statement's initialization section:
1. `final` variables may be mutated in the step (but still not in the condition or the body)
1. Non-`final` variables no longer lose their "effectively final" status when they are mutated in the step

Change 1 would allow code like this:
```java
for (final int i = 0; i < 10; i++) {
    System.out.println(i);          // rest assured that "i" can't change in here
}
```
Change 2 would allow code like this:
```java
for (int i = 0; i < 10; i++) {
    Runnable r = () -> System.out.println(i);   // hooray, "i" is effectively final
}
```
This PR implements these changes. A few notes:
* This is implemented as a preview feature in case this is needed (easy to remove if not)
* Both `Attr.java` and `Flow.java` check for assignment to final variables, so both files are affected.
* A `final` initialized loop variable that's modified in the step can no longer be considered to have a constant value (otherwise we'd get invalid `unreachable statement` errors)
* There is no change for blank `final` loop variables or variables not modified in the step. It's unnecessary for one thing,  but this also helps preserve existing behavior in certain corner cases, e.g., test `T4721076.java`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 24 to be approved (needs to be created)

### Issue
 * [JDK-8338711](https://bugs.openjdk.org/browse/JDK-8338711): Implement any outcomes of JDK-8300691: final variables in for loop headers should accept updates (**Task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20976/head:pull/20976` \
`$ git checkout pull/20976`

Update a local copy of the PR: \
`$ git checkout pull/20976` \
`$ git pull https://git.openjdk.org/jdk.git pull/20976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20976`

View PR using the GUI difftool: \
`$ git pr show -t 20976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20976.diff">https://git.openjdk.org/jdk/pull/20976.diff</a>

</details>
