### PR TITLE
8341261: Tests assume UnlockExperimentalVMOptions is disabled by default

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -63,6 +63,7 @@ requires.properties= \
     vm.gc.Z \
     vm.gc.ZGenerational \
     vm.gc.ZSinglegen \
+    vm.unlockExperimentalOptions \
     vm.jvmci \
     vm.jvmci.enabled \
     vm.emulatedClient \

--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -63,7 +63,6 @@ requires.properties= \
     vm.gc.Z \
     vm.gc.ZGenerational \
     vm.gc.ZSinglegen \
-    vm.unlockExperimentalOptions \
     vm.jvmci \
     vm.jvmci.enabled \
     vm.emulatedClient \

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
@@ -25,7 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
- * @requires ! vm.unlockExperimentalOptions
+ * @requires ! vm.opt.final.UnlockExperimentalVMOptions
  * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeExperimentalUnlockTest
  */

--- a/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
+++ b/test/hotspot/jtreg/compiler/blackhole/BlackholeExperimentalUnlockTest.java
@@ -25,6 +25,7 @@
  * @test
  * @library /test/lib /
  * @requires vm.flagless
+ * @requires ! vm.unlockExperimentalOptions
  * @requires vm.compMode != "Xint"
  * @run driver compiler.blackhole.BlackholeExperimentalUnlockTest
  */

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
@@ -22,15 +22,37 @@
  */
 
 /*
- * @test
+ * @test VMOptionWarningExperimental
  * @bug 8027314
- * @summary Warn if diagnostic or experimental vm option is used and -XX:+UnlockDiagnosticVMOptions or -XX:+UnlockExperimentalVMOptions, respectively, isn't specified. Warn if develop vm option is used with product version of VM.
+ * @summary Warn if experimental vm option is used and -XX:+UnlockExperimentalVMOptions isn't specified.
  * @requires vm.flagless
  * @requires ! vm.opt.final.UnlockExperimentalVMOptions
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management
- * @run driver VMOptionWarning
+ * @run driver VMOptionWarning Experimental
+ */
+
+/* @test VMOptionWarningDiagnostic
+ * @bug 8027314
+ * @summary Warn if diagnostic vm option is used and -XX:+UnlockDiagnosticVMOptions isn't specified.
+ * @requires vm.flagless
+ * @requires ! vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver VMOptionWarning Diagnostic
+ */
+
+/* @test VMOptionWarningDevelop
+ * @bug 8027314
+ * @summary Warn if develop vm option is used with product version of VM.
+ * @requires vm.flagless
+ * @requires ! vm.debug
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.management
+ * @run driver VMOptionWarning Develop
  */
 
 import jdk.test.lib.process.ProcessTools;
@@ -39,24 +61,37 @@ import jdk.test.lib.Platform;
 
 public class VMOptionWarning {
     public static void main(String[] args) throws Exception {
-        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+AlwaysSafeConstructors", "-version");
-        OutputAnalyzer output = new OutputAnalyzer(pb.start());
-        output.shouldNotHaveExitValue(0);
-        output.shouldContain("Error: VM option 'AlwaysSafeConstructors' is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions.");
-
-        if (Platform.isDebugBuild()) {
-            System.out.println("Skip the rest of the tests on debug builds since diagnostic, and develop options are available on debug builds.");
-            return;
+        if (args.length != 1) {
+            throw new RuntimeException("wrong number of args: " + args.length);
         }
 
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+PrintInlining", "-version");
-        output = new OutputAnalyzer(pb.start());
-        output.shouldNotHaveExitValue(0);
-        output.shouldContain("Error: VM option 'PrintInlining' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
-
-        pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+VerifyStack", "-version");
-        output = new OutputAnalyzer(pb.start());
-        output.shouldNotHaveExitValue(0);
-        output.shouldContain("Error: VM option 'VerifyStack' is develop and is available only in debug version of VM.");
+        ProcessBuilder pb;
+        OutputAnalyzer output;
+        switch (args[0]) {
+            case "Experimental": {
+                pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+AlwaysSafeConstructors", "-version");
+                output = new OutputAnalyzer(pb.start());
+                output.shouldNotHaveExitValue(0);
+                output.shouldContain("Error: VM option 'AlwaysSafeConstructors' is experimental and must be enabled via -XX:+UnlockExperimentalVMOptions.");
+                break;
+            }
+            case "Diagnostic": {
+                pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+PrintInlining", "-version");
+                output = new OutputAnalyzer(pb.start());
+                output.shouldNotHaveExitValue(0);
+                output.shouldContain("Error: VM option 'PrintInlining' is diagnostic and must be enabled via -XX:+UnlockDiagnosticVMOptions.");
+                break;
+            }
+            case "Develop": {
+                pb = ProcessTools.createLimitedTestJavaProcessBuilder("-XX:+VerifyStack", "-version");
+                output = new OutputAnalyzer(pb.start());
+                output.shouldNotHaveExitValue(0);
+                output.shouldContain("Error: VM option 'VerifyStack' is develop and is available only in debug version of VM.");
+                break;
+            }
+            default: {
+                throw new RuntimeException("Invalid argument: " + args[0]);
+            }
+        }
     }
 }

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
@@ -26,7 +26,7 @@
  * @bug 8027314
  * @summary Warn if diagnostic or experimental vm option is used and -XX:+UnlockDiagnosticVMOptions or -XX:+UnlockExperimentalVMOptions, respectively, isn't specified. Warn if develop vm option is used with product version of VM.
  * @requires vm.flagless
- * @requires ! vm.unlockExperimentalOptions
+ * @requires ! vm.opt.final.UnlockExperimentalVMOptions
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
+++ b/test/hotspot/jtreg/runtime/CommandLine/VMOptionWarning.java
@@ -26,6 +26,7 @@
  * @bug 8027314
  * @summary Warn if diagnostic or experimental vm option is used and -XX:+UnlockDiagnosticVMOptions or -XX:+UnlockExperimentalVMOptions, respectively, isn't specified. Warn if develop vm option is used with product version of VM.
  * @requires vm.flagless
+ * @requires ! vm.unlockExperimentalOptions
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -104,7 +104,6 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.flightRecorder", this::vmFlightRecorder);
         map.put("vm.simpleArch", this::vmArch);
         map.put("vm.debug", this::vmDebug);
-        map.put("vm.unlockExperimentalOptions", this::vmUnlockExperimentalOptions);
         map.put("vm.jvmci", this::vmJvmci);
         map.put("vm.jvmci.enabled", this::vmJvmciEnabled);
         map.put("vm.emulatedClient", this::vmEmulatedClient);
@@ -254,13 +253,6 @@ public class VMProps implements Callable<Map<String, String>> {
     }
 
     /**
-     * @return true if VM has experimental options unlocked
-     */
-    protected String vmUnlockExperimentalOptions() {
-        return "" + WB.getBooleanVMFlag("UnlockExperimentalVMOptions");
-    }
-
-    /**
      * @return true if VM supports JVMCI and false otherwise
      */
     protected String vmJvmci() {
@@ -392,6 +384,7 @@ public class VMProps implements Callable<Map<String, String>> {
         vmOptFinalFlag(map, "CriticalJNINatives");
         vmOptFinalFlag(map, "EnableJVMCI");
         vmOptFinalFlag(map, "EliminateAllocations");
+        vmOptFinalFlag(map, "UnlockExperimentalVMOptions");
         vmOptFinalFlag(map, "UseCompressedOops");
         vmOptFinalFlag(map, "UseLargePages");
         vmOptFinalFlag(map, "UseVectorizedMismatchIntrinsic");

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -104,6 +104,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.flightRecorder", this::vmFlightRecorder);
         map.put("vm.simpleArch", this::vmArch);
         map.put("vm.debug", this::vmDebug);
+        map.put("vm.unlockExperimentalOptions", this::vmUnlockExperimentalOptions);
         map.put("vm.jvmci", this::vmJvmci);
         map.put("vm.jvmci.enabled", this::vmJvmciEnabled);
         map.put("vm.emulatedClient", this::vmEmulatedClient);
@@ -250,6 +251,13 @@ public class VMProps implements Callable<Map<String, String>> {
         } else {
             return errorWithMessage("Can't get 'jdk.debug' property");
         }
+    }
+
+    /**
+     * @return true if VM has experimental options unlocked
+     */
+    protected String vmUnlockExperimentalOptions() {
+        return "" + WB.getBooleanVMFlag("UnlockExperimentalVMOptions");
     }
 
     /**


### PR DESCRIPTION
`-UnlockExperimentalVMOptions` isn't necessarily the default: a distro may enable it in order to default-enable other features like JVMCI/Graal.

I'm not entirely satisfied by adding a `@require` that only applies to a subset of the checks in a test class.  In `VMOptionWarning`, the experimental flag only applies to the first of the three scenarios it checks.  But I suspect this is a general problem with `@require`, and I'd be happy to hear suggestions on how to avoid disabling too much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341261](https://bugs.openjdk.org/browse/JDK-8341261): Tests assume UnlockExperimentalVMOptions is disabled by default (**Enhancement** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**) Review applies to [e8e42d22](https://git.openjdk.org/jdk/pull/21233/files/e8e42d2262a2a061802c4b30396072cc98033bd1)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21233/head:pull/21233` \
`$ git checkout pull/21233`

Update a local copy of the PR: \
`$ git checkout pull/21233` \
`$ git pull https://git.openjdk.org/jdk.git pull/21233/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21233`

View PR using the GUI difftool: \
`$ git pr show -t 21233`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21233.diff">https://git.openjdk.org/jdk/pull/21233.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21233#issuecomment-2386742771)