### PR TITLE
8340392: Handle OopStorage in location decoder

### DIFF
--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -1137,7 +1137,7 @@ const char* OopStorage::name() const { return _name; }
 
 bool OopStorage::print_containing(const oop* addr, outputStream* st) {
   if (addr != nullptr) {
-    Block *block = find_block_or_null(addr);
+    Block* block = find_block_or_null(addr);
     if (block != nullptr && block->print_containing(addr, st)) {
       st->print(" in oop storage \"%s\"", name());
       return true;

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -1148,7 +1148,7 @@ bool OopStorage::print_containing(oop* addr, outputStream* st) {
 
 bool OopStorage::Block::print_containing(oop* addr, outputStream* st) {
   if (contains(addr)) {
-    st->print(INTPTR_FORMAT " is a pointer %u/" SIZE_FORMAT " into block %zu",
+    st->print(PTR_FORMAT " is a pointer %u/%zu into block %zu",
               p2i(addr), get_index(addr), ARRAY_SIZE(_data), _active_index);
     return true;
   }

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -1148,7 +1148,7 @@ bool OopStorage::print_containing(oop* addr, outputStream* st) {
 
 bool OopStorage::Block::print_containing(oop* addr, outputStream* st) {
   if (contains(addr)) {
-    st->print(INTPTR_FORMAT " is a pointer %u/%lu into block %zu",
+    st->print(INTPTR_FORMAT " is a pointer %u/" SIZE_FORMAT " into block %zu",
               p2i(addr), get_index(addr), ARRAY_SIZE(_data), _active_index);
     return true;
   }

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -1135,6 +1135,26 @@ void OopStorage::BasicParState::report_num_dead() const {
 
 const char* OopStorage::name() const { return _name; }
 
+bool OopStorage::print_containing(oop* addr, outputStream* st) {
+  if (addr != nullptr) {
+    Block *block = find_block_or_null(addr);
+    if (block != nullptr && block->print_containing(addr, st)) {
+      st->print_cr(" in oop storage \"%s\"", name());
+      return true;
+    }
+  }
+  return false;
+}
+
+bool OopStorage::Block::print_containing(oop* addr, outputStream* st) {
+  if (contains(addr)) {
+    st->print(INTPTR_FORMAT " is a pointer %u/%lu in block %zu",
+              p2i(addr), get_index(addr), ARRAY_SIZE(_data), _active_index);
+    return true;
+  }
+  return false;
+}
+
 #ifndef PRODUCT
 
 void OopStorage::print_on(outputStream* st) const {

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -1148,7 +1148,7 @@ bool OopStorage::print_containing(oop* addr, outputStream* st) {
 
 bool OopStorage::Block::print_containing(oop* addr, outputStream* st) {
   if (contains(addr)) {
-    st->print(INTPTR_FORMAT " is a pointer %u/%lu in block %zu",
+    st->print(INTPTR_FORMAT " is a pointer %u/%lu into block %zu",
               p2i(addr), get_index(addr), ARRAY_SIZE(_data), _active_index);
     return true;
   }

--- a/src/hotspot/share/gc/shared/oopStorage.cpp
+++ b/src/hotspot/share/gc/shared/oopStorage.cpp
@@ -1135,18 +1135,18 @@ void OopStorage::BasicParState::report_num_dead() const {
 
 const char* OopStorage::name() const { return _name; }
 
-bool OopStorage::print_containing(oop* addr, outputStream* st) {
+bool OopStorage::print_containing(const oop* addr, outputStream* st) {
   if (addr != nullptr) {
     Block *block = find_block_or_null(addr);
     if (block != nullptr && block->print_containing(addr, st)) {
-      st->print_cr(" in oop storage \"%s\"", name());
+      st->print(" in oop storage \"%s\"", name());
       return true;
     }
   }
   return false;
 }
 
-bool OopStorage::Block::print_containing(oop* addr, outputStream* st) {
+bool OopStorage::Block::print_containing(const oop* addr, outputStream* st) {
   if (contains(addr)) {
     st->print(PTR_FORMAT " is a pointer %u/%zu into block %zu",
               p2i(addr), get_index(addr), ARRAY_SIZE(_data), _active_index);

--- a/src/hotspot/share/gc/shared/oopStorage.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.hpp
@@ -213,6 +213,7 @@ public:
   // Debugging and logging support.
   const char* name() const;
   void print_on(outputStream* st) const PRODUCT_RETURN;
+  bool print_containing(oop* addr, outputStream* st);
 
   // Provides access to storage internals, for unit testing.
   // Declare, but not define, the public class OopStorage::TestAccess.

--- a/src/hotspot/share/gc/shared/oopStorage.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.hpp
@@ -213,7 +213,7 @@ public:
   // Debugging and logging support.
   const char* name() const;
   void print_on(outputStream* st) const PRODUCT_RETURN;
-  bool print_containing(oop* addr, outputStream* st);
+  bool print_containing(const oop* addr, outputStream* st);
 
   // Provides access to storage internals, for unit testing.
   // Declare, but not define, the public class OopStorage::TestAccess.

--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -197,7 +197,7 @@ public:
   template<typename F> bool iterate(F f);
   template<typename F> bool iterate(F f) const;
 
-  bool print_containing(oop* addr, outputStream* st);
+  bool print_containing(const oop* addr, outputStream* st);
 }; // class Block
 
 inline OopStorage::Block* OopStorage::AllocationList::head() {

--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -196,6 +196,8 @@ public:
 
   template<typename F> bool iterate(F f);
   template<typename F> bool iterate(F f) const;
+
+  bool print_containing(oop* addr, outputStream* st);
 }; // class Block
 
 inline OopStorage::Block* OopStorage::AllocationList::head() {

--- a/src/hotspot/share/gc/shared/oopStorageSet.cpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.cpp
@@ -83,10 +83,10 @@ template OopStorage* OopStorageSet::get_storage(WeakId);
 template OopStorage* OopStorageSet::get_storage(Id);
 
 bool OopStorageSet::print_containing(const void* addr, outputStream* st) {
-  const void* aligned_addr = align_down(addr, alignof(oop*));
-  if (aligned_addr != nullptr) {
-    for (uint i = 0; i < OopStorageSet::all_count; i++) {
-      if (_storages[i]->print_containing((oop*) aligned_addr, st)) {
+  if (addr != nullptr) {
+    const void* aligned_addr = align_down(addr, alignof(oop));
+    for (OopStorage* storage : Range<Id>()) {
+      if (storage->print_containing((oop*) aligned_addr, st)) {
         if (aligned_addr != addr) {
           st->print_cr(" (unaligned)");
         } else {

--- a/src/hotspot/share/gc/shared/oopStorageSet.cpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.cpp
@@ -82,6 +82,17 @@ template OopStorage* OopStorageSet::get_storage(StrongId);
 template OopStorage* OopStorageSet::get_storage(WeakId);
 template OopStorage* OopStorageSet::get_storage(Id);
 
+bool OopStorageSet::print_containing(oop* addr, outputStream* st) {
+  if (addr != nullptr) {
+    for (uint i = 0; i < OopStorageSet::all_count; i++) {
+      if (_storages[i]->print_containing(addr, st)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 #ifdef ASSERT
 
 void OopStorageSet::verify_initialized(uint index) {

--- a/src/hotspot/share/gc/shared/oopStorageSet.cpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.cpp
@@ -82,10 +82,16 @@ template OopStorage* OopStorageSet::get_storage(StrongId);
 template OopStorage* OopStorageSet::get_storage(WeakId);
 template OopStorage* OopStorageSet::get_storage(Id);
 
-bool OopStorageSet::print_containing(oop* addr, outputStream* st) {
-  if (addr != nullptr) {
+bool OopStorageSet::print_containing(const void* addr, outputStream* st) {
+  const void* aligned_addr = align_down(addr, alignof(oop*));
+  if (aligned_addr != nullptr) {
     for (uint i = 0; i < OopStorageSet::all_count; i++) {
-      if (_storages[i]->print_containing(addr, st)) {
+      if (_storages[i]->print_containing((oop*) aligned_addr, st)) {
+        if (aligned_addr != addr) {
+          st->print_cr(" (unaligned)");
+        } else {
+          st->cr();
+        }
         return true;
       }
     }

--- a/src/hotspot/share/gc/shared/oopStorageSet.hpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_SHARED_OOPSTORAGESET_HPP
 
 #include "nmt/memTag.hpp"
+#include "oops/oop.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/enumIterator.hpp"
 #include "utilities/globalDefinitions.hpp"
@@ -89,6 +90,8 @@ public:
   template <typename Closure>
   static void strong_oops_do(Closure* cl);
 
+  // Debugging: print location info, if in storage.
+  static bool print_containing(oop* addr, outputStream* st);
 };
 
 ENUMERATOR_VALUE_RANGE(OopStorageSet::StrongId,

--- a/src/hotspot/share/gc/shared/oopStorageSet.hpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.hpp
@@ -91,7 +91,7 @@ public:
   static void strong_oops_do(Closure* cl);
 
   // Debugging: print location info, if in storage.
-  static bool print_containing(oop* addr, outputStream* st);
+  static bool print_containing(const void* addr, outputStream* st);
 };
 
 ENUMERATOR_VALUE_RANGE(OopStorageSet::StrongId,

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1319,7 +1319,7 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
 #endif
 
   // Ask if any OopStorage knows about this address.
-  if (OopStorageSet::print_containing((oop*)addr, st)) {
+  if (OopStorageSet::print_containing(addr, st)) {
     return;
   }
 

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -32,6 +32,7 @@
 #include "code/codeCache.hpp"
 #include "code/vtableStubs.hpp"
 #include "gc/shared/gcVMOperations.hpp"
+#include "gc/shared/oopStorageSet.hpp"
 #include "interpreter/interpreter.hpp"
 #include "jvm.h"
 #include "logging/log.hpp"
@@ -1316,6 +1317,11 @@ void os::print_location(outputStream* st, intptr_t x, bool verbose) {
     }
   }
 #endif
+
+  // Ask if any OopStorage knows about this address.
+  if (OopStorageSet::print_containing((oop*)addr, st)) {
+    return;
+  }
 
   // Still nothing? If NMT is enabled, we can ask what it thinks...
   if (MemTracker::print_containing_region(addr, st)) {

--- a/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
@@ -136,9 +136,8 @@ private:
 public:
   void doit() {
     PrintContainingClosure cl;
-    for (auto id: EnumRange<OopStorageSet::Id>()) {
-      OopStorage* oop_storage = OopStorageSet::storage(id);
-      oop_storage->oops_do(&cl);
+    for (OopStorage* storage : OopStorageSet::Range<OopStorageSet::Id>()) {
+      storage->oops_do(&cl);
     }
   }
 };
@@ -163,7 +162,7 @@ TEST_VM_F(OopStorageSetTest, print_containing) {
   // Goofy values print nothing: aligned out of storage pointer.
   {
     stringStream ss;
-    bool printed = OopStorageSet::print_containing((char*)0x8, &ss);
+    bool printed = OopStorageSet::print_containing((char*)alignof(oop), &ss);
     ASSERT_FALSE(printed);
     EXPECT_STREQ("", ss.freeze());
   }

--- a/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
@@ -35,7 +35,6 @@
 #include "utilities/macros.hpp"
 #include "unittest.hpp"
 
-using ::testing::StrEq;
 using ::testing::HasSubstr;
 
 class OopStorageSetTest : public ::testing::Test {
@@ -121,9 +120,9 @@ private:
 
 public:
   void doit() {
+    PrintContainingClosure cl;
     for (auto id: EnumRange<OopStorageSet::Id>()) {
       OopStorage* oop_storage = OopStorageSet::storage(id);
-      PrintContainingClosure cl;
       oop_storage->oops_do(&cl);
     }
   }
@@ -135,7 +134,7 @@ TEST_VM_F(OopStorageSetTest, print_containing) {
     stringStream ss;
     bool printed = OopStorageSet::print_containing(nullptr, &ss);
     ASSERT_FALSE(printed);
-    ASSERT_THAT("", StrEq(ss.freeze()));
+    EXPECT_STREQ("", ss.freeze());
   }
 
   // Goofy values print nothing: unaligned out of storage pointer.
@@ -143,7 +142,7 @@ TEST_VM_F(OopStorageSetTest, print_containing) {
     stringStream ss;
     bool printed = OopStorageSet::print_containing((oop*)0x1, &ss);
     ASSERT_FALSE(printed);
-    ASSERT_THAT("", StrEq(ss.freeze()));
+    EXPECT_STREQ("", ss.freeze());
   }
 
   // Goofy values print nothing: aligned out of storage pointer.
@@ -151,7 +150,7 @@ TEST_VM_F(OopStorageSetTest, print_containing) {
     stringStream ss;
     bool printed = OopStorageSet::print_containing((oop*)0x8, &ss);
     ASSERT_FALSE(printed);
-    ASSERT_THAT("", StrEq(ss.freeze()));
+    EXPECT_STREQ("", ss.freeze());
   }
 
   // All slot addresses should print well.

--- a/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
@@ -36,6 +36,7 @@
 #include "unittest.hpp"
 
 using ::testing::HasSubstr;
+using ::testing::Not;
 
 class OopStorageSetTest : public ::testing::Test {
 protected:
@@ -117,6 +118,7 @@ private:
           ASSERT_THAT(ss.freeze(), HasSubstr("is a pointer"));
           ASSERT_THAT(ss.freeze(), HasSubstr("into block"));
           ASSERT_THAT(ss.freeze(), HasSubstr("in oop storage"));
+          ASSERT_THAT(ss.freeze(), Not(HasSubstr("(unaligned)")));
         }
 
         // Unaligned pointer to adjacent slot, should still be in oop storage range.

--- a/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
@@ -114,7 +114,7 @@ private:
       bool printed = OopStorageSet::print_containing(addr, &ss);
       ASSERT_TRUE(printed);
       ASSERT_THAT(ss.freeze(), HasSubstr("is a pointer"));
-      ASSERT_THAT(ss.freeze(), HasSubstr("in block"));
+      ASSERT_THAT(ss.freeze(), HasSubstr("into block"));
       ASSERT_THAT(ss.freeze(), HasSubstr("in oop storage"));
     }
   };

--- a/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorageSet.cpp
@@ -106,16 +106,16 @@ TEST_VM_F(OopStorageSetTest, all_iteration) {
 
 class OopStorageSetTest::VM_PrintAtSafepoint : public VM_GTestExecuteAtSafepoint {
 private:
- class PrintContainingClosure : public Closure {
-  public:
-    void do_oop(oop* addr) {
-      stringStream ss;
-      bool printed = OopStorageSet::print_containing(addr, &ss);
-      ASSERT_TRUE(printed);
-      ASSERT_THAT(ss.freeze(), HasSubstr("is a pointer"));
-      ASSERT_THAT(ss.freeze(), HasSubstr("into block"));
-      ASSERT_THAT(ss.freeze(), HasSubstr("in oop storage"));
-    }
+  class PrintContainingClosure : public Closure {
+    public:
+      void do_oop(oop* addr) {
+        stringStream ss;
+        bool printed = OopStorageSet::print_containing(addr, &ss);
+        ASSERT_TRUE(printed);
+        ASSERT_THAT(ss.freeze(), HasSubstr("is a pointer"));
+        ASSERT_THAT(ss.freeze(), HasSubstr("into block"));
+        ASSERT_THAT(ss.freeze(), HasSubstr("in oop storage"));
+      }
   };
 
 public:


### PR DESCRIPTION
Another debugging QoL improvement.  Currently, when there is a pointer into `OopStorage` that we need to decode for the error log, we just print:
```
  0x00007ad45c169e10 into live malloced block starting at 0x00007ad45c169dd0, size 632, tag mtInternal
```

This is reported by NMT after [JDK-8304815](https://bugs.openjdk.org/browse/JDK-8304815). It is likely worse without NMT. We can actually decode which block in which `OopStorage` the address likely belongs to. This becomes handy when debugging GC crashes that involve `OopStorage`-handled roots.

This patch is able to print the following instead:

```
  0x0000000102c05bd0 is a pointer 2/64 into block 0 in oop storage "VM Global"
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340392](https://bugs.openjdk.org/browse/JDK-8340392): Handle OopStorage in location decoder (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21072/head:pull/21072` \
`$ git checkout pull/21072`

Update a local copy of the PR: \
`$ git checkout pull/21072` \
`$ git pull https://git.openjdk.org/jdk.git pull/21072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21072`

View PR using the GUI difftool: \
`$ git pr show -t 21072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21072.diff">https://git.openjdk.org/jdk/pull/21072.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21072#issuecomment-2359081302)