### PR TITLE
8340081: Test java/foreign/TestLinker.java failed failed: missing permission java.lang.foreign.native.threshold.power.fill

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -29,6 +29,7 @@ import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.util.Architecture;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.vm.annotation.ForceInline;
+import sun.security.action.GetPropertyAction;
 
 import java.lang.foreign.MemorySegment;
 
@@ -309,8 +310,15 @@ public final class SegmentBulkOperations {
 
     // The returned value is in the interval [0, 2^30]
     static int powerOfPropertyOr(String name, int defaultPower) {
-        final int power = Integer.getInteger(PROPERTY_PATH + name, defaultPower);
-        return 1 << Math.clamp(power, 0, Integer.SIZE - 2);
+        final String property = GetPropertyAction.privilegedGetProperty(PROPERTY_PATH + name);
+        if (property != null) {
+            try {
+                return 1 << Math.clamp(Integer.parseInt(property), 0, Integer.SIZE - 2);
+            } catch (NumberFormatException _) {
+                // ignore
+            }
+        }
+        return defaultPower;
     }
 
 }


### PR DESCRIPTION
This PR fixes a regression introduced by https://github.com/openjdk/jdk/pull/20848

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340081](https://bugs.openjdk.org/browse/JDK-8340081): Test java/foreign/TestLinker.java failed failed: missing permission java.lang.foreign.native.threshold.power.fill (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20983/head:pull/20983` \
`$ git checkout pull/20983`

Update a local copy of the PR: \
`$ git checkout pull/20983` \
`$ git pull https://git.openjdk.org/jdk.git pull/20983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20983`

View PR using the GUI difftool: \
`$ git pr show -t 20983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20983.diff">https://git.openjdk.org/jdk/pull/20983.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20983#issuecomment-2348137250)