### PR TITLE
8339845: Update color.org and wapforum.org links to use HTTPS instead of HTTP

### DIFF
--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_ColorSpace.java
@@ -48,7 +48,7 @@ import sun.java2d.cmm.PCMM;
  * {@code ColorSpace} class. This representation of device independent and
  * device dependent color spaces is based on the International Color Consortium
  * Specification ICC.1:2001-12, File Format for Color Profiles (see
- * <a href="http://www.color.org">http://www.color.org</a>).
+ * <a href="https://www.color.org">https://www.color.org</a>).
  * <p>
  * Typically, a {@code Color} or {@code ColorModel} would be associated with an
  * ICC Profile which is either an input, display, or output profile (see the ICC

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -64,7 +64,7 @@ import sun.java2d.cmm.ProfileDeferralInfo;
  * A representation of color profile data for device independent and device
  * dependent color spaces based on the International Color Consortium
  * Specification ICC.1:2001-12, File Format for Color Profiles, (see
- * <a href="http://www.color.org"> http://www.color.org</a>).
+ * <a href="https://www.color.org"> https://www.color.org</a>).
  * <p>
  * An {@code ICC_ColorSpace} object can be constructed from an appropriate
  * {@code ICC_Profile}. Typically, an {@code ICC_ColorSpace} would be associated

--- a/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
+++ b/src/java.desktop/share/classes/java/awt/image/ColorConvertOp.java
@@ -690,7 +690,7 @@ public class ColorConvertOp implements BufferedImageOp, RasterOp {
          * shall be set to zero. Thus, we are ignoring two most significant
          * bytes here.
          *
-         *  See http://www.color.org/ICC1v42_2006-05.pdf, section 7.2.15.
+         *  See https://www.color.org/ICC1v42_2006-05.pdf, section 7.2.15.
          */
         return ((header[index+2] & 0xff) <<  8) |
                 (header[index+3] & 0xff);

--- a/src/java.desktop/share/classes/javax/imageio/package-info.java
+++ b/src/java.desktop/share/classes/javax/imageio/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -101,7 +101,7 @@
  * <!-- WBMP plugin -->
  *   <tr>
  *     <th scope="row">
- *     <a href="http://www.wapforum.org/what/technical/SPEC-WAESpec-19990524.pdf">
+ *     <a href="https://www.wapforum.org/what/technical/SPEC-WAESpec-19990524.pdf">
  *     WBMP</a>
  *     <td>yes
  *     <td>yes

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/BaselineTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/BaselineTIFFTagSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/BaselineTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/BaselineTIFFTagSet.java
@@ -1008,7 +1008,7 @@ public final class BaselineTIFFTagSet extends TIFFTagSet {
     /**
      * Constant specifying the "ICC Profile" tag.
      *
-     * @see <a href="http://www.color.org/ICC1V42.pdf">ICC Specification, section B.4: Embedding ICC profiles in TIFF files</a>
+     * @see <a href="https://www.color.org/ICC1V42.pdf">ICC Specification, section B.4: Embedding ICC profiles in TIFF files</a>
      */
     public static final int TAG_ICC_PROFILE = 34675;
 


### PR DESCRIPTION
Can I get a review for this doc-only change? I updated some links because the websites moved from HTTP to HTTPS. The redirects can cause some false-positives on tests.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339845](https://bugs.openjdk.org/browse/JDK-8339845): Update color.org and wapforum.org links to use HTTPS instead of HTTP (**Sub-task** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21001/head:pull/21001` \
`$ git checkout pull/21001`

Update a local copy of the PR: \
`$ git checkout pull/21001` \
`$ git pull https://git.openjdk.org/jdk.git pull/21001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21001`

View PR using the GUI difftool: \
`$ git pr show -t 21001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21001.diff">https://git.openjdk.org/jdk/pull/21001.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21001#issuecomment-2349181773)