### PR TITLE
8340323: Test jdk/classfile/OptionsTest.java fails after JDK-8340200

### DIFF
--- a/test/jdk/jdk/classfile/OptionsTest.java
+++ b/test/jdk/jdk/classfile/OptionsTest.java
@@ -62,7 +62,7 @@ class OptionsTest {
     @MethodSource("corpus")
     void testAttributesProcessingOptionOnTransform(Path path) throws Exception {
         testNoUnstable(path, ClassFile.of().parse(
-                ClassFile.of(ClassFile.AttributesProcessingOption.DROP_UNSTABLE_ATRIBUTES).transformClass(
+                ClassFile.of(ClassFile.AttributesProcessingOption.DROP_UNSTABLE_ATTRIBUTES).transformClass(
                             ClassFile.of().parse(path),
                             ClassTransform.transformingMethodBodies(CodeTransform.ACCEPT_ALL))));
     }


### PR DESCRIPTION
A rename to a typo in preview enum constants missed a usage in tier1 tests. This fixes the typo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340323](https://bugs.openjdk.org/browse/JDK-8340323): Test jdk/classfile/OptionsTest.java fails after JDK-8340200 (**Bug** - P1)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21044/head:pull/21044` \
`$ git checkout pull/21044`

Update a local copy of the PR: \
`$ git checkout pull/21044` \
`$ git pull https://git.openjdk.org/jdk.git pull/21044/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21044`

View PR using the GUI difftool: \
`$ git pr show -t 21044`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21044.diff">https://git.openjdk.org/jdk/pull/21044.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21044#issuecomment-2356588000)