### PR TITLE
8341101: [ARM32] Error: ShouldNotReachHere() in TemplateInterpreterGenerator::generate_math_entry after 8338694

### DIFF
--- a/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
+++ b/src/hotspot/cpu/arm/templateInterpreterGenerator_arm.cpp
@@ -175,6 +175,7 @@ address TemplateInterpreterGenerator::generate_math_entry(AbstractInterpreter::M
     break;
   case Interpreter::java_lang_math_fmaD:
   case Interpreter::java_lang_math_fmaF:
+  case Interpreter::java_lang_math_tanh:
     // TODO: Implement intrinsic
     break;
   default:


### PR DESCRIPTION
[JDK-8338694](https://bugs.openjdk.org/browse/JDK-8338694) introduced Interpreter::java_lang_math_tanh which needs to be handled by the interpreter. Since the intrinsic is not implemented for ARM32, it should be implicitly skipped it in the TemplateInterpreterGenerator::generate_math_entry to avoid ShouldNotReachHere.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341101](https://bugs.openjdk.org/browse/JDK-8341101): [ARM32] Error: ShouldNotReachHere() in TemplateInterpreterGenerator::generate_math_entry after 8338694 (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21228/head:pull/21228` \
`$ git checkout pull/21228`

Update a local copy of the PR: \
`$ git checkout pull/21228` \
`$ git pull https://git.openjdk.org/jdk.git pull/21228/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21228`

View PR using the GUI difftool: \
`$ git pr show -t 21228`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21228.diff">https://git.openjdk.org/jdk/pull/21228.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21228#issuecomment-2379825029)