### PR TITLE
8340808: RISC-V: Client build fails after JDK-8339738

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1319,11 +1319,12 @@ public:
         Register table0, Register table1, Register table2, Register table3,
         bool upper);
   void update_byte_crc32(Register crc, Register val, Register table);
+
+#ifdef COMPILER2
   void vector_update_crc32(Register crc, Register buf, Register len,
                            Register tmp1, Register tmp2, Register tmp3, Register tmp4, Register tmp5,
                            Register table0, Register table3);
 
-#ifdef COMPILER2
   void mul_add(Register out, Register in, Register offset,
                Register len, Register k, Register tmp);
   void wide_mul(Register prod_lo, Register prod_hi, Register n, Register m);
@@ -1353,7 +1354,7 @@ public:
                        Register tmp1, Register tmp2, Register tmp3, Register tmp4,
                        Register tmp5, Register tmp6, Register product_hi);
 
-#endif
+#endif // COMPILER2
 
   void inflate_lo32(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2 = t1);
   void inflate_hi32(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2 = t1);


### PR DESCRIPTION
Hi,
Can you help to review this simple patch?
Previously, the crc32 intrinsic (scalar version) was added for both c1/c2, then the vector version was added but depends on a global flag MaxVectorSize which is only valid in c2.
This pr is to put all vector crc32 related code under COMPILER2 macro protection.
I tested with/without --with-jvm-variants=client.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340808](https://bugs.openjdk.org/browse/JDK-8340808): RISC-V: Client build fails after JDK-8339738 (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21159/head:pull/21159` \
`$ git checkout pull/21159`

Update a local copy of the PR: \
`$ git checkout pull/21159` \
`$ git pull https://git.openjdk.org/jdk.git pull/21159/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21159`

View PR using the GUI difftool: \
`$ git pr show -t 21159`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21159.diff">https://git.openjdk.org/jdk/pull/21159.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21159#issuecomment-2371419750)