### PR TITLE
8340436: Remove unused CompressedOops::AnyNarrowOopMode

### DIFF
--- a/src/hotspot/share/oops/compressedOops.hpp
+++ b/src/hotspot/share/oops/compressedOops.hpp
@@ -73,8 +73,7 @@ public:
     UnscaledNarrowOop  = 0,
     ZeroBasedNarrowOop = 1,
     DisjointBaseNarrowOop = 2,
-    HeapBasedNarrowOop = 3,
-    AnyNarrowOopMode = 4
+    HeapBasedNarrowOop = 3
   };
 
   // The representation type for narrowOop is assumed to be uint32_t.


### PR DESCRIPTION
Please review this trivial change to remove an unused enumerator.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340436](https://bugs.openjdk.org/browse/JDK-8340436): Remove unused CompressedOops::AnyNarrowOopMode (**Enhancement** - P4)


### Reviewers
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21098/head:pull/21098` \
`$ git checkout pull/21098`

Update a local copy of the PR: \
`$ git checkout pull/21098` \
`$ git pull https://git.openjdk.org/jdk.git pull/21098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21098`

View PR using the GUI difftool: \
`$ git pr show -t 21098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21098.diff">https://git.openjdk.org/jdk/pull/21098.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21098#issuecomment-2362329840)