### PR TITLE
8340945: Ubsan: oopStorage.cpp:374:8: runtime error: applying non-zero offset 18446744073709551168 to null pointer

### DIFF
--- a/src/hotspot/share/gc/shared/oopStorage.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.hpp
@@ -288,7 +288,7 @@ private:
   Block* block_for_allocation();
   void  log_block_transition(Block* block, const char* new_state) const;
 
-  Block* find_block_or_null(const oop* ptr) const;
+  Block* block_for_ptr(const oop* ptr) const;
   void delete_empty_block(const Block& block);
   bool reduce_deferred_updates();
   void record_needs_cleanup();

--- a/src/hotspot/share/gc/shared/oopStorage.inline.hpp
+++ b/src/hotspot/share/gc/shared/oopStorage.inline.hpp
@@ -184,7 +184,10 @@ public:
   void set_active_index(size_t index);
   static size_t active_index_safe(const Block* block); // Returns 0 if access fails.
 
-  // Returns null if ptr is not in a block or not allocated in that block.
+  // Return block of owner containing ptr, if ptr is a valid entry of owner.
+  // If ptr is not a valid entry of owner then returns either null or a "false
+  // positive" pointer; see allocation_status.
+  // precondition: ptr != nullptr
   static Block* block_for_ptr(const OopStorage* owner, const oop* ptr);
 
   oop* allocate();

--- a/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
+++ b/test/hotspot/gtest/gc/shared/test_oopStorage.cpp
@@ -93,6 +93,18 @@ public:
   static void block_array_set_block_count(ActiveArray* blocks, size_t count) {
     blocks->_block_count = count;
   }
+
+  static const oop* get_block_pointer(const Block& block, unsigned index) {
+    return block.get_pointer(index);
+  }
+
+  static Block* new_block(const OopStorage& owner) {
+    return Block::new_block(&owner);
+  }
+
+  static void delete_block(const Block& block) {
+    Block::delete_block(block);
+  }
 };
 
 typedef OopStorage::TestAccess TestAccess;
@@ -518,24 +530,35 @@ TEST_VM_F(OopStorageTest, bulk_allocation) {
   }
 }
 
-#ifndef DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS
-TEST_VM_F(OopStorageTest, invalid_pointer) {
-  {
-    char* mem = NEW_C_HEAP_ARRAY(char, 1000, mtInternal);
-    oop* ptr = reinterpret_cast<oop*>(align_down(mem + 250, sizeof(oop)));
-    // Predicate returns false for some malloc'ed block.
-    EXPECT_EQ(OopStorage::INVALID_ENTRY, storage().allocation_status(ptr));
-    FREE_C_HEAP_ARRAY(char, mem);
-  }
-
-  {
-    oop obj;
-    oop* ptr = &obj;
-    // Predicate returns false for some "random" location.
-    EXPECT_EQ(OopStorage::INVALID_ENTRY, storage().allocation_status(ptr));
-  }
+TEST_VM_F(OopStorageTest, invalid_malloc_pointer) {
+  char* mem = NEW_C_HEAP_ARRAY(char, 1000, mtInternal);
+  oop* ptr = reinterpret_cast<oop*>(align_down(mem + 250, sizeof(oop)));
+  // Predicate returns false for some malloc'ed block.
+  EXPECT_EQ(OopStorage::INVALID_ENTRY, storage().allocation_status(ptr));
+  FREE_C_HEAP_ARRAY(char, mem);
 }
-#endif // DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS
+
+TEST_VM_F(OopStorageTest, invalid_random_pointer) {
+  oop obj;
+  oop* ptr = &obj;
+  // Predicate returns false for some "random" location.
+  EXPECT_EQ(OopStorage::INVALID_ENTRY, storage().allocation_status(ptr));
+}
+
+TEST_VM_F(OopStorageTest, invalid_block_pointer) {
+  // Allocate a block for storage, but don't insert it into the storage.  This
+  // also tests the false positive case of block_for_ptr where we have a
+  // reference to storage at just the "right" place.
+  const OopBlock* block = TestAccess::new_block(storage());
+  ASSERT_NE(block, NULL_BLOCK);
+  const oop* ptr = TestAccess::get_block_pointer(*block, 0);
+  EXPECT_EQ(OopStorage::INVALID_ENTRY, storage().allocation_status(ptr));
+  TestAccess::delete_block(*block);
+}
+
+TEST_VM_F(OopStorageTest, invalid_null_pointer) {
+  EXPECT_EQ(OopStorage::INVALID_ENTRY, storage().allocation_status(nullptr));
+}
 
 class OopStorageTest::CountingIterateClosure {
 public:


### PR DESCRIPTION
Please review this change to the OopStorage handling of storage block lookup,
now being more careful about pointer arithmetic to avoid UB.

As an initial cleanup, renamed OopStorage::find_block_or_null to
block_for_ptr, for consistency with the Block function that implements it.
Also moved the precondition assert that the argument is non-null into the
Block function, where the requirement is located.

Changed OopStorage::Block::block_for_ptr to avoid pointer arithmetic that
might invoke UB, instead converting the pointer argument to uintptr_t and
performing arithmetic on it. Also fixed its description in the header file.

Similarly changed OopStorage::Block::active_index_safe to avoid pointer
arithmetic, instead converting to uintptr_t for arithmetic.  This avoids
potential problems when the Block argument is a "false positive" from
block_for_ptr. 

Changed OopStorage::allocation_status to check up front for a null argument,
immediately returning INVALID_ENTRY in that case. This avoids voilating
block_for_ptr's precondition that the argument is non-null. Added a gtest for
this.  Also added a gtest for the potential false-positive case.

While updating gtests, removed #ifndef DISABLE_GARBAGE_ALLOCATION_STATUS_TESTS.
That macro was included when these tests were first added, because some tests
needed to be disabled on Windows, due to SafeFetchN in gtest context not working
on that platform. That was later fixed by JDK-8185734. The conditional #define
of that macro in test_oopStorage.cpp was removed, but the no longer needed
#ifndef was inadvertently not removed.

Testing: mach5 tier1-5
Locally (linux-x64) reproduced the reported ubsan failure, and verified it no
longer reproduces with these changes.

While working on this change I noticed a related issue.  The recently added
OopStorage::print_containing doesn't verify the block is not a false positive
before using it as a block.  I'll file a JBS issue for this.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340945](https://bugs.openjdk.org/browse/JDK-8340945): Ubsan: oopStorage.cpp:374:8: runtime error: applying non-zero offset 18446744073709551168 to null pointer (**Bug** - P3)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21240/head:pull/21240` \
`$ git checkout pull/21240`

Update a local copy of the PR: \
`$ git checkout pull/21240` \
`$ git pull https://git.openjdk.org/jdk.git pull/21240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21240`

View PR using the GUI difftool: \
`$ git pr show -t 21240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21240.diff">https://git.openjdk.org/jdk/pull/21240.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21240#issuecomment-2380414537)