### PR TITLE
8340480: Bad copyright notices in changes from JDK-8339902

### DIFF
--- a/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
+++ b/test/jdk/java/awt/TextField/CaretPositionTest/CaretPositionTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.

--- a/test/jdk/java/awt/TextField/SetBoundsTest/SetBoundsTest.java
+++ b/test/jdk/java/awt/TextField/SetBoundsTest/SetBoundsTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.

--- a/test/jdk/java/awt/TextField/SetEchoCharTest4/SetEchoCharTest4.java
+++ b/test/jdk/java/awt/TextField/SetEchoCharTest4/SetEchoCharTest4.java
@@ -2,7 +2,6 @@
  * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.

--- a/test/jdk/java/awt/TextField/SetPasswordTest/SetPasswordTest.java
+++ b/test/jdk/java/awt/TextField/SetPasswordTest/SetPasswordTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.

--- a/test/jdk/java/awt/TextField/ZeroEchoCharTest/ZeroEchoCharTest.java
+++ b/test/jdk/java/awt/TextField/ZeroEchoCharTest/ZeroEchoCharTest.java
@@ -2,7 +2,6 @@
  * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
- * summary:
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
  * published by the Free Software Foundation.


### PR DESCRIPTION
fix legal notices

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340480](https://bugs.openjdk.org/browse/JDK-8340480): Bad copyright notices in changes from JDK-8339902 (**Bug** - P1)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21095/head:pull/21095` \
`$ git checkout pull/21095`

Update a local copy of the PR: \
`$ git checkout pull/21095` \
`$ git pull https://git.openjdk.org/jdk.git pull/21095/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21095`

View PR using the GUI difftool: \
`$ git pr show -t 21095`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21095.diff">https://git.openjdk.org/jdk/pull/21095.diff</a>

</details>
