### PR TITLE
8341027: Crash in java/runtime/Unsafe/InternalErrorTest when running with -XX:-UseCompressedClassPointers

### DIFF
--- a/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
+++ b/test/hotspot/jtreg/runtime/Unsafe/InternalErrorTest.java
@@ -147,7 +147,8 @@ public class InternalErrorTest {
                 break;
             case 1:
                 // testing Unsafe.copySwapMemory, trying to access next page after truncation.
-                unsafe.copySwapMemory(null, mapAddr + pageSize, new byte[4000], 16, 2000, 2);
+                int destOffset = Unsafe.ARRAY_BYTE_BASE_OFFSET;
+                unsafe.copySwapMemory(null, mapAddr + pageSize, new byte[4000], destOffset, 2000, 2);
                 break;
             case 2:
                 // testing Unsafe.copySwapMemory, trying to access next page after truncation.


### PR DESCRIPTION
The JVM crashes in the GC because the destroys the length fields of the array it uses as the destination.

One example of the failures you see with this:
```
# guarantee(p == top()) failed: end of last object must match end of space
...
V [libjvm.so+0x147e054] ContiguousSpace::verify() const+0x1e0 (space.cpp:95)
V [libjvm.so+0x974118] DefNewGeneration::verify()+0x18 (defNewGeneration.cpp:834)
V [libjvm.so+0x1448a88] SerialHeap::verify(VerifyOption)+0x78 (serialHeap.cpp:881)
V [libjvm.so+0x15d9cd0] Universe::verify(VerifyOption, char const*)+0x490 (universe.cpp:1240)
V [libjvm.so+0x1673890] VM_Exit::doit()+0xa0 (universe.hpp:349) 
```

Fix this by changing the hard-coded 16 to the proper array base offset, which changes depending on the value of `UseCompressedClassPointers`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341027](https://bugs.openjdk.org/browse/JDK-8341027): Crash in java/runtime/Unsafe/InternalErrorTest when running with -XX:-UseCompressedClassPointers (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21208/head:pull/21208` \
`$ git checkout pull/21208`

Update a local copy of the PR: \
`$ git checkout pull/21208` \
`$ git pull https://git.openjdk.org/jdk.git pull/21208/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21208`

View PR using the GUI difftool: \
`$ git pr show -t 21208`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21208.diff">https://git.openjdk.org/jdk/pull/21208.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21208#issuecomment-2376924378)