### PR TITLE
8340680: Fix typos in javax.lang.model.SourceVersion

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
+++ b/src/java.compiler/share/classes/javax/lang/model/SourceVersion.java
@@ -601,7 +601,7 @@ public enum SourceVersion {
      * keywords</i>.
      *
      * @param s the string to check
-     * @return {@code true} if {@code s} is a keyword, boolean
+     * @return {@code true} if {@code s} is a keyword, a boolean
      * literal, or the null literal, {@code false} otherwise.
      * @jls 3.9 Keywords
      * @jls 3.10.3 Boolean Literals
@@ -619,7 +619,7 @@ public enum SourceVersion {
      *
      * @param s the string to check
      * @param version the version to use
-     * @return {@code true} if {@code s} is a keyword, boolean
+     * @return {@code true} if {@code s} is a keyword, a boolean
      * literal, or the null literal, {@code false} otherwise.
      * @jls 3.9 Keywords
      * @jls 3.10.3 Boolean Literals


### PR DESCRIPTION
This PR fixes a few overlooked typos in the recent PR #20937. In particular, it fixes grammar issues which @dansmithcode pointed to: https://github.com/openjdk/jdk/pull/20937#pullrequestreview-2293456337. (#20937 fixed only some of those.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340680](https://bugs.openjdk.org/browse/JDK-8340680): Fix typos in javax.lang.model.SourceVersion (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21140/head:pull/21140` \
`$ git checkout pull/21140`

Update a local copy of the PR: \
`$ git checkout pull/21140` \
`$ git pull https://git.openjdk.org/jdk.git pull/21140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21140`

View PR using the GUI difftool: \
`$ git pr show -t 21140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21140.diff">https://git.openjdk.org/jdk/pull/21140.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21140#issuecomment-2368808917)