### PR TITLE
8340814: ZipFileInflaterInputStream should release its Inflater after observing EOF

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -473,6 +473,8 @@ public class ZipFile implements ZipConstants, Closeable {
             cleanable.clean();
         }
 
+        // Override read(byte[], int, int) method to track EOF
+        // and release the Inflater when it's no longer needed
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
             if (eof && !closeRequested) {
@@ -484,7 +486,6 @@ public class ZipFile implements ZipConstants, Closeable {
                 // Release Inflater back to the pool
                 cleanable.clean();
                 eof = true;
-
             }
             return read;
         }

--- a/test/jdk/java/util/zip/ZipFile/ReleaseInflaterOnEOF.java
+++ b/test/jdk/java/util/zip/ZipFile/ReleaseInflaterOnEOF.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/* @test
+   @bug 8340814
+   @summary Verify that ZipFileInputStream releases its Inflater after encountering EOF
+   @modules java.base/java.util.zip:+open
+   @run junit ReleaseInflaterOnEOF
+ */
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+public class ReleaseInflaterOnEOF {
+
+    // ZIP file produced during tests
+    private Path zip = Path.of("release-zip-inflaters.zip");
+
+    /**
+     * Create a sample ZIP file for use by tests
+     * @param name name of the ZIP file to create
+     * @return a sample ZIP file
+     * @throws IOException if an unexpected IOException occurs
+     */
+    private Path createZip(String name) throws IOException {
+        Path zip = Path.of(name);
+
+        try (OutputStream out = Files.newOutputStream(zip);
+             ZipOutputStream zo = new ZipOutputStream(out)) {
+            zo.putNextEntry(new ZipEntry("deflated.txt"));
+            zo.write("hello".getBytes(StandardCharsets.UTF_8));
+        }
+
+        return zip;
+    }
+
+    /**
+     * Delete the ZIP file produced after each test method
+     * @throws IOException if an unexpected IOException occurs
+     */
+    @AfterEach
+    public void cleanup() throws IOException {
+        Files.deleteIfExists(zip);
+    }
+
+    /**
+     * Verify that ZipFileInflaterInputStream releases its Inflater to the
+     * pool after the stream has been fully consumed.
+     *
+     * @throws IOException if an unexpected IOException occurs
+     */
+    @Test
+    public void shouldReleaseInflaterAfterEof() throws Exception {
+        zip = createZip("release-inflater.zip");
+        var zf = new ZipFile(zip.toFile());
+
+        ZipEntry entry = new ZipEntry("deflated.txt");
+
+        Inflater initialInflater;
+
+        // Open an input stream
+        var in = zf.getInputStream(entry);
+        // Record its Inflater instance
+        initialInflater = getInflater(in);
+        // Close the input stream to release the Inflater back to the cache
+        in.close();
+        // The Inflater cache now has a single entry
+
+        for (int i = 0; i < 100; i++) {
+            var is = zf.getInputStream(entry);
+            // Assert that the ZipFileInflaterInputStream reused the cached Inflater instance
+            assertSame(initialInflater, getInflater(is));
+            // Fully consume the stream to allow ZipFileInflaterInputStream to observe the EOF
+            in.transferTo(OutputStream.nullOutputStream());
+        }
+    }
+
+    // Use reflection to get the ZipFileInflaterInputStream's Inflater instance
+    private Inflater getInflater(InputStream in) throws IllegalAccessException, NoSuchFieldException {
+        Field field = InflaterInputStream.class.getDeclaredField("inf");
+        field.setAccessible(true);
+        return (Inflater) field.get(in);
+    }
+}

--- a/test/jdk/java/util/zip/ZipFile/ReleaseInflaterOnEOF.java
+++ b/test/jdk/java/util/zip/ZipFile/ReleaseInflaterOnEOF.java
@@ -103,7 +103,7 @@ public class ReleaseInflaterOnEOF {
             // Assert that the ZipFileInflaterInputStream reused the cached Inflater instance
             assertSame(initialInflater, getInflater(is));
             // Fully consume the stream to allow ZipFileInflaterInputStream to observe the EOF
-            in.transferTo(OutputStream.nullOutputStream());
+            is.transferTo(OutputStream.nullOutputStream());
         }
     }
 

--- a/test/jdk/java/util/zip/ZipFile/ReleaseInflaterOnEOF.java
+++ b/test/jdk/java/util/zip/ZipFile/ReleaseInflaterOnEOF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please consider this PR which makes `ZipFileInflaterInputStream` release its `Inflater` instance back to the pool when observing that the stream has been fully consumed.

This is motivated by the following observations:

* After a `ZipFileInflaterInputStream` has reached the end of stream, its `Inflater` instance no longer does useful work.
* Obtaining an input stream via `ZipFile::getInputStream` without properly closing it is probably common. Obtaining it without fully consuming it is probably more rare. (Something like `classLoader.getInputStream(entry).readAllBytes()` is probably common)
* While GC will eventually release the `Inflater` when the `Cleaner` closes the stream, this will only happen at some later point in time. In the meantime, `ZipFile::getInputStream` may produce many new `Inflater` instances. These will all be released to the pool once GC eventually catches up.
* Once an `Inflater` is released to to pool, it will stay there for the lifetime of the `ZipFile`
* The lifetime of a `ZipFile` may often be as long as the application (consider class loaders).

This PR suggests the following changes:

* Rename the existing field `ZipFileInflaterInputStream.eof` to `compressedEof`. (This tracks the EOF of the filtered input stream)
* Add a new field  `ZipFileInflaterInputStream.eof` to track the EOF of uncompressed data.
* Override  `ZipFileInflaterInputStream.read(byte[] b, int off, int len)` to detect the EOF of uncompressed data and release the `Inflater` instance back to the pool when it is no longer needed.
* To protect the `Inflater` instance from being used after being released and reset, the following updates are needed:
  * `ZipFileInflaterInputStream.read` must check if EOF has been reached  but that the stream has not yet been closed. In this case, EOF should be returned.
  * Similarly, `ZipFileInflaterInputStream.available` needs an update to return 0 if EOF has been detected.

The PR adds a test `ReleaseInflaterOnEOF` which verifies that all fully consumed input streams are backed by the same `Inflater` instance.

This PR was inspired by JDK-7031076 and this discussion: https://mail.openjdk.org/pipermail/core-libs-dev/2011-March/006341.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340814](https://bugs.openjdk.org/browse/JDK-8340814): ZipFileInflaterInputStream should release its Inflater after observing EOF (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21157/head:pull/21157` \
`$ git checkout pull/21157`

Update a local copy of the PR: \
`$ git checkout pull/21157` \
`$ git pull https://git.openjdk.org/jdk.git pull/21157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21157`

View PR using the GUI difftool: \
`$ git pr show -t 21157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21157.diff">https://git.openjdk.org/jdk/pull/21157.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21157#issuecomment-2397783022)