### PR TITLE
8339192: Native annotation parsing code of deprecated annotations causes crash

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1150,30 +1150,40 @@ static void parse_annotations(const ConstantPool* const cp,
     if (AnnotationCollector::_unknown == id)  continue;
     coll->set_annotation(id);
     if (AnnotationCollector::_java_lang_Deprecated == id) {
-      assert(count <= 2, "change this if more element-value pairs are added to the @Deprecated annotation");
-      // @Deprecated can specify forRemoval=true
+      // @Deprecated can specify forRemoval=true, which we need
+      // to record for JFR to use. If the annotation is not well-formed
+      // then we may not be able to determine that.
       const u1* offset = abase + member_off;
-      for (int i = 0; i < count; ++i) {
+      // There are only 2 members in @Deprecated.
+      int n_members = MIN(count, 2);
+      for (int i = 0; i < n_members; ++i) {
         int member_index = Bytes::get_Java_u2((address)offset);
         offset += 2;
         member = check_symbol_at(cp, member_index);
-        if (member == vmSymbols::since()) {
-          assert(*((address)offset) == s_tag_val, "invariant");
+        if (member == vmSymbols::since() &&
+            (*((address)offset) == s_tag_val)) {
+          // Found `since` first so skip over it
           offset += 3;
-          continue;
         }
-        if (member == vmSymbols::for_removal()) {
-          assert(*((address)offset) == b_tag_val, "invariant");
+        else if (member == vmSymbols::for_removal() &&
+                 (*((address)offset) == b_tag_val)) {
           const u2 boolean_value_index = Bytes::get_Java_u2((address)offset + 1);
-          if (cp->int_at(boolean_value_index) == 1) {
+          // No guarantee the entry is valid so check it refers to an int in the CP.
+          if (cp->is_within_bounds(boolean_value_index) &&
+              cp->tag_at(boolean_value_index).is_int() &&
+              cp->int_at(boolean_value_index) == 1) {
             // forRemoval == true
             coll->set_annotation(AnnotationCollector::_java_lang_Deprecated_for_removal);
           }
+          break; // no need to check further
+        }
+        else {
+          // This @Deprecated annotation is malformed so we don't try to
+          // determine whether forRemoval is set.
           break;
         }
-
       }
-      continue;
+      continue; // proceed to next annotation
     }
 
     if (AnnotationCollector::_jdk_internal_vm_annotation_Contended == id) {
@@ -1194,11 +1204,21 @@ static void parse_annotations(const ConstantPool* const cp,
         && s_tag_val == *(abase + tag_off)
         && member == vmSymbols::value_name()) {
         group_index = Bytes::get_Java_u2((address)abase + s_con_off);
-        if (cp->symbol_at(group_index)->utf8_length() == 0) {
-          group_index = 0; // default contended group
+        // No guarantee the group_index is valid so check it refers to a
+        // symbol in the CP.
+        if (cp->is_within_bounds(group_index) &&
+            cp->tag_at(group_index).is_utf8()) {
+          // Seems valid, so check for empty string and reset
+          if (cp->symbol_at(group_index)->utf8_length() == 0) {
+            group_index = 0; // default contended group
+          }
+        } else {
+          // Not valid so use the default
+          group_index = 0;
         }
       }
       coll->set_contended_group(group_index);
+      continue; // proceed to next annotation
     }
   }
 }

--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -1155,7 +1155,7 @@ static void parse_annotations(const ConstantPool* const cp,
       // then we may not be able to determine that.
       const u1* offset = abase + member_off;
       // There are only 2 members in @Deprecated.
-      int n_members = MIN(count, 2);
+      int n_members = MIN2(count, 2);
       for (int i = 0; i < n_members; ++i) {
         int member_index = Bytes::get_Java_u2((address)offset);
         offset += 2;

--- a/test/hotspot/jtreg/runtime/Annotations/BadContendedGroupBadCPIndex.jcod
+++ b/test/hotspot/jtreg/runtime/Annotations/BadContendedGroupBadCPIndex.jcod
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* Based on source:
+ * public class ContendedField {
+ *     @Contended("group1")
+ *     public int field;
+ * }
+ *
+ * We change the value of "value" so it refers to an invalid CP entry
+ */
+
+class BadContendedGroupBadCPIndex {
+  0xCAFEBABE;
+  0; // minor version
+  65; // version
+  [19] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "BadContendedGroupBadCPIndex"; // #8     at 0x3C
+    Utf8 "field"; // #9     at 0x4D
+    Utf8 "I"; // #10     at 0x55
+    Utf8 "RuntimeVisibleAnnotations"; // #11     at 0x59
+    Utf8 "Ljdk/internal/vm/annotation/Contended;"; // #12     at 0x75
+    Utf8 "value"; // #13     at 0x9E
+    Utf8 "group1"; // #14     at 0xA6
+    Utf8 "Code"; // #15     at 0xAF
+    Utf8 "LineNumberTable"; // #16     at 0xB6
+    Utf8 "SourceFile"; // #17     at 0xC8
+    Utf8 "BadContendedGroupBadCPIndex.java"; // #18     at 0xD5
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0xF5
+      0x0001; // access
+      #9; // name_index       : field
+      #10; // descriptor_index : I
+      [1] { // Attributes
+        Attr(#11, 11) { // RuntimeVisibleAnnotations at 0xFD
+          [1] { // annotations
+            {  //  annotation
+              #12;
+              [1] { // element_value_pairs
+                {  //  element value pair
+                  #13;
+                  {  //  element_value
+                    's';
+                    #1400; // Changed from #14 to #1400
+                  }  //  element_value
+                }  //  element value pair
+              }  //  element_value_pairs
+            }  //  annotation
+          }
+        } // end RuntimeVisibleAnnotations
+      } // Attributes
+    }
+  } // Fields
+
+  [1] { // Methods
+    {  // method at 0x0110
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#15, 29) { // Code at 0x0118
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#16, 6) { // LineNumberTable at 0x012F
+              [1] { // line_number_table
+                0  2; //  at 0x013B
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#17, 2) { // SourceFile at 0x013D
+      #18;
+    } // end SourceFile
+  } // Attributes
+} // end class BadContendedGroupBadCPIndex

--- a/test/hotspot/jtreg/runtime/Annotations/BadContendedGroupWrongType.jcod
+++ b/test/hotspot/jtreg/runtime/Annotations/BadContendedGroupWrongType.jcod
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* Based on source:
+ * public class ContendedField {
+ *     @Contended("group1")
+ *     public int field;
+ * }
+ *
+ * We change the value of "value" so it refers to the wrong type of CP entry
+ */
+
+class BadContendedGroupWrongType {
+  0xCAFEBABE;
+  0; // minor version
+  65; // version
+  [19] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "BadContendedGroupWrongType"; // #8     at 0x3C
+    Utf8 "field"; // #9     at 0x4D
+    Utf8 "I"; // #10     at 0x55
+    Utf8 "RuntimeVisibleAnnotations"; // #11     at 0x59
+    Utf8 "Ljdk/internal/vm/annotation/Contended;"; // #12     at 0x75
+    Utf8 "value"; // #13     at 0x9E
+    Utf8 "group1"; // #14     at 0xA6
+    Utf8 "Code"; // #15     at 0xAF
+    Utf8 "LineNumberTable"; // #16     at 0xB6
+    Utf8 "SourceFile"; // #17     at 0xC8
+    Utf8 "BadContendedGroupWrongType.java"; // #18     at 0xD5
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [1] { // Fields
+    {  // field at 0xF5
+      0x0001; // access
+      #9; // name_index       : field
+      #10; // descriptor_index : I
+      [1] { // Attributes
+        Attr(#11, 11) { // RuntimeVisibleAnnotations at 0xFD
+          [1] { // annotations
+            {  //  annotation
+              #12;
+              [1] { // element_value_pairs
+                {  //  element value pair
+                  #13;
+                  {  //  element_value
+                    's';
+                    #7; // Changed from #14 (utf8) to #7 (class)
+                  }  //  element_value
+                }  //  element value pair
+              }  //  element_value_pairs
+            }  //  annotation
+          }
+        } // end RuntimeVisibleAnnotations
+      } // Attributes
+    }
+  } // Fields
+
+  [1] { // Methods
+    {  // method at 0x0110
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#15, 29) { // Code at 0x0118
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#16, 6) { // LineNumberTable at 0x012F
+              [1] { // line_number_table
+                0  2; //  at 0x013B
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#17, 2) { // SourceFile at 0x013D
+      #18;
+    } // end SourceFile
+  } // Attributes
+} // end class BadContendedGroupWrongType

--- a/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedExtraMemberAtEnd.jcod
+++ b/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedExtraMemberAtEnd.jcod
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* Based on source:
+ *
+ * public class DeprecatedMethod {
+ *   @Deprecated(forRemoval=true, since="now")
+ *   public static void m() {}
+ * }
+ *
+ * We add an extra junk member at the end.
+ */
+
+class BadDeprecatedExtraMemberAtEnd {
+  0xCAFEBABE;
+  0; // minor version
+  65; // version
+  [21] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "BadDeprecatedExtraMemberAtEnd"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x4F
+    Utf8 "LineNumberTable"; // #10     at 0x56
+    Utf8 "m"; // #11     at 0x68
+    Utf8 "Deprecated"; // #12     at 0x6C
+    Utf8 "RuntimeVisibleAnnotations"; // #13     at 0x79
+    Utf8 "Ljava/lang/Deprecated;"; // #14     at 0x95
+    Utf8 "forRemoval"; // #15     at 0xAE
+    int 0x00000001; // #16     at 0xBB
+    Utf8 "since"; // #17     at 0xC0
+    Utf8 "now"; // #18     at 0xC8
+    Utf8 "SourceFile"; // #19     at 0xCE
+    Utf8 "BadDeprecatedExtraMemberAtEnd.java"; // #20     at 0xDB
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xFF
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x0107
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x011E
+              [1] { // line_number_table
+                0  1; //  at 0x012A
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x012A
+      0x0009; // access
+      #11; // name_index       : m
+      #6; // descriptor_index : ()V
+      [3] { // Attributes
+        Attr(#9, 25) { // Code at 0x0132
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x0145
+              [1] { // line_number_table
+                0  4; //  at 0x0151
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+        ;
+        Attr(#12, 0) { // Deprecated at 0x0151
+        } // end Deprecated
+        ;
+        Attr(#13, 21) { // RuntimeVisibleAnnotations at 0x0157 (length changed from 16 to 21)
+          [1] { // annotations
+            {  //  annotation
+              #14;
+              [3] { // element_value_pairs <= extra pair added
+                {  //  element value pair
+                  #15;
+                  {  //  element_value
+                    'Z';
+                    #16;
+                  }  //  element_value
+                }  //  element value pair
+                ;
+                {  //  element value pair
+                  #17;
+                  {  //  element_value
+                    's';
+                    #18;
+                  }  //  element_value
+                }  //  element value pair
+                ;
+                {  //  Extra element value pair: now=true
+                  #18;
+                  {  //  element_value
+                    'Z';
+                    #16;
+                  }  //  element_value
+                }  //  element value pair
+              }  //  element_value_pairs
+            }  //  annotation
+          }
+        } // end RuntimeVisibleAnnotations
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#19, 2) { // SourceFile at 0x016F
+      #20;
+    } // end SourceFile
+  } // Attributes
+} // end class BadDeprecatedExtraMemberAtEnd

--- a/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedExtraMemberAtStart.jcod
+++ b/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedExtraMemberAtStart.jcod
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* Based on source:
+ *
+ * public class DeprecatedMethod {
+ *   @Deprecated(forRemoval=true, since="now")
+ *   public static void m() {}
+ * }
+ *
+ * We add an extra junk member at the start.
+ */
+
+class BadDeprecatedExtraMemberAtStart {
+  0xCAFEBABE;
+  0; // minor version
+  65; // version
+  [21] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "BadDeprecatedExtraMemberAtStart"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x4F
+    Utf8 "LineNumberTable"; // #10     at 0x56
+    Utf8 "m"; // #11     at 0x68
+    Utf8 "Deprecated"; // #12     at 0x6C
+    Utf8 "RuntimeVisibleAnnotations"; // #13     at 0x79
+    Utf8 "Ljava/lang/Deprecated;"; // #14     at 0x95
+    Utf8 "forRemoval"; // #15     at 0xAE
+    int 0x00000001; // #16     at 0xBB
+    Utf8 "since"; // #17     at 0xC0
+    Utf8 "now"; // #18     at 0xC8
+    Utf8 "SourceFile"; // #19     at 0xCE
+    Utf8 "BadDeprecatedExtraMemberAtStart.java"; // #20     at 0xDB
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xFF
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x0107
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x011E
+              [1] { // line_number_table
+                0  1; //  at 0x012A
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x012A
+      0x0009; // access
+      #11; // name_index       : m
+      #6; // descriptor_index : ()V
+      [3] { // Attributes
+        Attr(#9, 25) { // Code at 0x0132
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x0145
+              [1] { // line_number_table
+                0  4; //  at 0x0151
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+        ;
+        Attr(#12, 0) { // Deprecated at 0x0151
+        } // end Deprecated
+        ;
+        Attr(#13, 21) { // RuntimeVisibleAnnotations at 0x0157 (length changed from 16 to 21)
+          [1] { // annotations
+            {  //  annotation
+              #14;
+              [3] { // element_value_pairs <= extra pair added
+                {  //  Extra element value pair: now=true
+                  #18;
+                  {  //  element_value
+                    'Z';
+                    #16;
+                  }  //  element_value
+                }  //  element value pair
+                ;
+                {  //  element value pair
+                  #15;
+                  {  //  element_value
+                    'Z';
+                    #16;
+                  }  //  element_value
+                }  //  element value pair
+                ;
+                {  //  element value pair
+                  #17;
+                  {  //  element_value
+                    's';
+                    #18;
+                  }  //  element_value
+                }  //  element value pair
+              }  //  element_value_pairs
+            }  //  annotation
+          }
+        } // end RuntimeVisibleAnnotations
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#19, 2) { // SourceFile at 0x016F
+      #20;
+    } // end SourceFile
+  } // Attributes
+} // end class BadDeprecatedExtraMemberAtStart

--- a/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedForRemovalBadCPIndex.jcod
+++ b/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedForRemovalBadCPIndex.jcod
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* Based on source:
+ *
+ * public class DeprecatedMethod {
+ *   @Deprecated(forRemoval=true, since="now")
+ *   public static void m() {}
+ * }
+ *
+ * We change the CP index for the value of forRemoval to a junk value
+ */
+
+class BadDeprecatedForRemovalBadCPIndex {
+  0xCAFEBABE;
+  0; // minor version
+  65; // version
+  [21] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "BadDeprecatedForRemovalBadCPIndex"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x4F
+    Utf8 "LineNumberTable"; // #10     at 0x56
+    Utf8 "m"; // #11     at 0x68
+    Utf8 "Deprecated"; // #12     at 0x6C
+    Utf8 "RuntimeVisibleAnnotations"; // #13     at 0x79
+    Utf8 "Ljava/lang/Deprecated;"; // #14     at 0x95
+    Utf8 "forRemoval"; // #15     at 0xAE
+    int 0x00000001; // #16     at 0xBB
+    Utf8 "since"; // #17     at 0xC0
+    Utf8 "now"; // #18     at 0xC8
+    Utf8 "SourceFile"; // #19     at 0xCE
+    Utf8 "BadDeprecatedForRemovalBadCPIndex.java"; // #20     at 0xDB
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xFF
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x0107
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x011E
+              [1] { // line_number_table
+                0  1; //  at 0x012A
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x012A
+      0x0009; // access
+      #11; // name_index       : m
+      #6; // descriptor_index : ()V
+      [3] { // Attributes
+        Attr(#9, 25) { // Code at 0x0132
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x0145
+              [1] { // line_number_table
+                0  4; //  at 0x0151
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+        ;
+        Attr(#12, 0) { // Deprecated at 0x0151
+        } // end Deprecated
+        ;
+        Attr(#13, 16) { // RuntimeVisibleAnnotations at 0x0157
+          [1] { // annotations
+            {  //  annotation
+              #14;
+              [2] { // element_value_pairs
+                {  //  element value pair
+                  #17;
+                  {  //  element_value
+                    's';
+                    #18;
+                  }  //  element_value
+                }  //  element value pair
+                ;
+                {  //  element value pair
+                  #15;
+                  {  //  element_value
+                    'Z';
+                    #1600;  // Changed from #16 to #1600
+                  }  //  element_value
+                }  //  element value pair
+              }  //  element_value_pairs
+            }  //  annotation
+          }
+        } // end RuntimeVisibleAnnotations
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#19, 2) { // SourceFile at 0x016F
+      #20;
+    } // end SourceFile
+  } // Attributes
+} // end class BadDeprecatedForRemovalBadCPIndex

--- a/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedForRemovalWrongType.jcod
+++ b/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedForRemovalWrongType.jcod
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* Based on source:
+ *
+ * public class DeprecatedMethod {
+ *   @Deprecated(forRemoval=true, since="now")
+ *   public static void m() {}
+ * }
+ *
+ * We change the type of forRemoval from 'Z' to 's' but don't change the value
+ */
+
+class BadDeprecatedForRemovalWrongType {
+  0xCAFEBABE;
+  0; // minor version
+  65; // version
+  [21] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "BadDeprecatedForRemovalWrongType"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x4F
+    Utf8 "LineNumberTable"; // #10     at 0x56
+    Utf8 "m"; // #11     at 0x68
+    Utf8 "Deprecated"; // #12     at 0x6C
+    Utf8 "RuntimeVisibleAnnotations"; // #13     at 0x79
+    Utf8 "Ljava/lang/Deprecated;"; // #14     at 0x95
+    Utf8 "forRemoval"; // #15     at 0xAE
+    int 0x00000001; // #16     at 0xBB
+    Utf8 "since"; // #17     at 0xC0
+    Utf8 "now"; // #18     at 0xC8
+    Utf8 "SourceFile"; // #19     at 0xCE
+    Utf8 "BadDeprecatedForRemovalWrongType.java"; // #20     at 0xDB
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xFF
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x0107
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x011E
+              [1] { // line_number_table
+                0  1; //  at 0x012A
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x012A
+      0x0009; // access
+      #11; // name_index       : m
+      #6; // descriptor_index : ()V
+      [3] { // Attributes
+        Attr(#9, 25) { // Code at 0x0132
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x0145
+              [1] { // line_number_table
+                0  4; //  at 0x0151
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+        ;
+        Attr(#12, 0) { // Deprecated at 0x0151
+        } // end Deprecated
+        ;
+        Attr(#13, 16) { // RuntimeVisibleAnnotations at 0x0157
+          [1] { // annotations
+            {  //  annotation
+              #14;
+              [2] { // element_value_pairs
+                {  //  element value pair
+                  #17;
+                  {  //  element_value
+                    's';
+                    #18;
+                  }  //  element_value
+                }  //  element value pair
+                ;
+                {  //  element value pair
+                  #15;
+                  {  //  element_value
+                    's';  // Changed from Z to s
+                    #16;
+                  }  //  element_value
+                }  //  element value pair
+              }  //  element_value_pairs
+            }  //  annotation
+          }
+        } // end RuntimeVisibleAnnotations
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#19, 2) { // SourceFile at 0x016F
+      #20;
+    } // end SourceFile
+  } // Attributes
+} // end class BadDeprecatedForRemovalWrongType

--- a/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedSinceWrongType.jcod
+++ b/test/hotspot/jtreg/runtime/Annotations/BadDeprecatedSinceWrongType.jcod
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* Based on source:
+ *
+ * public class DeprecatedMethod {
+ *   @Deprecated(forRemoval=true, since="now")
+ *   public static void m() {}
+ * }
+ *
+ * We change the type of since from 's' to 'Z'
+ */
+
+class BadDeprecatedSinceWrongType {
+  0xCAFEBABE;
+  0; // minor version
+  65; // version
+  [21] { // Constant Pool
+    ; // first element is empty
+    Method #2 #3; // #1     at 0x0A
+    class #4; // #2     at 0x0F
+    NameAndType #5 #6; // #3     at 0x12
+    Utf8 "java/lang/Object"; // #4     at 0x17
+    Utf8 "<init>"; // #5     at 0x2A
+    Utf8 "()V"; // #6     at 0x33
+    class #8; // #7     at 0x39
+    Utf8 "BadDeprecatedSinceWrongType"; // #8     at 0x3C
+    Utf8 "Code"; // #9     at 0x4F
+    Utf8 "LineNumberTable"; // #10     at 0x56
+    Utf8 "m"; // #11     at 0x68
+    Utf8 "Deprecated"; // #12     at 0x6C
+    Utf8 "RuntimeVisibleAnnotations"; // #13     at 0x79
+    Utf8 "Ljava/lang/Deprecated;"; // #14     at 0x95
+    Utf8 "forRemoval"; // #15     at 0xAE
+    int 0x00000001; // #16     at 0xBB
+    Utf8 "since"; // #17     at 0xC0
+    Utf8 "now"; // #18     at 0xC8
+    Utf8 "SourceFile"; // #19     at 0xCE
+    Utf8 "BadDeprecatedSinceWrongType.java"; // #20     at 0xDB
+  } // Constant Pool
+
+  0x0021; // access [ ACC_PUBLIC ACC_SUPER ]
+  #7;// this_cpx
+  #2;// super_cpx
+
+  [0] { // Interfaces
+  } // Interfaces
+
+  [0] { // Fields
+  } // Fields
+
+  [2] { // Methods
+    {  // method at 0xFF
+      0x0001; // access
+      #5; // name_index       : <init>
+      #6; // descriptor_index : ()V
+      [1] { // Attributes
+        Attr(#9, 29) { // Code at 0x0107
+          1; // max_stack
+          1; // max_locals
+          Bytes[5]{
+            0x2AB70001B1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x011E
+              [1] { // line_number_table
+                0  1; //  at 0x012A
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+      } // Attributes
+    }
+    ;
+    {  // method at 0x012A
+      0x0009; // access
+      #11; // name_index       : m
+      #6; // descriptor_index : ()V
+      [3] { // Attributes
+        Attr(#9, 25) { // Code at 0x0132
+          0; // max_stack
+          0; // max_locals
+          Bytes[1]{
+            0xB1;
+          }
+          [0] { // Traps
+          } // end Traps
+          [1] { // Attributes
+            Attr(#10, 6) { // LineNumberTable at 0x0145
+              [1] { // line_number_table
+                0  4; //  at 0x0151
+              }
+            } // end LineNumberTable
+          } // Attributes
+        } // end Code
+        ;
+        Attr(#12, 0) { // Deprecated at 0x0151
+        } // end Deprecated
+        ;
+        Attr(#13, 16) { // RuntimeVisibleAnnotations at 0x0157
+          [1] { // annotations
+            {  //  annotation
+              #14;
+              [2] { // element_value_pairs
+                {  //  element value pair
+                  #17;
+                  {  //  element_value
+                    'Z';  // Changed from 's' to 'Z'
+                    #18;
+                  }  //  element_value
+                }  //  element value pair
+                ;
+                {  //  element value pair
+                  #15;
+                  {  //  element_value
+                    'Z';
+                    #16;
+                  }  //  element_value
+                }  //  element value pair
+              }  //  element_value_pairs
+            }  //  annotation
+          }
+        } // end RuntimeVisibleAnnotations
+      } // Attributes
+    }
+  } // Methods
+
+  [1] { // Attributes
+    Attr(#19, 2) { // SourceFile at 0x016F
+      #20;
+    } // end SourceFile
+  } // Attributes
+} // end class BadDeprecatedSinceWrongType

--- a/test/hotspot/jtreg/runtime/Annotations/TestBadAnnotations.java
+++ b/test/hotspot/jtreg/runtime/Annotations/TestBadAnnotations.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8339192
+ * @summary Check that malformed annotations don't cause crashes
+ * @compile BadDeprecatedExtraMemberAtEnd.jcod
+ *          BadDeprecatedExtraMemberAtStart.jcod
+ *          BadDeprecatedSinceWrongType.jcod
+ *          BadDeprecatedForRemovalWrongType.jcod
+ *          BadDeprecatedForRemovalBadCPIndex.jcod
+ *          BadContendedGroupBadCPIndex.jcod
+ *          BadContendedGroupWrongType.jcod
+ * @modules java.base/jdk.internal.vm.annotation
+ * @run main/othervm -XX:-RestrictContended TestBadAnnotations
+ */
+import java.lang.annotation.Annotation;
+import java.lang.reflect.*;
+
+// None of the malformed nnotations should cause assertion failures or
+// other crashes, nor exceptions - we simply don't process them. Note that
+// even if the annotation is malformed the class will still be marked as having
+// that annotation; it is only the "forRemoval" state of @Deprecated, and
+// the "group" value of @Contended that is potentially afffected.
+// There is no API to query what annotations the VM considers applied
+// to a class/field/method, so we don't try to read anything back.
+
+// The testcases defined reflect the changes that were made to the code under
+// 8339192 - we do not try to define exhaustive tests for every potential
+// malformation. Each of these test case will trigger an assert prior to
+// the fix.
+
+public class TestBadAnnotations {
+    public static void main(String[] args) throws Throwable {
+        Class<?> c = Class.forName("BadDeprecatedExtraMemberAtEnd");
+        c = Class.forName("BadDeprecatedExtraMemberAtStart");
+        c = Class.forName("BadDeprecatedSinceWrongType");
+        c = Class.forName("BadDeprecatedForRemovalWrongType");
+        c = Class.forName("BadDeprecatedForRemovalBadCPIndex");
+        c = Class.forName("BadContendedGroupBadCPIndex");
+        c = Class.forName("BadContendedGroupWrongType");
+    }
+}


### PR DESCRIPTION
There are a couple of runtime visible annotations (`@Deprecated`, `@Contended`) that the VM processes during classfile parsing. These are expected to have a form that matches the corresponding Java source code in the JDK. The original test cases for this bug fuzzed the annotation entry in the classfile such that the correspondence was lost and so assertions and other errors could be triggered (depending on debug or release builds). The fix is to fully validate the annotation entries that appear to match, and to ignore them otherwise (which is what is required for unknown attributes/annotations).

Each of the jcod test cases is targeted at a specific change in the code (typically the removal of an assertion). There is no intent to try and write exhaustive tests for all possible malformities that might exist for an annotation entry. The original submitted test cases now run without error.

Testing was verified manually by adding debug printing to show we rejected each case as expected. Unfortunately there is no existing mechanism to read back the VM's view of what annotations are present, nor is there any logging to take advantage of. I briefly considered adding a WhiteBox API to query the annotations applied in the VM but I deemed it not worth the effort, particularly because it didn't really help validate the tests in many cases. For example, by default no class/method/field is "Deprecated for Removal" so a test that skips `forRemoval` setting just leaves you with the default situation. You can't actually tell a bad annotation was skipped.

Testing
 - new tests as described above 
 - tier 1-3 sanity

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339192](https://bugs.openjdk.org/browse/JDK-8339192): Native annotation parsing code of deprecated annotations causes crash (**Bug** - P4)


### Reviewers
 * [John R Rose](https://openjdk.org/census#jrose) (@rose00 - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21030/head:pull/21030` \
`$ git checkout pull/21030`

Update a local copy of the PR: \
`$ git checkout pull/21030` \
`$ git pull https://git.openjdk.org/jdk.git pull/21030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21030`

View PR using the GUI difftool: \
`$ git pr show -t 21030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21030.diff">https://git.openjdk.org/jdk/pull/21030.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21030#issuecomment-2354494563)