### PR TITLE
8340381: Shenandoah: Class mirrors verification should check forwarded objects

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahVerifier.cpp
@@ -220,18 +220,20 @@ private:
     }
 
     // Do additional checks for special objects: their fields can hold metadata as well.
-    // We want to check class loading/unloading did not corrupt them.
+    // We want to check class loading/unloading did not corrupt them. We can only reasonably
+    // trust the forwarded objects, as the from-space object can have the klasses effectively
+    // dead.
 
     if (obj_klass == vmClasses::Class_klass()) {
-      Metadata* klass = obj->metadata_field(java_lang_Class::klass_offset());
-      check(ShenandoahAsserts::_safe_oop, obj,
+      Metadata* klass = fwd->metadata_field(java_lang_Class::klass_offset());
+      check(ShenandoahAsserts::_safe_all, obj,
             klass == nullptr || Metaspace::contains(klass),
-            "Instance class mirror should point to Metaspace");
+            "Mirrored instance class should point to Metaspace");
 
-      Metadata* array_klass = obj->metadata_field(java_lang_Class::array_klass_offset());
-      check(ShenandoahAsserts::_safe_oop, obj,
+      Metadata* array_klass = fwd->metadata_field(java_lang_Class::array_klass_offset());
+      check(ShenandoahAsserts::_safe_all, obj,
             array_klass == nullptr || Metaspace::contains(array_klass),
-            "Array class mirror should point to Metaspace");
+            "Mirrored array class should point to Metaspace");
     }
 
     // ------------ obj and fwd are safe at this point --------------


### PR DESCRIPTION
The from-space objects can be effectively dead, and their backlinks to `InstanceKlass*` not updated anymore. So they can point to garbage. 

Additional testing:
 - [x] Some previously failing reproducers are not failing anymore
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340381](https://bugs.openjdk.org/browse/JDK-8340381): Shenandoah: Class mirrors verification should check forwarded objects (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21064/head:pull/21064` \
`$ git checkout pull/21064`

Update a local copy of the PR: \
`$ git checkout pull/21064` \
`$ git pull https://git.openjdk.org/jdk.git pull/21064/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21064`

View PR using the GUI difftool: \
`$ git pr show -t 21064`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21064.diff">https://git.openjdk.org/jdk/pull/21064.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21064#issuecomment-2358542973)