### PR TITLE
8340537: Typo in javadoc of java.util.jar.JarFile

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -90,7 +90,7 @@ import java.util.zip.ZipFile;
  * <p> If the {@code verify} flag is on when opening a signed jar file, the content
  * of the jar entry is verified against the signature embedded inside the manifest
  * that is associated with its {@link JarEntry#getRealName() path name}. For a
- * multi-release jar file, the content of a versioned entry is verfieid against
+ * multi-release jar file, the content of a versioned entry is verified against
  * its own signature and {@link JarEntry#getCodeSigners()} returns its own signers.
  *
  * Please note that the verification process does not include validating the


### PR DESCRIPTION
Can I please get a review of this trivial typo fix in `JarFile` class' javadoc?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340537](https://bugs.openjdk.org/browse/JDK-8340537): Typo in javadoc of java.util.jar.JarFile (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21108/head:pull/21108` \
`$ git checkout pull/21108`

Update a local copy of the PR: \
`$ git checkout pull/21108` \
`$ git pull https://git.openjdk.org/jdk.git pull/21108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21108`

View PR using the GUI difftool: \
`$ git pr show -t 21108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21108.diff">https://git.openjdk.org/jdk/pull/21108.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21108#issuecomment-2363638687)