### PR TITLE
8340826: Should not send unload notification for scratch classes 

### DIFF
--- a/src/hotspot/share/code/dependencyContext.cpp
+++ b/src/hotspot/share/code/dependencyContext.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -227,6 +227,10 @@ void DependencyContext::remove_and_mark_for_deoptimization_all_dependents(Deopti
 }
 
 #ifndef PRODUCT
+bool DependencyContext::is_empty() {
+  return dependencies() == nullptr;
+}
+
 void DependencyContext::print_dependent_nmethods(bool verbose) {
   int idx = 0;
   for (nmethodBucket* b = dependencies_not_unloading(); b != nullptr; b = b->next_not_unloading()) {

--- a/src/hotspot/share/code/dependencyContext.hpp
+++ b/src/hotspot/share/code/dependencyContext.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,6 +124,7 @@ class DependencyContext : public StackObj {
 
 #ifndef PRODUCT
   void print_dependent_nmethods(bool verbose);
+  bool is_empty();
 #endif //PRODUCT
   bool is_dependent_nmethod(nmethod* nm);
 };

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -484,6 +484,9 @@ static void do_primitives() {
 static void do_unloading_klass(Klass* klass) {
   assert(klass != nullptr, "invariant");
   assert(_subsystem_callback != nullptr, "invariant");
+  if(klass->is_instance_klass() && InstanceKlass::cast(klass)->is_scratch_class()) {
+    return;
+  }
   if (JfrKlassUnloading::on_unload(klass)) {
     _subsystem_callback->do_artifact(klass);
   }

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -484,7 +484,7 @@ static void do_primitives() {
 static void do_unloading_klass(Klass* klass) {
   assert(klass != nullptr, "invariant");
   assert(_subsystem_callback != nullptr, "invariant");
-  if(klass->is_instance_klass() && InstanceKlass::cast(klass)->is_scratch_class()) {
+  if (klass->is_instance_klass() && InstanceKlass::cast(klass)->is_scratch_class()) {
     return;
   }
   if (JfrKlassUnloading::on_unload(klass)) {

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2721,6 +2721,13 @@ static void clear_all_breakpoints(Method* m) {
 #endif
 
 void InstanceKlass::unload_class(InstanceKlass* ik) {
+
+  if (ik->is_scratch_class()) {
+    assert(ik->dependencies().is_empty(), "dependencies should be empty for scratch classes");
+    return;
+  }
+  assert(ik->is_loaded(), "class should be loaded " PTR_FORMAT, p2i(ik));
+
   // Release dependencies.
   ik->dependencies().remove_all_dependents();
 


### PR DESCRIPTION
The jvmti class redefinition creates temporary scratch classes for it's own purposes. These classes are added to corresponding classloaders and might be unloaded.
In this case the jvmti/jfr and log events are generated twice: for original class and for it's scratch.

The bug could be reproduced by jfr test
jdk/jfr/api/metadata/eventtype/TestUnloadingEventClass.java
with '-Xcomp -XX:TieredStopAtLevel=1' or with '-Xcomp'

The test log (modified slightly) shown

```
[167.294s][info ][class,unload] unloading class jdk.jfr.api.metadata.eventtype.TestUnloadingEventClass$ToBeUnloaded 0x00000000af1006d8 allocated
[167.294s][info ][class,unload] unloading class jdk.jfr.api.metadata.eventtype.TestUnloadingEventClass$ToBeUnloaded 0x00000000af100248 fully_initialized
[167.345s][trace][class,unload] unlinking class (subclass): jdk.jfr.api.metadata.eventtype.TestUnloadingEventClass$ToBeUnloaded
[167.872s][trace][gc          ] GC(0) Restored 3597 marks, occupying 57552 B
[167.924s][info ][gc          ] GC(0) Pause Full (System.gc()) 34M->2M(136M) 691.041ms
Unloaded count: 2
```

instead of expected


```
[159.737s][info ][class,unload] unloading class jdk.jfr.api.metadata.eventtype.TestUnloadingEventClass$ToBeUnloaded 0x0000000041100248 state: fully_initialized
[159.800s][trace][class,unload] unlinking class (subclass): jdk.jfr.api.metadata.eventtype.TestUnloadingEventClass$ToBeUnloaded
[160.341s][trace][gc          ] GC(0) Restored 3597 marks, occupying 57552 B
[160.384s][info ][gc          ] GC(0) Pause Full (System.gc()) 34M->2M(136M) 710.422ms
```


The test hang because got 2 events while waiting for one.
The "allocated" version is the scratch class generated by JVMTI JFR agent that redefine classes.

The fix is to don't send notification for scratch classes. The scratch classes shouldn't have dependency so added assertion. Also, we don't expect any other not loaded classes during unloaded.

Thanks Coleen for details about scratch classed. 

Tested with tier1-5 and with :jdk_jfr with Xcomp and c1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340826](https://bugs.openjdk.org/browse/JDK-8340826): Should not send unload notification for scratch classes (**Bug** - P4)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21166/head:pull/21166` \
`$ git checkout pull/21166`

Update a local copy of the PR: \
`$ git checkout pull/21166` \
`$ git pull https://git.openjdk.org/jdk.git pull/21166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21166`

View PR using the GUI difftool: \
`$ git pr show -t 21166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21166.diff">https://git.openjdk.org/jdk/pull/21166.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21166#issuecomment-2372037230)