### PR TITLE
8317801: java/net/Socket/asyncClose/Race.java fails intermittently (aix)

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
@@ -1903,11 +1903,21 @@ class DatagramChannelImpl
                     }
                     if (NativeThread.isNativeThread(reader)
                             || NativeThread.isNativeThread(writer)) {
-                        nd.preClose(fd);
-                        if (NativeThread.isNativeThread(reader))
-                            NativeThread.signal(reader);
-                        if (NativeThread.isNativeThread(writer))
-                            NativeThread.signal(writer);
+                        boolean isAix = System.getProperty("os.name").startsWith("AIX");
+                        if (isAix) {
+                            if (NativeThread.isNativeThread(reader))
+                                NativeThread.signal(reader);
+                            if (NativeThread.isNativeThread(writer))
+                                NativeThread.signal(writer);
+                                nd.preClose(fd);
+                        }
+                        else {
+                            nd.preClose(fd);
+                            if (NativeThread.isNativeThread(reader))
+                                NativeThread.signal(reader);
+                            if (NativeThread.isNativeThread(writer))
+                                NativeThread.signal(writer);
+                        }
                     }
                 }
             }

--- a/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java
@@ -908,11 +908,21 @@ public final class NioSocketImpl extends SocketImpl implements PlatformSocketImp
                 }
                 if (NativeThread.isNativeThread(reader)
                         || NativeThread.isNativeThread(writer)) {
-                    nd.preClose(fd);
-                    if (NativeThread.isNativeThread(reader))
-                        NativeThread.signal(reader);
-                    if (NativeThread.isNativeThread(writer))
-                        NativeThread.signal(writer);
+                    boolean isAix = System.getProperty("os.name").startsWith("AIX");
+                    if (isAix) {
+                        if (NativeThread.isNativeThread(reader))
+                            NativeThread.signal(reader);
+                        if (NativeThread.isNativeThread(writer))
+                            NativeThread.signal(writer);
+                        nd.preClose(fd);
+                    }
+                    else {
+                        nd.preClose(fd);
+                        if (NativeThread.isNativeThread(reader))
+                            NativeThread.signal(reader);
+                        if (NativeThread.isNativeThread(writer))
+                            NativeThread.signal(writer);
+                    }
                 }
             }
         }

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
@@ -610,8 +610,15 @@ class ServerSocketChannelImpl
                     if (NativeThread.isVirtualThread(th)) {
                         Poller.stopPoll(fdVal);
                     } else {
-                        nd.preClose(fd);
-                        NativeThread.signal(th);
+                        boolean isAix = System.getProperty("os.name").startsWith("AIX");
+                        if (isAix) {
+                            NativeThread.signal(th);
+                            nd.preClose(fd);
+                        }
+                        else {
+                            nd.preClose(fd);
+                            NativeThread.signal(th);
+                        }
                     }
                 }
             }

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -1147,11 +1147,21 @@ class SocketChannelImpl
                 }
                 if (NativeThread.isNativeThread(reader)
                         || NativeThread.isNativeThread(writer)) {
-                    nd.preClose(fd);
-                    if (NativeThread.isNativeThread(reader))
-                        NativeThread.signal(reader);
-                    if (NativeThread.isNativeThread(writer))
-                        NativeThread.signal(writer);
+                    boolean isAix = System.getProperty("os.name").startsWith("AIX");
+                    if (isAix) {
+                        if (NativeThread.isNativeThread(reader))
+                            NativeThread.signal(reader);
+                        if (NativeThread.isNativeThread(writer))
+                            NativeThread.signal(writer);
+                        nd.preClose(fd);
+                    }
+                    else {
+                        nd.preClose(fd);
+                        if (NativeThread.isNativeThread(reader))
+                            NativeThread.signal(reader);
+                        if (NativeThread.isNativeThread(writer))
+                            NativeThread.signal(writer);
+                    }
                 }
             }
         }

--- a/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SinkChannelImpl.java
@@ -157,8 +157,15 @@ class SinkChannelImpl
                     if (NativeThread.isVirtualThread(th)) {
                         Poller.stopPoll(fdVal);
                     } else {
-                        nd.preClose(fd);
-                        NativeThread.signal(th);
+                        boolean isAix = System.getProperty("os.name").startsWith("AIX");
+                        if (isAix) {
+                            NativeThread.signal(th);
+                            nd.preClose(fd);
+                        }
+                        else {
+                            nd.preClose(fd);
+                            NativeThread.signal(th);
+                        }
                     }
                 }
             }

--- a/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/SourceChannelImpl.java
@@ -157,8 +157,15 @@ class SourceChannelImpl
                     if (NativeThread.isVirtualThread(th)) {
                         Poller.stopPoll(fdVal);
                     } else {
-                        nd.preClose(fd);
-                        NativeThread.signal(th);
+                        boolean isAix = System.getProperty("os.name").startsWith("AIX");
+                        if (isAix) {
+                            NativeThread.signal(th);
+                            nd.preClose(fd);
+                        }
+                        else {
+                            nd.preClose(fd);
+                            NativeThread.signal(th);
+                        }
                     }
                 }
             }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -551,7 +551,6 @@ java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
-java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc64
 
 ############################################################################
 


### PR DESCRIPTION
The preClose() method internally calls the dup2() system call. If there is a dup2() call on a file descriptor on a thread while another thread is blocked in a read/write operation on the same file descriptor, then the dup2() call is known to hang. Currently, preClose() experiences a hang because we call dup2() before killing the reader/writer thread(s). The workaround is to first kill the reader/writer thread(s) and then do the preClose() sequence. This reordering in the different channel implementations resolves the problem.

JBS Issue : [JDK-8317801](https://bugs.openjdk.org/browse/JDK-8317801)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317801](https://bugs.openjdk.org/browse/JDK-8317801): java/net/Socket/asyncClose/Race.java fails intermittently (aix) (**Bug** - P4)


### Contributors
 * Shruthi.Shruthi1 `<Shruthi.Shruthi1@ibm.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21087/head:pull/21087` \
`$ git checkout pull/21087`

Update a local copy of the PR: \
`$ git checkout pull/21087` \
`$ git pull https://git.openjdk.org/jdk.git pull/21087/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21087`

View PR using the GUI difftool: \
`$ git pr show -t 21087`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21087.diff">https://git.openjdk.org/jdk/pull/21087.diff</a>

</details>
