### PR TITLE
8340132: Remove internal CpException for reading malformed utf8

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/AbstractPoolEntry.java
@@ -24,6 +24,7 @@
  */
 package jdk.internal.classfile.impl;
 
+import java.lang.classfile.constantpool.ConstantPoolException;
 import java.lang.constant.*;
 import java.lang.invoke.TypeDescriptor;
 import java.nio.charset.StandardCharsets;
@@ -258,11 +259,11 @@ public abstract sealed class AbstractPoolEntry {
                             // 110x xxxx  10xx xxxx
                             px += 2;
                             if (px > utfend) {
-                                throw new CpException("malformed input: partial character at end");
+                                throw malformedInput(utfend);
                             }
                             int char2 = rawBytes[px - 1];
                             if ((char2 & 0xC0) != 0x80) {
-                                throw new CpException("malformed input around byte " + px);
+                                throw malformedInput(px);
                             }
                             char v = (char) (((c & 0x1F) << 6) | (char2 & 0x3F));
                             chararr[chararr_count++] = v;
@@ -273,12 +274,12 @@ public abstract sealed class AbstractPoolEntry {
                             // 1110 xxxx  10xx xxxx  10xx xxxx
                             px += 3;
                             if (px > utfend) {
-                                throw new CpException("malformed input: partial character at end");
+                                throw malformedInput(utfend);
                             }
                             int char2 = rawBytes[px - 2];
                             int char3 = rawBytes[px - 1];
                             if (((char2 & 0xC0) != 0x80) || ((char3 & 0xC0) != 0x80)) {
-                                throw new CpException("malformed input around byte " + (px - 1));
+                                throw malformedInput(px - 1);
                             }
                             char v = (char) (((c & 0x0F) << 12) | ((char2 & 0x3F) << 6) | (char3 & 0x3F));
                             chararr[chararr_count++] = v;
@@ -287,7 +288,7 @@ public abstract sealed class AbstractPoolEntry {
                         }
                         default:
                             // 10xx xxxx,  1111 xxxx
-                            throw new CpException("malformed input around byte " + px);
+                            throw malformedInput(px);
                     }
                 }
                 this.hash = hashString(hash);
@@ -295,7 +296,10 @@ public abstract sealed class AbstractPoolEntry {
                 this.chars = chararr;
                 state = State.CHAR;
             }
+        }
 
+        private ConstantPoolException malformedInput(int px) {
+            return new ConstantPoolException("#%d: malformed modified UTF8 around byte %d".formatted(index(), px));
         }
 
         @Override
@@ -1132,14 +1136,6 @@ public abstract sealed class AbstractPoolEntry {
                 return doubleValue() == e.doubleValue();
             }
             return false;
-        }
-    }
-
-    static class CpException extends RuntimeException {
-        static final long serialVersionUID = 32L;
-
-        CpException(String s) {
-            super(s);
         }
     }
 }


### PR DESCRIPTION
Remove an internal exception for invalid utf8 entry format; it should have been an IllegalArgumentException but was an arbitrary subtype of RuntimeException. Converted to throw ConstantPoolException, and consolidated into a single method to reduce code size.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340132](https://bugs.openjdk.org/browse/JDK-8340132): Remove internal CpException for reading malformed utf8 (**Bug** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21027/head:pull/21027` \
`$ git checkout pull/21027`

Update a local copy of the PR: \
`$ git checkout pull/21027` \
`$ git pull https://git.openjdk.org/jdk.git pull/21027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21027`

View PR using the GUI difftool: \
`$ git pr show -t 21027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21027.diff">https://git.openjdk.org/jdk/pull/21027.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21027#issuecomment-2354433881)