### PR TITLE
8340643: RISC-V: Small refactoring for sub/subw macro-assembler routines

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2085,11 +2085,11 @@ void MacroAssembler::addw(Register Rd, Register Rn, int32_t increment, Register 
 }
 
 void MacroAssembler::sub(Register Rd, Register Rn, int64_t decrement, Register temp) {
-  add(Rd, Rn, -decrement, temp)
+  add(Rd, Rn, -decrement, temp);
 }
 
 void MacroAssembler::subw(Register Rd, Register Rn, int32_t decrement, Register temp) {
-  addw(Rd, Rn, -decrement, temp)
+  addw(Rd, Rn, -decrement, temp);
 }
 
 void MacroAssembler::andrw(Register Rd, Register Rs1, Register Rs2) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2085,23 +2085,11 @@ void MacroAssembler::addw(Register Rd, Register Rn, int32_t increment, Register 
 }
 
 void MacroAssembler::sub(Register Rd, Register Rn, int64_t decrement, Register temp) {
-  if (is_simm12(-decrement)) {
-    addi(Rd, Rn, -decrement);
-  } else {
-    assert_different_registers(Rn, temp);
-    li(temp, -decrement);
-    add(Rd, Rn, temp);
-  }
+  add(Rd, Rn, -decrement, temp)
 }
 
 void MacroAssembler::subw(Register Rd, Register Rn, int32_t decrement, Register temp) {
-  if (is_simm12(-decrement)) {
-    addiw(Rd, Rn, -decrement);
-  } else {
-    assert_different_registers(Rn, temp);
-    li(temp, -decrement);
-    addw(Rd, Rn, temp);
-  }
+  addw(Rd, Rn, -decrement, temp)
 }
 
 void MacroAssembler::andrw(Register Rd, Register Rs1, Register Rs2) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2089,8 +2089,8 @@ void MacroAssembler::sub(Register Rd, Register Rn, int64_t decrement, Register t
     addi(Rd, Rn, -decrement);
   } else {
     assert_different_registers(Rn, temp);
-    li(temp, decrement);
-    sub(Rd, Rn, temp);
+    li(temp, -decrement);
+    add(Rd, Rn, temp);
   }
 }
 
@@ -2099,8 +2099,8 @@ void MacroAssembler::subw(Register Rd, Register Rn, int32_t decrement, Register 
     addiw(Rd, Rn, -decrement);
   } else {
     assert_different_registers(Rn, temp);
-    li(temp, decrement);
-    subw(Rd, Rn, temp);
+    li(temp, -decrement);
+    addw(Rd, Rn, temp);
   }
 }
 


### PR DESCRIPTION
Hi, please help review that, small refactoring for sub/subw macro-assembler routines.

### Testing
- [x] Run tier1 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340643](https://bugs.openjdk.org/browse/JDK-8340643): RISC-V: Small refactoring for sub/subw macro-assembler routines (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21135/head:pull/21135` \
`$ git checkout pull/21135`

Update a local copy of the PR: \
`$ git checkout pull/21135` \
`$ git pull https://git.openjdk.org/jdk.git pull/21135/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21135`

View PR using the GUI difftool: \
`$ git pr show -t 21135`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21135.diff">https://git.openjdk.org/jdk/pull/21135.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21135#issuecomment-2369824819)