### PR TITLE
8341096: ProblemList compiler/cha/TypeProfileFinalMethod.java in Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -50,6 +50,8 @@ vmTestbase/nsk/jvmti/scenarios/capability/CM03/cm03t001/TestDescription.java 829
 
 vmTestbase/nsk/stress/thread/thread006.java 8321476 linux-all
 
+compiler/cha/TypeProfileFinalMethod.java 8341039 generic-all
+
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 
 runtime/condy/escapeAnalysis/TestEscapeCondy.java 8339694 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList compiler/cha/TypeProfileFinalMethod.java in Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341096](https://bugs.openjdk.org/browse/JDK-8341096): ProblemList compiler/cha/TypeProfileFinalMethod.java in Xcomp mode (**Sub-task** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21224/head:pull/21224` \
`$ git checkout pull/21224`

Update a local copy of the PR: \
`$ git checkout pull/21224` \
`$ git pull https://git.openjdk.org/jdk.git pull/21224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21224`

View PR using the GUI difftool: \
`$ git pr show -t 21224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21224.diff">https://git.openjdk.org/jdk/pull/21224.diff</a>

</details>
