### PR TITLE
8340707: ProblemList applications/ctw/modules/java_base.java due to JDK-8340683

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -43,6 +43,7 @@
 
 # :hotspot_compiler
 
+applications/ctw/modules/java_base.java 8340683 generic-all
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 


### PR DESCRIPTION
Please review

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340707](https://bugs.openjdk.org/browse/JDK-8340707): ProblemList applications/ctw/modules/java_base.java due to JDK-8340683 (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21146/head:pull/21146` \
`$ git checkout pull/21146`

Update a local copy of the PR: \
`$ git checkout pull/21146` \
`$ git pull https://git.openjdk.org/jdk.git pull/21146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21146`

View PR using the GUI difftool: \
`$ git pr show -t 21146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21146.diff">https://git.openjdk.org/jdk/pull/21146.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21146#issuecomment-2369836850)