### PR TITLE
8340708: Optimize StackMapGenerator::processMethod

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -400,6 +400,8 @@ public final class StackMapGenerator {
     }
 
     private void processMethod() {
+        var frames = this.frames;
+        var currentFrame = this.currentFrame;
         currentFrame.setLocalsFromArg(methodName, methodDesc, isStatic, thisType);
         currentFrame.stackSize = 0;
         currentFrame.flags = 0;
@@ -429,13 +431,17 @@ public final class StackMapGenerator {
                     currentFrame.copyFrom(nextFrame);
                     nextFrame.dirty = false;
                 } else if (thisOffset < bcs.bci()) {
-                    throw new ClassFormatError(String.format("Bad stack map offset %d", thisOffset));
+                    throw classFormatError(thisOffset);
                 }
             } else if (ncf) {
                 throw generatorError("Expecting a stack map frame");
             }
             ncf = processBlock(bcs);
         }
+    }
+
+    private static ClassFormatError classFormatError(int thisOffset) {
+        throw new ClassFormatError(String.format("Bad stack map offset %d", thisOffset));
     }
 
     private boolean processBlock(RawBytecodeHelper bcs) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -417,10 +417,10 @@ public final class StackMapGenerator {
                     throw generatorError("Expecting a stack map frame");
                 }
                 if (thisOffset == bcs.bci()) {
-                    if (!ncf) {
-                        currentFrame.checkAssignableTo(frames.get(stackmapIndex));
-                    }
                     Frame nextFrame = frames.get(stackmapIndex++);
+                    if (!ncf) {
+                        currentFrame.checkAssignableTo(nextFrame);
+                    }
                     while (!nextFrame.dirty) { //skip unmatched frames
                         if (stackmapIndex == frames.size()) return; //skip the rest of this round
                         nextFrame = frames.get(stackmapIndex++);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -431,17 +431,13 @@ public final class StackMapGenerator {
                     currentFrame.copyFrom(nextFrame);
                     nextFrame.dirty = false;
                 } else if (thisOffset < bcs.bci()) {
-                    throw classFormatError(thisOffset);
+                    throw generatorError("Bad stack map offset");
                 }
             } else if (ncf) {
                 throw generatorError("Expecting a stack map frame");
             }
             ncf = processBlock(bcs);
         }
-    }
-
-    private static ClassFormatError classFormatError(int thisOffset) {
-        return new ClassFormatError(String.format("Bad stack map offset %d", thisOffset));
     }
 
     private boolean processBlock(RawBytecodeHelper bcs) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -441,7 +441,7 @@ public final class StackMapGenerator {
     }
 
     private static ClassFormatError classFormatError(int thisOffset) {
-        throw new ClassFormatError(String.format("Bad stack map offset %d", thisOffset));
+        return new ClassFormatError(String.format("Bad stack map offset %d", thisOffset));
     }
 
     private boolean processBlock(RawBytecodeHelper bcs) {


### PR DESCRIPTION
A small optimization of processMethod, by using local variables and extracting exception methods, reduces codeSize from 326 to 283

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340708](https://bugs.openjdk.org/browse/JDK-8340708): Optimize StackMapGenerator::processMethod (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21137/head:pull/21137` \
`$ git checkout pull/21137`

Update a local copy of the PR: \
`$ git checkout pull/21137` \
`$ git pull https://git.openjdk.org/jdk.git pull/21137/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21137`

View PR using the GUI difftool: \
`$ git pr show -t 21137`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21137.diff">https://git.openjdk.org/jdk/pull/21137.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21137#issuecomment-2369878267)