### PR TITLE
8340574: Drop stackMapTable.cpp to -O1 for MacOS on XCode 16 to work around JDK-8340341

### DIFF
--- a/make/hotspot/lib/JvmOverrideFiles.gmk
+++ b/make/hotspot/lib/JvmOverrideFiles.gmk
@@ -86,6 +86,11 @@ else ifeq ($(call isTargetOs, macosx), true)
     # for the clang bug was still needed.
     BUILD_LIBJVM_loopTransform.cpp_CXXFLAGS := $(CXX_O_FLAG_NONE)
 
+    # See JDK-8340341
+    ifeq "$(firstword $(subst ., ,$(CXX_VERSION_NUMBER)))" "16"
+      BUILD_LIBJVM_stackMapTable.cpp_CXXFLAGS := "-O1"
+    endif
+
     # The following files are compiled at various optimization
     # levels due to optimization issues encountered at the
     # default level. The Clang compiler issues a compile


### PR DESCRIPTION
Trivial change to drop the optimization level (for both fastdebug and release) of stackMapTable.cpp to O1 on MacOS with Xcode 16.

This is a workaround for https://bugs.openjdk.org/browse/JDK-8340341, which prevents building on MacOS.

Tested: with patch fastdebug and release builds are green again.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340574](https://bugs.openjdk.org/browse/JDK-8340574): Drop stackMapTable.cpp to -O1 for MacOS on XCode 16 to work around JDK-8340341 (**Sub-task** - P2)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21119/head:pull/21119` \
`$ git checkout pull/21119`

Update a local copy of the PR: \
`$ git checkout pull/21119` \
`$ git pull https://git.openjdk.org/jdk.git pull/21119/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21119`

View PR using the GUI difftool: \
`$ git pr show -t 21119`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21119.diff">https://git.openjdk.org/jdk/pull/21119.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21119#issuecomment-2366452401)
</details>
