### PR TITLE
8340439: AArch64: Extra entry declaration for assember test

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -69,12 +69,6 @@ int TemplateInterpreter::InterpreterCodeSize = 200 * 1024;
 
 #define __ _masm->
 
-//-----------------------------------------------------------------------------
-
-extern "C" void entry(CodeBuffer*);
-
-//-----------------------------------------------------------------------------
-
 address TemplateInterpreterGenerator::generate_slow_signature_handler() {
   address entry = __ pc();
 


### PR DESCRIPTION
Hi all,
The function declaration `extern "C" void entry(CodeBuffer*);` in `src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp` line 74, seems to used for AArch64 assember test.
The AArch64 assember test has been moved to `test/hotspot/gtest` by [JDK-8252684](https://bugs.openjdk.org/browse/JDK-8252684) , so I think this function declaration can be remove.

Additional testing:

- [x] linux aarch64 jtreg(tier1/2/3 etc., include gtest) with release build
- [x] linux aarch64 jtreg(tier1/2/3 etc., include gtest) with fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340439](https://bugs.openjdk.org/browse/JDK-8340439): AArch64: Extra entry declaration for assember test (**Bug** - P4)


### Reviewers
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21086/head:pull/21086` \
`$ git checkout pull/21086`

Update a local copy of the PR: \
`$ git checkout pull/21086` \
`$ git pull https://git.openjdk.org/jdk.git pull/21086/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21086`

View PR using the GUI difftool: \
`$ git pr show -t 21086`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21086.diff">https://git.openjdk.org/jdk/pull/21086.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21086#issuecomment-2360801067)