### PR TITLE
8340420: ZGC: Should call `vm_shutdown_during_initialization` if initialization fails

### DIFF
--- a/src/hotspot/os/bsd/gc/z/zPhysicalMemoryBacking_bsd.cpp
+++ b/src/hotspot/os/bsd/gc/z/zPhysicalMemoryBacking_bsd.cpp
@@ -22,10 +22,10 @@
  */
 
 #include "precompiled.hpp"
-#include "gc/shared/gcLogPrecious.hpp"
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zErrno.hpp"
 #include "gc/z/zGlobals.hpp"
+#include "gc/z/zInitialize.hpp"
 #include "gc/z/zLargePages.inline.hpp"
 #include "gc/z/zPhysicalMemory.inline.hpp"
 #include "gc/z/zPhysicalMemoryBacking_bsd.hpp"
@@ -82,7 +82,7 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity)
   _base = (uintptr_t)os::reserve_memory(max_capacity);
   if (_base == 0) {
     // Failed
-    log_error_pd(gc)("Failed to reserve address space for backing memory");
+    ZInitialize::error("Failed to reserve address space for backing memory");
     return;
   }
 

--- a/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
+++ b/src/hotspot/os/linux/gc/z/zPhysicalMemoryBacking_linux.cpp
@@ -27,6 +27,7 @@
 #include "gc/z/zArray.inline.hpp"
 #include "gc/z/zErrno.hpp"
 #include "gc/z/zGlobals.hpp"
+#include "gc/z/zInitialize.hpp"
 #include "gc/z/zLargePages.inline.hpp"
 #include "gc/z/zMountPoint_linux.hpp"
 #include "gc/z/zNUMA.inline.hpp"
@@ -129,6 +130,7 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity)
   // Create backing file
   _fd = create_fd(ZFILENAME_HEAP);
   if (_fd == -1) {
+    ZInitialize::error("Failed to create heap backing file");
     return;
   }
 
@@ -136,7 +138,7 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity)
   while (ftruncate(_fd, max_capacity) == -1) {
     if (errno != EINTR) {
       ZErrno err;
-      log_error_p(gc)("Failed to truncate backing file (%s)", err.to_string());
+      ZInitialize::error("Failed to truncate backing file (%s)", err.to_string());
       return;
     }
   }
@@ -145,7 +147,7 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity)
   struct statfs buf;
   if (fstatfs(_fd, &buf) == -1) {
     ZErrno err;
-    log_error_p(gc)("Failed to determine filesystem type for backing file (%s)", err.to_string());
+    ZInitialize::error("Failed to determine filesystem type for backing file (%s)", err.to_string());
     return;
   }
 
@@ -158,39 +160,39 @@ ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity)
 
   // Make sure the filesystem type matches requested large page type
   if (ZLargePages::is_transparent() && !is_tmpfs()) {
-    log_error_p(gc)("-XX:+UseTransparentHugePages can only be enabled when using a %s filesystem",
-                    ZFILESYSTEM_TMPFS);
+    ZInitialize::error("-XX:+UseTransparentHugePages can only be enabled when using a %s filesystem",
+                       ZFILESYSTEM_TMPFS);
     return;
   }
 
   if (ZLargePages::is_transparent() && !tmpfs_supports_transparent_huge_pages()) {
-    log_error_p(gc)("-XX:+UseTransparentHugePages on a %s filesystem not supported by kernel",
-                    ZFILESYSTEM_TMPFS);
+    ZInitialize::error("-XX:+UseTransparentHugePages on a %s filesystem not supported by kernel",
+                       ZFILESYSTEM_TMPFS);
     return;
   }
 
   if (ZLargePages::is_explicit() && !is_hugetlbfs()) {
-    log_error_p(gc)("-XX:+UseLargePages (without -XX:+UseTransparentHugePages) can only be enabled "
-                    "when using a %s filesystem", ZFILESYSTEM_HUGETLBFS);
+    ZInitialize::error("-XX:+UseLargePages (without -XX:+UseTransparentHugePages) can only be enabled "
+                       "when using a %s filesystem", ZFILESYSTEM_HUGETLBFS);
     return;
   }
 
   if (!ZLargePages::is_explicit() && is_hugetlbfs()) {
-    log_error_p(gc)("-XX:+UseLargePages must be enabled when using a %s filesystem",
-                    ZFILESYSTEM_HUGETLBFS);
+    ZInitialize::error("-XX:+UseLargePages must be enabled when using a %s filesystem",
+                       ZFILESYSTEM_HUGETLBFS);
     return;
   }
 
   // Make sure the filesystem block size is compatible
   if (ZGranuleSize % _block_size != 0) {
-    log_error_p(gc)("Filesystem backing the heap has incompatible block size (" SIZE_FORMAT ")",
-                    _block_size);
+    ZInitialize::error("Filesystem backing the heap has incompatible block size (" SIZE_FORMAT ")",
+                       _block_size);
     return;
   }
 
   if (is_hugetlbfs() && _block_size != ZGranuleSize) {
-    log_error_p(gc)("%s filesystem has unexpected block size " SIZE_FORMAT " (expected " SIZE_FORMAT ")",
-                    ZFILESYSTEM_HUGETLBFS, _block_size, ZGranuleSize);
+    ZInitialize::error("%s filesystem has unexpected block size " SIZE_FORMAT " (expected " SIZE_FORMAT ")",
+                       ZFILESYSTEM_HUGETLBFS, _block_size, ZGranuleSize);
     return;
   }
 

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -49,6 +49,7 @@
 #include "memory/universe.hpp"
 #include "oops/stackChunkOop.hpp"
 #include "runtime/continuationJavaClasses.hpp"
+#include "runtime/java.hpp"
 #include "runtime/jniHandles.inline.hpp"
 #include "runtime/stackWatermarkSet.hpp"
 #include "services/memoryUsage.hpp"
@@ -78,10 +79,13 @@ const char* ZCollectedHeap::name() const {
 
 jint ZCollectedHeap::initialize() {
   if (!_heap.is_initialized()) {
+    vm_shutdown_during_initialization(_initialize.error_message());
     return JNI_ENOMEM;
   }
 
   Universe::set_verify_data(~(ZAddressHeapBase - 1) | 0x7, ZAddressHeapBase);
+
+  _initialize.finish();
 
   return JNI_OK;
 }

--- a/src/hotspot/share/gc/z/zCollectedHeap.cpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.cpp
@@ -61,7 +61,7 @@ ZCollectedHeap* ZCollectedHeap::heap() {
 
 ZCollectedHeap::ZCollectedHeap()
   : _barrier_set(),
-    _initialize(&_barrier_set),
+    _initializer(&_barrier_set),
     _heap(),
     _driver_minor(new ZDriverMinor()),
     _driver_major(new ZDriverMajor()),
@@ -79,13 +79,13 @@ const char* ZCollectedHeap::name() const {
 
 jint ZCollectedHeap::initialize() {
   if (!_heap.is_initialized()) {
-    vm_shutdown_during_initialization(_initialize.error_message());
+    vm_shutdown_during_initialization(ZInitialize::error_message());
     return JNI_ENOMEM;
   }
 
   Universe::set_verify_data(~(ZAddressHeapBase - 1) | 0x7, ZAddressHeapBase);
 
-  _initialize.finish();
+  ZInitialize::finish();
 
   return JNI_OK;
 }

--- a/src/hotspot/share/gc/z/zCollectedHeap.hpp
+++ b/src/hotspot/share/gc/z/zCollectedHeap.hpp
@@ -43,7 +43,7 @@ class ZCollectedHeap : public CollectedHeap {
 
 private:
   ZBarrierSet       _barrier_set;
-  ZInitialize       _initialize;
+  ZInitializer      _initializer;
   ZHeap             _heap;
   ZDriverMinor*     _driver_minor;
   ZDriverMajor*     _driver_major;

--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -34,6 +34,7 @@
 #include "gc/z/zHeap.inline.hpp"
 #include "gc/z/zHeapIterator.hpp"
 #include "gc/z/zHeuristics.hpp"
+#include "gc/z/zInitialize.hpp"
 #include "gc/z/zPage.inline.hpp"
 #include "gc/z/zPageTable.inline.hpp"
 #include "gc/z/zResurrection.hpp"
@@ -74,7 +75,7 @@ ZHeap::ZHeap()
 
   // Prime cache
   if (!_page_allocator.prime_cache(_old.workers(), InitialHeapSize)) {
-    log_error_p(gc)("Failed to allocate initial Java heap (" SIZE_FORMAT "M)", InitialHeapSize / M);
+    ZInitialize::error("Failed to allocate initial Java heap (" SIZE_FORMAT "M)", InitialHeapSize / M);
     return;
   }
 

--- a/src/hotspot/share/gc/z/zInitialize.cpp
+++ b/src/hotspot/share/gc/z/zInitialize.cpp
@@ -74,35 +74,35 @@ void ZInitialize::initialize(ZBarrierSet* barrier_set) {
   pd_initialize();
 }
 
-void ZInitialize::register_error(bool debug, const char *error) {
+void ZInitialize::register_error(bool debug, const char *error_msg) {
   guarantee(!_finished, "Only register errors during initialization");
 
   if (!_had_error) {
-    strncpy(_error_message, error, ErrorMessageLength - 1);
+    strncpy(_error_message, error_msg, ErrorMessageLength - 1);
     _had_error = true;
   }
 
   if (debug) {
-    log_error_pd(gc)("%s", error);
+    log_error_pd(gc)("%s", error_msg);
   } else {
-    log_error_p(gc)("%s", error);
+    log_error_p(gc)("%s", error_msg);
   }
 }
 
 void ZInitialize::error(const char* msg_format, ...) {
   va_list argp;
   va_start(argp, msg_format);
-  const FormatBuffer<ErrorMessageLength> error(FormatBufferDummy(), msg_format, argp);
+  const FormatBuffer<ErrorMessageLength> error_msg(FormatBufferDummy(), msg_format, argp);
   va_end(argp);
-  register_error(false /* debug */, error);
+  register_error(false /* debug */, error_msg);
 }
 
 void ZInitialize::error_d(const char* msg_format, ...) {
   va_list argp;
   va_start(argp, msg_format);
-  const FormatBuffer<ErrorMessageLength> error(FormatBufferDummy(), msg_format, argp);
+  const FormatBuffer<ErrorMessageLength> error_msg(FormatBufferDummy(), msg_format, argp);
   va_end(argp);
-  register_error(true /* debug */, error);
+  register_error(true /* debug */, error_msg);
 }
 
 bool ZInitialize::had_error() {

--- a/src/hotspot/share/gc/z/zInitialize.cpp
+++ b/src/hotspot/share/gc/z/zInitialize.cpp
@@ -111,10 +111,10 @@ bool ZInitialize::had_error() {
 
 const char* ZInitialize::error_message() {
   assert(had_error(), "Should have registered an error");
-  if (!had_error()) {
-    return "Unknown error, check error GC logs";
+  if (had_error()) {
+    return _error_message;
   }
-  return _error_message;
+  return "Unknown error, check error GC logs";
 }
 
 void ZInitialize::finish() {

--- a/src/hotspot/share/gc/z/zInitialize.cpp
+++ b/src/hotspot/share/gc/z/zInitialize.cpp
@@ -47,7 +47,11 @@ ZErrorMessage* ZInitialize::_error_message = nullptr;
 bool           ZInitialize::_had_error     = false;
 bool           ZInitialize::_finished      = false;
 
-ZInitialize::ZInitialize(ZBarrierSet* barrier_set) {
+ZInitializer::ZInitializer(ZBarrierSet* barrier_set) {
+  ZInitialize::initialize(barrier_set);
+}
+
+void ZInitialize::initialize(ZBarrierSet* barrier_set) {
   log_info(gc, init)("Initializing %s", ZName);
   log_info(gc, init)("Version: %s (%s)",
                      VM_Version::vm_release(),

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -24,12 +24,18 @@
 #ifndef SHARE_GC_Z_ZINITIALIZE_HPP
 #define SHARE_GC_Z_ZINITIALIZE_HPP
 
-#include "memory/allocation.hpp"
+#include "memory/allStatic.hpp"
+#include "utilities/compilerWarnings.hpp"
 
 class ZBarrierSet;
 class ZErrorMessage;
 
-class ZInitialize {
+class ZInitializer {
+ public:
+  ZInitializer(ZBarrierSet* barrier_set);
+};
+
+class ZInitialize : public AllStatic {
 private:
   static ZErrorMessage* _error_message;
   static bool           _had_error;
@@ -37,7 +43,7 @@ private:
 
   static void register_error(bool debug, const char *error);
 
-  void pd_initialize();
+  static void pd_initialize();
 
 public:
   static void error(const char* msg_format, ...) ATTRIBUTE_PRINTF(1, 2);
@@ -46,9 +52,8 @@ public:
   static bool had_error();
   static const char* error_message();
 
+  static void initialize(ZBarrierSet* barrier_set);
   static void finish();
-
-  ZInitialize(ZBarrierSet* barrier_set);
 };
 
 #endif // SHARE_GC_Z_ZINITIALIZE_HPP

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -27,8 +27,9 @@
 #include "memory/allStatic.hpp"
 #include "utilities/compilerWarnings.hpp"
 
+#include <cstddef>
+
 class ZBarrierSet;
-class ZErrorMessage;
 
 class ZInitializer {
  public:
@@ -37,9 +38,10 @@ class ZInitializer {
 
 class ZInitialize : public AllStatic {
 private:
-  static ZErrorMessage* _error_message;
-  static bool           _had_error;
-  static bool           _finished;
+  static constexpr size_t ErrorMessageLength = 256;
+  static char _error_message[ErrorMessageLength];
+  static bool _had_error;
+  static bool _finished;
 
   static void register_error(bool debug, const char *error);
 

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -32,7 +32,7 @@
 class ZBarrierSet;
 
 class ZInitializer {
- public:
+public:
   ZInitializer(ZBarrierSet* barrier_set);
 };
 

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -39,6 +39,7 @@ class ZInitializer {
 class ZInitialize : public AllStatic {
 private:
   static constexpr size_t ErrorMessageLength = 256;
+
   static char _error_message[ErrorMessageLength];
   static bool _had_error;
   static bool _finished;

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -44,7 +44,7 @@ private:
   static bool _had_error;
   static bool _finished;
 
-  static void register_error(bool debug, const char *error);
+  static void register_error(bool debug, const char *error_msg);
 
   static void pd_initialize();
 

--- a/src/hotspot/share/gc/z/zInitialize.hpp
+++ b/src/hotspot/share/gc/z/zInitialize.hpp
@@ -27,12 +27,27 @@
 #include "memory/allocation.hpp"
 
 class ZBarrierSet;
+class ZErrorMessage;
 
 class ZInitialize {
 private:
+  static ZErrorMessage* _error_message;
+  static bool           _had_error;
+  static bool           _finished;
+
+  static void register_error(bool debug, const char *error);
+
   void pd_initialize();
 
 public:
+  static void error(const char* msg_format, ...) ATTRIBUTE_PRINTF(1, 2);
+  static void error_d(const char* msg_format, ...) ATTRIBUTE_PRINTF(1, 2);
+
+  static bool had_error();
+  static const char* error_message();
+
+  static void finish();
+
   ZInitialize(ZBarrierSet* barrier_set);
 };
 

--- a/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
+++ b/src/hotspot/share/gc/z/zMarkStackAllocator.cpp
@@ -22,8 +22,8 @@
  */
 
 #include "precompiled.hpp"
-#include "gc/shared/gcLogPrecious.hpp"
 #include "gc/shared/gc_globals.hpp"
+#include "gc/z/zInitialize.hpp"
 #include "gc/z/zLock.inline.hpp"
 #include "gc/z/zMarkStack.inline.hpp"
 #include "gc/z/zMarkStackAllocator.hpp"
@@ -43,7 +43,7 @@ ZMarkStackSpace::ZMarkStackSpace()
   const size_t size = ZMarkStackSpaceLimit;
   const uintptr_t addr = (uintptr_t)os::reserve_memory(size, !ExecMem, mtGC);
   if (addr == 0) {
-    log_error_pd(gc, marking)("Failed to reserve address space for mark stacks");
+    ZInitialize::error_d("Failed to reserve address space for mark stacks");
     return;
   }
 

--- a/src/hotspot/share/gc/z/zVirtualMemory.cpp
+++ b/src/hotspot/share/gc/z/zVirtualMemory.cpp
@@ -27,6 +27,7 @@
 #include "gc/z/zAddress.inline.hpp"
 #include "gc/z/zAddressSpaceLimit.hpp"
 #include "gc/z/zGlobals.hpp"
+#include "gc/z/zInitialize.hpp"
 #include "gc/z/zNMT.hpp"
 #include "gc/z/zVirtualMemory.inline.hpp"
 #include "utilities/align.hpp"
@@ -44,7 +45,7 @@ ZVirtualMemoryManager::ZVirtualMemoryManager(size_t max_capacity)
 
   // Reserve address space
   if (!reserve(max_capacity)) {
-    log_error_pd(gc)("Failed to reserve enough address space for Java heap");
+    ZInitialize::error_d("Failed to reserve enough address space for Java heap");
     return;
   }
 


### PR DESCRIPTION
ZGC does not call `vm_shutdown_during_initialization` if initialization fails during the setup of the CollectedHeap, in contrast to the other GC.

I propose we add a `ZInitialize::error` which we can use during initialisation to record errors. The first error recored is also stored and used as the error message when shutting down the VM. 

Initially used malloc to allocate the error (ed9ba5dd6805291a6b1b56566c933424230d3b4a) but feels like it is just better to have static storage for the string and not have to care about malloc potentially failing to allocate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340420](https://bugs.openjdk.org/browse/JDK-8340420): ZGC: Should call `vm_shutdown_during_initialization` if initialization fails (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21254/head:pull/21254` \
`$ git checkout pull/21254`

Update a local copy of the PR: \
`$ git checkout pull/21254` \
`$ git pull https://git.openjdk.org/jdk.git pull/21254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21254`

View PR using the GUI difftool: \
`$ git pr show -t 21254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21254.diff">https://git.openjdk.org/jdk/pull/21254.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21254#issuecomment-2382235880)