### PR TITLE
JDK-8340210 : Add positionTestUI() to PassFailJFrame.Builder

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1270,11 +1270,6 @@ public final class PassFailJFrame {
             if (this.positionWindows != null) {
                 throw new IllegalStateException("PositionWindows is already set");
             }
-            if (windowListCreator == null || testWindows == null) {
-                throw new IllegalStateException("Neither a windows list creator "
-                                                + "nor a list of test windows "
-                                                + "has been provided");
-            }
             this.positionWindows = positionWindows;
             return this;
         }

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1251,6 +1251,35 @@ public final class PassFailJFrame {
         }
 
         /**
+         * Adds an implementation of {@link PositionWindows PositionWindows}
+         * which the framework will use to position multiple test UI windows.
+         *
+         * @param positionWindows an implementation of {@code PositionWindows}
+         *                        to position multiple test UI windows
+         * @return this builder
+         * @throws IllegalArgumentException if the {@code positionWindows}
+         *              parameter is {@code null}
+         * @throws IllegalStateException if the {@code positionWindows} field
+         *              is already set, or if neither a windows list creator
+         *              nor a list of test windows has been provided
+         */
+        public Builder positionTestUI(PositionWindows positionWindows) {
+            if (positionWindows == null) {
+                throw new IllegalArgumentException("positionWindows parameter can't be null");
+            }
+            if (this.positionWindows != null) {
+                throw new IllegalStateException("PositionWindows is already set");
+            }
+            if (windowListCreator == null || testWindows == null) {
+                throw new IllegalStateException("Neither a windows list creator "
+                                                + "nor a list of test windows "
+                                                + "has been provided");
+            }
+            this.positionWindows = positionWindows;
+            return this;
+        }
+
+        /**
          * Adds a {@code WindowListCreator} which the framework will use
          * to create a list of test UI windows.
          *

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -1260,8 +1260,7 @@ public final class PassFailJFrame {
          * @throws IllegalArgumentException if the {@code positionWindows}
          *              parameter is {@code null}
          * @throws IllegalStateException if the {@code positionWindows} field
-         *              is already set, or if neither a windows list creator
-         *              nor a list of test windows has been provided
+         *              is already set
          */
         public Builder positionTestUI(PositionWindows positionWindows) {
             if (positionWindows == null) {


### PR DESCRIPTION
`positionTestUI()` option is added to PassFailJFrame (PFJ).

With this change multiple UI can be positioned using the PFJ new builder pattern by providing implementation for the Functional Interface `PositionWindows.positionTestWindows(List<? extends Window> testWindows,InstructionUI instructionUI)` in the test code. 

Since the position implementation is done in test code it allows flexibility as the user can add custom positioning code as per test UI requirements.

Usage:
```
PassFailJFrame.builder()
                      .title("Test Instructions")
                      .instructions(INSTRUCTIONS)
                      .rows(int)
                      .columns(int)
                      .testUI(<TestClass::createAndShowUI>)
                      .positionTestUI(<TestClass::positionMultiTestUI>)
                      .build()
                      .awaitAndCheck();
```
where positionMultiTestUI is the implementation for positioning of multiple test windows for `PositionWindows.positionTestWindows(List<? extends Window> testWindows,InstructionUI instructionUI)`

@aivanov-jdk has demonstrated custom test UI positioning in this PR: 
**[8294156: Demo positioning of multiple test windows](https://github.com/openjdk/jdk/pull/15721)**

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340210](https://bugs.openjdk.org/browse/JDK-8340210): Add positionTestUI() to PassFailJFrame.Builder (**Enhancement** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Contributors
 * Alexey Ivanov `<aivanov@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21023/head:pull/21023` \
`$ git checkout pull/21023`

Update a local copy of the PR: \
`$ git checkout pull/21023` \
`$ git pull https://git.openjdk.org/jdk.git pull/21023/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21023`

View PR using the GUI difftool: \
`$ git pr show -t 21023`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21023.diff">https://git.openjdk.org/jdk/pull/21023.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21023#issuecomment-2353726197)