### PR TITLE
8340596: Remove dead code from RequiresSetenv function in java.base/unix/native/libjli/java_md.c

### DIFF
--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -227,7 +227,6 @@ static jboolean
 RequiresSetenv(const char *jvmpath) {
     char jpath[PATH_MAX + 1];
     char *llp;
-    char *dmllp = NULL;
     char *p; /* a utility pointer */
 
 #ifdef MUSL_LIBC
@@ -245,7 +244,7 @@ RequiresSetenv(const char *jvmpath) {
 
     llp = getenv("LD_LIBRARY_PATH");
     /* no environment variable is a good environment variable */
-    if (llp == NULL && dmllp == NULL) {
+    if (llp == NULL) {
         return JNI_FALSE;
     }
 #ifdef __linux
@@ -282,9 +281,6 @@ RequiresSetenv(const char *jvmpath) {
 
     /* scrutinize all the paths further */
     if (llp != NULL &&  ContainsLibJVM(llp)) {
-        return JNI_TRUE;
-    }
-    if (dmllp != NULL && ContainsLibJVM(dmllp)) {
         return JNI_TRUE;
     }
     return JNI_FALSE;


### PR DESCRIPTION
Can I please get a review of this trivial change which removes dead code from the `RequiresSetenv()` function?

As noted in https://bugs.openjdk.org/browse/JDK-8340596 this appears to be a left-over from the changes in https://bugs.openjdk.org/browse/JDK-8244224.

No new tests have been added and existing tier1, tier2 and tier3 tests continue to pass.