### PR TITLE
8340176: Replace usage of -noclassgc with -Xnoclassgc in test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.java

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@
  * @bug     4982128
  * @summary Test low memory detection of non-heap memory pool
  *
- * @run main/othervm/timeout=600 -noclassgc -XX:MaxMetaspaceSize=32m
+ * @run main/othervm/timeout=600 -Xnoclassgc -XX:MaxMetaspaceSize=32m
  * LowMemoryTest2
  */
 
@@ -45,7 +45,7 @@
  * @bug     4982128
  * @summary Test low memory detection of non-heap memory pool
  *
- * @run main/othervm/timeout=600 -noclassgc -XX:MaxMetaspaceSize=16m
+ * @run main/othervm/timeout=600 -Xnoclassgc -XX:MaxMetaspaceSize=16m
  * -XX:CompressedClassSpaceSize=4m LowMemoryTest2
  */
 


### PR DESCRIPTION
Can I please get a review of this test-only change which replaces the usage of `-noclassgc` with `-Xnoclassgc` option when launching the test?

As noted in https://bugs.openjdk.org/browse/JDK-8340176, the `-noclassgc` is an undocumented option of the `java` launcher, which it converts to `-Xnoclassgc` before passing it to the JVM. Instead of that option, the documented `-Xnoclassgc` should be used.

No new test has been introduced and the modified test continues to pass after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340176](https://bugs.openjdk.org/browse/JDK-8340176): Replace usage of -noclassgc with -Xnoclassgc in test/jdk/java/lang/management/MemoryMXBean/LowMemoryTest2.java (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21012/head:pull/21012` \
`$ git checkout pull/21012`

Update a local copy of the PR: \
`$ git checkout pull/21012` \
`$ git pull https://git.openjdk.org/jdk.git pull/21012/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21012`

View PR using the GUI difftool: \
`$ git pr show -t 21012`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21012.diff">https://git.openjdk.org/jdk/pull/21012.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21012#issuecomment-2352416724)