### PR TITLE
8341013: Optimize x86/aarch64 MD5 intrinsics by reducing data dependency

### DIFF
--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3417,14 +3417,14 @@ class StubGenerator: public StubCodeGenerator {
     Register rscratch3 = r10;
     Register rscratch4 = r11;
 
-    __ andw(rscratch3, r2, r4);
     __ bicw(rscratch4, r3, r4);
     reg_cache.extract_u32(rscratch1, k);
     __ movw(rscratch2, t);
-    __ orrw(rscratch3, rscratch3, rscratch4);
     __ addw(rscratch4, r1, rscratch2);
     __ addw(rscratch4, rscratch4, rscratch1);
     __ addw(rscratch3, rscratch3, rscratch4);
+    __ andw(rscratch2, r2, r4);
+    __ addw(rscratch2, rscratch2, rscratch3);
     __ rorw(rscratch2, rscratch3, 32 - s);
     __ addw(r1, rscratch2, r2);
   }

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3417,15 +3417,15 @@ class StubGenerator: public StubCodeGenerator {
     Register rscratch3 = r10;
     Register rscratch4 = r11;
 
-    __ bicw(rscratch4, r3, r4);
     reg_cache.extract_u32(rscratch1, k);
     __ movw(rscratch2, t);
     __ addw(rscratch4, r1, rscratch2);
     __ addw(rscratch4, rscratch4, rscratch1);
-    __ addw(rscratch3, rscratch3, rscratch4);
-    __ andw(rscratch2, r2, r4);
+    __ bicw(rscratch2, r3, r4);
+    __ andw(rscratch3, r2, r4);
+    __ addw(rscratch2, rscratch2, rscratch4);
     __ addw(rscratch2, rscratch2, rscratch3);
-    __ rorw(rscratch2, rscratch3, 32 - s);
+    __ rorw(rscratch2, rscratch2, 32 - s);
     __ addw(r1, rscratch2, r2);
   }
 

--- a/src/hotspot/cpu/x86/macroAssembler_x86_md5.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86_md5.cpp
@@ -81,8 +81,8 @@ void MacroAssembler::fast_md5(Register buf, Address state, Address ofs, Address 
   notl(rsi);                                     \
   andl(rdi, r2);                                 \
   andl(rsi, r3);                                 \
-  orl(rsi, rdi);                                 \
   addl(r1, rsi);                                 \
+  addl(r1, rdi);                                 \
   roll(r1, s);                                   \
   addl(r1, r2);
 


### PR DESCRIPTION
As suggested in https://github.com/animetosho/md5-optimisation?tab=readme-ov-file#dependency-shortcut-in-g-function, we can delay the dependency on 'b' by recognizing that the ((d & b) | (~d & c)) is equivalent to ((d & b) + (~d & c)) in this scenario, and we can perform those additions independently, leaving our dependency on b to the final addition. This speeds it up around 5%.

Benchmark results on my two hosts:

```
Benchmark                  (algorithm)  (dataSize)  (provider)   Mode  Cnt    Score   Error  Units

x86 Before:
MessageDigestBench.digest          MD5     1048576              thrpt   10  636.389 ± 0.240  ops/s

x86 After:
MessageDigestBench.digest          MD5     1048576              thrpt   10  671.611 ± 0.226  ops/s (+5.5%)


aarch64 Before:
MessageDigestBench.digest          MD5     1048576              thrpt   10  498.613 ± 0.359  ops/s

aarch64 After:
MessageDigestBench.digest          MD5     1048576              thrpt   10  526.008 ± 0.491  ops/s (+5.6%)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341013](https://bugs.openjdk.org/browse/JDK-8341013): Optimize x86/aarch64 MD5 intrinsics by reducing data dependency (**Enhancement** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21203/head:pull/21203` \
`$ git checkout pull/21203`

Update a local copy of the PR: \
`$ git checkout pull/21203` \
`$ git pull https://git.openjdk.org/jdk.git pull/21203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21203`

View PR using the GUI difftool: \
`$ git pr show -t 21203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21203.diff">https://git.openjdk.org/jdk/pull/21203.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21203#issuecomment-2376696939)