### PR TITLE
8340974: Ambiguous name of jtreg property vm.libgraal.enabled

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -81,7 +81,7 @@ requires.properties= \
     vm.jvmti \
     vm.graal.enabled \
     jdk.hasLibgraal \
-    vm.libgraal.enabled \
+    vm.libgraal.jit \
     vm.compiler1.enabled \
     vm.compiler2.enabled \
     vm.musl \

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -128,8 +128,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.graal.enabled", this::isGraalEnabled);
         // jdk.hasLibgraal is true if the libgraal shared library file is present
         map.put("jdk.hasLibgraal", this::hasLibgraal);
-        // vm.libgraal.enabled is true if libgraal is used as JIT
-        map.put("vm.libgraal.enabled", this::isLibgraalEnabled);
+        map.put("vm.libgraal.jit", this::isLibgraalJit);
         map.put("vm.compiler1.enabled", this::isCompiler1Enabled);
         map.put("vm.compiler2.enabled", this::isCompiler2Enabled);
         map.put("docker.support", this::dockerSupport);
@@ -560,7 +559,7 @@ public class VMProps implements Callable<Map<String, String>> {
      *
      * @return true if libgraal is used as JIT compiler.
      */
-    protected String isLibgraalEnabled() {
+    protected String isLibgraalJit() {
         return "" + Compiler.isLibgraalEnabled();
     }
 

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -128,7 +128,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.graal.enabled", this::isGraalEnabled);
         // jdk.hasLibgraal is true if the libgraal shared library file is present
         map.put("jdk.hasLibgraal", this::hasLibgraal);
-        map.put("vm.libgraal.jit", this::isLibgraalJit);
+        map.put("vm.libgraal.jit", this::isLibgraalJIT);
         map.put("vm.compiler1.enabled", this::isCompiler1Enabled);
         map.put("vm.compiler2.enabled", this::isCompiler2Enabled);
         map.put("docker.support", this::dockerSupport);
@@ -559,8 +559,8 @@ public class VMProps implements Callable<Map<String, String>> {
      *
      * @return true if libgraal is used as JIT compiler.
      */
-    protected String isLibgraalJit() {
-        return "" + Compiler.isLibgraalEnabled();
+    protected String isLibgraalJIT() {
+        return "" + Compiler.isLibgraalJIT();
     }
 
     /**

--- a/test/lib/jdk/test/whitebox/code/Compiler.java
+++ b/test/lib/jdk/test/whitebox/code/Compiler.java
@@ -91,12 +91,12 @@ public class Compiler {
     /**
      * Check if libgraal is used as JIT compiler.
      *
-     * libraal is enabled if isGraalEnabled is true and:
+     * libraal JIT is enabled if isGraalEnabled is true and:
      * - UseJVMCINativeLibrary flag is true
      *
      * @return true if libgraal is used as JIT compiler.
      */
-    public static boolean isLibgraalEnabled() {
+    public static boolean isLibgraalJIT() {
         if (!isGraalEnabled()) {
             return false;
         }


### PR DESCRIPTION
This disambiguates the situation where libgraal is "enabled" for use by non-CompilerBroker compilations, without being used as the JIT compiler.

Per discussion at https://github.com/openjdk/jdk/pull/21120#issuecomment-2372462365 

Grep shows that the property and related method are not used in this codebase.  Tier1 tests on linux-x86_64-server-release pass cleanly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340974](https://bugs.openjdk.org/browse/JDK-8340974): Ambiguous name of jtreg property vm.libgraal.enabled (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21190/head:pull/21190` \
`$ git checkout pull/21190`

Update a local copy of the PR: \
`$ git checkout pull/21190` \
`$ git pull https://git.openjdk.org/jdk.git pull/21190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21190`

View PR using the GUI difftool: \
`$ git pr show -t 21190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21190.diff">https://git.openjdk.org/jdk/pull/21190.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21190#issuecomment-2375314272)