### PR TITLE
8340426: ZGC: Move defragment out of the allocation path

### DIFF
--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -240,10 +240,10 @@ void ZHeap::undo_alloc_page(ZPage* page) {
   log_trace(gc)("Undo page allocation, thread: " PTR_FORMAT " (%s), page: " PTR_FORMAT ", size: " SIZE_FORMAT,
                 p2i(Thread::current()), ZUtils::thread_name(), p2i(page), page->size());
 
-  free_page(page);
+  free_page(page, false /* allow_defragment */);
 }
 
-void ZHeap::free_page(ZPage* page) {
+void ZHeap::free_page(ZPage* page, bool allow_defragment) {
   // Remove page table entry
   _page_table.remove(page);
 
@@ -253,7 +253,7 @@ void ZHeap::free_page(ZPage* page) {
   }
 
   // Free page
-  _page_allocator.free_page(page);
+  _page_allocator.free_page(page, allow_defragment);
 }
 
 size_t ZHeap::free_empty_pages(const ZArray<ZPage*>* pages) {

--- a/src/hotspot/share/gc/z/zHeap.hpp
+++ b/src/hotspot/share/gc/z/zHeap.hpp
@@ -104,7 +104,7 @@ public:
   // Page allocation
   ZPage* alloc_page(ZPageType type, size_t size, ZAllocationFlags flags, ZPageAge age);
   void undo_alloc_page(ZPage* page);
-  void free_page(ZPage* page);
+  void free_page(ZPage* page, bool allow_defragment);
   size_t free_empty_pages(const ZArray<ZPage*>* pages);
 
   // Object allocation

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -488,6 +488,9 @@ ZPage* ZPageAllocator::defragment_page(ZPage* page) {
   ZPage* new_page = new ZPage(ZPageType::small, vmem, pmem);
   map_page(new_page);
 
+  // Update statistics
+  ZStatInc(ZCounterDefragment);
+
   return new_page;
 }
 
@@ -834,7 +837,6 @@ void ZPageAllocator::free_pages(const ZArray<ZPage*>* pages) {
 
     // Check if page needs to be remapped to avoid fragmentation
     if (should_defragment(page)) {
-      ZStatInc(ZCounterDefragment);
       to_recycle.push(defragment_page(_safe_recycle.register_and_clone_if_activated(page)));
     } else {
       to_recycle.push(_safe_recycle.register_and_clone_if_activated(page));

--- a/src/hotspot/share/gc/z/zPageAllocator.hpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.hpp
@@ -106,6 +106,7 @@ private:
 
   bool should_defragment(const ZPage* page) const;
   ZPage* defragment_page(ZPage* page);
+  ZPage* maybe_defragment(ZPage* page, bool allow_defragment);
 
   bool is_alloc_allowed(size_t size) const;
 
@@ -151,6 +152,7 @@ public:
   void reset_statistics(ZGenerationId id);
 
   ZPage* alloc_page(ZPageType type, size_t size, ZAllocationFlags flags, ZPageAge age);
+  ZPage* prepare_to_recycle(ZPage* page, bool allow_defragment);
   void recycle_page(ZPage* page);
   void safe_destroy_page(ZPage* page);
   void free_page(ZPage* page, bool allow_defragment);

--- a/src/hotspot/share/gc/z/zPageAllocator.hpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.hpp
@@ -106,7 +106,6 @@ private:
 
   bool should_defragment(const ZPage* page) const;
   ZPage* defragment_page(ZPage* page);
-  ZPage* maybe_defragment(ZPage* page, bool allow_defragment);
 
   bool is_alloc_allowed(size_t size) const;
 

--- a/src/hotspot/share/gc/z/zPageAllocator.hpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.hpp
@@ -104,13 +104,15 @@ private:
 
   void destroy_page(ZPage* page);
 
+  bool should_defragment(const ZPage* page) const;
+  ZPage* defragment_page(ZPage* page);
+
   bool is_alloc_allowed(size_t size) const;
 
   bool alloc_page_common_inner(ZPageType type, size_t size, ZList<ZPage>* pages);
   bool alloc_page_common(ZPageAllocation* allocation);
   bool alloc_page_stall(ZPageAllocation* allocation);
   bool alloc_page_or_stall(ZPageAllocation* allocation);
-  bool should_defragment(const ZPage* page) const;
   bool is_alloc_satisfied(ZPageAllocation* allocation) const;
   ZPage* alloc_page_create(ZPageAllocation* allocation);
   ZPage* alloc_page_finalize(ZPageAllocation* allocation);

--- a/src/hotspot/share/gc/z/zPageAllocator.hpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.hpp
@@ -153,7 +153,7 @@ public:
   ZPage* alloc_page(ZPageType type, size_t size, ZAllocationFlags flags, ZPageAge age);
   void recycle_page(ZPage* page);
   void safe_destroy_page(ZPage* page);
-  void free_page(ZPage* page);
+  void free_page(ZPage* page, bool allow_defragment);
   void free_pages(const ZArray<ZPage*>* pages);
 
   void enable_safe_destroy() const;

--- a/src/hotspot/share/gc/z/zRelocate.cpp
+++ b/src/hotspot/share/gc/z/zRelocate.cpp
@@ -411,7 +411,7 @@ static void retire_target_page(ZGeneration* generation, ZPage* page) {
   // relocate the remaining objects, leaving the target page empty when
   // relocation completed.
   if (page->used() == 0) {
-    ZHeap::heap()->free_page(page);
+    ZHeap::heap()->free_page(page, true /* allow_defragment */);
   }
 }
 
@@ -1037,7 +1037,7 @@ public:
       page->log_msg(" (relocate page done normal)");
 
       // Free page
-      ZHeap::heap()->free_page(page);
+      ZHeap::heap()->free_page(page, true /* allow_defragment */);
     }
   }
 };


### PR DESCRIPTION
Please review this change to move defragmentation of small pages out of the allocation path,

**Summary**
In ZGC small pages are allocated at lower addresses while medium and large pages are allocated at higher addresses. Sometimes when memory usage is high or the distribution of pages in the cache demand it, small pages can be split out from medium or large pages. When this happens the small page is defragmented by remapping it to a lower address if it resides at a too high address. This is done to avoid fragmentation, but doing it in the allocation path comes with a cost since the remapping involves system calls.

This change moves the remapping away from the allocation path to when the pages are freed after being garbage collected. This can increase the fragmentation a bit, since small pages are allowed to reside at higher addresses for a period time. The expectation is that since small pages are frequently collected the period should be short enough to not cause any problems.

I've done detailed experiments with temporary JFR events to look at the cost of doing the defrag/remapping of pages. One problem is that by default we don't get a lot of defrags (unless we run out of memory), and to better investigate this I also altered the allocation path to force more defragmentation. These tests showed that moving defrag out of the allocation path not only have the positive effect of reducing the time spent allocating, but also spaced out the defragmentation a bit more.  The reason for this is that now we will defrag when a page is freed by the GC, instead of when the page is allocated and the tests show that often many threads allocate at the same time (and then also defrag at the same time). This in turn leads to many concurrent calls down to the system to remap the memory, and this increases the cost of the actual mapping (seen by adding JFR events).

**Additional testing**

- Functional testing in mach5 tier1-7
- Sanity performance testing in aurora

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340426](https://bugs.openjdk.org/browse/JDK-8340426): ZGC: Move defragment out of the allocation path (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Author)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21191/head:pull/21191` \
`$ git checkout pull/21191`

Update a local copy of the PR: \
`$ git checkout pull/21191` \
`$ git pull https://git.openjdk.org/jdk.git pull/21191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21191`

View PR using the GUI difftool: \
`$ git pr show -t 21191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21191.diff">https://git.openjdk.org/jdk/pull/21191.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21191#issuecomment-2375159256)