### PR TITLE
8334305: Remove all code for  nsk.share.Log verbose mode

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
+++ b/test/hotspot/jtreg/vmTestbase/jit/escape/LockElision/MatMul/MatMul.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2010, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,7 +85,7 @@ public class MatMul {
     }
 
     public int run() {
-        log = new Log(System.out, verbose);
+        log = new Log(System.out);
         log.display("Parallel matrix multiplication test");
 
         Matrix a = Matrix.randomMatrix(dim);

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launchnosuspend/launchnosuspend001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdi/LaunchingConnector/launchnosuspend/launchnosuspend001.java
@@ -73,7 +73,6 @@ public class launchnosuspend001 {
 
         argHandler = new ArgumentHandler(args);
         log = new Log(this.out, argHandler);
-        //log.enableVerbose(true);
     }
 
     private PrintStream out;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter_tagged/HeapFilter.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/IterateThroughHeap/filter_tagged/HeapFilter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,6 @@ public class HeapFilter extends DebugeeClass {
         log = new Log(out, argHandler);
         testObjects = new Object[]{new TaggedClass(),
                                    new UntaggedClass()};
-        log.enableVerbose(true);
         log.display("Verifying reachable objects.");
         status = checkStatus(status);
         testObjects = null;

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isCollectionUsageThresholdExceeded/isexceeded001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,6 @@ public class isexceeded001 {
     public static int run(String[] argv, PrintStream out) {
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         Log log = new Log(out, argHandler);
-        log.enableVerbose(true);
 
         monitor = Monitor.getMemoryMonitor(log, argHandler);
         List pools = monitor.getMemoryPoolMBeans();

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/MemoryPoolMBean/isUsageThresholdExceeded/isexceeded001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -47,7 +47,6 @@ public class isexceeded001 {
     public static int run(String[] argv, PrintStream out) {
         ArgumentHandler argHandler = new ArgumentHandler(argv);
         Log log = new Log(out, argHandler);
-        log.enableVerbose(true); // show log output
 
         MemoryMonitor monitor = Monitor.getMemoryMonitor(log, argHandler);
         List pools = monitor.getMemoryPoolMBeans();

--- a/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/lowmem/lowmem001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/monitoring/stress/lowmem/lowmem001.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,7 @@ public class lowmem001 extends ThreadedGCTest {
 
     @Override
     public void run() {
-        Log log = new Log(System.out, true);
+        Log log = new Log(System.out);
         // System.err is duplicated into buffer
         // it should be empty
         MyStream stream = new MyStream(System.err);

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -37,7 +37,7 @@ import java.util.Vector;
 
 
 /**
- * This class helps to print test-execution trace messages
+ * This class helps to print test-execution trace messages.
  * <p>
  * <code>Log</code> provides with two main methods to print messages:
  * <ul>
@@ -338,8 +338,6 @@ public class Log {
 
     /**
      * Redirect log to the given <code>stream</code>.
-     * Prints errors summary to current stream, cancel current stream
-     * and switches to new stream.
      *
      * @deprecated  This method is obsolete.
      */

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -261,7 +261,7 @@ public class Log {
     }
 
     /**
-     * Print <code>message</code> to the assigned output stream,
+     * Print <code>message</code> to the assigned output stream.
      */
     public synchronized void display(Object message) {
         doPrint(message.toString());
@@ -337,7 +337,7 @@ public class Log {
     /////////////////////////////////////////////////////////////////
 
     /**
-     * Redirect log to the given <code>stream</code>
+     * Redirect log to the given <code>stream</code>.
      * Prints errors summary to current stream, cancel current stream
      * and switches to new stream.
      *

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -29,22 +29,15 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringReader;
-import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
 import java.util.Vector;
 
-import nsk.share.test.LazyFormatString;
 
 /**
  * This class helps to print test-execution trace messages
- * and filter them when execution mode is not verbose.
- * <p>
- * Verbose mode if defined by providing <i>-verbose</i> command line
- * option, handled by <code>ArgumentParser</code>. Use <code>verbose()</code>
- * method to determine which mode is used.
  * <p>
  * <code>Log</code> provides with two main methods to print messages:
  * <ul>
@@ -60,7 +53,6 @@ import nsk.share.test.LazyFormatString;
  * To provide printing messages from different sources into one log
  * with distinct prefixes use internal <code>Log.Logger</code> class.
  *
- * @see #verbose()
  * @see #complain(String)
  * @see #display(String)
  * @see ArgumentParser
@@ -71,18 +63,6 @@ public class Log {
      * Report step-by-step activity to this stream.
      */
     private PrintStream out = null;
-
-    /**
-     * Is log-mode verbose?
-     * Always enabled.
-     */
-    private final boolean verbose = true;
-
-    /**
-     * Should log messages prefixed with timestamps?
-     * Always enabled.
-     */
-    private final boolean timestamp = true;
 
     /**
      * Names for trace levels
@@ -188,40 +168,13 @@ public class Log {
 
     /**
      * Incarnate new Log for the given <code>stream</code>; and
-     * either for verbose or for non-verbose mode accordingly to
-     * the given <code>verbose</code> key.
-     */
-    public Log(PrintStream stream, boolean verbose) {
-        this(stream);
-    }
-
-    /**
-     * Incarnate new Log for the given <code>stream</code>; and
-     * either for verbose or for non-verbose mode accordingly to
      * the given <code>argsHandler</code>.
      */
     public Log(PrintStream stream, ArgumentParser argsParser) {
-        this(stream, argsParser.verbose());
         traceLevel = argsParser.getTraceLevel();
     }
 
     /////////////////////////////////////////////////////////////////
-
-    /**
-     * Return <i>true</i> if log mode is verbose.
-     */
-    public boolean verbose() {
-        return verbose;
-    }
-
-    /**
-     * Enable or disable verbose mode for printing messages.
-     */
-    public void enableVerbose(boolean enable) {
-        if (!enable) {
-            throw new RuntimeException("The non-verbose logging is not supported.");
-        }
-    }
 
     public int getTraceLevel() {
         return traceLevel;
@@ -266,9 +219,6 @@ public class Log {
     @Deprecated
     public synchronized void println(String message) {
         doPrint(message);
-        if (!verbose()) {
-            keepLog(composeLine(message));
-        }
     }
 
     /**
@@ -282,9 +232,6 @@ public class Log {
      */
     @Deprecated
     public synchronized void comment(String message) {
-        if (!verbose()) {
-            doPrint(message);
-        }
     }
 
     /**
@@ -315,16 +262,9 @@ public class Log {
 
     /**
      * Print <code>message</code> to the assigned output stream,
-     * if log mode is verbose. The <code>message</code> will be lost,
-     * if execution mode is non-verbose, and there is no error messages
-     * printed.
      */
     public synchronized void display(Object message) {
-        if (verbose()) {
-            doPrint(message.toString());
-        } else {
-            keepLog(composeLine(message.toString()));
-        }
+        doPrint(message.toString());
     }
 
     /**
@@ -333,15 +273,6 @@ public class Log {
      * into <code>errorsBuffer</code>.
      */
     public synchronized void complain(Object message) {
-        if (!verbose()) {
-            PrintStream stream = findOutStream();
-            stream.println("#>  ");
-            stream.println("#>  WARNING: switching log to verbose mode,");
-            stream.println("#>      because error is complained");
-            stream.println("#>  ");
-            stream.flush();
-            enableVerbose(true);
-        }
         String msgStr = message.toString();
         printError(msgStr);
 
@@ -406,10 +337,9 @@ public class Log {
     /////////////////////////////////////////////////////////////////
 
     /**
-     * Redirect log to the given <code>stream</code>, and switch
-     * log mode to verbose.
+     * Redirect log to the given <code>stream</code>
      * Prints errors summary to current stream, cancel current stream
-     * and switches to new stream. Turns on verbose mode for new stream.
+     * and switches to new stream.
      *
      * @deprecated  This method is obsolete.
      */
@@ -428,20 +358,6 @@ public class Log {
      */
     public synchronized void clearLogBuffer() {
         logBuffer.clear();
-    }
-
-    /**
-     * Print all messages from log buffer which were hidden because
-     * of non-verbose mode,
-     */
-    private synchronized void flushLogBuffer() {
-        if (!logBuffer.isEmpty()) {
-            PrintStream stream = findOutStream();
-            for (int i = 0; i < logBuffer.size(); i++) {
-                stream.println(logBuffer.elementAt(i));
-            }
-            stream.flush();
-        }
     }
 
     /**
@@ -468,18 +384,15 @@ public class Log {
      * Compose line to print possible prefixing it with timestamp.
      */
     private String composeLine(String message) {
-        if (timestamp) {
-            long time = System.currentTimeMillis();
-            long ms = time % 1000;
-            time /= 1000;
-            long secs = time % 60;
-            time /= 60;
-            long mins = time % 60;
-            time /= 60;
-            long hours = time % 24;
-            return "[" + hours + ":" + mins + ":" + secs + "." + ms + "] " + message;
-        }
-        return message;
+        long time = System.currentTimeMillis();
+        long ms = time % 1000;
+        time /= 1000;
+        long secs = time % 60;
+        time /= 60;
+        long mins = time % 60;
+        time /= 60;
+        long hours = time % 24;
+        return "[" + hours + ":" + mins + ":" + secs + "." + ms + "] " + message;
     }
 
     /**
@@ -511,13 +424,6 @@ public class Log {
                 throw new TestBug("Exception in Log.printError(): " + e);
             };
         }
-    }
-
-    /**
-     * Keep the given log <code>message</code> into <code>logBuffer</code>.
-     */
-    private synchronized void keepLog(String message) {
-        logBuffer.addElement(message);
     }
 
     /**

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODTestRunner.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AODTestRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,7 +68,7 @@ public class AODTestRunner {
     protected AODRunnerArgParser argParser;
 
     protected AODTestRunner(String[] args) {
-        log = new Log(System.out, true);
+        log = new Log(System.out);
 
         argParser = createArgParser(args);
     }

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AbstractJarAgent.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/AbstractJarAgent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -157,7 +157,7 @@ abstract public class AbstractJarAgent {
         if (name == null)
             throw new TestBug("Agent name wasn't specified");
 
-        log = new Log(System.out, true);
+        log = new Log(System.out);
     }
 
     /*

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/DummyTargetApplication.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/DummyTargetApplication.java
@@ -39,7 +39,7 @@ it sends signal that it is ready for test and waits for signal permitting finish
  */
 public class DummyTargetApplication {
 
-    protected Log log = new Log(System.out, true);
+    protected Log log = new Log(System.out);
 
     protected AODTargetArgParser argParser;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/aod/TargetApplicationWaitingAgents.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/aod/TargetApplicationWaitingAgents.java
@@ -213,7 +213,7 @@ public class TargetApplicationWaitingAgents {
             if (targetApplicationInitialized)
                 throw new TestBug("TargetApplication already initialized");
 
-            log = new Log(System.out, true);
+            log = new Log(System.out);
 
             argParser = createArgParser(args);
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/JVMTITest.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jvmti/JVMTITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,7 +87,7 @@ public class JVMTITest {
 
         AgentsAttacher attacher = new AgentsAttacher(Utils.findCurrentVMIdUsingJPS(jdkPath),
                 agents,
-                new Log(System.out, true));
+                new Log(System.out));
         attacher.attachAgents();
     }
 }

--- a/test/hotspot/jtreg/vmTestbase/vm/compiler/coverage/parentheses/Parentheses.java
+++ b/test/hotspot/jtreg/vmTestbase/vm/compiler/coverage/parentheses/Parentheses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -69,7 +69,7 @@ public class Parentheses {
 
     public void run() throws IOException, ReflectiveOperationException {
 
-        log = new Log(System.out, verbose);
+        log = new Log(System.out);
 
         InstructionSequence instructionSequence = null;
         for (int i = 0; i < iterations * stressOptions.getIterationsFactor(); i++) {


### PR DESCRIPTION
Cleaning up nsk.share.Log code after the verbose mode was set always true.

Tested all the vmTestbase/ tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334305](https://bugs.openjdk.org/browse/JDK-8334305): Remove all code for  nsk.share.Log verbose mode (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) Review applies to [a346de1c](https://git.openjdk.org/jdk/pull/21267/files/a346de1ce3387f99bb3f8d63c64b9c6bc1212bcb)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21267/head:pull/21267` \
`$ git checkout pull/21267`

Update a local copy of the PR: \
`$ git checkout pull/21267` \
`$ git pull https://git.openjdk.org/jdk.git pull/21267/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21267`

View PR using the GUI difftool: \
`$ git pr show -t 21267`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21267.diff">https://git.openjdk.org/jdk/pull/21267.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21267#issuecomment-2383460447)