### PR TITLE
8286851: Deprecate for removal several of the undocumented java launcher options

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1463,14 +1463,18 @@ ParseArguments(int *pargc, char ***pargv,
             JLI_ShowMessage("%s %s", _launcher_name, GetFullVersion());
             return JNI_FALSE;
         } else if (JLI_StrCmp(arg, "-verbosegc") == 0) {
+            JLI_ReportErrorMessage(ARG_DEPRECATED, "-verbosegc");
             AddOption("-verbose:gc", NULL);
         } else if (JLI_StrCmp(arg, "-debug") == 0) {
             JLI_ReportErrorMessage(ARG_DEPRECATED, "-debug");
         } else if (JLI_StrCmp(arg, "-noclassgc") == 0) {
+            JLI_ReportErrorMessage(ARG_DEPRECATED, "-noclassgc");
             AddOption("-Xnoclassgc", NULL);
         } else if (JLI_StrCmp(arg, "-verify") == 0) {
+            JLI_ReportErrorMessage(ARG_DEPRECATED, "-verify");
             AddOption("-Xverify:all", NULL);
         } else if (JLI_StrCmp(arg, "-verifyremote") == 0) {
+            JLI_ReportErrorMessage(ARG_DEPRECATED, "-verifyremote");
             AddOption("-Xverify:remote", NULL);
         } else if (JLI_StrCmp(arg, "-noverify") == 0) {
             /*
@@ -1479,9 +1483,10 @@ ParseArguments(int *pargc, char ***pargv,
              */
             AddOption("-Xverify:none", NULL);
         } else if (JLI_StrCCmp(arg, "-ss") == 0 ||
-                   JLI_StrCCmp(arg, "-oss") == 0 ||
                    JLI_StrCCmp(arg, "-ms") == 0 ||
                    JLI_StrCCmp(arg, "-mx") == 0) {
+            JLI_ReportErrorMessage("Warning: %.3s option is deprecated"
+                                   " and may be removed in a future release.", arg);
             size_t tmpSize = JLI_StrLen(arg) + 6;
             char *tmp = JLI_MemAlloc(tmpSize);
             snprintf(tmp, tmpSize, "-X%s", arg + 1); /* skip '-' */


### PR DESCRIPTION
Can I please get a review of this change which proposes to deprecate several outdated and undocumented java launcher options? This addresses https://bugs.openjdk.org/browse/JDK-8286851.

Specifically, the non-standard launcher options `-verbosegc`, `-noclassgc`, `-verify`, `-verifyremote`, `-ss`, `-ms` and `-mx` will be deprecated for removal. With this change, a deprecation warning will be printed, if any of these options are used.

No new tests have been added for this change. Existing tests in tier1, tier2 and tier3 continue to pass.

I'll create a CSR shortly for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8340244](https://bugs.openjdk.org/browse/JDK-8340244) to be approved

### Issues
 * [JDK-8286851](https://bugs.openjdk.org/browse/JDK-8286851): Deprecate for removal several of the undocumented java launcher options (**Bug** - P4)
 * [JDK-8340244](https://bugs.openjdk.org/browse/JDK-8340244): Deprecate for removal several of the undocumented java launcher options (**CSR**)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21031/head:pull/21031` \
`$ git checkout pull/21031`

Update a local copy of the PR: \
`$ git checkout pull/21031` \
`$ git pull https://git.openjdk.org/jdk.git pull/21031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21031`

View PR using the GUI difftool: \
`$ git pr show -t 21031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21031.diff">https://git.openjdk.org/jdk/pull/21031.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21031#issuecomment-2354651739)