### PR TITLE
8340969: jdk/jfr/startupargs/TestStartDuration.java should be marked as flagless

### DIFF
--- a/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
+++ b/test/jdk/jdk/jfr/startupargs/TestStartDuration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,6 +38,7 @@ import jdk.test.lib.process.ProcessTools;
  * @summary Start a recording with duration. Verify recording stops.
  * @key jfr
  * @requires vm.hasJFR
+ * @requires vm.flagless
  * @library /test/lib /test/jdk
  * @run main jdk.jfr.startupargs.TestStartDuration
  */


### PR DESCRIPTION
Test jdk/jfr/startupargs/TestStartDuration.java
checks duration, the time might be too small for stress options like Xcomp.
So it makes sense to mark it as flaglesss.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340969](https://bugs.openjdk.org/browse/JDK-8340969): jdk/jfr/startupargs/TestStartDuration.java should be marked as flagless (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21237/head:pull/21237` \
`$ git checkout pull/21237`

Update a local copy of the PR: \
`$ git checkout pull/21237` \
`$ git pull https://git.openjdk.org/jdk.git pull/21237/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21237`

View PR using the GUI difftool: \
`$ git pr show -t 21237`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21237.diff">https://git.openjdk.org/jdk/pull/21237.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21237#issuecomment-2380332624)
</details>
