### PR TITLE
8307532: Implement LM_LIGHTWEIGHT for Zero

### DIFF
--- a/src/hotspot/cpu/zero/vm_version_zero.cpp
+++ b/src/hotspot/cpu/zero/vm_version_zero.cpp
@@ -116,11 +116,6 @@ void VM_Version::initialize() {
     FLAG_SET_DEFAULT(UseVectorizedMismatchIntrinsic, false);
   }
 
-  if ((LockingMode != LM_LEGACY) && (LockingMode != LM_MONITOR)) {
-    warning("Unsupported locking mode for this CPU.");
-    FLAG_SET_DEFAULT(LockingMode, LM_LEGACY);
-  }
-
   // Enable error context decoding on known platforms
 #if defined(IA32) || defined(AMD64) || defined(ARM) || \
     defined(AARCH64) || defined(PPC) || defined(RISCV) || \

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -1817,17 +1817,6 @@ bool Arguments::check_vm_args_consistency() {
   }
 #endif
 
-#if !defined(X86) && !defined(AARCH64) && !defined(RISCV64) && !defined(ARM) && !defined(PPC64) && !defined(S390)
-  if (LockingMode == LM_LIGHTWEIGHT) {
-    FLAG_SET_CMDLINE(LockingMode, LM_LEGACY);
-    warning("New lightweight locking not supported on this platform");
-  }
-  if (UseObjectMonitorTable) {
-    FLAG_SET_CMDLINE(UseObjectMonitorTable, false);
-    warning("UseObjectMonitorTable not supported on this platform");
-  }
-#endif
-
   if (UseObjectMonitorTable && LockingMode != LM_LIGHTWEIGHT) {
     // ObjectMonitorTable requires lightweight locking.
     FLAG_SET_CMDLINE(UseObjectMonitorTable, false);

--- a/src/hotspot/share/runtime/basicLock.inline.hpp
+++ b/src/hotspot/share/runtime/basicLock.inline.hpp
@@ -39,7 +39,7 @@ inline void BasicLock::set_displaced_header(markWord header) {
 
 inline ObjectMonitor* BasicLock::object_monitor_cache() const {
   assert(UseObjectMonitorTable, "must be");
-#if defined(X86) || defined(AARCH64) || defined(RISCV64) || defined(PPC64) || defined(S390)
+#if defined(X86) || defined(AARCH64) || defined(RISCV64) || defined(PPC64) || defined(S390) || defined(ZERO)
   return reinterpret_cast<ObjectMonitor*>(get_metadata());
 #else
   // Other platforms do not make use of the cache yet,

--- a/src/hotspot/share/runtime/basicLock.inline.hpp
+++ b/src/hotspot/share/runtime/basicLock.inline.hpp
@@ -39,7 +39,7 @@ inline void BasicLock::set_displaced_header(markWord header) {
 
 inline ObjectMonitor* BasicLock::object_monitor_cache() const {
   assert(UseObjectMonitorTable, "must be");
-#if defined(X86) || defined(AARCH64) || defined(RISCV64) || defined(PPC64) || defined(S390) || defined(ZERO)
+#if !defined(ZERO) && (defined(X86) || defined(AARCH64) || defined(RISCV64) || defined(PPC64) || defined(S390))
   return reinterpret_cast<ObjectMonitor*>(get_metadata());
 #else
   // Other platforms do not make use of the cache yet,


### PR DESCRIPTION
This implements the remaining parts of LW locking in Zero. Much of the work has already been done by Axel, this basically only implements the missing part that handles synchronized JNI entries. I basically preserved the LM_LEGACY case, except that I shuffled the code a little to match what we do in monitorexit case in bytecodeInterpreter.cpp (but should be functionally equivalent). The LM_LIGHTWEIGHT and LM_MONITOR case (the latter of which has been broken, before) simply call into the runtime.

With this change, we can now remove the block in arguments.cpp that deals with missing LM_LIGHTWEIGHT support.

Testing:
 - [x] bootcycle-images
 - [x] java -jar jcstress-latest.jar -tb 1h

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8307532](https://bugs.openjdk.org/browse/JDK-8307532): Implement LM_LIGHTWEIGHT for Zero (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21220/head:pull/21220` \
`$ git checkout pull/21220`

Update a local copy of the PR: \
`$ git checkout pull/21220` \
`$ git pull https://git.openjdk.org/jdk.git pull/21220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21220`

View PR using the GUI difftool: \
`$ git pr show -t 21220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21220.diff">https://git.openjdk.org/jdk/pull/21220.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21220#issuecomment-2379533549)