### PR TITLE
8339984: Open source AWT MenuItem related tests

### DIFF
--- a/test/jdk/java/awt/MenuItem/GiantFontTest.java
+++ b/test/jdk/java/awt/MenuItem/GiantFontTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+/*
+ * @test
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests menu item font is big
+ * @run main/manual GiantFontTest
+ */
+
+public class GiantFontTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                        A frame with one menu will appear.
+                        On Solaris, the menu's font should be quite large (48 point).
+                        If not, test fails.
+
+                        On Windows, the font should be normal size.  If so, test passes.
+                        If the menu text is clipped by the title bar, or is painted over
+                        the title bar or client area, the test fails.""";
+
+        PassFailJFrame.builder()
+                .title("GiantFontTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testTimeOut(5)
+                .testUI(GiantFontTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createAndShowUI() {
+        Font giantFont = new Font("Dialog", Font.PLAIN, 48);
+        Frame f = new Frame("GiantFontTest");
+        MenuBar mb = new MenuBar();
+        Menu m = new Menu("My font is too big!");
+        m.setFont(giantFont);
+        for (int i = 0; i < 5; i++) {
+            m.add(new MenuItem("Some MenuItems"));
+        }
+        mb.add(m);
+        f.setMenuBar(mb);
+        f.setSize (450, 400);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/MenuItem/GiantFontTest.java
+++ b/test/jdk/java/awt/MenuItem/GiantFontTest.java
@@ -44,8 +44,12 @@ public class GiantFontTest {
                         be quite large (48 point).
                         If not, test fails.
 
-                        On Windows and Mac, the menu's (present on menu bar) font
+                        On Windows, the menu's (present on menu bar) font
                         should be normal size.
+
+                        On both Windows and Linux, the menu items in the popup
+                        menu should be large.
+                        
                         If so, test passes.
                         If the menu text is clipped by the title bar, or is painted over
                         the title bar or client area, the test fails.""";

--- a/test/jdk/java/awt/MenuItem/GiantFontTest.java
+++ b/test/jdk/java/awt/MenuItem/GiantFontTest.java
@@ -52,7 +52,6 @@ public class GiantFontTest {
                 .instructions(INSTRUCTIONS)
                 .rows((int) INSTRUCTIONS.lines().count() + 2)
                 .columns(40)
-                .testTimeOut(5)
                 .testUI(GiantFontTest::createAndShowUI)
                 .build()
                 .awaitAndCheck();
@@ -69,7 +68,7 @@ public class GiantFontTest {
         }
         mb.add(m);
         f.setMenuBar(mb);
-        f.setSize (450, 400);
+        f.setSize(450, 400);
         return f;
     }
 }

--- a/test/jdk/java/awt/MenuItem/GiantFontTest.java
+++ b/test/jdk/java/awt/MenuItem/GiantFontTest.java
@@ -29,6 +29,7 @@ import java.awt.MenuItem;
 
 /*
  * @test
+ * @requires os.family != "mac"
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Tests menu item font is big

--- a/test/jdk/java/awt/MenuItem/GiantFontTest.java
+++ b/test/jdk/java/awt/MenuItem/GiantFontTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,6 +29,7 @@ import java.awt.MenuItem;
 
 /*
  * @test
+ * @bug 4700350
  * @requires os.family != "mac"
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
@@ -50,7 +51,7 @@ public class GiantFontTest {
 
                         On both Windows and Linux, the menu items in the popup
                         menu should be large.
-                        
+
                         If so, test passes.
                         If the menu text is clipped by the title bar, or is painted over
                         the title bar or client area, the test fails.""";

--- a/test/jdk/java/awt/MenuItem/GiantFontTest.java
+++ b/test/jdk/java/awt/MenuItem/GiantFontTest.java
@@ -40,10 +40,12 @@ public class GiantFontTest {
     public static void main(String[] args) throws Exception {
         String INSTRUCTIONS = """
                         A frame with one menu will appear.
-                        On Solaris, the menu's font should be quite large (48 point).
+                        On Solaris, the menu's (present on menu bar) font should
+                        be quite large (48 point).
                         If not, test fails.
 
-                        On Windows, the font should be normal size.  If so, test passes.
+                        On Windows, the menu's (present on menu bar) font should be normal size.
+                        If so, test passes.
                         If the menu text is clipped by the title bar, or is painted over
                         the title bar or client area, the test fails.""";
 

--- a/test/jdk/java/awt/MenuItem/GiantFontTest.java
+++ b/test/jdk/java/awt/MenuItem/GiantFontTest.java
@@ -48,13 +48,13 @@ public class GiantFontTest {
 
                         On Windows, the menu's (present on menu bar) font
                         should be normal size.
+                        If the menu text is clipped by the title bar, or is painted over
+                        the title bar or client area, the test fails.
 
                         On both Windows and Linux, the menu items in the popup
                         menu should be large.
 
-                        If so, test passes.
-                        If the menu text is clipped by the title bar, or is painted over
-                        the title bar or client area, the test fails.""";
+                        If so, test passes.""";
 
         PassFailJFrame.builder()
                 .title("GiantFontTest")

--- a/test/jdk/java/awt/MenuItem/GiantFontTest.java
+++ b/test/jdk/java/awt/MenuItem/GiantFontTest.java
@@ -40,11 +40,12 @@ public class GiantFontTest {
     public static void main(String[] args) throws Exception {
         String INSTRUCTIONS = """
                         A frame with one menu will appear.
-                        On Solaris, the menu's (present on menu bar) font should
+                        On Linux, the menu's (present on menu bar) font should
                         be quite large (48 point).
                         If not, test fails.
 
-                        On Windows, the menu's (present on menu bar) font should be normal size.
+                        On Windows and Mac, the menu's (present on menu bar) font
+                        should be normal size.
                         If so, test passes.
                         If the menu text is clipped by the title bar, or is painted over
                         the title bar or client area, the test fails.""";

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.Rectangle;
+import java.awt.event.ComponentEvent;
+import java.awt.event.ComponentListener;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * @test
+ * @bug 4175790
+ * @requires os.family == "windows"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Win32: Running out of command ids for menu items
+ * @run main/manual LotsOfMenuItemsTest
+ */
+
+public class LotsOfMenuItemsTest implements ComponentListener {
+    private static final int NUM_WINDOWS = 400;
+    private static TestFrame firstFrame, testFrame;
+    private static Rectangle rect;
+
+    public static void main(String[] args) throws Exception {
+        LotsOfMenuItemsTest obj = new LotsOfMenuItemsTest();
+        String INSTRUCTIONS = """
+                This test creates a lots of frames with menubars.
+                When it's done you will see two frames.
+                Try to select menu items from each of them.
+
+                If everything seems to work - test passed.
+                Click "Done" button in the test harness window.
+
+                If test crashes on you - test failed.""";
+
+        PassFailJFrame.builder()
+                .title("LotsOfMenuItemsTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testTimeOut(5)
+                .testUI(obj.createAndShowUI())
+                .build()
+                .awaitAndCheck();
+    }
+
+    private List<? extends Frame> createAndShowUI() {
+        List<Frame> list = new ArrayList<>();
+        firstFrame = new TestFrame("First frame");
+        firstFrame.addComponentListener(this);
+
+        for (int i = 1; i < NUM_WINDOWS; ++i) {
+            testFrame = new TestFrame("Running(" + i + ")...");
+            if (i != (NUM_WINDOWS - 1)) {
+                testFrame.setVisible(false);
+                testFrame.dispose();
+            } else {
+                testFrame.setTitle("Last Frame");
+            }
+        }
+        list.add(firstFrame);
+        list.add(testFrame);
+        return list;
+    }
+    public void componentMoved(ComponentEvent e) {}
+
+    public void componentHidden(ComponentEvent e) {}
+
+    public void componentShown(ComponentEvent e) {
+        firstFrame.setLocation(970, 350);
+        testFrame.setLocation(970, 510);
+    }
+
+    public void componentResized(ComponentEvent e) {}
+}
+
+class TestFrame extends Frame {
+    static int n = 0;
+
+    public TestFrame(String title) {
+        super(title);
+        MenuBar mb = new MenuBar();
+        for (int i = 0; i < 10; ++i) {
+            Menu m = new Menu("Menu_" + (i + 1));
+            for (int j = 0; j < 20; ++j) {
+                MenuItem mi = new MenuItem("Menu item " + ++n);
+                m.add(mi);
+            }
+            mb.add(m);
+        }
+        setMenuBar(mb);
+        setSize(450, 150);
+    }
+}

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -48,7 +48,7 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
     public static void main(String[] args) throws Exception {
         LotsOfMenuItemsTest obj = new LotsOfMenuItemsTest();
         String INSTRUCTIONS = """
-                This test creates lots of frames with menubars.
+                This test creates lots of frames with menu bars.
                 When it's done you will see two frames.
                 Try to select menu items from each of them.
 

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -62,7 +62,7 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
                 .instructions(INSTRUCTIONS)
                 .rows((int) INSTRUCTIONS.lines().count() + 2)
                 .columns(40)
-                .testUI(obj.createAndShowUI())
+                .testUI(obj::createAndShowUI)
                 .build()
                 .awaitAndCheck();
     }
@@ -80,6 +80,7 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
         return List.of(firstFrame, testFrame);
     }
 
+    @Override
     public void componentShown(ComponentEvent e) {
         PassFailJFrame.positionTestWindow(firstFrame,
                 PassFailJFrame.Position.HORIZONTAL);

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -66,21 +66,22 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
     }
 
     private Frame createAndShowUI() {
-        firstFrame = new TestFrame("First frame", false);
+        firstFrame = new TestFrame("First frame");
         firstFrame.addComponentListener(this);
         return firstFrame;
     }
 
     @Override
     public void componentShown(ComponentEvent e) {
+        final int x = firstFrame.getX();
+        final int y = firstFrame.getY() + firstFrame.getHeight() + 8;
+
         for (int i = 1; i < NUM_WINDOWS - 1; ++i) {
-            testFrame = new TestFrame("Running(" + i + ")...");
+            testFrame = new TestFrame("Running(" + i + ")...", x, y);
             testFrame.setVisible(false);
             testFrame.dispose();
         }
-        testFrame = new TestFrame("Last Frame");
-        testFrame.setLocation(firstFrame.getX(),
-                firstFrame.getY() + firstFrame.getHeight() + 8);
+        testFrame = new TestFrame("Last Frame", x, y);
         PassFailJFrame.addTestWindow(testFrame);
     }
 
@@ -88,10 +89,14 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
         static int n = 0;
 
         public TestFrame(String title) {
-            this(title, true);
+            this(title, 0, 0, false);
         }
 
-        public TestFrame(String title, boolean visible) {
+        public TestFrame(String s, int x, int y) {
+            this(s, x, y, true);
+        }
+
+        private TestFrame(String title, int x, int y, boolean visible) {
             super(title);
             MenuBar mb = new MenuBar();
             for (int i = 0; i < 10; ++i) {
@@ -103,6 +108,7 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
                 mb.add(m);
             }
             setMenuBar(mb);
+            setLocation(x, y);
             setSize(450, 150);
             if (visible) {
                 setVisible(true);

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -72,10 +72,9 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
 
     @Override
     public void componentShown(ComponentEvent e) {
-        TestFrame testFrame;
         final int x = firstFrame.getX();
         final int y = firstFrame.getY() + firstFrame.getHeight() + 8;
-
+        TestFrame testFrame;
         for (int i = 1; i < NUM_WINDOWS - 1; ++i) {
             testFrame = new TestFrame("Running(" + i + ")...", x, y);
             testFrame.setVisible(false);

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -28,8 +28,6 @@ import java.awt.MenuItem;
 import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 
-import java.util.List;
-
 /*
  * @test
  * @bug 4175790
@@ -67,31 +65,33 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
                 .awaitAndCheck();
     }
 
-    private List<Frame> createAndShowUI() {
-        firstFrame = new TestFrame("First frame");
+    private Frame createAndShowUI() {
+        firstFrame = new TestFrame("First frame", false);
         firstFrame.addComponentListener(this);
+        return firstFrame;
+    }
 
+    @Override
+    public void componentShown(ComponentEvent e) {
         for (int i = 1; i < NUM_WINDOWS - 1; ++i) {
             testFrame = new TestFrame("Running(" + i + ")...");
             testFrame.setVisible(false);
             testFrame.dispose();
         }
         testFrame = new TestFrame("Last Frame");
-        return List.of(firstFrame, testFrame);
-    }
-
-    @Override
-    public void componentShown(ComponentEvent e) {
-        PassFailJFrame.positionTestWindow(firstFrame,
-                PassFailJFrame.Position.HORIZONTAL);
         testFrame.setLocation(firstFrame.getX(),
                 firstFrame.getY() + firstFrame.getHeight() + 8);
+        PassFailJFrame.addTestWindow(testFrame);
     }
 
     private static class TestFrame extends Frame {
         static int n = 0;
 
         public TestFrame(String title) {
+            this(title, true);
+        }
+
+        public TestFrame(String title, boolean visible) {
             super(title);
             MenuBar mb = new MenuBar();
             for (int i = 0; i < 10; ++i) {
@@ -104,6 +104,9 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
             }
             setMenuBar(mb);
             setSize(450, 150);
+            if (visible) {
+                setVisible(true);
+            }
         }
     }
 }

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -41,7 +41,6 @@ import java.awt.event.ComponentEvent;
 public class LotsOfMenuItemsTest extends ComponentAdapter {
     private static final int NUM_WINDOWS = 400;
     private static TestFrame firstFrame;
-    private static TestFrame testFrame;
 
     public static void main(String[] args) throws Exception {
         LotsOfMenuItemsTest obj = new LotsOfMenuItemsTest();
@@ -73,6 +72,7 @@ public class LotsOfMenuItemsTest extends ComponentAdapter {
 
     @Override
     public void componentShown(ComponentEvent e) {
+        TestFrame testFrame;
         final int x = firstFrame.getX();
         final int y = firstFrame.getY() + firstFrame.getHeight() + 8;
 

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -33,6 +33,7 @@ import java.util.List;
 /*
  * @test
  * @bug 4175790
+ * @requires os.family == "windows"
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Win32: Running out of command ids for menu items

--- a/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
+++ b/test/jdk/java/awt/MenuItem/LotsOfMenuItemsTest.java
@@ -25,37 +25,34 @@ import java.awt.Frame;
 import java.awt.Menu;
 import java.awt.MenuBar;
 import java.awt.MenuItem;
-import java.awt.Rectangle;
+import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
-import java.awt.event.ComponentListener;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /*
  * @test
  * @bug 4175790
- * @requires os.family == "windows"
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @summary Win32: Running out of command ids for menu items
  * @run main/manual LotsOfMenuItemsTest
  */
 
-public class LotsOfMenuItemsTest implements ComponentListener {
+public class LotsOfMenuItemsTest extends ComponentAdapter {
     private static final int NUM_WINDOWS = 400;
-    private static TestFrame firstFrame, testFrame;
-    private static Rectangle rect;
+    private static TestFrame firstFrame;
+    private static TestFrame testFrame;
 
     public static void main(String[] args) throws Exception {
         LotsOfMenuItemsTest obj = new LotsOfMenuItemsTest();
         String INSTRUCTIONS = """
-                This test creates a lots of frames with menubars.
+                This test creates lots of frames with menubars.
                 When it's done you will see two frames.
                 Try to select menu items from each of them.
 
                 If everything seems to work - test passed.
-                Click "Done" button in the test harness window.
+                Click "Pass" button in the test harness window.
 
                 If test crashes on you - test failed.""";
 
@@ -64,57 +61,47 @@ public class LotsOfMenuItemsTest implements ComponentListener {
                 .instructions(INSTRUCTIONS)
                 .rows((int) INSTRUCTIONS.lines().count() + 2)
                 .columns(40)
-                .testTimeOut(5)
                 .testUI(obj.createAndShowUI())
                 .build()
                 .awaitAndCheck();
     }
 
-    private List<? extends Frame> createAndShowUI() {
-        List<Frame> list = new ArrayList<>();
+    private List<Frame> createAndShowUI() {
         firstFrame = new TestFrame("First frame");
         firstFrame.addComponentListener(this);
 
-        for (int i = 1; i < NUM_WINDOWS; ++i) {
+        for (int i = 1; i < NUM_WINDOWS - 1; ++i) {
             testFrame = new TestFrame("Running(" + i + ")...");
-            if (i != (NUM_WINDOWS - 1)) {
-                testFrame.setVisible(false);
-                testFrame.dispose();
-            } else {
-                testFrame.setTitle("Last Frame");
-            }
+            testFrame.setVisible(false);
+            testFrame.dispose();
         }
-        list.add(firstFrame);
-        list.add(testFrame);
-        return list;
+        testFrame = new TestFrame("Last Frame");
+        return List.of(firstFrame, testFrame);
     }
-    public void componentMoved(ComponentEvent e) {}
-
-    public void componentHidden(ComponentEvent e) {}
 
     public void componentShown(ComponentEvent e) {
-        firstFrame.setLocation(970, 350);
-        testFrame.setLocation(970, 510);
+        PassFailJFrame.positionTestWindow(firstFrame,
+                PassFailJFrame.Position.HORIZONTAL);
+        testFrame.setLocation(firstFrame.getX(),
+                firstFrame.getY() + firstFrame.getHeight() + 8);
     }
 
-    public void componentResized(ComponentEvent e) {}
-}
+    private static class TestFrame extends Frame {
+        static int n = 0;
 
-class TestFrame extends Frame {
-    static int n = 0;
-
-    public TestFrame(String title) {
-        super(title);
-        MenuBar mb = new MenuBar();
-        for (int i = 0; i < 10; ++i) {
-            Menu m = new Menu("Menu_" + (i + 1));
-            for (int j = 0; j < 20; ++j) {
-                MenuItem mi = new MenuItem("Menu item " + ++n);
-                m.add(mi);
+        public TestFrame(String title) {
+            super(title);
+            MenuBar mb = new MenuBar();
+            for (int i = 0; i < 10; ++i) {
+                Menu m = new Menu("Menu_" + (i + 1));
+                for (int j = 0; j < 20; ++j) {
+                    MenuItem mi = new MenuItem("Menu item " + ++n);
+                    m.add(mi);
+                }
+                mb.add(m);
             }
-            mb.add(m);
+            setMenuBar(mb);
+            setSize(450, 150);
         }
-        setMenuBar(mb);
-        setSize(450, 150);
     }
 }

--- a/test/jdk/java/awt/MenuItem/MenuSetFontTest.java
+++ b/test/jdk/java/awt/MenuItem/MenuSetFontTest.java
@@ -43,15 +43,15 @@ public class MenuSetFontTest {
         String INSTRUCTIONS = """
                     Look at the menu in the upper left corner of the 'SetFont Test' frame.
                     Click on the "File" menu. You will see "menu item" item.
-                    Press pass if menu item is displayed using bold and large font else fail.
-                    If you do not see menu at all, press fail.""";
+                    Press Pass if menu item is displayed using bold and large font,
+                    otherwise press Fail.
+                    If you do not see menu at all, press Fail.""";
 
         PassFailJFrame.builder()
                 .title("MenuSetFontTest")
                 .instructions(INSTRUCTIONS)
                 .rows((int) INSTRUCTIONS.lines().count() + 2)
                 .columns(40)
-                .testTimeOut(5)
                 .testUI(MenuSetFontTest::createAndShowUI)
                 .build()
                 .awaitAndCheck();
@@ -64,7 +64,7 @@ public class MenuSetFontTest {
         MenuItem item = new MenuItem("menu item");
         menu.add(item);
         menuBar.add(menu);
-        menuBar.setFont(new Font("Monospaced", 1, 24));
+        menuBar.setFont(new Font(Font.MONOSPACED, Font.BOLD, 24));
         frame.setMenuBar(menuBar);
         frame.setSize(300, 200);
         return frame;

--- a/test/jdk/java/awt/MenuItem/MenuSetFontTest.java
+++ b/test/jdk/java/awt/MenuItem/MenuSetFontTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Font;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+/*
+ * @test
+ * @bug 4066657 8009454
+ * @requires os.family != "mac"
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests that setting a font on the Menu with MenuItem takes effect.
+ * @run main/manual MenuSetFontTest
+ */
+
+public class MenuSetFontTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                    Look at the menu in the upper left corner of the 'SetFont Test' frame.
+                    Click on the "File" menu. You will see "menu item" item.
+                    Press pass if menu item is displayed using bold and large font else fail.
+                    If you do not see menu at all, press fail.""";
+
+        PassFailJFrame.builder()
+                .title("MenuSetFontTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testTimeOut(5)
+                .testUI(MenuSetFontTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createAndShowUI() {
+        Frame frame = new Frame("SetFont Test");
+        MenuBar menuBar = new MenuBar();
+        Menu menu = new Menu("File");
+        MenuItem item = new MenuItem("menu item");
+        menu.add(item);
+        menuBar.add(menu);
+        menuBar.setFont(new Font("Monospaced", 1, 24));
+        frame.setMenuBar(menuBar);
+        frame.setSize(300, 200);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/MenuItem/NullOrEmptyStringLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/NullOrEmptyStringLabelTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4251036
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary MenuItem setLabel(null/"") behaves differently under Win32 and Solaris
+ * @run main/manual NullOrEmptyStringLabelTest
+ */
+
+public class NullOrEmptyStringLabelTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                The bug is reproducible under Win32 and Solaris.
+                Setting 'null' and "" as a label of menu item
+                should by the spec set blank label on all platforms.
+                But under Solaris setting "" as a label of menu item used to
+                cause some garbage to be set as label.
+                Under Win32 setting 'null' as a label used to result in
+                throwing NullPointerException.
+
+                If you see any of these things happen test fails otherwise
+                it passes.""";
+
+        PassFailJFrame.builder()
+                .title("NullOrEmptyStringLabelTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testTimeOut(5)
+                .testUI(NullOrEmptyStringLabelTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createAndShowUI() {
+        Frame frame = new Frame("Null Or Empty String Label Test");
+        Menu menu = new Menu("Menu");
+        MenuItem mi = new MenuItem("Item");
+        MenuBar mb = new MenuBar();
+        Button button1 = new Button("Set MenuItem label to 'null'");
+        Button button2 = new Button("Set MenuItem label to \"\"");
+        Button button3 = new Button("Set MenuItem label to 'text'");
+        button1.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                System.out.println("Setting MenuItem label to null");
+                mi.setLabel(null);
+            }
+        });
+        button2.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                System.out.println("Setting MenuItem label to \"\"");
+                mi.setLabel("");
+            }
+        });
+        button3.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                System.out.println("Setting MenuItem label to 'text'");
+                mi.setLabel("text");
+            }
+        });
+        menu.add(mi);
+        mb.add(menu);
+        frame.add("North", button1);
+        frame.add("South", button2);
+        frame.add("Center", button3);
+        frame.setMenuBar(mb);
+        frame.setSize(200, 135);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/MenuItem/NullOrEmptyStringLabelTest.java
+++ b/test/jdk/java/awt/MenuItem/NullOrEmptyStringLabelTest.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import java.awt.BorderLayout;
 import java.awt.Button;
 import java.awt.Frame;
 import java.awt.Menu;
@@ -44,7 +45,7 @@ public class NullOrEmptyStringLabelTest {
         String INSTRUCTIONS = """
                 The bug is reproducible under Win32 and Solaris.
                 Setting 'null' and "" as a label of menu item
-                should by the spec set blank label on all platforms.
+                should set blank label on all platforms according to the specification.
                 But under Solaris setting "" as a label of menu item used to
                 cause some garbage to be set as label.
                 Under Win32 setting 'null' as a label used to result in
@@ -58,7 +59,6 @@ public class NullOrEmptyStringLabelTest {
                 .instructions(INSTRUCTIONS)
                 .rows((int) INSTRUCTIONS.lines().count() + 2)
                 .columns(40)
-                .testTimeOut(5)
                 .testUI(NullOrEmptyStringLabelTest::createAndShowUI)
                 .build()
                 .awaitAndCheck();
@@ -73,18 +73,21 @@ public class NullOrEmptyStringLabelTest {
         Button button2 = new Button("Set MenuItem label to \"\"");
         Button button3 = new Button("Set MenuItem label to 'text'");
         button1.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent ev) {
                 System.out.println("Setting MenuItem label to null");
                 mi.setLabel(null);
             }
         });
         button2.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent ev) {
                 System.out.println("Setting MenuItem label to \"\"");
                 mi.setLabel("");
             }
         });
         button3.addActionListener(new ActionListener() {
+            @Override
             public void actionPerformed(ActionEvent ev) {
                 System.out.println("Setting MenuItem label to 'text'");
                 mi.setLabel("text");
@@ -92,9 +95,9 @@ public class NullOrEmptyStringLabelTest {
         });
         menu.add(mi);
         mb.add(menu);
-        frame.add("North", button1);
-        frame.add("South", button2);
-        frame.add("Center", button3);
+        frame.add(button1, BorderLayout.NORTH);
+        frame.add(button2, BorderLayout.CENTER);
+        frame.add(button3, BorderLayout.SOUTH);
         frame.setMenuBar(mb);
         frame.setSize(200, 135);
         return frame;

--- a/test/jdk/java/awt/MenuItem/UnicodeMenuItemTest.java
+++ b/test/jdk/java/awt/MenuItem/UnicodeMenuItemTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+
+/*
+ * @test
+ * @bug 4099695
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary menu items with Unicode labels treated as separators
+ * @run main/manual UnicodeMenuItemTest
+ */
+
+public class UnicodeMenuItemTest {
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Click on the "Menu" on the top-left corner of frame.
+
+                The menu should have four entries:
+                1) a row of five unicode characters: \u00c4\u00cb\u00cf\u00d6\u00dc
+                2) a menu separator
+                3) a unicode character:  \u012d
+                4) a unicode character:  \u022d
+
+                If the menu items look like the list above, the test passes.
+                It is okay if the unicode characters look like empty boxes
+                or something - as long as they are not separators.
+
+                If either of the last two menu items show up as separators,
+                the test FAILS.
+
+                Press 'Pass' if above instructions hold good else press 'Fail'.""";
+
+        PassFailJFrame.builder()
+                .title("UnicodeMenuItemTest")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(40)
+                .testTimeOut(5)
+                .testUI(UnicodeMenuItemTest::createAndShowUI)
+                .build()
+                .awaitAndCheck();
+    }
+    private static Frame createAndShowUI() {
+        Frame frame = new Frame("Unicode MenuItem Test");
+        MenuBar mb = new MenuBar();
+        Menu m = new Menu("Menu");
+
+        MenuItem mi2 = new MenuItem("\u00c4\u00cb\u00cf\u00d6\u00dc");
+        m.add(mi2);
+
+        MenuItem separator = new MenuItem("-");
+        m.add(separator);
+
+        MenuItem mi6 = new MenuItem("\u012d");
+        m.add(mi6);
+
+        MenuItem mi7 = new MenuItem("\u022d");
+        m.add(mi7);
+
+        mb.add(m);
+
+        frame.setMenuBar(mb);
+        frame.setSize(450, 150);
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/MenuItem/UnicodeMenuItemTest.java
+++ b/test/jdk/java/awt/MenuItem/UnicodeMenuItemTest.java
@@ -61,7 +61,6 @@ public class UnicodeMenuItemTest {
                 .instructions(INSTRUCTIONS)
                 .rows((int) INSTRUCTIONS.lines().count() + 2)
                 .columns(40)
-                .testTimeOut(5)
                 .testUI(UnicodeMenuItemTest::createAndShowUI)
                 .build()
                 .awaitAndCheck();
@@ -71,17 +70,17 @@ public class UnicodeMenuItemTest {
         MenuBar mb = new MenuBar();
         Menu m = new Menu("Menu");
 
-        MenuItem mi2 = new MenuItem("\u00c4\u00cb\u00cf\u00d6\u00dc");
-        m.add(mi2);
+        MenuItem mi1 = new MenuItem("\u00c4\u00cb\u00cf\u00d6\u00dc");
+        m.add(mi1);
 
         MenuItem separator = new MenuItem("-");
         m.add(separator);
 
-        MenuItem mi6 = new MenuItem("\u012d");
-        m.add(mi6);
+        MenuItem mi2 = new MenuItem("\u012d");
+        m.add(mi2);
 
-        MenuItem mi7 = new MenuItem("\u022d");
-        m.add(mi7);
+        MenuItem mi3 = new MenuItem("\u022d");
+        m.add(mi3);
 
         mb.add(m);
 


### PR DESCRIPTION
Few AWT MenuItem related tests are converted from applet to manual and moved to open.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339984](https://bugs.openjdk.org/browse/JDK-8339984): Open source AWT MenuItem related tests (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21029/head:pull/21029` \
`$ git checkout pull/21029`

Update a local copy of the PR: \
`$ git checkout pull/21029` \
`$ git pull https://git.openjdk.org/jdk.git pull/21029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21029`

View PR using the GUI difftool: \
`$ git pr show -t 21029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21029.diff">https://git.openjdk.org/jdk/pull/21029.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21029#issuecomment-2354487593)