### PR TITLE
8340572: ConcurrentModificationException when sorting ArrayList sublists

### DIFF
--- a/src/java.base/share/classes/java/util/ArrayList.java
+++ b/src/java.base/share/classes/java/util/ArrayList.java
@@ -1808,6 +1808,7 @@ public class ArrayList<E> extends AbstractList<E>
     @Override
     public void sort(Comparator<? super E> c) {
         sortRange(c, 0, size);
+        modCount++;
     }
 
     @SuppressWarnings("unchecked")
@@ -1816,7 +1817,6 @@ public class ArrayList<E> extends AbstractList<E>
         Arrays.sort((E[]) elementData, fromIndex, toIndex, c);
         if (modCount != expectedModCount)
             throw new ConcurrentModificationException();
-        modCount++;
     }
 
     void checkInvariants() {

--- a/test/jdk/java/util/ArrayList/Bug8340572.java
+++ b/test/jdk/java/util/ArrayList/Bug8340572.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * @test
+ * @bug 8340572
+ * @summary ConcurrentModificationException when sorting ArrayList sublists
+ */
+
+public class Bug8340572 {
+    public static void main(String[] args) {
+        List<Integer> l = new ArrayList<>(List.of(1, 2, 3, 4));
+        var a = l.subList(0, 2);
+        var b = l.subList(2, 4);
+        Collections.sort(a);
+        Collections.sort(b);
+    }
+}

--- a/test/jdk/java/util/ArrayList/SortingModCount.java
+++ b/test/jdk/java/util/ArrayList/SortingModCount.java
@@ -23,6 +23,7 @@
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.ConcurrentModificationException;
 import java.util.List;
 
 /**
@@ -31,12 +32,28 @@ import java.util.List;
  * @summary ConcurrentModificationException when sorting ArrayList sublists
  */
 
-public class Bug8340572 {
+public class SortingModCount {
     public static void main(String[] args) {
+        testSortingSubListsDoesNotIncrementModCount();
+        testSortingListDoesIncrementModCount();
+    }
+
+    private static void testSortingSubListsDoesNotIncrementModCount() {
         List<Integer> l = new ArrayList<>(List.of(1, 2, 3, 4));
         var a = l.subList(0, 2);
         var b = l.subList(2, 4);
         Collections.sort(a);
         Collections.sort(b);
+    }
+
+    private static void testSortingListDoesIncrementModCount() {
+        List<Integer> l = new ArrayList<>(List.of(1, 2, 3, 4));
+        var b = l.subList(2, 4);
+        Collections.sort(l);
+        try {
+            Collections.sort(b);
+            throw new Error("expected ConcurrentModificationException not thrown");
+        } catch (ConcurrentModificationException expected) {
+        }
     }
 }


### PR DESCRIPTION
Fixes a regression with #17818 where `ArrayList.subList(…).sort()` started incrementing `ArrayList.modCount` resulting in some cases throwing a `ConcurrentModificationException` where none was thrown before.

This change keeps the optimization from #17818 but restores the behavior where only sorting the `ArrayList` changes the mod count, but sorting its sublists does not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340572](https://bugs.openjdk.org/browse/JDK-8340572): ConcurrentModificationException when sorting ArrayList sublists (**Bug** - P2)


### Reviewers
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21250/head:pull/21250` \
`$ git checkout pull/21250`

Update a local copy of the PR: \
`$ git checkout pull/21250` \
`$ git pull https://git.openjdk.org/jdk.git pull/21250/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21250`

View PR using the GUI difftool: \
`$ git pr show -t 21250`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21250.diff">https://git.openjdk.org/jdk/pull/21250.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21250#issuecomment-2381442263)