### PR TITLE
8340490: Shenandoah: Optimize ShenandoahPacer

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -693,7 +693,7 @@ void ShenandoahHeap::notify_mutator_alloc_words(size_t words, bool waste) {
   if (ShenandoahPacing) {
     control_thread()->pacing_notify_alloc(words);
     if (waste) {
-      pacer()->claim_for_alloc(words, true);
+      pacer()->claim_for_alloc<true>(words);
     }
   }
 }

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -264,7 +264,7 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
     claimed = claim_for_alloc<true>(words);
     assert(claimed, "Should always succeed");
   }
-  ShenandoahThreadLocalData::add_paced_time(JavaThread::current(), (double)(os::elapsed_counter() - start_time) / (double) NANOSECS_PER_SEC);
+  ShenandoahThreadLocalData::add_paced_time(current, (double)(os::elapsed_counter() - start_time) / NANOSECS_PER_SEC);
 }
 
 void ShenandoahPacer::wait(size_t time_ms) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -257,6 +257,7 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
   while (!claimed) {
     // We could instead assist GC, but this would suffice for now.
     wait(1);
+    claimed = claim_for_alloc<false>(words);
     total_delay = os::elapsedTime() - start;
     if (static_cast<size_t>(total_delay * 1000) > max_ms) {
       // Exiting if spent local time budget to wait for enough GC progress.
@@ -264,7 +265,6 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
       // and start Degenerated GC cycle.
       break;
     }
-    claimed = claim_for_alloc<false>(words);
   }
 
   if (total_delay > 0) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -188,8 +188,8 @@ void ShenandoahPacer::restart_with(size_t non_taxable_bytes, double tax_rate) {
   // Shake up stalled waiters after budget update.
   _need_notify_waiters.try_set();
 }
-
-bool ShenandoahPacer::claim_for_alloc(size_t words, bool force) {
+template<bool FORCE>
+bool ShenandoahPacer::claim_for_alloc(size_t words) {
   assert(ShenandoahPacing, "Only be here when pacing is enabled");
 
   intptr_t tax = MAX2<intptr_t>(1, words * Atomic::load(&_tax_rate));
@@ -198,14 +198,18 @@ bool ShenandoahPacer::claim_for_alloc(size_t words, bool force) {
   intptr_t new_val = 0;
   do {
     cur = Atomic::load(&_budget);
-    if (cur < tax && !force) {
+    if (cur < tax && !FORCE) {
       // Progress depleted, alas.
       return false;
     }
     new_val = cur - tax;
-  } while (Atomic::cmpxchg(&_budget, cur, new_val, memory_order_relaxed) != cur);
+  } while (Atomic::load(&_budget) == cur &&
+           Atomic::cmpxchg(&_budget, cur, new_val, memory_order_relaxed) != cur);
   return true;
 }
+
+template bool ShenandoahPacer::claim_for_alloc<true>(size_t words);
+template bool ShenandoahPacer::claim_for_alloc<false>(size_t words);
 
 void ShenandoahPacer::unpace_for_alloc(intptr_t epoch, size_t words) {
   assert(ShenandoahPacing, "Only be here when pacing is enabled");
@@ -227,17 +231,10 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
   assert(ShenandoahPacing, "Only be here when pacing is enabled");
 
   // Fast path: try to allocate right away
-  bool claimed = claim_for_alloc(words, false);
+  bool claimed = claim_for_alloc<false>(words);
   if (claimed) {
     return;
   }
-
-  // Forcefully claim the budget: it may go negative at this point, and
-  // GC should replenish for this and subsequent allocations. After this claim,
-  // we would wait a bit until our claim is matched by additional progress,
-  // or the time budget depletes.
-  claimed = claim_for_alloc(words, true);
-  assert(claimed, "Should always succeed");
 
   // Threads that are attaching should not block at all: they are not
   // fully initialized yet. Blocking them would be awkward.
@@ -249,32 +246,40 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
   JavaThread* current = JavaThread::current();
   if (current->is_attaching_via_jni() ||
       !current->is_active_Java_thread()) {
+    claim_for_alloc<true>(words);
     return;
   }
 
   double start = os::elapsedTime();
+  double end;
 
-  size_t max_ms = ShenandoahPacingMaxDelay;
-  size_t total_ms = 0;
+  size_t const max_ms = ShenandoahPacingMaxDelay;
+  double total_delay = 0;
 
-  while (true) {
+  while (!claimed) {
     // We could instead assist GC, but this would suffice for now.
-    size_t cur_ms = (max_ms > total_ms) ? (max_ms - total_ms) : 1;
-    wait(cur_ms);
+    wait(1);
+    claimed = claim_for_alloc<false>(words);
+    end = os::elapsedTime();
+    total_delay = end - start;
 
-    double end = os::elapsedTime();
-    total_ms = (size_t)((end - start) * 1000);
-
-    if (total_ms > max_ms || Atomic::load(&_budget) >= 0) {
-      // Exiting if either:
-      //  a) Spent local time budget to wait for enough GC progress.
-      //     Breaking out and allocating anyway, which may mean we outpace GC,
-      //     and start Degenerated GC cycle.
-      //  b) The budget had been replenished, which means our claim is satisfied.
-      ShenandoahThreadLocalData::add_paced_time(JavaThread::current(), end - start);
+    if (static_cast<size_t>(total_delay * 1000) > max_ms) {
+      // Exiting if spent local time budget to wait for enough GC progress.
+      // Breaking out and allocating anyway, which may mean we outpace GC,
+      // and start Degenerated GC cycle.
       break;
     }
   }
+
+  if (total_delay > 0) {
+    ShenandoahThreadLocalData::add_paced_time(JavaThread::current(), total_delay);
+  }
+
+  // Forcefully claim if still not claimed after attempts above.
+  if (!claimed) {
+    claimed = claim_for_alloc<true>(words);
+  }
+  assert(claimed, "Should always succeed");
 }
 
 void ShenandoahPacer::wait(size_t time_ms) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -257,7 +257,6 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
   while (!claimed) {
     // We could instead assist GC, but this would suffice for now.
     wait(1);
-    claimed = claim_for_alloc<false>(words);
     total_delay = os::elapsedTime() - start;
     if (static_cast<size_t>(total_delay * 1000) > max_ms) {
       // Exiting if spent local time budget to wait for enough GC progress.

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -251,24 +251,20 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
   }
 
   double start = os::elapsedTime();
-  double end;
-
   size_t const max_ms = ShenandoahPacingMaxDelay;
   double total_delay = 0;
 
   while (!claimed) {
     // We could instead assist GC, but this would suffice for now.
     wait(1);
-    claimed = claim_for_alloc<false>(words);
-    end = os::elapsedTime();
-    total_delay = end - start;
-
+    total_delay = os::elapsedTime() - start;
     if (static_cast<size_t>(total_delay * 1000) > max_ms) {
       // Exiting if spent local time budget to wait for enough GC progress.
       // Breaking out and allocating anyway, which may mean we outpace GC,
       // and start Degenerated GC cycle.
       break;
     }
+    claimed = claim_for_alloc<false>(words);
   }
 
   if (total_delay > 0) {

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -250,8 +250,8 @@ void ShenandoahPacer::pace_for_alloc(size_t words) {
     return;
   }
 
-  jlong max_delay = ShenandoahPacingMaxDelay * NANOSECS_PER_MILLISEC;
-  jlong start_time = os::elapsed_counter();
+  jlong const max_delay = ShenandoahPacingMaxDelay * NANOSECS_PER_MILLISEC;
+  jlong const start_time = os::elapsed_counter();
   while (!claimed && (os::elapsed_counter() - start_time) < max_delay) {
     // We could instead assist GC, but this would suffice for now.
     wait(1);

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
@@ -106,8 +106,9 @@ public:
   inline void report_updaterefs(size_t words);
 
   inline void report_alloc(size_t words);
+  template<bool FORCE>
+  bool claim_for_alloc(size_t words);
 
-  bool claim_for_alloc(size_t words, bool force);
   void pace_for_alloc(size_t words);
   void unpace_for_alloc(intptr_t epoch, size_t words);
 

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.hpp
@@ -106,6 +106,7 @@ public:
   inline void report_updaterefs(size_t words);
 
   inline void report_alloc(size_t words);
+
   template<bool FORCE>
   bool claim_for_alloc(size_t words);
 


### PR DESCRIPTION
In a simple latency benchmark for memory allocation, I found ShenandoahPacer contributed quite a lot to the long tail latency > 10ms, when there are multi mutator threads failed at fast path to claim budget [here](https://github.com/openjdk/jdk/blob/fdc16a373459cb2311316448c765b1bee5c73694/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp#L230), all of them will forcefully claim and them wait for up to 10ms([code link](https://github.com/openjdk/jdk/blob/fdc16a373459cb2311316448c765b1bee5c73694/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp#L239-L277))

The change in this PR makes ShenandoahPacer impact long tail latency much less, instead forcefully claim budget and them wait, it attempts to claim after waiting for 1ms, and keep doing this until: 1/ either spent 10ms waiting in total; 2/ or successfully claimed the budget.

Here the latency comparison for the optimization:
![hdr-histogram-optimize-pacer](https://github.com/user-attachments/assets/811f48c5-87eb-462d-8b27-d15bd08be7b0)

With the optimization, long tail latency from the test code below has been much improved from over 20ms to ~10ms on MacOS with M3 chip:
```
    static final int threadCount = Runtime.getRuntime().availableProcessors();
    static final LongAdder totalCount = new LongAdder();
    static volatile byte[] sink;
    public static void main(String[] args) {
        runAllocationTest(100000);
    }
    static void recordTimeToAllocate(final int dataSize, final Histogram histogram) {
        long startTime = System.nanoTime();
        sink = new byte[dataSize];
        long endTime = System.nanoTime();
        histogram.recordValue(endTime - startTime);
    }

    static void runAllocationTest(final int dataSize) {
        final long endTime = System.currentTimeMillis() + 30_000;
        final CountDownLatch startSignal = new CountDownLatch(1);
        final CountDownLatch finished = new CountDownLatch(threadCount);
        final Thread[] threads = new Thread[threadCount];
        final Histogram[] histograms = new Histogram[threadCount];
        final Histogram totalHistogram = new Histogram(3600000000000L, 3);
        for (int i = 0; i < threadCount; i++) {
            final var histogram = new Histogram(3600000000000L, 3);
            histograms[i] = histogram;
            threads[i] = new Thread(() -> {
                wait(startSignal);
                do {
                    recordTimeToAllocate(dataSize, histogram);
                } while (System.currentTimeMillis() < endTime);
                finished.countDown();
            });
            threads[i].start();
        }

        startSignal.countDown(); //Start to test
        wait(finished);
        
        for (Histogram histogram : histograms) {
            totalHistogram.add(histogram);
        }

        totalHistogram.outputPercentileDistribution(System.out, 1000.0);

    }

    public static void wait(final CountDownLatch latch) {
        try {
            latch.await();
        } catch (InterruptedException e) {
            throw new RuntimeException(e);
        }
    }
```

### Additional test
- [x] MacOS AArch64 server fastdebug, hotspot_gc_shenandoah

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340490](https://bugs.openjdk.org/browse/JDK-8340490): Shenandoah: Optimize ShenandoahPacer (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21099/head:pull/21099` \
`$ git checkout pull/21099`

Update a local copy of the PR: \
`$ git checkout pull/21099` \
`$ git pull https://git.openjdk.org/jdk.git pull/21099/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21099`

View PR using the GUI difftool: \
`$ git pr show -t 21099`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21099.diff">https://git.openjdk.org/jdk/pull/21099.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21099#issuecomment-2364303680)