### PR TITLE
8340183: Shenandoah: Incorrect match for clone barrier in is_gc_barrier_node

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -271,6 +271,11 @@ bool ShenandoahBarrierSetC2::is_shenandoah_wb_pre_call(Node* call) {
          call->as_CallLeaf()->entry_point() == CAST_FROM_FN_PTR(address, ShenandoahRuntime::write_ref_field_pre_entry);
 }
 
+bool ShenandoahBarrierSetC2::is_shenandoah_clone_call(Node* call) {
+  return call->is_CallLeaf() &&
+         call->as_CallLeaf()->entry_point() == CAST_FROM_FN_PTR(address, ShenandoahRuntime::shenandoah_clone_barrier);
+}
+
 bool ShenandoahBarrierSetC2::is_shenandoah_lrb_call(Node* call) {
   if (!call->is_CallLeaf()) {
     return false;
@@ -674,20 +679,10 @@ bool ShenandoahBarrierSetC2::is_gc_pre_barrier_node(Node* node) const {
   return is_shenandoah_wb_pre_call(node);
 }
 
-// Support for GC barriers emitted during parsing
 bool ShenandoahBarrierSetC2::is_gc_barrier_node(Node* node) const {
-  if (node->Opcode() == Op_ShenandoahLoadReferenceBarrier) return true;
-  if (node->Opcode() != Op_CallLeaf && node->Opcode() != Op_CallLeafNoFP) {
-    return false;
-  }
-  CallLeafNode *call = node->as_CallLeaf();
-  if (call->_name == nullptr) {
-    return false;
-  }
-
-  return strcmp(call->_name, "shenandoah_clone_barrier") == 0 ||
-         strcmp(call->_name, "shenandoah_cas_obj") == 0 ||
-         strcmp(call->_name, "shenandoah_wb_pre") == 0;
+  return is_shenandoah_lrb_call(node) ||
+         is_shenandoah_wb_pre_call(node) ||
+         is_shenandoah_clone_call(node);
 }
 
 Node* ShenandoahBarrierSetC2::step_over_gc_barrier(Node* c) const {

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.hpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.hpp
@@ -85,6 +85,7 @@ public:
   static ShenandoahBarrierSetC2* bsc2();
 
   static bool is_shenandoah_wb_pre_call(Node* call);
+  static bool is_shenandoah_clone_call(Node* call);
   static bool is_shenandoah_lrb_call(Node* call);
   static bool is_shenandoah_marking_if(PhaseValues* phase, Node* n);
   static bool is_shenandoah_state_load(Node* n);

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -414,7 +414,7 @@ void ShenandoahBarrierC2Support::verify(RootNode* root) {
         "cipherBlockChaining_decryptAESCrypt",
         { { TypeFunc::Parms, ShenandoahLoad },   { TypeFunc::Parms+1, ShenandoahStore },  { TypeFunc::Parms+2, ShenandoahLoad },
           { TypeFunc::Parms+3, ShenandoahLoad },  { -1,  ShenandoahNone},                 { -1,  ShenandoahNone} },
-        "shenandoah_clone_barrier",
+        "shenandoah_clone",
         { { TypeFunc::Parms, ShenandoahLoad },   { -1,  ShenandoahNone},                  { -1,  ShenandoahNone},
           { -1,  ShenandoahNone},                 { -1,  ShenandoahNone},                 { -1,  ShenandoahNone} },
         "ghash_processBlocks",


### PR DESCRIPTION
The name of the call we emit is "shenandoah_clone":
https://github.com/openjdk/jdk/blob/545951889c1ea68646be600decaf2bf4c049600b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp#L806

...yet we test for "shenandoah_clone_barrier" here:
https://github.com/openjdk/jdk/blob/545951889c1ea68646be600decaf2bf4c049600b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp#L688

I think we are better off polling the call target instead of relying on call name. This change also eliminates `shenandoah_cas_obj` matcher, for which we do not have the emitted call ever since we started doing CAS expansions inline.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [ ] Linux x86_64 server fastdebug, `all` with `-XX:+UseShenandoahGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340183](https://bugs.openjdk.org/browse/JDK-8340183): Shenandoah: Incorrect match for clone barrier in is_gc_barrier_node (**Bug** - P4)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21014/head:pull/21014` \
`$ git checkout pull/21014`

Update a local copy of the PR: \
`$ git checkout pull/21014` \
`$ git pull https://git.openjdk.org/jdk.git pull/21014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21014`

View PR using the GUI difftool: \
`$ git pr show -t 21014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21014.diff">https://git.openjdk.org/jdk/pull/21014.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21014#issuecomment-2352564035)