### PR TITLE
8340461: Amend description for logArea

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -159,7 +159,7 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  *     <li>the title of the instruction UI,</li>
  *     <li>the timeout of the test,</li>
  *     <li>the size of the instruction UI via rows and columns, and</li>
- *     <li>to add a log area</li>,
+ *     <li>to add a log area,</li>
  *     <li>to enable screenshots.</li>
  * </ul>
  */
@@ -1113,9 +1113,10 @@ public final class PassFailJFrame {
 
     /**
      * Adds a {@code message} to the log area, if enabled by
-     * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
+     * {@link Builder#logArea() logArea()} or
+     * {@link Builder#logArea(int) logArea(int)}.
      *
-     * @param message to log
+     * @param message the message to log
      */
     public static void log(String message) {
         System.out.println("PassFailJFrame: " + message);
@@ -1124,7 +1125,8 @@ public final class PassFailJFrame {
 
     /**
      * Clears the log area, if enabled by
-     * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
+     * {@link Builder#logArea() logArea()} or
+     * {@link Builder#logArea(int) logArea(int)}.
      */
     public static void logClear() {
         System.out.println("\nPassFailJFrame: log cleared\n");
@@ -1133,7 +1135,9 @@ public final class PassFailJFrame {
 
     /**
      * Replaces the log area content with provided {@code text}, if enabled by
-     * {@link Builder#logArea()} or {@link Builder#logArea(int)}.
+     * {@link Builder#logArea() logArea()} or
+     * {@link Builder#logArea(int) logArea(int)}.
+     *
      * @param text new text for the log area
      */
     public static void logSet(String text) {


### PR DESCRIPTION
Resolve the error:
```text
PassFailJFrame.java:161: error: text not allowed in <ul> element
 *     <li>to add a log area</li>,
                                 ^
```

Shorten the rendered javadoc for `log`, `logClear` and `logSet`.

@azvegint, could you take a look?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340461](https://bugs.openjdk.org/browse/JDK-8340461): Amend description for logArea (**Sub-task** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21138/head:pull/21138` \
`$ git checkout pull/21138`

Update a local copy of the PR: \
`$ git checkout pull/21138` \
`$ git pull https://git.openjdk.org/jdk.git pull/21138/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21138`

View PR using the GUI difftool: \
`$ git pr show -t 21138`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21138.diff">https://git.openjdk.org/jdk/pull/21138.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21138#issuecomment-2368482763)