### PR TITLE
8340171: CDS: Enhance bitmap truncation

### DIFF
--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -249,11 +249,16 @@ void ArchiveHeapWriter::copy_roots_to_buffer(GrowableArrayCHeap<oop, mtClassShar
   _heap_root_segments = segments;
 }
 
+// The goal is to sort the objects in increasing order of:
+// - objects that have only oop pointers
+// - objects that have both native and oop pointers
+// - objects that have only native pointers
+// - objects that have no pointers
 static int oop_sorting_rank(oop o) {
   bool has_oop_ptr, has_native_ptr;
   HeapShared::get_pointer_info(o, has_oop_ptr, has_native_ptr);
 
-  if (!has_oop_ptr) {
+  if (has_oop_ptr) {
     if (!has_native_ptr) {
       return 0;
     } else {
@@ -268,11 +273,6 @@ static int oop_sorting_rank(oop o) {
   }
 }
 
-// The goal is to sort the objects in increasing order of:
-// - objects that have no pointers
-// - objects that have only native pointers
-// - objects that have both native and oop pointers
-// - objects that have only oop pointers
 int ArchiveHeapWriter::compare_objs_by_oop_fields(HeapObjOrder* a, HeapObjOrder* b) {
   int rank_a = a->_rank;
   int rank_b = b->_rank;

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1581,39 +1581,47 @@ static size_t write_bitmap(const CHeapBitMap* map, char* output, size_t offset) 
   return offset + size_in_bytes;
 }
 
-// The start of the archived heap has many primitive arrays (String
-// bodies) that are not marked by the oop/ptr maps. So we must have
-// lots of leading zeros.
-size_t FileMapInfo::remove_bitmap_leading_zeros(CHeapBitMap* map) {
-  size_t old_zeros = map->find_first_set_bit(0);
+// The sorting code groups the objects with non-null oop/ptrs together.
+// Relevant bitmaps then have lots of leading and trailing zeros, which
+// we do not have to store.
+size_t FileMapInfo::remove_bitmap_zeros(CHeapBitMap* map) {
+  BitMap::idx_t first_set = map->find_first_set_bit(0);
+  BitMap::idx_t last_set  = map->find_last_set_bit(0);
   size_t old_size = map->size();
 
   // Slice and resize bitmap
-  map->truncate(old_zeros, map->size());
+  map->truncate(first_set, last_set + 1);
 
-  DEBUG_ONLY(
-    size_t new_zeros = map->find_first_set_bit(0);
-    assert(new_zeros == 0, "Should have removed leading zeros");
-  )
+  log_info(cds, map)("Truncated bitmap " PTR_FORMAT " " SIZE_FORMAT " -> " SIZE_FORMAT,
+                     p2i(map), old_size, last_set - first_set);
+
+  LogTarget(Info, cds, map) lt;
+  if (lt.is_enabled()) {
+    LogStream ls(lt);
+    map->print_on(&ls);
+  }
+
+  assert(map->at(0), "First bit should be set");
+  assert(map->at(map->size() - 1), "Last bit should be set");
   assert(map->size() <= old_size, "sanity");
-  return old_zeros;
+
+  return first_set;
 }
 
 char* FileMapInfo::write_bitmap_region(CHeapBitMap* rw_ptrmap, CHeapBitMap* ro_ptrmap, ArchiveHeapInfo* heap_info,
                                        size_t &size_in_bytes) {
-  size_t removed_rw_zeros = remove_bitmap_leading_zeros(rw_ptrmap);
-  size_t removed_ro_zeros = remove_bitmap_leading_zeros(ro_ptrmap);
-  header()->set_rw_ptrmap_start_pos(removed_rw_zeros);
-  header()->set_ro_ptrmap_start_pos(removed_ro_zeros);
+  size_t removed_rw_leading_zeros = remove_bitmap_zeros(rw_ptrmap);
+  size_t removed_ro_leading_zeros = remove_bitmap_zeros(ro_ptrmap);
+  header()->set_rw_ptrmap_start_pos(removed_rw_leading_zeros);
+  header()->set_ro_ptrmap_start_pos(removed_ro_leading_zeros);
   size_in_bytes = rw_ptrmap->size_in_bytes() + ro_ptrmap->size_in_bytes();
 
   if (heap_info->is_used()) {
-    // Remove leading zeros
-    size_t removed_oop_zeros = remove_bitmap_leading_zeros(heap_info->oopmap());
-    size_t removed_ptr_zeros = remove_bitmap_leading_zeros(heap_info->ptrmap());
-
-    header()->set_heap_oopmap_start_pos(removed_oop_zeros);
-    header()->set_heap_ptrmap_start_pos(removed_ptr_zeros);
+    // Remove leading and trailing zeros
+    size_t removed_oop_leading_zeros = remove_bitmap_zeros(heap_info->oopmap());
+    size_t removed_ptr_leading_zeros = remove_bitmap_zeros(heap_info->ptrmap());
+    header()->set_heap_oopmap_start_pos(removed_oop_leading_zeros);
+    header()->set_heap_ptrmap_start_pos(removed_ptr_leading_zeros);
 
     size_in_bytes += heap_info->oopmap()->size_in_bytes();
     size_in_bytes += heap_info->ptrmap()->size_in_bytes();

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1592,15 +1592,6 @@ size_t FileMapInfo::remove_bitmap_zeros(CHeapBitMap* map) {
   // Slice and resize bitmap
   map->truncate(first_set, last_set + 1);
 
-  log_info(cds, map)("Truncated bitmap " PTR_FORMAT " " SIZE_FORMAT " -> " SIZE_FORMAT,
-                     p2i(map), old_size, last_set - first_set);
-
-  LogTarget(Info, cds, map) lt;
-  if (lt.is_enabled()) {
-    LogStream ls(lt);
-    map->print_on(&ls);
-  }
-
   assert(map->at(0), "First bit should be set");
   assert(map->at(map->size() - 1), "Last bit should be set");
   assert(map->size() <= old_size, "sanity");

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -445,7 +445,7 @@ public:
   void  write_header();
   void  write_region(int region, char* base, size_t size,
                      bool read_only, bool allow_exec);
-  size_t remove_bitmap_leading_zeros(CHeapBitMap* map);
+  size_t remove_bitmap_zeros(CHeapBitMap* map);
   char* write_bitmap_region(CHeapBitMap* rw_ptrmap, CHeapBitMap* ro_ptrmap, ArchiveHeapInfo* heap_info,
                             size_t &size_in_bytes);
   size_t write_heap_region(ArchiveHeapInfo* heap_info);


### PR DESCRIPTION
Current CDS archive ships multiple bitmaps. Archival/loading code makes a useful optimization: it truncates the bitmaps at the beginning when it is known the prefix contains many zeroes. The object sorting code additionally sorts the pointer-rich objects at the end of the archive, increasing the zero-prefix length.

This optimization works less efficiently after [JDK-8338912](https://bugs.openjdk.org/browse/JDK-8338912), which moved the (pointer-rich) roots array at the beginning of the archive. We need to enhance current bitmap handling mechanism to truncate bitmaps better.

This PR does two things: a) enables bitmap truncation for both leading and trailing zeros; b) sorts the oop-rich objects at the beginning, where the oop-rich roots array is.

CDS archive sizes:

```
# Before JDK-8338912
$ ls -la build/linux-x86_64-server-release/images/jdk/lib/server/*.jsa
15450112 build/linux-x86_64-server-release/images/jdk/lib/server/classes.jsa
15851520 build/linux-x86_64-server-release/images/jdk/lib/server/classes_nocoops.jsa

# After JDK-8338912: +8..12K regression in size
$ ls -la build/linux-x86_64-server-release/images/jdk/lib/server/*.jsa
15462400 build/linux-x86_64-server-release/images/jdk/lib/server/classes.jsa
15859712 build/linux-x86_64-server-release/images/jdk/lib/server/classes_nocoops.jsa

# After this fix: recovered to pre-JDK-8338912 levels
$ ls -la build/linux-x86_64-server-release/images/jdk/lib/server/*.jsa
15450112 build/linux-x86_64-server-release/images/jdk/lib/server/classes.jsa
15851520 build/linux-x86_64-server-release/images/jdk/lib/server/classes_nocoops.jsa
```

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`, `tier1`
 - [x]  Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340171](https://bugs.openjdk.org/browse/JDK-8340171): CDS: Enhance bitmap truncation (**Enhancement** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21010/head:pull/21010` \
`$ git checkout pull/21010`

Update a local copy of the PR: \
`$ git checkout pull/21010` \
`$ git pull https://git.openjdk.org/jdk.git pull/21010/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21010`

View PR using the GUI difftool: \
`$ git pr show -t 21010`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21010.diff">https://git.openjdk.org/jdk/pull/21010.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21010#issuecomment-2352331151)