### PR TITLE
JDK-8339962 : Open source AWT TextField tests - Set1

### DIFF
--- a/test/jdk/java/awt/Label/ContainerValidateTest.java
+++ b/test/jdk/java/awt/Label/ContainerValidateTest.java
@@ -93,11 +93,11 @@ public class ContainerValidateTest extends Frame implements MouseListener {
     }
 
     private void testUI() throws Exception {
-        EventQueue.invokeAndWait(() ->
-                                         btnBounds = new Rectangle(btn1.getLocationOnScreen().x,
-                                                                   btn1.getLocationOnScreen().y,
-                                                                   btn1.getWidth(),
-                                                                   btn1.getHeight()));
+        EventQueue.invokeAndWait(() -> btnBounds
+                = new Rectangle(btn1.getLocationOnScreen().x,
+                                btn1.getLocationOnScreen().y,
+                                btn1.getWidth(),
+                                btn1.getHeight()));
         for (int i= 1; i < 4 ; i++) {
             EventQueue.invokeAndWait(() -> {
                 currentPanel = (Panel) this.getComponent(0);
@@ -139,7 +139,6 @@ public class ContainerValidateTest extends Frame implements MouseListener {
             }
         }
     }
-
 
     @Override
     public void mousePressed(MouseEvent evt) {

--- a/test/jdk/java/awt/Label/ContainerValidateTest.java
+++ b/test/jdk/java/awt/Label/ContainerValidateTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Panel;
+import java.awt.Rectangle;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.event.InputEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+
+/*
+ * @test
+ * @key headful
+ * @bug 4247913
+ * @summary Tests that Label repaints after call Container.validate()
+ * @run main ContainerValidateTest
+ */
+
+public class ContainerValidateTest extends Frame implements MouseListener {
+    private static Robot robot;
+    private static Panel currentPanel;
+    private static Button currentBtn;
+    private static Panel updatedPanel;
+    private static Label updatedLabel;
+    private static TextField updatedTxtField;
+    private static Button updatedBtn;
+
+    private static volatile Rectangle btnBounds;
+
+    Panel pnl1 = new Panel();
+    Panel pnl2 = new Panel();
+    Label lbl1 = new Label("Label 1");
+    Label lbl2 = new Label("Label 2");
+    TextField txt1 = new TextField("field1", 20);
+    TextField txt2 = new TextField("field2", 20);
+    Button btn1 = new Button("Swap 1");
+    Button btn2 = new Button("Swap 2");
+
+    public static void main(String[] args) throws Exception {
+        robot = new Robot();
+
+        ContainerValidateTest containerValidate = new ContainerValidateTest();
+        EventQueue.invokeAndWait(containerValidate::createAndShowUI);
+        robot.waitForIdle();
+        robot.delay(1000);
+
+        containerValidate.testUI();
+    }
+
+    private void createAndShowUI() {
+        this.setTitle("ContainerValidateTest Test");
+        pnl1.add(lbl1);
+        pnl1.add(txt1);
+        pnl1.add(btn1);
+
+        pnl2.add(lbl2);
+        pnl2.add(txt2);
+        pnl2.add(btn2);
+
+        btn1.addMouseListener(this);
+        btn2.addMouseListener(this);
+
+        this.add(pnl1, BorderLayout.CENTER);
+        pack();
+        setLocationRelativeTo(null);
+        setVisible(true);
+    }
+
+    private void testUI() throws Exception {
+        EventQueue.invokeAndWait(() ->
+                                         btnBounds = new Rectangle(btn1.getLocationOnScreen().x,
+                                                                   btn1.getLocationOnScreen().y,
+                                                                   btn1.getWidth(),
+                                                                   btn1.getHeight()));
+        for (int i= 1; i < 4 ; i++) {
+            EventQueue.invokeAndWait(() -> {
+                currentPanel = (Panel) this.getComponent(0);
+                currentBtn = (Button) currentPanel.getComponent(2);
+            });
+
+            robot.mouseMove(btnBounds.x + (int) btnBounds.getWidth() / 2,
+                            btnBounds.y + (int) btnBounds.getHeight() / 2);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.waitForIdle();
+            //large delay set for completion of UI validate()
+            robot.delay(500);
+
+            EventQueue.invokeAndWait(() -> {
+                updatedPanel = (Panel) this.getComponent(0);
+                updatedLabel = (Label) updatedPanel.getComponent(0);
+                updatedTxtField = (TextField) updatedPanel.getComponent(1);
+                updatedBtn = (Button) updatedPanel.getComponent(2);
+            });
+            testPanelComponents(currentBtn.getLabel());
+        }
+    }
+
+    private void testPanelComponents(String btnLabel) {
+        if (btnLabel.equals("Swap 1")) {
+            if (!(updatedLabel.getText().equals(lbl2.getText())
+                  && updatedTxtField.getText().equals(txt2.getText())
+                  && updatedBtn.getLabel().equals(btn2.getLabel()))) {
+                throw new RuntimeException("Test Failed!! Labels not repainted"
+                                           + " after Container.validate()");
+            }
+        } else {
+            if (!(updatedLabel.getText().equals(lbl1.getText())
+                  && updatedTxtField.getText().equals(txt1.getText())
+                  && updatedBtn.getLabel().equals(btn1.getLabel()))) {
+                throw new RuntimeException("Test Failed!! Labels not repainted"
+                                           + " after Container.validate()");
+            }
+        }
+    }
+
+
+    @Override
+    public void mousePressed(MouseEvent evt) {
+        if (evt.getComponent() instanceof Button btn) {
+            if (btn.equals(btn1)) {
+                remove(pnl1);
+                add(pnl2, BorderLayout.CENTER);
+            } else {
+                remove(pnl2);
+                add(pnl1, BorderLayout.CENTER);
+            }
+            invalidate();
+            validate();
+        }
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {}
+
+    @Override
+    public void mouseEntered(MouseEvent e) {}
+
+    @Override
+    public void mouseExited(MouseEvent e) {}
+
+    @Override
+    public void mouseClicked(MouseEvent e) {}
+}

--- a/test/jdk/java/awt/TextField/SetEchoCharTest.java
+++ b/test/jdk/java/awt/TextField/SetEchoCharTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.TextField;
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+
+import jdk.test.lib.Platform;
+
+/*
+ * @test
+ * @bug 4124697
+ * @key headful
+ * @summary Make sure that after setting and then changing the echo
+ *         character again, the TextField continues to function as expected.
+ * @library /test/lib
+ * @build jdk.test.lib.Platform
+ * @run main SetEchoCharTest
+ */
+
+public class SetEchoCharTest {
+    private static Frame frame;
+    private static Robot robot;
+    private static TextField tfPassword;
+    private static Button btn1;
+    private static Button btn2;
+    private static volatile Point btn1Loc;
+    private static volatile Point btn2Loc;
+
+    private static final String CHANGE = "Change echo char";
+    private static final String PRINT = "Print text";
+    private static final String INITIAL_TEXT = "DefaultPwd";
+    private static final String CHANGED_TEXT = "NewPwd";
+    private static final char NEW_ECHO_CHAR = '*';
+
+    public static void main(String[] args) throws Exception {
+        try {
+            robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.setAutoDelay(50);
+
+            EventQueue.invokeAndWait(() -> createAndShowUI());
+            robot.waitForIdle();
+            robot.delay(1000);
+
+            testEchoChar();
+            robot.waitForIdle();
+            robot.delay(200);
+
+            testNewEchoChar();
+            robot.waitForIdle();
+            robot.delay(200);
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
+        }
+    }
+
+    private static void createAndShowUI() {
+        frame = new Frame("SetEchoCharTest");
+        frame.setLayout(new FlowLayout());
+
+        Label label = new Label("Pwd:");
+        tfPassword = new TextField(INITIAL_TEXT, 10);
+        tfPassword.setEchoChar('X');
+        tfPassword.addActionListener((ActionListener) e -> {
+            if (e.getActionCommand().equals(CHANGED_TEXT)) {
+                //check the 2nd condition only if ActionEvent
+                //is triggered by changed text
+                if (!(tfPassword.getText().equals(CHANGED_TEXT)
+                    && tfPassword.getEchoChar() == NEW_ECHO_CHAR)) {
+                    throw new RuntimeException("Test Failed!!! TextField not working"
+                                               + " as expected after echo char change");
+                }
+            }
+        });
+        frame.add(label);
+        frame.add(tfPassword);
+
+        btn1 = new Button(PRINT);
+        btn1.addActionListener(new BtnActionListener());
+        frame.add(btn1);
+
+        btn2 = new Button(CHANGE);
+        btn2.addActionListener(new BtnActionListener());
+        frame.add(btn2);
+        frame.setSize(200,200);
+        frame.setLocationRelativeTo(null);
+        frame.setVisible(true);
+    }
+
+    private static void testEchoChar() throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            btn1Loc = btn1.getLocationOnScreen();
+            btn2Loc = btn2.getLocationOnScreen();
+        });
+
+        robot.mouseMove(btn1Loc.x + btn1.getWidth() / 2,
+                        btn1Loc.y + btn1.getHeight() / 2);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(1000);
+
+        robot.mouseMove(btn2Loc.x + btn2.getWidth() / 2,
+                        btn2Loc.y + btn2.getHeight() / 2);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(1000);
+    }
+
+    private static void testNewEchoChar() {
+        StringSelection stringSelection = new StringSelection(CHANGED_TEXT);
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(stringSelection, stringSelection);
+
+        int ctrlKey = Platform.isOSX() ? KeyEvent.VK_META : KeyEvent.VK_CONTROL;
+        robot.keyPress(ctrlKey);
+        robot.keyPress(KeyEvent.VK_V);
+        robot.keyRelease(KeyEvent.VK_V);
+        robot.keyRelease(ctrlKey);
+
+        robot.keyPress(KeyEvent.VK_ENTER);
+        robot.keyRelease(KeyEvent.VK_ENTER);
+    }
+
+    private static class BtnActionListener implements ActionListener {
+        public void actionPerformed(ActionEvent evt) {
+            String ac = evt.getActionCommand();
+            if (CHANGE.equals(ac)) {
+                tfPassword.setText("");
+                tfPassword.setEchoChar(NEW_ECHO_CHAR);
+                tfPassword.requestFocus();
+            }
+            if (PRINT.equals(ac)) {
+                if (!tfPassword.getText().equals(INITIAL_TEXT)) {
+                    throw new RuntimeException("Test Failed!!!"
+                                               + " Initial text not as expected");
+                }
+            }
+        }
+    }
+}
+

--- a/test/jdk/java/awt/TextField/SetEchoCharWordOpsTest.java
+++ b/test/jdk/java/awt/TextField/SetEchoCharWordOpsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Label;
+import java.awt.TextField;
+import javax.swing.JPanel;
+
+import jdk.test.lib.Platform;
+
+/*
+ * @test
+ * @bug 6191897
+ * @summary Verifies that ctrl+left/right does not move word-by-word in a TexField
+ *          with echo character set
+ * @library /java/awt/regtesthelpers  /test/lib
+ * @build PassFailJFrame jdk.test.lib.Platform
+ * @run main/manual SetEchoCharWordOpsTest
+ */
+
+public class SetEchoCharWordOpsTest {
+
+    public static void main(String[] args) throws Exception {
+        String selectAllKey;
+        String moveKeys;
+        String selectKeys;
+
+        if (Platform.isOSX()) {
+            selectAllKey = "Cmd + A";
+            moveKeys = "Alt + Right/Left";
+            selectKeys = "Shift + Alt + Right/Left";
+        } else {
+            selectAllKey = "Ctrl + A";
+            moveKeys = "Ctrl + Right/Left";
+            selectKeys = "Shift + Ctrl + Right/Left";
+        }
+
+        String instructions =
+                "The password field (in the bottom panel) in this test contains"
+                 + " a few words (3 words).\n"
+                 + "Move the focus to the text field and press " + selectAllKey + ".\n"
+                 + "Try moving the caret word-by-word with " + moveKeys + " or"
+                 + " extending selection with " + selectKeys + "."
+                 + " You should NOT be able to do that.\n\n"
+                 + "If you are able to move the caret word-by-word press FAIL,"
+                 + " else press PASS.";
+
+        PassFailJFrame.builder()
+                      .title("SetEchoCharClipboard Instructions")
+                      .instructions(instructions)
+                      .rows((int) instructions.lines().count() + 3)
+                      .columns(45)
+                      .splitUIBottom(SetEchoCharWordOpsTest::createAndShowUI)
+                      .build()
+                      .awaitAndCheck();
+    }
+
+
+    private static JPanel createAndShowUI() {
+        JPanel jPanel = new JPanel();
+        TextField tf = new TextField("one two three", 15);
+        Label tfLabel = new Label("Password Field:");
+
+        jPanel.setLayout(new FlowLayout());
+        tf.setEchoChar('*');
+        jPanel.add(tfLabel);
+        jPanel.add(tf);
+        return jPanel;
+    }
+}

--- a/test/jdk/java/awt/TextField/SetEchoCharWordOpsTest.java
+++ b/test/jdk/java/awt/TextField/SetEchoCharWordOpsTest.java
@@ -31,7 +31,7 @@ import jdk.test.lib.Platform;
 /*
  * @test
  * @bug 6191897
- * @summary Verifies that ctrl+left/right does not move word-by-word in a TexField
+ * @summary Verifies that ctrl+left/right does not move word-by-word in a TextField
  *          with echo character set
  * @library /java/awt/regtesthelpers  /test/lib
  * @build PassFailJFrame jdk.test.lib.Platform


### PR DESCRIPTION
Following test are open-sourced.

1. 	test/jdk/java/awt/Label/ContainerValidateTest.java - Automated
2. 	test/jdk/java/awt/TextField/SetEchoCharTest.java - Automated
3. 	test/jdk/java/awt/TextField/SetEchoCharWordOpsTest.java - PassFailJFrame manual test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339962](https://bugs.openjdk.org/browse/JDK-8339962): Open source AWT TextField tests - Set1 (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [fa890150](https://git.openjdk.org/jdk/pull/21005/files/fa890150e5fc7321c6051bf06869b993c8a8433f)
 * [Jayathirth D V](https://openjdk.org/census#jdv) (@jayathirthrao - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21005/head:pull/21005` \
`$ git checkout pull/21005`

Update a local copy of the PR: \
`$ git checkout pull/21005` \
`$ git pull https://git.openjdk.org/jdk.git pull/21005/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21005`

View PR using the GUI difftool: \
`$ git pr show -t 21005`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21005.diff">https://git.openjdk.org/jdk/pull/21005.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21005#issuecomment-2350452300)