### PR TITLE
8337679: Memset warning in src/hotspot/share/adlc/adlArena.cpp

### DIFF
--- a/src/hotspot/share/adlc/adlArena.cpp
+++ b/src/hotspot/share/adlc/adlArena.cpp
@@ -63,8 +63,6 @@ void AdlChunk::chop() {
   AdlChunk *k = this;
   while( k ) {
     AdlChunk *tmp = k->_next;
-    // clear out this chunk (to detect allocation bugs)
-    memset(k, 0xBE, k->_len);
     free(k);                    // Free chunk (was malloc'd)
     k = tmp;
   }


### PR DESCRIPTION
The purpose of this `memset` was to overwrite memory with garbage data before freeing it, helping detect bugs where the freed memory is accessed afterward. Therefore, removing it will no impact on functionality. Or it could be zapped with `memset_s` but zapping seems negligible in this case. It passes tier1 tests. See [JDK-8337679](https://bugs.openjdk.org/browse/JDK-8337679).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337679](https://bugs.openjdk.org/browse/JDK-8337679): Memset warning in src/hotspot/share/adlc/adlArena.cpp (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21200/head:pull/21200` \
`$ git checkout pull/21200`

Update a local copy of the PR: \
`$ git checkout pull/21200` \
`$ git pull https://git.openjdk.org/jdk.git pull/21200/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21200`

View PR using the GUI difftool: \
`$ git pr show -t 21200`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21200.diff">https://git.openjdk.org/jdk/pull/21200.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21200#issuecomment-2376413350)