### PR TITLE
Unnecessary Variable Removal for Optimized computeIfAbsent Implementation

### DIFF
--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -1063,10 +1063,9 @@ public interface Map<K, V> {
         Objects.requireNonNull(mappingFunction);
         V v;
         if ((v = get(key)) == null) {
-            V newValue;
-            if ((newValue = mappingFunction.apply(key)) != null) {
-                put(key, newValue);
-                return newValue;
+            if ((v = mappingFunction.apply(key)) != null) {
+                put(key, v);
+                return v;
             }
         }
 


### PR DESCRIPTION
Changes
- The computeIfAbsent method has been optimized by removing the newValue variable and reusing the v variable, thereby eliminating unnecessary local variable declarations.

Reason
- In the previous implementation, the newValue variable was used as an additional local variable without a specific purpose. By reusing the v variable, the code has been made more concise.

Impact
- This change simplifies the computeIfAbsent method in the Map interface by reducing unnecessary variable declarations. The existing behavior remains unchanged, and all functionality works as before.

Testing
- All existing test cases have passed successfully, confirming that this change does not affect current functionality.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21175/head:pull/21175` \
`$ git checkout pull/21175`

Update a local copy of the PR: \
`$ git checkout pull/21175` \
`$ git pull https://git.openjdk.org/jdk.git pull/21175/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21175`

View PR using the GUI difftool: \
`$ git pr show -t 21175`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21175.diff">https://git.openjdk.org/jdk/pull/21175.diff</a>

</details>
