### PR TITLE
8341028: Do not use lambdas or method refs for verifyConstantPool

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/ParserVerifier.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/verifier/ParserVerifier.java
@@ -78,31 +78,63 @@ public record ParserVerifier(ClassModel classModel) {
                     case MethodHandleEntry mhe -> mhe.asSymbol();
                     case MethodTypeEntry mte -> mte.asSymbol();
                     case FieldRefEntry fre -> {
-                        fre.owner().asSymbol();
-                        fre.typeSymbol();
+                        try {
+                            fre.owner().asSymbol();
+                        } catch (VerifyError|Exception e) {
+                            errors.add(cpeVerifyError(cpe, e));
+                        }
+                        try {
+                            fre.typeSymbol();
+                        } catch (VerifyError|Exception e) {
+                            errors.add(cpeVerifyError(cpe, e));
+                        }
                         verifyFieldName(fre.name().stringValue());
                     }
                     case InterfaceMethodRefEntry imre -> {
-                        imre.owner().asSymbol();
-                        imre.typeSymbol();
+                        try {
+                            imre.owner().asSymbol();
+                        } catch (VerifyError|Exception e) {
+                            errors.add(cpeVerifyError(cpe, e));
+                        }
+                        try {
+                            imre.typeSymbol();
+                        } catch (VerifyError|Exception e) {
+                            errors.add(cpeVerifyError(cpe, e));
+                        }
                         verifyMethodName(imre.name().stringValue());
                     }
                     case MethodRefEntry mre -> {
-                        mre.owner().asSymbol();
-                        mre.typeSymbol();
+                        try {
+                            mre.owner().asSymbol();
+                        } catch (VerifyError|Exception e) {
+                            errors.add(cpeVerifyError(cpe, e));
+                        }
+                        try {
+                            mre.typeSymbol();
+                        } catch (VerifyError|Exception e) {
+                            errors.add(cpeVerifyError(cpe, e));
+                        }
                         verifyMethodName(mre.name().stringValue());
                     }
                     case ModuleEntry me -> me.asSymbol();
                     case NameAndTypeEntry nate -> {
-                        nate.name().stringValue();
+                        try {
+                            nate.name().stringValue();
+                        } catch (VerifyError|Exception e) {
+                            errors.add(cpeVerifyError(cpe, e));
+                        }
                         nate.type().stringValue();
                     }
                     case PackageEntry pe -> pe.asSymbol();
                 }
             } catch (VerifyError|Exception e) {
-                errors.add(new VerifyError("%s at constant pool index %d in %s".formatted(e.getMessage(), cpe.index(), toString(classModel))));
+                errors.add(cpeVerifyError(cpe, e));
             }
         }
+    }
+
+    private VerifyError cpeVerifyError(final PoolEntry cpe, final Throwable e) {
+        return new VerifyError("%s at constant pool index %d in %s".formatted(e.getMessage(), cpe.index(), toString(classModel)));
     }
 
     private void verifyFieldName(String name) {


### PR DESCRIPTION
Currently, `ParserVerifier#verifyConstantPool` uses a `switch` to produce a `Runnable`, which is consumed by a `Consumer<Runnable>` (instantiated within a loop) which runs the task inside if a `try`/`catch`. We can eliminate a number of lambdas and method references, plus some allocation pressure, in this code by simplifying it so that the `switch` is itself run directly within the `try`/`catch`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341028](https://bugs.openjdk.org/browse/JDK-8341028): Do not use lambdas or method refs for verifyConstantPool (**Bug** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21209/head:pull/21209` \
`$ git checkout pull/21209`

Update a local copy of the PR: \
`$ git checkout pull/21209` \
`$ git pull https://git.openjdk.org/jdk.git pull/21209/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21209`

View PR using the GUI difftool: \
`$ git pr show -t 21209`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21209.diff">https://git.openjdk.org/jdk/pull/21209.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21209#issuecomment-2376996644)
</details>
