### PR TITLE
8340524: Remove NarrowPtrStruct

### DIFF
--- a/src/hotspot/share/oops/compressedOops.cpp
+++ b/src/hotspot/share/oops/compressedOops.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,10 @@
 #include "runtime/globals.hpp"
 
 // For UseCompressedOops.
-NarrowPtrStruct CompressedOops::_narrow_oop = { nullptr, 0, true };
-MemRegion       CompressedOops::_heap_address_range;
+address CompressedOops::_base = nullptr;
+int CompressedOops::_shift = 0;
+bool CompressedOops::_use_implicit_null_checks = true;
+MemRegion CompressedOops::_heap_address_range;
 
 // Choose the heap base address and oop encoding mode
 // when compressed oops are used:
@@ -88,16 +90,16 @@ void CompressedOops::initialize(const ReservedHeapSpace& heap_space) {
 
 void CompressedOops::set_base(address base) {
   assert(UseCompressedOops, "no compressed oops?");
-  _narrow_oop._base    = base;
+  _base = base;
 }
 
 void CompressedOops::set_shift(int shift) {
-  _narrow_oop._shift   = shift;
+  _shift = shift;
 }
 
 void CompressedOops::set_use_implicit_null_checks(bool use) {
   assert(UseCompressedOops, "no compressed ptrs?");
-  _narrow_oop._use_implicit_null_checks   = use;
+  _use_implicit_null_checks = use;
 }
 
 bool CompressedOops::is_in(void* addr) {
@@ -148,14 +150,14 @@ bool CompressedOops::is_disjoint_heap_base_address(address addr) {
 
 // Check for disjoint base compressed oops.
 bool CompressedOops::base_disjoint() {
-  return _narrow_oop._base != nullptr && is_disjoint_heap_base_address(_narrow_oop._base);
+  return _base != nullptr && is_disjoint_heap_base_address(_base);
 }
 
 // Check for real heapbased compressed oops.
 // We must subtract the base as the bits overlap.
 // If we negate above function, we also get unscaled and zerobased.
 bool CompressedOops::base_overlaps() {
-  return _narrow_oop._base != nullptr && !is_disjoint_heap_base_address(_narrow_oop._base);
+  return _base != nullptr && !is_disjoint_heap_base_address(_base);
 }
 
 void CompressedOops::print_mode(outputStream* st) {

--- a/src/hotspot/share/oops/compressedOops.hpp
+++ b/src/hotspot/share/oops/compressedOops.hpp
@@ -34,23 +34,18 @@
 class outputStream;
 class ReservedHeapSpace;
 
-struct NarrowPtrStruct {
-  // Base address for oop-within-java-object materialization.
-  // null if using wide oops or zero based narrow oops.
-  address _base;
-  // Number of shift bits for encoding/decoding narrow ptrs.
-  // 0 if using wide ptrs or zero based unscaled narrow ptrs,
-  // LogMinObjAlignmentInBytes otherwise.
-  int     _shift;
-  // Generate code with implicit null checks for narrow ptrs.
-  bool    _use_implicit_null_checks;
-};
-
 class CompressedOops : public AllStatic {
   friend class VMStructs;
 
-  // For UseCompressedOops.
-  static NarrowPtrStruct _narrow_oop;
+  // Base address for oop-within-java-object materialization.
+  // null if using wide oops or zero based narrow oops.
+  static address _base;
+  // Number of shift bits for encoding/decoding narrow ptrs.
+  // 0 if using wide oops or zero based unscaled narrow oops,
+  // LogMinObjAlignmentInBytes otherwise.
+  static int _shift;
+  // Generate code with implicit null checks for narrow oops.
+  static bool _use_implicit_null_checks;
 
   // The address range of the heap
   static MemRegion _heap_address_range;
@@ -86,13 +81,13 @@ public:
   static void set_shift(int shift);
   static void set_use_implicit_null_checks(bool use);
 
-  static address  base()                     { return _narrow_oop._base; }
-  static address  base_addr()                { return (address)&_narrow_oop._base; }
+  static address  base()                     { return _base; }
+  static address  base_addr()                { return (address)&_base; }
   static address  begin()                    { return (address)_heap_address_range.start(); }
   static address  end()                      { return (address)_heap_address_range.end(); }
   static bool     is_base(void* addr)        { return (base() == (address)addr); }
-  static int      shift()                    { return _narrow_oop._shift; }
-  static bool     use_implicit_null_checks() { return _narrow_oop._use_implicit_null_checks; }
+  static int      shift()                    { return _shift; }
+  static bool     use_implicit_null_checks() { return _use_implicit_null_checks; }
 
   static bool is_in(void* addr);
   static bool is_in(MemRegion mr);

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -373,9 +373,9 @@
   /* CompressedOops */                                                                                                               \
   /******************/                                                                                                               \
                                                                                                                                      \
-     static_field(CompressedOops,              _narrow_oop._base,                             address)                               \
-     static_field(CompressedOops,              _narrow_oop._shift,                            int)                                   \
-     static_field(CompressedOops,              _narrow_oop._use_implicit_null_checks,         bool)                                  \
+     static_field(CompressedOops,              _base,                                         address)                               \
+     static_field(CompressedOops,              _shift,                                        int)                                   \
+     static_field(CompressedOops,              _use_implicit_null_checks,                     bool)                                  \
                                                                                                                                      \
   /***************************/                                                                                                      \
   /* CompressedKlassPointers */                                                                                                      \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/CompressedOops.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/oops/CompressedOops.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,8 +64,8 @@ public class CompressedOops {
   private static synchronized void initialize(TypeDataBase db) {
     Type type = db.lookupType("CompressedOops");
 
-    baseField = type.getAddressField("_narrow_oop._base");
-    shiftField = type.getCIntegerField("_narrow_oop._shift");
+    baseField = type.getAddressField("_base");
+    shiftField = type.getCIntegerField("_shift");
   }
 
   public CompressedOops() {


### PR DESCRIPTION
Please review this change which removes the class NarrowPtrStruct. The only
place it was still being used was as the type of CompressedOops::_narrow_oops.
Instead, we move the members from NarrowPtrStruct directly into
CompressedOops, flattening its structure.

Testing: mach5 tier1-3
Tiers 2&3 run serviceability tests that hit the changes to that component.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340524](https://bugs.openjdk.org/browse/JDK-8340524): Remove NarrowPtrStruct (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21115/head:pull/21115` \
`$ git checkout pull/21115`

Update a local copy of the PR: \
`$ git checkout pull/21115` \
`$ git pull https://git.openjdk.org/jdk.git pull/21115/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21115`

View PR using the GUI difftool: \
`$ git pr show -t 21115`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21115.diff">https://git.openjdk.org/jdk/pull/21115.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21115#issuecomment-2364993197)