### PR TITLE
8341131: Some jdk/jfr/event/compiler tests shouldn't be executed with Xcomp

### DIFF
--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerCompile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,7 @@ import jdk.test.whitebox.WhiteBox;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.compMode!="Xint"
+ * @requires vm.compMode == "Xmixed"
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/jdk/jdk/jfr/event/compiler/TestCompilerInlining.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestCompilerInlining.java
@@ -57,7 +57,7 @@ import static java.lang.constant.ConstantDescs.INIT_NAME;
  * @key jfr
  * @summary Verifies that corresponding JFR events are emitted in case of inlining.
  * @requires vm.hasJFR
- *
+ * @requires vm.compMode == "Xmixed"
  * @requires vm.opt.Inline == true | vm.opt.Inline == null
  * @library /test/lib
  * @modules jdk.jfr

--- a/test/jdk/jdk/jfr/event/compiler/TestDeoptimization.java
+++ b/test/jdk/jdk/jfr/event/compiler/TestDeoptimization.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ class Dummy {
  * @key jfr
  * @summary sanity test for Deoptimization event, depends on Compilation event
  * @requires vm.hasJFR
- * @requires vm.compMode != "Xint"
+ * @requires vm.compMode == "Xmixed"
  * @requires vm.flavor == "server" & (vm.opt.TieredStopAtLevel == 4 | vm.opt.TieredStopAtLevel == null)
  * @requires vm.opt.StressUnstableIfTraps == null | !vm.opt.StressUnstableIfTraps
  * @library /test/lib


### PR DESCRIPTION
Few jdk/jfr/event/compiler tests sensitive to compile flags and shouldn't be executed with Xcomp.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341131](https://bugs.openjdk.org/browse/JDK-8341131): Some jdk/jfr/event/compiler tests shouldn't be executed with Xcomp (**Bug** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21239/head:pull/21239` \
`$ git checkout pull/21239`

Update a local copy of the PR: \
`$ git checkout pull/21239` \
`$ git pull https://git.openjdk.org/jdk.git pull/21239/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21239`

View PR using the GUI difftool: \
`$ git pr show -t 21239`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21239.diff">https://git.openjdk.org/jdk/pull/21239.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21239#issuecomment-2380391280)