### PR TITLE
8340923: The class LogSelection copies uninitialized memory

### DIFF
--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -43,7 +43,7 @@ LogSelection::LogSelection(const LogTagType tags[LogTag::MaxTags], bool wildcard
     _ntags++;
   }
 
-  for (int i = _ntags; i < _LogTag::MaxTags; i++) {
+  for (size_t i = _ntags; i < LogTag::MaxTags; i++) {
     _tags[i] = LogTag::__NO_TAG;
   }
 

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -33,18 +33,14 @@
 
 const LogSelection LogSelection::Invalid;
 
-LogSelection::LogSelection() : _ntags(0), _wildcard(false), _level(LogLevel::Invalid), _tag_sets_selected(0) {
+LogSelection::LogSelection() : _ntags(0), _tags(), _wildcard(false), _level(LogLevel::Invalid), _tag_sets_selected(0) {
 }
 
 LogSelection::LogSelection(const LogTagType tags[LogTag::MaxTags], bool wildcard, LogLevelType level)
-    : _ntags(0), _wildcard(wildcard), _level(level), _tag_sets_selected(0) {
+  : _ntags(0), _tags(), _wildcard(wildcard), _level(level), _tag_sets_selected(0) {
   while (_ntags < LogTag::MaxTags && tags[_ntags] != LogTag::__NO_TAG) {
     _tags[_ntags] = tags[_ntags];
     _ntags++;
-  }
-
-  for (size_t i = _ntags; i < LogTag::MaxTags; i++) {
-    _tags[i] = LogTag::__NO_TAG;
   }
 
   for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {

--- a/src/hotspot/share/logging/logSelection.cpp
+++ b/src/hotspot/share/logging/logSelection.cpp
@@ -43,6 +43,10 @@ LogSelection::LogSelection(const LogTagType tags[LogTag::MaxTags], bool wildcard
     _ntags++;
   }
 
+  for (int i = _ntags; i < _LogTag::MaxTags; i++) {
+    _tags[i] = LogTag::__NO_TAG;
+  }
+
   for (LogTagSet* ts = LogTagSet::first(); ts != nullptr; ts = ts->next()) {
     if (selects(*ts)) {
       _tag_sets_selected++;


### PR DESCRIPTION
The class LogSelection's custom constructor does not initialize the whole _tags array but is lacking a custom copy constructor and assignment operator. This means that any copy will copy uninitialized memory, which is undefined behavior. UBSAN has seen this happen, as reported by Matthias Baesken.

For some surrounding context: Unified Logging uses a statically defined array size (`LogTag::MaxTag`) but uses the `LogTag::__NO_TAG` to signify the end of the array. Think "NULL-terminated string but log tags".

We fill the whole array to avoid this issue. Specifically, we filll the remainder of the array with `LogTag::__NO_TAG`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340923](https://bugs.openjdk.org/browse/JDK-8340923): The class LogSelection copies uninitialized memory (**Bug** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21185/head:pull/21185` \
`$ git checkout pull/21185`

Update a local copy of the PR: \
`$ git checkout pull/21185` \
`$ git pull https://git.openjdk.org/jdk.git pull/21185/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21185`

View PR using the GUI difftool: \
`$ git pr show -t 21185`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21185.diff">https://git.openjdk.org/jdk/pull/21185.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21185#issuecomment-2374155806)