### PR TITLE
8340620: Fix -Wzero-as-null-pointer-constant warnings for CompressedOops

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -6598,7 +6598,7 @@ instruct encodeP_not_null_Ex(iRegNdst dst, iRegPsrc src) %{
 instruct encodeP_not_null_base_null(iRegNdst dst, iRegPsrc src) %{
   match(Set dst (EncodeP src));
   predicate(CompressedOops::shift() != 0 &&
-            CompressedOops::base() ==0);
+            CompressedOops::base() == nullptr);
 
   format %{ "SRDI    $dst, $src, #3 \t// encodeP, $src != nullptr" %}
   size(4);
@@ -6695,7 +6695,7 @@ instruct decodeN_Ex(iRegPdst dst, iRegNsrc src, flagsReg crx) %{
   predicate((n->bottom_type()->is_oopptr()->ptr() != TypePtr::NotNull &&
              n->bottom_type()->is_oopptr()->ptr() != TypePtr::Constant) &&
             CompressedOops::shift() != 0 &&
-            CompressedOops::base() != 0);
+            CompressedOops::base() != nullptr);
   ins_cost(4 * DEFAULT_COST); // Should be more expensive than decodeN_Disjoint_isel_Ex.
   effect(TEMP crx);
 
@@ -6707,7 +6707,7 @@ instruct decodeN_Ex(iRegPdst dst, iRegNsrc src, flagsReg crx) %{
 instruct decodeN_nullBase(iRegPdst dst, iRegNsrc src) %{
   match(Set dst (DecodeN src));
   predicate(CompressedOops::shift() != 0 &&
-            CompressedOops::base() == 0);
+            CompressedOops::base() == nullptr);
 
   format %{ "SLDI    $dst, $src, #3 \t// DecodeN (zerobased)" %}
   size(4);
@@ -6825,7 +6825,7 @@ instruct decodeN_notNull_addBase_Ex(iRegPdst dst, iRegNsrc src) %{
   predicate((n->bottom_type()->is_oopptr()->ptr() == TypePtr::NotNull ||
              n->bottom_type()->is_oopptr()->ptr() == TypePtr::Constant) &&
             CompressedOops::shift() != 0 &&
-            CompressedOops::base() != 0);
+            CompressedOops::base() != nullptr);
   ins_cost(2 * DEFAULT_COST);
 
   format %{ "DecodeN $dst, $src \t// $src != nullptr, postalloc expanded" %}

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -4628,7 +4628,7 @@ instruct encodeP(iRegN dst, iRegP src, flagsReg cr) %{
   match(Set dst (EncodeP src));
   effect(KILL cr);
   predicate((n->bottom_type()->make_ptr()->ptr() != TypePtr::NotNull) &&
-            (CompressedOops::base() == 0 ||
+            (CompressedOops::base() == nullptr ||
              CompressedOops::base_disjoint() ||
              !ExpandLoadingBaseEncode));
   ins_cost(MEMORY_REF_COST+3 * DEFAULT_COST);
@@ -4651,7 +4651,7 @@ instruct encodeP_NN(iRegN dst, iRegP src, flagsReg cr) %{
   match(Set dst (EncodeP src));
   effect(KILL cr);
   predicate((n->bottom_type()->make_ptr()->ptr() == TypePtr::NotNull) &&
-            (CompressedOops::base() == 0 ||
+            (CompressedOops::base() == nullptr ||
              CompressedOops::base_disjoint() ||
              !ExpandLoadingBaseEncode_NN));
   ins_cost(MEMORY_REF_COST+3 * DEFAULT_COST);

--- a/src/hotspot/share/oops/compressedOops.cpp
+++ b/src/hotspot/share/oops/compressedOops.cpp
@@ -61,7 +61,7 @@ void CompressedOops::initialize(const ReservedHeapSpace& heap_space) {
   }
   if ((uint64_t)heap_space.end() <= OopEncodingHeapMax) {
     // Did reserve heap below 32Gb. Can use base == 0;
-    set_base(0);
+    set_base(nullptr);
   } else {
     set_base((address)heap_space.compressed_oop_base());
   }

--- a/src/hotspot/share/oops/compressedOops.cpp
+++ b/src/hotspot/share/oops/compressedOops.cpp
@@ -115,7 +115,7 @@ CompressedOops::Mode CompressedOops::mode() {
     return DisjointBaseNarrowOop;
   }
 
-  if (base() != 0) {
+  if (base() != nullptr) {
     return HeapBasedNarrowOop;
   }
 
@@ -166,7 +166,7 @@ void CompressedOops::print_mode(outputStream* st) {
 
   st->print(", Compressed Oops mode: %s", mode_to_string(mode()));
 
-  if (base() != 0) {
+  if (base() != nullptr) {
     st->print(": " PTR_FORMAT, p2i(base()));
   }
 

--- a/src/hotspot/share/oops/compressedOops.inline.hpp
+++ b/src/hotspot/share/oops/compressedOops.inline.hpp
@@ -48,9 +48,6 @@ inline oop CompressedOops::decode_raw_not_null(narrowOop v) {
 }
 
 inline oop CompressedOops::decode_raw(narrowOop v) {
-  // Assume a null base casts to zero.  Otherwise we need more complexity that
-  // we can't test, since this is true for all currently supported platforms.
-  assert(0 == reinterpret_cast<uintptr_t>(nullptr), "null pointer value not zero?");
   return cast_to_oop((uintptr_t)base() + ((uintptr_t)v << shift()));
 }
 
@@ -70,9 +67,6 @@ inline narrowOop CompressedOops::encode_not_null(oop v) {
   assert(!is_null(v), "oop value can never be zero");
   assert(is_object_aligned(v), "address not aligned: " PTR_FORMAT, p2i(v));
   assert(is_in(v), "address not in heap range: " PTR_FORMAT, p2i(v));
-  // Assume a null base casts to zero.  Otherwise we need more complexity that
-  // we can't test, since this is true for all currently supported platforms.
-  assert(0 == reinterpret_cast<uintptr_t>(nullptr), "null pointer value not zero?");
   uint64_t  pd = (uint64_t)(pointer_delta((void*)v, (void*)base(), 1));
   assert(OopEncodingHeapMax > pd, "change encoding max if new encoding");
   narrowOop result = narrow_oop_cast(pd >> shift());

--- a/src/hotspot/share/oops/compressedOops.inline.hpp
+++ b/src/hotspot/share/oops/compressedOops.inline.hpp
@@ -48,6 +48,9 @@ inline oop CompressedOops::decode_raw_not_null(narrowOop v) {
 }
 
 inline oop CompressedOops::decode_raw(narrowOop v) {
+  // Assume a null base casts to zero.  Otherwise we need more complexity that
+  // we can't test, since this is true for all currently supported platforms.
+  assert(0 == reinterpret_cast<uintptr_t>(nullptr), "null pointer value not zero?");
   return cast_to_oop((uintptr_t)base() + ((uintptr_t)v << shift()));
 }
 
@@ -67,6 +70,9 @@ inline narrowOop CompressedOops::encode_not_null(oop v) {
   assert(!is_null(v), "oop value can never be zero");
   assert(is_object_aligned(v), "address not aligned: " PTR_FORMAT, p2i(v));
   assert(is_in(v), "address not in heap range: " PTR_FORMAT, p2i(v));
+  // Assume a null base casts to zero.  Otherwise we need more complexity that
+  // we can't test, since this is true for all currently supported platforms.
+  assert(0 == reinterpret_cast<uintptr_t>(nullptr), "null pointer value not zero?");
   uint64_t  pd = (uint64_t)(pointer_delta((void*)v, (void*)base(), 1));
   assert(OopEncodingHeapMax > pd, "change encoding max if new encoding");
   narrowOop result = narrow_oop_cast(pd >> shift());


### PR DESCRIPTION
Please review this change that fixes -Wzero-as-null-pointer-constant warnings
in CompressedOops code.  These all relate to CompressedOops::base().

I also added a couple of asserts to verify our assumptions about null pointer
constants being representationally zero. That isn't a Standard-conforming
assumption, but holds for all platforms we currently support. I considered,
and even explored, a couple of different options.

(1) Continue to have CompressedOops::base() be a pointer, but avoid that
assumption, being more careful about how zero-valued pointers are treated. But
that adds significant complexity that we can't test, since we don't support
any platforms needing that extra work.

(2) Change CompressedOops::base() to an integral adjustment.  This is probably
the correct approach, but is much more intrusive and wide ranging in the
changes required.  Maybe something for the future.

Testing: mach5 tier1-5
GHA testing, verifying builds on some platforms not supported by Oracle.

There are some simple changes to s390 and ppc code that I haven't tested,
beyond verifying compilation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340620](https://bugs.openjdk.org/browse/JDK-8340620): Fix -Wzero-as-null-pointer-constant warnings for CompressedOops (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**) Review applies to [ef0dc56e](https://git.openjdk.org/jdk/pull/21172/files/ef0dc56e3c71563e6c0dbf4eaf38b3dcce5764e8)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**) Review applies to [ef0dc56e](https://git.openjdk.org/jdk/pull/21172/files/ef0dc56e3c71563e6c0dbf4eaf38b3dcce5764e8)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer) Review applies to [ef0dc56e](https://git.openjdk.org/jdk/pull/21172/files/ef0dc56e3c71563e6c0dbf4eaf38b3dcce5764e8)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21172/head:pull/21172` \
`$ git checkout pull/21172`

Update a local copy of the PR: \
`$ git checkout pull/21172` \
`$ git pull https://git.openjdk.org/jdk.git pull/21172/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21172`

View PR using the GUI difftool: \
`$ git pr show -t 21172`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21172.diff">https://git.openjdk.org/jdk/pull/21172.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21172#issuecomment-2372568597)