### PR TITLE
8340360: Update -mx to -Xmx in UnninstallUIMemoryLeaks test

### DIFF
--- a/test/jdk/javax/swing/UI/UnninstallUIMemoryLeaks/UnninstallUIMemoryLeaks.java
+++ b/test/jdk/javax/swing/UI/UnninstallUIMemoryLeaks/UnninstallUIMemoryLeaks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -225,7 +225,7 @@ public final class UnninstallUIMemoryLeaks {
 
     private static Process runProcess(LookAndFeelInfo laf) throws Exception {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
-                "-Dswing.defaultlaf=" + laf.getClassName(), "-mx9m",
+                "-Dswing.defaultlaf=" + laf.getClassName(), "-Xmx9m",
                 "-XX:+HeapDumpOnOutOfMemoryError",
                 UnninstallUIMemoryLeaks.class.getSimpleName(), "mark");
         return ProcessTools.startProcess(laf.getName(), pb);


### PR DESCRIPTION
Can I please get a review of this test-only change which replaces the use of the outdated "-mx" option with the "-Xmx" option when launching the java processes in this test? This test was missed out from one of the earlier integrated PR.

The test continues to pass after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340360](https://bugs.openjdk.org/browse/JDK-8340360): Update -mx to -Xmx in UnninstallUIMemoryLeaks test (**Sub-task** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21053/head:pull/21053` \
`$ git checkout pull/21053`

Update a local copy of the PR: \
`$ git checkout pull/21053` \
`$ git pull https://git.openjdk.org/jdk.git pull/21053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21053`

View PR using the GUI difftool: \
`$ git pr show -t 21053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21053.diff">https://git.openjdk.org/jdk/pull/21053.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21053#issuecomment-2357923456)