### PR TITLE
8340073: Support "%z" time zone abbreviation format in TZ files

### DIFF
--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -1216,11 +1216,9 @@ public class CLDRConverter {
     // This method assumes handlerMetaZones is already initialized
     private static Set<String> getAvailableZoneIds() {
         assert handlerMetaZones != null;
-        assert tzdbLinks != null;
         if (AVAILABLE_TZIDS == null) {
-            AVAILABLE_TZIDS = new HashSet<>(ZoneId.getAvailableZoneIds());
+            AVAILABLE_TZIDS = new HashSet<>(Arrays.asList(TimeZone.getAvailableIDs()));
             AVAILABLE_TZIDS.addAll(handlerMetaZones.keySet());
-            AVAILABLE_TZIDS.addAll(tzdbLinks.keySet());
             AVAILABLE_TZIDS.remove(MetaZonesParseHandler.NO_METAZONE_KEY);
         }
 

--- a/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
+++ b/make/jdk/src/classes/build/tools/cldrconverter/CLDRConverter.java
@@ -786,7 +786,10 @@ public class CLDRConverter {
             String tzKey = Optional.ofNullable((String)handlerSupplMeta.get(tzid))
                                    .orElse(tzid);
             // Follow link, if needed
-            var tzLink = tzdbLinks.get(tzKey);
+            String tzLink = null;
+            for (var k = tzKey; tzdbLinks.containsKey(k);) {
+                k = tzLink = tzdbLinks.get(k);
+            }
             if (tzLink == null && tzdbLinks.containsValue(tzKey)) {
                 // reverse link search
                 // this is needed as in tzdb, "America/Buenos_Aires" links to
@@ -1213,9 +1216,11 @@ public class CLDRConverter {
     // This method assumes handlerMetaZones is already initialized
     private static Set<String> getAvailableZoneIds() {
         assert handlerMetaZones != null;
+        assert tzdbLinks != null;
         if (AVAILABLE_TZIDS == null) {
             AVAILABLE_TZIDS = new HashSet<>(ZoneId.getAvailableZoneIds());
             AVAILABLE_TZIDS.addAll(handlerMetaZones.keySet());
+            AVAILABLE_TZIDS.addAll(tzdbLinks.keySet());
             AVAILABLE_TZIDS.remove(MetaZonesParseHandler.NO_METAZONE_KEY);
         }
 
@@ -1490,13 +1495,14 @@ public class CLDRConverter {
     /*
      * Convert TZDB offsets to JDK's offsets, eg, "-08" to "GMT-08:00".
      * If it cannot recognize the pattern, return the argument as is.
+     * Returning null results in generating the GMT format at runtime.
      */
     private static String convertGMTName(String f) {
         try {
-            // Should pre-fill GMT format once COMPAT is gone.
-            // Till then, fall back to GMT format at runtime, after COMPAT short
-            // names are populated
-            ZoneOffset.of(f);
+            if (!f.equals("%z")) {
+                // Validate if the format is an offset
+                ZoneOffset.of(f);
+            }
             return null;
         } catch (DateTimeException dte) {
             // textual representation. return as is

--- a/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRTimeZoneNameProviderImpl.java
@@ -264,7 +264,13 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
     }
 
     private String toGMTFormat(String id, boolean daylight, Locale l) {
-        var zr = ZoneInfoFile.getZoneInfo(id).toZoneId().getRules();
+        LocaleResources lr = LocaleProviderAdapter.forType(Type.CLDR).getLocaleResources(l);
+        ResourceBundle fd = lr.getJavaTimeFormatData();
+        var zi = ZoneInfoFile.getZoneInfo(id);
+        if (zi == null) {
+            return fd.getString("timezone.gmtZeroFormat");
+        }
+        var zr = zi.toZoneId().getRules();
         var now = Instant.now();
         var saving = zr.getTransitions().reversed().stream()
                 .dropWhile(zot -> zot.getInstant().isAfter(now))
@@ -276,8 +282,6 @@ public class CLDRTimeZoneNameProviderImpl extends TimeZoneNameProviderImpl {
                 .orElse(0);
         int offset = (zr.getStandardOffset(now).getTotalSeconds() +
                 (daylight ? saving : 0)) / 60;
-        LocaleResources lr = LocaleProviderAdapter.forType(Type.CLDR).getLocaleResources(l);
-        ResourceBundle fd = lr.getJavaTimeFormatData();
 
         if (offset == 0) {
             return fd.getString("timezone.gmtZeroFormat");


### PR DESCRIPTION
Yet another preparation for upgrading the time zone data to 2024b, which introduced a new abbreviation format "%z". The update includes:
...
      The main source files' time zone abbreviations now use %z,
      supported by zic since release 2015f and used in vanguard form
      since release 2022b. For example, America/Sao_Paulo now contains
      the zone continuation line "-3:00 Brazil %z", which is less error
      prone than the old "-3:00 Brazil -03/-02". This does not change
      the represented data: the generated TZif files are unchanged.
      Rearguard form still avoids %z, to support obsolescent parsers.
...

Also fixed the logic to retrieve the linked tz name that is chaining.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340073](https://bugs.openjdk.org/browse/JDK-8340073): Support "%z" time zone abbreviation format in TZ files (**Enhancement** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20979/head:pull/20979` \
`$ git checkout pull/20979`

Update a local copy of the PR: \
`$ git checkout pull/20979` \
`$ git pull https://git.openjdk.org/jdk.git pull/20979/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20979`

View PR using the GUI difftool: \
`$ git pr show -t 20979`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20979.diff">https://git.openjdk.org/jdk/pull/20979.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20979#issuecomment-2347391660)