### PR TITLE
8340092: [Linux] containers/systemd/SystemdMemoryAwarenessTest.java failing on some systems

### DIFF
--- a/test/hotspot/jtreg/containers/systemd/TEST.properties
+++ b/test/hotspot/jtreg/containers/systemd/TEST.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+exclusiveAccess.dirs=.

--- a/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
@@ -189,7 +189,19 @@ public class SystemdTestUtils {
         daemonReload.add("daemon-reload");
 
         if (execute(daemonReload).getExitValue() != 0) {
-            throw new AssertionError("Failed to reload systemd daemon");
+            if (RUN_AS_USER) {
+                // When run as user the systemd user manager needs to be
+                // accessible and working. This is usually the case when
+                // connected via SSH or user login, but may not work for
+                // sessions set up via 'su <user>' or similar.
+                // In that case, 'systemctl --user status' usually doesn't
+                // work. There is no other option than skip the test.
+                String msg = "Service user@.service not properly configured. " +
+                             "Skipping the test!";
+                throw new SkippedException(msg);
+            } else {
+                throw new AssertionError("Failed to reload systemd daemon");
+            }
         }
     }
 

--- a/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -135,15 +136,21 @@ public class SystemdTestUtils {
         if (runOpts.hasSliceDLimit()) {
             String dirName = String.format("%s.slice.d", SLICE_NAMESPACE_PREFIX);
             sliceDotDDir = SYSTEMD_CONFIG_HOME.resolve(Path.of(dirName));
-            Files.createDirectory(sliceDotDDir);
+            // Using createDirectories since we only need to ensure the directory
+            // exists. Ignore it if already existent.
+            Files.createDirectories(sliceDotDDir);
 
             if (runOpts.sliceDMemoryLimit != null) {
                 Path memoryConfig = sliceDotDDir.resolve(Path.of(SLICE_D_MEM_CONFIG_FILE));
-                Files.writeString(memoryConfig, getMemoryDSliceContent(runOpts));
+                Files.writeString(memoryConfig,
+                                  getMemoryDSliceContent(runOpts),
+                                  StandardOpenOption.TRUNCATE_EXISTING);
             }
             if (runOpts.sliceDCpuLimit != null) {
                 Path cpuConfig = sliceDotDDir.resolve(Path.of(SLICE_D_CPU_CONFIG_FILE));
-                Files.writeString(cpuConfig, getCPUDSliceContent(runOpts));
+                Files.writeString(cpuConfig,
+                                  getCPUDSliceContent(runOpts),
+                                  StandardOpenOption.TRUNCATE_EXISTING);
             }
         }
 

--- a/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
+++ b/test/lib/jdk/test/lib/containers/systemd/SystemdTestUtils.java
@@ -144,13 +144,15 @@ public class SystemdTestUtils {
                 Path memoryConfig = sliceDotDDir.resolve(Path.of(SLICE_D_MEM_CONFIG_FILE));
                 Files.writeString(memoryConfig,
                                   getMemoryDSliceContent(runOpts),
-                                  StandardOpenOption.TRUNCATE_EXISTING);
+                                  StandardOpenOption.TRUNCATE_EXISTING,
+                                  StandardOpenOption.CREATE);
             }
             if (runOpts.sliceDCpuLimit != null) {
                 Path cpuConfig = sliceDotDDir.resolve(Path.of(SLICE_D_CPU_CONFIG_FILE));
                 Files.writeString(cpuConfig,
                                   getCPUDSliceContent(runOpts),
-                                  StandardOpenOption.TRUNCATE_EXISTING);
+                                  StandardOpenOption.TRUNCATE_EXISTING,
+                                  StandardOpenOption.CREATE);
             }
         }
 


### PR DESCRIPTION
Please review this trivial test fix. The test fails if the `<slice>.d` directory already exists (for some reason). It needs to exist for the test to work. But if it exists we ignore the failure, thus using `Files.createDirectories()`.

As a benefit I've also added `exclusiveAccess.dirs=.` to the `systemd` test directory to match container tests in `docker` folder and added `TRUNCATE_EXISTING` and `CREATE` open options for files in the `<slice>.d` directory. Both of which should ensure the test runs more reliably.

Testing:
- [x] GHA
- [x] Manual testing by creating the directory first, running the test. Failed. The same handshake passes after the patch. Similarly for the user manager service not being accessible (for some reason).

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340092](https://bugs.openjdk.org/browse/JDK-8340092): [Linux] containers/systemd/SystemdMemoryAwarenessTest.java failing on some systems (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20989/head:pull/20989` \
`$ git checkout pull/20989`

Update a local copy of the PR: \
`$ git checkout pull/20989` \
`$ git pull https://git.openjdk.org/jdk.git pull/20989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20989`

View PR using the GUI difftool: \
`$ git pr show -t 20989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20989.diff">https://git.openjdk.org/jdk/pull/20989.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20989#issuecomment-2348450227)