### PR TITLE
8341015: OopStorage location decoder crashes accessing non-initalized OopStorage

### DIFF
--- a/src/hotspot/share/gc/shared/oopStorageSet.cpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.cpp
@@ -86,7 +86,9 @@ bool OopStorageSet::print_containing(const void* addr, outputStream* st) {
   if (addr != nullptr) {
     const void* aligned_addr = align_down(addr, alignof(oop));
     for (OopStorage* storage : Range<Id>()) {
-      if (storage != nullptr && storage->print_containing((oop*) aligned_addr, st)) {
+      // Check for null for extra safety: might get here while handling error
+      // before storage initialization.
+      if ((storage != nullptr) && storage->print_containing((oop*) aligned_addr, st)) {
         if (aligned_addr != addr) {
           st->print_cr(" (unaligned)");
         } else {

--- a/src/hotspot/share/gc/shared/oopStorageSet.cpp
+++ b/src/hotspot/share/gc/shared/oopStorageSet.cpp
@@ -86,7 +86,7 @@ bool OopStorageSet::print_containing(const void* addr, outputStream* st) {
   if (addr != nullptr) {
     const void* aligned_addr = align_down(addr, alignof(oop));
     for (OopStorage* storage : Range<Id>()) {
-      if (storage->print_containing((oop*) aligned_addr, st)) {
+      if (storage != nullptr && storage->print_containing((oop*) aligned_addr, st)) {
         if (aligned_addr != addr) {
           st->print_cr(" (unaligned)");
         } else {


### PR DESCRIPTION
When debugging CDS, I asked for `os::print_location` before OopStorage was initialized, like an error handler would do. This is a fairly unusual situation, this is why we have not seen it before. Anyhow, we entered the new code added by [JDK-8340392](https://bugs.openjdk.org/browse/JDK-8340392), which crashed on `OopStorage` that was `nullptr`. I think we should null-check `OopStorage` before calling into it.

Additional testing:
 - [x] OopStorageSetTest still passing
 - [x] Verified the check is now passing in similar debugging session

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341015](https://bugs.openjdk.org/browse/JDK-8341015): OopStorage location decoder crashes accessing non-initalized OopStorage (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21204/head:pull/21204` \
`$ git checkout pull/21204`

Update a local copy of the PR: \
`$ git checkout pull/21204` \
`$ git pull https://git.openjdk.org/jdk.git pull/21204/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21204`

View PR using the GUI difftool: \
`$ git pr show -t 21204`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21204.diff">https://git.openjdk.org/jdk/pull/21204.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21204#issuecomment-2376707062)