### PR TITLE
8341006: Optimize StackMapGenerator detect frames

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -911,6 +911,7 @@ public final class StackMapGenerator {
     }
 
     private void addFrame(List<Frame> frames, int offset) {
+        Preconditions.checkIndex(offset, bytecode.length(), RawBytecodeHelper.IAE_FORMATTER);
         int i = 0;
         for (; i < frames.size(); i++) {
             Frame frame = frames.get(i);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -40,7 +40,6 @@ import java.lang.constant.ClassDesc;
 import java.lang.constant.MethodTypeDesc;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -57,8 +56,8 @@ import static java.lang.constant.ConstantDescs.*;
  * <p>
  * The {@linkplain #generate() frames computation} consists of following steps:
  * <ol>
- * <li>{@linkplain #detectFrameOffsets() Detection} of mandatory stack map frames offsets:<ul>
- *      <li>Mandatory stack map frame offsets include all jump and switch instructions targets,
+ * <li>{@linkplain #detectFrames() Detection} of mandatory stack map frames:<ul>
+ *      <li>Mandatory stack map frame include all jump and switch instructions targets,
  *          offsets immediately following {@linkplain #noControlFlow(int) "no control flow"}
  *          and all exception table handlers.
  *      <li>Detection is performed in a single fast pass through the bytecode,
@@ -282,8 +281,8 @@ public final class StackMapGenerator {
     private int exMin, exMax;
 
     private boolean isAnyFrameDirty() {
-        for (var f : frames) {
-            if (f.dirty) return true;
+        for (int i = 0; i < frames.size(); i++) {
+            if (frames.get(i).dirty) return true;
         }
         return false;
     }
@@ -291,7 +290,30 @@ public final class StackMapGenerator {
     private void generate() {
         exMin = bytecode.length();
         exMax = -1;
-        for (var exhandler : handlers) {
+        if (!handlers.isEmpty()) {
+            generateHandlers();
+        }
+        List<Frame> frames = detectFrames();
+        this.frames = frames;
+        do {
+            processMethod();
+        } while (isAnyFrameDirty());
+        maxLocals = currentFrame.frameMaxLocals;
+        maxStack = currentFrame.frameMaxStack;
+
+        //dead code patching
+        for (int i = 0, framesCount = frames.size(); i < framesCount; i++) {
+            var frame = frames.get(i);
+            if (frame.flags == -1) {
+                deadCodePatching(frame, framesCount, i);
+            }
+        }
+    }
+
+    private void generateHandlers() {
+        var labelContext = this.labelContext;
+        for (int i = 0; i < handlers.size(); i++) {
+            var exhandler = handlers.get(i);
             int start_pc = labelContext.labelToBci(exhandler.tryStart());
             int end_pc = labelContext.labelToBci(exhandler.tryEnd());
             int handler_pc = labelContext.labelToBci(exhandler.handler());
@@ -301,40 +323,23 @@ public final class StackMapGenerator {
                 var catchType = exhandler.catchType();
                 rawHandlers.add(new RawExceptionCatch(start_pc, end_pc, handler_pc,
                         catchType.isPresent() ? cpIndexToType(catchType.get().index(), cp)
-                                              : Type.THROWABLE_TYPE));
+                                : Type.THROWABLE_TYPE));
             }
         }
-        BitSet frameOffsets = detectFrameOffsets();
-        int framesCount = frameOffsets.cardinality();
-        frames = new ArrayList<>(framesCount);
-        int offset = -1;
-        for (int i = 0; i < framesCount; i++) {
-            offset = frameOffsets.nextSetBit(offset + 1);
-            frames.add(new Frame(offset, classHierarchy));
-        }
-        do {
-            processMethod();
-        } while (isAnyFrameDirty());
-        maxLocals = currentFrame.frameMaxLocals;
-        maxStack = currentFrame.frameMaxStack;
+    }
 
-        //dead code patching
-        for (int i = 0; i < framesCount; i++) {
-            var frame = frames.get(i);
-            if (frame.flags == -1) {
-                if (!patchDeadCode) throw generatorError("Unable to generate stack map frame for dead code", frame.offset);
-                //patch frame
-                frame.pushStack(Type.THROWABLE_TYPE);
-                if (maxStack < 1) maxStack = 1;
-                int end = (i < framesCount - 1 ? frames.get(i + 1).offset : bytecode.length()) - 1;
-                //patch bytecode
-                var arr = bytecode.array();
-                Arrays.fill(arr, frame.offset, end, (byte) NOP);
-                arr[end] = (byte) ATHROW;
-                //patch handlers
-                removeRangeFromExcTable(frame.offset, end + 1);
-            }
-        }
+    private void deadCodePatching(Frame frame, int framesCount, int i) {
+        if (!patchDeadCode) throw generatorError("Unable to generate stack map frame for dead code", frame.offset);
+        //patch frame
+        frame.pushStack(Type.THROWABLE_TYPE);
+        if (maxStack < 1) maxStack = 1;
+        int end = (i < framesCount - 1 ? frames.get(i + 1).offset : bytecode.length()) - 1;
+        //patch bytecode
+        var arr = bytecode.array();
+        Arrays.fill(arr, frame.offset, end, (byte) NOP);
+        arr[end] = (byte) ATHROW;
+        //patch handlers
+        removeRangeFromExcTable(frame.offset, end + 1);
     }
 
     private void removeRangeFromExcTable(int rangeStart, int rangeEnd) {
@@ -840,18 +845,11 @@ public final class StackMapGenerator {
     }
 
     /**
-     * Performs detection of mandatory stack map frames offsets
-     * in a single bytecode traversing pass
-     * @return <code>java.lang.BitSet</code> of detected frames offsets
+     * Performs detection of mandatory stack map frames in a single bytecode traversing pass
+     * @return detected frames
      */
-    private BitSet detectFrameOffsets() {
-        var offsets = new BitSet() {
-            @Override
-            public void set(int i) {
-                Preconditions.checkIndex(i, bytecode.length(), RawBytecodeHelper.IAE_FORMATTER);
-                super.set(i);
-            }
-        };
+    private List<Frame> detectFrames() {
+        List<Frame> frames = new ArrayList<>();
         var bcs = bytecode.start();
         boolean no_control_flow = false;
         int opcode, bci = 0;
@@ -859,22 +857,22 @@ public final class StackMapGenerator {
             opcode = bcs.opcode();
             bci = bcs.bci();
             if (no_control_flow) {
-                offsets.set(bci);
+                addFrame(frames, bci);
             }
             no_control_flow = switch (opcode) {
                 case GOTO -> {
-                            offsets.set(bcs.dest());
+                            addFrame(frames, bcs.dest());
                             yield true;
                         }
                 case GOTO_W -> {
-                            offsets.set(bcs.destW());
+                            addFrame(frames, bcs.destW());
                             yield true;
                         }
                 case IF_ICMPEQ, IF_ICMPNE, IF_ICMPLT, IF_ICMPGE,
                      IF_ICMPGT, IF_ICMPLE, IFEQ, IFNE,
                      IFLT, IFGE, IFGT, IFLE, IF_ACMPEQ,
                      IF_ACMPNE , IFNULL , IFNONNULL -> {
-                            offsets.set(bcs.dest());
+                            addFrame(frames, bcs.dest());
                             yield false;
                         }
                 case TABLESWITCH, LOOKUPSWITCH -> {
@@ -890,9 +888,9 @@ public final class StackMapGenerator {
                                 keys = bcs.getIntUnchecked(aligned_bci + 4);
                                 delta = 2;
                             }
-                            offsets.set(bci + default_ofset);
+                            addFrame(frames, bci + default_ofset);
                             for (int i = 0; i < keys; i++) {
-                                offsets.set(bci + bcs.getIntUnchecked(aligned_bci + (3 + i * delta) * 4));
+                                addFrame(frames, bci + bcs.getIntUnchecked(aligned_bci + (3 + i * delta) * 4));
                             }
                             yield true;
                         }
@@ -903,13 +901,27 @@ public final class StackMapGenerator {
         } catch (IllegalArgumentException iae) {
             throw generatorError("Detected branch target out of bytecode range", bci);
         }
-        for (var exhandler : rawHandlers) try {
-             offsets.set(exhandler.handler());
+        for (int i = 0; i < rawHandlers.size(); i++) try {
+            addFrame(frames, rawHandlers.get(i).handler());
         } catch (IllegalArgumentException iae) {
             if (!filterDeadLabels)
                 throw generatorError("Detected exception handler out of bytecode range");
         }
-        return offsets;
+        return frames;
+    }
+
+    private void addFrame(List<Frame> frames, int offset) {
+        int i = 0;
+        for (; i < frames.size(); i++) {
+            Frame frame = frames.get(i);
+            if (frame.offset == offset) {
+                return;
+            }
+            if (frame.offset > offset) {
+                break;
+            }
+        }
+        frames.add(i, new Frame(offset, classHierarchy));
     }
 
     private final class Frame {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -923,8 +923,8 @@ public final class StackMapGenerator {
                 break;
             }
         }
-        if (i >= frames.length) {
-            int newCapacity = i + 8;
+        if (framesCount >= frames.length) {
+            int newCapacity = framesCount + 8;
             this.frames = frames = framesCount == 0 ? new Frame[newCapacity] : Arrays.copyOf(frames, newCapacity);
         }
         if (i != framesCount) {

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -916,11 +916,11 @@ public final class StackMapGenerator {
         var frames = this.frames;
         int i = 0, framesCount = this.framesCount;
         for (; i < framesCount; i++) {
-            var frame = frames[i];
-            if (frame.offset == offset) {
+            var frameOffset = frames[i].offset;
+            if (frameOffset == offset) {
                 return;
             }
-            if (frame.offset > offset) {
+            if (frameOffset > offset) {
                 break;
             }
         }


### PR DESCRIPTION
1. Construct Frames directly without BitSet
2. Use Frame[] instead of ArrayList
3. Use EMPTY_FRAME_ARRAY for initialization. No need to allocate objects when there is no frame.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341006](https://bugs.openjdk.org/browse/JDK-8341006): Optimize StackMapGenerator detect frames (**Sub-task** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21183/head:pull/21183` \
`$ git checkout pull/21183`

Update a local copy of the PR: \
`$ git checkout pull/21183` \
`$ git pull https://git.openjdk.org/jdk.git pull/21183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21183`

View PR using the GUI difftool: \
`$ git pr show -t 21183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21183.diff">https://git.openjdk.org/jdk/pull/21183.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21183#issuecomment-2376524066)