### PR TITLE
8330302: strace004 can still fail

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/ThreadController.java
@@ -663,6 +663,9 @@ class SleepingThread extends BaseThread {
         expectedMethods.add(Thread.class.getName() + ".currentCarrierThread");
         expectedMethods.add(Thread.class.getName() + ".currentThread");
         // jdk.internal.event.ThreadSleepEvent not accessible
+        expectedMethods.add("java.lang.Object.<init>");
+        expectedMethods.add("jdk.internal.event.Event.<init>");
+        expectedMethods.add("jdk.internal.event.ThreadSleepEvent.<init>");
         expectedMethods.add("jdk.internal.event.ThreadSleepEvent.<clinit>");
         expectedMethods.add("jdk.internal.event.ThreadSleepEvent.isEnabled");
         expectedMethods.add(SleepingThread.class.getName() + ".run");

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/SleepingThread.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/SleepingThread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/SleepingThread.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/share/thread/SleepingThread.java
@@ -41,6 +41,9 @@ public class SleepingThread extends RecursiveMonitoringThread {
                 "java.lang.Thread.beforeSleep",
                 "java.lang.Thread.afterSleep",
                 "java.util.concurrent.TimeUnit.toNanos",
+                "java.lang.Object.<init>",
+                "jdk.internal.event.Event.<init>",
+                "jdk.internal.event.ThreadSleepEvent.<init>",
                 "jdk.internal.event.ThreadSleepEvent.<clinit>",
                 "jdk.internal.event.ThreadSleepEvent.isEnabled",
                 "nsk.monitoring.share.thread.SleepingThread.runInside"

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/thread/strace001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,6 +150,8 @@ public class strace001 {
                 "java.lang.Thread.currentThread",
                 "java.util.concurrent.TimeUnit.toNanos",
                 "jdk.internal.event.ThreadSleepEvent.<clinit>",
+                "java.lang.Object.<init>",
+                "jdk.internal.event.Event.<init>",
                 "jdk.internal.event.ThreadSleepEvent.<init>",
                 "jdk.internal.event.ThreadSleepEvent.isEnabled"
         };


### PR DESCRIPTION
This is a trivial point fix for the `strace` tests to add in the missing event (super)constructors. These tests have started failing more regularly after the `Thread.sleep` code was recently changed.

The fragility of these tests is well known but I simply want to deal with current failures in our CI. It remains a future RFE to fix these tests so they don't need continual updating like this.

Testing:
 - themselves
 - tier 5 (which is where we see CI failures most often)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330302](https://bugs.openjdk.org/browse/JDK-8330302): strace004 can still fail (**Bug** - P3)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20980/head:pull/20980` \
`$ git checkout pull/20980`

Update a local copy of the PR: \
`$ git checkout pull/20980` \
`$ git pull https://git.openjdk.org/jdk.git pull/20980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20980`

View PR using the GUI difftool: \
`$ git pr show -t 20980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20980.diff">https://git.openjdk.org/jdk/pull/20980.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20980#issuecomment-2347402599)