### PR TITLE
8340368: windows-x64-slowdebug build fails after JDK-8319873

### DIFF
--- a/src/hotspot/os/windows/memMapPrinter_windows.cpp
+++ b/src/hotspot/os/windows/memMapPrinter_windows.cpp
@@ -24,9 +24,9 @@
  */
 
 #include "precompiled.hpp"
-
 #include "nmt/memMapPrinter.hpp"
-#include "runtime/os.hpp"
+#include "os_windows.hpp"
+#include "runtime/vm_version.hpp"
 
 #include <limits.h>
 #include <winnt.h>


### PR DESCRIPTION
The build fails with:
```
 * For target hotspot_variant-server_libjvm_objs_static_memMapPrinter_windows.obj:
 memMapPrinter_windows.cpp
 src\hotspot\os\windows\memMapPrinter_windows.cpp(126): error C2504: 'os::win32': base class undefined
 src\hotspot\os\windows\memMapPrinter_windows.cpp(130): error C2027: use of undefined type 'os::win32'
 src\hotspot\share\runtime/os.hpp(1015): note: see declaration of 'os::win32'
 src\hotspot\os\windows\memMapPrinter_windows.cpp(130): error C3861: 'print_windows_version': identifier not found
 src\hotspot\os\windows\memMapPrinter_windows.cpp(131): error C2027: use of undefined type 'os::win32'
 src\hotspot\share\runtime/os.hpp(1015): note: see declaration of 'os::win32'
 src\hotspot\os\windows\memMapPrinter_windows.cpp(131): error C3861: 'print_uptime_info': identifier not found
 src\hotspot\os\windows\memMapPrinter_windows.cpp(132): error C2653: 'VM_Version': is not a class or namespace name
 src\hotspot\os\windows\memMapPrinter_windows.cpp(132): error C3861: 'print_platform_virtualization_info': identifier not found 
```
when you build without precompiled headers.

I've added the missing includes for the things listed above and ran it through our CI build system.

My intention is to push this ASAP to un-break the builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340368](https://bugs.openjdk.org/browse/JDK-8340368): windows-x64-slowdebug build fails after JDK-8319873 (**Bug** - P1)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21063/head:pull/21063` \
`$ git checkout pull/21063`

Update a local copy of the PR: \
`$ git checkout pull/21063` \
`$ git pull https://git.openjdk.org/jdk.git pull/21063/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21063`

View PR using the GUI difftool: \
`$ git pr show -t 21063`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21063.diff">https://git.openjdk.org/jdk/pull/21063.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21063#issuecomment-2358497016)