### PR TITLE
8340087: (fs) Files.copy include symbolic link detailed message for NoSuchFileException

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -26,7 +26,20 @@
 package sun.nio.fs;
 
 import java.nio.ByteBuffer;
-import java.nio.file.*;
+import java.nio.file.AtomicMoveNotSupportedException;
+import java.nio.file.CopyOption;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.FileStore;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystemException;
+import java.nio.file.LinkOption;
+import java.nio.file.LinkPermission;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.UserPrincipalLookupService;

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -26,18 +26,7 @@
 package sun.nio.fs;
 
 import java.nio.ByteBuffer;
-import java.nio.file.AtomicMoveNotSupportedException;
-import java.nio.file.CopyOption;
-import java.nio.file.DirectoryNotEmptyException;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.FileStore;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystemException;
-import java.nio.file.LinkOption;
-import java.nio.file.LinkPermission;
-import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.StandardCopyOption;
+import java.nio.file.*;
 import java.nio.file.attribute.GroupPrincipal;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.UserPrincipalLookupService;
@@ -1011,6 +1000,19 @@ abstract class UnixFileSystem
         try {
             sourceAttrs = UnixFileAttributes.get(source, flags.followLinks);
         } catch (UnixException x) {
+            if (x.errno() == UnixConstants.ENOENT) {
+                if (Files.isSymbolicLink(source)) {
+                    Path symbolicLink = null;
+                    try {
+                        symbolicLink = Files.readSymbolicLink(source);
+                    } catch (IOException e) {
+                        //use rethrowAsIOException
+                    }
+                    if (symbolicLink != null) {
+                        throw new NoSuchFileException(source.toString(), null, "due to " + symbolicLink);
+                    }
+                }
+            }
             x.rethrowAsIOException(source);
         }
 


### PR DESCRIPTION
(fs) Files.copy include symbolic link detailed message for NoSuchFileException

Description
Simulation case:
```
touch testfile
ln -s testfile testlink
mv testfile testfile1
```

code:
```
    public static void main(String[] args) throws IOException {
        Files.copy(Paths.get("/data/testfiles/testlink"), Paths.get("/data/testfiles/xx"));
    }
```

Program current information：
Exception in thread "main" java.nio.file.NoSuchFileException: /data/testfiles/testlink


Devops check file exists with ll

After additional information：
Exception in thread "main" java.nio.file.NoSuchFileException: /data/testfiles/testlink: due to testfile

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340087](https://bugs.openjdk.org/browse/JDK-8340087): (fs) Files.copy include symbolic link detailed message for NoSuchFileException (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20984/head:pull/20984` \
`$ git checkout pull/20984`

Update a local copy of the PR: \
`$ git checkout pull/20984` \
`$ git pull https://git.openjdk.org/jdk.git pull/20984/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20984`

View PR using the GUI difftool: \
`$ git pr show -t 20984`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20984.diff">https://git.openjdk.org/jdk/pull/20984.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20984#issuecomment-2348188218)