### PR TITLE
8340657: [PPC64] SA determines wrong unextendedSP

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ppc64/PPC64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ppc64/PPC64Frame.java
@@ -345,8 +345,9 @@ public class PPC64Frame extends Frame {
   //------------------------------------------------------------------------------
   // frame::adjust_unextended_sp
   private void adjustUnextendedSP() {
-    raw_unextendedSP = getFP();
+    // Nothing to do. senderForInterpreterFrame finds the correct unextendedSP.
   }
+
   private Frame senderForInterpreterFrame(PPC64RegisterMap map) {
     if (DEBUG) {
       System.out.println("senderForInterpreterFrame");


### PR DESCRIPTION
Using the FP as raw_unextendedSP is wrong and causes problems like [JDK-8339772](https://bugs.openjdk.org/browse/JDK-8339772).
"test/hotspot/jtreg/serviceability" tests have passed with this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340657](https://bugs.openjdk.org/browse/JDK-8340657): [PPC64] SA determines wrong unextendedSP (**Bug** - P4)


### Reviewers
 * [Yasumasa Suenaga](https://openjdk.org/census#ysuenaga) (@YaSuenag - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21139/head:pull/21139` \
`$ git checkout pull/21139`

Update a local copy of the PR: \
`$ git checkout pull/21139` \
`$ git pull https://git.openjdk.org/jdk.git pull/21139/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21139`

View PR using the GUI difftool: \
`$ git pr show -t 21139`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21139.diff">https://git.openjdk.org/jdk/pull/21139.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21139#issuecomment-2368617740)