### PR TITLE
8339542: compiler/codecache/CheckSegmentedCodeCache.java fails

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -181,7 +181,9 @@ public class CheckSegmentedCodeCache {
                                                               "-XX:ReservedCodeCacheSize=10M",
                                                               "-XX:NonNMethodCodeHeapSize=5M",
                                                               "-XX:ProfiledCodeHeapSize=5M",
-                                                              "-XX:NonProfiledCodeHeapSize=5M",
+                                                              // After fixing a round_down issue with large page sizes (JDK-8334564),
+                                                              // 5M is a bit too small for NonProfiledCodeHeap
+                                                              "-XX:NonProfiledCodeHeapSize=6M",
                                                               "-version");
         failsWith(pb, "Invalid code heap sizes");
 


### PR DESCRIPTION
On systems with large page sizes, the minimum size required for non-method code heap may be larger than the value preset in the test. This effect is triggered by JDK-8334564, which increases the required minimum size such that it will not be rounded down to zero.

Tests pending.