### PR TITLE
8340269: [s390x] TestLargeStub.java failure after 8338123

### DIFF
--- a/src/hotspot/cpu/s390/downcallLinker_s390.cpp
+++ b/src/hotspot/cpu/s390/downcallLinker_s390.cpp
@@ -36,8 +36,8 @@
 
 #define __ _masm->
 
-static const int native_invoker_code_base_size = 256;
-static const int native_invoker_size_per_args = 16;
+static const int native_invoker_code_base_size = 384;
+static const int native_invoker_size_per_args = 12;
 
 RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
                                                 int num_args,

--- a/src/hotspot/cpu/s390/downcallLinker_s390.cpp
+++ b/src/hotspot/cpu/s390/downcallLinker_s390.cpp
@@ -36,8 +36,8 @@
 
 #define __ _masm->
 
-static const int native_invoker_code_base_size = 512;
-static const int native_invoker_size_per_args = 8;
+static const int native_invoker_code_base_size = 256;
+static const int native_invoker_size_per_args = 16;
 
 RuntimeStub* DowncallLinker::make_downcall_stub(BasicType* signature,
                                                 int num_args,


### PR DESCRIPTION
Fixes the test case; Ran tier1 with fastdebug-vm, didn't see any regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340269](https://bugs.openjdk.org/browse/JDK-8340269): [s390x] TestLargeStub.java failure after 8338123 (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21033/head:pull/21033` \
`$ git checkout pull/21033`

Update a local copy of the PR: \
`$ git checkout pull/21033` \
`$ git pull https://git.openjdk.org/jdk.git pull/21033/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21033`

View PR using the GUI difftool: \
`$ git pr show -t 21033`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21033.diff">https://git.openjdk.org/jdk/pull/21033.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21033#issuecomment-2354914181)