### PR TITLE
8340864: Remove unused lines related to vmClasses

### DIFF
--- a/src/hotspot/share/classfile/systemDictionary.hpp
+++ b/src/hotspot/share/classfile/systemDictionary.hpp
@@ -293,13 +293,6 @@ public:
                                   const char* message);
   static const char* find_nest_host_error(const constantPoolHandle& pool, int which);
 
-protected:
-  static InstanceKlass* _well_known_klasses[];
-
-private:
-  // table of box klasses (int_klass, etc.)
-  static InstanceKlass* _box_klasses[T_VOID+1];
-
   static OopHandle  _java_system_loader;
   static OopHandle  _java_platform_loader;
 

--- a/src/hotspot/share/classfile/vmClasses.cpp
+++ b/src/hotspot/share/classfile/vmClasses.cpp
@@ -45,14 +45,6 @@ InstanceKlass* vmClasses::_klasses[static_cast<int>(vmClassID::LIMIT)]
                                                  =  { nullptr /*, nullptr...*/ };
 InstanceKlass* vmClasses::_box_klasses[T_VOID+1] =  { nullptr /*, nullptr...*/ };
 
-
-// CDS: scan and relocate all classes referenced by _klasses[].
-void vmClasses::metaspace_pointers_do(MetaspaceClosure* it) {
-  for (auto id : EnumRange<vmClassID>{}) {
-    it->push(klass_addr_at(id));
-  }
-}
-
 bool vmClasses::is_loaded(InstanceKlass* klass) {
   return klass != nullptr && klass->is_loaded();
 }
@@ -205,8 +197,6 @@ void vmClasses::resolve_all(TRAPS) {
   _box_klasses[T_SHORT]   = vmClasses::Short_klass();
   _box_klasses[T_INT]     = vmClasses::Integer_klass();
   _box_klasses[T_LONG]    = vmClasses::Long_klass();
-  //_box_klasses[T_OBJECT]  = vmClasses::object_klass();
-  //_box_klasses[T_ARRAY]   = vmClasses::object_klass();
 
 #ifdef ASSERT
   if (CDSConfig::is_using_archive()) {

--- a/src/hotspot/share/classfile/vmClasses.hpp
+++ b/src/hotspot/share/classfile/vmClasses.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@
 
 class ClassLoaderData;
 class InstanceKlass;
-class MetaspaceClosure;
 
 class vmClasses : AllStatic {
   friend class VMStructs;
@@ -95,7 +94,6 @@ public:
     return &_klasses[as_int(id)];
   }
 
-  static void metaspace_pointers_do(MetaspaceClosure* it);
   static void resolve_all(TRAPS);
 
   static BasicType box_klass_type(Klass* k);  // inverse of box_klass


### PR DESCRIPTION
Trivial fix -- remove some lines that are no longer used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340864](https://bugs.openjdk.org/browse/JDK-8340864): Remove unused lines related to vmClasses (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21173/head:pull/21173` \
`$ git checkout pull/21173`

Update a local copy of the PR: \
`$ git checkout pull/21173` \
`$ git pull https://git.openjdk.org/jdk.git pull/21173/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21173`

View PR using the GUI difftool: \
`$ git pr show -t 21173`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21173.diff">https://git.openjdk.org/jdk/pull/21173.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21173#issuecomment-2372604438)