### PR TITLE
8340276: Test java/lang/management/ThreadMXBean/Locks.java failed with NullPointerException

### DIFF
--- a/test/jdk/java/lang/management/ThreadMXBean/Locks.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/Locks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -422,6 +422,9 @@ public class Locks {
                             lock + " expected to have owner");
                 }
                 for (ThreadInfo info1 : infos) {
+                    if (info1 == null) {
+                        continue; // Missing thread, e.g. completed. Ignore.
+                    }
                     if (info1.getThreadId() == threadId) {
                         ownerInfo = info1;
                         break;


### PR DESCRIPTION
One more place in this test where it iterates a list of ThreadInfo and should be skipping nulls, representing threads that may have exited, or be virtual, or not exist.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340276](https://bugs.openjdk.org/browse/JDK-8340276): Test java/lang/management/ThreadMXBean/Locks.java failed with NullPointerException (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21056/head:pull/21056` \
`$ git checkout pull/21056`

Update a local copy of the PR: \
`$ git checkout pull/21056` \
`$ git pull https://git.openjdk.org/jdk.git pull/21056/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21056`

View PR using the GUI difftool: \
`$ git pr show -t 21056`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21056.diff">https://git.openjdk.org/jdk/pull/21056.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21056#issuecomment-2358191034)