### PR TITLE
8340146: ZGC: TestAllocateHeapAt.java should not run with UseLargePages

### DIFF
--- a/test/hotspot/jtreg/gc/x/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/x/TestAllocateHeapAt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package gc.x;
 /*
  * @test TestAllocateHeapAt
  * @requires vm.gc.ZSinglegen & os.family == "linux"
+ * @requires !vm.opt.final.UseLargePages
  * @summary Test ZGC with -XX:AllocateHeapAt
  * @library /test/lib
  * @run main/othervm gc.x.TestAllocateHeapAt . true

--- a/test/hotspot/jtreg/gc/z/TestAllocateHeapAt.java
+++ b/test/hotspot/jtreg/gc/z/TestAllocateHeapAt.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,7 @@ package gc.z;
 /*
  * @test TestAllocateHeapAt
  * @requires vm.gc.ZGenerational & os.family == "linux"
+ * @requires !vm.opt.final.UseLargePages
  * @summary Test ZGC with -XX:AllocateHeapAt
  * @library /test/lib
  * @run main/othervm gc.z.TestAllocateHeapAt . true

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -386,6 +386,7 @@ public class VMProps implements Callable<Map<String, String>> {
         vmOptFinalFlag(map, "EnableJVMCI");
         vmOptFinalFlag(map, "EliminateAllocations");
         vmOptFinalFlag(map, "UseCompressedOops");
+        vmOptFinalFlag(map, "UseLargePages");
         vmOptFinalFlag(map, "UseVectorizedMismatchIntrinsic");
         vmOptFinalFlag(map, "ZGenerational");
     }


### PR DESCRIPTION
TestAllocateHeapAt.java expects that creating the heap file works in the current director (`.`). But when using persistent hugepages (-XX:+UseLargePages) this would require the filesystem to be a HugeTLBFS.

I propose that we do not allow running these tests with persistent hugepages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340146](https://bugs.openjdk.org/browse/JDK-8340146): ZGC: TestAllocateHeapAt.java should not run with UseLargePages (**Bug** - P3)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21127/head:pull/21127` \
`$ git checkout pull/21127`

Update a local copy of the PR: \
`$ git checkout pull/21127` \
`$ git pull https://git.openjdk.org/jdk.git pull/21127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21127`

View PR using the GUI difftool: \
`$ git pr show -t 21127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21127.diff">https://git.openjdk.org/jdk/pull/21127.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21127#issuecomment-2367422104)