### PR TITLE
8340623: Remove outdated PROCESSOR_ARCHITECTURE_IA64 from Windows coding

### DIFF
--- a/src/java.base/windows/native/libjava/java_props_md.c
+++ b/src/java.base/windows/native/libjava/java_props_md.c
@@ -233,9 +233,6 @@ cpu_isalist(void)
     SYSTEM_INFO info;
     GetSystemInfo(&info);
     switch (info.wProcessorArchitecture) {
-#ifdef PROCESSOR_ARCHITECTURE_IA64
-    case PROCESSOR_ARCHITECTURE_IA64: return "ia64";
-#endif
 #ifdef PROCESSOR_ARCHITECTURE_AMD64
     case PROCESSOR_ARCHITECTURE_AMD64: return "amd64";
 #endif


### PR DESCRIPTION
We still check for PROCESSOR_ARCHITECTURE_IA64 but this is not supported any more for a very long time in OpenJDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340623](https://bugs.openjdk.org/browse/JDK-8340623): Remove outdated PROCESSOR_ARCHITECTURE_IA64 from Windows coding (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21130/head:pull/21130` \
`$ git checkout pull/21130`

Update a local copy of the PR: \
`$ git checkout pull/21130` \
`$ git pull https://git.openjdk.org/jdk.git pull/21130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21130`

View PR using the GUI difftool: \
`$ git pr show -t 21130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21130.diff">https://git.openjdk.org/jdk/pull/21130.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21130#issuecomment-2367507527)