### PR TITLE
8340103

### DIFF
--- a/src/hotspot/share/nmt/nmtTreap.hpp
+++ b/src/hotspot/share/nmt/nmtTreap.hpp
@@ -304,6 +304,36 @@ public:
     return candidate;
   }
 
+  TreapNode* closest_gt(const K& key) {
+    TreapNode* candidate = nullptr;
+    TreapNode* pos = _root;
+    while (pos != nullptr) {
+      int cmp_r = COMPARATOR::cmp(pos->key(), key);
+      if (cmp_r > 0) {
+        // Found a match, try to find a better one.
+        candidate = pos;
+        pos = pos->_left;
+      } else if (cmp_r <= 0) {
+        pos = pos->_right;
+      }
+    }
+    return candidate;
+  }
+
+  struct Range {
+    TreapNode* start;
+    TreapNode* end;
+  };
+
+  // Return the range [start, end)
+  // where start->key() <= addr < end->key().
+  // Failure to find the range leads to start and/or end being null.
+  Range find_enclosing_range(K addr) {
+    TreapNode* start = closest_leq(addr);
+    TreapNode* end = closest_gt(addr);
+    return Range{start, end};
+  }
+
   // Visit all TreapNodes in ascending key order.
   template<typename F>
   void visit_in_order(F f) const {


### PR DESCRIPTION
Hi!

The old VirtualMemoryTracker has a method set_reserved_region_type(address, flag). We implement this for the new VMATree implementation by altering the signature slightly to set_reserved_region_type(address, size, flag). This simplifies the implementation greatly for our new data structure and leads to trivial changes for the callers (all callers already know the size).

This PR implements the internal implementation along with tests, but does not change any callers.

I also do a few cleanups:

- Change `Node` to `TreeNode` in tests, we've seen build failures because of this (probably a precompiled headers issue)
- Add a few `print_on` methods for  easy debugging
- Add a `size` alias, it was a bit confusing that some functions took an argument `position sz`, so changed that to `size sz` 

Thanks.