### PR TITLE
8340587: Optimize StackMapGenerator$Frame::checkAssignableTo

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -1093,11 +1093,15 @@ public final class StackMapGenerator {
         }
 
         void checkAssignableTo(Frame target) {
+            int localsSize = this.localsSize;
+            int stackSize = this.stackSize;
             if (target.flags == -1) {
                 target.locals = locals == null ? null : Arrays.copyOf(locals, localsSize);
                 target.localsSize = localsSize;
-                target.stack = stack == null ? null : Arrays.copyOf(stack, stackSize);
-                target.stackSize = stackSize;
+                if (stackSize > 0) {
+                    target.stack = Arrays.copyOf(stack, stackSize);
+                    target.stackSize = stackSize;
+                }
                 target.flags = flags;
                 target.dirty = true;
             } else {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -1096,10 +1096,10 @@ public final class StackMapGenerator {
             int localsSize = this.localsSize;
             int stackSize = this.stackSize;
             if (target.flags == -1) {
-                target.locals = locals == null ? null : Arrays.copyOf(locals, localsSize);
+                target.locals = locals == null ? null : locals.clone();
                 target.localsSize = localsSize;
                 if (stackSize > 0) {
-                    target.stack = Arrays.copyOf(stack, stackSize);
+                    target.stack = stack.clone();
                     target.stackSize = stackSize;
                 }
                 target.flags = flags;


### PR DESCRIPTION
Optimize checkAssignableTo to avoid clone when stackSize is 0, and use clone instead of Array.copyOf to avoid compression and then expansion

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340587](https://bugs.openjdk.org/browse/JDK-8340587): Optimize StackMapGenerator$Frame::checkAssignableTo (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21121/head:pull/21121` \
`$ git checkout pull/21121`

Update a local copy of the PR: \
`$ git checkout pull/21121` \
`$ git pull https://git.openjdk.org/jdk.git pull/21121/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21121`

View PR using the GUI difftool: \
`$ git pr show -t 21121`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21121.diff">https://git.openjdk.org/jdk/pull/21121.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21121#issuecomment-2367121900)