### PR TITLE
Sample tests which demonstrate the standard multi-window layouts

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckSegmentedCodeCache.java
@@ -179,7 +179,9 @@ public class CheckSegmentedCodeCache {
         // Fails if code heap sizes do not add up
         pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+SegmentedCodeCache",
                                                               "-XX:ReservedCodeCacheSize=10M",
-                                                              "-XX:NonNMethodCodeHeapSize=5M",
+                                                              // After fixing a round_down issue with large page sizes (JDK-8334564),
+                                                              // 5M is a bit too small for NonNMethodCodeHeap
+                                                              "-XX:NonNMethodCodeHeapSize=6M",
                                                               "-XX:ProfiledCodeHeapSize=5M",
                                                               "-XX:NonProfiledCodeHeapSize=5M",
                                                               "-version");

--- a/test/jdk/java/awt/Window/8294156/layouts/BottomOneColumn.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/BottomOneColumn.java
@@ -23,7 +23,7 @@ public class BottomOneColumn {
             the bottom of the instruction frame in one column.
             The test windows are aligned to the left of the
             instruction frame.
-            
+
             Layout: WindowLayouts::bottomOneColumn
             """;
 }

--- a/test/jdk/java/awt/Window/8294156/layouts/BottomOneColumn.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/BottomOneColumn.java
@@ -1,0 +1,29 @@
+/*
+ * @test
+ * @bug 8294156 8317116
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Position test windows in a column to the bottom of the instructions
+ * @run main/manual BottomOneColumn
+ */
+public class BottomOneColumn {
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .instructions(INSTRUCTIONS)
+                      .rows(7)
+                      .columns(30)
+                      .testUI(() -> WindowCreator.createTestWindows(2))
+                      .positionTestUIBottomColumn()
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static final String INSTRUCTIONS = """
+            A simple demo with 2 test windows positioned to
+            the bottom of the instruction frame in one column.
+            The test windows are aligned to the left of the
+            instruction frame.
+            
+            Layout: WindowLayouts::bottomOneColumn
+            """;
+}

--- a/test/jdk/java/awt/Window/8294156/layouts/BottomOneRow.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/BottomOneRow.java
@@ -23,7 +23,7 @@ public class BottomOneRow {
             the bottom of the instruction frame in one row.
             The left of the first test window is aligned to
             that of the instruction frame.
-            
+
             Layout: WindowLayouts::bottomOneRow
             """;
 }

--- a/test/jdk/java/awt/Window/8294156/layouts/BottomOneRow.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/BottomOneRow.java
@@ -1,0 +1,29 @@
+/*
+ * @test
+ * @bug 8294156 8317116
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Position test windows in a row to the bottom of the instructions
+ * @run main/manual BottomOneRow
+ */
+public class BottomOneRow {
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .instructions(INSTRUCTIONS)
+                      .rows(15)
+                      .columns(30)
+                      .testUI(() -> WindowCreator.createTestWindows(3))
+                      .positionTestUIBottomRow()
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static final String INSTRUCTIONS = """
+            A simple demo with 3 test windows positioned to
+            the bottom of the instruction frame in one row.
+            The left of the first test window is aligned to
+            that of the instruction frame.
+            
+            Layout: WindowLayouts::bottomOneRow
+            """;
+}

--- a/test/jdk/java/awt/Window/8294156/layouts/BottomOneRowCentered.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/BottomOneRowCentered.java
@@ -22,7 +22,7 @@ public class BottomOneRowCentered {
             A simple demo with 4 test windows positioned to
             the bottom of the instruction frame in one row.
             The row of the test windows is centered on the screen.
-            
+
             Layout: WindowLayouts::bottomOneRowCentered
             """;
 }

--- a/test/jdk/java/awt/Window/8294156/layouts/BottomOneRowCentered.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/BottomOneRowCentered.java
@@ -1,0 +1,28 @@
+/*
+ * @test
+ * @bug 8294156 8317116
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Position test windows in a centered row to the bottom of the instructions
+ * @run main/manual BottomOneRowCentered
+ */
+public class BottomOneRowCentered {
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .instructions(INSTRUCTIONS)
+                      .rows(7)
+                      .columns(30)
+                      .testUI(() -> WindowCreator.createTestWindows(4))
+                      .positionTestUIBottomRowCentered()
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static final String INSTRUCTIONS = """
+            A simple demo with 4 test windows positioned to
+            the bottom of the instruction frame in one row.
+            The row of the test windows is centered on the screen.
+            
+            Layout: WindowLayouts::bottomOneRowCentered
+            """;
+}

--- a/test/jdk/java/awt/Window/8294156/layouts/RightOneColumn.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/RightOneColumn.java
@@ -23,7 +23,7 @@ public class RightOneColumn {
             the right of the instruction frame in one column.
             The top of the first test window is aligned to
             that of the instruction frame.
-            
+
             Layout: WindowLayouts::rightOneColumn
             """;
 }

--- a/test/jdk/java/awt/Window/8294156/layouts/RightOneColumn.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/RightOneColumn.java
@@ -1,0 +1,29 @@
+/*
+ * @test
+ * @bug 8294156 8317116
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Position test windows in a column to the right of the instructions
+ * @run main/manual RightOneColumn
+ */
+public class RightOneColumn {
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .instructions(INSTRUCTIONS)
+                      .rows(15)
+                      .columns(30)
+                      .testUI(() -> WindowCreator.createTestWindows(3))
+                      .positionTestUIRightColumn()
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static final String INSTRUCTIONS = """
+            A simple demo with 3 test windows positioned to
+            the right of the instruction frame in one column.
+            The top of the first test window is aligned to
+            that of the instruction frame.
+            
+            Layout: WindowLayouts::rightOneColumn
+            """;
+}

--- a/test/jdk/java/awt/Window/8294156/layouts/RightOneColumnCentered.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/RightOneColumnCentered.java
@@ -23,7 +23,7 @@ public class RightOneColumnCentered {
             the right of the instruction frame in one column.
             The column of the windows is centered vertically
             on the screen.
-            
+
             Layout: WindowLayouts::rightOneColumnCentered
             """;
 }

--- a/test/jdk/java/awt/Window/8294156/layouts/RightOneColumnCentered.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/RightOneColumnCentered.java
@@ -1,0 +1,29 @@
+/*
+ * @test
+ * @bug 8294156 8317116
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Position test windows in a centered column to the right of the instructions
+ * @run main/manual RightOneColumnCentered
+ */
+public class RightOneColumnCentered {
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .instructions(INSTRUCTIONS)
+                      .rows(15)
+                      .columns(30)
+                      .testUI(() -> WindowCreator.createTestWindows(5))
+                      .positionTestUIRightColumnCentered()
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static final String INSTRUCTIONS = """
+            A simple demo with 5 test windows positioned to
+            the right of the instruction frame in one column.
+            The column of the windows is centered vertically
+            on the screen.
+            
+            Layout: WindowLayouts::rightOneColumnCentered
+            """;
+}

--- a/test/jdk/java/awt/Window/8294156/layouts/RightOneRow.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/RightOneRow.java
@@ -12,14 +12,14 @@ public class RightOneRow {
                       .instructions(INSTRUCTIONS)
                       .rows(15)
                       .columns(30)
-                      .testUI(() -> WindowCreator.createTestWindows(3))
+                      .testUI(() -> WindowCreator.createTestWindows(2))
                       .positionTestUIRightRow()
                       .build()
                       .awaitAndCheck();
     }
 
     private static final String INSTRUCTIONS = """
-            A simple demo with 3 test windows positioned to
+            A simple demo with 2 test windows positioned to
             the right of the instruction frame in one row.
             The top of the test windows is aligned to
             that of the instruction frame.

--- a/test/jdk/java/awt/Window/8294156/layouts/RightOneRow.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/RightOneRow.java
@@ -23,7 +23,7 @@ public class RightOneRow {
             the right of the instruction frame in one row.
             The top of the test windows is aligned to
             that of the instruction frame.
-            
+
             Layout: WindowLayouts::rightOneColumn
             """;
 }

--- a/test/jdk/java/awt/Window/8294156/layouts/RightOneRow.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/RightOneRow.java
@@ -1,0 +1,29 @@
+/*
+ * @test
+ * @bug 8294156 8317116
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @summary Position test windows in a row to the right of the instructions
+ * @run main/manual RightOneRow
+ */
+public class RightOneRow {
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .instructions(INSTRUCTIONS)
+                      .rows(15)
+                      .columns(30)
+                      .testUI(() -> WindowCreator.createTestWindows(3))
+                      .positionTestUIRightRow()
+                      .build()
+                      .awaitAndCheck();
+    }
+
+    private static final String INSTRUCTIONS = """
+            A simple demo with 3 test windows positioned to
+            the right of the instruction frame in one row.
+            The top of the test windows is aligned to
+            that of the instruction frame.
+            
+            Layout: WindowLayouts::rightOneColumn
+            """;
+}

--- a/test/jdk/java/awt/Window/8294156/layouts/WindowCreator.java
+++ b/test/jdk/java/awt/Window/8294156/layouts/WindowCreator.java
@@ -1,0 +1,44 @@
+import java.awt.Color;
+import java.awt.Dimension;
+import java.util.List;
+import java.util.stream.IntStream;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+
+public final class WindowCreator {
+    public static List<JFrame> createTestWindows(final int windowLimit) {
+        return IntStream.rangeClosed(0, windowLimit - 1)
+                        .mapToObj(WindowCreator::createFrame)
+                        .toList();
+    }
+
+    private static final Dimension[] SIZE = {
+            new Dimension(300, 150),
+            new Dimension(250, 100),
+            new Dimension(350, 200),
+            new Dimension(225, 100),
+    };
+
+    private static final Color[] COLORS = {
+            new Color(240, 200, 240),
+            new Color(200, 240, 200),
+            new Color(200, 240, 240)
+    };
+
+    private static JFrame createFrame(int index) {
+        JFrame frame = new JFrame("Window " + (index + 1));
+        frame.add(createPanel(SIZE[index % SIZE.length],
+                              COLORS[index % COLORS.length]));
+        frame.pack();
+        return frame;
+    }
+
+    private static JPanel createPanel(final Dimension size,
+                                      final Color color) {
+        JPanel panel = new JPanel();
+        panel.setPreferredSize(size);
+        panel.setBackground(color);
+        return panel;
+    }
+}

--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -171,6 +171,11 @@ public final class PassFailJFrame {
     private static final int COLUMNS = 40;
 
     /**
+     * A gap between windows.
+     */
+    public static final int WINDOW_GAP = 8;
+
+    /**
      * Prefix for the user-provided failure reason.
      */
     private static final String FAILURE_REASON = "Failure Reason:\n";
@@ -1007,13 +1012,13 @@ public final class PassFailJFrame {
 
         switch (position) {
             case HORIZONTAL:
-                int newX = ((screenSize.width / 2) - frame.getWidth());
+                int newX = (((screenSize.width + WINDOW_GAP) / 2) - frame.getWidth());
                 frame.setLocation((newX + screenInsets.left),
                                   (frame.getY() + screenInsets.top));
                 break;
 
             case VERTICAL:
-                int newY = ((screenSize.height / 2) - frame.getHeight());
+                int newY = ((screenSize.height + WINDOW_GAP / 2) - frame.getHeight());
                 frame.setLocation((frame.getX() + screenInsets.left),
                                   (newY + screenInsets.top));
                 break;
@@ -1061,13 +1066,13 @@ public final class PassFailJFrame {
             switch (position) {
                 case HORIZONTAL:
                 case TOP_LEFT_CORNER:
-                    testWindow.setLocation((frame.getX() + frame.getWidth() + 5),
+                    testWindow.setLocation((frame.getX() + frame.getWidth() + WINDOW_GAP),
                                            frame.getY());
                     break;
 
                 case VERTICAL:
                     testWindow.setLocation(frame.getX(),
-                                           (frame.getY() + frame.getHeight() + 5));
+                                           (frame.getY() + frame.getHeight() + WINDOW_GAP));
                     break;
             }
         }
@@ -1370,6 +1375,7 @@ public final class PassFailJFrame {
             return this;
         }
 
+
         /**
          * Adds an implementation of {@link PositionWindows PositionWindows}
          * which the framework will use to position multiple test UI windows.
@@ -1392,6 +1398,77 @@ public final class PassFailJFrame {
             this.positionWindows = positionWindows;
             return this;
         }
+
+        /**
+         * Positions the test UI windows in a row to the right of
+         * the instruction frame. The top of the windows is aligned to
+         * that of the instruction frame.
+         *
+         * @return this builder
+         */
+        public Builder positionTestUIRightRow() {
+            return position(Position.HORIZONTAL)
+                   .positionTestUI(WindowLayouts::rightOneRow);
+        }
+
+        /**
+         * Positions the test UI windows in a column to the right of
+         * the instruction frame. The top of the first window is aligned to
+         * that of the instruction frame.
+         *
+         * @return this builder
+         */
+        public Builder positionTestUIRightColumn() {
+            return position(Position.HORIZONTAL)
+                   .positionTestUI(WindowLayouts::rightOneColumn);
+        }
+
+        /**
+         * Positions the test UI windows in a column to the right of
+         * the instruction frame centering the stack of the windows.
+         *
+         * @return this builder
+         */
+        public Builder positionTestUIRightColumnCentered() {
+            return position(Position.HORIZONTAL)
+                   .positionTestUI(WindowLayouts::rightOneColumnCentered);
+        }
+
+        /**
+         * Positions the test UI windows in a row to the bottom of
+         * the instruction frame. The left of the first window is aligned to
+         * that of the instruction frame.
+         *
+         * @return this builder
+         */
+        public Builder positionTestUIBottomRow() {
+            return position(Position.VERTICAL)
+                   .positionTestUI(WindowLayouts::bottomOneRow);
+        }
+
+        /**
+         * Positions the test UI windows in a row to the bottom of
+         * the instruction frame centering the row of the windows.
+         *
+         * @return this builder
+         */
+        public Builder positionTestUIBottomRowCentered() {
+            return position(Position.VERTICAL)
+                   .positionTestUI(WindowLayouts::bottomOneRowCentered);
+        }
+
+        /**
+         * Positions the test UI windows in a column to the bottom of
+         * the instruction frame. The left of the first window is aligned to
+         * that of the instruction frame.
+         *
+         * @return this builder
+         */
+        public Builder positionTestUIBottomColumn() {
+            return position(Position.VERTICAL)
+                   .positionTestUI(WindowLayouts::bottomOneColumn);
+        }
+
 
         /**
          * Adds a {@code WindowListCreator} which the framework will use
@@ -1494,6 +1571,7 @@ public final class PassFailJFrame {
             this.panelCreator = panelCreator;
             return this;
         }
+
 
         /**
          * Adds a {@code PanelCreator} which the framework will use

--- a/test/jdk/java/awt/regtesthelpers/WindowLayouts.java
+++ b/test/jdk/java/awt/regtesthelpers/WindowLayouts.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.Insets;
+import java.awt.Point;
+import java.awt.Window;
+import java.util.List;
+
+import static java.awt.GraphicsEnvironment.getLocalGraphicsEnvironment;
+import static java.awt.Toolkit.getDefaultToolkit;
+
+/**
+ * A utility class which provides standard window layouts for multi-window
+ * manual tests using the {@link PassFailJFrame} framework.
+ * The layout methods {@code right-} and {@code bottom-} implement the
+ * {@link PassFailJFrame.PositionWindows PositionWindows} interface and
+ * can be used directly or via builder methods.
+ * <p>
+ * There are several helper methods, such as
+ * {@link #getScreenCenter() getScreenCenter}, which could help you
+ * implement customized windows layouts.
+ */
+public final class WindowLayouts {
+
+    /** Private constructor to prevent instantiating the utility class. */
+    private WindowLayouts() {
+    }
+
+    /** A gap between windows. (Local copy makes expressions shorter.) */
+    private static final int WINDOW_GAP = PassFailJFrame.WINDOW_GAP;
+
+    /**
+     * Lays out the window list in one row to the right of
+     * the instruction frame. The top of the windows is aligned to
+     * that of the instruction frame.
+     *
+     * @param windows the list of windows to lay out
+     * @param instructionUI information about the instruction frame
+     */
+    public static void rightOneRow(final List<Window> windows,
+                                   final PassFailJFrame.InstructionUI instructionUI) {
+        layoutRow(instructionUI.getLocation().x
+                  + instructionUI.getSize().width
+                  + WINDOW_GAP,
+                  instructionUI.getLocation().y,
+                  windows);
+    }
+
+    /**
+     * Lays out the window list in one column to the right of
+     * the instruction frame. The top of the first window is aligned to
+     * that of the instruction frame.
+     *
+     * @param windows the list of windows to lay out
+     * @param instructionUI information about the instruction frame
+     */
+    public static void rightOneColumn(final List<Window> windows,
+                                      final PassFailJFrame.InstructionUI instructionUI) {
+        layoutColumn(instructionUI.getLocation().x
+                     + instructionUI.getSize().width
+                     + WINDOW_GAP,
+                     instructionUI.getLocation().y,
+                     windows);
+    }
+
+    /**
+     * Lays out the window list in one column to the right of
+     * the instruction frame centering the stack of the windows.
+     *
+     * @param windows the list of windows to lay out
+     * @param instructionUI information about the instruction frame
+     */
+    public static void rightOneColumnCentered(final List<Window> windows,
+                                              final PassFailJFrame.InstructionUI instructionUI) {
+        layoutColumn(instructionUI.getLocation().x
+                     + instructionUI.getSize().width
+                     + WINDOW_GAP,
+                     getScreenCenter().y
+                     - getWindowListHeight(windows) / 2,
+                     windows);
+    }
+
+
+    /**
+     * Lays out the window list in one row to the bottom of
+     * the instruction frame. The left of the first window is aligned to
+     * that of the instruction frame.
+     *
+     * @param windows the list of windows to lay out
+     * @param instructionUI information about the instruction frame
+     */
+    public static void bottomOneRow(final List<Window> windows,
+                                    final PassFailJFrame.InstructionUI instructionUI) {
+        layoutRow(instructionUI.getLocation().x,
+                  instructionUI.getLocation().y
+                  + instructionUI.getSize().height
+                  + WINDOW_GAP,
+                  windows);
+    }
+
+    /**
+     * Lays out the window list in one row to the bottom of
+     * the instruction frame centering the row of the windows.
+     *
+     * @param windows the list of windows to lay out
+     * @param instructionUI information about the instruction frame
+     */
+    public static void bottomOneRowCentered(final List<Window> windows,
+                                            final PassFailJFrame.InstructionUI instructionUI) {
+        layoutColumn(getScreenCenter().x
+                     - getWindowListWidth(windows) / 2,
+                     instructionUI.getLocation().y
+                     + instructionUI.getSize().height
+                     + WINDOW_GAP,
+                     windows);
+    }
+
+    /**
+     * Lays out the window list in one column to the bottom of
+     * the instruction frame. The left of the first window is aligned to
+     * that of the instruction frame.
+     *
+     * @param windows the list of windows to lay out
+     * @param instructionUI information about the instruction frame
+     */
+    public static void bottomOneColumn(final List<Window> windows,
+                                       final PassFailJFrame.InstructionUI instructionUI) {
+        layoutColumn(instructionUI.getLocation().x,
+                     instructionUI.getLocation().y
+                     + instructionUI.getSize().height
+                     + WINDOW_GAP,
+                     windows);
+    }
+
+
+    /**
+     * Lays out the window list in one row starting at
+     * ({@code x0}, {@code y}).
+     *
+     * @param x0 the starting <var>x</var> coordinate of the windows
+     * @param y the <var>y</var> coordinate of the windows
+     * @param windows the list of windows to lay out
+     */
+    public static void layoutRow(final int x0,
+                                 final int y,
+                                 final List<Window> windows) {
+        int x = x0;
+        for (Window w : windows) {
+            w.setLocation(x, y);
+            x += w.getWidth() + WINDOW_GAP;
+        }
+
+    }
+
+    /**
+     * Lays out the window list in one column starting at
+     * ({@code x}, {@code y0}).
+     *
+     * @param x the <var>x</var> coordinate of the windows
+     * @param y0 the starting <var>y</var> coordinate of the windows
+     * @param windows the list of windows to lay out
+     */
+    public static void layoutColumn(final int x,
+                                    final int y0,
+                                    final List<Window> windows) {
+        int y = y0;
+        for (Window w : windows) {
+            w.setLocation(x, y);
+            y += w.getHeight() + WINDOW_GAP;
+        }
+    }
+
+
+    /**
+     * {@return the center point of the main screen}
+     */
+    public static Point getScreenCenter() {
+        GraphicsConfiguration gc = getLocalGraphicsEnvironment()
+                                   .getDefaultScreenDevice()
+                                   .getDefaultConfiguration();
+        Dimension size = gc.getBounds()
+                           .getSize();
+        Insets insets = getDefaultToolkit()
+                        .getScreenInsets(gc);
+
+        return new Point((size.width - insets.left - insets.right) / 2,
+                         (size.height - insets.top - insets.bottom) / 2);
+    }
+
+    /**
+     * {@return width of the windows in the list, taking into account
+     * the gap between windows}
+     *
+     * @param windows the list of windows to get the width of
+     */
+    public static int getWindowListWidth(final List<Window> windows) {
+        return windows.stream()
+                      .mapToInt(Component::getWidth)
+                      .sum()
+               + WINDOW_GAP * (windows.size() - 1);
+    }
+
+    /**
+     * {@return height of the windows in the list, taking into account
+     * the gap between windows}
+     *
+     * @param windows the list of windows to get the height of
+     */
+    public static int getWindowListHeight(final List<Window> windows) {
+        return windows.stream()
+                      .mapToInt(Component::getHeight)
+                      .sum()
+               + WINDOW_GAP * (windows.size() - 1);
+    }
+}


### PR DESCRIPTION
**This PR is not meant to be integrated.**

The purpose of this PR is to demonstrate the standard multi-window layouts added in #21207. This PR similar to #15721 which demonstrated the initial proof of concept for multiple test UI windows.

There are six tests in `test/jdk/java/awt/Window/8294156/layouts` for each layout method provided and a helper `WindowCreator` class which creates a given set of windows.

To play around, you can checkout the PR branch using the commands that bots add. Alternatively, you can checkout directly the branch from my fork:

```bash
git fetch https://github.com/aivanov-jdk/jdk.git 8317116-passFail-WindowLayouts-demo:8317116-passFail-WindowLayouts-demo
git checkout 8317116-passFail-WindowLayouts-demo
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21210/head:pull/21210` \
`$ git checkout pull/21210`

Update a local copy of the PR: \
`$ git checkout pull/21210` \
`$ git pull https://git.openjdk.org/jdk.git pull/21210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21210`

View PR using the GUI difftool: \
`$ git pr show -t 21210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21210.diff">https://git.openjdk.org/jdk/pull/21210.diff</a>

</details>
