### PR TITLE
8340120: Remove redundant code in SegmentBulkOperations::mismatch

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -207,15 +207,6 @@ public final class SegmentBulkOperations {
             }
         }
         int remaining = length - offset;
-        // 0...XXX000
-        for (; remaining >= 8; remaining -= 8) {
-            final long s = SCOPED_MEMORY_ACCESS.getLongUnaligned(src.sessionImpl(), src.unsafeGetBase(), src.unsafeGetOffset() + srcFromOffset + offset, !Architecture.isLittleEndian());
-            final long d = SCOPED_MEMORY_ACCESS.getLongUnaligned(dst.sessionImpl(), dst.unsafeGetBase(), dst.unsafeGetOffset() + dstFromOffset + offset, !Architecture.isLittleEndian());
-            if (s != d) {
-                return start + offset + mismatch(s, d);
-            }
-            offset += 8;
-        }
 
         // 0...0X00
         if (remaining >= 4) {


### PR DESCRIPTION
This PR removes redundant code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340120](https://bugs.openjdk.org/browse/JDK-8340120): Remove redundant code in SegmentBulkOperations::mismatch (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/20998/head:pull/20998` \
`$ git checkout pull/20998`

Update a local copy of the PR: \
`$ git checkout pull/20998` \
`$ git pull https://git.openjdk.org/jdk.git pull/20998/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20998`

View PR using the GUI difftool: \
`$ git pr show -t 20998`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/20998.diff">https://git.openjdk.org/jdk/pull/20998.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/20998#issuecomment-2348923212)