### PR TITLE
8255414: Ensure OS functions always report to NMT

### DIFF
--- a/src/hotspot/os/aix/os_aix.cpp
+++ b/src/hotspot/os/aix/os_aix.cpp
@@ -1765,18 +1765,20 @@ static void warn_fail_commit_memory(char* addr, size_t size, bool exec,
 }
 #endif
 
+// Alignment_hint is ignored on this OS.
 void os::pd_commit_memory_or_exit(char* addr, size_t size, bool exec,
-                                  const char* mesg) {
+                                  const char* mesg, size_t alignment_hint) {
   assert(mesg != nullptr, "mesg must be specified");
-  if (!pd_commit_memory(addr, size, exec)) {
+  if (!pd_commit_memory(addr, size, exec, alignment_hint)) {
     // Add extra info in product mode for vm_exit_out_of_memory():
     PRODUCT_ONLY(warn_fail_commit_memory(addr, size, exec, errno);)
     vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "%s", mesg);
   }
 }
 
-bool os::pd_commit_memory(char* addr, size_t size, bool exec) {
-
+// Alignment_hint is ignored on this OS.
+bool os::pd_commit_memory(char* addr, size_t size, bool exec,
+                          size_t alignment_hint) {
   assert(is_aligned_to(addr, os::vm_page_size()),
     "addr " PTR_FORMAT " not aligned to vm_page_size (" SIZE_FORMAT ")",
     p2i(addr), os::vm_page_size());
@@ -1798,17 +1800,6 @@ bool os::pd_commit_memory(char* addr, size_t size, bool exec) {
   }
 
   return true;
-}
-
-bool os::pd_commit_memory(char* addr, size_t size, size_t alignment_hint, bool exec) {
-  return pd_commit_memory(addr, size, exec);
-}
-
-void os::pd_commit_memory_or_exit(char* addr, size_t size,
-                                  size_t alignment_hint, bool exec,
-                                  const char* mesg) {
-  // Alignment_hint is ignored on this OS.
-  pd_commit_memory_or_exit(addr, size, exec, mesg);
 }
 
 bool os::pd_uncommit_memory(char* addr, size_t size, bool exec) {

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1782,7 +1782,7 @@ bool os::pd_uncommit_memory(char* addr, size_t size, bool exec) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  return os::commit_memory(addr, size, !ExecMem);
+  return os::pd_commit_memory(addr, size, !ExecMem);
 }
 
 // If this is a growable mapping, remove the guard pages entirely by

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -1782,7 +1782,7 @@ bool os::pd_uncommit_memory(char* addr, size_t size, bool exec) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  return os::pd_commit_memory(addr, size, !ExecMem);
+  return os::commit_memory(addr, size, !ExecMem);
 }
 
 // If this is a growable mapping, remove the guard pages entirely by

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3569,7 +3569,7 @@ bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
     }
   }
 
-  return os::pd_commit_memory(addr, size, !ExecMem);
+  return os::commit_memory(addr, size, !ExecMem);
 }
 
 // If this is a growable mapping, remove the guard pages entirely by

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3569,7 +3569,7 @@ bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
     }
   }
 
-  return os::commit_memory(addr, size, !ExecMem);
+  return os::pd_commit_memory(addr, size, !ExecMem);
 }
 
 // If this is a growable mapping, remove the guard pages entirely by

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -59,10 +59,6 @@ class os::Linux {
 
   static void initialize_system_info();
 
-  static int commit_memory_impl(char* addr, size_t bytes, bool exec);
-  static int commit_memory_impl(char* addr, size_t bytes,
-                                size_t alignment_hint, bool exec);
-
   static void set_libc_version(const char *s)       { _libc_version = s; }
   static void set_libpthread_version(const char *s) { _libpthread_version = s; }
 

--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -409,7 +409,7 @@ static int util_posix_fallocate(int fd, off_t offset, off_t len) {
 }
 
 // Map the given address range to the provided file descriptor.
-char* os::map_memory_to_file(char* base, size_t size, int fd) {
+char* os::map_memory_to_file(char* base, size_t size, int fd, MemTag mem_tag) {
   assert(fd != -1, "File descriptor is not valid");
 
   // allocate space for the file
@@ -436,14 +436,15 @@ char* os::map_memory_to_file(char* base, size_t size, int fd) {
     }
     return nullptr;
   }
+  MemTracker::record_virtual_memory_reserve_and_commit(addr, size, CALLER_PC, mem_tag);
   return addr;
 }
 
-char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd) {
+char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd, MemTag mem_tag) {
   assert(fd != -1, "File descriptor is not valid");
   assert(base != nullptr, "Base cannot be null");
 
-  return map_memory_to_file(base, size, fd);
+  return map_memory_to_file(base, size, fd, mem_tag);
 }
 
 static size_t calculate_aligned_extra_size(size_t size, size_t alignment) {
@@ -486,9 +487,9 @@ static char* chop_extra_memory(size_t size, size_t alignment, char* extra_base, 
 // Multiple threads can race in this code, and can remap over each other with MAP_FIXED,
 // so on posix, unmap the section at the start and at the end of the chunk that we mapped
 // rather than unmapping and remapping the whole chunk to get requested alignment.
-char* os::reserve_memory_aligned(size_t size, size_t alignment, bool exec) {
+char* os::reserve_memory_aligned(size_t size, size_t alignment, bool exec, MemTag mem_tag) {
   size_t extra_size = calculate_aligned_extra_size(size, alignment);
-  char* extra_base = os::reserve_memory(extra_size, exec);
+  char* extra_base = os::reserve_memory(extra_size, exec, mem_tag);
   if (extra_base == nullptr) {
     return nullptr;
   }
@@ -509,7 +510,7 @@ char* os::map_memory_to_file_aligned(size_t size, size_t alignment, int file_des
   }
   char* aligned_base = chop_extra_memory(size, alignment, extra_base, extra_size);
   // After we have an aligned address, we can replace anonymous mapping with file mapping
-  if (replace_existing_mapping_with_file_mapping(aligned_base, size, file_desc) == nullptr) {
+  if (replace_existing_mapping_with_file_mapping(aligned_base, size, file_desc, mem_tag) == nullptr) {
     vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
   }
   MemTracker::record_virtual_memory_commit((address)aligned_base, size, CALLER_PC);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3803,7 +3803,7 @@ bool os::pd_release_memory(char* addr, size_t bytes) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  return os::commit_memory(addr, size, !ExecMem);
+  return os::pd_commit_memory(addr, size, !ExecMem);
 }
 
 bool os::remove_stack_guard_pages(char* addr, size_t size) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3803,7 +3803,7 @@ bool os::pd_release_memory(char* addr, size_t bytes) {
 }
 
 bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
-  return os::pd_commit_memory(addr, size, !ExecMem);
+  return os::commit_memory(addr, size, !ExecMem);
 }
 
 bool os::remove_stack_guard_pages(char* addr, size_t size) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3391,7 +3391,7 @@ int os::create_file_for_heap(const char* dir) {
 }
 
 // If 'base' is not null, function will return null if it cannot get 'base'
-char* os::map_memory_to_file(char* base, size_t size, int fd, MemTag flag) {
+char* os::map_memory_to_file(char* base, size_t size, int fd, MemTag mem_tag) {
   assert(fd != -1, "File descriptor is not valid");
 
   HANDLE fh = (HANDLE)_get_osfhandle(fd);

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3391,7 +3391,7 @@ int os::create_file_for_heap(const char* dir) {
 }
 
 // If 'base' is not null, function will return null if it cannot get 'base'
-char* os::map_memory_to_file(char* base, size_t size, int fd) {
+char* os::map_memory_to_file(char* base, size_t size, int fd, MEMFLAGS flag) {
   assert(fd != -1, "File descriptor is not valid");
 
   HANDLE fh = (HANDLE)_get_osfhandle(fd);
@@ -3417,15 +3417,16 @@ char* os::map_memory_to_file(char* base, size_t size, int fd) {
 
   CloseHandle(fileMapping);
 
+  MemTracker::record_virtual_memory_reserve_and_commit((address)addr, size, CALLER_PC, flag);
   return (char*)addr;
 }
 
-char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd) {
+char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd, MEMFLAGS flag) {
   assert(fd != -1, "File descriptor is not valid");
   assert(base != nullptr, "Base address cannot be null");
 
   release_memory(base, size);
-  return map_memory_to_file(base, size, fd);
+  return map_memory_to_file(base, size, fd, flag);
 }
 
 // Multiple threads can race in this code but it's not possible to unmap small sections of
@@ -3471,9 +3472,9 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
   return aligned_base;
 }
 
-char* os::reserve_memory_aligned(size_t size, size_t alignment, bool exec) {
+char* os::reserve_memory_aligned(size_t size, size_t alignment, bool exec, MEMFLAGS flag) {
   // exec can be ignored
-  return map_or_reserve_memory_aligned(size, alignment, -1 /* file_desc */);
+  return map_or_reserve_memory_aligned(size, alignment, -1 /* file_desc */, flag);
 }
 
 char* os::map_memory_to_file_aligned(size_t size, size_t alignment, int fd, MemTag mem_tag) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3716,26 +3716,13 @@ bool os::pd_commit_memory(char* addr, size_t bytes, bool exec) {
   return true;
 }
 
-bool os::pd_commit_memory(char* addr, size_t size, size_t alignment_hint,
-                          bool exec) {
-  // alignment_hint is ignored on this OS
-  return pd_commit_memory(addr, size, exec);
-}
-
 void os::pd_commit_memory_or_exit(char* addr, size_t size, bool exec,
-                                  const char* mesg) {
+                                  const char* mesg, size_t alignment_hint) {
   assert(mesg != nullptr, "mesg must be specified");
-  if (!pd_commit_memory(addr, size, exec)) {
+  if (!pd_commit_memory(addr, size, exec, alignment_hint)) {
     warn_fail_commit_memory(addr, size, exec);
     vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "%s", mesg);
   }
-}
-
-void os::pd_commit_memory_or_exit(char* addr, size_t size,
-                                  size_t alignment_hint, bool exec,
-                                  const char* mesg) {
-  // alignment_hint is ignored on this OS
-  pd_commit_memory_or_exit(addr, size, exec, mesg);
 }
 
 bool os::pd_uncommit_memory(char* addr, size_t bytes, bool exec) {

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -3391,7 +3391,7 @@ int os::create_file_for_heap(const char* dir) {
 }
 
 // If 'base' is not null, function will return null if it cannot get 'base'
-char* os::map_memory_to_file(char* base, size_t size, int fd, MEMFLAGS flag) {
+char* os::map_memory_to_file(char* base, size_t size, int fd, MemTag flag) {
   assert(fd != -1, "File descriptor is not valid");
 
   HANDLE fh = (HANDLE)_get_osfhandle(fd);
@@ -3417,16 +3417,16 @@ char* os::map_memory_to_file(char* base, size_t size, int fd, MEMFLAGS flag) {
 
   CloseHandle(fileMapping);
 
-  MemTracker::record_virtual_memory_reserve_and_commit((address)addr, size, CALLER_PC, flag);
+  MemTracker::record_virtual_memory_reserve_and_commit((address)addr, size, CALLER_PC, mem_tag);
   return (char*)addr;
 }
 
-char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd, MEMFLAGS flag) {
+char* os::replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd, MemTag mem_tag) {
   assert(fd != -1, "File descriptor is not valid");
   assert(base != nullptr, "Base address cannot be null");
 
   release_memory(base, size);
-  return map_memory_to_file(base, size, fd, flag);
+  return map_memory_to_file(base, size, fd, mem_tag);
 }
 
 // Multiple threads can race in this code but it's not possible to unmap small sections of
@@ -3472,9 +3472,9 @@ static char* map_or_reserve_memory_aligned(size_t size, size_t alignment, int fi
   return aligned_base;
 }
 
-char* os::reserve_memory_aligned(size_t size, size_t alignment, bool exec, MEMFLAGS flag) {
+char* os::reserve_memory_aligned(size_t size, size_t alignment, bool exec, MemTag mem_tag) {
   // exec can be ignored
-  return map_or_reserve_memory_aligned(size, alignment, -1 /* file_desc */, flag);
+  return map_or_reserve_memory_aligned(size, alignment, -1 /* file_desc */, mem_tag);
 }
 
 char* os::map_memory_to_file_aligned(size_t size, size_t alignment, int fd, MemTag mem_tag) {

--- a/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
+++ b/src/hotspot/share/gc/g1/g1PageBasedVirtualSpace.cpp
@@ -135,14 +135,15 @@ void G1PageBasedVirtualSpace::commit_preferred_pages(size_t start, size_t num_pa
   char* start_addr = page_start(start);
   size_t size = num_pages * _page_size;
 
-  os::commit_memory_or_exit(start_addr, size, _page_size, false, "G1 virtual space");
+  os::commit_memory_or_exit(start_addr, size, false, "G1 virtual space", _page_size);
 }
 
 void G1PageBasedVirtualSpace::commit_tail() {
   vmassert(_tail_size > 0, "The size of the tail area must be > 0 when reaching here");
 
   char* const aligned_end_address = align_down(_high_boundary, _page_size);
-  os::commit_memory_or_exit(aligned_end_address, _tail_size, os::vm_page_size(), false, "G1 virtual space");
+  os::commit_memory_or_exit(aligned_end_address, _tail_size, false,
+                            "G1 virtual space", os::vm_page_size());
 }
 
 void G1PageBasedVirtualSpace::commit_internal(size_t start_page, size_t end_page) {

--- a/src/hotspot/share/gc/parallel/psVirtualspace.cpp
+++ b/src/hotspot/share/gc/parallel/psVirtualspace.cpp
@@ -78,7 +78,7 @@ bool PSVirtualSpace::expand_by(size_t bytes) {
 
   char* const base_addr = committed_high_addr();
   bool result = special() ||
-         os::commit_memory(base_addr, bytes, alignment(), !ExecMem);
+         os::commit_memory(base_addr, bytes, !ExecMem, alignment());
   if (result) {
     _committed_high_addr += bytes;
   }

--- a/src/hotspot/share/gc/shared/cardTable.cpp
+++ b/src/hotspot/share/gc/shared/cardTable.cpp
@@ -164,9 +164,9 @@ void CardTable::resize_covered_region(MemRegion new_region) {
 
     os::commit_memory_or_exit((char*)delta.start(),
                               delta.byte_size(),
-                              _page_size,
                               !ExecMem,
-                              "card table expansion");
+                              "card table expansion",
+                              _page_size);
 
     memset(delta.start(), clean_card, delta.byte_size());
   } else {

--- a/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahHeap.cpp
@@ -213,8 +213,8 @@ jint ShenandoahHeap::initialize() {
 
   ReservedSpace sh_rs = heap_rs.first_part(max_byte_size);
   if (!_heap_region_special) {
-    os::commit_memory_or_exit(sh_rs.base(), _initial_size, heap_alignment, false,
-                              "Cannot commit heap memory");
+    os::commit_memory_or_exit(sh_rs.base(), _initial_size, false,
+                              "Cannot commit heap memory", heap_alignment);
   }
 
   //
@@ -260,8 +260,8 @@ jint ShenandoahHeap::initialize() {
                               align_up(num_committed_regions, _bitmap_regions_per_slice) / _bitmap_regions_per_slice;
   bitmap_init_commit = MIN2(_bitmap_size, bitmap_init_commit);
   if (!_bitmap_region_special) {
-    os::commit_memory_or_exit((char *) _bitmap_region.start(), bitmap_init_commit, bitmap_page_size, false,
-                              "Cannot commit bitmap memory");
+    os::commit_memory_or_exit((char *) _bitmap_region.start(), bitmap_init_commit, false,
+                              "Cannot commit bitmap memory", bitmap_page_size);
   }
 
   _marking_context = new ShenandoahMarkingContext(_heap_region, _bitmap_region, _num_regions, _max_workers);
@@ -273,8 +273,8 @@ jint ShenandoahHeap::initialize() {
                                             verify_bitmap.base(),
                                             verify_bitmap.size(), verify_bitmap.page_size());
     if (!verify_bitmap.special()) {
-      os::commit_memory_or_exit(verify_bitmap.base(), verify_bitmap.size(), bitmap_page_size, false,
-                                "Cannot commit verification bitmap memory");
+      os::commit_memory_or_exit(verify_bitmap.base(), verify_bitmap.size(), false,
+                                "Cannot commit verification bitmap memory", bitmap_page_size);
     }
     MemTracker::record_virtual_memory_tag(verify_bitmap.base(), mtGC);
     MemRegion verify_bitmap_region = MemRegion((HeapWord *) verify_bitmap.base(), verify_bitmap.size() / HeapWordSize);
@@ -310,8 +310,8 @@ jint ShenandoahHeap::initialize() {
                                           region_storage.size(), region_storage.page_size());
   MemTracker::record_virtual_memory_tag(region_storage.base(), mtGC);
   if (!region_storage.special()) {
-    os::commit_memory_or_exit(region_storage.base(), region_storage_size, region_page_size, false,
-                              "Cannot commit region memory");
+    os::commit_memory_or_exit(region_storage.base(), region_storage_size, false,
+                              "Cannot commit region memory", region_page_size);
   }
 
   // Try to fit the collection set bitmap at lower addresses. This optimizes code generation for cset checks.

--- a/src/hotspot/share/memory/virtualspace.cpp
+++ b/src/hotspot/share/memory/virtualspace.cpp
@@ -837,7 +837,7 @@ static void pretouch_expanded_memory(void* start, void* end) {
 }
 
 static bool commit_expanded(char* start, size_t size, size_t alignment, bool pre_touch, bool executable) {
-  if (os::commit_memory(start, size, alignment, executable)) {
+  if (os::commit_memory(start, size, executable, alignment)) {
     if (pre_touch || AlwaysPreTouch) {
       pretouch_expanded_memory(start, start + size);
     }

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -293,7 +293,6 @@ size_t ReservedMemoryRegion::committed_size() const {
 }
 
 void ReservedMemoryRegion::set_mem_tag(MemTag new_mem_tag) {
-  fprintf(stderr, "ReservedMemoryRegion::set_mem_tag(%s)\n", NMTUtil::tag_to_name(new_mem_tag));
   assert((mem_tag() == mtNone || mem_tag() == new_mem_tag),
          "Overwrite memory tag for region [" INTPTR_FORMAT "-" INTPTR_FORMAT "), %u->%u.",
          p2i(base()), p2i(end()), (unsigned)mem_tag(), (unsigned)new_mem_tag);

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -293,6 +293,7 @@ size_t ReservedMemoryRegion::committed_size() const {
 }
 
 void ReservedMemoryRegion::set_mem_tag(MemTag new_mem_tag) {
+  fprintf(stderr, "ReservedMemoryRegion::set_mem_tag(%s)\n", NMTUtil::tag_to_name(new_mem_tag));
   assert((mem_tag() == mtNone || mem_tag() == new_mem_tag),
          "Overwrite memory tag for region [" INTPTR_FORMAT "-" INTPTR_FORMAT "), %u->%u.",
          p2i(base()), p2i(end()), (unsigned)mem_tag(), (unsigned)new_mem_tag);

--- a/src/hotspot/share/oops/compressedKlass.cpp
+++ b/src/hotspot/share/oops/compressedKlass.cpp
@@ -73,7 +73,7 @@ void CompressedKlassPointers::initialize_for_given_encoding(address addr, size_t
 
 char* CompressedKlassPointers::reserve_address_space_X(uintptr_t from, uintptr_t to, size_t size, size_t alignment, bool aslr) {
   alignment = MAX2(Metaspace::reserve_alignment(), alignment);
-  return os::attempt_reserve_memory_between((char*)from, (char*)to, size, alignment, aslr);
+  return os::attempt_reserve_memory_between((char*)from, (char*)to, size, alignment, aslr, mtClass);
 }
 
 char* CompressedKlassPointers::reserve_address_space_for_unscaled_encoding(size_t size, bool aslr) {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -1936,7 +1936,7 @@ static void hemi_split(T* arr, unsigned num) {
 
 // Given an address range [min, max), attempts to reserve memory within this area, with the given alignment.
 // If randomize is true, the location will be randomized.
-char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize) {
+char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize, MemTag mem_tag) {
 
   // Please keep the following constants in sync with the companion gtests:
 
@@ -2094,7 +2094,7 @@ char* os::attempt_reserve_memory_between(char* min, char* max, size_t bytes, siz
     assert(is_aligned(result, alignment), "alignment invalid (" ERRFMT ")", ERRFMTARGS);
     log_trace(os, map)(ERRFMT, ERRFMTARGS);
     log_debug(os, map)("successfully attached at " PTR_FORMAT, p2i(result));
-    MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC);
+    MemTracker::record_virtual_memory_reserve((address)result, bytes, CALLER_PC, mem_tag);
   } else {
     log_debug(os, map)("failed to attach anywhere in [" PTR_FORMAT "-" PTR_FORMAT ")", p2i(min), p2i(max));
   }
@@ -2245,7 +2245,7 @@ char* os::map_memory_to_file(size_t bytes, int file_desc, MemTag mem_tag) {
   // Could have called pd_reserve_memory() followed by replace_existing_mapping_with_file_mapping(),
   // but AIX may use SHM in which case its more trouble to detach the segment and remap memory to the file.
   // On all current implementations null is interpreted as any available address.
-  char* result = os::map_memory_to_file(nullptr /* addr */, bytes, file_desc);
+  char* result = os::map_memory_to_file(nullptr /* addr */, bytes, file_desc, mem_tag);
   if (result != nullptr) {
     MemTracker::record_virtual_memory_reserve_and_commit(result, bytes, CALLER_PC, mem_tag);
   }

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2122,23 +2122,10 @@ julong os::used_memory() {
   return os::physical_memory() - os::available_memory();
 }
 
-
-bool os::commit_memory(char* addr, size_t bytes, bool executable) {
-  assert_nonempty_range(addr, bytes);
-  bool res = pd_commit_memory(addr, bytes, executable);
-  if (res) {
-    MemTracker::record_virtual_memory_commit((address)addr, bytes, CALLER_PC);
-    log_debug(os, map)("Committed " RANGEFMT, RANGEFMTARGS(addr, bytes));
-  } else {
-    log_info(os, map)("Failed to commit " RANGEFMT, RANGEFMTARGS(addr, bytes));
-  }
-  return res;
-}
-
-bool os::commit_memory(char* addr, size_t size, size_t alignment_hint,
-                              bool executable) {
+bool os::commit_memory(char* addr, size_t size, bool executable,
+                       size_t alignment_hint) {
   assert_nonempty_range(addr, size);
-  bool res = os::pd_commit_memory(addr, size, alignment_hint, executable);
+  bool res = os::pd_commit_memory(addr, size, executable, alignment_hint);
   if (res) {
     MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC);
     log_debug(os, map)("Committed " RANGEFMT, RANGEFMTARGS(addr, size));
@@ -2148,17 +2135,10 @@ bool os::commit_memory(char* addr, size_t size, size_t alignment_hint,
   return res;
 }
 
-void os::commit_memory_or_exit(char* addr, size_t bytes, bool executable,
-                               const char* mesg) {
-  assert_nonempty_range(addr, bytes);
-  pd_commit_memory_or_exit(addr, bytes, executable, mesg);
-  MemTracker::record_virtual_memory_commit((address)addr, bytes, CALLER_PC);
-}
-
-void os::commit_memory_or_exit(char* addr, size_t size, size_t alignment_hint,
-                               bool executable, const char* mesg) {
+void os::commit_memory_or_exit(char* addr, size_t size, bool executable,
+                               const char* mesg, size_t alignment_hint) {
   assert_nonempty_range(addr, size);
-  os::pd_commit_memory_or_exit(addr, size, alignment_hint, executable, mesg);
+  os::pd_commit_memory_or_exit(addr, size, executable, mesg, alignment_hint);
   MemTracker::record_virtual_memory_commit((address)addr, size, CALLER_PC);
 }
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -239,7 +239,6 @@ class os: AllStatic {
   static size_t pd_pretouch_memory(void* first, void* last, size_t page_size);
 
   static char*  pd_reserve_memory_special(size_t size, size_t alignment, size_t page_size,
-
                                           char* addr, bool executable);
   static bool   pd_release_memory_special(char* addr, size_t bytes);
 
@@ -453,7 +452,8 @@ class os: AllStatic {
   static char*  reserve_memory(size_t bytes, bool executable = false, MemTag mem_tag = mtNone);
 
   // Reserves virtual memory that starts at an address that is aligned to 'alignment'.
-  static char*  reserve_memory_aligned(size_t size, size_t alignment, bool executable = false);
+  static char*  reserve_memory_aligned(size_t size, size_t alignment,
+                                       bool executable = false, MemTag mem_tag = mtNone);
 
   // Attempts to reserve the virtual memory at [addr, addr + bytes).
   // Does not overwrite existing mappings.
@@ -461,7 +461,8 @@ class os: AllStatic {
 
   // Given an address range [min, max), attempts to reserve memory within this area, with the given alignment.
   // If randomize is true, the location will be randomized.
-  static char* attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment, bool randomize);
+  static char* attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment,
+                                              bool randomize, MemTag mem_tag = mtNone);
 
   static bool   commit_memory(char* addr, size_t bytes, bool executable);
   static bool   commit_memory(char* addr, size_t size, size_t alignment_hint,
@@ -511,10 +512,11 @@ class os: AllStatic {
   // and is added to be used for implementation of -XX:AllocateHeapAt
   static char* map_memory_to_file(size_t size, int fd, MemTag mem_tag = mtNone);
   static char* map_memory_to_file_aligned(size_t size, size_t alignment, int fd, MemTag mem_tag = mtNone);
-  static char* map_memory_to_file(char* base, size_t size, int fd);
+  static char* map_memory_to_file(char* base, size_t size, int fd, MemTag mem_tag = mtNone);
   static char* attempt_map_memory_to_file_at(char* base, size_t size, int fd, MemTag mem_tag = mtNone);
+
   // Replace existing reserved memory with file mapping
-  static char* replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd);
+  static char* replace_existing_mapping_with_file_mapping(char* base, size_t size, int fd, MemTag mem_tag = mtNone);
 
   static char*  map_memory(int fd, const char* file_name, size_t file_offset,
                            char *addr, size_t bytes, bool read_only = false,

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -212,16 +212,13 @@ class os: AllStatic {
 
   static char*  pd_attempt_reserve_memory_at(char* addr, size_t bytes, bool executable);
 
-  static bool   pd_commit_memory(char* addr, size_t bytes, bool executable);
-  static bool   pd_commit_memory(char* addr, size_t size, size_t alignment_hint,
-                                 bool executable);
+  static bool   pd_commit_memory(char* addr, size_t size, bool executable,
+                                 size_t alignment_hint = 0);
   // Same as pd_commit_memory() that either succeeds or calls
   // vm_exit_out_of_memory() with the specified mesg.
-  static void   pd_commit_memory_or_exit(char* addr, size_t bytes,
-                                         bool executable, const char* mesg);
-  static void   pd_commit_memory_or_exit(char* addr, size_t size,
-                                         size_t alignment_hint,
-                                         bool executable, const char* mesg);
+  static void   pd_commit_memory_or_exit(char* addr, size_t bytes, bool executable,
+                                         const char* mesg, size_t alignment_hint = 0);
+
   static bool   pd_uncommit_memory(char* addr, size_t bytes, bool executable);
   static bool   pd_release_memory(char* addr, size_t bytes);
 
@@ -464,16 +461,13 @@ class os: AllStatic {
   static char* attempt_reserve_memory_between(char* min, char* max, size_t bytes, size_t alignment,
                                               bool randomize, MemTag mem_tag = mtNone);
 
-  static bool   commit_memory(char* addr, size_t bytes, bool executable);
-  static bool   commit_memory(char* addr, size_t size, size_t alignment_hint,
-                              bool executable);
+  static bool   commit_memory(char* addr, size_t size, bool executable,
+                              size_t alignment_hint = 0);
   // Same as commit_memory() that either succeeds or calls
   // vm_exit_out_of_memory() with the specified mesg.
-  static void   commit_memory_or_exit(char* addr, size_t bytes,
-                                      bool executable, const char* mesg);
-  static void   commit_memory_or_exit(char* addr, size_t size,
-                                      size_t alignment_hint,
-                                      bool executable, const char* mesg);
+  static void   commit_memory_or_exit(char* addr, size_t size, bool executable,
+                                      const char* mesg, size_t alignment_hint = 0);
+
   static bool   uncommit_memory(char* addr, size_t bytes, bool executable = false);
   static bool   release_memory(char* addr, size_t bytes);
 


### PR DESCRIPTION
We add `MemTag` parameter to `map_memory_to_file(..., MemTag mem_tag)`.

We also simplify/minimize `commit_memory` implementation, by making `size_t alignment_hint` parameter take default value and be optional.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8255414](https://bugs.openjdk.org/browse/JDK-8255414): Ensure OS functions always report to NMT (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21231/head:pull/21231` \
`$ git checkout pull/21231`

Update a local copy of the PR: \
`$ git checkout pull/21231` \
`$ git pull https://git.openjdk.org/jdk.git pull/21231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21231`

View PR using the GUI difftool: \
`$ git pr show -t 21231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21231.diff">https://git.openjdk.org/jdk/pull/21231.diff</a>

</details>
