### PR TITLE
8340415: Update failure handler to print more info using gdb scripts

### DIFF
--- a/test/failure_handler/README
+++ b/test/failure_handler/README
@@ -1,4 +1,4 @@
-Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
 This code is free software; you can redistribute it and/or modify it
@@ -81,6 +81,12 @@ parameter 'p1' will be:
  - 'C' for 'a.b.c'
  - 'B' for 'a.c'
  - 'A' for 'b.c'
+
+The '%' could be used to define parameters substituted during execution:
+ %p - pid or core of target processes
+ %java - path to java executable
+ %{filename} - the scripts, which are located in 'conf' directory
+
 
 RUNNING
 

--- a/test/failure_handler/src/share/classes/jdk/test/failurehandler/Utils.java
+++ b/test/failure_handler/src/share/classes/jdk/test/failurehandler/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,11 +23,13 @@
 
 package jdk.test.failurehandler;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.util.Properties;
 
 public final class Utils {
@@ -82,6 +84,27 @@ public final class Utils {
                     resourceName, e.getMessage()), e);
         }
         return properties;
+    }
+
+    public static String unpack(String filename) {
+        InputStream stream = Utils.class.getResourceAsStream("/" + filename);
+        if (stream == null) {
+            throw new IllegalStateException(String.format(
+                    "file '%s' doesn't exist%n", filename));
+        }
+        try {
+            File file = new File(filename);
+            if (file.exists()) {
+                file.delete();
+            }
+            Files.copy(stream, file.toPath());
+            return file.getAbsolutePath();
+        } catch (IOException e) {
+            throw new IllegalStateException(String.format(
+                    "can't unpack resource '%s' : %s%n",
+                    filename, e.getMessage()), e);
+        }
+
     }
 
     private Utils() { }

--- a/test/failure_handler/src/share/conf/linux.properties
+++ b/test/failure_handler/src/share/conf/linux.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ config.getChildren.args=--no-headers -o pid --ppid %p
 onTimeout=\
   native.pmap.normal native.pmap.everything \
   native.files native.locks \
-  native.stack native.core
+  native.stack.print_info native.stack.backtrace native.core
 
 ################################################################################
 native.pattern=%p
@@ -49,9 +49,11 @@ native.locks.app=lslocks
 native.locks.args=-u --pid %p
 
 native.stack.app=gdb
-native.stack.args=--pid=%p\0-batch\0-ex\0info threads\0-ex\0thread apply all backtrace
-native.stack.args.delimiter=\0
-native.stack.params.repeat=6
+native.stack.print_info.args=--pid=%p -batch -x %{print_info.gdb}
+native.stack.print_info.params.repeat=6
+native.stack.backtrace.args=--pid=%p\0-batch\0-ex\0info threads\0-ex\0thread apply all backtrace
+native.stack.backtrace.args.delimiter=\0
+native.stack.backtrace.params.repeat=6
 
 # has to be the last command
 native.core.app=bash
@@ -60,11 +62,12 @@ native.core.args=-c\0kill -ABRT %p && tail --pid=%p -f /dev/null
 native.core.args.delimiter=\0
 native.core.timeout=600000
 
-cores=native.gdb
+cores=native.gdb.print_info native.gdb.backtrace
 native.gdb.app=gdb
 # Assume that java standard laucher has been used
-native.gdb.args=%java\0-c\0%p\0-batch\0-ex\0info threads\0-ex\0thread apply all backtrace
-native.gdb.args.delimiter=\0
+native.gdb.print_info.args=%java -c %p -batch -x %{print_info.gdb}
+native.gdb.backtrace.args=%java\0-c\0%p\0-batch\0-ex\0info threads\0-ex\0thread apply all backtrace
+native.gdb.backtrace.args.delimiter=\0
 
 ################################################################################
 # environment info to gather

--- a/test/failure_handler/src/share/conf/print_info.gdb
+++ b/test/failure_handler/src/share/conf/print_info.gdb
@@ -1,0 +1,155 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+define print_mutex
+  set $mutex = $arg0
+  set $_owner =  $mutex._owner
+  if $_owner != 0
+    printf "Mutex: %s owned by %p\n", $mutex._name, $_owner
+  end
+end
+
+define print_mutexes
+  set $i = 0
+  set $owned = 0
+  while $i < _num_mutex
+    print_mutex _mutex_array[$i]
+    set $i = $i + 1
+  end
+  if $owned == 0
+    printf "None\n"
+  end
+end
+
+define print_safepoint
+  printf "_state: "
+  p SafepointSynchronize::_state
+  printf "\n"
+end
+
+define print_thread
+  set $thread = $arg0
+  printf "\nThread: \n"
+  print $thread
+  printf "LWP ID: "
+  print $thread._osthread._thread_id
+  printf "OSThread state: "
+  print $thread._osthread._state
+  printf "Thread info: "
+end
+
+
+define print_vmthread
+  set $thread = VMThread::_vm_thread
+  print_thread $thread
+end
+
+define print_java_thread
+  set $thread = $arg0
+  print_thread $thread
+  printf "JavaThreadState: "
+  print $thread._thread_state
+  printf "ThreadSafepointState: "
+  print *$thread._safepoint_state
+  printf "Suspend flags: "
+  print $thread._suspend_flags
+end
+
+define print_non_java_thread
+  set $thread = $arg0
+  print_thread $thread
+end
+
+
+define print_java_thread_raw
+  set $thread = $arg0
+  print *$thread
+  print *$thread._osthread._thread_d
+end
+
+define print_java_threads
+  set $threads = ThreadsSMRSupport::_java_thread_list._threads
+  set $length = ThreadsSMRSupport::_java_thread_list._length
+  set $i = 0
+  while $i < $length
+    print_java_thread $threads[$i]
+    set $i = $i + 1
+  end
+end
+
+define print_non_java_threads
+  set $thread = NonJavaThread::_the_list._head
+  while $thread != 0
+    print_non_java_thread $thread
+    set $thread = $thread._next
+  end
+end
+
+printf "==============================================================================================\n"
+printf "The list of owned mutexes:\n"
+printf "==============================================================================================\n"
+print_mutexes
+printf "\n"
+printf "\n"
+
+printf "==============================================================================================\n"
+printf "The Safepoint:\n"
+printf "==============================================================================================\n"
+print_safepoint
+printf "\n"
+printf "\n"
+
+printf "==============================================================================================\n"
+printf "The VMThread:\n"
+printf "==============================================================================================\n"
+print_vmthread
+printf "\n"
+printf "\n"
+
+
+printf "==============================================================================================\n"
+printf "The JavaThreads (ThreadsSMRSupport::_java_thread_list) :\n"
+printf "==============================================================================================\n"
+print_java_threads
+printf "\n"
+printf "\n"
+
+printf "==============================================================================================\n"
+printf "The NonJavaThreads (NonJavaThread::_the_list) :\n"
+printf "==============================================================================================\n"
+print_non_java_threads
+printf "\n"
+printf "\n"
+
+
+
+printf "==============================================================================================\n"
+printf "Thread info (info threads):\n"
+printf "==============================================================================================\n"
+info threads
+printf "\n"
+printf "\n"
+printf "==============================================================================================\n"
+printf "All stack traces (thread apply all backtrace):\n"
+printf "==============================================================================================\n"
+thread apply all backtrace


### PR DESCRIPTION
The failure handler updated to use gdb scripts.
The initial version print some information about mutextes, safepoint and threads state. So the deadlocks are easier to analyze without opening core files.
The existing gdb processing is not changed.


Later the script might be improved with more information.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340415](https://bugs.openjdk.org/browse/JDK-8340415): Update failure handler to print more info using gdb scripts (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21078/head:pull/21078` \
`$ git checkout pull/21078`

Update a local copy of the PR: \
`$ git checkout pull/21078` \
`$ git pull https://git.openjdk.org/jdk.git pull/21078/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21078`

View PR using the GUI difftool: \
`$ git pr show -t 21078`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21078.diff">https://git.openjdk.org/jdk/pull/21078.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21078#issuecomment-2359889579)