### PR TITLE
8340721: Clarify special case handling of unboxedType and getWildcardType

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -276,9 +276,9 @@ public interface Types {
      * @param extendsBound  the extends (upper) bound, or {@code null} if none
      * @param superBound    the super (lower) bound, or {@code null} if none
      *
-     * @throws IllegalArgumentException if bounds are not valid,
-     * including for types that are <em>not</em> {@linkplain ReferenceType
-     * reference types}
+     * @throws IllegalArgumentException if bounds are not valid. Invalid bounds
+     * include all types that are not {@linkplain ReferenceType
+     * reference types}.
      * @jls 4.5.1 Type Arguments of Parameterized Types
      */
     WildcardType getWildcardType(TypeMirror extendsBound,

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -50,6 +50,11 @@ import javax.lang.model.type.*;
  * <p><b>Compatibility Note:</b> Methods may be added to this interface
  * in future releases of the platform.
  *
+ * @apiNote
+ * In the reference implementation, handling {@linkplain ErrorType
+ * error types} generally does not cause an {@code
+ * UnsupportedOperationException} from the methods in this interface.
+ *
  * @see javax.annotation.processing.ProcessingEnvironment#getTypeUtils
  * @since 1.6
  */
@@ -198,8 +203,10 @@ public interface Types {
      *
      * @param t  the type to be unboxed
      * @return the type of an unboxed value of type {@code t}
+     *
      * @throws IllegalArgumentException if the given type has no
-     *          unboxing conversion
+     *         unboxing conversion. Only types for the wrapper classes
+     *         have an unboxing conversion.
      * @jls 5.1.8 Unboxing Conversion
      */
     PrimitiveType unboxedType(TypeMirror t);
@@ -268,7 +275,10 @@ public interface Types {
      *
      * @param extendsBound  the extends (upper) bound, or {@code null} if none
      * @param superBound    the super (lower) bound, or {@code null} if none
-     * @throws IllegalArgumentException if bounds are not valid
+     *
+     * @throws IllegalArgumentException if bounds are not valid,
+     * including for types that are <em>not</em> {@linkplain ReferenceType
+     * reference types}
      * @jls 4.5.1 Type Arguments of Parameterized Types
      */
     WildcardType getWildcardType(TypeMirror extendsBound,

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -53,7 +53,7 @@ import javax.lang.model.type.*;
  * @apiNote
  * In the reference implementation, handling {@linkplain ErrorType
  * error types} generally does not cause an {@code
- * UnsupportedOperationException} from the methods in this interface.
+ * IllegalArgumentException} from the methods in this interface.
  *
  * @see javax.annotation.processing.ProcessingEnvironment#getTypeUtils
  * @since 1.6

--- a/test/langtools/tools/javac/processing/model/util/types/TestInvalidInputs.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestInvalidInputs.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8340721
+ * @summary Test invalid inputs to javax.lang.model.util.Types methods
+ * @library /tools/javac/lib
+ * @modules java.compiler
+ * @build JavacTestingAbstractProcessor TestInvalidInputs
+ * @compile -processor TestInvalidInputs -proc:only TestInvalidInputs.java
+ */
+
+import java.util.*;
+import javax.annotation.processing.*;
+import javax.lang.model.element.*;
+import javax.lang.model.type.*;
+import javax.lang.model.util.*;
+
+/**
+ * Test if exceptions are thrown for invalid arguments as expected.
+ */
+public class TestInvalidInputs extends JavacTestingAbstractProcessor {
+
+    // Reference types are ArrayType, DeclaredType, ErrorType, NullType, and TypeVariable
+
+    private TypeMirror       objectType;
+    private TypeMirror       stringType;
+    private ArrayType        arrayType;
+    private DeclaredType     declaredType;
+    // private ErrorType        errorType; // skip for now
+    private ExecutableType   executableType;
+    private IntersectionType intersectionType;
+
+    private NoType           noTypeVoid;
+    private NoType           noTypeNone;
+    private NoType           noTypePackage;
+    private NoType           noTypeModule;
+
+    private NullType         nullType;
+    private PrimitiveType    primitiveType;
+    private UnionType        unionType;
+    private WildcardType     wildcardType;
+
+    /**
+     * Check expected behavior on classes and packages.
+     */
+    public boolean process(Set<? extends TypeElement> annotations,
+                           RoundEnvironment roundEnv) {
+        if (!roundEnv.processingOver()) {
+            initializeTypes();
+            testUnboxedType();
+            testGetWildcardType();
+        }
+        return true;
+    }
+
+    void initializeTypes() {
+        objectType = elements.getTypeElement("java.lang.Object").asType();
+        stringType = elements.getTypeElement("java.lang.String").asType();
+
+        arrayType = types.getArrayType(objectType); // Object[]
+        declaredType = (DeclaredType)objectType;
+        executableType = extractExecutableType();
+        intersectionType = extractIntersectionType();
+
+        noTypeVoid = types.getNoType(TypeKind.VOID);
+        noTypeNone = types.getNoType(TypeKind.NONE);
+        noTypePackage = (NoType)(elements.getPackageElement("java.lang").asType());
+        noTypeModule  = (NoType)(elements.getModuleElement("java.base").asType());
+
+        nullType = types.getNullType();
+        primitiveType = types.getPrimitiveType(TypeKind.DOUBLE);
+        // unionType; // more work here
+        wildcardType = types.getWildcardType(objectType, null);
+
+        return;
+    }
+
+    ExecutableType extractExecutableType() {
+        var typeElement = elements.getTypeElement("TestInvalidInputs.InvalidInputsHost");
+        for (var method : ElementFilter.methodsIn(typeElement.getEnclosedElements())) {
+            if ("foo7".equals(method.getSimpleName().toString())) {
+                return (ExecutableType)method.asType();
+            }
+        }
+        throw new RuntimeException("Expected method not found");
+    }
+
+    IntersectionType extractIntersectionType() {
+        var typeElement = elements.getTypeElement("TestInvalidInputs.InvalidInputsHost");
+        for (var method : ElementFilter.methodsIn(typeElement.getEnclosedElements())) {
+            if ("foo9".equals(method.getSimpleName().toString())) {
+                return (IntersectionType) ((TypeVariable)method.getReturnType()).getUpperBound();
+            }
+        }
+        throw new RuntimeException("Expected method not found");
+    }
+
+    /*
+     * Class to host inputs for testing.
+     */
+    class InvalidInputsHost {
+        // Use a method to get an ExecutableType
+        public static String foo7(int arg) {return null;}
+
+        // Type variable with intersection type
+        public static <S extends Number &  Runnable>  S foo9() {return null;}
+    }
+
+    /**
+     * @throws IllegalArgumentException if the given type has no
+     *         unboxing conversion, including for types that are not
+     *         {@linkplain ReferenceType reference types}
+     */
+    void testUnboxedType() {
+        // Only DeclaredType's for wrapper classes should have unboxing converions defined.
+
+        // Reference types are ArrayType, DeclaredType, ErrorType, NullType, TypeVariable
+        // non-reference: ExecutableType, IntersectionType, NoType, PrimitiveType, UnionType, WildcardType
+        var invalidInputs = List.of(objectType, stringType, arrayType,
+                                    executableType, intersectionType,
+                                    noTypeVoid, noTypeNone, noTypePackage, noTypeModule, nullType,
+                                    primitiveType, /*unionType, */ wildcardType);
+
+        for (TypeMirror tm : invalidInputs) {
+            try {
+                PrimitiveType pt = types.unboxedType(tm);
+            } catch(IllegalArgumentException iae) {
+                ; // Expected
+            }
+        }
+        return;
+    }
+
+    /**
+     * @throws IllegalArgumentException if bounds are not valid,
+     * including for types that are not {@linkplain ReferenceType
+     * reference types}
+     */
+    void testGetWildcardType() {
+        // Reference types are ArrayType, DeclaredType, ErrorType, NullType, TypeVariable
+        // non-reference: ExecutableType, IntersectionType, NoType, PrimitiveType, UnionType, WildcardType
+        var invalidInputs = List.of( arrayType,
+                                    executableType, intersectionType,
+                                    noTypeVoid, noTypeNone, noTypePackage, noTypeModule, nullType,
+                                    primitiveType, /*unionType, */ wildcardType);
+
+        for (TypeMirror tm : invalidInputs) {
+            try {
+                WildcardType wc1 = types.getWildcardType(tm,   null);
+            } catch(IllegalArgumentException iae) {
+                ; // Expected
+            }
+
+            try {
+                WildcardType wc2 = types.getWildcardType(null, tm);
+            } catch(IllegalArgumentException iae) {
+                ; // Expected
+            }
+        }
+        return;
+    }
+}

--- a/test/langtools/tools/javac/processing/model/util/types/TestInvalidInputs.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestInvalidInputs.java
@@ -44,10 +44,9 @@ public class TestInvalidInputs extends JavacTestingAbstractProcessor {
 
     // Reference types are ArrayType, DeclaredType, ErrorType, NullType, and TypeVariable
 
-    private TypeMirror       objectType;
-    private TypeMirror       stringType;
+    private TypeMirror       objectType; // Notable DeclaredType
+    private TypeMirror       stringType; // Another notable DeclaredType
     private ArrayType        arrayType;
-    private DeclaredType     declaredType;
     // private ErrorType        errorType; // skip for now
     private ExecutableType   executableType;
     private IntersectionType intersectionType;
@@ -80,7 +79,6 @@ public class TestInvalidInputs extends JavacTestingAbstractProcessor {
         stringType = elements.getTypeElement("java.lang.String").asType();
 
         arrayType = types.getArrayType(objectType); // Object[]
-        declaredType = (DeclaredType)objectType;
         executableType = extractExecutableType();
         intersectionType = extractIntersectionType();
 
@@ -134,7 +132,7 @@ public class TestInvalidInputs extends JavacTestingAbstractProcessor {
      *         {@linkplain ReferenceType reference types}
      */
     void testUnboxedType() {
-        // Only DeclaredType's for wrapper classes should have unboxing converions defined.
+        // Only DeclaredType's for wrapper classes should have unboxing conversions defined.
 
         // Reference types are ArrayType, DeclaredType, ErrorType, NullType, TypeVariable
         // non-reference: ExecutableType, IntersectionType, NoType, PrimitiveType, UnionType, WildcardType
@@ -146,6 +144,7 @@ public class TestInvalidInputs extends JavacTestingAbstractProcessor {
         for (TypeMirror tm : invalidInputs) {
             try {
                 PrimitiveType pt = types.unboxedType(tm);
+                throw new RuntimeException("Should not reach" + tm);
             } catch(IllegalArgumentException iae) {
                 ; // Expected
             }
@@ -161,20 +160,21 @@ public class TestInvalidInputs extends JavacTestingAbstractProcessor {
     void testGetWildcardType() {
         // Reference types are ArrayType, DeclaredType, ErrorType, NullType, TypeVariable
         // non-reference: ExecutableType, IntersectionType, NoType, PrimitiveType, UnionType, WildcardType
-        var invalidInputs = List.of( arrayType,
-                                    executableType, intersectionType,
+        var invalidInputs = List.of(executableType, intersectionType,
                                     noTypeVoid, noTypeNone, noTypePackage, noTypeModule, nullType,
                                     primitiveType, /*unionType, */ wildcardType);
 
         for (TypeMirror tm : invalidInputs) {
             try {
                 WildcardType wc1 = types.getWildcardType(tm,   null);
+                throw new RuntimeException("Should not reach " + tm);
             } catch(IllegalArgumentException iae) {
                 ; // Expected
             }
 
             try {
                 WildcardType wc2 = types.getWildcardType(null, tm);
+                throw new RuntimeException("Should not reach" + tm);
             } catch(IllegalArgumentException iae) {
                 ; // Expected
             }

--- a/test/langtools/tools/javac/processing/model/util/types/TestInvalidInputs.java
+++ b/test/langtools/tools/javac/processing/model/util/types/TestInvalidInputs.java
@@ -144,7 +144,7 @@ public class TestInvalidInputs extends JavacTestingAbstractProcessor {
         for (TypeMirror tm : invalidInputs) {
             try {
                 PrimitiveType pt = types.unboxedType(tm);
-                throw new RuntimeException("Should not reach" + tm);
+                throw new RuntimeException("Should not reach " + tm);
             } catch(IllegalArgumentException iae) {
                 ; // Expected
             }
@@ -174,7 +174,7 @@ public class TestInvalidInputs extends JavacTestingAbstractProcessor {
 
             try {
                 WildcardType wc2 = types.getWildcardType(null, tm);
-                throw new RuntimeException("Should not reach" + tm);
+                throw new RuntimeException("Should not reach " + tm);
             } catch(IllegalArgumentException iae) {
                 ; // Expected
             }


### PR DESCRIPTION
First piece of a larger set of updates that may be made for JDK-8055219 to clarify the exceptional behavior of `javax.lang.model.util.Types`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8340979](https://bugs.openjdk.org/browse/JDK-8340979) to be approved

### Issues
 * [JDK-8340721](https://bugs.openjdk.org/browse/JDK-8340721): Clarify special case handling of unboxedType and getWildcardType (**Sub-task** - P4)
 * [JDK-8340979](https://bugs.openjdk.org/browse/JDK-8340979): Clarify special case handling of unboxedType and getWildcardType (**CSR**)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21193/head:pull/21193` \
`$ git checkout pull/21193`

Update a local copy of the PR: \
`$ git checkout pull/21193` \
`$ git pull https://git.openjdk.org/jdk.git pull/21193/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21193`

View PR using the GUI difftool: \
`$ git pr show -t 21193`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21193.diff">https://git.openjdk.org/jdk/pull/21193.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21193#issuecomment-2375391880)