### PR TITLE
8340605: Open source several AWT PopupMenu tests

### DIFF
--- a/test/jdk/java/awt/PopupMenu/PeripheryOfScreen.java
+++ b/test/jdk/java/awt/PopupMenu/PeripheryOfScreen.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Frame;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 6267162
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Popup Menu gets hidden below the screen when opened near the periphery
+ *          of the screen, XToolkit Test if popup menu window is adjusted on screen
+ *          when trying to show outside
+ * @run main/manual PeripheryOfScreen
+ */
+
+public class PeripheryOfScreen {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Click on the button to show popup menu in the center of
+                frame. Move frame beyond the edge of screen and click on
+                button to show the popup menu and see if popup menu is
+                adjusted to the edge.
+
+                Press Pass if popup menu behaves as per instruction, otherwise
+                press Fail.
+                """;
+
+        PassFailJFrame.builder()
+                .title("PeripheryOfScreen Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(PeripheryOfScreen::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private static Frame createUI () {
+        Frame f = new Frame("PeripheryOfScreen Test frame");
+        Button b = new Button("Click to show popup menu");
+        PopupMenu pm = new PopupMenu("Test menu");
+        MenuItem i = new MenuItem("Click me");
+        pm.add(i);
+        b.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                pm.show(f, 100, 100);
+            }
+        });
+        f.add(b);
+        f.add(pm);
+        f.setSize(300, 200);
+        f.toFront();
+        return f;
+    }
+}

--- a/test/jdk/java/awt/PopupMenu/PopupLeadingSeparatorTest.java
+++ b/test/jdk/java/awt/PopupMenu/PopupLeadingSeparatorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.Font;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 4169155
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Popup menus get a leading separator on Motif system
+ * @run main/manual PopupLeadingSeparatorTest
+ */
+
+public class PopupLeadingSeparatorTest {
+    public static void main(String[] args) throws Exception {
+        PopupLeadingSeparatorTest obj = new PopupLeadingSeparatorTest();
+        String INSTRUCTIONS = """
+                Press mouse button on the frame. Popup menu without leading
+                separator should appear.
+                If a PopupMenu behaves same, press Pass, else press Fail.
+                """;
+
+        PassFailJFrame.builder()
+                .title("PopupLeadingSeparatorTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(obj::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private Frame createUI() {
+        Frame f = new Frame("PopupLeadingSeparatorTest Test");
+        PopupMenu popupMenu = new PopupMenu("Popup Menu Title");
+        popupMenu.add(new MenuItem("Item1"));
+        PopupMenu cascadeMenu = new PopupMenu("Multifont menu");
+        cascadeMenu.add(new MenuItem("Item1"));
+        MenuItem item2 = new MenuItem("Item2");
+        item2.setFont(new Font("Serif", Font.BOLD, 36));
+        cascadeMenu.add(item2);
+
+        popupMenu.add(cascadeMenu);
+        f.add(popupMenu);
+        f.setSize(300, 150);
+        f.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent evt) {
+                popupMenu.show((Component) evt.getSource(), evt.getX(), evt.getY());
+            }
+        });
+        return f;
+    }
+}

--- a/test/jdk/java/awt/PopupMenu/PopupMenuShowTest.java
+++ b/test/jdk/java/awt/PopupMenu/PopupMenuShowTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 4168006 4196790
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Popup menu test fails on x86/Solaris 2.6 combination.
+ * @run main/manual PopupMenuShowTest
+ */
+
+public class PopupMenuShowTest {
+    public static void main(String[] args) throws Exception {
+        PopupMenuShowTest obj = new PopupMenuShowTest();
+        String INSTRUCTIONS = """
+                Press the right mouse button in the PopupTest window.
+                If a PopupMenu appears, press Pass, else press Fail.
+                """;
+
+        PassFailJFrame.builder()
+                .title("PopupMenuShowTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(obj::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private Frame createUI() {
+        Frame f = new Frame("PopupMenuShowTest Test");
+        f.setLayout(new FlowLayout());
+        f.add(new Label("Press right mouse button inside this frame."));
+        f.add(new Label("A pop-up menu should appear."));
+        PopupMenu popupMenu = new PopupMenu("Popup Menu Title");
+        MenuItem mi = new MenuItem("Menu Item");
+        popupMenu.add(mi);
+        f.add(popupMenu);
+        f.setSize(400, 350);
+        f.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                popupMenu.show(e.getComponent(), e.getX(), e.getY());
+            }
+        });
+        return f;
+    }
+}

--- a/test/jdk/java/awt/PopupMenu/PopupMenuWithMenuBar.java
+++ b/test/jdk/java/awt/PopupMenu/PopupMenuWithMenuBar.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 4038140
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Test for functionality of PopupMenuWithMenuBar
+ * @run main/manual PopupMenuWithMenuBar
+ */
+
+public class PopupMenuWithMenuBar {
+
+    public static void main(String[] args) throws Exception {
+        PopupMenuWithMenuBar obj = new PopupMenuWithMenuBar();
+        String INSTRUCTIONS = """
+                There was a bug that prevented the popup menu from appearing properly
+                (if even at all) for a frame window when there is also a menu bar.
+
+                Right click inside the frame window to display the popup window. If
+                the popup menu appears normally, then the test is successful and the
+                bug has been fixed.""";
+
+        PassFailJFrame.builder()
+                .title("PopupMenuWithMenuBar Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(obj::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    private Frame createUI() {
+        Frame f = new Frame("PopupMenuWithMenuBar Test");
+        f.setBounds(10, 10, 300, 250);
+        MenuBar menuBar = new MenuBar();
+        Menu fileMenu = createFileMenu();
+        menuBar.add(fileMenu);
+        f.setMenuBar(menuBar);
+        PopupMenu popupMenu = createPopupMenu();
+        f.add(popupMenu);
+        f.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mouseClicked(MouseEvent e) {
+                popupMenu.show(f, e.getX(), e.getY());
+            }
+        });
+        return f;
+    }
+
+    private Menu createFileMenu() {
+        String[] menu1Labels = new String[]
+                {"Save As", "Save As", "Quit"};
+        MenuItem menuItem;
+        Menu returnMenu = new Menu("File");
+        for (int menu1Index = 0; menu1Index < menu1Labels.length; menu1Index++) {
+            menuItem = new MenuItem(menu1Labels[menu1Index]);
+            returnMenu.add(menuItem);
+        }
+        return returnMenu;
+    }
+
+    private PopupMenu createPopupMenu() {
+        String[] popupLabels = new String[]
+                {"Popup 1", "Popup 2", "Quit"};
+        MenuItem menuItem;
+        PopupMenu returnMenu = new PopupMenu("Popups");
+        for (int popupIndex = 0; popupIndex < popupLabels.length; popupIndex++) {
+            menuItem = new MenuItem(popupLabels[popupIndex]);
+            returnMenu.add(menuItem);
+        }
+        return returnMenu;
+    }
+}

--- a/test/jdk/java/awt/PopupMenu/PopupMenuWithMenuBar.java
+++ b/test/jdk/java/awt/PopupMenu/PopupMenuWithMenuBar.java
@@ -40,7 +40,6 @@ import java.awt.event.MouseEvent;
  */
 
 public class PopupMenuWithMenuBar {
-
     public static void main(String[] args) throws Exception {
         PopupMenuWithMenuBar obj = new PopupMenuWithMenuBar();
         String INSTRUCTIONS = """

--- a/test/jdk/java/awt/PopupMenu/PopupOnButton.java
+++ b/test/jdk/java/awt/PopupMenu/PopupOnButton.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Component;
+import java.awt.Frame;
+import java.awt.MenuItem;
+import java.awt.PopupMenu;
+
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+
+/*
+ * @test
+ * @bug 4181790
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Tests a popup menu on a button.
+ * @run main/manual PopupOnButton
+ */
+
+public class PopupOnButton {
+   public static void main(String[] args) throws Exception {
+       PopupOnButton obj = new PopupOnButton();
+       String INSTRUCTIONS = """
+                Right-click on the button.
+                Popup Menu should appear and behave fine.
+                If a PopupMenu appears, press Pass, else press Fail.
+                """;
+
+       PassFailJFrame.builder()
+               .title("PopupOnButton Instruction")
+               .instructions(INSTRUCTIONS)
+               .columns(40)
+               .testUI(obj::createUI)
+               .build()
+               .awaitAndCheck();
+   }
+
+    private Frame createUI() {
+        Frame f = new Frame("PopupOnButton Test");
+        Button b = new Button("button with popup menu");
+        PopupMenu m = new PopupMenu("popup");
+        m.add(new MenuItem("item1"));
+        m.add(new MenuItem("item2"));
+        m.add(new MenuItem("item3"));
+        b.add(m);
+        b.addMouseListener(new MouseAdapter() {
+            @Override
+            public void mousePressed(MouseEvent e) {
+                if (e.isPopupTrigger()) {
+                    m.show((Component) e.getSource(), e.getX(), e.getY());
+                }
+            }
+
+            @Override
+            public void mouseReleased(MouseEvent e) {
+                if (e.isPopupTrigger()) {
+                    m.show((Component) e.getSource(), e.getX(), e.getY());
+                }
+            }
+        });
+
+        f.add(b);
+        f.setSize(200, 150);
+        return f;
+    }
+ }


### PR DESCRIPTION
Several AWT PopupMEnu related tests are converted from applet to manual and moved to open.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340605](https://bugs.openjdk.org/browse/JDK-8340605): Open source several AWT PopupMenu tests (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21151/head:pull/21151` \
`$ git checkout pull/21151`

Update a local copy of the PR: \
`$ git checkout pull/21151` \
`$ git pull https://git.openjdk.org/jdk.git pull/21151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21151`

View PR using the GUI difftool: \
`$ git pr show -t 21151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21151.diff">https://git.openjdk.org/jdk/pull/21151.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21151#issuecomment-2370462220)