### PR TITLE
8341060: Cleanup statics in HeapDumper

### DIFF
--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1512,6 +1512,45 @@ class ClassDumper : public KlassClosure {
   }
 };
 
+// Support class used to generate HPROF_LOAD_CLASS records
+
+class LoadedClassDumper : public LockedClassesDo {
+ private:
+  AbstractDumpWriter* _writer;
+  GrowableArray<Klass*>* _klass_map;
+  u4 _class_serial_num;
+  AbstractDumpWriter* writer() const { return _writer; }
+  void add_class_serial_number(Klass* k, int serial_num) {
+      _klass_map->at_put_grow(serial_num, k);
+  }
+ public:
+  LoadedClassDumper(AbstractDumpWriter* writer, GrowableArray<Klass*>* klass_map)
+    : _writer(writer), _klass_map(klass_map), _class_serial_num(0) {}
+  void do_klass(Klass* k);
+};
+
+void LoadedClassDumper::do_klass(Klass* k) {
+  // len of HPROF_LOAD_CLASS record
+  u4 remaining = 2 * oopSize + 2 * sizeof(u4);
+
+  DumperSupport::write_header(writer(), HPROF_LOAD_CLASS, remaining);
+
+  // class serial number is just a number
+  writer()->write_u4(++_class_serial_num);
+
+  // class ID
+  writer()->write_classID(k);
+
+  // add the Klass* and class serial number pair
+  add_class_serial_number(k, _class_serial_num);
+
+  writer()->write_u4(STACK_TRACE_ID);
+
+  // class name ID
+  Symbol* name = k->name();
+  writer()->write_symbolID(name);
+};
+
 // Support class used to generate HPROF_GC_ROOT_JNI_LOCAL records
 
 class JNILocalsDumper : public OopClosure {
@@ -2190,9 +2229,7 @@ void DumpMerger::do_merge() {
 // The VM operation that performs the heap dump
 class VM_HeapDumper : public VM_GC_Operation, public WorkerTask, public UnmountedVThreadDumper {
  private:
-  static VM_HeapDumper*   _global_dumper;
-  static DumpWriter*      _global_writer;
-  DumpWriter*             _local_writer;
+  DumpWriter*             _writer;
   JavaThread*             _oome_thread;
   Method*                 _oome_constructor;
   bool                    _gc_before_heap_dump;
@@ -2218,32 +2255,12 @@ class VM_HeapDumper : public VM_GC_Operation, public WorkerTask, public Unmounte
     return Atomic::fetch_then_add(&_dump_seq, 1);
   }
 
-  // accessors and setters
-  static VM_HeapDumper* dumper()         {  assert(_global_dumper != nullptr, "Error"); return _global_dumper; }
-  static DumpWriter* writer()            {  assert(_global_writer != nullptr, "Error"); return _global_writer; }
-
-  void set_global_dumper() {
-    assert(_global_dumper == nullptr, "Error");
-    _global_dumper = this;
-  }
-  void set_global_writer() {
-    assert(_global_writer == nullptr, "Error");
-    _global_writer = _local_writer;
-  }
-  void clear_global_dumper() { _global_dumper = nullptr; }
-  void clear_global_writer() { _global_writer = nullptr; }
+  DumpWriter* writer() const { return _writer; }
 
   bool skip_operation() const;
 
-  // writes a HPROF_LOAD_CLASS record to global writer
-  static void do_load_class(Klass* k);
-
   // HPROF_GC_ROOT_THREAD_OBJ records for platform and mounted virtual threads
   void dump_threads(AbstractDumpWriter* writer);
-
-  void add_class_serial_number(Klass* k, int serial_num) {
-    _klass_map->at_put_grow(serial_num, k);
-  }
 
   bool is_oom_thread(JavaThread* thread) const {
     return thread == _oome_thread && _oome_constructor != nullptr;
@@ -2259,7 +2276,7 @@ class VM_HeapDumper : public VM_GC_Operation, public WorkerTask, public Unmounte
                     0 /* total full collections, dummy, ignored */,
                     gc_before_heap_dump),
     WorkerTask("dump heap") {
-    _local_writer = writer;
+    _writer = writer;
     _gc_before_heap_dump = gc_before_heap_dump;
     _klass_map = new (mtServiceability) GrowableArray<Klass*>(INITIAL_CLASS_COUNT, mtServiceability);
 
@@ -2313,9 +2330,6 @@ class VM_HeapDumper : public VM_GC_Operation, public WorkerTask, public Unmounte
   void dump_vthread(oop vt, AbstractDumpWriter* segment_writer);
 };
 
-VM_HeapDumper* VM_HeapDumper::_global_dumper = nullptr;
-DumpWriter*    VM_HeapDumper::_global_writer = nullptr;
-
 bool VM_HeapDumper::skip_operation() const {
   return false;
 }
@@ -2327,31 +2341,6 @@ void DumperSupport::end_of_dump(AbstractDumpWriter* writer) {
   writer->write_u1(HPROF_HEAP_DUMP_END);
   writer->write_u4(0);
   writer->write_u4(0);
-}
-
-// writes a HPROF_LOAD_CLASS record for the class
-void VM_HeapDumper::do_load_class(Klass* k) {
-  static u4 class_serial_num = 0;
-
-  // len of HPROF_LOAD_CLASS record
-  u4 remaining = 2*oopSize + 2*sizeof(u4);
-
-  DumperSupport::write_header(writer(), HPROF_LOAD_CLASS, remaining);
-
-  // class serial number is just a number
-  writer()->write_u4(++class_serial_num);
-
-  // class ID
-  writer()->write_classID(k);
-
-  // add the Klass* and class serial number pair
-  dumper()->add_class_serial_number(k, class_serial_num);
-
-  writer()->write_u4(STACK_TRACE_ID);
-
-  // class name ID
-  Symbol* name = k->name();
-  writer()->write_symbolID(name);
 }
 
 // Write a HPROF_GC_ROOT_THREAD_OBJ record for platform/carrier and mounted virtual threads.
@@ -2430,11 +2419,6 @@ void VM_HeapDumper::doit() {
     }
   }
 
-  // At this point we should be the only dumper active, so
-  // the following should be safe.
-  set_global_dumper();
-  set_global_writer();
-
   WorkerThreads* workers = ch->safepoint_workers();
   prepare_parallel_dump(workers);
 
@@ -2446,10 +2430,6 @@ void VM_HeapDumper::doit() {
     workers->run_task(this, _num_dumper_threads);
     _poi = nullptr;
   }
-
-  // Now we clear the global variables, so that a future dumper can run.
-  clear_global_dumper();
-  clear_global_writer();
 }
 
 void VM_HeapDumper::work(uint worker_id) {
@@ -2480,8 +2460,8 @@ void VM_HeapDumper::work(uint worker_id) {
 
     // write HPROF_LOAD_CLASS records
     {
-      LockedClassesDo locked_load_classes(&do_load_class);
-      ClassLoaderDataGraph::classes_do(&locked_load_classes);
+      LoadedClassDumper loaded_class_dumper(writer(), _klass_map);
+      ClassLoaderDataGraph::classes_do(&loaded_class_dumper);
     }
 
     // write HPROF_FRAME and HPROF_TRACE records

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -1521,34 +1521,27 @@ class LoadedClassDumper : public LockedClassesDo {
   u4 _class_serial_num;
   AbstractDumpWriter* writer() const { return _writer; }
   void add_class_serial_number(Klass* k, int serial_num) {
-      _klass_map->at_put_grow(serial_num, k);
+    _klass_map->at_put_grow(serial_num, k);
   }
  public:
   LoadedClassDumper(AbstractDumpWriter* writer, GrowableArray<Klass*>* klass_map)
     : _writer(writer), _klass_map(klass_map), _class_serial_num(0) {}
-  void do_klass(Klass* k);
-};
 
-void LoadedClassDumper::do_klass(Klass* k) {
-  // len of HPROF_LOAD_CLASS record
-  u4 remaining = 2 * oopSize + 2 * sizeof(u4);
-
-  DumperSupport::write_header(writer(), HPROF_LOAD_CLASS, remaining);
-
-  // class serial number is just a number
-  writer()->write_u4(++_class_serial_num);
-
-  // class ID
-  writer()->write_classID(k);
-
-  // add the Klass* and class serial number pair
-  add_class_serial_number(k, _class_serial_num);
-
-  writer()->write_u4(STACK_TRACE_ID);
-
-  // class name ID
-  Symbol* name = k->name();
-  writer()->write_symbolID(name);
+  void do_klass(Klass* k) {
+    // len of HPROF_LOAD_CLASS record
+    u4 remaining = 2 * oopSize + 2 * sizeof(u4);
+    DumperSupport::write_header(writer(), HPROF_LOAD_CLASS, remaining);
+    // class serial number is just a number
+    writer()->write_u4(++_class_serial_num);
+    // class ID
+    writer()->write_classID(k);
+    // add the Klass* and class serial number pair
+    add_class_serial_number(k, _class_serial_num);
+    writer()->write_u4(STACK_TRACE_ID);
+    // class name ID
+    Symbol* name = k->name();
+    writer()->write_symbolID(name);
+  }
 };
 
 // Support class used to generate HPROF_GC_ROOT_JNI_LOCAL records


### PR DESCRIPTION
The fix cleans up static variables/methods in HeapDumper.
See jira for details.

Testing:
  heap dump-related tests (test/hotspot/jtreg/serviceability, test/hotspot/jtreg/compiler/c2/TestReduceAllocationAndHeapDump.java, test/hotspot/jtreg/runtime/ErrorHandling, test/hotspot/jtreg/gc/epsilon, test/jdk/sun/tools/jhsdb, test/jdk/sun/tools/jmap, test/jdk/com/sun/management/HotSpotDiagnosticMXBean)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341060](https://bugs.openjdk.org/browse/JDK-8341060): Cleanup statics in HeapDumper (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) Review applies to [98abe42c](https://git.openjdk.org/jdk/pull/21216/files/98abe42cdb69fdcecfde17146f2dd13647c46abf)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21216/head:pull/21216` \
`$ git checkout pull/21216`

Update a local copy of the PR: \
`$ git checkout pull/21216` \
`$ git pull https://git.openjdk.org/jdk.git pull/21216/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21216`

View PR using the GUI difftool: \
`$ git pr show -t 21216`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21216.diff">https://git.openjdk.org/jdk/pull/21216.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21216#issuecomment-2378233724)