### PR TITLE
8340365: Position the first window of a window list

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -348,11 +348,9 @@ public final class PassFailJFrame {
                         builder.positionWindows
                                .positionTestWindows(unmodifiableList(builder.testWindows),
                                                     builder.instructionUIHandler));
-            } else if (builder.testWindows.size() == 1) {
+            } else {
                 Window window = builder.testWindows.get(0);
                 positionTestWindow(window, builder.position);
-            } else {
-                positionTestWindow(null, builder.position);
             }
         }
         showAllWindows();


### PR DESCRIPTION
Support of multiple test UI windows in `PassFailJFrame` is still evolving. After [JDK-8340210](https://bugs.openjdk.org/browse/JDK-8340210), the `Builder` has a method `positionTestUI` to supply an implementation of the `PositionWindows` interface which handles the positioning of all test UI windows created.

If `PositionWindows` is not provided, all the test UI windows are left with the default coordinates: (0, 0).

If `PassFailJFrame` called `positionTestWindow` for the first window, it would allow the test developer to position other windows based on the position of the first one.

This issue was raised in #21029 in [this thread of comments](https://github.com/openjdk/jdk/pull/21029#discussion_r1763744407).

To make it easier to position multiple test UI windows without implementing the `PositionWindows` interface, the `PassFailJFrame` should position the first window of the list.

The `LotsOfMenuItemsTest.java` test in #21029 had to hard-code the coordinates or use `PassFailJFrame.positionTestWindow` explicitly in its `ComponentListener.componentShown`.

With the proposed change in this pull request, the implementation would use `ComponentListener.componentMoved`:

```java
    @Override
    public void componentMoved(ComponentEvent e) {
        testFrame.setLocation(firstFrame.getX(),
                              firstFrame.getY() + firstFrame.getHeight() + 8);
    }
```

This has the advantage in that the test UI windows don't flicker for a short time in the upper left corner of the screen; and the developer has to handle only positioning the second window (frame).

However, this has a funny effect: if you move the first frame with mouse or in any other way, the second frame follows. To avoid such kind of behaviour, call `removeComponentListener` in the handler.

@honkar-jdk, @azvegint, could you take a look?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340365](https://bugs.openjdk.org/browse/JDK-8340365): Position the first window of a window list (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21057/head:pull/21057` \
`$ git checkout pull/21057`

Update a local copy of the PR: \
`$ git checkout pull/21057` \
`$ git pull https://git.openjdk.org/jdk.git pull/21057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21057`

View PR using the GUI difftool: \
`$ git pr show -t 21057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21057.diff">https://git.openjdk.org/jdk/pull/21057.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21057#issuecomment-2358297580)