### PR TITLE
8340812: LambdaForm customization via MethodHandle::updateForm is not thread safe

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1879,6 +1879,7 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
                 if (oldForm != newForm) {
                     assert (newForm.customized == null || newForm.customized == this);
                     newForm.prepare(); // as in MethodHandle.<init>
+                    UNSAFE.storeStoreFence(); // properly publish newForm
                     UNSAFE.putReference(this, FORM_OFFSET, newForm);
                     UNSAFE.fullFence();
                 }

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1881,7 +1881,6 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
                     newForm.prepare(); // as in MethodHandle.<init>
                     UNSAFE.storeStoreFence(); // properly publish newForm
                     UNSAFE.putReference(this, FORM_OFFSET, newForm);
-                    UNSAFE.fullFence();
                 }
             } finally {
                 updateInProgress = false;

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -1879,8 +1879,7 @@ assertEquals("[three, thee, tee]", asListFix.invoke((Object)argv).toString());
                 if (oldForm != newForm) {
                     assert (newForm.customized == null || newForm.customized == this);
                     newForm.prepare(); // as in MethodHandle.<init>
-                    UNSAFE.storeStoreFence(); // properly publish newForm
-                    UNSAFE.putReference(this, FORM_OFFSET, newForm);
+                    UNSAFE.putReferenceRelease(this, FORM_OFFSET, newForm); // properly publish newForm
                 }
             } finally {
                 updateInProgress = false;

--- a/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
+++ b/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.ArrayList;
+
+/**
+  * @test
+  * @bug 8340812
+  * @summary Verify that LambdaForm customization via MethodHandle::updateForm is thread safe.
+  * @run driver TestLambdaFormCustomization
+  * @run main/othervm -Djava.lang.invoke.MethodHandle.CUSTOMIZE_THRESHOLD=0 -Djava.lang.invoke.MethodHandle.COMPILE_THRESHOLD=1 TestLambdaFormCustomization
+  */
+public class TestLambdaFormCustomization {
+
+    String str = "test";
+    static final String value = "test" + 42;
+
+    // Trigger concurrent LambdaForm customization for VarHandle invokers
+    void test(VarHandle varHandle) {
+        ArrayList<Thread> threads = new ArrayList<>();
+        for (int threadIdx = 0; threadIdx < 10; threadIdx++) {
+            threads.add(new Thread(() -> {
+                for (int i = 0; i < 1000; i++) {
+                    varHandle.compareAndExchange(this, value, value);
+                    varHandle.compareAndExchange(this, value, value);
+                    varHandle.compareAndExchange(this, value, value);
+                }
+            }));
+        }
+        threads.forEach(Thread::start);
+        threads.forEach(t -> {
+            try {
+                t.join();
+            } catch (Throwable e) {
+                throw new IllegalStateException(e);
+            }
+        });
+    }
+
+    public static void main(String[] args) throws NoSuchFieldException, IllegalAccessException {
+        TestLambdaFormCustomization t = new TestLambdaFormCustomization();
+        VarHandle varHandle = MethodHandles.lookup().in(t.getClass()).findVarHandle(t.getClass(), "str", String.class);
+        for (int i = 0; i < 4000; ++i) {
+            t.test(varHandle);
+        }
+    }
+}

--- a/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
+++ b/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
@@ -30,7 +30,7 @@ import java.util.ArrayList;
   * @bug 8340812
   * @summary Verify that LambdaForm customization via MethodHandle::updateForm is thread safe.
   * @run driver TestLambdaFormCustomization
-  * @run main/othervm -Djava.lang.invoke.MethodHandle.CUSTOMIZE_THRESHOLD=0 -Djava.lang.invoke.MethodHandle.COMPILE_THRESHOLD=1 TestLambdaFormCustomization
+  * @run main/othervm -Djava.lang.invoke.MethodHandle.CUSTOMIZE_THRESHOLD=0 TestLambdaFormCustomization
   */
 public class TestLambdaFormCustomization {
 
@@ -38,7 +38,9 @@ public class TestLambdaFormCustomization {
     static final String value = "test" + 42;
 
     // Trigger concurrent LambdaForm customization for VarHandle invokers
-    void test(VarHandle varHandle) {
+    void test() throws NoSuchFieldException, IllegalAccessException {
+        VarHandle varHandle = MethodHandles.lookup().in(getClass()).findVarHandle(getClass(), "str", String.class);
+
         ArrayList<Thread> threads = new ArrayList<>();
         for (int threadIdx = 0; threadIdx < 10; threadIdx++) {
             threads.add(new Thread(() -> {
@@ -59,11 +61,10 @@ public class TestLambdaFormCustomization {
         });
     }
 
-    public static void main(String[] args) throws NoSuchFieldException, IllegalAccessException {
+    public static void main(String[] args) throws Exception {
         TestLambdaFormCustomization t = new TestLambdaFormCustomization();
-        VarHandle varHandle = MethodHandles.lookup().in(t.getClass()).findVarHandle(t.getClass(), "str", String.class);
         for (int i = 0; i < 4000; ++i) {
-            t.test(varHandle);
+            t.test();
         }
     }
 }

--- a/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
+++ b/test/jdk/java/lang/invoke/TestLambdaFormCustomization.java
@@ -29,7 +29,7 @@ import java.util.ArrayList;
   * @test
   * @bug 8340812
   * @summary Verify that LambdaForm customization via MethodHandle::updateForm is thread safe.
-  * @run driver TestLambdaFormCustomization
+  * @run main TestLambdaFormCustomization
   * @run main/othervm -Djava.lang.invoke.MethodHandle.CUSTOMIZE_THRESHOLD=0 TestLambdaFormCustomization
   */
 public class TestLambdaFormCustomization {


### PR DESCRIPTION
When investigating an intermittent NPE with an Oracle internal test on AArch64, I noticed that the NPE is actually a SIGSEGV in the code emitted by `MethodHandles::jump_to_lambda_form` when trying to load the `MemberName::method` field because the `MemberName` we retrieved from `LambdaForm::vmentry` is null:

https://github.com/openjdk/jdk/blob/f0374a0bc181d0f2a8c0aa9aa032b07998ffaf60/src/hotspot/cpu/aarch64/methodHandles_aarch64.cpp#L141-L143

The JVM translates SIGSEGVs happening in method handle intrinsics to NPEs, assuming that they are implicit NPEs due to a null receiver:
https://github.com/openjdk/jdk/blob/f0374a0bc181d0f2a8c0aa9aa032b07998ffaf60/src/hotspot/share/runtime/sharedRuntime.cpp#L979-L982

After digging around in the MethodHandle implementation that I'm not too familiar with, I found this suspicious code in `MethodHandle::updateForm`:
https://github.com/openjdk/jdk/blob/36314a90c15e2ab2a9b32c2e471655c1b07d452c/src/java.base/share/classes/java/lang/invoke/MethodHandle.java#L1881-L1883

The `Unsafe.fullFence` was added by [JDK-8059877](https://bugs.openjdk.org/browse/JDK-8059877) and replaced a `// ISSUE: Should we have a memory fence here?` [comment](https://github.com/openjdk/jdk/commit/224c42ee4d4c3027d1f8f0d8b7ecf6646e9418c3#diff-5a4b2f817a4273eacf07f3ee24782c58c8ff474c6d790f72298e906837c5543aL1442). If the intention was to [prevent publishing a partially initialized object](https://wiki.sei.cmu.edu/confluence/display/java/TSM03-J.+Do+not+publish+partially+initialized+objects), I think it was added to the wrong place (paging @iwanowww).

In the failing scenario, we concurrently trigger LambdaForm customization for a VarHandle invoker:
```
	at java.base/java.lang.invoke.MethodHandle.updateForm(MethodHandle.java:1883)
	at java.base/java.lang.invoke.MethodHandle.customize(MethodHandle.java:1856)
	at java.base/java.lang.invoke.MethodHandle.maybeCustomize(MethodHandle.java:1846)
	at java.base/java.lang.invoke.Invokers.maybeCustomize(Invokers.java:632)
	at java.base/java.lang.invoke.Invokers.checkCustomized(Invokers.java:626)
```
The problem is that another thread can observe `newForm` which via the `MethodHandle::form` field before the store to `vmentry` in `prepare()` (see [here](https://github.com/openjdk/jdk/blob/36314a90c15e2ab2a9b32c2e471655c1b07d452c/src/java.base/share/classes/java/lang/invoke/LambdaForm.java#L821)) is visible and therefore observe null. We need a StoreStore barrier to prevent stores that initialize the newForm from being reordered with the subsequent store to the `MethodHandle::form` field that would make it accessible by other threads.

I removed the `fullFence` which should not be needed. 

Unfortunately, my new tests seems to trigger another issue (even if I leave the `fullFence` in):
```
java.lang.AssertionError
	at java.base/java.lang.invoke.LambdaForm.arityCheck(LambdaForm.java:1006)
	at TestLambdaFormCustomization.lambda$test$0(TestLambdaFormCustomization.java:46)
	at java.base/java.lang.Thread.run(Thread.java:1576)
```

It's this assert:
https://github.com/openjdk/jdk/blob/36314a90c15e2ab2a9b32c2e471655c1b07d452c/src/java.base/share/classes/java/lang/invoke/LambdaForm.java#L1010

UPDATE: After discussing with @JornVernee, it seems that my test using `-Djava.lang.invoke.MethodHandle.COMPILE_THRESHOLD=1` was the issue since that flag triggers some untested code paths. I removed that flag from the test, verified that it still triggers the original issue and leave it to the method handle maintainers to address this issue separately.

Thanks to @eme64 for taking a first step at simplifying the original test.

Best regards,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340812](https://bugs.openjdk.org/browse/JDK-8340812): LambdaForm customization via MethodHandle::updateForm is not thread safe (**Bug** - P2)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21160/head:pull/21160` \
`$ git checkout pull/21160`

Update a local copy of the PR: \
`$ git checkout pull/21160` \
`$ git pull https://git.openjdk.org/jdk.git pull/21160/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21160`

View PR using the GUI difftool: \
`$ git pr show -t 21160`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21160.diff">https://git.openjdk.org/jdk/pull/21160.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21160#issuecomment-2373145268)