### PR TITLE
8340398: [JVMCI] Unintuitive behavior of UseJVMCICompiler option

### DIFF
--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -79,6 +79,15 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   CHECK_NOT_SET(JVMCIHostThreads,             UseJVMCICompiler)
   CHECK_NOT_SET(LibJVMCICompilerThreadHidden, UseJVMCICompiler)
 
+  if (UseJVMCICompiler) {
+    if (!FLAG_IS_DEFAULT(EnableJVMCI) && !EnableJVMCI) {
+      jio_fprintf(defaultStream::error_stream(),
+          "Improperly specified VM option UseJVMCICompiler: EnableJVMCI cannot be disabled\n");
+      return false;
+    }
+    FLAG_SET_DEFAULT(EnableJVMCI, true);
+  }
+
   if (EnableJVMCI) {
     if (FLAG_IS_DEFAULT(UseJVMCINativeLibrary) && !UseJVMCINativeLibrary) {
       char path[JVM_MAXPATHLEN];
@@ -91,12 +100,6 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   }
 
   if (UseJVMCICompiler) {
-    if (!FLAG_IS_DEFAULT(EnableJVMCI) && !EnableJVMCI) {
-      jio_fprintf(defaultStream::error_stream(),
-          "Improperly specified VM option UseJVMCICompiler: EnableJVMCI cannot be disabled\n");
-      return false;
-    }
-    FLAG_SET_DEFAULT(EnableJVMCI, true);
     if (BootstrapJVMCI && UseJVMCINativeLibrary) {
       jio_fprintf(defaultStream::error_stream(), "-XX:+BootstrapJVMCI is not compatible with -XX:+UseJVMCINativeLibrary\n");
       return false;

--- a/src/hotspot/share/jvmci/jvmci_globals.cpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.cpp
@@ -79,7 +79,7 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
   CHECK_NOT_SET(JVMCIHostThreads,             UseJVMCICompiler)
   CHECK_NOT_SET(LibJVMCICompilerThreadHidden, UseJVMCICompiler)
 
-  if (UseJVMCICompiler) {
+  if (EnableJVMCI) {
     if (FLAG_IS_DEFAULT(UseJVMCINativeLibrary) && !UseJVMCINativeLibrary) {
       char path[JVM_MAXPATHLEN];
       if (os::dll_locate_lib(path, sizeof(path), Arguments::get_dll_dir(), JVMCI_SHARED_LIBRARY_NAME)) {
@@ -88,6 +88,9 @@ bool JVMCIGlobals::check_jvmci_flags_are_consistent() {
         FLAG_SET_DEFAULT(UseJVMCINativeLibrary, true);
       }
     }
+  }
+
+  if (UseJVMCICompiler) {
     if (!FLAG_IS_DEFAULT(EnableJVMCI) && !EnableJVMCI) {
       jio_fprintf(defaultStream::error_stream(),
           "Improperly specified VM option UseJVMCICompiler: EnableJVMCI cannot be disabled\n");

--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -140,7 +140,7 @@ class fileStream;
   product(bool, UseJVMCINativeLibrary, false, EXPERIMENTAL,                 \
           "Execute JVMCI Java code from a shared library (\"libjvmci\") "   \
           "instead of loading it from class files and executing it "        \
-          "on the HotSpot heap. Defaults to true if EnableJVMCIProduct is " \
+          "on the HotSpot heap. Defaults to true if EnableJVMCI is "        \
           "true and a JVMCI native library is available.")                  \
                                                                             \
   product(double, JVMCINativeLibraryThreadFraction, 0.33, EXPERIMENTAL,     \

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCICompilerConfig.java
@@ -104,12 +104,15 @@ final class HotSpotJVMCICompilerConfig {
                         }
                     }
                     if (factory == null) {
+                        String reason;
                         if (Services.IS_IN_NATIVE_IMAGE) {
-                            throw runtime.exitHotSpotWithMessage(1, "JVMCI compiler '%s' not found in JVMCI native library.%n" +
+                            reason = String.format("JVMCI compiler '%s' not found in JVMCI native library.%n" +
                                             "Use -XX:-UseJVMCINativeLibrary when specifying a JVMCI compiler available on a class path with %s.%n",
                                             compilerName, compPropertyName);
+                        } else {
+                            reason = String.format("JVMCI compiler '%s' specified by %s not found%n", compilerName, compPropertyName);
                         }
-                        throw runtime.exitHotSpotWithMessage(1, "JVMCI compiler '%s' specified by %s not found%n", compilerName, compPropertyName);
+                        factory = new DummyCompilerFactory(reason, runtime);
                     }
                 }
             } else {


### PR DESCRIPTION
Disabling the JVMCI compiler with `-XX:-UseJVMCICompiler` not only deactivates JVMCI-based CompileBroker compilations but also prevents the loading of the libjvmci compiler. While this works as expected for CompileBroker compilations, it poses issues for the Truffle compiler. When `-XX:-UseJVMCICompiler` is used, Truffle falls back to the jargraal compiler, if available. This behavior may be confusing for Truffle users.

Expected behavior:

With `-XX:+UseGraalJIT`, both CompileBroker compilations and Truffle compilations should utilize the libjvmci compiler, if available.
With `-XX:+EnableJVMCI`, CompileBroker compilations should use the C2 compiler, while only Truffle compilations should leverage the libjvmci compiler, if available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340398](https://bugs.openjdk.org/browse/JDK-8340398): [JVMCI] Unintuitive behavior of UseJVMCICompiler option (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21069/head:pull/21069` \
`$ git checkout pull/21069`

Update a local copy of the PR: \
`$ git checkout pull/21069` \
`$ git pull https://git.openjdk.org/jdk.git pull/21069/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21069`

View PR using the GUI difftool: \
`$ git pr show -t 21069`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21069.diff">https://git.openjdk.org/jdk/pull/21069.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21069#issuecomment-2358981035)