### PR TITLE
8340364: JFR: Fix up Class mirror after event retransformation

### DIFF
--- a/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrEventClassTransformer.cpp
@@ -1595,6 +1595,10 @@ static void rewrite_klass_pointer(InstanceKlass*& ik, InstanceKlass* new_ik, Cla
   assert(IS_EVENT_OR_HOST_KLASS(new_ik), "invariant");
   assert(TRACE_ID(ik) == TRACE_ID(new_ik), "invariant");
   assert(!thread->has_pending_exception(), "invariant");
+  // Rewrite InstanceKlass* in associated Java mirror.
+  oop java_mirror = ik->java_mirror();
+  assert(java_mirror != nullptr, "invariant");
+  java_lang_Class::set_klass(java_mirror, new_ik);
   // Assign original InstanceKlass* back onto "its" parser object for proper destruction.
   parser.set_klass_to_deallocate(ik);
   // Finally rewrite the original pointer to the newly created InstanceKlass.


### PR DESCRIPTION
See the bug description for details. I tried and failed to build a regression test for it, because I need to be able to touch the Java mirror for the JFR event class itself, and that does not seem to be reachable from Java code (easily). So I think we let Metaspace/GC verification to catch up later and find these issues.

Additional testing:
 - [x] Original Shenandoah verifier reproducer no longer crashes
 - [x] Linux x86_64 server fastdebug, `jdk_jfr`
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8340364](https://bugs.openjdk.org/browse/JDK-8340364)

### Issue
 * [JDK-8340364](https://bugs.openjdk.org/browse/JDK-8340364): Shenandoah: Dead class mirrors crash GC (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21054/head:pull/21054` \
`$ git checkout pull/21054`

Update a local copy of the PR: \
`$ git checkout pull/21054` \
`$ git pull https://git.openjdk.org/jdk.git pull/21054/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21054`

View PR using the GUI difftool: \
`$ git pr show -t 21054`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21054.diff">https://git.openjdk.org/jdk/pull/21054.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21054#issuecomment-2358119238)