### PR TITLE
8340329: (fs) Message of NotLinkException thrown by FIles.readSymbolicLink does not include file name (win)

### DIFF
--- a/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -86,7 +86,7 @@ class WindowsLinkSupport {
             x.rethrowAsIOException(path);
         }
         try {
-            return readLinkImpl(handle);
+            return readLinkImpl(path, handle);
         } finally {
             CloseHandle(handle);
         }
@@ -297,20 +297,18 @@ class WindowsLinkSupport {
      * Returns target of a symbolic link given the handle of an open file
      * (that should be a link).
      */
-    private static String readLinkImpl(long handle) throws IOException {
+    private static String readLinkImpl(WindowsPath path, long handle)
+        throws IOException
+    {
         int size = MAXIMUM_REPARSE_DATA_BUFFER_SIZE;
         try (NativeBuffer buffer = NativeBuffers.getNativeBuffer(size)) {
             try {
                 DeviceIoControlGetReparsePoint(handle, buffer.address(), size);
             } catch (WindowsException x) {
-                String filename = null;
-                try {
-                    filename = GetFinalPathNameByHandle(handle);
-                } catch (WindowsException ignore) {
-                }
+                String pathname = path.getPathForExceptionMessage();
                 if (x.lastError() == ERROR_NOT_A_REPARSE_POINT)
-                    throw new NotLinkException(filename, null, x.errorString());
-                x.rethrowAsIOException(filename + ": " + x.errorString());
+                    throw new NotLinkException(pathname, null, x.errorString());
+                x.rethrowAsIOException(pathname + ": " + x.errorString());
             }
 
             /*
@@ -346,12 +344,8 @@ class WindowsLinkSupport {
 
             int tag = (int)unsafe.getLong(buffer.address() + OFFSETOF_REPARSETAG);
             if (tag != IO_REPARSE_TAG_SYMLINK) {
-                String filename = null;
-                try {
-                    filename = GetFinalPathNameByHandle(handle);
-                } catch (WindowsException ignore) {
-                }
-                throw new NotLinkException(filename, null, "Reparse point is not a symbolic link");
+                String pathname = path.getPathForExceptionMessage();
+                throw new NotLinkException(pathname, null, "Reparse point is not a symbolic link");
             }
 
             // get offset and length of target

--- a/test/jdk/java/nio/file/Files/Links.java
+++ b/test/jdk/java/nio/file/Files/Links.java
@@ -135,7 +135,6 @@ public class Links {
         // Check message of NotLinkException
         try {
             Files.createDirectory(mydir);
-            Files.createFile(myfile);
 
             try {
                 Path mytarget = Files.readSymbolicLink(mydir);
@@ -150,21 +149,7 @@ public class Links {
                     assertTrue(okay);
                 }
             }
-            try {
-                Path mytarget = Files.readSymbolicLink(myfile);
-            } catch (NotLinkException expected) {
-                String filename = myfile.getFileName().toString();
-                String message = expected.getMessage();
-                boolean okay = message.contains(filename);
-                if (!okay) {
-                    System.err.println("Message \"" + message + "\"" +
-                        " does not contain the filename \"" +
-                        filename + "\"");
-                    assertTrue(okay);
-                }
-            }
         } finally {
-            Files.deleteIfExists(myfile);
             Files.deleteIfExists(mydir);
         }
     }

--- a/test/jdk/java/nio/file/Files/Links.java
+++ b/test/jdk/java/nio/file/Files/Links.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6838333 6863864
+ * @bug 4313887 6838333 6863864 8340329
  * @summary Unit test for java.nio.file.Files createSymbolicLink,
  *     readSymbolicLink, and createLink methods
  * @library ..
@@ -45,7 +45,7 @@ public class Links {
     }
 
     /**
-     * Exercise createSymbolicLink and readLink methods
+     * Exercise createSymbolicLink and readSymbolicLink methods
      */
     static void testSymLinks(Path dir) throws IOException {
         final Path link = dir.resolve("link");
@@ -130,6 +130,42 @@ public class Links {
             Files.deleteIfExists(myfile);
             Files.deleteIfExists(mydir);
             Files.deleteIfExists(link);
+        }
+
+        // Check message of NotLinkException
+        try {
+            Files.createDirectory(mydir);
+            Files.createFile(myfile);
+
+            try {
+                Path mytarget = Files.readSymbolicLink(mydir);
+            } catch (NotLinkException expected) {
+                String filename = mydir.getFileName().toString();
+                String message = expected.getMessage();
+                boolean okay = message.contains(filename);
+                if (!okay) {
+                    System.err.println("Message \"" + message + "\"" +
+                        " does not contain the filename \"" +
+                        filename + "\"");
+                    assertTrue(okay);
+                }
+            }
+            try {
+                Path mytarget = Files.readSymbolicLink(myfile);
+            } catch (NotLinkException expected) {
+                String filename = myfile.getFileName().toString();
+                String message = expected.getMessage();
+                boolean okay = message.contains(filename);
+                if (!okay) {
+                    System.err.println("Message \"" + message + "\"" +
+                        " does not contain the filename \"" +
+                        filename + "\"");
+                    assertTrue(okay);
+                }
+            }
+        } finally {
+            Files.deleteIfExists(myfile);
+            Files.deleteIfExists(mydir);
         }
     }
 


### PR DESCRIPTION
Add the file name of the Path passed to `Files.readSymbolicLink` to the message of the `NotLinkException` thrown when the path is not a reparse point which represents a symbolic link.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340329](https://bugs.openjdk.org/browse/JDK-8340329): (fs) Message of NotLinkException thrown by FIles.readSymbolicLink does not include file name (win) (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21047/head:pull/21047` \
`$ git checkout pull/21047`

Update a local copy of the PR: \
`$ git checkout pull/21047` \
`$ git pull https://git.openjdk.org/jdk.git pull/21047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21047`

View PR using the GUI difftool: \
`$ git pr show -t 21047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21047.diff">https://git.openjdk.org/jdk/pull/21047.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21047#issuecomment-2357209418)