### PR TITLE
8340200: Misspelled constant `AttributesProcessingOption.DROP_UNSTABLE_ATRIBUTES`

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/ClassFile.java
+++ b/src/java.base/share/classes/java/lang/classfile/ClassFile.java
@@ -295,7 +295,7 @@ public sealed interface ClassFile
         DROP_UNKNOWN_ATTRIBUTES,
 
         /** Drop unknown and unstable original attributes during transformation */
-        DROP_UNSTABLE_ATRIBUTES;
+        DROP_UNSTABLE_ATTRIBUTES
     }
 
     /**


### PR DESCRIPTION
Please review this small change to fix a misspelling. The constant is not used directly; rather it is used by ordinal, which explains why the error was not found sooner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8340201](https://bugs.openjdk.org/browse/JDK-8340201) to be approved

### Issues
 * [JDK-8340200](https://bugs.openjdk.org/browse/JDK-8340200): Misspelled constant `AttributesProcessingOption.DROP_UNSTABLE_ATRIBUTES` (**Bug** - P4)
 * [JDK-8340201](https://bugs.openjdk.org/browse/JDK-8340201): Misspelled constant `AttributesProcessingOption.DROP_UNSTABLE_ATRIBUTES` (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21020/head:pull/21020` \
`$ git checkout pull/21020`

Update a local copy of the PR: \
`$ git checkout pull/21020` \
`$ git pull https://git.openjdk.org/jdk.git pull/21020/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21020`

View PR using the GUI difftool: \
`$ git pr show -t 21020`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21020.diff">https://git.openjdk.org/jdk/pull/21020.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21020#issuecomment-2352856937)