### PR TITLE
8340194: Replace usage of -ms with -Xms in LauncherCommon.gmk make file

### DIFF
--- a/make/common/modules/LauncherCommon.gmk
+++ b/make/common/modules/LauncherCommon.gmk
@@ -74,7 +74,7 @@ define SetupBuildLauncherBody
   endif
 
   ifneq ($$($1_MAIN_CLASS), )
-    $1_JAVA_ARGS += -ms8m
+    $1_JAVA_ARGS += -Xms8m
     $1_LAUNCHER_CLASS := -m $$($1_MAIN_MODULE)/$$($1_MAIN_CLASS)
   endif
 


### PR DESCRIPTION
Can I please get a review of this trivial change in the `LauncherCommon.gmk` file which replaces the use of the outdated `-ms` option with `-Xms`?

This is a cleanup prior to the effort of deprecating the outdated `-ms` launcher option for removal.

Local build on a macosx M1 passed with this change. CI build against various platforms is currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340194](https://bugs.openjdk.org/browse/JDK-8340194): Replace usage of -ms with -Xms in LauncherCommon.gmk make file (**Sub-task** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21017/head:pull/21017` \
`$ git checkout pull/21017`

Update a local copy of the PR: \
`$ git checkout pull/21017` \
`$ git pull https://git.openjdk.org/jdk.git pull/21017/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21017`

View PR using the GUI difftool: \
`$ git pr show -t 21017`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21017.diff">https://git.openjdk.org/jdk/pull/21017.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21017#issuecomment-2352674222)