### PR TITLE
8340573: Remove unused G1ParScanThreadState::_partial_objarray_chunk_size

### DIFF
--- a/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
+++ b/src/hotspot/share/gc/g1/g1ParScanThreadState.hpp
@@ -87,8 +87,6 @@ class G1ParScanThreadState : public CHeapObj<mtGC> {
   // Indicates whether in the last generation (old) there is no more space
   // available for allocation.
   bool _old_gen_is_full;
-  // Size (in elements) of a partial objArray task chunk.
-  size_t _partial_objarray_chunk_size;
   PartialArrayStateAllocator* _partial_array_state_allocator;
   PartialArrayTaskStepper _partial_array_stepper;
   StringDedup::Requests _string_dedup_requests;


### PR DESCRIPTION
Please review this trivial change to remove unused G1ParScanThreadState::_partial_objarray_chunk_size.

Testing: local (linux-x64) clean build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340573](https://bugs.openjdk.org/browse/JDK-8340573): Remove unused G1ParScanThreadState::_partial_objarray_chunk_size (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21117/head:pull/21117` \
`$ git checkout pull/21117`

Update a local copy of the PR: \
`$ git checkout pull/21117` \
`$ git pull https://git.openjdk.org/jdk.git pull/21117/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21117`

View PR using the GUI difftool: \
`$ git pr show -t 21117`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21117.diff">https://git.openjdk.org/jdk/pull/21117.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21117#issuecomment-2365361401)