### PR TITLE
8338405: JFR: Use FILE type for dcmds

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/AbstractDCmd.java
@@ -30,7 +30,6 @@ import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -287,42 +286,5 @@ abstract class AbstractDCmd {
         } else {
             return "/directory/recordings";
         }
-    }
-
-    static String expandFilename(String filename) {
-        if (filename == null || filename.indexOf('%') == -1) {
-            return filename;
-        }
-
-        String pid = null;
-        String time = null;
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < filename.length(); i++) {
-            char c = filename.charAt(i);
-            if (c == '%' && i < filename.length() - 1) {
-                char nc = filename.charAt(i + 1);
-                if (nc == '%') { // %% ==> %
-                    sb.append('%');
-                    i++;
-                } else if (nc == 'p') {
-                    if (pid == null) {
-                        pid = JVM.getPid();
-                    }
-                    sb.append(pid);
-                    i++;
-                } else if (nc == 't') {
-                    if (time == null) {
-                        time = ValueFormatter.formatDateTime(LocalDateTime.now());
-                    }
-                    sb.append(time);
-                    i++;
-                } else {
-                    sb.append('%');
-                }
-            } else {
-                sb.append(c);
-            }
-        }
-        return sb.toString();
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdDump.java
@@ -55,7 +55,7 @@ final class DCmdDump extends AbstractDCmd {
     public void execute(ArgumentParser parser) throws DCmdException {
         parser.checkUnknownArguments();
         String name = parser.getOption("name");
-        String filename = expandFilename(parser.getOption("filename"));
+        String filename = parser.getOption("filename");
         Long maxAge = parser.getOption("maxage");
         Long maxSize = parser.getOption("maxsize");
         String begin = parser.getOption("begin");
@@ -230,7 +230,7 @@ final class DCmdDump extends AbstractDCmd {
                                   dumped. If no filename is given, a filename is generated from the PID
                                   and the current date. The filename may also be a directory in which
                                   case, the filename is generated from the PID and the current date in
-                                  the specified directory. (STRING, no default value)
+                                  the specified directory. (FILE, no default value)
 
                                   Note: If a filename is given, '%%p' in the filename will be
                                   replaced by the PID, and '%%t' will be replaced by the time in
@@ -284,7 +284,7 @@ final class DCmdDump extends AbstractDCmd {
                "STRING", false, true, null, false),
            new Argument("filename",
                "Copy recording data to file, e.g. \\\"" + exampleFilename() + "\\\"",
-               "STRING", false, true, null, false),
+               "FILE", false, true, null, false),
            new Argument("maxage",
                "Maximum duration to dump, in (s)econds, (m)inutes, (h)ours, or (d)ays, e.g. 60m, or 0 for no limit",
                "NANOTIME", false, true, null, false),

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -80,7 +80,7 @@ final class DCmdStart extends AbstractDCmd {
         Long delay = parser.getOption("delay");
         Long duration = parser.getOption("duration");
         Boolean disk = parser.getOption("disk");
-        String path = expandFilename(parser.getOption("filename"));
+        String path = parser.getOption("filename");
         Long maxAge = parser.getOption("maxage");
         Long maxSize = parser.getOption("maxsize");
         Long flush = parser.getOption("flush-interval");
@@ -377,7 +377,7 @@ final class DCmdStart extends AbstractDCmd {
                                   placed in the directory where the process was started. The
                                   filename may also be a directory in which case, the filename is
                                   generated from the PID and the current date in the specified
-                                  directory. (STRING, no default value)
+                                  directory. (FILE, no default value)
 
                                   Note: If a filename is given, '%p' in the filename will be
                                   replaced by the PID, and '%t' will be replaced by the time in
@@ -501,7 +501,7 @@ final class DCmdStart extends AbstractDCmd {
                 "BOOLEAN", false, true, "true", false),
             new Argument("filename",
                 "Resulting recording filename, e.g. \\\"" + exampleFilename() +  "\\\"",
-                "STRING", false, true, "hotspot-pid-xxxxx-id-y-YYYY_MM_dd_HH_mm_ss.jfr", false),
+                "FILE", false, true, "hotspot-pid-xxxxx-id-y-YYYY_MM_dd_HH_mm_ss.jfr", false),
             new Argument("maxage",
                 "Maximum time to keep recorded data (on disk) in (s)econds, (m)inutes, (h)ours, or (d)ays, e.g. 60m, or 0 for no limit",
                 "NANOTIME", false, true, "0", false),

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStop.java
@@ -44,7 +44,7 @@ final class DCmdStop extends AbstractDCmd {
     protected void execute(ArgumentParser parser)  throws DCmdException {
         parser.checkUnknownArguments();
         String name = parser.getOption("name");
-        String filename = expandFilename(parser.getOption("filename"));
+        String filename = parser.getOption("filename");
         try {
             Recording recording = findRecording(name);
             WriteableUserPath path = PrivateAccess.getInstance().getPlatformRecording(recording).getDestination();
@@ -80,7 +80,7 @@ final class DCmdStop extends AbstractDCmd {
 
                  filename  (Optional) Name of the file to which the recording is written when the
                            recording is stopped. If no path is provided, the data from the recording
-                           is discarded. (STRING, no default value)
+                           is discarded. (FILE, no default value)
 
                            Note: If a path is given, '%%p' in the path will be replaced by the PID,
                            and '%%t' will be replaced by the time in 'yyyy_MM_dd_HH_mm_ss' format.
@@ -107,7 +107,7 @@ final class DCmdStop extends AbstractDCmd {
                 "STRING", true, true, null, false),
             new Argument("filename",
                 "Copy recording data to file, e.g. \\\"" + exampleFilename() +  "\\\"",
-                "STRING", false, true, null, false)
+                "FILE", false, true, null, false)
         };
     }
 }


### PR DESCRIPTION
Hi all, 

This PR addresses [8338405](https://bugs.openjdk.org/browse/JDK-8338405) switching `STRING` to `FILE` for JFR.start, JFR.stop and JFR.dump where appropriate. 

This is consistent with the new `FILE` type that was introduced in [8334492](https://bugs.openjdk.org/browse/JDK-8334492).

Testing:
- [x] JFR test suite passes 
- [x] GHA 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338405](https://bugs.openjdk.org/browse/JDK-8338405): JFR: Use FILE type for dcmds (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21025/head:pull/21025` \
`$ git checkout pull/21025`

Update a local copy of the PR: \
`$ git checkout pull/21025` \
`$ git pull https://git.openjdk.org/jdk.git pull/21025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21025`

View PR using the GUI difftool: \
`$ git pr show -t 21025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21025.diff">https://git.openjdk.org/jdk/pull/21025.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21025#issuecomment-2356174290)