### PR TITLE
8340391: Windows jcmd System.map and System.dump_map tests failing

### DIFF
--- a/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/SystemMapTestBase.java
@@ -78,7 +78,7 @@ public class SystemMapTestBase {
     private static final String winbase = range + space + someSize + space + winprot + space;
 
     private static final String winimage     = winbase + "c-img" + space + someNumber + space;
-    private static final String wincommitted = winbase + "c-pvt" + space + someNumber + space;
+    private static final String wincommitted = winbase + "(c-pvt|c-map)" + space + someNumber + space;
     private static final String winreserved  = winbase + "r-pvt" + space + someNumber + space;
 
     private static final String shouldMatchUnconditionally_windows[] = {


### PR DESCRIPTION
New test is failing on Windows with ZGC: the regex for JAVAHEAP is not matching.

Matching "mapped", as well as "private", is testing OK for me: ZGC JAVAHEAP is not private in terms of Windows _MEMORY_BASIC_INFORMATION

Simple regex update to a new test which is failing - I'd like to push this as a trivial change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340391](https://bugs.openjdk.org/browse/JDK-8340391): Windows jcmd System.map and System.dump_map tests failing (**Bug** - P2)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21073/head:pull/21073` \
`$ git checkout pull/21073`

Update a local copy of the PR: \
`$ git checkout pull/21073` \
`$ git pull https://git.openjdk.org/jdk.git pull/21073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21073`

View PR using the GUI difftool: \
`$ git pr show -t 21073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21073.diff">https://git.openjdk.org/jdk/pull/21073.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21073#issuecomment-2359124720)