### PR TITLE
8330606: Redefinition doesn't but should verify the new klass

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.cpp
+++ b/src/hotspot/share/classfile/classFileParser.cpp
@@ -4688,7 +4688,7 @@ const char* ClassFileParser::skip_over_field_signature(const char* signature,
 
 // Checks if name is a legal class name.
 void ClassFileParser::verify_legal_class_name(const Symbol* name, TRAPS) const {
-  if (!_need_verify || _relax_verify) { return; }
+  if (!_need_verify) { return; }
 
   assert(name->refcount() > 0, "symbol must be kept alive");
   char* bytes = (char*)name->bytes();
@@ -4728,7 +4728,7 @@ void ClassFileParser::verify_legal_class_name(const Symbol* name, TRAPS) const {
 
 // Checks if name is a legal field name.
 void ClassFileParser::verify_legal_field_name(const Symbol* name, TRAPS) const {
-  if (!_need_verify || _relax_verify) { return; }
+  if (!_need_verify) { return; }
 
   char* bytes = (char*)name->bytes();
   unsigned int length = name->utf8_length();
@@ -4761,7 +4761,7 @@ void ClassFileParser::verify_legal_field_name(const Symbol* name, TRAPS) const {
 
 // Checks if name is a legal method name.
 void ClassFileParser::verify_legal_method_name(const Symbol* name, TRAPS) const {
-  if (!_need_verify || _relax_verify) { return; }
+  if (!_need_verify) { return; }
 
   assert(name != nullptr, "method name is null");
   char* bytes = (char*)name->bytes();
@@ -5265,17 +5265,6 @@ void ClassFileParser::update_class_name(Symbol* new_class_name) {
   _class_name->increment_refcount();
 }
 
-static bool relax_format_check_for(ClassLoaderData* loader_data) {
-  bool trusted = loader_data->is_boot_class_loader_data() ||
-                 loader_data->is_platform_class_loader_data();
-  bool need_verify =
-    // verifyAll
-    (BytecodeVerificationLocal && BytecodeVerificationRemote) ||
-    // verifyRemote
-    (!BytecodeVerificationLocal && BytecodeVerificationRemote && !trusted);
-  return !need_verify;
-}
-
 ClassFileParser::ClassFileParser(ClassFileStream* stream,
                                  Symbol* name,
                                  ClassLoaderData* loader_data,
@@ -5332,7 +5321,6 @@ ClassFileParser::ClassFileParser(ClassFileStream* stream,
   _itfs_len(0),
   _java_fields_count(0),
   _need_verify(false),
-  _relax_verify(false),
   _has_nonstatic_concrete_methods(false),
   _declares_nonstatic_concrete_methods(false),
   _has_localvariable_table(false),
@@ -5358,7 +5346,7 @@ ClassFileParser::ClassFileParser(ClassFileStream* stream,
     // Verification decision is based on BytecodeVerificationRemote flag
     // for those classes.
     _need_verify = (stream->need_verify()) ? BytecodeVerificationRemote :
-                                              BytecodeVerificationLocal;
+                                             BytecodeVerificationLocal;
   }
   else {
     _need_verify = Verifier::should_verify_for(_loader_data->class_loader(),
@@ -5367,10 +5355,6 @@ ClassFileParser::ClassFileParser(ClassFileStream* stream,
 
   // synch back verification state to stream
   stream->set_verify(_need_verify);
-
-  // Check if verification needs to be relaxed for this class file
-  // Do not restrict it to jdk1.0 or jdk1.1 to maintain backward compatibility (4982376)
-  _relax_verify = relax_format_check_for(_loader_data);
 
   parse_stream(stream, CHECK);
 

--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -185,7 +185,6 @@ class ClassFileParser {
   u2 _java_fields_count;
 
   bool _need_verify;
-  bool _relax_verify;
 
   bool _has_nonstatic_concrete_methods;
   bool _declares_nonstatic_concrete_methods;

--- a/src/hotspot/share/classfile/classLoader.cpp
+++ b/src/hotspot/share/classfile/classLoader.cpp
@@ -1193,7 +1193,12 @@ InstanceKlass* ClassLoader::load_class(Symbol* name, PackageEntry* pkg_entry, bo
     return nullptr;
   }
 
-  stream->set_verify(ClassLoaderExt::should_verify(classpath_index));
+  // For CDS, don't verify app class loaders if they are shared, else let Verifier::should_verify_for() figure it out.
+  bool should_verify =
+    CDS_ONLY(classpath_index >= ClassLoaderExt::app_class_paths_start_index();)
+    NOT_CDS(ClassFileStream::should_verify;)
+
+  stream->set_verify(should_verify);
 
   ClassLoaderData* loader_data = ClassLoaderData::the_null_class_loader_data();
   Handle protection_domain;

--- a/src/hotspot/share/classfile/classLoaderExt.hpp
+++ b/src/hotspot/share/classfile/classLoaderExt.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,10 +33,6 @@ class ClassListParser;
 
 class ClassLoaderExt: public ClassLoader { // AllStatic
 public:
-  static bool should_verify(int classpath_index) {
-    CDS_ONLY(return (classpath_index >= _app_class_paths_start_index);)
-    NOT_CDS(return false;)
-  }
 
 #if INCLUDE_CDS
 private:

--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -109,16 +109,6 @@ bool Verifier::should_verify_for(oop class_loader, bool should_verify_class) {
     BytecodeVerificationLocal : BytecodeVerificationRemote;
 }
 
-bool Verifier::relax_access_for(oop loader) {
-  bool trusted = java_lang_ClassLoader::is_trusted_loader(loader);
-  bool need_verify =
-    // verifyAll
-    (BytecodeVerificationLocal && BytecodeVerificationRemote) ||
-    // verifyRemote
-    (!BytecodeVerificationLocal && BytecodeVerificationRemote && !trusted);
-  return !need_verify;
-}
-
 void Verifier::trace_class_resolution(Klass* resolve_class, InstanceKlass* verify_class) {
   assert(verify_class != nullptr, "Unexpected null verify_class");
   ResourceMark rm;
@@ -274,15 +264,7 @@ bool Verifier::is_eligible_for_verification(InstanceKlass* klass, bool should_ve
   bool is_reflect_accessor = refl_serialization_ctor_klass != nullptr &&
                                 klass->is_subtype_of(refl_serialization_ctor_klass);
 
-  return (should_verify_for(klass->class_loader(), should_verify_class) &&
-    // return if the class is a bootstrapping class
-    // or defineClass specified not to verify by default (flags override passed arg)
-    // We need to skip the following four for bootstraping
-    name != vmSymbols::java_lang_Object() &&
-    name != vmSymbols::java_lang_Class() &&
-    name != vmSymbols::java_lang_String() &&
-    name != vmSymbols::java_lang_Throwable() &&
-
+  return (should_verify_class &&
     // Can not verify the bytecodes for shared classes because they have
     // already been rewritten to contain constant pool cache indices,
     // which the verifier can't understand.

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,9 +53,6 @@ class Verifier : AllStatic {
   // or if defineClass was called requesting skipping verification
   // -Xverify:all overrides this value
   static bool should_verify_for(oop class_loader, bool should_verify_class);
-
-  // Relax certain access checks to enable some broken 1.1 apps to run on 1.2.
-  static bool relax_access_for(oop class_loader);
 
   // Print output for class+resolve
   static void trace_class_resolution(Klass* resolve_class, InstanceKlass* verify_class);

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineVerifyError.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineVerifyError.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6402717 8330606
+ * @summary Redefine VerifyError to get a VerifyError should not throw SOE
+ * @requires vm.jvmti
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.org.objectweb.asm
+ *          java.compiler
+ *          java.instrument
+ *          jdk.jartool/sun.tools.jar
+ * @run main RedefineClassHelper
+ * @compile RedefineVerifyError.java
+ * @run main/othervm/timeout=180
+ *         -javaagent:redefineagent.jar
+ *         -Xlog:class+init
+ *         RedefineVerifyError
+ */
+
+import jdk.internal.org.objectweb.asm.AnnotationVisitor;
+import jdk.internal.org.objectweb.asm.Attribute;
+import jdk.internal.org.objectweb.asm.ClassReader;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.ConstantDynamic;
+import jdk.internal.org.objectweb.asm.FieldVisitor;
+import jdk.internal.org.objectweb.asm.Handle;
+import jdk.internal.org.objectweb.asm.Label;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.RecordComponentVisitor;
+import jdk.internal.org.objectweb.asm.Type;
+import jdk.internal.org.objectweb.asm.TypePath;
+
+public class RedefineVerifyError implements Opcodes {
+
+    public static byte[] dump () throws Exception {
+
+        ClassWriter classWriter = new ClassWriter(0);
+        FieldVisitor fieldVisitor;
+        RecordComponentVisitor recordComponentVisitor;
+        MethodVisitor methodVisitor;
+        AnnotationVisitor annotationVisitor0;
+
+        classWriter.visit(52, ACC_SUPER | ACC_PUBLIC, "java/lang/VerifyError", null, "java/lang/LinkageError", null);
+        {
+            fieldVisitor = classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, "serialVersionUID", "J", null, new Long(7001962396098498785L));
+            fieldVisitor.visitEnd();
+        }
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(43, label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/LinkageError", "<init>", "()V", false);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLineNumber(44, label1);
+            methodVisitor.visitInsn(RETURN);
+            Label label2 = new Label();
+            methodVisitor.visitLabel(label2);
+            methodVisitor.visitLocalVariable("this", "Ljava/lang/VerifyError;", null, label0, label2, 0);
+            methodVisitor.visitMaxs(1, 1);
+            methodVisitor.visitEnd();
+        }
+
+        {   // broken method
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "(Ljava/lang/String;)V", null, null);
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            Label label1 = new Label();
+            Label label2 = new Label();
+            methodVisitor.visitTryCatchBlock(label0, label1, label2, "java/lang/Exception");
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitVarInsn(ALOAD, 1);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/LinkageError", "<init>", "(Ljava/lang/String;)V", false);
+            methodVisitor.visitLabel(label1);
+            Label label3 = new Label();
+            methodVisitor.visitJumpInsn(GOTO, label3);
+            methodVisitor.visitLabel(label2);
+            methodVisitor.visitFrame(Opcodes.F_FULL, 2, new Object[] {"MyError", "java/lang/String"}, 1, new Object[] {"java/lang/Exception"});
+            methodVisitor.visitVarInsn(ASTORE, 2);
+            methodVisitor.visitLabel(label3);
+            // methodVisitor.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+            methodVisitor.visitInsn(RETURN);
+            methodVisitor.visitMaxs(2, 3);
+            methodVisitor.visitEnd();
+            classWriter.visitEnd();
+        }
+
+        return classWriter.toByteArray();
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        Class<?> verifyErrorMirror = java.lang.VerifyError.class;
+
+        try {
+            RedefineClassHelper.redefineClass(verifyErrorMirror, dump());
+            VerifyError err = new VerifyError("verify me now");
+            throw new RuntimeException("This should throw VerifyError or fail redefinition with a crash");
+        } catch (VerifyError e) {
+            System.out.println("Passed");
+        }
+    }
+}


### PR DESCRIPTION
We really need to force verification for classes that are redefined even if they're on the boot loader.  The Redefinition code thinks passing 'true' to Verifier::verify() does this, but it doesn't.  The reason in general for not verifying classes loaded by the boot loader is that we assume they're correct and for better performance.  The extra time to verify in redefinition is not performance critical and this prevents errors and crashes down the line since it's easier to create a bad class for redefinition.

I also removed relax_verify since comments around it point to a 20 year old bug having to do with extra bits at the end of the class file.  It is mostly the same as ClassFileParser::need_verify, except for the platform class loader.  Not sure if that was the intention, but it is only tested with verify_legal_method_name, verify_legal_class_namd and verify_legal_field_name.  Removing this condition around checking doesn't hurt performance and also doesn't prohibit a class/field/method name that should be allowed by the platform class loader.

Lastly, I moved a couple of functions closer to their use making it easier to reason about why they're there.

Tested with tier1-7.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Issue
 * [JDK-8330606](https://bugs.openjdk.org/browse/JDK-8330606): Redefinition doesn't but should verify the new klass (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21214/head:pull/21214` \
`$ git checkout pull/21214`

Update a local copy of the PR: \
`$ git checkout pull/21214` \
`$ git pull https://git.openjdk.org/jdk.git pull/21214/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21214`

View PR using the GUI difftool: \
`$ git pr show -t 21214`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21214.diff">https://git.openjdk.org/jdk/pull/21214.diff</a>

</details>
