### PR TITLE
8339296: Record deconstruction pattern in switch fails to compile

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -408,9 +408,6 @@ public class Symtab {
 
         names = Names.instance(context);
 
-        // Create the unknown type
-        unknownType = new UnknownType();
-
         messages = JavacMessages.instance(context);
 
         MissingInfoHandler missingInfoHandler = MissingInfoHandler.instance(context);
@@ -475,8 +472,8 @@ public class Symtab {
         errType = new ErrorType(errSymbol, Type.noType);
 
         unknownSymbol = new ClassSymbol(PUBLIC|STATIC|ACYCLIC, names.fromString("<any?>"), null, rootPackage);
-        unknownSymbol.members_field = new Scope.ErrorScope(unknownSymbol);
-        unknownSymbol.type = unknownType;
+        // Create the unknown type
+        unknownType = new UnknownType(unknownSymbol);
 
         // initialize builtin types
         initType(byteType, "byte", "Byte");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -51,7 +51,6 @@ import com.sun.tools.javac.code.Type.ErrorType;
 import com.sun.tools.javac.code.Type.JCPrimitiveType;
 import com.sun.tools.javac.code.Type.JCVoidType;
 import com.sun.tools.javac.code.Type.MethodType;
-import com.sun.tools.javac.code.Type.UnknownType;
 import com.sun.tools.javac.code.Types.UniqueType;
 import com.sun.tools.javac.comp.Modules;
 import com.sun.tools.javac.jvm.Target;
@@ -473,7 +472,7 @@ public class Symtab {
 
         unknownSymbol = new ClassSymbol(PUBLIC|STATIC|ACYCLIC, names.fromString("<any?>"), null, rootPackage);
         // Create the unknown type
-        unknownType = new UnknownType(unknownSymbol);
+        unknownType = new ErrorType(unknownSymbol, Type.noType);
 
         // initialize builtin types
         initType(byteType, "byte", "Byte");

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -2408,25 +2408,6 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         }
     }
 
-    public static class UnknownType extends ErrorType {
-
-        public UnknownType(ClassSymbol unknownSymbol) {
-            // Unknown is a synthesized internal type, so it cannot be
-            // annotated.
-            super(unknownSymbol, noType);
-        }
-
-        @Override @DefinedBy(Api.LANGUAGE_MODEL)
-        public <R, P> R accept(TypeVisitor<R, P> v, P p) {
-            return v.visitUnknown(this, p);
-        }
-
-        @Override @DefinedBy(Api.LANGUAGE_MODEL)
-        public TypeKind getKind() {
-            return TypeKind.OTHER;
-        }
-    }
-
     /**
      * A visitor for types.  A visitor is used to implement operations
      * (or relations) on types.  Most common operations on types are

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Type.java
@@ -2408,17 +2408,12 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
         }
     }
 
-    public static class UnknownType extends Type {
+    public static class UnknownType extends ErrorType {
 
-        public UnknownType() {
+        public UnknownType(ClassSymbol unknownSymbol) {
             // Unknown is a synthesized internal type, so it cannot be
             // annotated.
-            super(null, List.nil());
-        }
-
-        @Override
-        public TypeTag getTag() {
-            return UNKNOWN;
+            super(unknownSymbol, noType);
         }
 
         @Override @DefinedBy(Api.LANGUAGE_MODEL)
@@ -2426,9 +2421,9 @@ public abstract class Type extends AnnoConstruct implements TypeMirror, PoolCons
             return v.visitUnknown(this, p);
         }
 
-        @Override
-        public boolean isPartial() {
-            return true;
+        @Override @DefinedBy(Api.LANGUAGE_MODEL)
+        public TypeKind getKind() {
+            return TypeKind.OTHER;
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeTag.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/TypeTag.java
@@ -121,10 +121,6 @@ public enum TypeTag {
      */
     ERROR,
 
-    /** The tag of an unknown type
-     */
-    UNKNOWN,
-
     /** The tag of all instantiatable type variables.
      */
     UNDETVAR,

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java
@@ -1216,7 +1216,7 @@ public class Types {
             @Override
             public Boolean visitUndetVar(UndetVar t, Type s) {
                 //todo: test against origin needed? or replace with substitution?
-                if (t == s || t.qtype == s || s.hasTag(ERROR) || s.hasTag(UNKNOWN)) {
+                if (t == s || t.qtype == s || s.hasTag(ERROR)) {
                     return true;
                 } else if (s.hasTag(BOT)) {
                     //if 's' is 'null' there's no instantiated type U for which
@@ -1466,7 +1466,7 @@ public class Types {
                     return false;
                 }
 
-                if (t == s || t.qtype == s || s.hasTag(ERROR) || s.hasTag(UNKNOWN)) {
+                if (t == s || t.qtype == s || s.hasTag(ERROR)) {
                     return true;
                 }
 
@@ -2422,7 +2422,7 @@ public class Types {
                              ARRAY, MODULE, TYPEVAR, WILDCARD, BOT:
                             return s.dropMetadata(Annotations.class);
                         case VOID, METHOD, PACKAGE, FORALL, DEFERRED,
-                             NONE, ERROR, UNKNOWN, UNDETVAR, UNINITIALIZED_THIS,
+                             NONE, ERROR, UNDETVAR, UNINITIALIZED_THIS,
                              UNINITIALIZED_OBJECT:
                             return s;
                         default:

--- a/test/langtools/tools/javac/patterns/Switches.java
+++ b/test/langtools/tools/javac/patterns/Switches.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 
 /*
  * @test
- * @bug 8262891 8268333 8268896 8269802 8269808 8270151 8269113 8277864 8290709
+ * @bug 8262891 8268333 8268896 8269802 8269808 8270151 8269113 8277864 8290709 8339296
  * @summary Check behavior of pattern switches.
  */
 public class Switches {
@@ -117,6 +117,9 @@ public class Switches {
         assertEquals(0, constantAndPatternGuardEnum(E.B, true));
         assertEquals(1, constantAndPatternGuardEnum(E.B, false));
         assertEquals(2, constantAndPatternGuardEnum(E.A, false));
+        assertEquals(0, nestedSwitchesInArgumentPosition(1));
+        assertEquals(1, nestedSwitchesInArgumentPosition(new R(1)));
+        assertEquals(5, nestedSwitchesInArgumentPosition(new R(new R("hello"))));
     }
 
     void run(Function<Object, Integer> mapper) {
@@ -747,6 +750,24 @@ public class Switches {
             case E.B -> 1;
             case E f -> 2;
         };
+    }
+
+    int nestedSwitchesInArgumentPosition(Object o1) {
+        return id(switch (o1) {
+            case R(var o2) -> switch (o2) {
+                case R(String s) -> s;
+                default -> "n";
+            };
+            default -> "";
+        });
+    }
+
+    int id(String s) {
+        return s.length();
+    }
+
+    int id(int i) {
+        return i;
     }
 
     //verify that for cases like:

--- a/test/langtools/tools/javac/types/UnknownTypeTest.java
+++ b/test/langtools/tools/javac/types/UnknownTypeTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8339296
+ * @summary Verify that the UnknownType behaves as an erroneous type
+ * @library /tools/lib/types
+ * @modules jdk.compiler/com.sun.tools.javac.code
+ *          jdk.compiler/com.sun.tools.javac.comp
+ *          jdk.compiler/com.sun.tools.javac.file
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.compiler/com.sun.tools.javac.tree
+ * @build TypeHarness
+ * @run main UnknownTypeTest
+ */
+
+import com.sun.tools.javac.code.Type;
+import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.code.Type.TypeVar;
+import com.sun.tools.javac.code.Type.UnionClassType;
+import com.sun.tools.javac.util.List;
+import java.util.Objects;
+
+public class UnknownTypeTest extends TypeHarness {
+
+    private final Type error;
+    private final Type unknown;
+    private final Type[] testTypes;
+    private final Operation[] testOperations;
+
+    UnknownTypeTest() {
+        Symtab syms = Symtab.instance(context);
+        error = syms.errType;
+        unknown = syms.unknownType;
+        testTypes = new Type[] {
+            syms.objectType,
+            syms.errType,
+            syms.unknownType,
+            new TypeVar(syms.unknownSymbol, syms.objectType, syms.objectType),
+            types.makeIntersectionType(List.of(syms.annotationType, syms.stringType)),
+            new UnionClassType((Type.ClassType) syms.annotationType, List.of(syms.stringType)),
+            syms.intType,
+            types.makeArrayType(syms.stringType)
+        };
+        testOperations = new Operation[] {
+            types::containedBy,
+            types::containsType,
+            types::isAssignable,
+            types::isCastable,
+            types::isConvertible,
+            types::isSameType,
+            types::isSubtype,
+            types::isSuperType,
+            types::isUnconditionallyExact,
+            (t1, _) -> types.isArray(t1),
+            (t1, _) -> types.isDerivedRaw(t1),
+            (t1, _) -> types.isReifiable(t1),
+            (t1, _) -> types.isUnbounded(t1),
+            (t1, _) -> types.boxedTypeOrType(t1),
+            (t1, _) -> types.unboxedType(t1),
+            (t1, _) -> types.unboxedTypeOrType(t1),
+        };
+    }
+
+    void test(Type[] testTypes, Operation[] testOperations) {
+        for (int typeIndex = 0; typeIndex < testTypes.length ; typeIndex++) {
+            for (int operationIndex = 0; operationIndex < testOperations.length ; operationIndex++) {
+                Object expected;
+                Object actual;
+                expected = testOperations[operationIndex].run(error, testTypes[typeIndex]);
+                actual = testOperations[operationIndex].run(unknown, testTypes[typeIndex]);
+                checkEquals("Type index: " + typeIndex + ", operationIndex: " + operationIndex + ", unknown in the first position", expected, actual);
+                expected = testOperations[operationIndex].run(testTypes[typeIndex], error);
+                actual = testOperations[operationIndex].run(testTypes[typeIndex], unknown);
+                checkEquals("Type index: " + typeIndex + ", operationIndex: " + operationIndex + ", unknown in the second position", expected, actual);
+            }
+        }
+    }
+
+    void checkEquals(String message, Object expected, Object actual) {
+        boolean matches;
+
+        if (expected instanceof Type t1 && actual instanceof Type t2) {
+            matches = types.isSameType(t1, t2);
+        } else {
+            matches = Objects.equals(expected, actual);
+        }
+
+        if (!matches) {
+            throw new AssertionError("Unexpected outcome: " + actual +
+                                     ", expected: " + expected +
+                                     ", for test: " + message);
+        }
+    }
+
+    void runTests() {
+        test(testTypes, testOperations);
+    }
+
+    public static void main(String[] args) {
+        new UnknownTypeTest().runTests();
+    }
+
+    interface Operation {
+        public Object run(Type t1, Type t2);
+    }
+}


### PR DESCRIPTION
Consider code like this:
```
    int nestedSwitchesInArgumentPosition(Object o1) {
        return id(switch (o1) {
            case R(var o2) -> switch (o2) {
                case R(String s) -> s;
                default -> "n";
            };
            default -> "";
        });
    }

    int id(String s) {
        return s.length();
    }

    int id(int i) {
        return i;
    }
```

Compiling this fails with a `StackOverflowError`, because:
 - there are speculative attribution happening for the switch expressions,
 - "completes normally" is computed during these speculative attribution, which have parts of the AST unfilled - specifically the nested `case R(String s)`
 - so, `Attr.PostAttrAnalyzer` fills in the missing types. In particular, the `String s` binding will get the `Symtab.unknownType`.
 - `Flow.makePatternDescription` will eventually ask `Types.isSubtype(..., unknownType)`. This is guaranteed to fail with the `StackOverflowError`, as:
 - `unknownType.isPartial()` returns `true`, so `Types.isSubtype(t, s)` (`s` is the `unknownType`) calls `Types.isSuperType(s, t)`, and `Types.isSuperType(s, t)` does not contain any special handling for the `unknownType`, so it will delegate to `Types.isSubtype(t, s)`, leading to an infinite recursion.

It may be possible to side-step the issue by not computing the completes normally property during speculative attribution, or move that computation outside of `Attr`. It may be good to do, for performance reasons.

But, that does not seem to solve the underlying issue with `unknownType`. Many methods in `Types` misbehave in weird ways when the `unknownType` is passed to them.

The proposal herein is to attempt to resolve that. In particular, the `UnknownType` is proposed to extend the `ErrorType`, dropping the (internal) `UNKNOWN` type tag. The uses of the `UNKNOWN` type tag appear to be equivalent to handling of the `ERROR` type tag anyway. And the special handling of the `unknownType` appear to usually use ` == syms.unknownType`:
https://github.com/openjdk/jdk/blob/0c36177fead8b64a4cee9da3c895e3799f8ba231/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Types.java#L904

After this change, the `unknownType` should behave as an erroneous type, unless specifically requested otherwise.

The intent is that the public API behavior for the `unknownType` should remain the same.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339296](https://bugs.openjdk.org/browse/JDK-8339296): Record deconstruction pattern in switch fails to compile (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**) Review applies to [71942f9d](https://git.openjdk.org/jdk/pull/20990/files/71942f9d11beb5db63e255e436833e37a701f8e1)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20990/head:pull/20990` \
`$ git checkout pull/20990`

Update a local copy of the PR: \
`$ git checkout pull/20990` \
`$ git pull https://git.openjdk.org/jdk.git pull/20990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20990`

View PR using the GUI difftool: \
`$ git pr show -t 20990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20990.diff">https://git.openjdk.org/jdk/pull/20990.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20990#issuecomment-2348480086)