### PR TITLE
8342082: Remove unused BasicProgressBarUI.Animator.interval

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import javax.swing.event.*;
 import javax.swing.plaf.*;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeEvent;
-import java.io.Serializable;
 import sun.swing.DefaultLookup;
 
 /**
@@ -1224,7 +1223,6 @@ public class BasicProgressBarUI extends ProgressBarUI {
     private class Animator implements ActionListener {
         private Timer timer;
         private long previousDelay; //used to tune the repaint interval
-        private int interval; //the fixed repaint interval
         private long lastCall; //the last time actionPerformed was called
         private int MINIMUM_DELAY = 5;
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
@@ -25,16 +25,36 @@
 
 package javax.swing.plaf.basic;
 
-import sun.swing.SwingUtilities2;
-import java.awt.*;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.HierarchyEvent;
+import java.awt.event.HierarchyListener;
 import java.awt.geom.AffineTransform;
-import java.awt.event.*;
-import javax.swing.*;
-import javax.swing.event.*;
-import javax.swing.plaf.*;
+import javax.swing.BoundedRangeModel;
+import javax.swing.JComponent;
+import javax.swing.JProgressBar;
+import javax.swing.LookAndFeel;
+import javax.swing.SwingUtilities;
+import javax.swing.Timer;
+import javax.swing.UIManager;
+import javax.swing.event.ChangeEvent;
+import javax.swing.event.ChangeListener;
+import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.ProgressBarUI;
 import java.beans.PropertyChangeListener;
 import java.beans.PropertyChangeEvent;
 import sun.swing.DefaultLookup;
+import sun.swing.SwingUtilities2;
 
 /**
  * A Basic L&amp;F implementation of ProgressBarUI.
@@ -1224,7 +1244,7 @@ public class BasicProgressBarUI extends ProgressBarUI {
         private Timer timer;
         private long previousDelay; //used to tune the repaint interval
         private long lastCall; //the last time actionPerformed was called
-        private int MINIMUM_DELAY = 5;
+        private static final int MINIMUM_DELAY = 5;
 
         /**
          * Creates a timer if one doesn't already exist,

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicProgressBarUI.java
@@ -1265,9 +1265,9 @@ public class BasicProgressBarUI extends ProgressBarUI {
                 if (lastCall > 0) { //adjust nextDelay
                 //XXX maybe should cache this after a while
                     //actual = time - lastCall
-                    //difference = actual - interval
+                    //difference = actual - repaintInterval
                     //nextDelay = previousDelay - difference
-                    //          = previousDelay - (time - lastCall - interval)
+                    //          = previousDelay - (time - lastCall - repaintInterval)
                    int nextDelay = (int)(previousDelay
                                           - time + lastCall
                                           + getRepaintInterval());


### PR DESCRIPTION
The field `javax.swing.plaf.basic.BasicProgressBarUI.Animator.interval` is unused and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342082](https://bugs.openjdk.org/browse/JDK-8342082): Remove unused BasicProgressBarUI.Animator.interval (**Enhancement** - P5)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**) Review applies to [d93b287d](https://git.openjdk.org/jdk/pull/21132/files/d93b287d7bd216eca4ef22d3e97eb5af5d984c5f)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21132/head:pull/21132` \
`$ git checkout pull/21132`

Update a local copy of the PR: \
`$ git checkout pull/21132` \
`$ git pull https://git.openjdk.org/jdk.git pull/21132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21132`

View PR using the GUI difftool: \
`$ git pr show -t 21132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21132.diff">https://git.openjdk.org/jdk/pull/21132.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21132#issuecomment-2412092917)
</details>
