### PR TITLE
8339847: Broken link to the dieharder distribution website in SplittableRandom

### DIFF
--- a/src/java.base/share/classes/java/util/SplittableRandom.java
+++ b/src/java.base/share/classes/java/util/SplittableRandom.java
@@ -47,7 +47,7 @@ import jdk.internal.util.random.RandomSupport.AbstractSplittableGenerator;
  * <li>Series of generated values pass the DieHarder suite testing
  * independence and uniformity properties of random number generators.
  * (Most recently validated with <a
- * href="http://www.phy.duke.edu/~rgb/General/dieharder.php"> version
+ * href="https://webhome.phy.duke.edu/~rgb/General/dieharder.php"> version
  * 3.31.1</a>.) These tests validate only the methods for certain
  * types and ranges, but similar properties are expected to hold, at
  * least approximately, for others as well. The <em>period</em>


### PR DESCRIPTION
Could I get a review for this small change?
The page linked in `SplittableRandom` was moved at some point, this change points to the correct page to avoid redirects.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339847](https://bugs.openjdk.org/browse/JDK-8339847): Broken link to the dieharder distribution website in SplittableRandom (**Sub-task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21000/head:pull/21000` \
`$ git checkout pull/21000`

Update a local copy of the PR: \
`$ git checkout pull/21000` \
`$ git pull https://git.openjdk.org/jdk.git pull/21000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21000`

View PR using the GUI difftool: \
`$ git pr show -t 21000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21000.diff">https://git.openjdk.org/jdk/pull/21000.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21000#issuecomment-2349181535)