### PR TITLE
8339935: Open source several AWT focus tests - series 5

### DIFF
--- a/test/jdk/java/awt/Focus/DeiconifyTest.java
+++ b/test/jdk/java/awt/Focus/DeiconifyTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4380809
+ * @summary Focus disappears after deiconifying frame
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DeiconifyTest
+*/
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.event.FocusEvent;
+import java.awt.event.FocusListener;
+
+public class DeiconifyTest {
+
+    private static final String INSTRUCTIONS = """
+         1. Activate frame \"Main frame\"
+         be sure that button has focus
+         2. Minimize frame and then restore it.
+         If the button has focus then test passed, else failed""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("DeiconifyTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int)INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(DeiconifyTest::createTestUI)
+                .logArea()
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI()   {
+        Frame frame = new Frame("Main frame");
+        Button button = new Button("button");
+        button.addFocusListener(new FocusListener() {
+              public void focusGained(FocusEvent fe) {
+                  println("focus gained");
+              }
+              public void focusLost(FocusEvent fe) {
+                  println("focus lost");
+              }
+          });
+        frame.add(button);
+        frame.setSize(300, 100);
+
+        return frame;
+    }
+
+    static void println(String messageIn) {
+        PassFailJFrame.log(messageIn);
+    }
+}
+

--- a/test/jdk/java/awt/Focus/HiddenTraversalTest.java
+++ b/test/jdk/java/awt/Focus/HiddenTraversalTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 4157017
+ * @summary Checks whether focus can be traversed when component not visible
+           within parent container.
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual HiddenTraversalTest
+*/
+
+import java.awt.Button;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Panel;
+
+public class HiddenTraversalTest {
+
+    private static final String INSTRUCTIONS = """
+         Examine the Frame. If six buttons are visible, resize the frame
+         so that only four are visible. If fewer than six buttons are
+         visible, do nothing.\n
+         Now, repeatedly press the tab key. Focus should cycle through the
+         visible and invisible buttons. If after six presses of the tab
+         button 'Button 0' has focus, the test passes. If focus is instead
+         stuck at 'Button 3', the test fails.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("HiddenTraversalTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(HiddenTraversalTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createTestUI() {
+        Frame f = new Frame("Focus test");
+        Panel p = new Panel(new FlowLayout());
+        for (int i = 0; i < 6; i++) {
+            p.add(new Button("Button " + i));
+        }
+        f.add(p);
+        f.setSize(200, 100);
+        return f;
+    }
+
+}
+

--- a/test/jdk/java/awt/Focus/LightweightPopupTest.java
+++ b/test/jdk/java/awt/Focus/LightweightPopupTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4472032
+ * @summary Switching between lightweight menus by holizontal arrow key works incorrect
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual LightweightPopupTest
+*/
+
+import javax.swing.JButton;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+
+public class LightweightPopupTest {
+
+    private static final String INSTRUCTIONS = """
+            When the test starts, you will see a frame titled
+            'Lightweight Popup Test', which contains a button
+            (titled 'JButton') and two menus ('Menu 1' and 'Menu 2').
+            Make sure that both menus, when expanded, fit entirely
+            into the frame. Now take the following steps:
+                1. Click on 'JButton' to focus it.
+                2. Click 'Menu 1' to expand it.
+                3. Press right arrow to select 'Menu 2'.
+            Now check where the focus is. If it is on 'JButton'
+            (you can press space bar to see if it is there), then
+            the test failed. If 'JButton' is not focused, then
+            the test passed.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("LightweightPopupTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int)INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(LightweightPopupTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+
+        JFrame frame = new JFrame("Lightweight Popup Test");
+        JButton button = new JButton("JButton");
+        JMenuBar menuBar = new JMenuBar();
+        JMenu menu1 = new JMenu("Menu 1");
+        menu1.add(new JMenuItem("Menu Item 1"));
+        menu1.add(new JMenuItem("Menu Item 2"));
+        menuBar.add(menu1);
+        JMenu menu2 = new JMenu("Menu 2");
+        menu2.add(new JMenuItem("Menu Item 3"));
+        menu2.add(new JMenuItem("Menu Item 4"));
+        menuBar.add(menu2);
+
+        frame.add(button);
+        frame.setJMenuBar(menuBar);
+        frame.setSize(300, 200);
+        return frame;
+    }
+
+}
+

--- a/test/jdk/java/awt/Focus/LightweightPopupTest.java
+++ b/test/jdk/java/awt/Focus/LightweightPopupTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 4472032
- * @summary Switching between lightweight menus by holizontal arrow key works incorrect
+ * @summary Switching between lightweight menus by horizontal arrow key works incorrect
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual LightweightPopupTest

--- a/test/jdk/java/awt/Focus/ProxiedWindowHideTest.java
+++ b/test/jdk/java/awt/Focus/ProxiedWindowHideTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4396407
+ * @summary Tests that after proxied window were hidden focus is being restored correctly
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ProxiedWindowHideTest
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Container;
+import javax.swing.Box;
+import javax.swing.JComboBox;
+import javax.swing.JFrame;
+
+public class ProxiedWindowHideTest {
+
+    private static final String INSTRUCTIONS = """
+           You will see JFrame with title 'TEST'.
+           Click on JComboBox, list will expand then select any item in it.
+           After selection, list should collapse.
+           Click on Button('Push').
+           If you are able to make it focused by mouse click,
+           (black rectangle will appear around it) the test is PASSED,
+           otherwise the test is FAILED.""";
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ProxiedWindowHideTest Instructions")
+                .instructions(INSTRUCTIONS)
+                .rows((int) INSTRUCTIONS.lines().count() + 2)
+                .columns(35)
+                .testUI(ProxiedWindowHideTest::createTestUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static JFrame createTestUI() {
+        JFrame frame = new JFrame("ProxiedWindowHideTest frame");
+        String[] petStrings = { "Bird", "Cat", "Dog", "Rabbit", "Pig" };
+        JComboBox cb = new JComboBox(petStrings);
+
+        cb.setLightWeightPopupEnabled(false);
+        Container parent = Box.createVerticalBox();
+        parent.add(new Button("Push"));
+        parent.add(cb);
+        frame.add(parent, BorderLayout.CENTER);
+        frame.pack();
+        return frame;
+    }
+
+}
+

--- a/test/jdk/java/awt/Focus/ProxiedWindowHideTest.java
+++ b/test/jdk/java/awt/Focus/ProxiedWindowHideTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 4396407
- * @summary Tests that after proxied window were hidden focus is being restored correctly
+ * @summary Tests that after a proxied window is hidden, focus is being restored correctly
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual ProxiedWindowHideTest
@@ -40,7 +40,7 @@ import javax.swing.JFrame;
 public class ProxiedWindowHideTest {
 
     private static final String INSTRUCTIONS = """
-           You will see JFrame with title 'TEST'.
+           You will see a JFrame.
            Click on JComboBox, list will expand then select any item in it.
            After selection, list should collapse.
            Click on Button('Push').


### PR DESCRIPTION
Opensource few AWT focus tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339935](https://bugs.openjdk.org/browse/JDK-8339935): Open source several AWT focus tests - series 5 (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21103/head:pull/21103` \
`$ git checkout pull/21103`

Update a local copy of the PR: \
`$ git checkout pull/21103` \
`$ git pull https://git.openjdk.org/jdk.git pull/21103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21103`

View PR using the GUI difftool: \
`$ git pr show -t 21103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21103.diff">https://git.openjdk.org/jdk/pull/21103.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21103#issuecomment-2362685648)