### PR TITLE
8340418: GHA: MacOS AArch64 bundles can be removed prematurely

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -384,6 +384,7 @@ jobs:
       - build-windows-aarch64
       - test-linux-x64
       - test-macos-x64
+      - test-macos-aarch64
       - test-windows-x64
 
     steps:


### PR DESCRIPTION
`remove-bundles` step does not depend on `test-macos-aarch64`, which means it can run before macos-aarch64 tests start to run, which would fail those steps. This is not frequent, but will happen if macos-aarch64 runners are lagging behind to pick up the jobs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340418](https://bugs.openjdk.org/browse/JDK-8340418): GHA: MacOS AArch64 bundles can be removed prematurely (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21080/head:pull/21080` \
`$ git checkout pull/21080`

Update a local copy of the PR: \
`$ git checkout pull/21080` \
`$ git pull https://git.openjdk.org/jdk.git pull/21080/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21080`

View PR using the GUI difftool: \
`$ git pr show -t 21080`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21080.diff">https://git.openjdk.org/jdk/pull/21080.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21080#issuecomment-2360040053)