### PR TITLE
8340419: ZGC: Create an UseLargePages adaptation of TestAllocateHeapAt.java

### DIFF
--- a/test/hotspot/jtreg/gc/z/TestAllocateHeapAtWithHugeTLBFS.java
+++ b/test/hotspot/jtreg/gc/z/TestAllocateHeapAtWithHugeTLBFS.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc.z;
+
+/*
+ * @test TestAllocateHeapAtWithHugeTLBFS
+ * @requires vm.gc.ZGenerational & os.family == "linux"
+ * @summary Test ZGC with -XX:AllocateHeapAt and -XX:+UseLargePages
+ * @library /test/lib
+ * @run driver gc.z.TestAllocateHeapAtWithHugeTLBFS true
+ * @run driver gc.z.TestAllocateHeapAtWithHugeTLBFS false
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jtreg.SkippedException;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.Scanner;
+
+public class TestAllocateHeapAtWithHugeTLBFS {
+    static String find_hugetlbfs_mountpoint() {
+        Pattern pat = Pattern.compile("\\d+ \\d+ \\d+:\\d+ \\S+ (\\S+) [^-]*- hugetlbfs (.+)");
+        try (Scanner scanner = new Scanner(new File("/proc/self/mountinfo"))) {
+            while (scanner.hasNextLine()) {
+                final Matcher mat = pat.matcher(scanner.nextLine());
+                if (mat.matches() && mat.group(2).contains("pagesize=2M")) {
+                    final Path path = Paths.get(mat.group(1));
+                    if (Files.isReadable(path) &&
+                        Files.isWritable(path) &&
+                        Files.isExecutable(path)) {
+                        // Found a usable mount point.
+                        return path.toString();
+                    }
+                }
+            }
+        } catch (FileNotFoundException e) {
+            System.out.println("Could not open /proc/self/mountinfo");
+        }
+        return null;
+    }
+    public static void main(String[] args) throws Exception {
+        final boolean exists = Boolean.parseBoolean(args[0]);
+        final String directory = exists ? find_hugetlbfs_mountpoint()
+                                        : "non-existing-directory";
+        if (directory == null) {
+            throw new SkippedException("No valid hugetlbfs mount point found");
+        }
+        final String heapBackingFile = "Heap Backing File: " + directory;
+        final String failedToCreateFile = "Failed to create file " + directory;
+
+        ProcessTools.executeTestJava(
+            "-XX:+UseZGC",
+            "-XX:+ZGenerational",
+            "-Xlog:gc*",
+            "-Xms32M",
+            "-Xmx32M",
+            "-XX:+UseLargePages",
+            "-XX:AllocateHeapAt=" + directory,
+            "-version")
+                .shouldContain(exists ? heapBackingFile : failedToCreateFile)
+                .shouldNotContain(exists ? failedToCreateFile : heapBackingFile)
+                .shouldHaveExitValue(exists ? 0 : 1);
+    }
+}


### PR DESCRIPTION
[JDK-8340146](https://bugs.openjdk.org/browse/JDK-8340146) / #21127  disables TestAllocateHeapAt.java when running with persistent hugepages because it makes assumptions on the underlying file systems.

I propose creating a version of this tests which instead first checks if there is an appropriate mount point for a persistent hugepages heap file, and only runs the test if exists.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340419](https://bugs.openjdk.org/browse/JDK-8340419): ZGC: Create an UseLargePages adaptation of TestAllocateHeapAt.java (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Author)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21128/head:pull/21128` \
`$ git checkout pull/21128`

Update a local copy of the PR: \
`$ git checkout pull/21128` \
`$ git pull https://git.openjdk.org/jdk.git pull/21128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21128`

View PR using the GUI difftool: \
`$ git pr show -t 21128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21128.diff">https://git.openjdk.org/jdk/pull/21128.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21128#issuecomment-2367430602)