### PR TITLE
8340491: Thread stack-base assertion should report which thread has the un-set stack

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -145,6 +145,14 @@ Thread::Thread(MemTag mem_tag) {
   MACOS_AARCH64_ONLY(DEBUG_ONLY(_wx_init = false));
 }
 
+address Thread::stack_base() const {
+  // Note: can't report Thread::name() here as that can require a ResourceMark which we
+  // can't use because this gets called too early in the thread initialization.
+  assert(_stack_base != nullptr, "Stack base not yet set for thread id:%d (0 if not set)",
+         osthread() != nullptr ? osthread()->thread_id() : 0);
+  return _stack_base;
+}
+
 void Thread::initialize_tlab() {
   if (UseTLAB) {
     tlab().initialize();

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -145,7 +145,7 @@ Thread::Thread(MemTag mem_tag) {
   MACOS_AARCH64_ONLY(DEBUG_ONLY(_wx_init = false));
 }
 
-#ifndef DEBUG
+#ifdef ASSERT
 address Thread::stack_base() const {
   // Note: can't report Thread::name() here as that can require a ResourceMark which we
   // can't use because this gets called too early in the thread initialization.

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -145,6 +145,7 @@ Thread::Thread(MemTag mem_tag) {
   MACOS_AARCH64_ONLY(DEBUG_ONLY(_wx_init = false));
 }
 
+#ifndef DEBUG
 address Thread::stack_base() const {
   // Note: can't report Thread::name() here as that can require a ResourceMark which we
   // can't use because this gets called too early in the thread initialization.
@@ -152,6 +153,7 @@ address Thread::stack_base() const {
          osthread() != nullptr ? osthread()->thread_id() : 0);
   return _stack_base;
 }
+#endif
 
 void Thread::initialize_tlab() {
   if (UseTLAB) {

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -532,7 +532,7 @@ protected:
 
  public:
   // Stack overflow support
-  address stack_base() const;
+  address stack_base() const DEBUG_ONLY(;) NOT_DEBUG({ return _stack_base; })
   void    set_stack_base(address base) { _stack_base = base; }
   size_t  stack_size() const           { return _stack_size; }
   void    set_stack_size(size_t size)  { _stack_size = size; }

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -532,7 +532,7 @@ protected:
 
  public:
   // Stack overflow support
-  address stack_base() const           { assert(_stack_base != nullptr,"Sanity check"); return _stack_base; }
+  address stack_base() const;
   void    set_stack_base(address base) { _stack_base = base; }
   size_t  stack_size() const           { return _stack_size; }
   void    set_stack_size(size_t size)  { _stack_size = size; }


### PR DESCRIPTION
Please review this simple enhancement to an assertion so we can identify which thread had the problem.

I had to move the function to the cpp file due to include file issues.

We are limited in what we can print due to this being used very early in the thread initialization process - in particular no ResourceMarks are possible so we can't print the name.

Testing:
 - tier 5 (used to debug [JDK-8340401](https://bugs.openjdk.org/browse/JDK-8340401))
 - tiers 1-3 sanity

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340491](https://bugs.openjdk.org/browse/JDK-8340491): Thread stack-base assertion should report which thread has the un-set stack (**Enhancement** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) Review applies to [e6358a57](https://git.openjdk.org/jdk/pull/21102/files/e6358a57d0d73909a2c30c465edea45027c371d5)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21102/head:pull/21102` \
`$ git checkout pull/21102`

Update a local copy of the PR: \
`$ git checkout pull/21102` \
`$ git pull https://git.openjdk.org/jdk.git pull/21102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21102`

View PR using the GUI difftool: \
`$ git pr show -t 21102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21102.diff">https://git.openjdk.org/jdk/pull/21102.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21102#issuecomment-2362586549)