### PR TITLE
8339735: Remove references to Applet in core-libs/security APIs

### DIFF
--- a/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
+++ b/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
@@ -92,7 +92,7 @@ methods:</p>
                 Thread.sleep(interval);
             } catch (InterruptedException e){
             }
-            repaint();
+            blink();
         }
     }
 </pre>
@@ -112,7 +112,7 @@ application's <code>stop</code> and <code>run</code> methods with:
                 Thread.sleep(interval);
             } catch (InterruptedException e){
             }
-            repaint();
+            blink();
         }
     }
 </pre>

--- a/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
+++ b/src/java.base/share/classes/java/lang/doc-files/threadPrimitiveDeprecation.html
@@ -71,7 +71,7 @@ the variable indicates that it is to stop running. To ensure prompt
 communication of the stop-request, the variable must be
 <code>volatile</code> (or access to the variable must be
 synchronized).</p>
-<p>For example, suppose your applet contains the following
+<p>For example, suppose your application contains the following
 <code>start</code>, <code>stop</code> and <code>run</code>
 methods:</p>
 <pre>
@@ -97,7 +97,7 @@ methods:</p>
     }
 </pre>
 You can avoid the use of <code>Thread.stop</code> by replacing the
-applet's <code>stop</code> and <code>run</code> methods with:
+application's <code>stop</code> and <code>run</code> methods with:
 <pre>
     private volatile Thread blinker;
 

--- a/src/java.base/share/classes/java/net/HttpURLConnection.java
+++ b/src/java.base/share/classes/java/net/HttpURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -373,8 +373,7 @@ public abstract class HttpURLConnection extends URLConnection {
 
     /**
      * Sets whether HTTP redirects  (requests with response code 3xx) should
-     * be automatically followed by this class.  True by default.  Applets
-     * cannot change this variable.
+     * be automatically followed by this class.  True by default.
      * <p>
      * If there is a security manager, this method first calls
      * the security manager's {@code checkSetFactory} method

--- a/src/java.base/share/classes/java/nio/charset/spi/CharsetProvider.java
+++ b/src/java.base/share/classes/java/nio/charset/spi/CharsetProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,7 @@ import java.util.Iterator;
  * zero-argument constructor and some number of associated charset
  * implementation classes.  Charset providers may be installed in an instance
  * of the Java platform as extensions.  Providers may also be made available by
- * adding them to the applet or application class path or by some other
+ * adding them to the application class path or by some other
  * platform-specific means.  Charset providers are looked up via the current
  * thread's {@link java.lang.Thread#getContextClassLoader() context class
  * loader}.

--- a/src/java.base/share/classes/javax/crypto/CryptoPermission.java
+++ b/src/java.base/share/classes/javax/crypto/CryptoPermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import javax.crypto.spec.*;
  * The {@code CryptoPermission} class extends the
  * {@code java.security.Permission} class. A
  * {@code CryptoPermission} object is used to represent
- * the ability of an application/applet to use certain
+ * the ability of an application to use certain
  * algorithms with certain key sizes and other
  * restrictions in certain environments.
  *

--- a/src/java.base/share/classes/javax/crypto/ExemptionMechanism.java
+++ b/src/java.base/share/classes/javax/crypto/ExemptionMechanism.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -43,7 +43,7 @@ import sun.security.jca.GetInstance.Instance;
  * of which are <i>key recovery</i>, <i>key weakening</i>, and
  * <i>key escrow</i>.
  *
- * <p>Applications or applets that use an exemption mechanism may be granted
+ * <p>Applications that use an exemption mechanism may be granted
  * stronger encryption capabilities than those which don't.
  *
  * @since 1.4

--- a/src/java.base/share/classes/javax/crypto/JceSecurityManager.java
+++ b/src/java.base/share/classes/javax/crypto/JceSecurityManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,9 @@ import java.lang.StackWalker.*;
  * The JCE security manager.
  *
  * <p>The JCE security manager is responsible for determining the maximum
- * allowable cryptographic strength for a given applet/application, for a given
+ * allowable cryptographic strength for a given application, for a given
  * algorithm, by consulting the configured jurisdiction policy files and
- * the cryptographic permissions bundled with the applet/application.
+ * the cryptographic permissions bundled with the application.
  *
  * @author Jan Luehe
  *
@@ -85,7 +85,7 @@ final class JceSecurityManager {
 
     /**
      * Returns the maximum allowable crypto strength for the given
-     * applet/application, for the given algorithm.
+     * application, for the given algorithm.
      */
     CryptoPermission getCryptoPermission(String theAlg) {
 

--- a/src/java.base/share/classes/javax/net/SocketFactory.java
+++ b/src/java.base/share/classes/javax/net/SocketFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ import java.net.UnknownHostException;
  *
  * <P> Factory classes are specified by environment-specific configuration
  * mechanisms.  For example, the <em>getDefault</em> method could return
- * a factory that was appropriate for a particular user or applet, and a
+ * a factory that was appropriate for a particular user, and a
  * framework could use a factory customized to its own purposes.
  *
  * @since 1.4

--- a/src/java.base/share/classes/javax/net/SocketFactory.java
+++ b/src/java.base/share/classes/javax/net/SocketFactory.java
@@ -60,7 +60,7 @@ import java.net.UnknownHostException;
  *
  * <P> Factory classes are specified by environment-specific configuration
  * mechanisms.  For example, the <em>getDefault</em> method could return
- * a factory that was appropriate for a particular user, and a
+ * a factory that was appropriate for a particular application, and a
  * framework could use a factory customized to its own purposes.
  *
  * @since 1.4


### PR DESCRIPTION
Please review this PR which removes occurrences of 'applet' within the corelibs specification. Applet has been deprecated since JDK9, and may be a confusing term for new Java developers, so it should be removed from the documentation.

Primarily, usages where 'applet' is used interchangeably with 'application' are removed.
This change does not include removal of usages in a historical sense. For example, something such as 

```
 * @apiNote
 * Thread groups provided a way in early Java releases to group threads and provide
 * a form of <i>job control</i> for threads. Thread groups supported the isolation
 * of applets and defined methods intended for diagnostic purposes. It should be
 * rare for new applications to create ThreadGroups and interact with this API.
```

in _src/java.base/share/classes/java/lang/ThreadGroup.java_. 
Please see the JBS issue comments for further reasoning on why other occurrences were not removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8340211](https://bugs.openjdk.org/browse/JDK-8340211) to be approved

### Issues
 * [JDK-8339735](https://bugs.openjdk.org/browse/JDK-8339735): Remove references to Applet in core-libs/security APIs (**Bug** - P4)
 * [JDK-8340211](https://bugs.openjdk.org/browse/JDK-8340211): Remove references to Applet in core-libs/security APIs (**CSR**)


### Reviewers
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21046/head:pull/21046` \
`$ git checkout pull/21046`

Update a local copy of the PR: \
`$ git checkout pull/21046` \
`$ git pull https://git.openjdk.org/jdk.git pull/21046/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21046`

View PR using the GUI difftool: \
`$ git pr show -t 21046`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21046.diff">https://git.openjdk.org/jdk/pull/21046.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21046#issuecomment-2357169695)