### PR TITLE
8341024: [test] build/AbsPathsInImage.java fails with OOM when using ubsan-enabled binaries

### DIFF
--- a/test/jdk/build/AbsPathsInImage.java
+++ b/test/jdk/build/AbsPathsInImage.java
@@ -40,7 +40,7 @@ import java.util.zip.ZipInputStream;
  * @bug 8226346
  * @summary Check all output files for absolute path fragments
  * @requires !vm.debug
- * @run main AbsPathsInImage
+ * @run main/othervm -Xmx900m AbsPathsInImage
  */
 public class AbsPathsInImage {
 


### PR DESCRIPTION
The jtreg test build/AbsPathsInImage.java fails with OOM when using ubsan-enabled binaries (on Linux x86_64).
Reason seems to be that the ubsan-enabled binaries are much larger than 'normal' product binaries.
(for debug binaries the test is already disabled)
Error is :
java.lang.OutOfMemoryError: Java heap space
at java.base/java.nio.file.Files.read(Files.java:3242)
at java.base/java.nio.file.Files.readAllBytes(Files.java:3299)
at AbsPathsInImage.scanFile(AbsPathsInImage.java:181)
at AbsPathsInImage$1.visitFile(AbsPathsInImage.java:173)
at AbsPathsInImage$1.visitFile(AbsPathsInImage.java:153)
at java.base/java.nio.file.Files.walkFileTree(Files.java:2810)
at java.base/java.nio.file.Files.walkFileTree(Files.java:2881)
at AbsPathsInImage.scanFiles(AbsPathsInImage.java:153)
at AbsPathsInImage.main(AbsPathsInImage.java:119)
at java.base/java.lang.invoke.LambdaForm$DMH/0x00007fb6087003a8.invokeStatic(LambdaForm$DMH)
at java.base/java.lang.invoke.LambdaForm$MH/0x00007fb608a2f3d8.invoke(LambdaForm$MH)
at java.base/java.lang.invoke.Invokers$Holder.invokeExact_MT(Invokers$Holder)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(DirectMethodHandleAccessor.java:154)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
at java.base/java.lang.reflect.Method.invoke(Method.java:573)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:333)
at java.base/java.lang.Thread.runWith(Thread.java:1589)
at java.base/java.lang.Thread.run(Thread.java:1576)

Especially the debuginfo file for libjvm.so gets HUGE, and needs a higher Xmx setting for this test.

At some later point in time, the test could be rewritten to use less memory when looking into the JDK image files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341024](https://bugs.openjdk.org/browse/JDK-8341024): [test] build/AbsPathsInImage.java fails with OOM when using ubsan-enabled binaries (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21217/head:pull/21217` \
`$ git checkout pull/21217`

Update a local copy of the PR: \
`$ git checkout pull/21217` \
`$ git pull https://git.openjdk.org/jdk.git pull/21217/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21217`

View PR using the GUI difftool: \
`$ git pr show -t 21217`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21217.diff">https://git.openjdk.org/jdk/pull/21217.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21217#issuecomment-2378928331)