### PR TITLE
8340585: [JVMCI] compiler/unsafe/UnsafeGetStableArrayElement.java fails with -XX:-UseCompressedClassPointers

### DIFF
--- a/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
+++ b/test/hotspot/jtreg/compiler/unsafe/UnsafeGetStableArrayElement.java
@@ -244,9 +244,9 @@ public class UnsafeGetStableArrayElement {
         testMismatched(Test::testZ_S, Test::changeZ);
         testMismatched(Test::testZ_C, Test::changeZ);
         testMismatched(Test::testZ_I, Test::changeZ);
-        testMismatched(Test::testZ_J, Test::changeZ);
+        testMismatched(Test::testZ_J, Test::changeZ, false, ARRAY_BOOLEAN_BASE_OFFSET == ARRAY_LONG_BASE_OFFSET);
         testMismatched(Test::testZ_F, Test::changeZ);
-        testMismatched(Test::testZ_D, Test::changeZ);
+        testMismatched(Test::testZ_D, Test::changeZ, false, ARRAY_BOOLEAN_BASE_OFFSET == ARRAY_DOUBLE_BASE_OFFSET);
 
         // byte[], aligned accesses
         testMismatched(Test::testB_Z, Test::changeB);
@@ -254,9 +254,9 @@ public class UnsafeGetStableArrayElement {
         testMismatched(Test::testB_S, Test::changeB);
         testMismatched(Test::testB_C, Test::changeB);
         testMismatched(Test::testB_I, Test::changeB);
-        testMismatched(Test::testB_J, Test::changeB);
+        testMismatched(Test::testB_J, Test::changeB, false, ARRAY_BYTE_BASE_OFFSET == ARRAY_LONG_BASE_OFFSET);
         testMismatched(Test::testB_F, Test::changeB);
-        testMismatched(Test::testB_D, Test::changeB);
+        testMismatched(Test::testB_D, Test::changeB, false, ARRAY_BYTE_BASE_OFFSET == ARRAY_DOUBLE_BASE_OFFSET);
 
         // short[], aligned accesses
         testMismatched(Test::testS_Z, Test::changeS);
@@ -264,9 +264,9 @@ public class UnsafeGetStableArrayElement {
         testMatched(   Test::testS_S, Test::changeS);
         testMismatched(Test::testS_C, Test::changeS);
         testMismatched(Test::testS_I, Test::changeS);
-        testMismatched(Test::testS_J, Test::changeS);
+        testMismatched(Test::testS_J, Test::changeS, false, ARRAY_SHORT_BASE_OFFSET == ARRAY_LONG_BASE_OFFSET);
         testMismatched(Test::testS_F, Test::changeS);
-        testMismatched(Test::testS_D, Test::changeS);
+        testMismatched(Test::testS_D, Test::changeS, false, ARRAY_SHORT_BASE_OFFSET == ARRAY_DOUBLE_BASE_OFFSET);
 
         // char[], aligned accesses
         testMismatched(Test::testC_Z, Test::changeC);
@@ -274,9 +274,9 @@ public class UnsafeGetStableArrayElement {
         testMismatched(Test::testC_S, Test::changeC);
         testMatched(   Test::testC_C, Test::changeC);
         testMismatched(Test::testC_I, Test::changeC);
-        testMismatched(Test::testC_J, Test::changeC);
+        testMismatched(Test::testC_J, Test::changeC, false, ARRAY_CHAR_BASE_OFFSET == ARRAY_LONG_BASE_OFFSET);
         testMismatched(Test::testC_F, Test::changeC);
-        testMismatched(Test::testC_D, Test::changeC);
+        testMismatched(Test::testC_D, Test::changeC, false, ARRAY_CHAR_BASE_OFFSET == ARRAY_DOUBLE_BASE_OFFSET);
 
         // int[], aligned accesses
         testMismatched(Test::testI_Z, Test::changeI);
@@ -284,9 +284,9 @@ public class UnsafeGetStableArrayElement {
         testMismatched(Test::testI_S, Test::changeI);
         testMismatched(Test::testI_C, Test::changeI);
         testMatched(   Test::testI_I, Test::changeI);
-        testMismatched(Test::testI_J, Test::changeI);
+        testMismatched(Test::testI_J, Test::changeI, false, ARRAY_INT_BASE_OFFSET == ARRAY_LONG_BASE_OFFSET);
         testMismatched(Test::testI_F, Test::changeI);
-        testMismatched(Test::testI_D, Test::changeI);
+        testMismatched(Test::testI_D, Test::changeI, false, ARRAY_INT_BASE_OFFSET == ARRAY_DOUBLE_BASE_OFFSET);
 
         // long[], aligned accesses
         testMismatched(Test::testJ_Z, Test::changeJ);
@@ -304,9 +304,9 @@ public class UnsafeGetStableArrayElement {
         testMismatched(Test::testF_S, Test::changeF);
         testMismatched(Test::testF_C, Test::changeF);
         testMismatched(Test::testF_I, Test::changeF);
-        testMismatched(Test::testF_J, Test::changeF);
+        testMismatched(Test::testF_J, Test::changeF, false, ARRAY_FLOAT_BASE_OFFSET == ARRAY_LONG_BASE_OFFSET);
         testMatched(   Test::testF_F, Test::changeF);
-        testMismatched(Test::testF_D, Test::changeF);
+        testMismatched(Test::testF_D, Test::changeF, false, ARRAY_FLOAT_BASE_OFFSET == ARRAY_DOUBLE_BASE_OFFSET);
 
         // double[], aligned accesses
         testMismatched(Test::testD_Z, Test::changeD);


### PR DESCRIPTION
Graal does not constant fold unaligned long/double reads from primitive stable arrays. Update UnsafeGetStableArrayElement.java accordingly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340585](https://bugs.openjdk.org/browse/JDK-8340585): [JVMCI] compiler/unsafe/UnsafeGetStableArrayElement.java fails with -XX:-UseCompressedClassPointers (**Bug** - P5)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21136/head:pull/21136` \
`$ git checkout pull/21136`

Update a local copy of the PR: \
`$ git checkout pull/21136` \
`$ git pull https://git.openjdk.org/jdk.git pull/21136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21136`

View PR using the GUI difftool: \
`$ git pr show -t 21136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21136.diff">https://git.openjdk.org/jdk/pull/21136.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21136#issuecomment-2368191799)