### PR TITLE
8339992: RISC-V: some minor improvements of base64_vector_decode_round

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5331,7 +5331,7 @@ class StubGenerator: public StubCodeGenerator {
    * NOTE: each field will occupy a single vector register group
    */
   void base64_vector_decode_round(Register src, Register dst, Register codec,
-                    Register size, Register stepSrc, Register stepDst, Register failedIdx, Register minusOne,
+                    Register size, Register stepSrc, Register stepDst, Register failedIdx,
                     VectorRegister inputV1, VectorRegister inputV2, VectorRegister inputV3, VectorRegister inputV4,
                     VectorRegister idxV1, VectorRegister idxV2, VectorRegister idxV3, VectorRegister idxV4,
                     VectorRegister outputV1, VectorRegister outputV2, VectorRegister outputV3,
@@ -5358,8 +5358,9 @@ class StubGenerator: public StubCodeGenerator {
     __ vor_vv(outputV1, outputV1, outputV2);
     __ vmseq_vi(v0, outputV1, -1);
     __ vfirst_m(failedIdx, v0);
-    Label NoFailure;
-    __ beq(failedIdx, minusOne, NoFailure);
+    Label NoFailure, FailureAt0Idx;
+    __ bltz(failedIdx, NoFailure); // valid value can only be -1 when < 0
+    __ beqz(failedIdx, FailureAt0Idx);
     __ vsetvli(x0, failedIdx, Assembler::e8, lmul, Assembler::mu, Assembler::tu);
     __ slli(stepDst, failedIdx, 1);
     __ add(stepDst, failedIdx, stepDst);
@@ -5382,6 +5383,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // dst = dst + register_group_len_bytes * 3
     __ add(dst, dst, stepDst);
+    __ BIND(FailureAt0Idx);
   }
 
   /**
@@ -5501,7 +5503,7 @@ class StubGenerator: public StubCodeGenerator {
       // Assembler::m2
       __ BIND(ProcessM2);
       base64_vector_decode_round(src, dst, codec,
-                    size, stepSrcM2, stepDst, failedIdx, minusOne,
+                    size, stepSrcM2, stepDst, failedIdx,
                     v2, v4, v6, v8,      // inputs
                     v10, v12, v14, v16,  // indexes
                     v18, v20, v22,       // outputs
@@ -5521,7 +5523,7 @@ class StubGenerator: public StubCodeGenerator {
       __ srli(size, size, 1);
       __ srli(stepDst, stepDst, 1);
       base64_vector_decode_round(src, dst, codec,
-                    size, stepSrcM1, stepDst, failedIdx, minusOne,
+                    size, stepSrcM1, stepDst, failedIdx,
                     v1, v2, v3, v4,      // inputs
                     v5, v6, v7, v8,      // indexes
                     v9, v10, v11,        // outputs

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5359,7 +5359,9 @@ class StubGenerator: public StubCodeGenerator {
     __ vmseq_vi(v0, outputV1, -1);
     __ vfirst_m(failedIdx, v0);
     Label NoFailure, FailureAt0Idx;
-    __ bltz(failedIdx, NoFailure); // valid value can only be -1 when < 0
+    // valid value can only be -1 when < 0
+    __ bltz(failedIdx, NoFailure);
+    // when the first data (at index 0) fails, no need to process data anymore
     __ beqz(failedIdx, FailureAt0Idx);
     __ vsetvli(x0, failedIdx, Assembler::e8, lmul, Assembler::mu, Assembler::tu);
     __ slli(stepDst, failedIdx, 1);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -5358,11 +5358,11 @@ class StubGenerator: public StubCodeGenerator {
     __ vor_vv(outputV1, outputV1, outputV2);
     __ vmseq_vi(v0, outputV1, -1);
     __ vfirst_m(failedIdx, v0);
-    Label NoFailure, FailureAt0Idx;
+    Label NoFailure, FailureAtIdx0;
     // valid value can only be -1 when < 0
     __ bltz(failedIdx, NoFailure);
     // when the first data (at index 0) fails, no need to process data anymore
-    __ beqz(failedIdx, FailureAt0Idx);
+    __ beqz(failedIdx, FailureAtIdx0);
     __ vsetvli(x0, failedIdx, Assembler::e8, lmul, Assembler::mu, Assembler::tu);
     __ slli(stepDst, failedIdx, 1);
     __ add(stepDst, failedIdx, stepDst);
@@ -5385,7 +5385,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // dst = dst + register_group_len_bytes * 3
     __ add(dst, dst, stepDst);
-    __ BIND(FailureAt0Idx);
+    __ BIND(FailureAtIdx0);
   }
 
   /**


### PR DESCRIPTION
Hi,
Can you help to review this simple improvement?
Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339992](https://bugs.openjdk.org/browse/JDK-8339992): RISC-V: some minor improvements of base64_vector_decode_round (**Enhancement** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer) Review applies to [9fa797a7](https://git.openjdk.org/jdk/pull/21059/files/9fa797a7c12b0be1f19b3d1c919cd1cdb73e0612)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21059/head:pull/21059` \
`$ git checkout pull/21059`

Update a local copy of the PR: \
`$ git checkout pull/21059` \
`$ git pull https://git.openjdk.org/jdk.git pull/21059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21059`

View PR using the GUI difftool: \
`$ git pr show -t 21059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21059.diff">https://git.openjdk.org/jdk/pull/21059.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21059#issuecomment-2358414258)