### PR TITLE
8338571: [TestBug] DefaultCloseOperation.java test not working as expected wrt instruction after JDK-8325851 fix

### DIFF
--- a/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
+++ b/test/jdk/javax/swing/JFrame/DefaultCloseOperation.java
@@ -99,7 +99,6 @@ public class DefaultCloseOperation extends JPanel {
 
         CloseOpFrame testFrame = new CloseOpFrame();
         testFrame.setLocationRelativeTo(null);
-        PassFailJFrame.addTestWindow(testFrame);
 
         add(new JLabel("JFrame Default Close Operation:"));
         frameCloseOp = new JComboBox<>();
@@ -127,7 +126,6 @@ public class DefaultCloseOperation extends JPanel {
 
         testDialog = new CloseOpDialog(testFrame);
         testDialog.setLocationRelativeTo(null);
-        PassFailJFrame.addTestWindow(testDialog);
 
         add(new JLabel("JDialog Default Close Operation:"));
         dialogCloseOp = new JComboBox<>();


### PR DESCRIPTION
Fixed test and fix is working fine. 

Fix
testUI(DefaultCloseOperation::createUI) will create PassfailJFrame test windows when test starts.

PassFailJFrame.addTestWindow(testFrame);
PassFailJFrame.addTestWindow(testDialog);

Above code exists in the Test. So TestFrame and TestDailog windows will be created when testUI(DefaultCloseOperation::createUI) invoked.

Need to remove above code as this code is not required.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338571](https://bugs.openjdk.org/browse/JDK-8338571): [TestBug] DefaultCloseOperation.java test not working as expected wrt instruction after JDK-8325851 fix (**Bug** - P3)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21061/head:pull/21061` \
`$ git checkout pull/21061`

Update a local copy of the PR: \
`$ git checkout pull/21061` \
`$ git pull https://git.openjdk.org/jdk.git pull/21061/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21061`

View PR using the GUI difftool: \
`$ git pr show -t 21061`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21061.diff">https://git.openjdk.org/jdk/pull/21061.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21061#issuecomment-2427361222)
</details>
