### PR TITLE
8340272: C2 SuperWord: JMH benchmark for Reduction vectorization

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/VectorReduction2.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorReduction2.java
@@ -1,0 +1,1454 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+
+import java.util.concurrent.TimeUnit;
+import java.util.Random;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+public abstract class VectorReduction2 {
+    @Param({"2048"})
+    public int SIZE;
+
+    private byte[] in1B;
+    private byte[] in2B;
+    private byte[] in3B;
+    private char[] in1C;
+    private char[] in2C;
+    private char[] in3C;
+    private short[] in1S;
+    private short[] in2S;
+    private short[] in3S;
+
+    private int[] in1I;
+    private int[] in2I;
+    private int[] in3I;
+    private long[] in1L;
+    private long[] in2L;
+    private long[] in3L;
+
+    private float[] in1F;
+    private float[] in2F;
+    private float[] in3F;
+    private double[] in1D;
+    private double[] in2D;
+    private double[] in3D;
+
+    @Param("0")
+    private int seed;
+    private Random r = new Random(seed);
+
+    private static int globalResI;
+
+    @Setup
+    public void init() {
+        in1B = new byte[SIZE];
+        in2B = new byte[SIZE];
+        in3B = new byte[SIZE];
+        in1C = new char[SIZE];
+        in2C = new char[SIZE];
+        in3C = new char[SIZE];
+        in1S = new short[SIZE];
+        in2S = new short[SIZE];
+        in3S = new short[SIZE];
+
+        in1I = new int[SIZE];
+        in2I = new int[SIZE];
+        in3I = new int[SIZE];
+        in1L = new long[SIZE];
+        in2L = new long[SIZE];
+        in3L = new long[SIZE];
+
+        in1F = new float[SIZE];
+        in2F = new float[SIZE];
+        in3F = new float[SIZE];
+        in1D = new double[SIZE];
+        in2D = new double[SIZE];
+        in3D = new double[SIZE];
+
+        for (int i = 0; i < SIZE; i++) {
+            in1B[i] = (byte)r.nextInt();
+            in2B[i] = (byte)r.nextInt();
+            in3B[i] = (byte)r.nextInt();
+            in1C[i] = (char)r.nextInt();
+            in2C[i] = (char)r.nextInt();
+            in3C[i] = (char)r.nextInt();
+            in1S[i] = (short)r.nextInt();
+            in2S[i] = (short)r.nextInt();
+            in3S[i] = (short)r.nextInt();
+
+            in1I[i] = r.nextInt();
+            in2I[i] = r.nextInt();
+            in3I[i] = r.nextInt();
+            in1L[i] = r.nextLong();
+            in2L[i] = r.nextLong();
+            in3L[i] = r.nextLong();
+
+            in1F[i] = r.nextFloat();
+            in2F[i] = r.nextFloat();
+            in3F[i] = r.nextFloat();
+            in1D[i] = r.nextDouble();
+            in2D[i] = r.nextDouble();
+            in3D[i] = r.nextDouble();
+        }
+    }
+
+    // Naming convention:
+    //   How much work?
+    //     - simple:   val = a[i]
+    //     - dotprod:  val = a[i] * b[i]
+    //     - big:      val = (a[i] * b[i]) + (a[i] * c[i]) + (b[i] * c[i])
+    //   Reduction operator:
+    //     - and:     acc &= val
+    //     - or:      acc |= val
+    //     - xor:     acc ^= val
+    //     - add:     acc += val
+    //     - mul:     acc *= val
+    //     - min:     acc = min(acc, val)
+    //     - max:     acc = max(acc, val)
+
+    // ---------byte***Simple ------------------------------------------------------------
+    @Benchmark
+    public void byteAndSimple(Blackhole bh) {
+        byte acc = (byte)0xFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = in1B[i];
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteOrSimple(Blackhole bh) {
+        byte acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = in1B[i];
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteXorSimple(Blackhole bh) {
+        byte acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = in1B[i];
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteAddSimple(Blackhole bh) {
+        byte acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = in1B[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteMulSimple(Blackhole bh) {
+        byte acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = in1B[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteMinSimple(Blackhole bh) {
+        byte acc = Byte.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = in1B[i];
+            acc = (byte)Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteMaxSimple(Blackhole bh) {
+        byte acc = Byte.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = in1B[i];
+            acc = (byte)Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------byte***DotProduct ------------------------------------------------------------
+    @Benchmark
+    public void byteAndDotProduct(Blackhole bh) {
+        byte acc = (byte)0xFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)(in1B[i] * in2B[i]);
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteOrDotProduct(Blackhole bh) {
+        byte acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)(in1B[i] * in2B[i]);
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteXorDotProduct(Blackhole bh) {
+        byte acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)(in1B[i] * in2B[i]);
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteAddDotProduct(Blackhole bh) {
+        byte acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)(in1B[i] * in2B[i]);
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteMulDotProduct(Blackhole bh) {
+        byte acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)(in1B[i] * in2B[i]);
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteMinDotProduct(Blackhole bh) {
+        byte acc = Byte.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)(in1B[i] * in2B[i]);
+            acc = (byte)Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteMaxDotProduct(Blackhole bh) {
+        byte acc = Byte.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)(in1B[i] * in2B[i]);
+            acc = (byte)Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------byte***Big ------------------------------------------------------------
+    @Benchmark
+    public void byteAndBig(Blackhole bh) {
+        byte acc = (byte)0xFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)((in1B[i] * in2B[i]) + (in1B[i] * in3B[i]) + (in2B[i] * in3B[i]));
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteOrBig(Blackhole bh) {
+        byte acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)((in1B[i] * in2B[i]) + (in1B[i] * in3B[i]) + (in2B[i] * in3B[i]));
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteXorBig(Blackhole bh) {
+        byte acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)((in1B[i] * in2B[i]) + (in1B[i] * in3B[i]) + (in2B[i] * in3B[i]));
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteAddBig(Blackhole bh) {
+        byte acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)((in1B[i] * in2B[i]) + (in1B[i] * in3B[i]) + (in2B[i] * in3B[i]));
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteMulBig(Blackhole bh) {
+        byte acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)((in1B[i] * in2B[i]) + (in1B[i] * in3B[i]) + (in2B[i] * in3B[i]));
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteMinBig(Blackhole bh) {
+        byte acc = Byte.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)((in1B[i] * in2B[i]) + (in1B[i] * in3B[i]) + (in2B[i] * in3B[i]));
+            acc = (byte)Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void byteMaxBig(Blackhole bh) {
+        byte acc = Byte.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            byte val = (byte)((in1B[i] * in2B[i]) + (in1B[i] * in3B[i]) + (in2B[i] * in3B[i]));
+            acc = (byte)Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------char***Simple ------------------------------------------------------------
+    @Benchmark
+    public void charAndSimple(Blackhole bh) {
+        char acc = (char)0xFFFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = in1C[i];
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charOrSimple(Blackhole bh) {
+        char acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = in1C[i];
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charXorSimple(Blackhole bh) {
+        char acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = in1C[i];
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charAddSimple(Blackhole bh) {
+        char acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = in1C[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charMulSimple(Blackhole bh) {
+        char acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = in1C[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charMinSimple(Blackhole bh) {
+        char acc = Character.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = in1C[i];
+            acc = (char)Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charMaxSimple(Blackhole bh) {
+        char acc = Character.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = in1C[i];
+            acc = (char)Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------char***DotProduct ------------------------------------------------------------
+    @Benchmark
+    public void charAndDotProduct(Blackhole bh) {
+        char acc = (char)0xFFFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)(in1C[i] * in2C[i]);
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charOrDotProduct(Blackhole bh) {
+        char acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)(in1C[i] * in2C[i]);
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charXorDotProduct(Blackhole bh) {
+        char acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)(in1C[i] * in2C[i]);
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charAddDotProduct(Blackhole bh) {
+        char acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)(in1C[i] * in2C[i]);
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charMulDotProduct(Blackhole bh) {
+        char acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)(in1C[i] * in2C[i]);
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charMinDotProduct(Blackhole bh) {
+        char acc = Character.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)(in1C[i] * in2C[i]);
+            acc = (char)Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charMaxDotProduct(Blackhole bh) {
+        char acc = Character.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)(in1C[i] * in2C[i]);
+            acc = (char)Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------char***Big ------------------------------------------------------------
+    @Benchmark
+    public void charAndBig(Blackhole bh) {
+        char acc = (char)0xFFFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)((in1C[i] * in2C[i]) + (in1C[i] * in3C[i]) + (in2C[i] * in3C[i]));
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charOrBig(Blackhole bh) {
+        char acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)((in1C[i] * in2C[i]) + (in1C[i] * in3C[i]) + (in2C[i] * in3C[i]));
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charXorBig(Blackhole bh) {
+        char acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)((in1C[i] * in2C[i]) + (in1C[i] * in3C[i]) + (in2C[i] * in3C[i]));
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charAddBig(Blackhole bh) {
+        char acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)((in1C[i] * in2C[i]) + (in1C[i] * in3C[i]) + (in2C[i] * in3C[i]));
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charMulBig(Blackhole bh) {
+        char acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)((in1C[i] * in2C[i]) + (in1C[i] * in3C[i]) + (in2C[i] * in3C[i]));
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charMinBig(Blackhole bh) {
+        char acc = Character.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)((in1C[i] * in2C[i]) + (in1C[i] * in3C[i]) + (in2C[i] * in3C[i]));
+            acc = (char)Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void charMaxBig(Blackhole bh) {
+        char acc = Character.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            char val = (char)((in1C[i] * in2C[i]) + (in1C[i] * in3C[i]) + (in2C[i] * in3C[i]));
+            acc = (char)Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------short***Simple ------------------------------------------------------------
+    @Benchmark
+    public void shortAndSimple(Blackhole bh) {
+        short acc = (short)0xFFFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = in1S[i];
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortOrSimple(Blackhole bh) {
+        short acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = in1S[i];
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortXorSimple(Blackhole bh) {
+        short acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = in1S[i];
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortAddSimple(Blackhole bh) {
+        short acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = in1S[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortMulSimple(Blackhole bh) {
+        short acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = in1S[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortMinSimple(Blackhole bh) {
+        short acc = Short.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = in1S[i];
+            acc = (short)Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortMaxSimple(Blackhole bh) {
+        short acc = Short.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = in1S[i];
+            acc = (short)Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------short***DotProduct ------------------------------------------------------------
+    @Benchmark
+    public void shortAndDotProduct(Blackhole bh) {
+        short acc = (short)0xFFFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)(in1S[i] * in2S[i]);
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortOrDotProduct(Blackhole bh) {
+        short acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)(in1S[i] * in2S[i]);
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortXorDotProduct(Blackhole bh) {
+        short acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)(in1S[i] * in2S[i]);
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortAddDotProduct(Blackhole bh) {
+        short acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)(in1S[i] * in2S[i]);
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortMulDotProduct(Blackhole bh) {
+        short acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)(in1S[i] * in2S[i]);
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortMinDotProduct(Blackhole bh) {
+        short acc = Short.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)(in1S[i] * in2S[i]);
+            acc = (short)Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortMaxDotProduct(Blackhole bh) {
+        short acc = Short.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)(in1S[i] * in2S[i]);
+            acc = (short)Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------short***Big ------------------------------------------------------------
+    @Benchmark
+    public void shortAndBig(Blackhole bh) {
+        short acc = (short)0xFFFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)((in1S[i] * in2S[i]) + (in1S[i] * in3S[i]) + (in2S[i] * in3S[i]));
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortOrBig(Blackhole bh) {
+        short acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)((in1S[i] * in2S[i]) + (in1S[i] * in3S[i]) + (in2S[i] * in3S[i]));
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortXorBig(Blackhole bh) {
+        short acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)((in1S[i] * in2S[i]) + (in1S[i] * in3S[i]) + (in2S[i] * in3S[i]));
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortAddBig(Blackhole bh) {
+        short acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)((in1S[i] * in2S[i]) + (in1S[i] * in3S[i]) + (in2S[i] * in3S[i]));
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortMulBig(Blackhole bh) {
+        short acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)((in1S[i] * in2S[i]) + (in1S[i] * in3S[i]) + (in2S[i] * in3S[i]));
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortMinBig(Blackhole bh) {
+        short acc = Short.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)((in1S[i] * in2S[i]) + (in1S[i] * in3S[i]) + (in2S[i] * in3S[i]));
+            acc = (short)Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void shortMaxBig(Blackhole bh) {
+        short acc = Short.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            short val = (short)((in1S[i] * in2S[i]) + (in1S[i] * in3S[i]) + (in2S[i] * in3S[i]));
+            acc = (short)Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------int***Simple ------------------------------------------------------------
+    @Benchmark
+    public void intAndSimple(Blackhole bh) {
+        int acc = 0xFFFFFFFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i];
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intOrSimple(Blackhole bh) {
+        int acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i];
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intXorSimple(Blackhole bh) {
+        int acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i];
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intAddSimple(Blackhole bh) {
+        int acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intMulSimple(Blackhole bh) {
+        int acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intMinSimple(Blackhole bh) {
+        int acc = Integer.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i];
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intMaxSimple(Blackhole bh) {
+        int acc = Integer.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i];
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------int***DotProduct ------------------------------------------------------------
+    @Benchmark
+    public void intAndDotProduct(Blackhole bh) {
+        int acc = 0xFFFFFFFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i] * in2I[i];
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intOrDotProduct(Blackhole bh) {
+        int acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i] * in2I[i];
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intXorDotProduct(Blackhole bh) {
+        int acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i] * in2I[i];
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intAddDotProduct(Blackhole bh) {
+        int acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i] * in2I[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intMulDotProduct(Blackhole bh) {
+        int acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i] * in2I[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intMinDotProduct(Blackhole bh) {
+        int acc = Integer.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i] * in2I[i];
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intMaxDotProduct(Blackhole bh) {
+        int acc = Integer.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = in1I[i] * in2I[i];
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------int***Big ------------------------------------------------------------
+    @Benchmark
+    public void intAndBig(Blackhole bh) {
+        int acc = 0xFFFFFFFF; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = (in1I[i] * in2I[i]) + (in1I[i] * in3I[i]) + (in2I[i] * in3I[i]);
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intOrBig(Blackhole bh) {
+        int acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = (in1I[i] * in2I[i]) + (in1I[i] * in3I[i]) + (in2I[i] * in3I[i]);
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intXorBig(Blackhole bh) {
+        int acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = (in1I[i] * in2I[i]) + (in1I[i] * in3I[i]) + (in2I[i] * in3I[i]);
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intAddBig(Blackhole bh) {
+        int acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = (in1I[i] * in2I[i]) + (in1I[i] * in3I[i]) + (in2I[i] * in3I[i]);
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intMulBig(Blackhole bh) {
+        int acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = (in1I[i] * in2I[i]) + (in1I[i] * in3I[i]) + (in2I[i] * in3I[i]);
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intMinBig(Blackhole bh) {
+        int acc = Integer.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = (in1I[i] * in2I[i]) + (in1I[i] * in3I[i]) + (in2I[i] * in3I[i]);
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void intMaxBig(Blackhole bh) {
+        int acc = Integer.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            int val = (in1I[i] * in2I[i]) + (in1I[i] * in3I[i]) + (in2I[i] * in3I[i]);
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------long***Simple ------------------------------------------------------------
+    @Benchmark
+    public void longAndSimple(Blackhole bh) {
+        long acc = 0xFFFFFFFFFFFFFFFFL; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i];
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longOrSimple(Blackhole bh) {
+        long acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i];
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longXorSimple(Blackhole bh) {
+        long acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i];
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longAddSimple(Blackhole bh) {
+        long acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longMulSimple(Blackhole bh) {
+        long acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longMinSimple(Blackhole bh) {
+        long acc = Long.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i];
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longMaxSimple(Blackhole bh) {
+        long acc = Long.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i];
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------long***DotProduct ------------------------------------------------------------
+    @Benchmark
+    public void longAndDotProduct(Blackhole bh) {
+        long acc = 0xFFFFFFFFFFFFFFFFL; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i] * in2L[i];
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longOrDotProduct(Blackhole bh) {
+        long acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i] * in2L[i];
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longXorDotProduct(Blackhole bh) {
+        long acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i] * in2L[i];
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longAddDotProduct(Blackhole bh) {
+        long acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i] * in2L[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longMulDotProduct(Blackhole bh) {
+        long acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i] * in2L[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longMinDotProduct(Blackhole bh) {
+        long acc = Long.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i] * in2L[i];
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longMaxDotProduct(Blackhole bh) {
+        long acc = Long.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = in1L[i] * in2L[i];
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------long***Big ------------------------------------------------------------
+    @Benchmark
+    public void longAndBig(Blackhole bh) {
+        long acc = 0xFFFFFFFFFFFFFFFFL; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = (in1L[i] * in2L[i]) + (in1L[i] * in3L[i]) + (in2L[i] * in3L[i]);
+            acc &= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longOrBig(Blackhole bh) {
+        long acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = (in1L[i] * in2L[i]) + (in1L[i] * in3L[i]) + (in2L[i] * in3L[i]);
+            acc |= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longXorBig(Blackhole bh) {
+        long acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = (in1L[i] * in2L[i]) + (in1L[i] * in3L[i]) + (in2L[i] * in3L[i]);
+            acc ^= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longAddBig(Blackhole bh) {
+        long acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = (in1L[i] * in2L[i]) + (in1L[i] * in3L[i]) + (in2L[i] * in3L[i]);
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longMulBig(Blackhole bh) {
+        long acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = (in1L[i] * in2L[i]) + (in1L[i] * in3L[i]) + (in2L[i] * in3L[i]);
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longMinBig(Blackhole bh) {
+        long acc = Long.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = (in1L[i] * in2L[i]) + (in1L[i] * in3L[i]) + (in2L[i] * in3L[i]);
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void longMaxBig(Blackhole bh) {
+        long acc = Long.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            long val = (in1L[i] * in2L[i]) + (in1L[i] * in3L[i]) + (in2L[i] * in3L[i]);
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------float***Simple ------------------------------------------------------------
+    @Benchmark
+    public void floatAddSimple(Blackhole bh) {
+        float acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = in1F[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void floatMulSimple(Blackhole bh) {
+        float acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = in1F[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void floatMinSimple(Blackhole bh) {
+        float acc = Float.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = in1F[i];
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void floatMaxSimple(Blackhole bh) {
+        float acc = Float.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = in1F[i];
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------float***DotProduct ------------------------------------------------------------
+    @Benchmark
+    public void floatAddDotProduct(Blackhole bh) {
+        float acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = in1F[i] * in2F[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void floatMulDotProduct(Blackhole bh) {
+        float acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = in1F[i] * in2F[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void floatMinDotProduct(Blackhole bh) {
+        float acc = Float.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = in1F[i] * in2F[i];
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void floatMaxDotProduct(Blackhole bh) {
+        float acc = Float.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = in1F[i] * in2F[i];
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------float***Big ------------------------------------------------------------
+    @Benchmark
+    public void floatAddBig(Blackhole bh) {
+        float acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = (in1F[i] * in2F[i]) + (in1F[i] * in3F[i]) + (in2F[i] * in3F[i]);
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void floatMulBig(Blackhole bh) {
+        float acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = (in1F[i] * in2F[i]) + (in1F[i] * in3F[i]) + (in2F[i] * in3F[i]);
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void floatMinBig(Blackhole bh) {
+        float acc = Float.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = (in1F[i] * in2F[i]) + (in1F[i] * in3F[i]) + (in2F[i] * in3F[i]);
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void floatMaxBig(Blackhole bh) {
+        float acc = Float.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            float val = (in1F[i] * in2F[i]) + (in1F[i] * in3F[i]) + (in2F[i] * in3F[i]);
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------double***Simple ------------------------------------------------------------
+    @Benchmark
+    public void doubleAddSimple(Blackhole bh) {
+        double acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = in1D[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void doubleMulSimple(Blackhole bh) {
+        double acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = in1D[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void doubleMinSimple(Blackhole bh) {
+        double acc = Double.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = in1D[i];
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void doubleMaxSimple(Blackhole bh) {
+        double acc = Double.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = in1D[i];
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------double***DotProduct ------------------------------------------------------------
+    @Benchmark
+    public void doubleAddDotProduct(Blackhole bh) {
+        double acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = in1D[i] * in2D[i];
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void doubleMulDotProduct(Blackhole bh) {
+        double acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = in1D[i] * in2D[i];
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void doubleMinDotProduct(Blackhole bh) {
+        double acc = Double.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = in1D[i] * in2D[i];
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void doubleMaxDotProduct(Blackhole bh) {
+        double acc = Double.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = in1D[i] * in2D[i];
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    // ---------double***Big ------------------------------------------------------------
+    @Benchmark
+    public void doubleAddBig(Blackhole bh) {
+        double acc = 0; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = (in1D[i] * in2D[i]) + (in1D[i] * in3D[i]) + (in2D[i] * in3D[i]);
+            acc += val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void doubleMulBig(Blackhole bh) {
+        double acc = 1; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = (in1D[i] * in2D[i]) + (in1D[i] * in3D[i]) + (in2D[i] * in3D[i]);
+            acc *= val;
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void doubleMinBig(Blackhole bh) {
+        double acc = Double.MAX_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = (in1D[i] * in2D[i]) + (in1D[i] * in3D[i]) + (in2D[i] * in3D[i]);
+            acc = Math.min(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Benchmark
+    public void doubleMaxBig(Blackhole bh) {
+        double acc = Double.MIN_VALUE; // neutral element
+        for (int i = 0; i < SIZE; i++) {
+            double val = (in1D[i] * in2D[i]) + (in1D[i] * in3D[i]) + (in2D[i] * in3D[i]);
+            acc = Math.max(acc, val);
+        }
+        bh.consume(acc);
+    }
+
+    @Fork(value = 1, jvmArgsPrepend = {"-XX:+UseSuperWord"})
+    public static class WithSuperword extends VectorReduction2 {}
+
+    @Fork(value = 1, jvmArgsPrepend = {"-XX:-UseSuperWord"})
+    public static class NoSuperword extends VectorReduction2 {}
+}
+


### PR DESCRIPTION
I'm adding some proper JMH benchmarks for vectorized reductions. There are already some others, but they are not comprehensive or not JMH.

Plus, I wanted to do a performance-investigation, hopefully leading to some improvements. **See Future Work below**.

**How I run my benchmarks**

All benchmarks
`make test TEST="micro:vm.compiler.VectorReduction2" CONF=linux-x64`

Some specific benchmark, with profiler that tells me which code snippet is hottest:
`make test TEST="micro:vm.compiler.VectorReduction2.*doubleMinDotProduct" CONF=linux-x64 MICRO="OPTIONS=-prof perfasm"`

**JMH logs**

Run on my AVX512 laptop, with master:
[run_avx512_master.txt](https://github.com/user-attachments/files/17025111/run_avx512_master.txt)

Run on remote asimd (aarch64, NEON) machine:
[run_asimd_master.txt](https://github.com/user-attachments/files/17025579/run_asimd_master.txt)

**Results**

I ran it on 2 machines so far. Left on my AVX512 machine, right on a ASIMD/NEON/aarch64 machine.

Here the interesting `int / long / float / double` results, discussion further below:
![image](https://github.com/user-attachments/assets/20abfa7b-aee6-4654-bf4d-e3abc4bbfc8b)


And there the less spectacular `byte / char / short` results. There is no vectorization of these cases. But there seems to be some issue with over-unrolling on my AVX512 machine, one case I looked at would only unroll 4x without SuperWord, but 16x with, and that seems to be unfavourable.

![image](https://github.com/user-attachments/assets/6e1c69cf-db6c-4d33-8750-c8797ffc39a2)

Here the PDF:
[benchmark_results.pdf](https://github.com/user-attachments/files/17027695/benchmark_results.pdf)


**Why are all the ...Simple benchmarks not vectorizing, i.e. "not profitable"?**

Apparently, there must be sufficient "work" vectors to outweith the "reduction" vectors.
The idea used to be that one should have at least 2 work vectors which tend to be profitable, to outweigh the cost of a single reduction vector.
```
  // Check if reductions are connected
  if (is_marked_reduction(p0)) {
    Node* second_in = p0->in(2);
    Node_List* second_pk = get_pack(second_in);
    if ((second_pk == nullptr) || (_num_work_vecs == _num_reductions)) {
      // No parent pack or not enough work
      // to cover reduction expansion overhead
      return false;
    } else if (second_pk->size() != p->size()) {
      return false;
    }
  }
```

But when I disable this code, then I see on the aarch64/ASIMD machine:
```
VectorReduction2.NoSuperword.intAddSimple      2048       0  avgt    3  751.453 ± 1603.353  ns/op
VectorReduction2.WithSuperword.intAddSimple    2048       0  avgt    3  344.263 ±    2.888  ns/op
```

Hence, this assumption no longer holds. I think it is because we are actually able to move the reductions out of the loop now, and that was not the case when this code was added.

**2-Element Reductions for INT / LONG**

Apparently, all 2-element int and long reductions are currently deemed not profitable, see change: https://github.com/openjdk/jdk/commit/a880f3d1399469c2cd7ef1ace1deb7e04c5ab3d5

This means that the `long` reductions do not vectorize on the ASIMD / aarch64 machine with `MaxVectorSize=16`.
```
      // Length 2 reductions of INT/LONG do not offer performance benefits
      if (((arith_type->basic_type() == T_INT) || (arith_type->basic_type() == T_LONG)) && (size == 2)) {
        retValue = false;
      } else {
        retValue = ReductionNode::implemented(opc, size, arith_type->basic_type());
      }
```

**AARCH64 / NEON / ASIMD**

This is why the `float / double` `add / mul` reductions (yellow `MATCHER`) do not vectorize. We might be able to tackle this with an appropriate alternative implementation.

Also all of the `long` cases fail. For one because they would only be 2-element reductions (because only `MaxVectorSize=16`). But also because the `MulVL` is not allowed apparently, see below.

```
  bool Matcher::match_rule_supported_auto_vectorization(int opcode, int vlen, BasicType bt) {
    if (UseSVE == 0) {
      // These operations are not profitable to be vectorized on NEON, because no direct
      // NEON instructions support them. But the match rule support for them is profitable for
      // Vector API intrinsics.
      if ((opcode == Op_VectorCastD2X && bt == T_INT) ||
          (opcode == Op_VectorCastL2X && bt == T_FLOAT) ||
          (opcode == Op_CountLeadingZerosV && bt == T_LONG) ||
          (opcode == Op_CountTrailingZerosV && bt == T_LONG) ||
          // The implementations of Op_AddReductionVD/F in Neon are for the Vector API only.
          // They are not suitable for auto-vectorization because the result would not conform
          // to the JLS, Section Evaluation Order.
          opcode == Op_AddReductionVD || opcode == Op_AddReductionVF ||
          opcode == Op_MulReductionVD || opcode == Op_MulReductionVF ||
          opcode == Op_MulVL) {
        return false;
      }
    }
    return match_rule_supported_vector(opcode, vlen, bt);
  }
```
**Float / Double with Add and Mul**

On `aarch64` NEON these cases do not vectorize, see last section.

It turns out that many of these cases actually do vectorize (on x64), but the code is just as fast as the scalar code.
This is because the reduction order is strict, to maintain correct rounding.
Interestingly, the code runs about at the same speed, if vectorized or not. it seems that the latency of the reduction is simply the determining factor, no matter if it is vectorized or scalar.

Running this for example shows that the loop-bodies are quite different:
```
make test TEST="micro:vm.compiler.VectorReduction2.*floatAddBig" CONF=linux-x64 MICRO="OPTIONS=-prof perfasm"
```

Scalar loop body, note only scalar xmm registers are used:
```
            0x00007fcee43ffedb:   vaddss %xmm3,%xmm6,%xmm6
            0x00007fcee43ffedf:   vmulss %xmm2,%xmm4,%xmm4
   6.69%    0x00007fcee43ffee3:   vmulss %xmm2,%xmm1,%xmm1
            0x00007fcee43ffee7:   vaddss %xmm4,%xmm5,%xmm3
            0x00007fcee43ffeeb:   vmulss %xmm18,%xmm13,%xmm2
            0x00007fcee43ffef1:   vaddss %xmm1,%xmm3,%xmm3
            0x00007fcee43ffef5:   vmulss %xmm12,%xmm10,%xmm1
            0x00007fcee43ffefa:   vmulss %xmm11,%xmm13,%xmm5
            0x00007fcee43ffeff:   vaddss %xmm17,%xmm1,%xmm1
            0x00007fcee43fff05:   vaddss %xmm5,%xmm2,%xmm4            ;   {no_reloc}
   5.81%    0x00007fcee43fff09:   vaddss %xmm14,%xmm1,%xmm1
            0x00007fcee43fff0e:   vaddss %xmm15,%xmm4,%xmm4
            0x00007fcee43fff13:   vaddss %xmm9,%xmm4,%xmm2
            0x00007fcee43fff18:   vaddss %xmm2,%xmm3,%xmm3
  24.14%    0x00007fcee43fff1c:   vaddss %xmm3,%xmm6,%xmm2
  24.50%    0x00007fcee43fff20:   vaddss %xmm2,%xmm1,%xmm9
```

Vector loop uses `zmm`, `ymm` and `xmm` registers, and not just `mul` and `add`, but also `vpshufd` and `vextractf128` instructions to shuffle the values around in the reduction.
```
            0x00007f4578400c36:   vmulps %zmm3,%zmm2,%zmm12
            0x00007f4578400c3c:   vmulps %zmm9,%zmm11,%zmm13
   0.33%    0x00007f4578400c42:   vmulps %zmm10,%zmm11,%zmm11
            0x00007f4578400c48:   vmulps %zmm2,%zmm4,%zmm2
            0x00007f4578400c4e:   vaddps %zmm13,%zmm11,%zmm11
            0x00007f4578400c54:   vmulps %zmm3,%zmm4,%zmm3
            0x00007f4578400c5a:   vmulps %zmm5,%zmm15,%zmm13
            0x00007f4578400c60:   vaddps %zmm2,%zmm3,%zmm2
            0x00007f4578400c66:   vmulps %zmm10,%zmm9,%zmm3
            0x00007f4578400c6c:   vaddps %zmm12,%zmm2,%zmm2
   0.39%    0x00007f4578400c72:   vaddps %zmm3,%zmm11,%zmm3           ;   {no_reloc}
            0x00007f4578400c78:   vmulps %zmm7,%zmm8,%zmm4
            0x00007f4578400c7e:   vmulps %zmm6,%zmm8,%zmm8
   0.03%    0x00007f4578400c84:   vmulps %zmm7,%zmm6,%zmm6
            0x00007f4578400c8a:   vaddps %zmm8,%zmm4,%zmm4
            0x00007f4578400c90:   vmulps %zmm5,%zmm16,%zmm5
            0x00007f4578400c96:   vaddps %zmm6,%zmm4,%zmm4
            0x00007f4578400c9c:   vmulps %zmm15,%zmm16,%zmm6
   0.36%    0x00007f4578400ca2:   vaddps %zmm6,%zmm5,%zmm5
            0x00007f4578400ca8:   vaddps %zmm13,%zmm5,%zmm5
            0x00007f4578400cae:   vaddss %xmm3,%xmm1,%xmm1
            0x00007f4578400cb2:   vpshufd $0x1,%xmm3,%xmm13
   0.23%    0x00007f4578400cb7:   vaddss %xmm13,%xmm1,%xmm1
   0.85%    0x00007f4578400cbc:   vpshufd $0x2,%xmm3,%xmm13
            0x00007f4578400cc1:   vaddss %xmm13,%xmm1,%xmm1
   1.31%    0x00007f4578400cc6:   vpshufd $0x3,%xmm3,%xmm13
            0x00007f4578400ccb:   vaddss %xmm13,%xmm1,%xmm1
   1.61%    0x00007f4578400cd0:   vextractf128 $0x1,%ymm3,%xmm13
            0x00007f4578400cd6:   vaddss %xmm13,%xmm1,%xmm1
   1.08%    0x00007f4578400cdb:   vpshufd $0x1,%xmm13,%xmm12
            0x00007f4578400ce1:   vaddss %xmm12,%xmm1,%xmm1
   1.48%    0x00007f4578400ce6:   vpshufd $0x2,%xmm13,%xmm12
            0x00007f4578400cec:   vaddss %xmm12,%xmm1,%xmm1
   1.48%    0x00007f4578400cf1:   vpshufd $0x3,%xmm13,%xmm12
            0x00007f4578400cf7:   vaddss %xmm12,%xmm1,%xmm1
   1.15%    0x00007f4578400cfc:   vextracti64x4 $0x1,%zmm3,%ymm12
            0x00007f4578400d03:   vaddss %xmm12,%xmm1,%xmm1
   1.64%    0x00007f4578400d08:   vpshufd $0x1,%xmm12,%xmm13
            0x00007f4578400d0e:   vaddss %xmm13,%xmm1,%xmm1
   1.12%    0x00007f4578400d13:   vpshufd $0x2,%xmm12,%xmm13
            0x00007f4578400d19:   vaddss %xmm13,%xmm1,%xmm1
   1.34%    0x00007f4578400d1e:   vpshufd $0x3,%xmm12,%xmm13
            0x00007f4578400d24:   vaddss %xmm13,%xmm1,%xmm1
   1.41%    0x00007f4578400d29:   vextractf128 $0x1,%ymm12,%xmm13
            0x00007f4578400d2f:   vaddss %xmm13,%xmm1,%xmm1
   1.54%    0x00007f4578400d34:   vpshufd $0x1,%xmm13,%xmm12
            0x00007f4578400d3a:   vaddss %xmm12,%xmm1,%xmm1
   1.41%    0x00007f4578400d3f:   vpshufd $0x2,%xmm13,%xmm12
            0x00007f4578400d45:   vaddss %xmm12,%xmm1,%xmm1
   1.28%    0x00007f4578400d4a:   vpshufd $0x3,%xmm13,%xmm12
            0x00007f4578400d50:   vaddss %xmm12,%xmm1,%xmm1
   1.57%    0x00007f4578400d55:   vaddss %xmm4,%xmm1,%xmm1
   1.31%    0x00007f4578400d59:   vpshufd $0x1,%xmm4,%xmm6
            0x00007f4578400d5e:   vaddss %xmm6,%xmm1,%xmm1
   1.28%    0x00007f4578400d62:   vpshufd $0x2,%xmm4,%xmm6
            0x00007f4578400d67:   vaddss %xmm6,%xmm1,%xmm1
   1.34%    0x00007f4578400d6b:   vpshufd $0x3,%xmm4,%xmm6
            0x00007f4578400d70:   vaddss %xmm6,%xmm1,%xmm1
   1.05%    0x00007f4578400d74:   vextractf128 $0x1,%ymm4,%xmm6       ;   {no_reloc}
            0x00007f4578400d7a:   vaddss %xmm6,%xmm1,%xmm1
   1.67%    0x00007f4578400d7e:   vpshufd $0x1,%xmm6,%xmm11
            0x00007f4578400d83:   vaddss %xmm11,%xmm1,%xmm1
   1.48%    0x00007f4578400d88:   vpshufd $0x2,%xmm6,%xmm11
            0x00007f4578400d8d:   vaddss %xmm11,%xmm1,%xmm1
   1.25%    0x00007f4578400d92:   vpshufd $0x3,%xmm6,%xmm11
            0x00007f4578400d97:   vaddss %xmm11,%xmm1,%xmm1
   1.21%    0x00007f4578400d9c:   vextracti64x4 $0x1,%zmm4,%ymm11
            0x00007f4578400da3:   vaddss %xmm11,%xmm1,%xmm1
   1.94%    0x00007f4578400da8:   vpshufd $0x1,%xmm11,%xmm6
            0x00007f4578400dae:   vaddss %xmm6,%xmm1,%xmm1
   1.21%    0x00007f4578400db2:   vpshufd $0x2,%xmm11,%xmm6
            0x00007f4578400db8:   vaddss %xmm6,%xmm1,%xmm1
   1.77%    0x00007f4578400dbc:   vpshufd $0x3,%xmm11,%xmm6
            0x00007f4578400dc2:   vaddss %xmm6,%xmm1,%xmm1
   1.57%    0x00007f4578400dc6:   vextractf128 $0x1,%ymm11,%xmm6
            0x00007f4578400dcc:   vaddss %xmm6,%xmm1,%xmm1
   1.02%    0x00007f4578400dd0:   vpshufd $0x1,%xmm6,%xmm11
            0x00007f4578400dd5:   vaddss %xmm11,%xmm1,%xmm1
   1.48%    0x00007f4578400dda:   vpshufd $0x2,%xmm6,%xmm11
            0x00007f4578400ddf:   vaddss %xmm11,%xmm1,%xmm1
   1.31%    0x00007f4578400de4:   vpshufd $0x3,%xmm6,%xmm11
            0x00007f4578400de9:   vaddss %xmm11,%xmm1,%xmm1
   1.54%    0x00007f4578400dee:   vaddss %xmm5,%xmm1,%xmm1
   1.61%    0x00007f4578400df2:   vpshufd $0x1,%xmm5,%xmm9
            0x00007f4578400df7:   vaddss %xmm9,%xmm1,%xmm1
   1.51%    0x00007f4578400dfc:   vpshufd $0x2,%xmm5,%xmm9
            0x00007f4578400e01:   vaddss %xmm9,%xmm1,%xmm1
   1.61%    0x00007f4578400e06:   vpshufd $0x3,%xmm5,%xmm9
            0x00007f4578400e0b:   vaddss %xmm9,%xmm1,%xmm1
   1.34%    0x00007f4578400e10:   vextractf128 $0x1,%ymm5,%xmm9
            0x00007f4578400e16:   vaddss %xmm9,%xmm1,%xmm1
   1.25%    0x00007f4578400e1b:   vpshufd $0x1,%xmm9,%xmm8
            0x00007f4578400e21:   vaddss %xmm8,%xmm1,%xmm1
   2.16%    0x00007f4578400e26:   vpshufd $0x2,%xmm9,%xmm8
            0x00007f4578400e2c:   vaddss %xmm8,%xmm1,%xmm1
   1.44%    0x00007f4578400e31:   vpshufd $0x3,%xmm9,%xmm8
            0x00007f4578400e37:   vaddss %xmm8,%xmm1,%xmm1
   1.38%    0x00007f4578400e3c:   vextracti64x4 $0x1,%zmm5,%ymm8
            0x00007f4578400e43:   vaddss %xmm8,%xmm1,%xmm1
   1.51%    0x00007f4578400e48:   vpshufd $0x1,%xmm8,%xmm9
            0x00007f4578400e4e:   vaddss %xmm9,%xmm1,%xmm1
   1.74%    0x00007f4578400e53:   vpshufd $0x2,%xmm8,%xmm9
            0x00007f4578400e59:   vaddss %xmm9,%xmm1,%xmm1
   1.87%    0x00007f4578400e5e:   vpshufd $0x3,%xmm8,%xmm9
            0x00007f4578400e64:   vaddss %xmm9,%xmm1,%xmm1
   1.28%    0x00007f4578400e69:   vextractf128 $0x1,%ymm8,%xmm9
            0x00007f4578400e6f:   vaddss %xmm9,%xmm1,%xmm1
   1.67%    0x00007f4578400e74:   vpshufd $0x1,%xmm9,%xmm8            ;   {no_reloc}
            0x00007f4578400e7a:   vaddss %xmm8,%xmm1,%xmm1
   1.57%    0x00007f4578400e7f:   vpshufd $0x2,%xmm9,%xmm8
            0x00007f4578400e85:   vaddss %xmm8,%xmm1,%xmm1
   1.48%    0x00007f4578400e8a:   vpshufd $0x3,%xmm9,%xmm8
            0x00007f4578400e90:   vaddss %xmm8,%xmm1,%xmm1
   1.57%    0x00007f4578400e95:   vaddss %xmm2,%xmm1,%xmm1
   1.57%    0x00007f4578400e99:   vpshufd $0x1,%xmm2,%xmm7
            0x00007f4578400e9e:   vaddss %xmm7,%xmm1,%xmm1
   1.61%    0x00007f4578400ea2:   vpshufd $0x2,%xmm2,%xmm7
            0x00007f4578400ea7:   vaddss %xmm7,%xmm1,%xmm1
   1.48%    0x00007f4578400eab:   vpshufd $0x3,%xmm2,%xmm7
            0x00007f4578400eb0:   vaddss %xmm7,%xmm1,%xmm1
   1.44%    0x00007f4578400eb4:   vextractf128 $0x1,%ymm2,%xmm7
            0x00007f4578400eba:   vaddss %xmm7,%xmm1,%xmm1
   1.02%    0x00007f4578400ebe:   vpshufd $0x1,%xmm7,%xmm10
            0x00007f4578400ec3:   vaddss %xmm10,%xmm1,%xmm1
   1.54%    0x00007f4578400ec8:   vpshufd $0x2,%xmm7,%xmm10
            0x00007f4578400ecd:   vaddss %xmm10,%xmm1,%xmm1
   1.31%    0x00007f4578400ed2:   vpshufd $0x3,%xmm7,%xmm10
            0x00007f4578400ed7:   vaddss %xmm10,%xmm1,%xmm1
   1.28%    0x00007f4578400edc:   vextracti64x4 $0x1,%zmm2,%ymm10
            0x00007f4578400ee3:   vaddss %xmm10,%xmm1,%xmm1
   1.28%    0x00007f4578400ee8:   vpshufd $0x1,%xmm10,%xmm7
            0x00007f4578400eee:   vaddss %xmm7,%xmm1,%xmm1
   2.03%    0x00007f4578400ef2:   vpshufd $0x2,%xmm10,%xmm7
            0x00007f4578400ef8:   vaddss %xmm7,%xmm1,%xmm1
   1.44%    0x00007f4578400efc:   vpshufd $0x3,%xmm10,%xmm7
            0x00007f4578400f02:   vaddss %xmm7,%xmm1,%xmm1
   1.48%    0x00007f4578400f06:   vextractf128 $0x1,%ymm10,%xmm7
            0x00007f4578400f0c:   vaddss %xmm7,%xmm1,%xmm1
   1.31%    0x00007f4578400f10:   vpshufd $0x1,%xmm7,%xmm10
            0x00007f4578400f15:   vaddss %xmm10,%xmm1,%xmm1
   1.08%    0x00007f4578400f1a:   vpshufd $0x2,%xmm7,%xmm10
            0x00007f4578400f1f:   vaddss %xmm10,%xmm1,%xmm1
   1.64%    0x00007f4578400f24:   vpshufd $0x3,%xmm7,%xmm10
            0x00007f4578400f29:   vaddss %xmm10,%xmm1,%xmm1
```

**No vectorization for longMulBig?**

I locally can get vectorization in another setting, but somehow not in the JMH benchmark. This is strange, and I'll have to keep investigating.

**No speedup with doubleMinDotProduct**

Strangely, on my AVX512 machine, that benchmark did vectorize, but it did not experience any speedup. I'm quite confused about that. Especially because the parallel benchmark `doubleMaxDotProduct` vectorizes just fine. More investigation needed.

----------------------------------------


**Future Work**

- [JDK-8307513](https://bugs.openjdk.org/browse/JDK-8307513): C2: intrinsify Math.max(long,long) and Math.min(long,long)
- The `Simple` benchmarks should be profitable -> allow vectorization!
- Investigate the results for `byte / char / short`: is it all due to over-unrolling?
- `float / double` with `add / mul`:
  - the main issue is with the strict order of operations. Maybe we can add some `Float.addAssociative` so that we can do non-strict reduction? That could be a cool feature for those who care about performance and are willing to give up some rounding precision.
  - The aarch64 backend simply refuses to vectorize these, because there is no strict order implementation. That could be changed. Though we would need a benchmark where it is worth it...
- Investigate the strange results with `longMulBig` and `doubleMinDotProduct`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340272](https://bugs.openjdk.org/browse/JDK-8340272): C2 SuperWord: JMH benchmark for Reduction vectorization (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Jasmine Karthikeyan](https://openjdk.org/census#jkarthikeyan) (@jaskarth - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21032/head:pull/21032` \
`$ git checkout pull/21032`

Update a local copy of the PR: \
`$ git checkout pull/21032` \
`$ git pull https://git.openjdk.org/jdk.git pull/21032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21032`

View PR using the GUI difftool: \
`$ git pr show -t 21032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21032.diff">https://git.openjdk.org/jdk/pull/21032.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21032#issuecomment-2355522076)