### PR TITLE
8340102: Move assert-only loop in OopMapSort::sort under debug macro

### DIFF
--- a/src/hotspot/share/compiler/oopMap.cpp
+++ b/src/hotspot/share/compiler/oopMap.cpp
@@ -246,10 +246,13 @@ private:
 };
 
 void OopMapSort::sort() {
+#ifdef ASSERT
   for (OopMapStream oms(_map); !oms.is_done(); oms.next()) {
     OopMapValue omv = oms.current();
-    assert(omv.type() == OopMapValue::oop_value || omv.type() == OopMapValue::narrowoop_value || omv.type() == OopMapValue::derived_oop_value || omv.type() == OopMapValue::callee_saved_value, "");
+    assert(omv.type() == OopMapValue::oop_value || omv.type() == OopMapValue::narrowoop_value ||
+           omv.type() == OopMapValue::derived_oop_value || omv.type() == OopMapValue::callee_saved_value, "");
   }
+#endif
 
   for (OopMapStream oms(_map); !oms.is_done(); oms.next()) {
     if (oms.current().type() == OopMapValue::callee_saved_value) {


### PR DESCRIPTION
Found this papercut when looking at Leyden perf runs.

In OopMapSort::sort, there is a loop that apparently is only there for asserts. At least GCC 11.4 apparently not smart enough to eliminate the whole loop in release builds, probably because iterator reads things from the stream. Wrapping the loop with #ifdef ASSERT saves about 144 bytes in code stream.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340102](https://bugs.openjdk.org/browse/JDK-8340102): Move assert-only loop in OopMapSort::sort under debug macro (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20992/head:pull/20992` \
`$ git checkout pull/20992`

Update a local copy of the PR: \
`$ git checkout pull/20992` \
`$ git pull https://git.openjdk.org/jdk.git pull/20992/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20992`

View PR using the GUI difftool: \
`$ git pr show -t 20992`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20992.diff">https://git.openjdk.org/jdk/pull/20992.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20992#issuecomment-2348569335)