### PR TITLE
8340553: ZipEntry field validation does not take into account the size of a CEN header

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipEntry.java
+++ b/src/java.base/share/classes/java/util/zip/ZipEntry.java
@@ -100,11 +100,11 @@ public class ZipEntry implements ZipConstants, Cloneable {
      *
      * @throws NullPointerException if the entry name is null
      * @throws IllegalArgumentException if the entry name is longer than
-     *         0xFFFF bytes
+     *         0xFFD1 bytes
      */
     public ZipEntry(String name) {
         Objects.requireNonNull(name, "name");
-        if (name.length() > 0xFFFF) {
+        if (name.length() > 0xFFD1) {
             throw new IllegalArgumentException("entry name too long");
         }
         this.name = name;
@@ -520,7 +520,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
      *         The extra field data bytes
      *
      * @throws IllegalArgumentException if the length of the specified
-     *         extra field data is greater than 0xFFFF bytes
+     *         extra field data is greater than 0xFFD1 bytes
      *
      * @see #getExtra()
      */
@@ -541,7 +541,7 @@ public class ZipEntry implements ZipConstants, Cloneable {
      */
     void setExtra0(byte[] extra, boolean doZIP64, boolean isLOC) {
         if (extra != null) {
-            if (extra.length > 0xFFFF) {
+            if (extra.length > 0xFFD1) {
                 throw new IllegalArgumentException("invalid extra field length");
             }
             // extra fields are in "HeaderID(2)DataSize(2)Data... format
@@ -643,9 +643,9 @@ public class ZipEntry implements ZipConstants, Cloneable {
     /**
      * Sets the optional comment string for the entry.
      *
-     * <p>ZIP entry comments have maximum length of 0xffff. If the length of the
-     * specified comment string is greater than 0xFFFF bytes after encoding, only
-     * the first 0xFFFF bytes are output to the ZIP file entry.
+     * <p>ZIP entry comments have maximum length of 0xFFD1. If the length of the
+     * specified comment string is greater than 0xFFD1 bytes after encoding, only
+     * the first 0xFFD1 bytes are output to the ZIP file entry.
      *
      * @param comment the comment string
      *

--- a/test/jdk/java/util/zip/ZipOutputStream/ZipOutputStreamMaxCenHdrTest.java
+++ b/test/jdk/java/util/zip/ZipOutputStream/ZipOutputStreamMaxCenHdrTest.java
@@ -51,7 +51,7 @@ public class ZipOutputStreamMaxCenHdrTest {
     // CEN header size + name length + comment length + extra length
     // should not exceed 65,535 bytes per the PKWare APP.NOTE
     // 4.4.10, 4.4.11, & 4.4.12.
-    static final int MAX_COMBINED_CEN_HEADER_SIZE = 0xFFFF;
+    static final int MAX_COMBINED_CEN_HEADER_SIZE = 0xFFD1;
 
     // Maximum possible size of name length + comment length + extra length
     // for entries in order to not exceed 65,489 bytes minus 46 bytes for the CEN


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340553](https://bugs.openjdk.org/browse/JDK-8340553): ZipEntry field validation does not take into account the size of a CEN header (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21147/head:pull/21147` \
`$ git checkout pull/21147`

Update a local copy of the PR: \
`$ git checkout pull/21147` \
`$ git pull https://git.openjdk.org/jdk.git pull/21147/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21147`

View PR using the GUI difftool: \
`$ git pr show -t 21147`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21147.diff">https://git.openjdk.org/jdk/pull/21147.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21147#issuecomment-2369850371)