### PR TITLE
8341070: javac fails with an exception when compiling import module under source level 8

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symtab.java
@@ -420,6 +420,23 @@ public class Symtab {
                                             missingInfoHandler,
                                             target.runtimeUseNestAccess());
 
+        noModule = new ModuleSymbol(names.empty, null) {
+            @Override public boolean isNoModule() {
+                return true;
+            }
+        };
+        addRootPackageFor(noModule);
+
+        Source source = Source.instance(context);
+        if (Feature.MODULES.allowedInSource(source)) {
+            java_base = enterModule(names.java_base);
+            //avoid completing java.base during the Symtab initialization
+            java_base.completer = Completer.NULL_COMPLETER;
+            java_base.visiblePackages = Collections.emptyMap();
+        } else {
+            java_base = noModule;
+        }
+
         // create the basic builtin symbols
         unnamedModule = new ModuleSymbol(names.empty, null) {
                 {
@@ -427,7 +444,6 @@ public class Symtab {
                     exports = List.nil();
                     provides = List.nil();
                     uses = List.nil();
-                    ModuleSymbol java_base = enterModule(names.java_base);
                     com.sun.tools.javac.code.Directive.RequiresDirective d =
                             new com.sun.tools.javac.code.Directive.RequiresDirective(java_base,
                                     EnumSet.of(com.sun.tools.javac.code.Directive.RequiresFlag.MANDATED));
@@ -447,7 +463,6 @@ public class Symtab {
                     exports = List.nil();
                     provides = List.nil();
                     uses = List.nil();
-                    ModuleSymbol java_base = enterModule(names.java_base);
                     com.sun.tools.javac.code.Directive.RequiresDirective d =
                             new com.sun.tools.javac.code.Directive.RequiresDirective(java_base,
                                     EnumSet.of(com.sun.tools.javac.code.Directive.RequiresFlag.MANDATED));
@@ -455,13 +470,6 @@ public class Symtab {
                 }
             };
         addRootPackageFor(errModule);
-
-        noModule = new ModuleSymbol(names.empty, null) {
-            @Override public boolean isNoModule() {
-                return true;
-            }
-        };
-        addRootPackageFor(noModule);
 
         noSymbol = new TypeSymbol(NIL, 0, names.empty, Type.noType, rootPackage) {
             @Override @DefinedBy(Api.LANGUAGE_MODEL)
@@ -525,16 +533,6 @@ public class Symtab {
 
         // Enter symbol for the errSymbol
         scope.enter(errSymbol);
-
-        Source source = Source.instance(context);
-        if (Feature.MODULES.allowedInSource(source)) {
-            java_base = enterModule(names.java_base);
-            //avoid completing java.base during the Symtab initialization
-            java_base.completer = Completer.NULL_COMPLETER;
-            java_base.visiblePackages = Collections.emptyMap();
-        } else {
-            java_base = noModule;
-        }
 
         // Get the initial completer for ModuleSymbols from Modules
         moduleCompleter = Modules.instance(context).getCompleter();

--- a/test/langtools/tools/javac/ImportModule.java
+++ b/test/langtools/tools/javac/ImportModule.java
@@ -808,10 +808,7 @@ public class ImportModule extends TestRunner {
                           package test;
                           import module java.base;
                           public class Test {
-                              public static void main(String... args) {
-                                  List<String> l = new ArrayList<>();
-                                  System.out.println(l.getClass().getName());
-                              }
+                              List<String> l;
                           }
                           """);
 
@@ -834,9 +831,8 @@ public class ImportModule extends TestRunner {
                 "- compiler.warn.option.obsolete.suppression",
                 "Test.java:2:8: compiler.err.preview.feature.disabled.plural: (compiler.misc.feature.module.imports)",
                 "Test.java:2:1: compiler.err.import.module.not.found: java.base",
-                "Test.java:5:9: compiler.err.cant.resolve.location: kindname.class, List, , , (compiler.misc.location: kindname.class, test.Test, null)",
-                "Test.java:5:30: compiler.err.cant.resolve.location: kindname.class, ArrayList, , , (compiler.misc.location: kindname.class, test.Test, null)",
-                "4 errors",
+                "Test.java:4:5: compiler.err.cant.resolve.location: kindname.class, List, , , (compiler.misc.location: kindname.class, test.Test, null)",
+                "3 errors",
                 "3 warnings"
         );
 


### PR DESCRIPTION
Consider code like:
```
package test;

import module java.base;

public class Test {
    List<String> l;
}
```

Compiling this may cause javac to fail with an exception under some circumstances:
```
$ javac --source 8 -XDshould-stop.at=FLOW -XDdev /tmp/Test.java
warning: [options] bootstrap class path is not set in conjunction with -source 8
  not setting the bootstrap class path may lead to class files that cannot run on JDK 8
    --release 8 is recommended instead of -source 8 because it sets the bootstrap class path automatically
warning: [options] source value 8 is obsolete and will be removed in a future release
warning: [options] To suppress warnings about obsolete options, use -Xlint:-options.
/tmp/Test.java:3: error: module imports are a preview feature and are disabled by default.
import module java.base;
       ^
  (use --enable-preview to enable module imports)
1 error
3 warnings
An exception has occurred in the compiler (23-internal). Please file a bug against the Java compiler via the Java bug reporting page (https://bugreport.java.com/) after checking the Bug Database (https://bugs.java.com/) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.NullPointerException: Cannot invoke "java.util.Set.contains(Object)" because "this.env.toplevel.modle.readModules" is null
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter$ImportsPhase.doModuleImport(TypeEnter.java:477)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter$ImportsPhase.handleImports(TypeEnter.java:414)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter$ImportsPhase.resolveImports(TypeEnter.java:389)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter$ImportsPhase.runPhase(TypeEnter.java:318)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter$Phase.doCompleteEnvs(TypeEnter.java:279)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter$Phase.completeEnvs(TypeEnter.java:248)
        at jdk.compiler/com.sun.tools.javac.comp.TypeEnter.complete(TypeEnter.java:195)
        at jdk.compiler/com.sun.tools.javac.code.Symbol.complete(Symbol.java:687)
        at jdk.compiler/com.sun.tools.javac.code.Symbol$ClassSymbol.complete(Symbol.java:1455)
        at jdk.compiler/com.sun.tools.javac.comp.Enter.complete(Enter.java:632)
        at jdk.compiler/com.sun.tools.javac.comp.Enter.main(Enter.java:599)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.enterTrees(JavaCompiler.java:1077)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:948)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:319)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:178)
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:66)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:52)
printing javac parameters to: /tmp/javac.20240927_093418.args
```

The reason is that while there are no modules under `--source 8`, the javac's `Symtab` still has a partial `java.base` module as a consequence of the initialization order. This partial modules is then found while evaluating `import module java.base;`, and leads to the subsequent crash.

The proposal herein is to reorganize the `Symtab` initialization a little, to ensure there's no partial `java.base` module.
