### PR TITLE
8325090: javadoc fails when -subpackages option is used with non-modular -source

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/tool/ElementsTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -870,10 +870,12 @@ public class ElementsTable {
 
     private ModuleSymbol findModuleOfPackageName(String packageName) {
             Name pack = names.fromString(packageName);
-            for (ModuleSymbol msym : modules.allModules()) {
-                PackageSymbol p = syms.getPackage(msym, pack);
-                if (p != null && !p.members().isEmpty()) {
-                    return msym;
+            if (modules.modulesInitialized()) {
+                for (ModuleSymbol msym : modules.allModules()) {
+                    PackageSymbol p = syms.getPackage(msym, pack);
+                    if (p != null && !p.members().isEmpty()) {
+                        return msym;
+                    }
                 }
             }
             return null;

--- a/test/langtools/jdk/javadoc/tool/subpackageNoModules/SubpackageNoModules.java
+++ b/test/langtools/jdk/javadoc/tool/subpackageNoModules/SubpackageNoModules.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8325090
+ * @summary javadoc fails when -subpackages option is used with non-modular -source
+ * @modules jdk.javadoc/jdk.javadoc.internal.api
+ *          jdk.javadoc/jdk.javadoc.internal.tool
+ * @library /tools/lib
+ * @build toolbox.TestRunner toolbox.ToolBox
+ * @run main SubpackageNoModules
+ */
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import toolbox.*;
+import toolbox.Task.Expect;
+
+public class SubpackageNoModules extends TestRunner {
+
+    final ToolBox tb = new ToolBox();
+
+    public SubpackageNoModules() {
+        super(System.err);
+    }
+
+    public static void main(String[] args) throws Exception {
+        SubpackageNoModules t = new SubpackageNoModules();
+        t.runTests(m -> new Object[] { Paths.get(m.getName()) });
+    }
+
+    @Test
+    public void testSubpackageNoModules(Path base) throws Exception {
+        Files.createDirectories(base);
+        tb.writeFile(base.resolve("pkg/A.java"), "package pkg;\npublic class A {}\n");
+
+        Path outDir = base.resolve("out");
+        Files.createDirectory(outDir);
+        // Combine -subpackages option with -source release that doesn't support modules
+        new JavadocTask(tb)
+                .outdir(outDir)
+                .sourcepath(base)
+                .options("-source", "8",
+                        "-subpackages", "pkg")
+                .run(Expect.SUCCESS);
+        // Check for presence of generated docs
+        if (!Files.isRegularFile(outDir.resolve("pkg/A.html"))) {
+            error("File not found: " + outDir.resolve("pkg/A.html"));
+        }
+
+    }
+}

--- a/test/langtools/jdk/javadoc/tool/subpackageNoModules/SubpackageNoModules.java
+++ b/test/langtools/jdk/javadoc/tool/subpackageNoModules/SubpackageNoModules.java
@@ -64,12 +64,11 @@ public class SubpackageNoModules extends TestRunner {
                 .outdir(outDir)
                 .sourcepath(base)
                 .options("-source", "8",
-                        "-subpackages", "pkg")
+                         "-subpackages", "pkg")
                 .run(Expect.SUCCESS);
         // Check for presence of generated docs
         if (!Files.isRegularFile(outDir.resolve("pkg/A.html"))) {
             error("File not found: " + outDir.resolve("pkg/A.html"));
         }
-
     }
 }


### PR DESCRIPTION
Please review a simple fix to prevent `java.lang.AssertionError` from being thrown when the `javadoc` `-subpackages` option is used with a `-source` release that doesn't support modules.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8325090: javadoc fails when -subpackages option is used with non-modular -source`

### Issue
 * [JDK-8325090](https://bugs.openjdk.org/browse/JDK-8325090): javadoc fails when -subpackages option is used with non-modular -source (**Bug** - P3)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21201/head:pull/21201` \
`$ git checkout pull/21201`

Update a local copy of the PR: \
`$ git checkout pull/21201` \
`$ git pull https://git.openjdk.org/jdk.git pull/21201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21201`

View PR using the GUI difftool: \
`$ git pr show -t 21201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21201.diff">https://git.openjdk.org/jdk/pull/21201.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21201#issuecomment-2376465666)