### PR TITLE
8340089: Simplify SegmentBulkOperations::powerOfProperty

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -29,6 +29,7 @@ import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.util.Architecture;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.vm.annotation.ForceInline;
+import sun.security.action.GetPropertyAction;
 
 import java.lang.foreign.MemorySegment;
 
@@ -309,8 +310,15 @@ public final class SegmentBulkOperations {
 
     // The returned value is in the interval [0, 2^30]
     static int powerOfPropertyOr(String name, int defaultPower) {
-        final int power = Integer.getInteger(PROPERTY_PATH + name, defaultPower);
-        return 1 << Math.clamp(power, 0, Integer.SIZE - 2);
+        final String property = GetPropertyAction.privilegedGetProperty(PROPERTY_PATH + name);
+        if (property != null) {
+            try {
+                return 1 << Math.clamp(Integer.parseInt(property), 0, Integer.SIZE - 2);
+            } catch (NumberFormatException _) {
+                // ignore
+            }
+        }
+        return defaultPower;
     }
 
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -29,11 +29,7 @@ import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.util.Architecture;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.vm.annotation.ForceInline;
-<<<<<<< HEAD
 import sun.security.action.GetIntegerAction;
-=======
->>>>>>> master
-import sun.security.action.GetPropertyAction;
 
 import java.lang.foreign.MemorySegment;
 

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -310,13 +310,11 @@ public final class SegmentBulkOperations {
 
     // The returned value is in the interval [0, 2^30]
     static int powerOfPropertyOr(String name, int defaultPower) {
-        final String property = GetPropertyAction.privilegedGetProperty(PROPERTY_PATH + name);
-        if (property != null) {
-            try {
-                return 1 << Math.clamp(Integer.parseInt(property), 0, Integer.SIZE - 2);
-            } catch (NumberFormatException _) {
-                // ignore
-            }
+        final String property = GetPropertyAction.privilegedGetProperty(PROPERTY_PATH + name, Integer.toString(defaultPower));
+        try {
+            return 1 << Math.clamp(Integer.parseInt(property), 0, Integer.SIZE - 2);
+        } catch (NumberFormatException _) {
+            // ignore
         }
         return defaultPower;
     }

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -29,6 +29,7 @@ import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.util.Architecture;
 import jdk.internal.util.ArraysSupport;
 import jdk.internal.vm.annotation.ForceInline;
+import sun.security.action.GetIntegerAction;
 import sun.security.action.GetPropertyAction;
 
 import java.lang.foreign.MemorySegment;
@@ -310,13 +311,8 @@ public final class SegmentBulkOperations {
 
     // The returned value is in the interval [0, 2^30]
     static int powerOfPropertyOr(String name, int defaultPower) {
-        final String property = GetPropertyAction.privilegedGetProperty(PROPERTY_PATH + name, Integer.toString(defaultPower));
-        try {
-            return 1 << Math.clamp(Integer.parseInt(property), 0, Integer.SIZE - 2);
-        } catch (NumberFormatException _) {
-            // ignore
-        }
-        return defaultPower;
+        final int power = GetIntegerAction.privilegedGetProperty(PROPERTY_PATH + name, defaultPower);
+        return 1 << Math.clamp(power, 0, Integer.SIZE - 2);
     }
 
 }


### PR DESCRIPTION
This PR suggests to simplify the. method `SegmebtBulkOperations::powerOfPropertyOr`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340089](https://bugs.openjdk.org/browse/JDK-8340089): Simplify SegmentBulkOperations::powerOfProperty (**Enhancement** - P5)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20985/head:pull/20985` \
`$ git checkout pull/20985`

Update a local copy of the PR: \
`$ git checkout pull/20985` \
`$ git pull https://git.openjdk.org/jdk.git pull/20985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20985`

View PR using the GUI difftool: \
`$ git pr show -t 20985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20985.diff">https://git.openjdk.org/jdk/pull/20985.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20985#issuecomment-2348196814)