### PR TITLE
8340717: Remove unused function declarations from java.c/java.h of the launcher

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -118,7 +118,6 @@ static jclass GetApplicationClass(JNIEnv *env);
 
 static void TranslateApplicationArgs(int jargc, const char **jargv, int *pargc, char ***pargv);
 static jboolean AddApplicationOptions(int cpathc, const char **cpathv);
-static void SetApplicationClassPath(const char**);
 
 static void PrintJavaVersion(JNIEnv *env);
 static void PrintUsage(JNIEnv* env, jboolean doXUsage);
@@ -126,9 +125,6 @@ static void ShowSettings(JNIEnv* env, char *optString);
 static void ShowResolvedModules(JNIEnv* env);
 static void ListModules(JNIEnv* env);
 static void DescribeModule(JNIEnv* env, char* optString);
-static jboolean ValidateModules(JNIEnv* env);
-
-static void SetPaths(int argc, char **argv);
 
 static void DumpState();
 

--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -48,8 +48,6 @@
 # define MB (1024UL * KB)
 # define GB (1024UL * MB)
 
-#define CURRENT_DATA_MODEL (CHAR_BIT * sizeof(void*))
-
 /*
  * Older versions of java launcher used to support JRE version selection - specifically,
  * the java launcher in JDK 1.8 can be used to launch a java application using a different
@@ -103,16 +101,11 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argc */
 jboolean
 LoadJavaVM(const char *jvmpath, InvocationFunctions *ifn);
 
-void
-GetXUsagePath(char *buf, jint bufsize);
-
 jboolean
 GetApplicationHome(char *buf, jint bufsize);
 
 jboolean
 GetApplicationHomeFromDll(char *buf, jint bufsize);
-
-#define GetArch() GetArchPath(CURRENT_DATA_MODEL)
 
 /*
  * Different platforms will implement this, here
@@ -149,7 +142,6 @@ void JLI_ShowMessage(const char * message, ...);
  */
 JNIEXPORT void JNICALL
 JLI_ReportExceptionDescription(JNIEnv * env);
-void PrintMachineDependentOptions();
 
 /*
  * Block current thread and continue execution in new thread.


### PR DESCRIPTION
Can I please get a review of this cleanup to the launcher code to remove declarations of unused functions?

The `ValidateModules` function appears to be a left-over from https://bugs.openjdk.org/browse/JDK-8194937.

The `SetApplicationClassPath` and `PrintMachineDependentOptions` appear to have been unused for a long time (ever since the first commit in the current JDK repo).

The data model related macros, being removed in this PR, are unused and no longer relevant.

No new tests have been added and existing tier1, tier2 and tier3 tests continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340717](https://bugs.openjdk.org/browse/JDK-8340717): Remove unused function declarations from java.c/java.h of the launcher (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21149/head:pull/21149` \
`$ git checkout pull/21149`

Update a local copy of the PR: \
`$ git checkout pull/21149` \
`$ git pull https://git.openjdk.org/jdk.git pull/21149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21149`

View PR using the GUI difftool: \
`$ git pr show -t 21149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21149.diff">https://git.openjdk.org/jdk/pull/21149.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21149#issuecomment-2370136200)