### PR TITLE
8340983: Use index and definition tags in Object and Double

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -148,7 +148,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * relations that can be defined over floating-point values:
  *
  * <dl>
- * <dt><a id=fpNumericalEq><i>numerical equality</i></a> ({@code ==}
+ * <dt><a id=fpNumericalEq></a><dfn>{@index "numerical equality"}</dfn> ({@code ==}
  * operator): (<em>Not</em> an equivalence relation)</dt>
  * <dd>Two floating-point values represent the same extended real
  * number. The extended real numbers are the real numbers augmented
@@ -158,7 +158,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * number and is not equal to any value, including itself.
  * </dd>
  *
- * <dt><i>bit-wise equivalence</i>:</dt>
+ * <dt><dfn>{@index "bit-wise equivalence"}</dfn>:</dt>
  * <dd>The bits of the two floating-point values are the same. This
  * equivalence relation for {@code double} values {@code a} and {@code
  * b} is implemented by the expression
@@ -168,7 +168,7 @@ import jdk.internal.vm.annotation.IntrinsicCandidate;
  * is distinguished from every other bit pattern encoding a NaN.
  * </dd>
  *
- * <dt><i><a id=repEquivalence>representation equivalence</a></i>:</dt>
+ * <dt><dfn><a id=repEquivalence></a>{@index "representation equivalence"}</dfn>:</dt>
  * <dd>The two floating-point values represent the same IEEE 754
  * <i>datum</i>. In particular, for {@linkplain #isFinite(double)
  * finite} values, the sign, {@linkplain Math#getExponent(double)

--- a/src/java.base/share/classes/java/lang/Object.java
+++ b/src/java.base/share/classes/java/lang/Object.java
@@ -109,7 +109,7 @@ public class Object {
     /**
      * Indicates whether some other object is "equal to" this one.
      * <p>
-     * The {@code equals} method implements an equivalence relation
+     * The {@code equals} method implements an <dfn>{@index "equivalence relation"}</dfn>
      * on non-null object references:
      * <ul>
      * <li>It is <i>reflexive</i>: for any non-null reference value


### PR DESCRIPTION
Simple change to add a few more index tags on terms related to equality and equivalence.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340983](https://bugs.openjdk.org/browse/JDK-8340983): Use index and definition tags in Object and Double (**Enhancement** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21195/head:pull/21195` \
`$ git checkout pull/21195`

Update a local copy of the PR: \
`$ git checkout pull/21195` \
`$ git pull https://git.openjdk.org/jdk.git pull/21195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21195`

View PR using the GUI difftool: \
`$ git pr show -t 21195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21195.diff">https://git.openjdk.org/jdk/pull/21195.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21195#issuecomment-2375439607)