### PR TITLE
8317801: java/net/Socket/asyncClose/Race.java fails intermittently (aix)

### DIFF
--- a/src/java.base/aix/classes/sun/nio/ch/NioSocketImpl.java
+++ b/src/java.base/aix/classes/sun/nio/ch/NioSocketImpl.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package sun.nio.ch;
+
+import java.io.FileDescriptor;
+import java.net.StandardSocketOptions;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.net.SocketException;
+import java.lang.ref.Cleaner.Cleanable;
+import jdk.internal.access.JavaIOFileDescriptorAccess;
+import jdk.internal.access.SharedSecrets;
+import java.net.SocketImpl;
+import sun.net.PlatformSocketImpl;
+import java.net.SocketAddress;
+import java.net.InetAddress;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.SocketOption;
+import java.util.Objects;
+import java.util.Set;
+import java.net.InetSocketAddress;
+
+public final class NioSocketImpl extends SocketImpl implements PlatformSocketImpl {
+
+    private static final NativeDispatcher nd = new SocketDispatcher();
+    private final FileDescriptor fd = new FileDescriptor();
+
+   // private final FileDescriptor fd;
+    // The stateLock for read/changing state
+    private final Object stateLock = new Object();
+    private static final int ST_NEW = 0;
+    private static final int ST_UNCONNECTED = 1;
+    private static final int ST_CONNECTING = 2;
+    private static final int ST_CONNECTED = 3;
+    private static final int ST_CLOSING = 4;
+    private static final int ST_CLOSED = 5;
+    private volatile int state;  // need stateLock to change
+    // used by connect/read/write/accept, protected by stateLock
+    private long readerThread;
+    private long writerThread;
+    private Cleanable cleaner;
+    private boolean stream;
+    private final boolean server;
+    private final NioSocketImpl impl;
+
+    public NioSocketImpl(boolean server) {
+        impl = new sun.nio.ch.NioSocketImpl(server);
+        this.server = server;
+//        this.fd = fd;
+    }
+
+    //public NioSocketImpl(boolean server) {
+      //  impl = new sun.nio.ch.NioSocketImpl(server);
+   // }
+
+    public void create(boolean stream) throws IOException {
+        impl.create(stream);
+    }
+
+    public void connect(SocketAddress remote, int millis) throws IOException {
+       impl.connect(remote, millis);
+    }
+
+    public void connect(String host, int port) throws IOException {
+        impl.connect(host, port);
+    }
+
+    public void connect(InetAddress address, int port) throws IOException {
+        impl.connect(address, port);
+    }
+
+    public void bind(InetAddress address, int port) throws IOException {
+        impl.bind(address, port);
+   }
+
+    public void listen(int backlog) throws IOException {
+        impl.listen(backlog);
+    }
+
+    public void accept(SocketImpl si) throws IOException {
+        System.out.println("accept /n");
+        impl.accept(si);
+    }
+
+    public InputStream getInputStream() throws IOException {
+        return impl.getInputStream();
+    }
+
+    public OutputStream getOutputStream() throws IOException {
+        return impl.getOutputStream();
+    }
+
+    public int available() throws IOException {
+        return impl.available();
+    }
+
+    public Set<SocketOption<?>> supportedOptions() {
+        return impl.supportedOptions();
+    }
+
+    public <T> void setOption(SocketOption<T> opt, T value) throws IOException {
+        impl.setOption(opt, value);
+    }
+
+    public <T> T getOption(SocketOption<T> opt) throws IOException {
+        return impl.getOption(opt);
+    }
+
+    public void setOption(int opt, Object value) throws SocketException {
+        impl.setOption(opt, value);
+    }
+
+    public Object getOption(int opt) throws SocketException {
+       return impl.getOption(opt);
+    }
+
+    public void shutdownInput() throws IOException {
+       impl.shutdownInput();
+    }
+
+    public void shutdownOutput() throws IOException {
+        impl.shutdownOutput();
+    }
+
+    public boolean supportsUrgentData() {
+        return impl.supportsUrgentData();
+    }
+
+    public void sendUrgentData(int data) throws IOException {
+        impl.sendUrgentData(data);
+    }
+
+    public int timedAccept(FileDescriptor fd,
+                            FileDescriptor newfd,
+                            InetSocketAddress[] isaa,
+                            long nanos) {
+        return impl.timedAccept(fd, newfd, isaa, nanos);
+    }
+
+    public void close() throws IOException {
+        synchronized (stateLock) {
+            int state = this.state;
+            if (state >= ST_CLOSING)
+                return;
+            if (state == ST_NEW) {
+                // stillborn
+                this.state = ST_CLOSED;
+                return;
+            }
+            boolean connected = (state == ST_CONNECTED);
+            this.state = ST_CLOSING;
+
+            // shutdown output when linger interval not set to 0
+            if (connected) {
+                try {
+                    var SO_LINGER = StandardSocketOptions.SO_LINGER;
+                    if ((int) Net.getSocketOption(fd, SO_LINGER) != 0) {
+                        Net.shutdown(fd, Net.SHUT_WR);
+                    }
+                } catch (IOException ignore) { }
+            }
+
+            // attempt to close the socket. If there are I/O operations in progress
+            // then the socket is pre-closed and the thread(s) signalled. The
+            // last thread will close the file descriptor.
+            if (!tryClose()) {
+                long reader = readerThread;
+                long writer = writerThread;
+                if (NativeThread.isVirtualThread(reader)
+                        || NativeThread.isVirtualThread(writer)) {
+                    Poller.stopPoll(fdVal(fd));
+                }
+                if (NativeThread.isNativeThread(reader)
+                        || NativeThread.isNativeThread(writer)) {
+                    if (NativeThread.isNativeThread(reader))
+                        NativeThread.signal(reader);
+                    if (NativeThread.isNativeThread(writer))
+                        NativeThread.signal(writer);
+                    nd.preClose(fd);
+                }
+            }
+        }
+    }
+
+    /**
+     * Closes the socket if there are no I/O operations in progress.
+     */
+    private boolean tryClose() throws IOException {
+        assert Thread.holdsLock(stateLock) && state == ST_CLOSING;
+        if (readerThread == 0 && writerThread == 0) {
+            try {
+                cleaner.clean();
+            } catch (UncheckedIOException ioe) {
+                throw ioe.getCause();
+            } finally {
+                state = ST_CLOSED;
+            }
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * Return the file descriptor value.
+     */
+    private static int fdVal(FileDescriptor fd) {
+        return JIOFDA.get(fd);
+    }
+
+    private static final JavaIOFileDescriptorAccess JIOFDA = SharedSecrets.getJavaIOFileDescriptorAccess();
+}

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -551,7 +551,6 @@ java/net/MulticastSocket/SetLoopbackMode.java                   7122846,8308807 
 java/net/MulticastSocket/SetOutgoingIf.java                     8308807 aix-ppc64
 java/net/MulticastSocket/Test.java                              7145658,8308807 macosx-all,aix-ppc64
 
-java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc64
 
 ############################################################################
 


### PR DESCRIPTION
The preClose() method internally calls the dup2() system call. If there is a dup2() call on a file descriptor on a thread while another thread is blocked in a read/write operation on the same file descriptor, then the dup2() call is known to hang. Currently, preClose() experiences a hang because we call dup2() before killing the reader/writer thread(s). The workaround is to first kill the reader/writer thread(s) and then do the preClose() sequence. This reordering in the different channel implementations resolves the problem.

This is an AIX specific patch by bringing the code change under AIX folder. However, we noticed that the test is not picking up the new code changes. It is going back to old code [NioSocketImpl.java#L876](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/sun/nio/ch/NioSocketImpl.java#L876). 
Therefore, we used System.property and checked for AIX platform [pull/21087](https://github.com/openjdk/jdk/pull/21087)

We would like to know which is better patch and why the new code change is not recognized by the test.

JBS Issue : [JDK-8317801](https://bugs.openjdk.org/browse/JDK-8317801)
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317801](https://bugs.openjdk.org/browse/JDK-8317801): java/net/Socket/asyncClose/Race.java fails intermittently (aix) (**Bug** - P4)


### Contributors
 * Shruthi.Shruthi1 `<Shruthi.Shruthi1@ibm.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21088/head:pull/21088` \
`$ git checkout pull/21088`

Update a local copy of the PR: \
`$ git checkout pull/21088` \
`$ git pull https://git.openjdk.org/jdk.git pull/21088/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21088`

View PR using the GUI difftool: \
`$ git pr show -t 21088`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21088.diff">https://git.openjdk.org/jdk/pull/21088.diff</a>

</details>
