### PR TITLE
8340131: Refactor internal makeHiddenClassDefiner to take option mask instead of Set<ClassOption>

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -53,6 +53,8 @@ import java.lang.classfile.constantpool.ClassEntry;
 import java.lang.classfile.constantpool.ConstantPoolBuilder;
 import java.lang.classfile.constantpool.MethodRefEntry;
 import static java.lang.constant.ConstantDescs.*;
+import static java.lang.invoke.MethodHandleNatives.Constants.NESTMATE_CLASS;
+import static java.lang.invoke.MethodHandleNatives.Constants.STRONG_LOADER_LINK;
 import static java.lang.invoke.MethodHandles.Lookup.ClassOption.NESTMATE;
 import static java.lang.invoke.MethodHandles.Lookup.ClassOption.STRONG;
 import static java.lang.invoke.MethodType.methodType;
@@ -76,8 +78,6 @@ import sun.invoke.util.Wrapper;
     private static final ClassFileDumper lambdaProxyClassFileDumper;
 
     private static final boolean disableEagerInitialization;
-
-    private static final MethodHandles.Lookup.ClassOption[] LAMBDA_CLASS_OPTIONS = { NESTMATE, STRONG };
 
     static {
         // To dump the lambda proxy classes, set this system property:
@@ -350,7 +350,7 @@ import sun.invoke.util.Wrapper;
         try {
             // this class is linked at the indy callsite; so define a hidden nestmate
             var classdata = useImplMethodHandle? implementation : null;
-            return caller.makeHiddenClassDefiner(lambdaClassName, classBytes, lambdaProxyClassFileDumper, LAMBDA_CLASS_OPTIONS)
+            return caller.makeHiddenClassDefiner(lambdaClassName, classBytes, lambdaProxyClassFileDumper, NESTMATE_CLASS | STRONG_LOADER_LINK)
                          .defineClass(!disableEagerInitialization, classdata);
 
         } catch (Throwable t) {

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -77,7 +77,7 @@ import sun.invoke.util.Wrapper;
 
     private static final boolean disableEagerInitialization;
 
-    public static final MethodHandles.Lookup.ClassOption[] LAMBDA_CLASS_OPTIONS = { NESTMATE, STRONG };
+    private static final MethodHandles.Lookup.ClassOption[] LAMBDA_CLASS_OPTIONS = { NESTMATE, STRONG };
 
     static {
         // To dump the lambda proxy classes, set this system property:

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -77,6 +77,8 @@ import sun.invoke.util.Wrapper;
 
     private static final boolean disableEagerInitialization;
 
+    public static final MethodHandles.Lookup.ClassOption[] LAMBDA_CLASS_OPTIONS = { NESTMATE, STRONG };
+
     static {
         // To dump the lambda proxy classes, set this system property:
         //    -Djdk.invoke.LambdaMetafactory.dumpProxyClassFiles
@@ -348,7 +350,7 @@ import sun.invoke.util.Wrapper;
         try {
             // this class is linked at the indy callsite; so define a hidden nestmate
             var classdata = useImplMethodHandle? implementation : null;
-            return caller.makeHiddenClassDefiner(lambdaClassName, classBytes, Set.of(NESTMATE, STRONG), lambdaProxyClassFileDumper)
+            return caller.makeHiddenClassDefiner(lambdaClassName, classBytes, lambdaProxyClassFileDumper, LAMBDA_CLASS_OPTIONS)
                          .defineClass(!disableEagerInitialization, classdata);
 
         } catch (Throwable t) {

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -224,7 +224,7 @@ class InvokerBytecodeGenerator {
      * Extract the MemberName of a newly-defined method.
      */
     private MemberName loadMethod(byte[] classFile) {
-        Class<?> invokerClass = LOOKUP.makeHiddenClassDefiner(className, classFile, Set.of(), dumper())
+        Class<?> invokerClass = LOOKUP.makeHiddenClassDefiner(className, classFile, dumper())
                                       .defineClass(true, classDataValues());
         return resolveInvokerMember(invokerClass, invokerName, invokerType);
     }

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -47,7 +47,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import jdk.internal.constant.MethodTypeDescImpl;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1043,6 +1043,7 @@ abstract class MethodHandleImpl {
         private static final ClassDesc CD_Object_array = ReferenceClassDescImpl.ofValidated("[Ljava/lang/Object;");
         private static final MethodType INVOKER_MT = MethodType.methodType(Object.class, MethodHandle.class, Object[].class);
         private static final MethodType REFLECT_INVOKER_MT = MethodType.methodType(Object.class, MethodHandle.class, Object.class, Object[].class);
+        private static final Lookup.ClassOption[] INVOKER_CLASS_OPTIONS = { NESTMATE };
 
         static MethodHandle bindCaller(MethodHandle mh, Class<?> hostClass) {
             // Code in the boot layer should now be careful while creating method handles or
@@ -1111,7 +1112,7 @@ abstract class MethodHandleImpl {
                 }
                 name = name.replace('.', '/');
                 Class<?> invokerClass = new Lookup(targetClass)
-                        .makeHiddenClassDefiner(name, INJECTED_INVOKER_TEMPLATE, dumper(), NESTMATE)
+                        .makeHiddenClassDefiner(name, INJECTED_INVOKER_TEMPLATE, dumper(), INVOKER_CLASS_OPTIONS)
                         .defineClass(true, targetClass);
                 assert checkInjectedInvoker(targetClass, invokerClass);
                 return invokerClass;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -1111,7 +1111,7 @@ abstract class MethodHandleImpl {
                 }
                 name = name.replace('.', '/');
                 Class<?> invokerClass = new Lookup(targetClass)
-                        .makeHiddenClassDefiner(name, INJECTED_INVOKER_TEMPLATE, Set.of(NESTMATE), dumper())
+                        .makeHiddenClassDefiner(name, INJECTED_INVOKER_TEMPLATE, dumper(), NESTMATE)
                         .defineClass(true, targetClass);
                 assert checkInjectedInvoker(targetClass, invokerClass);
                 return invokerClass;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleImpl.java
@@ -64,6 +64,7 @@ import static java.lang.constant.ConstantDescs.*;
 import static java.lang.invoke.LambdaForm.*;
 import static java.lang.invoke.MethodHandleNatives.Constants.MN_CALLER_SENSITIVE;
 import static java.lang.invoke.MethodHandleNatives.Constants.MN_HIDDEN_MEMBER;
+import static java.lang.invoke.MethodHandleNatives.Constants.NESTMATE_CLASS;
 import static java.lang.invoke.MethodHandleStatics.*;
 import static java.lang.invoke.MethodHandles.Lookup.IMPL_LOOKUP;
 import static java.lang.invoke.MethodHandles.Lookup.ClassOption.NESTMATE;
@@ -1043,7 +1044,6 @@ abstract class MethodHandleImpl {
         private static final ClassDesc CD_Object_array = ReferenceClassDescImpl.ofValidated("[Ljava/lang/Object;");
         private static final MethodType INVOKER_MT = MethodType.methodType(Object.class, MethodHandle.class, Object[].class);
         private static final MethodType REFLECT_INVOKER_MT = MethodType.methodType(Object.class, MethodHandle.class, Object.class, Object[].class);
-        private static final Lookup.ClassOption[] INVOKER_CLASS_OPTIONS = { NESTMATE };
 
         static MethodHandle bindCaller(MethodHandle mh, Class<?> hostClass) {
             // Code in the boot layer should now be careful while creating method handles or
@@ -1112,7 +1112,7 @@ abstract class MethodHandleImpl {
                 }
                 name = name.replace('.', '/');
                 Class<?> invokerClass = new Lookup(targetClass)
-                        .makeHiddenClassDefiner(name, INJECTED_INVOKER_TEMPLATE, dumper(), INVOKER_CLASS_OPTIONS)
+                        .makeHiddenClassDefiner(name, INJECTED_INVOKER_TEMPLATE, dumper(), NESTMATE_CLASS)
                         .defineClass(true, targetClass);
                 assert checkInjectedInvoker(targetClass, invokerClass);
                 return invokerClass;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -285,7 +285,7 @@ public class MethodHandleProxies {
         byte[] template = createTemplate(loader, binaryNameToDesc(className),
                 referenceClassDesc(intfc), uniqueName, methods);
         // define the dynamic module to the class loader of the interface
-        var definer = new Lookup(intfc).makeHiddenClassDefiner(className, template, Set.of(), DUMPER);
+        var definer = new Lookup(intfc).makeHiddenClassDefiner(className, template, DUMPER);
 
         @SuppressWarnings("removal")
         var sm = System.getSecurityManager();

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1906,7 +1906,7 @@ public class MethodHandles {
                 this.flag = flag;
             }
 
-            static int optionsToFlag(Set<ClassOption> options) {
+            static int optionsToFlag(ClassOption ... options) {
                 int flags = 0;
                 for (ClassOption cp : options) {
                     flags |= cp.flag;
@@ -2133,7 +2133,7 @@ public class MethodHandles {
                 throw new IllegalAccessException(this + " does not have full privilege access");
             }
 
-            return makeHiddenClassDefiner(bytes.clone(), Set.of(options), false).defineClassAsLookup(initialize);
+            return makeHiddenClassDefiner(bytes.clone(), false, options).defineClassAsLookup(initialize);
         }
 
         /**
@@ -2220,7 +2220,7 @@ public class MethodHandles {
                 throw new IllegalAccessException(this + " does not have full privilege access");
             }
 
-            return makeHiddenClassDefiner(bytes.clone(), Set.of(options), false)
+            return makeHiddenClassDefiner(bytes.clone(), false, options.clone())
                        .defineClassAsLookup(initialize, classData);
         }
 
@@ -2366,7 +2366,7 @@ public class MethodHandles {
          */
         ClassDefiner makeHiddenClassDefiner(byte[] bytes, ClassFileDumper dumper) {
             ClassFile cf = ClassFile.newInstance(bytes, lookupClass().getPackageName());
-            return makeHiddenClassDefiner(cf, Set.of(), false, dumper);
+            return makeHiddenClassDefiner(cf, false, dumper);
         }
 
         /**
@@ -2386,10 +2386,10 @@ public class MethodHandles {
          * {@code bytes} denotes a class in a different package than the lookup class
          */
         private ClassDefiner makeHiddenClassDefiner(byte[] bytes,
-                                                    Set<ClassOption> options,
-                                                    boolean accessVmAnnotations) {
+                                                    boolean accessVmAnnotations,
+                                                    ClassOption ... options) {
             ClassFile cf = ClassFile.newInstance(bytes, lookupClass().getPackageName());
-            return makeHiddenClassDefiner(cf, options, accessVmAnnotations, defaultDumper());
+            return makeHiddenClassDefiner(cf, accessVmAnnotations, defaultDumper(), options);
         }
 
         /**
@@ -2402,10 +2402,10 @@ public class MethodHandles {
          * @param dumper  dumper to write the given bytes to the dumper's output directory
          * @return ClassDefiner that defines a hidden class of the given bytes and options.
          */
-        ClassDefiner makeHiddenClassDefiner(String name, byte[] bytes, Set<ClassOption> options, ClassFileDumper dumper) {
+        ClassDefiner makeHiddenClassDefiner(String name, byte[] bytes, ClassFileDumper dumper, ClassOption ... options) {
             Objects.requireNonNull(dumper);
             // skip name and access flags validation
-            return makeHiddenClassDefiner(ClassFile.newInstanceNoCheck(name, bytes), options, false, dumper);
+            return makeHiddenClassDefiner(ClassFile.newInstanceNoCheck(name, bytes), false, dumper, options);
         }
 
         /**
@@ -2418,9 +2418,9 @@ public class MethodHandles {
          * @param dumper dumper to write the given bytes to the dumper's output directory
          */
         private ClassDefiner makeHiddenClassDefiner(ClassFile cf,
-                                                    Set<ClassOption> options,
                                                     boolean accessVmAnnotations,
-                                                    ClassFileDumper dumper) {
+                                                    ClassFileDumper dumper,
+                                                    ClassOption ... options) {
             int flags = HIDDEN_CLASS | ClassOption.optionsToFlag(options);
             if (accessVmAnnotations | VM.isSystemDomainLoader(lookupClass.getClassLoader())) {
                 // jdk.internal.vm.annotations are permitted for classes

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1913,6 +1913,8 @@ public class MethodHandles {
                 }
                 return flags;
             }
+
+            private static final ClassOption[] NO_OPTIONS = new ClassOption[0];
         }
 
         /**
@@ -2366,7 +2368,7 @@ public class MethodHandles {
          */
         ClassDefiner makeHiddenClassDefiner(byte[] bytes, ClassFileDumper dumper) {
             ClassFile cf = ClassFile.newInstance(bytes, lookupClass().getPackageName());
-            return makeHiddenClassDefiner(cf, false, dumper);
+            return makeHiddenClassDefiner(cf, false, dumper, ClassOption.NO_OPTIONS);
         }
 
         /**
@@ -2390,6 +2392,21 @@ public class MethodHandles {
                                                     ClassOption[] options) {
             ClassFile cf = ClassFile.newInstance(bytes, lookupClass().getPackageName());
             return makeHiddenClassDefiner(cf, accessVmAnnotations, defaultDumper(), options);
+        }
+
+        /**
+         * Returns a ClassDefiner that creates a {@code Class} object of a hidden class
+         * from the given bytes and the given options.  No package name check on the given bytes.
+         *
+         * @param name    internal name that specifies the prefix of the hidden class
+         * @param bytes   class bytes
+         * @param dumper  dumper to write the given bytes to the dumper's output directory
+         * @return ClassDefiner that defines a hidden class of the given bytes and options.
+         */
+        ClassDefiner makeHiddenClassDefiner(String name, byte[] bytes, ClassFileDumper dumper) {
+            Objects.requireNonNull(dumper);
+            // skip name and access flags validation
+            return makeHiddenClassDefiner(ClassFile.newInstanceNoCheck(name, bytes), false, dumper, ClassOption.NO_OPTIONS);
         }
 
         /**

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2128,7 +2128,9 @@ public class MethodHandles {
                 throws IllegalAccessException
         {
             Objects.requireNonNull(bytes);
-            Objects.requireNonNull(options);
+
+            // Disallow null and duplicate options
+            Set.of(options);
 
             ensureDefineClassPermission();
             if (!hasFullPrivilegeAccess()) {
@@ -2215,7 +2217,9 @@ public class MethodHandles {
         {
             Objects.requireNonNull(bytes);
             Objects.requireNonNull(classData);
-            Objects.requireNonNull(options);
+
+            // Disallow null and duplicate options
+            Set.of(options);
 
             ensureDefineClassPermission();
             if (!hasFullPrivilegeAccess()) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2220,7 +2220,7 @@ public class MethodHandles {
                 throw new IllegalAccessException(this + " does not have full privilege access");
             }
 
-            return makeHiddenClassDefiner(bytes.clone(), false, options.clone())
+            return makeHiddenClassDefiner(bytes.clone(), false, options)
                        .defineClassAsLookup(initialize, classData);
         }
 

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2420,7 +2420,7 @@ public class MethodHandles {
         private ClassDefiner makeHiddenClassDefiner(ClassFile cf,
                                                     boolean accessVmAnnotations,
                                                     ClassFileDumper dumper,
-                                                    ClassOption ... options) {
+                                                    ClassOption[] options) {
             int flags = HIDDEN_CLASS | ClassOption.optionsToFlag(options);
             if (accessVmAnnotations | VM.isSystemDomainLoader(lookupClass.getClassLoader())) {
                 // jdk.internal.vm.annotations are permitted for classes

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2402,7 +2402,7 @@ public class MethodHandles {
          * @param dumper  dumper to write the given bytes to the dumper's output directory
          * @return ClassDefiner that defines a hidden class of the given bytes and options.
          */
-        ClassDefiner makeHiddenClassDefiner(String name, byte[] bytes, ClassFileDumper dumper, ClassOption ... options) {
+        ClassDefiner makeHiddenClassDefiner(String name, byte[] bytes, ClassFileDumper dumper, ClassOption... options) {
             Objects.requireNonNull(dumper);
             // skip name and access flags validation
             return makeHiddenClassDefiner(ClassFile.newInstanceNoCheck(name, bytes), false, dumper, options);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -2387,7 +2387,7 @@ public class MethodHandles {
          */
         private ClassDefiner makeHiddenClassDefiner(byte[] bytes,
                                                     boolean accessVmAnnotations,
-                                                    ClassOption ... options) {
+                                                    ClassOption[] options) {
             ClassFile cf = ClassFile.newInstance(bytes, lookupClass().getPackageName());
             return makeHiddenClassDefiner(cf, accessVmAnnotations, defaultDumper(), options);
         }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1906,7 +1906,7 @@ public class MethodHandles {
                 this.flag = flag;
             }
 
-            static int optionsToFlag(ClassOption ... options) {
+            static int optionsToFlag(ClassOption[] options) {
                 int flags = 0;
                 for (ClassOption cp : options) {
                     flags |= cp.flag;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -1909,12 +1909,13 @@ public class MethodHandles {
             static int optionsToFlag(ClassOption[] options) {
                 int flags = 0;
                 for (ClassOption cp : options) {
+                    if ((flags & cp.flag) != 0) {
+                        throw new IllegalArgumentException("Duplicate ClassOption " + cp);
+                    }
                     flags |= cp.flag;
                 }
                 return flags;
             }
-
-            private static final ClassOption[] NO_OPTIONS = new ClassOption[0];
         }
 
         /**
@@ -2128,16 +2129,13 @@ public class MethodHandles {
                 throws IllegalAccessException
         {
             Objects.requireNonNull(bytes);
-
-            // Disallow null and duplicate options
-            Set.of(options);
-
+            int flags = ClassOption.optionsToFlag(options);
             ensureDefineClassPermission();
             if (!hasFullPrivilegeAccess()) {
                 throw new IllegalAccessException(this + " does not have full privilege access");
             }
 
-            return makeHiddenClassDefiner(bytes.clone(), false, options).defineClassAsLookup(initialize);
+            return makeHiddenClassDefiner(bytes.clone(), false, flags).defineClassAsLookup(initialize);
         }
 
         /**
@@ -2218,15 +2216,14 @@ public class MethodHandles {
             Objects.requireNonNull(bytes);
             Objects.requireNonNull(classData);
 
-            // Disallow null and duplicate options
-            Set.of(options);
+            int flags = ClassOption.optionsToFlag(options);
 
             ensureDefineClassPermission();
             if (!hasFullPrivilegeAccess()) {
                 throw new IllegalAccessException(this + " does not have full privilege access");
             }
 
-            return makeHiddenClassDefiner(bytes.clone(), false, options)
+            return makeHiddenClassDefiner(bytes.clone(), false, flags)
                        .defineClassAsLookup(initialize, classData);
         }
 
@@ -2372,7 +2369,7 @@ public class MethodHandles {
          */
         ClassDefiner makeHiddenClassDefiner(byte[] bytes, ClassFileDumper dumper) {
             ClassFile cf = ClassFile.newInstance(bytes, lookupClass().getPackageName());
-            return makeHiddenClassDefiner(cf, false, dumper, ClassOption.NO_OPTIONS);
+            return makeHiddenClassDefiner(cf, false, dumper, 0);
         }
 
         /**
@@ -2384,7 +2381,7 @@ public class MethodHandles {
          * before calling this factory method.
          *
          * @param bytes   class bytes
-         * @param options class options
+         * @param flags   class option flag mask
          * @param accessVmAnnotations true to give the hidden class access to VM annotations
          * @return ClassDefiner that defines a hidden class of the given bytes and options
          *
@@ -2393,9 +2390,9 @@ public class MethodHandles {
          */
         private ClassDefiner makeHiddenClassDefiner(byte[] bytes,
                                                     boolean accessVmAnnotations,
-                                                    ClassOption[] options) {
+                                                    int flags) {
             ClassFile cf = ClassFile.newInstance(bytes, lookupClass().getPackageName());
-            return makeHiddenClassDefiner(cf, accessVmAnnotations, defaultDumper(), options);
+            return makeHiddenClassDefiner(cf, accessVmAnnotations, defaultDumper(), flags);
         }
 
         /**
@@ -2410,7 +2407,7 @@ public class MethodHandles {
         ClassDefiner makeHiddenClassDefiner(String name, byte[] bytes, ClassFileDumper dumper) {
             Objects.requireNonNull(dumper);
             // skip name and access flags validation
-            return makeHiddenClassDefiner(ClassFile.newInstanceNoCheck(name, bytes), false, dumper, ClassOption.NO_OPTIONS);
+            return makeHiddenClassDefiner(ClassFile.newInstanceNoCheck(name, bytes), false, dumper, 0);
         }
 
         /**
@@ -2419,14 +2416,14 @@ public class MethodHandles {
          *
          * @param name    internal name that specifies the prefix of the hidden class
          * @param bytes   class bytes
-         * @param options class options
+         * @param flags   class options flag mask
          * @param dumper  dumper to write the given bytes to the dumper's output directory
          * @return ClassDefiner that defines a hidden class of the given bytes and options.
          */
-        ClassDefiner makeHiddenClassDefiner(String name, byte[] bytes, ClassFileDumper dumper, ClassOption... options) {
+        ClassDefiner makeHiddenClassDefiner(String name, byte[] bytes, ClassFileDumper dumper, int flags) {
             Objects.requireNonNull(dumper);
             // skip name and access flags validation
-            return makeHiddenClassDefiner(ClassFile.newInstanceNoCheck(name, bytes), false, dumper, options);
+            return makeHiddenClassDefiner(ClassFile.newInstanceNoCheck(name, bytes), false, dumper, flags);
         }
 
         /**
@@ -2434,15 +2431,15 @@ public class MethodHandles {
          * from the given class file and options.
          *
          * @param cf ClassFile
-         * @param options class options
+         * @param flags class option flag mask
          * @param accessVmAnnotations true to give the hidden class access to VM annotations
          * @param dumper dumper to write the given bytes to the dumper's output directory
          */
         private ClassDefiner makeHiddenClassDefiner(ClassFile cf,
                                                     boolean accessVmAnnotations,
                                                     ClassFileDumper dumper,
-                                                    ClassOption[] options) {
-            int flags = HIDDEN_CLASS | ClassOption.optionsToFlag(options);
+                                                    int flags) {
+            flags |= HIDDEN_CLASS;
             if (accessVmAnnotations | VM.isSystemDomainLoader(lookupClass.getClassLoader())) {
                 // jdk.internal.vm.annotations are permitted for classes
                 // defined to boot loader and platform loader

--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -51,7 +51,6 @@ import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.ref.SoftReference;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 import java.util.function.Supplier;

--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1353,7 +1353,7 @@ public final class StringConcatFactory {
                             }
                     }});
             try {
-                var hiddenClass = lookup.makeHiddenClassDefiner(CLASS_NAME, classBytes, Set.of(), DUMPER)
+                var hiddenClass = lookup.makeHiddenClassDefiner(CLASS_NAME, classBytes, DUMPER)
                                         .defineClass(true, null);
 
                 if (staticConcat) {


### PR DESCRIPTION
Simple internal refactor to load a few classes less on startup. Arguably cleaner and avoids some iterator allocations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340131](https://bugs.openjdk.org/browse/JDK-8340131): Refactor internal makeHiddenClassDefiner to take option mask instead of Set&lt;ClassOption&gt; (**Sub-task** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21002/head:pull/21002` \
`$ git checkout pull/21002`

Update a local copy of the PR: \
`$ git checkout pull/21002` \
`$ git pull https://git.openjdk.org/jdk.git pull/21002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21002`

View PR using the GUI difftool: \
`$ git pr show -t 21002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21002.diff">https://git.openjdk.org/jdk/pull/21002.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21002#issuecomment-2349259571)