### PR TITLE
8340105: Expose BitMap::print_on in release builds

### DIFF
--- a/src/hotspot/share/utilities/bitMap.cpp
+++ b/src/hotspot/share/utilities/bitMap.cpp
@@ -705,8 +705,6 @@ void BitMap::IteratorImpl::assert_not_empty() const {
 }
 #endif
 
-#ifndef PRODUCT
-
 void BitMap::print_on(outputStream* st) const {
   st->print("Bitmap (" SIZE_FORMAT " bits):", size());
   for (idx_t index = 0; index < size(); index++) {
@@ -721,8 +719,6 @@ void BitMap::print_on(outputStream* st) const {
   }
   st->cr();
 }
-
-#endif
 
 template class GrowableBitMap<ArenaBitMap>;
 template class GrowableBitMap<ResourceBitMap>;

--- a/src/hotspot/share/utilities/bitMap.hpp
+++ b/src/hotspot/share/utilities/bitMap.hpp
@@ -391,13 +391,10 @@ class BitMap {
   bool is_empty() const;
 
   void write_to(bm_word_t* buffer, size_t buffer_size_in_bytes) const;
-  void print_on_error(outputStream* st, const char* prefix) const;
 
-#ifndef PRODUCT
- public:
   // Printing
+  void print_on_error(outputStream* st, const char* prefix) const;
   void print_on(outputStream* st) const;
-#endif
 };
 
 // Implementation support for bitmap iteration.  While it could be used to


### PR DESCRIPTION
A small quality of life improvement.  This irritates me often enough when I am looking at various bitmaps in release builds. BitMap::print_on is not available in release builds, and bitmaps in debug builds are sometimes different than the ones in release builds. This often forces me to do additional hack to expose it. I think it should just be available in release builds to begin with.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340105](https://bugs.openjdk.org/browse/JDK-8340105): Expose BitMap::print_on in release builds (**Enhancement** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20995/head:pull/20995` \
`$ git checkout pull/20995`

Update a local copy of the PR: \
`$ git checkout pull/20995` \
`$ git pull https://git.openjdk.org/jdk.git pull/20995/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20995`

View PR using the GUI difftool: \
`$ git pr show -t 20995`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20995.diff">https://git.openjdk.org/jdk/pull/20995.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20995#issuecomment-2348603202)