### PR TITLE
8340229: Improve opening sentence of FileInputStream constructor specification

### DIFF
--- a/src/java.base/share/classes/java/io/FileInputStream.java
+++ b/src/java.base/share/classes/java/io/FileInputStream.java
@@ -82,10 +82,9 @@ public class FileInputStream extends InputStream
     private volatile boolean closed;
 
     /**
-     * Creates a {@code FileInputStream} by
-     * opening a connection to an actual file,
-     * the file named by the path name {@code name}
-     * in the file system.  {@linkplain java.nio.file##links Symbolic links}
+     * Creates a {@code FileInputStream} to read from an existing file
+     * named by the path name {@code name}.
+     * {@linkplain java.nio.file##links Symbolic links}
      * are automatically redirected to the <i>target</i> of the link.
      * A new {@code FileDescriptor}
      * object is created to represent this file
@@ -115,10 +114,8 @@ public class FileInputStream extends InputStream
     }
 
     /**
-     * Creates a {@code FileInputStream} by
-     * opening a connection to an actual file,
-     * the file named by the {@code File}
-     * object {@code file} in the file system.
+     * Creates a {@code FileInputStream} to read from an existing file
+     * named by the {@code File} object {@code file}.
      * {@linkplain java.nio.file##links Symbolic links}
      * are automatically redirected to the <i>target</i> of the link.
      * A new {@code FileDescriptor} object
@@ -165,9 +162,8 @@ public class FileInputStream extends InputStream
     }
 
     /**
-     * Creates a {@code FileInputStream} by using the file descriptor
-     * {@code fdObj}, which represents an existing connection to an
-     * actual file in the file system.
+     * Creates a {@code FileInputStream} to read from an existing file
+     * represented by the {@code FileDescriptor} object {@code fdObj}.
      * <p>
      * If there is a security manager, its {@code checkRead} method is
      * called with the file descriptor {@code fdObj} as its argument to


### PR DESCRIPTION
Improve the first sentences of the three `FileInputStream` constructors, in particular removing the term "connection."