### PR TITLE
8337066: Repeated call of StringBuffer.reverse with double byte string returns wrong result

### DIFF
--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -746,6 +746,21 @@ Block* PhaseCFG::insert_anti_dependences(Block* LCA, Node* load, bool verify) {
   // The anti-dependence constraints apply only to the fringe of this tree.
 
   Node* initial_mem = load->in(MemNode::Memory);
+
+  // We don't optimize memory graph for pinned loads, so we may need to raise the
+  // root of our search tree through the corresponding slices of MergeMem nodes to
+  // get to the node that really creates the memory state for this slice.
+  if (load_alias_idx >= Compile::AliasIdxRaw) {
+    while (initial_mem->is_MergeMem()) {
+      MergeMemNode* mm = initial_mem->as_MergeMem();
+      Node* p = mm->memory_at(load_alias_idx);
+      if (p != mm->base_memory()) {
+        initial_mem = p;
+      } else {
+        break;
+      }
+    }
+  }
   worklist_def_use_mem_states.push(nullptr, initial_mem);
   while (worklist_def_use_mem_states.is_nonempty()) {
     // Examine a nearby store to see if it might interfere with our load.

--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -747,7 +747,7 @@ Block* PhaseCFG::insert_anti_dependences(Block* LCA, Node* load, bool verify) {
 
   Node* initial_mem = load->in(MemNode::Memory);
 
-  // We don't optimize memory graph for pinned loads, so we may need to raise the
+  // We don't optimize the memory graph for pinned loads, so we may need to raise the
   // root of our search tree through the corresponding slices of MergeMem nodes to
   // get to the node that really creates the memory state for this slice.
   if (load_alias_idx >= Compile::AliasIdxRaw) {

--- a/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyForPinnedLoads.java
+++ b/test/hotspot/jtreg/compiler/controldependency/TestAntiDependencyForPinnedLoads.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8337066
+ * @summary Test that MergeMem is skipped when looking for stores
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ *                   -XX:CompileCommand=compileonly,java.lang.StringUTF16::reverse
+ *                   compiler.controldependency.TestAntiDependencyForPinnedLoads
+ */
+
+package compiler.controldependency;
+
+public class TestAntiDependencyForPinnedLoads {
+    public static void main(String[] args) {
+        for(int i = 0; i < 50_000; i++) {
+            String str = "YYYY年MM月DD日";
+            StringBuffer strBuffer = new StringBuffer(str);
+            String revStr = strBuffer.reverse().toString();
+            if (!revStr.equals("日DD月MM年YYYY")) throw new InternalError("FAIL");
+        }
+    }
+}


### PR DESCRIPTION
This is essentially a defensive forward port of a solution for an issue discovered in 11, where a use of pinned load (for which we disable almost all transforms in `LoadNode::Ideal()`) leads to a graph shape that is not expected by `insert_anti_dependences()`

The `insert_anti_dependences()` assumes that the memory input for a load is the root of the memory subgraph that it has to search for the possibly conflicting store. Usually this is true if we run all the memory optimizations but with pinned we don't.

Compare the good graph shape (with control dependency set to `UnknownControl`):
<img width="1128" alt="Good graph" src="https://github.com/user-attachments/assets/d2c72d20-bc3c-403f-b340-e7cfe6d1796d">

With the graph produce with the nodes pinned:
<img width="1206" alt="Bad graph" src="https://github.com/user-attachments/assets/bbd14b37-584b-4906-973e-93c9046975a6">

With the "bad graph" loads and store don't share the same memory graph root, and therefore are not considered by `insert_anti_dependences()`. The solution, I think, could be to walk up the memory chain of the load, skipping MergeMems, in order to get to the real root and then run the precedence edge insertion algorithm from there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337066](https://bugs.openjdk.org/browse/JDK-8337066): Repeated call of StringBuffer.reverse with double byte string returns wrong result (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) Review applies to [e9295d93](https://git.openjdk.org/jdk/pull/21222/files/e9295d93c3efa4d989df3396cef7924f142fe9e2)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21222/head:pull/21222` \
`$ git checkout pull/21222`

Update a local copy of the PR: \
`$ git checkout pull/21222` \
`$ git pull https://git.openjdk.org/jdk.git pull/21222/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21222`

View PR using the GUI difftool: \
`$ git pr show -t 21222`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21222.diff">https://git.openjdk.org/jdk/pull/21222.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21222#issuecomment-2379622735)