### PR TITLE
8331391: Enhance the keytool code by invoking the buildTrustedCerts method for essential options

### DIFF
--- a/src/java.base/share/classes/sun/security/tools/keytool/Main.java
+++ b/src/java.base/share/classes/sun/security/tools/keytool/Main.java
@@ -1132,7 +1132,6 @@ public final class Main {
             }
         }
 
-        KeyStore cakstore = buildTrustedCerts();
         // -trustcacerts can be specified on -importcert, -printcert or -printcrl.
         // Reset it so that warnings on CA cert will remain for other command.
         if (command != IMPORTCERT && command != PRINTCERT
@@ -1141,6 +1140,7 @@ public final class Main {
         }
 
         if (trustcacerts) {
+            KeyStore cakstore = buildTrustedCerts();
             if (cakstore != null) {
                 caks = cakstore;
             } else {


### PR DESCRIPTION
Updated the code to call buildTrustedCerts only when the -trustcacerts option is specified

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331391](https://bugs.openjdk.org/browse/JDK-8331391): Enhance the keytool code by invoking the buildTrustedCerts method for essential options (**Bug** - P4)


### Reviewers
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21058/head:pull/21058` \
`$ git checkout pull/21058`

Update a local copy of the PR: \
`$ git checkout pull/21058` \
`$ git pull https://git.openjdk.org/jdk.git pull/21058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21058`

View PR using the GUI difftool: \
`$ git pr show -t 21058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21058.diff">https://git.openjdk.org/jdk/pull/21058.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21058#issuecomment-2358337187)