### PR TITLE
8340166: [REDO] CDS: Trim down minimum GC region alignment

### DIFF
--- a/src/hotspot/share/cds/archiveHeapWriter.hpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.hpp
@@ -111,11 +111,10 @@ class ArchiveHeapWriter : AllStatic {
 public:
   static const intptr_t NOCOOPS_REQUESTED_BASE = 0x10000000;
 
-  // The minimum region size of all collectors that are supported by CDS in
-  // ArchiveHeapLoader::can_map() mode. Currently only G1 is supported. G1's region size
-  // depends on -Xmx, but can never be smaller than 1 * M.
-  // (TODO: Perhaps change to 256K to be compatible with Shenandoah)
-  static constexpr int MIN_GC_REGION_ALIGNMENT = 1 * M;
+  // The minimum region size of all collectors that are supported by CDS.
+  // G1 heap region size can never be smaller than 1M.
+  // Shenandoah heap region size can never be smaller than 256K.
+  static constexpr int MIN_GC_REGION_ALIGNMENT = 256 * K;
 
 private:
   class EmbeddedOopRelocator;


### PR DESCRIPTION
Now that [JDK-8338912](https://bugs.openjdk.org/browse/JDK-8338912) is in, we can try to redo [JDK-8337828](https://bugs.openjdk.org/browse/JDK-8337828). See the rationale for this change in [JDK-8337828](https://bugs.openjdk.org/browse/JDK-8337828) PR: https://github.com/openjdk/jdk/pull/20469. This change is identical to that PR.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`
 - [x] Linux x86_64 server fastdebug, `runtime/cds` `-XX:-UseCompressedOops` (failed during the original attempt to do this)
 - [x] Linux x86_64 server fastdebug, `runtime/cds` `-XX:+UseShenandoahGC`
 - [x] Linux x86_64 server fastdebug, `runtime/cds` `-XX:+UseShenandoahGC -XX:-UseCompressedOops`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340166](https://bugs.openjdk.org/browse/JDK-8340166): [REDO] CDS: Trim down minimum GC region alignment (**Enhancement** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21011/head:pull/21011` \
`$ git checkout pull/21011`

Update a local copy of the PR: \
`$ git checkout pull/21011` \
`$ git pull https://git.openjdk.org/jdk.git pull/21011/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21011`

View PR using the GUI difftool: \
`$ git pr show -t 21011`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21011.diff">https://git.openjdk.org/jdk/pull/21011.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21011#issuecomment-2352390563)