### PR TITLE
8340075: Autoconf bundle cannot run on read-only filesystem

### DIFF
--- a/make/devkit/createAutoconfBundle.sh
+++ b/make/devkit/createAutoconfBundle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -25,50 +25,70 @@
 #
 
 # Create a bundle in the current directory, containing what's needed to run
-# the 'autoconf' program by the OpenJDK build.
+# the 'autoconf' program by the OpenJDK build. To override TARGET_PLATFORM
+# just set the variable before running this script.
 
 # Autoconf depends on m4, so download and build that first.
 AUTOCONF_VERSION=2.69
 M4_VERSION=1.4.18
 
 PACKAGE_VERSION=1.0.1
-TARGET_PLATFORM=linux_x86
+case `uname -s` in
+    Darwin)
+        os=macosx
+        ;;
+    Linux)
+        os=linux
+        ;;
+    CYGWIN*)
+        os=cygwin
+        ;;
+esac
+case `uname -m` in
+    arm64|aarch64)
+        arch=aarch64
+        ;;
+    amd64|x86_64|x64)
+        arch=x64
+        ;;
+esac
+TARGET_PLATFORM=${TARGET_PLATFORM:="${os}_${arch}"}
+
 MODULE_NAME=autoconf-$TARGET_PLATFORM-$AUTOCONF_VERSION+$PACKAGE_VERSION
 BUNDLE_NAME=$MODULE_NAME.tar.gz
 
-TMPDIR=`mktemp -d -t autoconfbundle-XXXX`
-trap "rm -rf \"$TMPDIR\"" EXIT
+SCRIPT_DIR="$(cd "$(dirname $0)" > /dev/null && pwd)"
+OUTPUT_ROOT="${SCRIPT_DIR}/../../build/autoconf"
 
-ORIG_DIR=`pwd`
-cd $TMPDIR
-OUTPUT_DIR=$TMPDIR/$MODULE_NAME
-mkdir -p $OUTPUT_DIR/usr
+cd $OUTPUT_ROOT
+IMAGE_DIR=$OUTPUT_ROOT/$MODULE_NAME
+mkdir -p $IMAGE_DIR/usr
 
 # Download and build m4
 
 if test "x$TARGET_PLATFORM" = xcygwin_x64; then
   # On cygwin 64-bit, just copy the cygwin .exe file
-  mkdir -p $OUTPUT_DIR/usr/bin
-  cp /usr/bin/m4 $OUTPUT_DIR/usr/bin
+  mkdir -p $IMAGE_DIR/usr/bin
+  cp /usr/bin/m4 $IMAGE_DIR/usr/bin
 elif test "x$TARGET_PLATFORM" = xcygwin_x86; then
   # On cygwin 32-bit, just copy the cygwin .exe file
-  mkdir -p $OUTPUT_DIR/usr/bin
-  cp /usr/bin/m4 $OUTPUT_DIR/usr/bin
+  mkdir -p $IMAGE_DIR/usr/bin
+  cp /usr/bin/m4 $IMAGE_DIR/usr/bin
 elif test "x$TARGET_PLATFORM" = xlinux_x64; then
   M4_VERSION=1.4.13-5
   wget http://yum.oracle.com/repo/OracleLinux/OL6/latest/x86_64/getPackage/m4-$M4_VERSION.el6.x86_64.rpm
-  cd $OUTPUT_DIR
-  rpm2cpio ../m4-$M4_VERSION.el6.x86_64.rpm | cpio -d -i
+  cd $IMAGE_DIR
+  rpm2cpio $OUTPUT_ROOT/m4-$M4_VERSION.el6.x86_64.rpm | cpio -d -i
 elif test "x$TARGET_PLATFORM" = xlinux_x86; then
   M4_VERSION=1.4.13-5
   wget http://yum.oracle.com/repo/OracleLinux/OL6/latest/i386/getPackage/m4-$M4_VERSION.el6.i686.rpm
-  cd $OUTPUT_DIR
-  rpm2cpio ../m4-$M4_VERSION.el6.i686.rpm | cpio -d -i
+  cd $IMAGE_DIR
+  rpm2cpio $OUTPUT_ROOT/m4-$M4_VERSION.el6.i686.rpm | cpio -d -i
 else
   wget https://ftp.gnu.org/gnu/m4/m4-$M4_VERSION.tar.gz
   tar xzf m4-$M4_VERSION.tar.gz
   cd m4-$M4_VERSION
-  ./configure --prefix=$OUTPUT_DIR/usr
+  ./configure --prefix=$IMAGE_DIR/usr CFLAGS="-w -Wno-everything"
   make
   make install
   cd ..
@@ -79,15 +99,14 @@ fi
 wget https://ftp.gnu.org/gnu/autoconf/autoconf-$AUTOCONF_VERSION.tar.gz
 tar xzf autoconf-$AUTOCONF_VERSION.tar.gz
 cd autoconf-$AUTOCONF_VERSION
-./configure --prefix=$OUTPUT_DIR/usr M4=$OUTPUT_DIR/usr/bin/m4
+./configure --prefix=$IMAGE_DIR/usr M4=$IMAGE_DIR/usr/bin/m4
 make
 make install
 cd ..
 
-perl -pi -e "s!$OUTPUT_DIR/!./!" $OUTPUT_DIR/usr/bin/auto* $OUTPUT_DIR/usr/share/autoconf/autom4te.cfg
-cp $OUTPUT_DIR/usr/share/autoconf/autom4te.cfg $OUTPUT_DIR/autom4te.cfg
+perl -pi -e "s!$IMAGE_DIR/!./!" $IMAGE_DIR/usr/bin/auto* $IMAGE_DIR/usr/share/autoconf/autom4te.cfg
 
-cat > $OUTPUT_DIR/autoconf << EOF
+cat > $IMAGE_DIR/autoconf << EOF
 #!/bin/bash
 # Get an absolute path to this script
 this_script_dir=\`dirname \$0\`
@@ -100,17 +119,10 @@ export AUTOHEADER="\$this_script_dir/usr/bin/autoheader"
 export AC_MACRODIR="\$this_script_dir/usr/share/autoconf"
 export autom4te_perllibdir="\$this_script_dir/usr/share/autoconf"
 
-autom4te_cfg=\$this_script_dir/usr/share/autoconf/autom4te.cfg
-cp \$this_script_dir/autom4te.cfg \$autom4te_cfg
+PREPEND_INCLUDE="--prepend-include \$this_script_dir/usr/share/autoconf"
 
-echo 'begin-language: "M4sugar"' >> \$autom4te_cfg
-echo "args: --prepend-include '"\$this_script_dir/usr/share/autoconf"'" >> \$autom4te_cfg
-echo 'end-language: "M4sugar"' >> \$autom4te_cfg
-
-exec \$this_script_dir/usr/bin/autoconf "\$@"
+exec \$this_script_dir/usr/bin/autoconf \$PREPEND_INCLUDE "\$@"
 EOF
-chmod +x $OUTPUT_DIR/autoconf
-cd $OUTPUT_DIR
-tar -cvzf ../$BUNDLE_NAME *
-cd ..
-cp $BUNDLE_NAME "$ORIG_DIR"
+chmod +x $IMAGE_DIR/autoconf
+cd $IMAGE_DIR
+tar -cvzf $OUTPUT_ROOT/$BUNDLE_NAME *


### PR DESCRIPTION
The autoconf launcher script in the autoconf bundle created by `make/devkit/createAutoconf.sh` currently writes a config file into the bundle installation dir every time it runs. This prevents it from functioning when installed on a read-only filesystem. We can work around the need for writing to this config file by instead adding a parameter to the command line sent to the actual autoconf executable.

This is what the script adds to the config file (with the $this_script_dir variable expanded):

begin-language: "M4sugar"
args: --prepend-include $this_script_dir/usr/share/autoconf
end-language: "M4sugar"

Looking at the original config file, it has several lines similar to this where the --prepend-include arg points to $PREFIX/usr/share/autoconf (where $PREFIX was specified at autoconf build time). Removing this addition from the config file causes autoconf to fail as it can't find m4sugar.m4 (which is located in $this_script_dir/usr/share/autoconf).

My proposed workaround, is to just add `--prepend-include $this_script_dir/usr/share/autoconf` as a command line option to the real autoconf script, which we call from the wrapper script. This would have the benefit of also fixing the other instances of this that are present in the config file, but that we aren't using in our configure script.

In addition to this, I made the script conform better to the current standard for these bundle creation scripts. The output should end up in a sub directory of `build`. No temp dirs should be used instead of the build dir. I also added some automation for setting the target platform tuple based on `uname` for the most common platforms, and added the ability to override for any others, without having to edit the file.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340075](https://bugs.openjdk.org/browse/JDK-8340075): Autoconf bundle cannot run on read-only filesystem (**Bug** - P4)


### Reviewers
 * [Mikael Vidstedt](https://openjdk.org/census#mikael) (@vidmik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20978/head:pull/20978` \
`$ git checkout pull/20978`

Update a local copy of the PR: \
`$ git checkout pull/20978` \
`$ git pull https://git.openjdk.org/jdk.git pull/20978/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20978`

View PR using the GUI difftool: \
`$ git pr show -t 20978`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20978.diff">https://git.openjdk.org/jdk/pull/20978.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20978#issuecomment-2347360764)