### PR TITLE
8339475: Clean up return code handling for pthread calls in library coding

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -297,6 +297,7 @@ static void ParkEventLoop() {
 static void MacOSXStartup(int argc, char *argv[]) {
     // Thread already started?
     static jboolean started = false;
+    int rc;
     if (started) {
         return;
     }
@@ -309,12 +310,14 @@ static void MacOSXStartup(int argc, char *argv[]) {
 
     // Fire up the main thread
     pthread_t main_thr;
-    if (pthread_create(&main_thr, NULL, &apple_main, &args) != 0) {
-        JLI_ReportErrorMessageSys("Could not create main thread: %s\n", strerror(errno));
+    rc = pthread_create(&main_thr, NULL, &apple_main, &args);
+    if (rc != 0) {
+        JLI_ReportErrorMessageSys("Could not create main thread, return code: %s\n", rc);
         exit(1);
     }
-    if (pthread_detach(main_thr)) {
-        JLI_ReportErrorMessageSys("pthread_detach() failed: %s\n", strerror(errno));
+    rc = pthread_detach(main_thr);
+    if (rc != 0) {
+        JLI_ReportErrorMessage("pthread_detach() failed, return code: %s\n", rc);
         exit(1);
     }
 

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -243,13 +243,7 @@ JLI_ReportErrorMessage(const char* fmt, ...) {
 JNIEXPORT void JNICALL
 JLI_ReportErrorMessageSys(const char* fmt, ...) {
     va_list vl;
-    char *emsg;
-
-    /*
-     * TODO: its safer to use strerror_r but is not available on
-     * Solaris 8. Until then....
-     */
-    emsg = strerror(errno);
+    char *emsg = strerror(errno);
     if (emsg != NULL) {
         fprintf(stderr, "%s\n", emsg);
     }

--- a/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
+++ b/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
@@ -276,6 +276,9 @@ SplashCreateThread(Splash * splash) {
     int rslt = pthread_attr_init(&attr);
     if (rslt != 0) return;
     rc = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    if (rc != 0) {
+        fprintf(stderr, "Could not create SplashScreen thread, error number:%d\n", rc);
+    }
     pthread_attr_destroy(&attr);
 }
 

--- a/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
+++ b/src/java.desktop/macosx/native/libsplashscreen/splashscreen_sys.m
@@ -271,13 +271,12 @@ void
 SplashCreateThread(Splash * splash) {
     pthread_t thr;
     pthread_attr_t attr;
-    int rc;
 
     int rslt = pthread_attr_init(&attr);
     if (rslt != 0) return;
-    rc = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
-    if (rc != 0) {
-        fprintf(stderr, "Could not create SplashScreen thread, error number:%d\n", rc);
+    rslt = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    if (rslt != 0) {
+        fprintf(stderr, "Could not create SplashScreen thread, error number:%d\n", rslt);
     }
     pthread_attr_destroy(&attr);
 }

--- a/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
+++ b/src/java.desktop/unix/native/libsplashscreen/splashscreen_sys.c
@@ -741,7 +741,10 @@ SplashCreateThread(Splash * splash) {
 
     int rslt = pthread_attr_init(&attr);
     if (rslt != 0) return;
-    pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    rslt = pthread_create(&thr, &attr, SplashScreenThread, (void *) splash);
+    if (rslt != 0) {
+        fprintf(stderr, "Could not create SplashScreen thread, error number:%d\n", rslt);
+    }
     pthread_attr_destroy(&attr);
 }
 


### PR DESCRIPTION
It has been discussed that checking the return value of pthread_create should be done.
See the discussion here https://github.com/openjdk/jdk/pull/20812 about the splashscreen coding .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339475](https://bugs.openjdk.org/browse/JDK-8339475): Clean up return code handling for pthread calls in library coding (**Bug** - P4)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21182/head:pull/21182` \
`$ git checkout pull/21182`

Update a local copy of the PR: \
`$ git checkout pull/21182` \
`$ git pull https://git.openjdk.org/jdk.git pull/21182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21182`

View PR using the GUI difftool: \
`$ git pr show -t 21182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21182.diff">https://git.openjdk.org/jdk/pull/21182.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21182#issuecomment-2373864027)