### PR TITLE
8340815: Add SECURITY.md file

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,19 +1,3 @@
 # OpenJDK Vulnerabilities
 
-Vulnerabilities in OpenJDK source code are handled by the [OpenJDK Vulnerability Group](https://openjdk.org/groups/vulnerability), who coordinate fixes and releases.
-
-## How to report a vulnerability
-
-We welcome reports of vulnerabilities in the JDK. To submit a report, please send e-mail to vuln-report@openjdk.org. We prefer mail encrypted with our [report encryption key](https://openjdk.org/groups/vulnerability/report-key). Please include as much detail as is reasonable, e.g., the output of the java -version command, a proof-of-concept (PoC) program, crash logs, and relevant environment and configuration information.
-
-Vulnerability reports that you submit are covered by the [OpenJDK Web Site Terms of Use](https://openjdk.org/legal/tou).
-
-Oracle values the members of the independent security research community who find security vulnerabilities and work with Oracle so that security fixes can be issued to all customers. Oracle's policy is to credit all researchers in the Critical Patch Update Advisory document when a fix for the reported security bug is issued. In order to receive credit, security researchers must follow responsible disclosure practices, including:
-
-They do not publish the vulnerability prior to Oracle releasing a fix for it
-
-They do not divulge exact details of the issue, for example, through exploits or proof-of-concept code
-
-## Advisories
-
-Current and previous [advisories](https://openjdk.org/groups/vulnerability/advisories) are available for reference.
+Please follow the process outlined in the [OpenJDK Vulnerability Policy](https://openjdk.org/groups/vulnerability/report) to disclose vulnerabilities in the OpenJDK codebase.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,3 @@
-# OpenJDK Vulnerabilities
+# JDK Vulnerabilities
 
-Please follow the process outlined in the [OpenJDK Vulnerability Policy](https://openjdk.org/groups/vulnerability/report) to disclose vulnerabilities in the OpenJDK codebase.
+Please follow the process outlined in the [OpenJDK Vulnerability Policy](https://openjdk.org/groups/vulnerability/report) to disclose vulnerabilities in the JDK.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# OpenJDK Vulnerabilities
+
+Vulnerabilities in OpenJDK source code are handled by the [OpenJDK Vulnerability Group](https://openjdk.org/groups/vulnerability), who coordinate fixes and releases.
+
+## How to report a vulnerability
+
+We welcome reports of vulnerabilities in the JDK. To submit a report, please send e-mail to vuln-report@openjdk.org. We prefer mail encrypted with our [report encryption key](https://openjdk.org/groups/vulnerability/report-key). Please include as much detail as is reasonable, e.g., the output of the java -version command, a proof-of-concept (PoC) program, crash logs, and relevant environment and configuration information.
+
+Vulnerability reports that you submit are covered by the [OpenJDK Web Site Terms of Use](https://openjdk.org/legal/tou).
+
+Oracle values the members of the independent security research community who find security vulnerabilities and work with Oracle so that security fixes can be issued to all customers. Oracle's policy is to credit all researchers in the Critical Patch Update Advisory document when a fix for the reported security bug is issued. In order to receive credit, security researchers must follow responsible disclosure practices, including:
+
+They do not publish the vulnerability prior to Oracle releasing a fix for it
+
+They do not divulge exact details of the issue, for example, through exploits or proof-of-concept code
+
+## Advisories
+
+Current and previous [advisories](https://openjdk.org/groups/vulnerability/advisories) are available for reference.


### PR DESCRIPTION
Currently the [security tab](https://github.com/openjdk/jdk/security) on the GitHub repos is empty with no clear information or links on where to report security vulnerabilities.

<img width="1278" alt="Screenshot 2024-09-24 at 14 28 37" src="https://github.com/user-attachments/assets/4fd68f9f-46d8-4c06-ad71-52747c8f5cf2">

I've added a simple SECURITY.md file which includes the link to the official policy on the website.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340815](https://bugs.openjdk.org/browse/JDK-8340815): Add SECURITY.md file (**Enhancement** - P4)


### Reviewers
 * [Mark Reinhold](https://openjdk.org/census#mr) (@mbreinhold - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21155/head:pull/21155` \
`$ git checkout pull/21155`

Update a local copy of the PR: \
`$ git checkout pull/21155` \
`$ git pull https://git.openjdk.org/jdk.git pull/21155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21155`

View PR using the GUI difftool: \
`$ git pr show -t 21155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21155.diff">https://git.openjdk.org/jdk/pull/21155.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21155#issuecomment-2371299593)