### PR TITLE
8339772: serviceability/sa/TestJhsdbJstackUpcall.java fails on Linux ppc64le

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ppc64/PPC64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ppc64/PPC64Frame.java
@@ -253,9 +253,6 @@ public class PPC64Frame extends Frame {
     return true;
   }
 
-  // FIXME: not applicable in current system
-  //  void    patch_pc(Thread* thread, address pc);
-
   public Frame sender(RegisterMap regMap, CodeBlob cb) {
     PPC64RegisterMap map = (PPC64RegisterMap) regMap;
 
@@ -278,8 +275,9 @@ public class PPC64Frame extends Frame {
       }
     }
 
-    if (cb != null) {
-      return cb.isUpcallStub() ? senderForUpcallStub(map, (UpcallStub)cb) : senderForCompiledFrame(map, cb);
+    if (cb != null && !cb.isUpcallStub()) {
+      // Note: Other platforms use the UpcallStub. We use the Backchain instead which works for all ABI compliant frames.
+      return senderForCompiledFrame(map, cb);
     }
 
     // Must be native-compiled frame, i.e. the marshaling code for native
@@ -306,34 +304,6 @@ public class PPC64Frame extends Frame {
       fr = new PPC64Frame(jcw.getLastJavaSP(), jcw.getLastJavaFP(), jcw.getLastJavaPC());
     } else {
       fr = new PPC64Frame(jcw.getLastJavaSP(), jcw.getLastJavaFP());
-    }
-    map.clear();
-    if (Assert.ASSERTS_ENABLED) {
-      Assert.that(map.getIncludeArgumentOops(), "should be set by clear");
-    }
-    return fr;
-  }
-
-  private Frame senderForUpcallStub(PPC64RegisterMap map, UpcallStub stub) {
-    if (DEBUG) {
-      System.out.println("senderForUpcallStub");
-    }
-    if (Assert.ASSERTS_ENABLED) {
-      Assert.that(map != null, "map must be set");
-    }
-
-    var lastJavaFP = stub.getLastJavaFP(this); // This will be null
-    var lastJavaSP = stub.getLastJavaSP(this);
-    var lastJavaPC = stub.getLastJavaPC(this);
-
-    if (Assert.ASSERTS_ENABLED) {
-      Assert.that(lastJavaSP.greaterThan(getSP()), "must be above this frame on stack");
-    }
-    PPC64Frame fr;
-    if (lastJavaPC != null) {
-      fr = new PPC64Frame(lastJavaSP, lastJavaFP, lastJavaPC);
-    } else {
-      fr = new PPC64Frame(lastJavaSP, lastJavaFP);
     }
     map.clear();
     if (Assert.ASSERTS_ENABLED) {


### PR DESCRIPTION
The SA model of the UpcallStub doesn't work reliably on PPC64. We can use the Backchain which works for all Power Architecture 64-Bit ELF ABI compliant frames. (The backtrace should stop when hitting a non-compliant frame which can occur with some compiler options. Also see comment in JBS issue.)
Note that this enables walking the native frames which is possible on PPC64, but not on some other platforms due to missing backlinks.

"test/hotspot/jtreg/serviceability" tests have passed with this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339772](https://bugs.openjdk.org/browse/JDK-8339772): serviceability/sa/TestJhsdbJstackUpcall.java fails on Linux ppc64le (**Bug** - P4) ⚠️ Issue is not open.


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21092/head:pull/21092` \
`$ git checkout pull/21092`

Update a local copy of the PR: \
`$ git checkout pull/21092` \
`$ git pull https://git.openjdk.org/jdk.git pull/21092/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21092`

View PR using the GUI difftool: \
`$ git pr show -t 21092`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21092.diff">https://git.openjdk.org/jdk/pull/21092.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21092#issuecomment-2361251728)