### PR TITLE
8341199: Use ClassFile's new API loadConstant(int)

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/StringConcatFactory.java
@@ -1526,7 +1526,7 @@ public final class StringConcatFactory {
                      * length = length(this.length, arg0, arg1, ..., argN);
                      */
                     if (staticConcat) {
-                        cb.ldc(length);
+                        cb.loadConstant(length);
                     } else {
                         cb.aload(thisSlot)
                           .getfield(concatClass, "length", CD_int);
@@ -1549,7 +1549,7 @@ public final class StringConcatFactory {
                      * length -= suffix.length();
                      */
                     if (staticConcat) {
-                        cb.ldc(constants[paramCount].length())
+                        cb.loadConstant(constants[paramCount].length())
                           .isub()
                           .istore(lengthSlot);
                     } else {
@@ -1557,7 +1557,7 @@ public final class StringConcatFactory {
                           .getfield(concatClass, "constants", CD_Array_String)
                           .dup()
                           .astore(constantsSlot)
-                          .ldc(paramCount)
+                          .loadConstant(paramCount)
                           .aaload()
                           .dup()
                           .astore(suffixSlot)
@@ -1572,7 +1572,7 @@ public final class StringConcatFactory {
                      *  buf = newArrayWithSuffix(suffix, length, coder)
                      */
                     if (staticConcat) {
-                        cb.ldc(constants[paramCount]);
+                        cb.loadConstant(constants[paramCount]);
                     } else {
                         cb.aload(suffixSlot);
                     }
@@ -1759,10 +1759,10 @@ public final class StringConcatFactory {
                           .loadLocal(kind, cb.parameterSlot(i));
 
                         if (staticConcat) {
-                            cb.ldc(constants[i - 3]);
+                            cb.loadConstant(constants[i - 3]);
                         } else {
                             cb.aload(constantsSlot)
-                              .ldc(i - 4)
+                              .loadConstant(i - 4)
                               .aaload();
                         }
 

--- a/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
+++ b/src/java.base/share/classes/java/lang/runtime/SwitchBootstraps.java
@@ -659,7 +659,7 @@ public class SwitchBootstraps {
                             MethodTypeDesc.of(ConstantDescs.CD_char));
                     cb.labelBinding(compare);
 
-                    cb.ldc(integerLabel);
+                    cb.loadConstant(integerLabel);
                     cb.if_icmpne(next);
                 } else if ((caseLabel instanceof Long ||
                         caseLabel instanceof Float ||

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventClassBuilder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventClassBuilder.java
@@ -84,7 +84,7 @@ public final class EventClassBuilder {
             int index = 0;
             for (ValueDescriptor v : fields) {
                 codeBuilder.iload(1);
-                codeBuilder.ldc(index);
+                codeBuilder.loadConstant(index);
                 Label notEqual = codeBuilder.newLabel();
                 codeBuilder.if_icmpne(notEqual);
                 codeBuilder.aload(0); // this

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/EventInstrumentation.java
@@ -499,7 +499,7 @@ final class EventInstrumentation {
                 // if (!settingsMethod(eventConfiguration.settingX)) goto fail;
                 codeBuilder.aload(0);
                 getEventConfiguration(codeBuilder);
-                codeBuilder.ldc(index);
+                codeBuilder.loadConstant(index);
                 invokevirtual(codeBuilder, TYPE_EVENT_CONFIGURATION, METHOD_EVENT_CONFIGURATION_GET_SETTING);
                 MethodTypeDesc mdesc = MethodTypeDesc.ofDescriptor("(" + sd.paramType().descriptorString() + ")Z");
                 codeBuilder.checkcast(sd.paramType());


### PR DESCRIPTION
The new API loadConstant(int) can shorten the calling path and can replace ldc when the parameter is of int/Integer type.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341199](https://bugs.openjdk.org/browse/JDK-8341199): Use ClassFile's new API loadConstant(int) (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21259/head:pull/21259` \
`$ git checkout pull/21259`

Update a local copy of the PR: \
`$ git checkout pull/21259` \
`$ git pull https://git.openjdk.org/jdk.git pull/21259/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21259`

View PR using the GUI difftool: \
`$ git pr show -t 21259`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21259.diff">https://git.openjdk.org/jdk/pull/21259.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21259#issuecomment-2382876404)