### PR TITLE
8340233: Missed ThreadWXEnable in jfrNativeLibraryLoadEvent.cpp

### DIFF
--- a/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrNativeLibraryLoadEvent.cpp
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+* Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
 * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 *
 * This code is free software; you can redistribute it and/or modify it
@@ -117,6 +117,7 @@ static void commit(const HelperType& helper) {
     JavaThread* jt = JavaThread::cast(thread);
     if (jt->thread_state() == _thread_in_native) {
       // For a JavaThread to take a JFR stacktrace, it must be in _thread_in_vm. Can safepoint here.
+      MACOS_AARCH64_ONLY(ThreadWXEnable __wx(WXWrite, jt));
       ThreadInVMfromNative transition(jt);
       event.commit();
       return;


### PR DESCRIPTION
The bug is reproduced and fix verified by running 
java/lang/ClassLoader/loadLibraryUnload/LoadLibraryUnloadTest.java with JFR enabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340233](https://bugs.openjdk.org/browse/JDK-8340233): Missed ThreadWXEnable in jfrNativeLibraryLoadEvent.cpp (**Bug** - P4)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21028/head:pull/21028` \
`$ git checkout pull/21028`

Update a local copy of the PR: \
`$ git checkout pull/21028` \
`$ git pull https://git.openjdk.org/jdk.git pull/21028/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21028`

View PR using the GUI difftool: \
`$ git pr show -t 21028`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21028.diff">https://git.openjdk.org/jdk/pull/21028.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21028#issuecomment-2354473698)