### PR TITLE
8341242: Shenandoah: LRB node is not matched as GC barrier after JDK-8340183

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahBarrierSetC2.cpp
@@ -682,7 +682,8 @@ bool ShenandoahBarrierSetC2::is_gc_pre_barrier_node(Node* node) const {
 }
 
 bool ShenandoahBarrierSetC2::is_gc_barrier_node(Node* node) const {
-  return is_shenandoah_lrb_call(node) ||
+  return (node->Opcode() == Op_ShenandoahLoadReferenceBarrier) ||
+         is_shenandoah_lrb_call(node) ||
          is_shenandoah_wb_pre_call(node) ||
          is_shenandoah_clone_call(node);
 }


### PR DESCRIPTION
[JDK-8340183](https://bugs.openjdk.org/browse/JDK-8340183) introduced a regression: `ShenandoahBarrierSetC2::is_gc_barrier_node` is now answering `false` for the actual `ShenandoahLoadReferenceBarrierNode`. The fix reinstates the check for LRB node.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`
 - [x] Linux x86_64 server fastdebug, `jdk/jfr/api/consumer/ ` (100x) -- used to fail intermittently, now it does not

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341242](https://bugs.openjdk.org/browse/JDK-8341242): Shenandoah: LRB node is not matched as GC barrier after JDK-8340183 (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21266/head:pull/21266` \
`$ git checkout pull/21266`

Update a local copy of the PR: \
`$ git checkout pull/21266` \
`$ git pull https://git.openjdk.org/jdk.git pull/21266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21266`

View PR using the GUI difftool: \
`$ git pr show -t 21266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21266.diff">https://git.openjdk.org/jdk/pull/21266.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21266#issuecomment-2383456448)