### PR TITLE
8340838: Clean up MutableCallSite to use explicit release fence instead of AtomicInteger

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MutableCallSite.java
+++ b/src/java.base/share/classes/java/lang/invoke/MutableCallSite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,8 @@
 package java.lang.invoke;
 
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicInteger;
+
+import static java.lang.invoke.MethodHandleStatics.UNSAFE;
 
 /**
  * A {@code MutableCallSite} is a {@link CallSite} whose target variable
@@ -274,11 +275,10 @@ public non-sealed class MutableCallSite extends CallSite {
      */
     public static void syncAll(MutableCallSite[] sites) {
         if (sites.length == 0)  return;
-        STORE_BARRIER.lazySet(0);
+        UNSAFE.storeFence();
         for (MutableCallSite site : sites) {
             Objects.requireNonNull(site); // trigger NPE on first null
         }
         // FIXME: NYI
     }
-    private static final AtomicInteger STORE_BARRIER = new AtomicInteger();
 }


### PR DESCRIPTION
This implementation code was written in JDK 7, before storeFence was available in JDK 8. We should update this legacy code to make it clear.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340838](https://bugs.openjdk.org/browse/JDK-8340838): Clean up MutableCallSite to use explicit release fence instead of AtomicInteger (**Enhancement** - P4)


### Reviewers
 * [John R Rose](https://openjdk.org/census#jrose) (@rose00 - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21169/head:pull/21169` \
`$ git checkout pull/21169`

Update a local copy of the PR: \
`$ git checkout pull/21169` \
`$ git pull https://git.openjdk.org/jdk.git pull/21169/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21169`

View PR using the GUI difftool: \
`$ git pr show -t 21169`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21169.diff">https://git.openjdk.org/jdk/pull/21169.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21169#issuecomment-2372309783)