### PR TITLE
8339974: Graphics2D.drawString doesn't always work with Font derived from AffineTransform

### DIFF
--- a/src/java.desktop/share/classes/java/awt/font/TextLayout.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextLayout.java
@@ -2663,10 +2663,19 @@ public final class TextLayout implements Cloneable {
      */
     public Shape getOutline(AffineTransform tx) {
         ensureCache();
-        Shape result = textLine.getOutline(tx);
+        Shape result = textLine.getOutline();
         LayoutPathImpl lp = textLine.getLayoutPath();
         if (lp != null) {
             result = lp.mapShape(result);
+        }
+        if (tx != null) {
+            if (result instanceof GeneralPath gp) {
+                // transform in place
+                gp.transform(tx);
+            } else {
+                // create a transformed copy
+                result = tx.createTransformedShape(result);
+            }
         }
         return result;
     }

--- a/src/java.desktop/share/classes/java/awt/font/TextLine.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextLine.java
@@ -864,19 +864,15 @@ final class TextLine {
         return new Rectangle2D.Float(left, top, right-left, bottom-top);
     }
 
-    public Shape getOutline(AffineTransform tx) {
+    public Shape getOutline() {
 
         GeneralPath dstShape = new GeneralPath(GeneralPath.WIND_NON_ZERO);
 
         for (int i=0, n = 0; i < fComponents.length; i++, n += 2) {
             TextLineComponent tlc = fComponents[getComponentLogicalIndex(i)];
-
             dstShape.append(tlc.getOutline(locs[n], locs[n+1]), false);
         }
 
-        if (tx != null) {
-            dstShape.transform(tx);
-        }
         return dstShape;
     }
 

--- a/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
+++ b/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
@@ -30,6 +30,8 @@ import java.awt.image.BufferedImage;
 
 /*
  * @test
+ * @bug 8339974
+ * @summary Verifies that text draws correctly using scaled and rotated fonts.
  */
 public class RotatedScaledFontTest {
 

--- a/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
+++ b/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
@@ -27,6 +27,9 @@ import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
+import java.io.File;
+
+import javax.imageio.ImageIO;
 
 /*
  * @test
@@ -63,26 +66,32 @@ public class RotatedScaledFontTest {
                 g2d.drawString("TEST", center, center);
                 Rectangle bounds = findTextBoundingBox(image);
                 if (bounds == null) {
+                    String path = saveImage("bounds", image);
                     throw new RuntimeException("Text missing: scale=" + scale
-                        + ", quadrants=" + quadrants + ", center=" + center);
+                        + ", quadrants=" + quadrants + ", center=" + center
+                        + ", png=" + path);
                 }
                 boolean horizontal = (bounds.width > bounds.height);
                 boolean expectedHorizontal = (quadrants % 2 == 0);
                 if (horizontal != expectedHorizontal) {
+                    String path = saveImage("orientation", image);
                     throw new RuntimeException("Wrong orientation: scale=" + scale
                         + ", quadrants=" + quadrants + ", center=" + center
                         + ", bounds=" + bounds + ", horizontal=" + horizontal
-                        + ", expectedHorizontal=" + expectedHorizontal);
+                        + ", expectedHorizontal=" + expectedHorizontal
+                        + ", png=" + path);
                 }
                 if (!roughlyEqual(center, bounds.x, scale) && !roughlyEqual(center, bounds.x + bounds.width, scale)) {
+                    String path = saveImage("xedge", image);
                     throw new RuntimeException("No x-edge at center: scale=" + scale
                         + ", quadrants=" + quadrants + ", center=" + center
-                        + ", bounds=" + bounds);
+                        + ", bounds=" + bounds + ", png=" + path);
                 }
                 if (!roughlyEqual(center, bounds.y, scale) && !roughlyEqual(center, bounds.y + bounds.height, scale)) {
+                    String path = saveImage("yedge", image);
                     throw new RuntimeException("No y-edge at center: scale=" + scale
                         + ", quadrants=" + quadrants + ", center=" + center
-                        + ", bounds=" + bounds);
+                        + ", bounds=" + bounds + ", png=" + path);
                 }
             }
         } finally {
@@ -127,5 +136,15 @@ public class RotatedScaledFontTest {
 
     private static boolean roughlyEqual(int x1, int x2, int scale) {
         return Math.abs(x1 - x2) <= Math.ceil(scale / 2d) + 1; // higher scale = higher allowed variance
+    }
+
+    private static String saveImage(String name, BufferedImage image) {
+        try {
+            File file = new File(name + ".png");
+            ImageIO.write(image, "png", file);
+            return file.getAbsolutePath();
+        } catch (Exception e) {
+            return null;
+        }
     }
 }

--- a/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
+++ b/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
@@ -66,32 +66,30 @@ public class RotatedScaledFontTest {
                 g2d.drawString("TEST", center, center);
                 Rectangle bounds = findTextBoundingBox(image);
                 if (bounds == null) {
-                    String path = saveImage("bounds", image);
+                    saveImage("bounds", image);
                     throw new RuntimeException("Text missing: scale=" + scale
-                        + ", quadrants=" + quadrants + ", center=" + center
-                        + ", png=" + path);
+                        + ", quadrants=" + quadrants + ", center=" + center);
                 }
                 boolean horizontal = (bounds.width > bounds.height);
                 boolean expectedHorizontal = (quadrants % 2 == 0);
                 if (horizontal != expectedHorizontal) {
-                    String path = saveImage("orientation", image);
+                    saveImage("orientation", image);
                     throw new RuntimeException("Wrong orientation: scale=" + scale
                         + ", quadrants=" + quadrants + ", center=" + center
                         + ", bounds=" + bounds + ", horizontal=" + horizontal
-                        + ", expectedHorizontal=" + expectedHorizontal
-                        + ", png=" + path);
+                        + ", expectedHorizontal=" + expectedHorizontal);
                 }
                 if (!roughlyEqual(center, bounds.x, scale) && !roughlyEqual(center, bounds.x + bounds.width, scale)) {
-                    String path = saveImage("xedge", image);
+                    saveImage("xedge", image);
                     throw new RuntimeException("No x-edge at center: scale=" + scale
                         + ", quadrants=" + quadrants + ", center=" + center
-                        + ", bounds=" + bounds + ", png=" + path);
+                        + ", bounds=" + bounds);
                 }
                 if (!roughlyEqual(center, bounds.y, scale) && !roughlyEqual(center, bounds.y + bounds.height, scale)) {
-                    String path = saveImage("yedge", image);
+                    saveImage("yedge", image);
                     throw new RuntimeException("No y-edge at center: scale=" + scale
                         + ", quadrants=" + quadrants + ", center=" + center
-                        + ", bounds=" + bounds + ", png=" + path);
+                        + ", bounds=" + bounds);
                 }
             }
         } finally {
@@ -138,13 +136,14 @@ public class RotatedScaledFontTest {
         return Math.abs(x1 - x2) <= Math.ceil(scale / 2d) + 1; // higher scale = higher allowed variance
     }
 
-    private static String saveImage(String name, BufferedImage image) {
+    private static void saveImage(String name, BufferedImage image) {
         try {
-            File file = new File(name + ".png");
+            String dir = System.getProperty("test.classes", ".");
+            String path = dir + File.separator + name + ".png";
+            File file = new File(path);
             ImageIO.write(image, "png", file);
-            return file.getAbsolutePath();
         } catch (Exception e) {
-            return null;
+            // we tried, and that's enough
         }
     }
 }

--- a/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
+++ b/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Color;
+import java.awt.Font;
+import java.awt.Graphics2D;
+import java.awt.Rectangle;
+import java.awt.geom.AffineTransform;
+import java.awt.image.BufferedImage;
+
+/*
+ * @test
+ */
+public class RotatedScaledFontTest {
+
+    public static void main(String[] args) throws Exception {
+        test(0);
+        test(1);
+        test(2);
+        test(3);
+        test(4);
+    }
+
+    private static void test(int quadrants) throws Exception {
+
+        int size = 2000;
+        int center = size / 2;
+        Font base = new Font("SansSerif", Font.PLAIN, 10);
+        BufferedImage image = new BufferedImage(size, size, BufferedImage.TYPE_BYTE_BINARY);
+        Graphics2D g2d = image.createGraphics();
+
+        try {
+            for (int scale = 1; scale <= 100; scale++) {
+                AffineTransform at = AffineTransform.getQuadrantRotateInstance(quadrants);
+                at.scale(scale, scale);
+                Font font = base.deriveFont(at);
+                g2d.setColor(Color.WHITE);
+                g2d.fillRect(0, 0, image.getWidth(), image.getHeight());
+                g2d.setColor(Color.BLACK);
+                g2d.setFont(font);
+                g2d.drawString("TEST", center, center);
+                Rectangle bounds = findTextBoundingBox(image);
+                if (bounds == null) {
+                    throw new RuntimeException("Text missing: scale=" + scale
+                        + ", quadrants=" + quadrants);
+                }
+                boolean horizontal = (bounds.width > bounds.height);
+                boolean expectedHorizontal = (quadrants % 2 == 0);
+                if (horizontal != expectedHorizontal) {
+                    throw new RuntimeException("Wrong orientation: scale=" + scale
+                        + ", quadrants=" + quadrants + ", horizontal=" + horizontal);
+                }
+                if (!roughlyEqual(center, bounds.x, scale) && !roughlyEqual(center, bounds.x + bounds.width, scale)) {
+                    throw new RuntimeException("No x-edge at center: scale=" + scale
+                        + ", quadrants=" + quadrants);
+                }
+                if (!roughlyEqual(center, bounds.y, scale) && !roughlyEqual(center, bounds.y + bounds.height, scale)) {
+                    throw new RuntimeException("No y-edge at center: scale=" + scale
+                        + ", quadrants=" + quadrants);
+                }
+            }
+        } finally {
+            g2d.dispose();
+        }
+    }
+
+    private static Rectangle findTextBoundingBox(BufferedImage image) {
+        int minX = Integer.MAX_VALUE;
+        int minY = Integer.MAX_VALUE;
+        int maxX = Integer.MIN_VALUE;
+        int maxY = Integer.MIN_VALUE;
+        int width = image.getWidth();
+        int height = image.getHeight();
+        int[] rowPixels = new int[width];
+        for (int y = 0; y < height; y++) {
+            image.getRGB(0, y, width, 1, rowPixels, 0, width);
+            for (int x = 0; x < width; x++) {
+                boolean white = (rowPixels[x] == -1);
+                if (!white) {
+                    if (x < minX) {
+                        minX = x;
+                    }
+                    if (y < minY) {
+                        minY = y;
+                    }
+                    if (x > maxX) {
+                        maxX = x;
+                    }
+                    if (y > maxY) {
+                        maxY = y;
+                    }
+                }
+            }
+        }
+        if (minX != Integer.MAX_VALUE) {
+            return new Rectangle(minX, minY, maxX - minX, maxY - minY);
+        } else {
+            return null;
+        }
+    }
+
+    private static boolean roughlyEqual(int x1, int x2, int scale) {
+        return Math.abs(x1 - x2) <= Math.ceil(scale / 2d); // higher scale = higher allowed variance
+    }
+}

--- a/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
+++ b/test/jdk/java/awt/font/FontScaling/RotatedScaledFontTest.java
@@ -64,21 +64,25 @@ public class RotatedScaledFontTest {
                 Rectangle bounds = findTextBoundingBox(image);
                 if (bounds == null) {
                     throw new RuntimeException("Text missing: scale=" + scale
-                        + ", quadrants=" + quadrants);
+                        + ", quadrants=" + quadrants + ", center=" + center);
                 }
                 boolean horizontal = (bounds.width > bounds.height);
                 boolean expectedHorizontal = (quadrants % 2 == 0);
                 if (horizontal != expectedHorizontal) {
                     throw new RuntimeException("Wrong orientation: scale=" + scale
-                        + ", quadrants=" + quadrants + ", horizontal=" + horizontal);
+                        + ", quadrants=" + quadrants + ", center=" + center
+                        + ", bounds=" + bounds + ", horizontal=" + horizontal
+                        + ", expectedHorizontal=" + expectedHorizontal);
                 }
                 if (!roughlyEqual(center, bounds.x, scale) && !roughlyEqual(center, bounds.x + bounds.width, scale)) {
                     throw new RuntimeException("No x-edge at center: scale=" + scale
-                        + ", quadrants=" + quadrants);
+                        + ", quadrants=" + quadrants + ", center=" + center
+                        + ", bounds=" + bounds);
                 }
                 if (!roughlyEqual(center, bounds.y, scale) && !roughlyEqual(center, bounds.y + bounds.height, scale)) {
                     throw new RuntimeException("No y-edge at center: scale=" + scale
-                        + ", quadrants=" + quadrants);
+                        + ", quadrants=" + quadrants + ", center=" + center
+                        + ", bounds=" + bounds);
                 }
             }
         } finally {
@@ -122,6 +126,6 @@ public class RotatedScaledFontTest {
     }
 
     private static boolean roughlyEqual(int x1, int x2, int scale) {
-        return Math.abs(x1 - x2) <= Math.ceil(scale / 2d); // higher scale = higher allowed variance
+        return Math.abs(x1 - x2) <= Math.ceil(scale / 2d) + 1; // higher scale = higher allowed variance
     }
 }

--- a/test/jdk/javax/print/PostScriptRotatedScaledFontTest.java
+++ b/test/jdk/javax/print/PostScriptRotatedScaledFontTest.java
@@ -101,7 +101,9 @@ public class PostScriptRotatedScaledFontTest {
                 boolean expectedHorizontal = (quadrants % 2 == 0);
                 if (horizontal != expectedHorizontal) {
                     throw new RuntimeException("Wrong orientation: scale=" + scale
-                        + ", quadrants=" + quadrants + ", horizontal=" + horizontal);
+                        + ", quadrants=" + quadrants + ", bounds=" + bounds
+                        + ", expectedHorizontal=" + expectedHorizontal
+                        + ", horizontal=" + horizontal);
                 }
             }
         } finally {

--- a/test/jdk/javax/print/PostScriptRotatedScaledFontTest.java
+++ b/test/jdk/javax/print/PostScriptRotatedScaledFontTest.java
@@ -45,6 +45,8 @@ import javax.print.event.PrintJobEvent;
 
 /*
  * @test
+ * @bug 8339974
+ * @summary Verifies that text prints correctly using scaled and rotated fonts.
  */
 public class PostScriptRotatedScaledFontTest {
 

--- a/test/jdk/javax/print/PostScriptRotatedScaledFontTest.java
+++ b/test/jdk/javax/print/PostScriptRotatedScaledFontTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Font;
+import java.awt.Graphics;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Rectangle2D;
+import java.awt.print.PageFormat;
+import java.awt.print.Printable;
+import java.awt.print.PrinterException;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.print.Doc;
+import javax.print.DocFlavor;
+import javax.print.DocPrintJob;
+import javax.print.SimpleDoc;
+import javax.print.StreamPrintService;
+import javax.print.StreamPrintServiceFactory;
+import javax.print.event.PrintJobAdapter;
+import javax.print.event.PrintJobEvent;
+
+/*
+ * @test
+ */
+public class PostScriptRotatedScaledFontTest {
+
+    public static void main(String[] args) throws Exception {
+        test(0);
+        test(1);
+        test(2);
+        test(3);
+        test(4);
+    }
+
+    private static void test(int quadrants) throws Exception {
+
+        DocFlavor flavor = DocFlavor.SERVICE_FORMATTED.PRINTABLE;
+        String mime = "application/postscript";
+        StreamPrintServiceFactory[] factories = StreamPrintServiceFactory.lookupStreamPrintServiceFactories(flavor, mime);
+        if (factories.length == 0) {
+            throw new RuntimeException("Unable to find PostScript print service factory");
+        }
+
+        StreamPrintServiceFactory factory = factories[0];
+
+        // required to trigger "text-as-shapes" code path in
+        // PSPathGraphics.drawString(String, float, float, Font, FontRenderContext, float)
+        // for *all* text, not just text that uses a transformed font
+        String shapeText = "sun.java2d.print.shapetext";
+        System.setProperty(shapeText, "true");
+
+        try {
+            for (int scale = 1; scale <= 100; scale++) {
+
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                StreamPrintService service = factory.getPrintService(output);
+                DocPrintJob job = service.createPrintJob();
+
+                PrintJobMonitor monitor = new PrintJobMonitor();
+                job.addPrintJobListener(monitor);
+
+                Printable printable = new TestPrintable(scale, quadrants);
+                Doc doc = new SimpleDoc(printable, flavor, null);
+                job.print(doc, null);
+                monitor.waitForJobToFinish();
+
+                byte[] ps = output.toByteArray();
+                Rectangle2D.Double bounds = findTextBoundingBox(ps);
+                if (bounds == null) {
+                    throw new RuntimeException("Text missing: scale=" + scale
+                        + ", quadrants=" + quadrants);
+                }
+
+                boolean horizontal = (bounds.width > bounds.height);
+                boolean expectedHorizontal = (quadrants % 2 == 0);
+                if (horizontal != expectedHorizontal) {
+                    throw new RuntimeException("Wrong orientation: scale=" + scale
+                        + ", quadrants=" + quadrants + ", horizontal=" + horizontal);
+                }
+            }
+        } finally {
+            System.clearProperty(shapeText);
+        }
+    }
+
+    // very basic, uses moveto ("x y M"), lineto ("x y L"), and curveto ("x1 y1 x2 y2 x3 y3 C")
+    private static Rectangle2D.Double findTextBoundingBox(byte[] ps) {
+        double minX = Double.MAX_VALUE;
+        double minY = Double.MAX_VALUE;
+        double maxX = Double.MIN_VALUE;
+        double maxY = Double.MIN_VALUE;
+        boolean pastPageClip = false;
+        List< String > lines = new String(ps, StandardCharsets.ISO_8859_1).lines().toList();
+        for (String line : lines) {
+            if (!pastPageClip) {
+                pastPageClip = "WC".equals(line);
+                continue;
+            }
+            String[] values = line.split(" ");
+            if (values.length == 3 || values.length == 7) {
+                String cmd = values[values.length - 1];
+                if ("M".equals(cmd) || "L".equals(cmd) || "C".equals(cmd)) {
+                    String sx = values[values.length - 3];
+                    String sy = values[values.length - 2];
+                    double x = Double.parseDouble(sx);
+                    double y = Double.parseDouble(sy);
+                    if (x < minX) {
+                        minX = x;
+                    }
+                    if (y < minY) {
+                        minY = y;
+                    }
+                    if (x > maxX) {
+                        maxX = x;
+                    }
+                    if (y > maxY) {
+                        maxY = y;
+                    }
+                }
+            }
+        }
+        if (minX != Double.MAX_VALUE) {
+            return new Rectangle2D.Double(minX, minY, maxX - minX, maxY - minY);
+        } else {
+            return null;
+        }
+    }
+
+    private static final class TestPrintable implements Printable {
+        private final int scale;
+        private final int quadrants;
+        public TestPrintable(int scale, int quadrants) {
+            this.scale = scale;
+            this.quadrants = quadrants;
+        }
+        @Override
+        public int print(Graphics graphics, PageFormat pageFormat, int pageIndex) throws PrinterException {
+            if (pageIndex > 0) {
+                return NO_SUCH_PAGE;
+            }
+            AffineTransform at = AffineTransform.getQuadrantRotateInstance(quadrants);
+            at.scale(scale, scale);
+            Font base = new Font("SansSerif", Font.PLAIN, 10);
+            Font font = base.deriveFont(at);
+            graphics.setFont(font);
+            graphics.drawString("TEST", 300, 300);
+            return PAGE_EXISTS;
+        }
+    }
+
+    private static class PrintJobMonitor extends PrintJobAdapter {
+        private boolean finished;
+        @Override
+        public void printJobCanceled(PrintJobEvent pje) {
+            finished();
+        }
+        @Override
+        public void printJobCompleted(PrintJobEvent pje) {
+            finished();
+        }
+        @Override
+        public void printJobFailed(PrintJobEvent pje) {
+            finished();
+        }
+        @Override
+        public void printJobNoMoreEvents(PrintJobEvent pje) {
+            finished();
+        }
+        private synchronized void finished() {
+            finished = true;
+            notify();
+        }
+        public synchronized void waitForJobToFinish() {
+            try {
+                while (!finished) {
+                    wait();
+                }
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
There is a bug in `TextLayout.getOutline(AffineTransform)`, where the transformation is applied too early (before the layout path applies its mapping). The most obvious error caused by this bug is that `Graphics2D.drawString(...)` fails to draw the string when using a rotated + scaled `AffineTransform` (see minimal test case in the bug report).

There are two uses of `TextLayout.getOutline(AffineTransform)`: the first one, triggered via a simple `Graphics2D.drawString(...)` was the one I ran into; the second one requires the use of a transformed font with a `PSPrinterJob`. Both are broken. This PR includes two test classes verifying that both scenarios were broken before the fix and are working after the fix.

Two points which might require some discussion:
1. I've changed the signature of method `TextLine.getOutline(AffineTransform)`, to just `TextLine.getOutline()`; I'm assuming this is OK since `TextLine` is a package-private class.
2. I've added a fast path in `TextLayout.getOutline(AffineTransform)` to transform the shape in place if it is a `GeneralPath` (it should usually be, and avoids an extra `Shape` copy vs. the current code, which makes no copy). A bit more complex, but efficient.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339974](https://bugs.openjdk.org/browse/JDK-8339974): Graphics2D.drawString doesn't always work with Font derived from AffineTransform (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20993/head:pull/20993` \
`$ git checkout pull/20993`

Update a local copy of the PR: \
`$ git checkout pull/20993` \
`$ git pull https://git.openjdk.org/jdk.git pull/20993/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20993`

View PR using the GUI difftool: \
`$ git pr show -t 20993`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20993.diff">https://git.openjdk.org/jdk/pull/20993.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20993#issuecomment-2348576891)