### PR TITLE
8340363: Tag-specific default decorators for UnifiedLogging

### DIFF
--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -476,6 +476,11 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
   return success;
 }
 
+LogDecorators LogConfiguration::get_default_decorators(LogSelectionList selection_list) {
+  uint mask = 0;
+  return selection_list.triggers_default(&mask) ? LogDecorators(mask) : LogDecorators();
+}
+
 bool LogConfiguration::parse_log_arguments(const char* outputstr,
                                            const char* selectionstr,
                                            const char* decoratorstr,
@@ -491,7 +496,7 @@ bool LogConfiguration::parse_log_arguments(const char* outputstr,
     return false;
   }
 
-  LogDecorators decorators;
+  LogDecorators decorators = get_default_decorators(selections);
   if (!decorators.parse(decoratorstr, errstream)) {
     return false;
   }

--- a/src/hotspot/share/logging/logConfiguration.cpp
+++ b/src/hotspot/share/logging/logConfiguration.cpp
@@ -477,8 +477,7 @@ bool LogConfiguration::parse_command_line_arguments(const char* opts) {
 }
 
 LogDecorators LogConfiguration::get_default_decorators(LogSelectionList selection_list) {
-  uint mask = 0;
-  return selection_list.triggers_default(&mask) ? LogDecorators(mask) : LogDecorators();
+  return LogDecorators(selection_list.get_defaults_mask());
 }
 
 bool LogConfiguration::parse_log_arguments(const char* outputstr,

--- a/src/hotspot/share/logging/logConfiguration.hpp
+++ b/src/hotspot/share/logging/logConfiguration.hpp
@@ -90,6 +90,7 @@ class LogConfiguration : public AllStatic {
   static void describe_available(outputStream* out);
   static void describe_current_configuration(outputStream* out);
 
+  static LogDecorators get_default_decorators(LogSelectionList selection_list);
 
  public:
   // Initialization and finalization of log configuration, to be run at vm startup and shutdown respectively.

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -26,6 +26,10 @@
 #include "runtime/os.hpp"
 #include "logDecorators.hpp"
 
+#define DEFAULT_DECORATORS \
+  DEFAULT_VALUE((1 << pid_decorator) | (1 << tags_decorator), NotMentioned, LOG_TAGS(ref, gc, jit, jni, jfr)) \
+  DEFAULT_VALUE(0, Trace, LOG_TAGS(jit))
+
 template <LogDecorators::Decorator d>
 struct AllBitmask {
   // Use recursive template deduction to calculate the bitmask of all decorations.

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -27,8 +27,8 @@
 #include "logDecorators.hpp"
 
 #define DEFAULT_DECORATORS \
-  DEFAULT_VALUE((1 << pid_decorator) | (1 << tags_decorator), NotMentioned, LOG_TAGS(ref, gc, jit, jni, jfr)) \
-  DEFAULT_VALUE(0, Trace, LOG_TAGS(jit))
+  DEFAULT_VALUE(mask_from_decorators(pid_decorator, time_decorator), NotMentioned, LOG_TAGS(ref, gc, jit, jni, jfr)) \
+  DEFAULT_VALUE(mask_from_decorators(NoDecorators), Trace, LOG_TAGS(jit))
 
 template <LogDecorators::Decorator d>
 struct AllBitmask {

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -106,9 +106,9 @@ bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
   return result;
 }
 
-bool LogDecorators::has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults) {
+bool LogDecorators::has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults, size_t defaults_cnt) {
   size_t max_specificity = 0;
-  for (size_t i = 0; i < number_of_default_decorators; ++i) {
+  for (size_t i = 0; i < defaults_cnt; ++i) {
     auto current_default = defaults[i];
     const bool ignore_level = current_default.selection().level() == AnyLevel;
     const bool level_matches = ignore_level || selection.level() == current_default.selection().level();

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -67,7 +67,7 @@ LogDecorators::Decorator LogDecorators::from_string(const char* str) {
 
 bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
   if (decorator_args == nullptr || strlen(decorator_args) == 0) {
-    // Decorators have already been set
+    //No decorators supplied, keep default decorators
     return true;
   }
 

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -28,7 +28,7 @@
 
 const LogLevelType AnyLevel = LogLevelType::NotMentioned;
 #define DEFAULT_DECORATORS \
-  DEFAULT_VALUE(mask_from_decorators(NoDecorators), AnyLevel, LOG_TAGS(jit, inlining)) 
+  DEFAULT_VALUE(mask_from_decorators(NoDecorators), AnyLevel, LOG_TAGS(jit, inlining))
 
 template <LogDecorators::Decorator d>
 struct AllBitmask {

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -106,9 +106,9 @@ bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
   return result;
 }
 
-bool LogDecorators::has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults, size_t defaults_cnt) {
+bool LogDecorators::has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults, size_t defaults_count) {
   size_t max_specificity = 0;
-  for (size_t i = 0; i < defaults_cnt; ++i) {
+  for (size_t i = 0; i < defaults_count; ++i) {
     auto current_default = defaults[i];
     const bool ignore_level = current_default.selection().level() == AnyLevel;
     const bool level_matches = ignore_level || selection.level() == current_default.selection().level();

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -24,6 +24,7 @@
 #include "precompiled.hpp"
 #include "logging/logDecorators.hpp"
 #include "runtime/os.hpp"
+#include "logDecorators.hpp"
 
 template <LogDecorators::Decorator d>
 struct AllBitmask {
@@ -45,6 +46,15 @@ const char* LogDecorators::_name[][2] = {
 #undef DECORATOR
 };
 
+const LogDecorators::DefaultDecorator LogDecorators::DefaultDecorator::Invalid;
+
+LogDecorators::DefaultDecorator LogDecorators::DefaultDecorators[] = {
+#define DEFAULT_VALUE(mask, level, ...) LogDecorators::DefaultDecorator(LogLevel::level, mask, __VA_ARGS__),
+  DEFAULT_DECORATORS
+#undef DEFAULT_VALUE
+  LogDecorators::DefaultDecorator::Invalid
+};
+
 LogDecorators::Decorator LogDecorators::from_string(const char* str) {
   for (size_t i = 0; i < Count; i++) {
     Decorator d = static_cast<Decorator>(i);
@@ -57,7 +67,7 @@ LogDecorators::Decorator LogDecorators::from_string(const char* str) {
 
 bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
   if (decorator_args == nullptr || strlen(decorator_args) == 0) {
-    _decorators = DefaultDecoratorsMask;
+    // Decorators have already been set
     return true;
   }
 
@@ -92,4 +102,13 @@ bool LogDecorators::parse(const char* decorator_args, outputStream* errstream) {
     _decorators = tmp_decorators;
   }
   return result;
+}
+
+
+bool LogDecorators::DefaultDecorator::operator==(const DefaultDecorator &ref) const {
+  return this->_selection == ref._selection && this->_mask == ref._mask;
+}
+
+bool LogDecorators::DefaultDecorator::operator!=(const DefaultDecorator &ref) const {
+  return !operator==(ref);
 }

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -30,7 +30,6 @@ const LogLevelType AnyLevel = LogLevelType::NotMentioned;
 #define DEFAULT_DECORATORS \
   DEFAULT_VALUE(mask_from_decorators(NoDecorators), AnyLevel, LOG_TAGS(jit, inlining)) 
 
-
 template <LogDecorators::Decorator d>
 struct AllBitmask {
   // Use recursive template deduction to calculate the bitmask of all decorations.

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -126,14 +126,3 @@ bool LogDecorators::has_default_decorator(const LogSelection& selection, uint* m
   }
   return max_specificity > 0;
 }
-
-template<typename... Decorators>
-uint LogDecorators::mask_from_decorators(LogDecorators::Decorator first, Decorators... rest) {
-  uint bitmask = 0;
-  LogDecorators::Decorator decorators[1 + sizeof...(rest)] = { first, rest... };
-  for (const LogDecorators::Decorator decorator : decorators) {
-    if (decorator == NoDecorators) return 0;
-    bitmask |= mask(decorator);
-  }
-  return bitmask;
-}

--- a/src/hotspot/share/logging/logDecorators.cpp
+++ b/src/hotspot/share/logging/logDecorators.cpp
@@ -28,7 +28,8 @@
 
 const LogLevelType AnyLevel = LogLevelType::NotMentioned;
 #define DEFAULT_DECORATORS \
-  DEFAULT_VALUE(mask_from_decorators(NoDecorators), Trace, LOG_TAGS(jit))
+  DEFAULT_VALUE(mask_from_decorators(NoDecorators), AnyLevel, LOG_TAGS(jit, inlining)) 
+
 
 template <LogDecorators::Decorator d>
 struct AllBitmask {
@@ -51,7 +52,7 @@ const char* LogDecorators::_name[][2] = {
 };
 
 const LogDecorators::DefaultDecorator LogDecorators::default_decorators[] = {
-#define DEFAULT_VALUE(mask, level, ...) LogDecorators::DefaultDecorator(LogLevel::level, mask, __VA_ARGS__),
+#define DEFAULT_VALUE(mask, level, ...) LogDecorators::DefaultDecorator(level, mask, __VA_ARGS__),
   DEFAULT_DECORATORS
 #undef DEFAULT_VALUE
 };

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -86,8 +86,10 @@ class LogDecorators {
 
       LogTagType tag_arr[LogTag::MaxTags + 1] = { first, rest... };
 
-      assert(tag_arr[sizeof...(rest)] == LogTag::__NO_TAG,
-             "Too many tags specified! Can only have up to " SIZE_FORMAT " tags in a tag set.", LogTag::MaxTags);
+      if (sizeof...(rest) == LogTag::MaxTags) {
+        assert(tag_arr[sizeof...(rest)] == LogTag::__NO_TAG,
+               "Too many tags specified! Can only have up to " SIZE_FORMAT " tags in a tag set.", LogTag::MaxTags);
+      }
 
       _selection = LogSelection(tag_arr, false, level);
     }

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -93,7 +93,7 @@ class LogDecorators {
     }
 
     const LogSelection& selection() const { return _selection; }
-    uint mask()              const { return _mask; }
+    uint mask()                     const { return _mask; }
 
     bool operator==(const DefaultDecorator& ref) const;
     bool operator!=(const DefaultDecorator& ref) const;
@@ -114,11 +114,9 @@ class LogDecorators {
   static const LogDecorators None;
   static const LogDecorators All;
 
-  constexpr LogDecorators(uint mask) : _decorators(mask) {
-  }
+  constexpr LogDecorators(uint mask) : _decorators(mask) {}
 
-  LogDecorators() : _decorators(DefaultDecoratorsMask) {
-  }
+  LogDecorators() : _decorators(DefaultDecoratorsMask) {}
 
   void clear() {
     _decorators = 0;

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -133,6 +133,7 @@ class LogDecorators {
 
   template<typename... Decorators>
   static uint mask_from_decorators(LogDecorators::Decorator first, Decorators... rest) {
+    uint bitmask = 0;
     LogDecorators::Decorator decorators[1 + sizeof...(rest)] = { first, rest... };
     for (const auto decorator : decorators) {
       if (decorator == NoDecorators) return 0;

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -143,7 +143,7 @@ class LogDecorators {
 
   // Check if we have some default decorators for a given LogSelection. If that is the case,
   // the output parameter mask will contain the defaults-specified decorators mask
-  static bool has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = default_decorators, size_t defaults_cnt = number_of_default_decorators);
+  static bool has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = default_decorators, size_t defaults_count = number_of_default_decorators);
 
   static LogDecorators::Decorator from_string(const char* str);
 

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -115,7 +115,7 @@ class LogDecorators {
 
   constexpr LogDecorators(uint mask) : _decorators(mask) {}
 
-  LogDecorators() {}
+  LogDecorators() : _decorators(0) {}
 
   void clear() {
     _decorators = 0;

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -145,7 +145,7 @@ class LogDecorators {
   // Check if we have some default decorators for a given LogSelection. If that is the case,
   // the output parameter mask will contain the defaults-specified decorators mask
   static bool has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = DefaultDecorators) {
-    int max_specificity = 0;
+    size_t max_specificity = 0;
     for (size_t i = 0; DefaultDecorators[i] != DefaultDecorator::Invalid; ++i) {
       const bool ignore_level = DefaultDecorators[i].selection().level() == LogLevelType::NotMentioned;
       const bool level_matches = ignore_level || selection.level() == DefaultDecorators[i].selection().level();
@@ -153,7 +153,7 @@ class LogDecorators {
       if (!selection.superset_of(DefaultDecorators[i].selection())) {
         continue;
       }
-      int specificity = DefaultDecorators[i].selection().ntags();
+      size_t specificity = DefaultDecorators[i].selection().ntags();
       if (specificity > max_specificity) {
         *mask = DefaultDecorators[i].mask();
         max_specificity = specificity;

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -133,8 +133,8 @@ class LogDecorators {
 
   template<typename... Decorators>
   static uint mask_from_decorators(LogDecorators::Decorator first, Decorators... rest) {
-    uint bitmask = 0;
-    for (const LogDecorators::Decorator& decorator : (LogDecorators::Decorator[]){first, rest...}) {
+    LogDecorators::Decorator decorators[1 + sizeof...(rest)] = { first, rest... };
+    for (const auto decorator : decorators) {
       if (decorator == NoDecorators) return 0;
       bitmask |= mask(decorator);
     }

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -136,13 +136,15 @@ class LogDecorators {
   }
 
   static bool has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = DefaultDecorators) {
-    int specificity, max_specificity = 0;
+    int max_specificity = 0;
     for (size_t i = 0; DefaultDecorators[i] != DefaultDecorator::Invalid; ++i) {
       const bool ignore_level = DefaultDecorators[i].selection().level() == LogLevelType::NotMentioned;
       const bool level_matches = ignore_level || selection.level() == DefaultDecorators[i].selection().level();
       if (!level_matches) continue;
-      specificity = selection.contains(DefaultDecorators[i].selection()) ? DefaultDecorators[i].selection().ntags() : 0;
-      if (specificity == 0) continue;
+      if (!selection.contains(DefaultDecorators[i].selection())) {
+        continue;
+      }
+      int specificity = DefaultDecorators[i].selection().ntags();
       if (specificity > max_specificity) {
         *mask = DefaultDecorators[i].mask();
         max_specificity = specificity;

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -74,15 +74,16 @@ class LogDecorators {
   };
 
   class DefaultDecorator {
-    LogSelection _selection = LogSelection::Invalid;
+    LogSelection _selection;
     uint         _mask;
   
+    DefaultDecorator() : _selection(LogSelection::Invalid), _mask(0) {}
+
   public:
-    DefaultDecorator() {}
     static const DefaultDecorator Invalid;
 
     template<typename... Tags>
-    DefaultDecorator(LogLevelType level, uint mask, LogTagType first, Tags... rest) : _mask(mask) {
+    DefaultDecorator(LogLevelType level, uint mask, LogTagType first, Tags... rest) : _selection(LogSelection::Invalid), _mask(mask) {
       static_assert(sizeof...(rest) <= LogTag::MaxTags,
                     "Too many tags specified! Can only have up to tags in a tag set.");
 
@@ -134,7 +135,7 @@ class LogDecorators {
     return _name[decorator][1];
   }
 
-  static bool has_default_decorator(LogSelection selection, uint* mask) {
+  static bool has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = DefaultDecorators) {
     bool match_level;
     int specificity, max_specificity = 0;
     for (size_t i = 0; DefaultDecorators[i] != DefaultDecorator::Invalid; ++i) {

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -67,7 +67,8 @@ class LogDecorators {
     DECORATOR_LIST
 #undef DECORATOR
     Count,
-    Invalid
+    Invalid,
+    NoDecorators
   };
 
   class DefaultDecorator {
@@ -130,6 +131,18 @@ class LogDecorators {
     return _name[decorator][1];
   }
 
+  template<typename... Decorators>
+  static uint mask_from_decorators(LogDecorators::Decorator first, Decorators... rest) {
+    uint bitmask = 0;
+    for (const LogDecorators::Decorator& decorator : (LogDecorators::Decorator[]){first, rest...}) {
+      if (decorator == NoDecorators) return 0;
+      bitmask |= mask(decorator);
+    }
+    return bitmask;
+  }
+
+  // Check if we have some default decorators for a given LogSelection. If that is the case,
+  // the output parameter mask will contain the defaults-specified decorators mask
   static bool has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = DefaultDecorators) {
     int max_specificity = 0;
     for (size_t i = 0; DefaultDecorators[i] != DefaultDecorator::Invalid; ++i) {

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -101,7 +101,6 @@ class LogDecorators {
  private:
   uint _decorators;
   static const char* _name[][2];
-  static const uint defaultsMask = (1 << uptime_decorator) | (1 << level_decorator) | (1 << tags_decorator);
   static const LogDecorators::DefaultDecorator default_decorators[];
   static const size_t number_of_default_decorators;
 
@@ -116,7 +115,7 @@ class LogDecorators {
 
   constexpr LogDecorators(uint mask) : _decorators(mask) {}
 
-  LogDecorators() : _decorators(defaultsMask) {}
+  LogDecorators() {}
 
   void clear() {
     _decorators = 0;
@@ -143,7 +142,7 @@ class LogDecorators {
 
   // Check if we have some default decorators for a given LogSelection. If that is the case,
   // the output parameter mask will contain the defaults-specified decorators mask
-  static bool has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = default_decorators, size_t defaults_count = number_of_default_decorators);
+  static void get_default_decorators(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = default_decorators, size_t defaults_count = number_of_default_decorators);
 
   static LogDecorators::Decorator from_string(const char* str);
 

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -60,6 +60,7 @@ class outputStream;
 // declared above. For example, logging with 'uptime, level, tags' decorators results in:
 // [0,943s][info   ][logging] message.
 class LogDecorators {
+  friend class TestLogDecorators;
  public:
   enum Decorator {
 #define DECORATOR(name, abbr) name##_decorator,
@@ -71,9 +72,10 @@ class LogDecorators {
   };
 
   class DefaultDecorator {
+    friend class TestLogDecorators;
     LogSelection _selection;
     uint         _mask;
-  
+
     DefaultDecorator() : _selection(LogSelection::Invalid), _mask(0) {}
 
   public:

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -129,7 +129,15 @@ class LogDecorators {
   }
 
   template<typename... Decorators>
-  static uint mask_from_decorators(LogDecorators::Decorator first, Decorators... rest);
+  static uint mask_from_decorators(LogDecorators::Decorator first, Decorators... rest) {
+    uint bitmask = 0;
+    LogDecorators::Decorator decorators[1 + sizeof...(rest)] = { first, rest... };
+    for (const LogDecorators::Decorator decorator : decorators) {
+      if (decorator == NoDecorators) return 0;
+      bitmask |= mask(decorator);
+    }
+    return bitmask;
+  }
 
   // Check if we have some default decorators for a given LogSelection. If that is the case,
   // the output parameter mask will contain the defaults-specified decorators mask

--- a/src/hotspot/share/logging/logDecorators.hpp
+++ b/src/hotspot/share/logging/logDecorators.hpp
@@ -143,7 +143,7 @@ class LogDecorators {
 
   // Check if we have some default decorators for a given LogSelection. If that is the case,
   // the output parameter mask will contain the defaults-specified decorators mask
-  static bool has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = default_decorators);
+  static bool has_default_decorator(const LogSelection& selection, uint* mask, const DefaultDecorator* defaults = default_decorators, size_t defaults_cnt = number_of_default_decorators);
 
   static LogDecorators::Decorator from_string(const char* str);
 

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -69,7 +69,7 @@ bool LogSelection::operator!=(const LogSelection& ref) const {
   return !operator==(ref);
 }
 
-bool LogSelection::contains(const LogSelection &other) const {
+bool LogSelection::superset_of(const LogSelection& other) const {
   bool match;
   for (size_t i = 0; i < other.ntags(); ++i) {
     match = false;
@@ -199,7 +199,7 @@ static bool contains(LogTagType tag, const LogTagType tags[LogTag::MaxTags], siz
 bool LogSelection::consists_of(const LogTagType tags[LogTag::MaxTags]) const {
   size_t i;
   for (i = 0; tags[i] != LogTag::__NO_TAG; i++) {
-    if (!::contains(tags[i], _tags, _ntags)) {
+    if (!contains(tags[i], _tags, _ntags)) {
       return false;
     }
   }

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -69,13 +69,12 @@ bool LogSelection::operator!=(const LogSelection& ref) const {
   return !operator==(ref);
 }
 
-bool LogSelection::contains(const LogSelection &ref, bool match_level) const {
-  if (match_level && ref.level() != _level) return false;
+bool LogSelection::contains(const LogSelection &other) const {
   bool match;
-  for (size_t i = 0; i < ref.ntags(); ++i) {
+  for (size_t i = 0; i < other.ntags(); ++i) {
     match = false;
     for (size_t j = 0; j < _ntags; ++j) {
-      if (ref._tags[i] == _tags[j]) {
+      if (other._tags[i] == _tags[j]) {
         match = true;
         break;
       }

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -69,6 +69,24 @@ bool LogSelection::operator!=(const LogSelection& ref) const {
   return !operator==(ref);
 }
 
+bool LogSelection::contains(const LogSelection &ref, bool match_level) const {
+  if (match_level && ref.level() != _level) return false;
+  bool match;
+  for (size_t i = 0; i < ref.ntags(); ++i) {
+    match = false;
+    for (size_t j = 0; j < _ntags; ++j) {
+      if (ref._tags[i] == _tags[j]) {
+        match = true;
+        break;
+      }
+    }
+
+    if (!match) return false;
+  }
+
+  return true;
+}
+
 static LogSelection parse_internal(char *str, outputStream* errstream) {
   // Parse the level, if specified
   LogLevelType level = LogLevel::Unspecified;
@@ -182,7 +200,7 @@ static bool contains(LogTagType tag, const LogTagType tags[LogTag::MaxTags], siz
 bool LogSelection::consists_of(const LogTagType tags[LogTag::MaxTags]) const {
   size_t i;
   for (i = 0; tags[i] != LogTag::__NO_TAG; i++) {
-    if (!contains(tags[i], _tags, _ntags)) {
+    if (!::contains(tags[i], _tags, _ntags)) {
       return false;
     }
   }

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -70,6 +70,9 @@ bool LogSelection::operator!=(const LogSelection& ref) const {
 }
 
 bool LogSelection::superset_of(const LogSelection& other) const {
+  // Every set contains the empty set, so if other is empty we return true
+  if (other._tags[0] == LogTag::__NO_TAG) return true;
+  
   bool match;
   for (size_t i = 0; i < other.ntags(); ++i) {
     match = false;

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -72,7 +72,7 @@ bool LogSelection::operator!=(const LogSelection& ref) const {
 bool LogSelection::superset_of(const LogSelection& other) const {
   // Every set contains the empty set, so if other is empty we return true
   if (other._tags[0] == LogTag::__NO_TAG) return true;
-  
+
   bool match;
   for (size_t i = 0; i < other.ntags(); ++i) {
     match = false;

--- a/src/hotspot/share/logging/logSelection.hpp
+++ b/src/hotspot/share/logging/logSelection.hpp
@@ -54,6 +54,8 @@ class LogSelection : public StackObj {
   bool operator==(const LogSelection& ref) const;
   bool operator!=(const LogSelection& ref) const;
 
+  bool contains(const LogSelection& ref, bool match_level) const;
+
   size_t ntags() const;
   LogLevelType level() const;
   size_t tag_sets_selected() const;

--- a/src/hotspot/share/logging/logSelection.hpp
+++ b/src/hotspot/share/logging/logSelection.hpp
@@ -54,7 +54,7 @@ class LogSelection : public StackObj {
   bool operator==(const LogSelection& ref) const;
   bool operator!=(const LogSelection& ref) const;
 
-  bool contains(const LogSelection& ref) const;
+  bool superset_of(const LogSelection& ref) const;
 
   size_t ntags() const;
   LogLevelType level() const;

--- a/src/hotspot/share/logging/logSelection.hpp
+++ b/src/hotspot/share/logging/logSelection.hpp
@@ -54,7 +54,7 @@ class LogSelection : public StackObj {
   bool operator==(const LogSelection& ref) const;
   bool operator!=(const LogSelection& ref) const;
 
-  bool contains(const LogSelection& ref, bool match_level) const;
+  bool contains(const LogSelection& ref) const;
 
   size_t ntags() const;
   LogLevelType level() const;

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -57,7 +57,10 @@ bool LogSelectionList::triggers_default(uint* mask) const {
   bool match = false;
   for (size_t i = 0; i < _nselections; ++i) {
     if (LogDecorators::has_default_decorator(_selections[i], mask)) {
-      if (match) return false;  // None to be applied if several selections have conflicting defaults
+      if (match) {
+        // None to be applied if several selections have conflicting defaults
+        return false;
+      }
       match = true;
     }
   }

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -53,7 +53,7 @@ bool LogSelectionList::verify_selections(outputStream* out) const {
   return valid;
 }
 
-bool LogSelectionList::triggers_default(uint *mask) const {
+bool LogSelectionList::triggers_default(uint* mask) const {
   bool match = false;
   for (size_t i = 0; i < _nselections; ++i) {
     if (LogDecorators::has_default_decorator(_selections[i], mask)) {

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -26,6 +26,7 @@
 #include "logging/logSelectionList.hpp"
 #include "logging/logTagSet.hpp"
 #include "runtime/os.hpp"
+#include "logSelectionList.hpp"
 
 static const char* DefaultExpressionString = "all";
 
@@ -53,6 +54,15 @@ bool LogSelectionList::verify_selections(outputStream* out) const {
   return valid;
 }
 
+bool LogSelectionList::triggers_default(uint *mask) const {
+  bool match = false;
+  for (size_t i = 0; i < _nselections; ++i) {
+    if (LogDecorators::has_default_decorator(_selections[i], mask)) {
+      match = true;
+    }
+  }
+  return match;
+}
 
 bool LogSelectionList::parse(const char* str, outputStream* errstream) {
   bool success = true;
@@ -91,7 +101,7 @@ bool LogSelectionList::parse(const char* str, outputStream* errstream) {
 LogLevelType LogSelectionList::level_for(const LogTagSet& ts) const {
   // Return NotMentioned if the given tagset isn't covered by this expression.
   LogLevelType level = LogLevel::NotMentioned;
-  for (size_t i= 0; i < _nselections; i++) {
+  for (size_t i = 0; i < _nselections; i++) {
     if (_selections[i].selects(ts)) {
       level = _selections[i].level();
     }

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -53,18 +53,12 @@ bool LogSelectionList::verify_selections(outputStream* out) const {
   return valid;
 }
 
-bool LogSelectionList::triggers_default(uint* mask) const {
-  bool match = false;
+uint LogSelectionList::get_defaults_mask() const {
+  uint mask = 0;
   for (size_t i = 0; i < _nselections; ++i) {
-    if (LogDecorators::has_default_decorator(_selections[i], mask)) {
-      if (match) {
-        // None to be applied if several selections have conflicting defaults
-        return false;
-      }
-      match = true;
-    }
+    LogDecorators::get_default_decorators(_selections[i], &mask);
   }
-  return match;
+  return mask;
 }
 
 bool LogSelectionList::parse(const char* str, outputStream* errstream) {

--- a/src/hotspot/share/logging/logSelectionList.cpp
+++ b/src/hotspot/share/logging/logSelectionList.cpp
@@ -26,7 +26,6 @@
 #include "logging/logSelectionList.hpp"
 #include "logging/logTagSet.hpp"
 #include "runtime/os.hpp"
-#include "logSelectionList.hpp"
 
 static const char* DefaultExpressionString = "all";
 
@@ -58,6 +57,7 @@ bool LogSelectionList::triggers_default(uint *mask) const {
   bool match = false;
   for (size_t i = 0; i < _nselections; ++i) {
     if (LogDecorators::has_default_decorator(_selections[i], mask)) {
+      if (match) return false;  // None to be applied if several selections have conflicting defaults
       match = true;
     }
   }

--- a/src/hotspot/share/logging/logSelectionList.hpp
+++ b/src/hotspot/share/logging/logSelectionList.hpp
@@ -60,6 +60,8 @@ class LogSelectionList : public StackObj {
   // Returns false if some invalid selection was found. If given an outputstream,
   // this function will list all the invalid selections on the stream.
   bool verify_selections(outputStream* out = nullptr) const;
+
+  bool triggers_default(uint* mask) const;
 };
 
 #endif // SHARE_LOGGING_LOGSELECTIONLIST_HPP

--- a/src/hotspot/share/logging/logSelectionList.hpp
+++ b/src/hotspot/share/logging/logSelectionList.hpp
@@ -61,7 +61,7 @@ class LogSelectionList : public StackObj {
   // this function will list all the invalid selections on the stream.
   bool verify_selections(outputStream* out = nullptr) const;
 
-  bool triggers_default(uint* mask) const;
+  uint get_defaults_mask() const;
 };
 
 #endif // SHARE_LOGGING_LOGSELECTIONLIST_HPP

--- a/test/hotspot/gtest/logging/test_logDefaultDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDefaultDecorators.cpp
@@ -45,53 +45,53 @@ class TestLogDecorators : public testing::Test {
 public:
   void test_default_decorators() {
     LogTagType tags[LogTag::MaxTags] = { LogTag::__NO_TAG, LogTag::__NO_TAG, LogTag::__NO_TAG, LogTag::__NO_TAG, LogTag::__NO_TAG };
-    uint out_mask;
+    uint out_mask = 0;
 
 
     // Log selection with matching tag exactly should find default
     tags[0] = LogTagType::_jit;
-    bool result = LD::has_default_decorator(LogSelection(tags, false, LogLevelType::Trace), &out_mask, defaults, defaults_cnt);
-    EXPECT_TRUE(result);
+    LD::get_default_decorators(LogSelection(tags, false, LogLevelType::Trace), &out_mask, defaults, defaults_cnt);
     EXPECT_EQ(LD::mask_from_decorators(LD::NoDecorators), out_mask);
 
 
     // Wildcards are ignored
-    tags[0] = LogTag::__NO_TAG;
-    result = LD::has_default_decorator(LogSelection(tags, true, LogLevelType::Trace), &out_mask, defaults, defaults_cnt);
-    EXPECT_FALSE(result);
+    tags[0] = LogTag::_compilation;
+    out_mask = 0;
+    LD::get_default_decorators(LogSelection(tags, true, LogLevelType::Debug), &out_mask, defaults, defaults_cnt);
+    EXPECT_EQ(LD::mask_from_decorators(LD::pid_decorator), out_mask);
 
 
     // If several defaults match with the same specificity, all defaults are applied
     tags[0] = LogTagType::_gc;
-    result = LD::has_default_decorator(LogSelection(tags, false, LogLevelType::Trace), &out_mask, defaults, defaults_cnt);
-    EXPECT_TRUE(result);
+    out_mask = 0;
+    LD::get_default_decorators(LogSelection(tags, false, LogLevelType::Trace), &out_mask, defaults, defaults_cnt);
     EXPECT_EQ(LD::mask_from_decorators(LD::pid_decorator, LD::time_decorator), out_mask);
 
 
     // If several defaults match but one has higher specificity, only its defaults are applied
     tags[0] = LogTagType::_compilation;
     tags[1] = LogTagType::_codecache;
-    result = LD::has_default_decorator(LogSelection(tags, false, LogLevelType::Debug), &out_mask, defaults, defaults_cnt);
-    EXPECT_TRUE(result);
+    out_mask = 0;
+    LD::get_default_decorators(LogSelection(tags, false, LogLevelType::Debug), &out_mask, defaults, defaults_cnt);
     EXPECT_EQ(LD::mask_from_decorators(LD::uptimemillis_decorator), out_mask);
 
 
     // If a level is not specified to match (via AnyTag or NotMentioned), it should not be taken into account
     tags[0] = LogTagType::_ref;
     tags[1] = LogTagType::__NO_TAG;
-    result = LD::has_default_decorator(LogSelection(tags, false, LogLevelType::Info), &out_mask, defaults, defaults_cnt);
-    EXPECT_TRUE(result);
+    out_mask = 0;
+    LD::get_default_decorators(LogSelection(tags, false, LogLevelType::Info), &out_mask, defaults, defaults_cnt);
     EXPECT_EQ(LD::mask_from_decorators(LD::pid_decorator, LD::tid_decorator), out_mask);
-    result = LD::has_default_decorator(LogSelection(tags, false, LogLevelType::Trace), &out_mask, defaults, defaults_cnt);
-    EXPECT_TRUE(result);
+    out_mask = 0;
+    LD::get_default_decorators(LogSelection(tags, false, LogLevelType::Trace), &out_mask, defaults, defaults_cnt);
     EXPECT_EQ(LD::mask_from_decorators(LD::pid_decorator, LD::tid_decorator), out_mask);
 
 
     // In spite of the previous, higher specificities should still prevail
     defaults[5] = { LogLevelType::Debug, LD::mask_from_decorators(LD::uptimemillis_decorator), LogTagType::_ref, LogTagType::_codecache };
     tags[1] = LogTagType::_codecache;
-    result = LD::has_default_decorator(LogSelection(tags, false, LogLevelType::Debug), &out_mask, defaults, defaults_cnt);
-    EXPECT_TRUE(result);
+    out_mask = 0;
+    LD::get_default_decorators(LogSelection(tags, false, LogLevelType::Debug), &out_mask, defaults, defaults_cnt);
     EXPECT_EQ(LD::mask_from_decorators(LD::uptimemillis_decorator), out_mask);
   }
 

--- a/test/hotspot/gtest/logging/test_logDefaultDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDefaultDecorators.cpp
@@ -75,6 +75,7 @@ public:
     EXPECT_TRUE(result);
     EXPECT_EQ(LD::mask_from_decorators(LD::uptimemillis_decorator), out_mask);
 
+
     // If a level is not specified to match (via AnyTag or NotMentioned), it should not be taken into account
     tags[0] = LogTagType::_ref;
     tags[1] = LogTagType::__NO_TAG;
@@ -101,12 +102,15 @@ public:
     EXPECT_EQ(LD::mask_from_decorators(LD::tid_decorator),  (uint)(1 << LD::tid_decorator));
     EXPECT_EQ(LD::mask_from_decorators(LD::tags_decorator), (uint)(1 << LD::tags_decorator));
 
+
     // NoDecorators should yield an empty mask
     EXPECT_EQ(LD::mask_from_decorators(LD::NoDecorators), 0U);
+
 
     // Combinations of decorators should fill the mask accordingly to their bitmask positions
     uint mask = (1 << LD::time_decorator) | (1 << LD::uptimemillis_decorator) | (1 << LD::tid_decorator);
     EXPECT_EQ(LD::mask_from_decorators(LD::time_decorator, LD::uptimemillis_decorator, LD::tid_decorator), mask);
+
 
     // If a combination has NoDecorators in it, it takes precedence and the mask is zero
     EXPECT_EQ(LD::mask_from_decorators(LD::time_decorator, LD::NoDecorators, LD::tid_decorator), 0U);

--- a/test/hotspot/gtest/logging/test_logDefaultDecorators.cpp
+++ b/test/hotspot/gtest/logging/test_logDefaultDecorators.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+#include "precompiled.hpp"
+#include "jvm.h"
+#include "logging/logDecorators.hpp"
+#include "runtime/os.hpp"
+#include "unittest.hpp"
+
+
+class TestLogDecorators : public testing::Test {
+  using DefaultDecorator = LogDecorators::DefaultDecorator;
+  using LD = LogDecorators;
+
+public:
+  void test_default_decorators() {
+    DefaultDecorator decs[1] = { { LogLevelType::Trace, LD::mask_from_decorators(LD::pid_decorator), LogTagType::_gc } };
+    LogTagType tags[LogTag::MaxTags] = { LogTag::__NO_TAG, LogTag::__NO_TAG, LogTag::__NO_TAG, LogTag::__NO_TAG, LogTag::__NO_TAG };
+    uint out_mask;
+
+
+    // Log selection with matching tag exactly should find default
+    tags[0] = LogTagType::_gc;
+    bool result = LD::has_default_decorator(LogSelection(tags, false, LogLevelType::Trace), &out_mask, decs);
+    EXPECT_TRUE(result);
+    EXPECT_EQ(LD::mask_from_decorators(LD::pid_decorator), out_mask);
+
+
+    // Wildcards are ignored
+    tags[0] = LogTag::__NO_TAG;
+    result = LD::has_default_decorator(LogSelection(tags, true, LogLevelType::Trace), &out_mask, decs);
+    EXPECT_FALSE(result);
+  }
+};
+
+TEST_VM_F(TestLogDecorators, MaskFromDecorators) {
+}
+
+TEST_VM_F(TestLogDecorators, HasDefaultDecorators) {
+  test_default_decorators();
+}

--- a/test/hotspot/jtreg/runtime/logging/DefaultLogDecoratorsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/DefaultLogDecoratorsTest.java
@@ -57,7 +57,7 @@ public class DefaultLogDecoratorsTest {
         List<String> allLines = Files.readAllLines(Path.of("decorators.log"));
         for (String line : allLines) {
             if (DECORATED_LINE.matcher(line).find() == !shouldHave) {
-                throw new RuntimeException("Logging should " + (shouldHave ? "not " : "") + "contain decorators!");
+                throw new RuntimeException("Logging should " + (shouldHave ? "" : "not ") + "contain decorators!");
             }
         }
     }
@@ -72,11 +72,11 @@ public class DefaultLogDecoratorsTest {
 
 
         // Even if decorators are only supplied for another tag(s), the defaults are not taken into account
-        doTest(true, "-Xlog:jit*=trace:decorators.log", "-Xlog:os*=info:decorators.log:time");
+        doTest(true, "-Xlog:jit*=trace:decorators.log", "-Xlog:gc*=info:decorators.log:time");
 
 
         // Defaults are not taken into account also when another tag implicitly imposes the "standard" defaults
-        doTest(true, "-Xlog:jit*=trace:decorators.log", "-Xlog:os*=info:decorators.log");
+        doTest(true, "-Xlog:jit*=trace:decorators.log", "-Xlog:gc*=info:decorators.log");
 
 
         // Other logging shall not be affected by a tag with defaults

--- a/test/hotspot/jtreg/runtime/logging/DefaultLogDecoratorsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/DefaultLogDecoratorsTest.java
@@ -68,15 +68,15 @@ public class DefaultLogDecoratorsTest {
 
 
         // If decorators are specified, the defaults are not taken into account
-        doTest(true, "-Xlog:jit*=trace:decorators.log:time");
+        doTest(true, "-Xlog:jit+inlining*=trace:decorators.log:time");
 
 
         // Even if decorators are only supplied for another tag(s), the defaults are not taken into account
-        doTest(true, "-Xlog:jit*=trace:decorators.log", "-Xlog:gc*=info:decorators.log:time");
+        doTest(true, "-Xlog:jit+inlining*=trace:decorators.log", "-Xlog:gc*=info:decorators.log:time");
 
 
         // Defaults are not taken into account also when another tag implicitly imposes the "standard" defaults
-        doTest(true, "-Xlog:jit*=trace:decorators.log", "-Xlog:gc*=info:decorators.log");
+        doTest(true, "-Xlog:jit+inlining*=trace:decorators.log", "-Xlog:gc*=info:decorators.log");
 
 
         // Other logging shall not be affected by a tag with defaults

--- a/test/hotspot/jtreg/runtime/logging/DefaultLogDecoratorsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/DefaultLogDecoratorsTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @requires vm.flagless
+ * @summary Running -Xlog with tags which have default decorators should pick them
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver CompressedOopsTest
+ */
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.Platform;
+import jdk.test.lib.process.ProcessTools;
+
+public class DefaultLogDecoratorsTest {
+    public static void main(String[] args) throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+UseCompressedOops",
+                                                                             "-Xlog:jit=trace",
+                                                                             InnerClass.class.getName());
+
+        output = new OutputAnalyzer(pb.start());
+        output.shouldContain("[gc,heap,coops] Heap address");
+        output.shouldHaveExitValue(0);
+
+        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+UseCompressedOops",
+                                                              "-Xlog:jit=trace::tid",
+                                                              InnerClass.class.getName());
+
+        output = new OutputAnalyzer(pb.start());
+        output.shouldContain("[gc,heap,coops] Heap address");
+        output.shouldHaveExitValue(0);
+    }
+
+    public static class InnerClass {
+        public static void main(String[] args) throws Exception {
+            System.out.println("Compressed Oops (gc+heap+coops) test");
+        }
+    }
+}

--- a/test/hotspot/jtreg/runtime/logging/DefaultLogDecoratorsTest.java
+++ b/test/hotspot/jtreg/runtime/logging/DefaultLogDecoratorsTest.java
@@ -63,8 +63,8 @@ public class DefaultLogDecoratorsTest {
     }
 
     public static void main(String[] args) throws Exception {
-        // JIT logging, as per defaults, shall have all decorators disabled
-        doTest(false, "-Xlog:jit*=trace:decorators.log");
+        // JIT inlining logging, as per defaults, shall have all decorators disabled
+        doTest(false, "-Xlog:jit+inlining*=trace:decorators.log");
 
 
         // If decorators are specified, the defaults are not taken into account


### PR DESCRIPTION
Hi all,

Currently, the Unified Logging framework defaults to three decorators (uptime, level, tags) whenever the user does not specify otherwise through `-Xlog`. This can result in cumbersome input whenever a specific user that relies on a particular tag(s) has some predefined needs. For example, C2 developers rarely need decorations, and having to manually specify this every time results inconvenient.

To address this, this PR enables the possibility of adding tag-specific default decorators to UL. These defaults are in no way overriding user input -- they will only act whenever `-Xlog` has no decorators supplied and there is a positive match with the pre-specified defaults. Such a match is based on the following:

- Inclusion: if `-Xlog:jit+compilation` is provided, a default for `jit` may be applied.
- Specificity: if, for the above line, there is a more specific default for `jit+compilation` the latter shall be applied. Upon equal specificity cases, both defaults will be applied.
- Additionally, defaults may target a specific log level.

Decorators are also associated with an output file, so an output device may only have one set of decorators. For this reason, if different `LogSelection`s trigger defaults, none is to be applied.

In summary, these defaults may be seen as a "tailored" or "flavoured" version of the existing "uptime-level-tags" current defaults.

Please consider this PR, and thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340363](https://bugs.openjdk.org/browse/JDK-8340363): Tag-specific default decorators for UnifiedLogging (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20988/head:pull/20988` \
`$ git checkout pull/20988`

Update a local copy of the PR: \
`$ git checkout pull/20988` \
`$ git pull https://git.openjdk.org/jdk.git pull/20988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20988`

View PR using the GUI difftool: \
`$ git pr show -t 20988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20988.diff">https://git.openjdk.org/jdk/pull/20988.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20988#issuecomment-2358040386)