### PR TITLE
8340213: jcmd VM.events ignores max argument

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -899,7 +899,6 @@ void EventLogDCmd::execute(DCmdSource source, TRAPS) {
   int max = -1;
   if (max_value != nullptr) {
     char* endptr = nullptr;
-    int max;
     if (!parse_integer(max_value, &max)) {
       output()->print_cr("Invalid max option: \"%s\".", max_value);
       return;

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/EventsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/EventsTest.java
@@ -39,7 +39,7 @@ import org.testng.Assert;
  */
 public class EventsTest {
 
-    // MAX should be less then number of actually recored events
+    // MAX should be less than number of actually recorded events
     private static int MAX = 9;
 
     static String buildHeaderPattern(String logname) {

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/EventsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/EventsTest.java
@@ -39,7 +39,7 @@ import org.testng.Assert;
  */
 public class EventsTest {
 
-    // MAX should be less then naumber of actually recored events
+    // MAX should be less then number of actually recored events
     private static int MAX = 9;
 
     static String buildHeaderPattern(String logname) {

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/EventsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/EventsTest.java
@@ -76,6 +76,7 @@ public class EventsTest {
 
     public void run_max_selected(CommandExecutor executor) {
         OutputAnalyzer output = executor.execute("VM.events log=load max=" + MAX);
+        output.stdoutShouldMatch(buildHeaderPattern("Classes loaded"));
         long lines = output.asLines().stream().filter(x -> x.contains("Loading class")).count();
         Assert.assertTrue(lines == MAX, "There are should be " + MAX + " lines");
         output.stdoutShouldNotMatch(buildHeaderPattern("Events"));

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/EventsTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/EventsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,6 +25,7 @@ import jdk.test.lib.dcmd.CommandExecutor;
 import jdk.test.lib.dcmd.JMXExecutor;
 import jdk.test.lib.process.OutputAnalyzer;
 import org.testng.annotations.Test;
+import org.testng.Assert;
 
 /*
  * @test
@@ -37,6 +38,9 @@ import org.testng.annotations.Test;
  * @run testng  EventsTest
  */
 public class EventsTest {
+
+    // MAX should be less then naumber of actually recored events
+    private static int MAX = 9;
 
     static String buildHeaderPattern(String logname) {
         return "^" + logname + ".*\\(\\d+ events\\):";
@@ -64,9 +68,26 @@ public class EventsTest {
         output.stdoutShouldNotMatch(buildHeaderPattern("Classes unloaded"));
     }
 
+    public void run_max(CommandExecutor executor) {
+        OutputAnalyzer output = executor.execute("VM.events max=" + MAX);
+        long lines = output.asLines().stream().filter(x -> x.contains("Loading class")).count();
+        Assert.assertTrue(lines == MAX, "There are should be " + MAX + " lines");
+    }
+
+    public void run_max_selected(CommandExecutor executor) {
+        OutputAnalyzer output = executor.execute("VM.events log=load max=" + MAX);
+        long lines = output.asLines().stream().filter(x -> x.contains("Loading class")).count();
+        Assert.assertTrue(lines == MAX, "There are should be " + MAX + " lines");
+        output.stdoutShouldNotMatch(buildHeaderPattern("Events"));
+        output.stdoutShouldNotMatch(buildHeaderPattern("Compilation"));
+    }
+
+
     @Test
     public void jmx() {
         run_all(new JMXExecutor());
         run_selected(new JMXExecutor());
+        run_max(new JMXExecutor());
+        run_max_selected(new JMXExecutor());
     }
 }


### PR DESCRIPTION
The inner  'int max;' declaration hide previous max.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8340213: jcmd VM.events ignores max argument`

### Issue
 * [JDK-8340213](https://bugs.openjdk.org/browse/JDK-8340213): jcmd VM.events ignores max argument (**Bug** - P4)


### Reviewers
 * [Sonia Zaldana Calles](https://openjdk.org/census#szaldana) (@SoniaZaldana - Committer)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21024/head:pull/21024` \
`$ git checkout pull/21024`

Update a local copy of the PR: \
`$ git checkout pull/21024` \
`$ git pull https://git.openjdk.org/jdk.git pull/21024/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21024`

View PR using the GUI difftool: \
`$ git pr show -t 21024`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21024.diff">https://git.openjdk.org/jdk/pull/21024.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21024#issuecomment-2353730736)