### PR TITLE
8211400: nsk.share.gc.Memory::getArrayLength returns wrong value

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/Memory.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/Memory.java
@@ -163,7 +163,7 @@ public final class Memory {
          *  @return size of array
          */
         public static long getArraySize(int length, long objectSize) {
-                return getObjectExtraSize() + length * objectSize;
+                return getArrayExtraSize() + length * objectSize;
         }
 
         /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/gc/Memory.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/gc/Memory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,12 +150,9 @@ public final class Memory {
          *  @return length of array
          */
         public static int getArrayLength(long memory, long objectSize) {
-                int referenceSize = getReferenceSize();
                 int arrayExtraSize = getArrayExtraSize();
-                return (int) Math.min(
-                                (memory - arrayExtraSize) / (objectSize + referenceSize),
-                                Integer.MAX_VALUE
-                                );
+                return (int) Math.min((memory - arrayExtraSize) / objectSize,
+                        Integer.MAX_VALUE);
         }
 
         /**
@@ -166,7 +163,7 @@ public final class Memory {
          *  @return size of array
          */
         public static long getArraySize(int length, long objectSize) {
-                return getObjectExtraSize() + length * (objectSize + getReferenceSize());
+                return getObjectExtraSize() + length * objectSize;
         }
 
         /**


### PR DESCRIPTION
Current formula is incorrect since array doesn't use reference for each element.

Tested with test groups,
vmTestbase_vm_gc_ref
vmTestbase_vm_gc_juggle
vmTestbase_vm_gc_misc

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211400](https://bugs.openjdk.org/browse/JDK-8211400): nsk.share.gc.Memory::getArrayLength returns wrong value (**Bug** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21247/head:pull/21247` \
`$ git checkout pull/21247`

Update a local copy of the PR: \
`$ git checkout pull/21247` \
`$ git pull https://git.openjdk.org/jdk.git pull/21247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21247`

View PR using the GUI difftool: \
`$ git pr show -t 21247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21247.diff">https://git.openjdk.org/jdk/pull/21247.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21247#issuecomment-2381264628)