### PR TITLE
8339416: [s390x] Provide implementation for resolve_global_jobject

### DIFF
--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -143,7 +143,7 @@ void BarrierSetAssembler::resolve_global_jobject(MacroAssembler* masm, Register 
   NearLabel done;
 
   __ z_ltgr(value, value);
-  __ z_bre(done); // null as-is.
+  __ z_bre(done); // use null as-is.
 
 #ifdef ASSERT
   {

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.cpp
@@ -105,16 +105,60 @@ void BarrierSetAssembler::store_at(MacroAssembler* masm, DecoratorSet decorators
   }
 }
 
+// Generic implementation. GCs can provide an optimized one.
 void BarrierSetAssembler::resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2) {
-  NearLabel Ldone;
-  __ z_ltgr(tmp1, value);
-  __ z_bre(Ldone);          // Use null result as-is.
 
-  __ z_nill(value, ~JNIHandles::tag_mask);
-  __ z_lg(value, 0, value); // Resolve (untagged) jobject.
+  assert_different_registers(value, tmp1, tmp2);
+  NearLabel done, weak_tag, verify, tagged;
+  __ z_ltgr(value, value);
+  __ z_bre(done);          // Use null result as-is.
 
+  __ z_tmll(value, JNIHandles::tag_mask);
+  __ z_btrue(tagged); // not zero
+
+  // Resolve Local handle
+  __ access_load_at(T_OBJECT, IN_NATIVE | AS_RAW, Address(value, 0), value, tmp1, tmp2);
+  __ z_bru(verify);
+
+  __ bind(tagged);
+  __ testbit(value, exact_log2(JNIHandles::TypeTag::weak_global)); // test for weak tag
+  __ z_btrue(weak_tag);
+
+  // resolve global handle
+  __ access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::TypeTag::global), value, tmp1, tmp2);
+  __ z_bru(verify);
+
+  __ bind(weak_tag);
+  // resolve jweak.
+  __ access_load_at(T_OBJECT, IN_NATIVE | ON_PHANTOM_OOP_REF,
+                    Address(value, -JNIHandles::TypeTag::weak_global), value, tmp1, tmp2);
+  __ bind(verify);
   __ verify_oop(value, FILE_AND_LINE);
-  __ bind(Ldone);
+  __ bind(done);
+}
+
+// Generic implementation. GCs can provide an optimized one.
+void BarrierSetAssembler::resolve_global_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2) {
+  assert_different_registers(value, tmp1, tmp2);
+  NearLabel done;
+
+  __ z_ltgr(value, value);
+  __ z_bre(done); // null as-is.
+
+#ifdef ASSERT
+  {
+    NearLabel valid_global_tag;
+    __ testbit(value, exact_log2(JNIHandles::TypeTag::global)); // test for global tag
+    __ z_btrue(valid_global_tag);
+    __ stop("non global jobject using resolve_global_jobject");
+    __ bind(valid_global_tag);
+  }
+#endif // ASSERT
+
+  // Resolve global handle
+  __ access_load_at(T_OBJECT, IN_NATIVE, Address(value, -JNIHandles::TypeTag::global), value, tmp1, tmp2);
+  __ verify_oop(value, FILE_AND_LINE);
+  __ bind(done);
 }
 
 void BarrierSetAssembler::try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,

--- a/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/barrierSetAssembler_s390.hpp
@@ -51,6 +51,7 @@ public:
                         const Address& addr, Register val, Register tmp1, Register tmp2, Register tmp3);
 
   virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2);
+  virtual void resolve_global_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2);
 
   virtual void try_resolve_jobject_in_native(MacroAssembler* masm, Register jni_env,
                                              Register obj, Register tmp, Label& slowpath);

--- a/src/hotspot/cpu/s390/gc/shared/modRefBarrierSetAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/gc/shared/modRefBarrierSetAssembler_s390.hpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2018 SAP SE. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,6 +48,8 @@ public:
 
   virtual void store_at(MacroAssembler* masm, DecoratorSet decorators, BasicType type,
                         const Address& dst, Register val, Register tmp1, Register tmp2, Register tmp3);
+
+  virtual void resolve_jobject(MacroAssembler* masm, Register value, Register tmp1, Register tmp2);
 };
 
 #endif // CPU_S390_GC_SHARED_MODREFBARRIERSETASSEMBLER_S390_HPP

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3674,6 +3674,12 @@ void MacroAssembler::resolve_jobject(Register value, Register tmp1, Register tmp
   bs->resolve_jobject(this, value, tmp1, tmp2);
 }
 
+void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Register tmp2) {
+  BarrierSetAssembler* bs = BarrierSet::barrier_set()->barrier_set_assembler();
+  bs->resolve_global_jobject(this, value, tmp1, tmp2);
+}
+
+
 // Last_Java_sp must comply to the rules in frame_s390.hpp.
 void MacroAssembler::set_last_Java_frame(Register last_Java_sp, Register last_Java_pc, bool allow_relocation) {
   BLOCK_COMMENT("set_last_Java_frame {");

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3679,7 +3679,6 @@ void MacroAssembler::resolve_global_jobject(Register value, Register tmp1, Regis
   bs->resolve_global_jobject(this, value, tmp1, tmp2);
 }
 
-
 // Last_Java_sp must comply to the rules in frame_s390.hpp.
 void MacroAssembler::set_last_Java_frame(Register last_Java_sp, Register last_Java_pc, bool allow_relocation) {
   BLOCK_COMMENT("set_last_Java_frame {");

--- a/src/hotspot/cpu/s390/macroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.hpp
@@ -758,6 +758,7 @@ class MacroAssembler: public Assembler {
   void compiler_fast_unlock_lightweight_object(Register obj, Register tmp1, Register tmp2);
 
   void resolve_jobject(Register value, Register tmp1, Register tmp2);
+  void resolve_global_jobject(Register value, Register tmp1, Register tmp2);
 
   // Support for last Java frame (but use call_VM instead where possible).
  private:
@@ -819,7 +820,6 @@ class MacroAssembler: public Assembler {
   void compare_klass_ptr(Register Rop1, int64_t disp, Register Rbase, bool maybenull);
 
   // Access heap oop, handle encoding and GC barriers.
- private:
   void access_store_at(BasicType type, DecoratorSet decorators,
                        const Address& addr, Register val,
                        Register tmp1, Register tmp2, Register tmp3);


### PR DESCRIPTION
This PR provides "resolve_global_jobject" method implementation for s390x-port. 

Testing:
* Tier1 test with Fastdebug; 
* Added these changes on top of https://github.com/openjdk/jdk/pull/20479 and modified the call in the stubGenerator_s390.cpp file; 
*  1. Ran tier1 test with a call to  "resolve_jobect"
*  2. Ran tier1 test with a call to  "resolve_global_jobject" 

I didn't see any new failure appearing there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339416](https://bugs.openjdk.org/browse/JDK-8339416): [s390x] Provide implementation for resolve_global_jobject (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20986/head:pull/20986` \
`$ git checkout pull/20986`

Update a local copy of the PR: \
`$ git checkout pull/20986` \
`$ git pull https://git.openjdk.org/jdk.git pull/20986/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20986`

View PR using the GUI difftool: \
`$ git pr show -t 20986`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20986.diff">https://git.openjdk.org/jdk/pull/20986.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20986#issuecomment-2348257657)