### PR TITLE
8340899: Remove wildcard bound in PositionWindows.positionTestWindows

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -587,7 +587,7 @@ public final class PassFailJFrame {
          * @param testWindows the list of test windows
          * @param instructionUI information about the instruction frame
          */
-        void positionTestWindows(List<? extends Window> testWindows,
+        void positionTestWindows(List<Window> testWindows,
                                  InstructionUI instructionUI);
     }
 


### PR DESCRIPTION
Removes the wildcard bound from `PassFailJFrame.PositionWindows.positionTestWindows` so that implementing the interface is simpler as one don't have to remember to declare the `testWindows` parameter as `List<? extends Window>` — just use `List<Window>`.

It is a backwards compatible change, all the tests which use `List<? extends Window>` continue to compile successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340899](https://bugs.openjdk.org/browse/JDK-8340899): Remove wildcard bound in PositionWindows.positionTestWindows (**Bug** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21181/head:pull/21181` \
`$ git checkout pull/21181`

Update a local copy of the PR: \
`$ git checkout pull/21181` \
`$ git pull https://git.openjdk.org/jdk.git pull/21181/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21181`

View PR using the GUI difftool: \
`$ git pr show -t 21181`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21181.diff">https://git.openjdk.org/jdk/pull/21181.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21181#issuecomment-2373835507)