### PR TITLE
8341059: Change Entrust TLS distrust date to November 12, 2024

### DIFF
--- a/src/java.base/share/classes/sun/security/validator/CADistrustPolicy.java
+++ b/src/java.base/share/classes/sun/security/validator/CADistrustPolicy.java
@@ -57,7 +57,7 @@ enum CADistrustPolicy {
 
     /**
      * Distrust TLS Server certificates anchored by an Entrust root CA and
-     * issued after October 31, 2024. If enabled, this policy is currently
+     * issued after November 11, 2024. If enabled, this policy is currently
      * enforced by the PKIX and SunX509 TrustManager implementations
      * of the SunJSSE provider implementation.
      */

--- a/src/java.base/share/classes/sun/security/validator/EntrustTLSPolicy.java
+++ b/src/java.base/share/classes/sun/security/validator/EntrustTLSPolicy.java
@@ -88,8 +88,8 @@ final class EntrustTLSPolicy {
 
     // Any TLS Server certificate that is anchored by one of the Entrust
     // roots above and is issued after this date will be distrusted.
-    private static final LocalDate OCTOBER_31_2024 =
-        LocalDate.of(2024, Month.OCTOBER, 31);
+    private static final LocalDate NOVEMBER_11_2024 =
+        LocalDate.of(2024, Month.NOVEMBER, 11);
 
     /**
      * This method assumes the eeCert is a TLS Server Cert and chains back to
@@ -111,8 +111,8 @@ final class EntrustTLSPolicy {
             Date notBefore = chain[0].getNotBefore();
             LocalDate ldNotBefore = LocalDate.ofInstant(notBefore.toInstant(),
                                                         ZoneOffset.UTC);
-            // reject if certificate is issued after October 31, 2024
-            checkNotBefore(ldNotBefore, OCTOBER_31_2024, anchor);
+            // reject if certificate is issued after November 11, 2024
+            checkNotBefore(ldNotBefore, NOVEMBER_11_2024, anchor);
         }
     }
 

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -1358,7 +1358,7 @@ jdk.sasl.disabledMechanisms=
 #        Distrust after December 31, 2019.
 #
 #   ENTRUST_TLS : Distrust TLS Server certificates anchored by
-#   an Entrust root CA and issued after October 31, 2024.
+#   an Entrust root CA and issued after November 11, 2024.
 #
 # Leading and trailing whitespace surrounding each value are ignored.
 # Unknown values are ignored. If the property is commented out or set to the

--- a/test/jdk/sun/security/ssl/X509TrustManagerImpl/distrust/Entrust.java
+++ b/test/jdk/sun/security/ssl/X509TrustManagerImpl/distrust/Entrust.java
@@ -28,7 +28,7 @@ import javax.net.ssl.*;
 
 /**
  * @test
- * @bug 8337664
+ * @bug 8337664 8341059
  * @summary Check that TLS Server certificates chaining back to distrusted
  *          Entrust roots are invalid
  * @library /test/lib
@@ -52,7 +52,7 @@ public class Entrust {
 
     // Date when the restrictions take effect
     private static final ZonedDateTime DISTRUST_DATE =
-            LocalDate.of(2024, 11, 1).atStartOfDay(ZoneOffset.UTC);
+            LocalDate.of(2024, 11, 12).atStartOfDay(ZoneOffset.UTC);
 
     public static void main(String[] args) throws Exception {
         Distrust distrust = new Distrust(args);


### PR DESCRIPTION
Please review this change to distrust TLS server certificates issued after November 11, 2024 and anchored by Entrust Root CAs. This is a follow up fix after JDK-8337664 to update only the distrust date. TLS server certificates issued before this date will continue to be valid until they expire. This restriction should have minimal compatibility impact since Entrust has announced they will be using a partner (SSL.com) for all TLS server certificates issued after Nov 11, 2024. The addition of these new TLS root certificates from SSL.com is tracked with https://bugs.openjdk.org/browse/JDK-8341057

See the CSR for more details: https://bugs.openjdk.org/browse/JDK-8341087

