### PR TITLE
8340670: Policy.UNSUPPORTED_EMPTY_COLLECTION.isReadOnly does not return true

### DIFF
--- a/src/java.base/share/classes/java/security/Policy.java
+++ b/src/java.base/share/classes/java/security/Policy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/security/Policy.java
+++ b/src/java.base/share/classes/java/security/Policy.java
@@ -896,5 +896,15 @@ public abstract class Policy {
         @Override public Enumeration<Permission> elements() {
             return perms.elements();
         }
+
+        /**
+         * If this object is readonly, no new objects can be added to it using {@code add}.
+         *
+         * @return {@code true} if this object is marked as readonly, {@code false} otherwise.
+         */
+        @Override
+        public boolean isReadOnly() {
+            return perms.isReadOnly();
+        }
     }
 }


### PR DESCRIPTION
https://bugs.openjdk.org/browse/JDK-8340670

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340670](https://bugs.openjdk.org/browse/JDK-8340670): Policy.UNSUPPORTED_EMPTY_COLLECTION.isReadOnly does not return true (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21165/head:pull/21165` \
`$ git checkout pull/21165`

Update a local copy of the PR: \
`$ git checkout pull/21165` \
`$ git pull https://git.openjdk.org/jdk.git pull/21165/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21165`

View PR using the GUI difftool: \
`$ git pr show -t 21165`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21165.diff">https://git.openjdk.org/jdk/pull/21165.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21165#issuecomment-2371735039)