### PR TITLE
8340383: VM issues warning failure to find kernel32.dll on Windows nanoserver

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4108,6 +4108,10 @@ void os::win32::initialize_windows_version() {
     return;
   }
   strncat(kernel32_path, "\\kernel32.dll", MAX_PATH - ret);
+  // On Windows Nanoserver the kernel32.dll is located in the forwarders subdirectory
+  if (!os::file_exists(kernel32_path)) {
+    strncat(kernel32_path, "\\forwarders\\kernel32.dll", MAX_PATH - ret);
+  }
 
   DWORD version_size = GetFileVersionInfoSize(kernel32_path, nullptr);
   if (version_size == 0) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4090,7 +4090,7 @@ int    os::win32::_build_minor               = 0;
 bool   os::win32::_processor_group_warning_displayed = false;
 bool   os::win32::_job_object_processor_group_warning_displayed = false;
 
-void GetWindowsInstallationType(char* buffer, int bufferSize) {
+void getWindowsInstallationType(char* buffer, int bufferSize) {
   HKEY hKey;
   const char* subKey = "SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion";
   const char* valueName = "InstallationType";
@@ -4116,11 +4116,11 @@ void GetWindowsInstallationType(char* buffer, int bufferSize) {
   RegCloseKey(hKey);
 }
 
-bool IsNanoServer() {
+bool isNanoServer() {
   const int BUFFER_SIZE = 256;
   char installationType[BUFFER_SIZE];
-  GetWindowsInstallationType(installationType, BUFFER_SIZE);
-  return (lstrcmpA(installationType, "Nano Server") == 0);
+  getWindowsInstallationType(installationType, BUFFER_SIZE);
+  return (strcmp(installationType, "Nano Server") == 0);
 }
 
 void os::win32::initialize_windows_version() {
@@ -4141,7 +4141,7 @@ void os::win32::initialize_windows_version() {
     return;
   }
 
-  if (IsNanoServer()) {
+  if (isNanoServer()) {
     // On Windows Nanoserver the kernel32.dll is located in the forwarders subdirectory
     strncat(kernel32_path, "\\forwarders\\kernel32.dll", MAX_PATH - ret);
   } else {


### PR DESCRIPTION
On Windows Nanoserver the `kernel32.dll` is not within the System32 directory itself but within the "forwarders" sub-folder.

See a similar bug reported in dotnet a while back: https://github.com/dotnet/sdk/issues/6056

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340383](https://bugs.openjdk.org/browse/JDK-8340383): VM issues warning failure to find kernel32.dll on Windows nanoserver (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21070/head:pull/21070` \
`$ git checkout pull/21070`

Update a local copy of the PR: \
`$ git checkout pull/21070` \
`$ git pull https://git.openjdk.org/jdk.git pull/21070/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21070`

View PR using the GUI difftool: \
`$ git pr show -t 21070`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21070.diff">https://git.openjdk.org/jdk/pull/21070.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21070#issuecomment-2358989161)