### PR TITLE
8340792: -XX:+PrintInterpreter: instructions should only be printed if printing all InterpreterCodelets

### DIFF
--- a/src/hotspot/share/interpreter/abstractInterpreter.cpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.cpp
@@ -74,7 +74,9 @@ void AbstractInterpreter::print() {
     tty->print_cr("avg codelet size = %6d bytes", _code->used_space() / _code->number_of_stubs());
     tty->cr();
   }
+  _should_print_instructions = PrintInterpreter;
   _code->print();
+  _should_print_instructions = false;
   tty->print_cr("----------------------------------------------------------------------");
   tty->cr();
 }
@@ -90,6 +92,8 @@ address    AbstractInterpreter::_rethrow_exception_entry                    = nu
 address    AbstractInterpreter::_slow_signature_handler;
 address    AbstractInterpreter::_entry_table            [AbstractInterpreter::number_of_method_entries];
 address    AbstractInterpreter::_native_abi_to_tosca    [AbstractInterpreter::number_of_result_handlers];
+
+bool       AbstractInterpreter::_should_print_instructions = false;
 
 //------------------------------------------------------------------------------------------------------------------------
 // Generation of complete interpreter

--- a/src/hotspot/share/interpreter/abstractInterpreter.hpp
+++ b/src/hotspot/share/interpreter/abstractInterpreter.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -125,6 +125,8 @@ class AbstractInterpreter: AllStatic {
 
   static address    _rethrow_exception_entry;                   // rethrows an activation in previous frame
 
+  static bool       _should_print_instructions;                 // only with PrintInterpreter and when printing all InterpreterCodelet
+
   friend class      AbstractInterpreterGenerator;
   friend class      InterpreterMacroAssembler;
 
@@ -132,6 +134,7 @@ class AbstractInterpreter: AllStatic {
   // Initialization/debugging
   static void       initialize();
   static StubQueue* code()                                      { return _code; }
+  static bool       should_print_instructions()                 { return _should_print_instructions; }
 
 
   // Method activation

--- a/src/hotspot/share/interpreter/interpreter.cpp
+++ b/src/hotspot/share/interpreter/interpreter.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -66,7 +66,7 @@ void InterpreterCodelet::verify() {}
 void InterpreterCodelet::print_on(outputStream* st) const {
   ttyLocker ttyl;
 
-  if (PrintInterpreter) {
+  if (AbstractInterpreter::should_print_instructions()) {
     st->cr();
     st->print_cr("----------------------------------------------------------------------");
   }
@@ -76,7 +76,7 @@ void InterpreterCodelet::print_on(outputStream* st) const {
   st->print_cr("[" INTPTR_FORMAT ", " INTPTR_FORMAT "]  %d bytes",
                 p2i(code_begin()), p2i(code_end()), code_size());
 
-  if (PrintInterpreter) {
+  if (AbstractInterpreter::should_print_instructions()) {
     st->cr();
     Disassembler::decode(code_begin(), code_end(), st NOT_PRODUCT(COMMA &_asm_remarks));
   }


### PR DESCRIPTION
With `-XX:+PrintInterpreter` the instructions of the generated interpreter are printed at startup.

But also after startup when printing an interpreted frame the instructions of the corresponding `InterpreterCodelet` are also printed. This can become a problem with `-Xlog:continuations=trace` because large sections of the interpreter are printed repeatedly and redundantly.

With this change the instructions are only printed when printing all codelets, i.e. normally once at start-up.

I've tested with the reproducer from the JBS-Issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340792](https://bugs.openjdk.org/browse/JDK-8340792): -XX:+PrintInterpreter: instructions should only be printed if printing all InterpreterCodelets (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21158/head:pull/21158` \
`$ git checkout pull/21158`

Update a local copy of the PR: \
`$ git checkout pull/21158` \
`$ git pull https://git.openjdk.org/jdk.git pull/21158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21158`

View PR using the GUI difftool: \
`$ git pr show -t 21158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21158.diff">https://git.openjdk.org/jdk/pull/21158.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21158#issuecomment-2373552055)