### PR TITLE
8341243: Use ArraySupport.SOFT_MAX_ARRAY_LENGTH for max array size in java.base

### DIFF
--- a/src/java.base/share/classes/java/io/InputStream.java
+++ b/src/java.base/share/classes/java/io/InputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,8 @@
  */
 
 package java.io;
+
+import jdk.internal.util.ArraysSupport;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -305,12 +307,9 @@ public abstract class InputStream implements Closeable {
     }
 
     /**
-     * The maximum size of array to allocate.
-     * Some VMs reserve some header words in an array.
-     * Attempts to allocate larger arrays may result in
-     * OutOfMemoryError: Requested array size exceeds VM limit
+     * The maximum size of array to allocate
      */
-    private static final int MAX_BUFFER_SIZE = Integer.MAX_VALUE - 8;
+    private static final int MAX_BUFFER_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
     /**
      * Reads all remaining bytes from the input stream. This method blocks until

--- a/src/java.base/share/classes/java/util/ArrayDeque.java
+++ b/src/java.base/share/classes/java/util/ArrayDeque.java
@@ -38,6 +38,7 @@ import java.io.Serializable;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.util.ArraysSupport;
 
 /**
  * Resizable-array implementation of the {@link Deque} interface.  Array
@@ -124,12 +125,9 @@ public class ArrayDeque<E> extends AbstractCollection<E>
     transient int tail;
 
     /**
-     * The maximum size of array to allocate.
-     * Some VMs reserve some header words in an array.
-     * Attempts to allocate larger arrays may result in
-     * OutOfMemoryError: Requested array size exceeds VM limit
+     * The maximum size of array to allocate
      */
-    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+    private static final int MAX_ARRAY_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
     /**
      * Increases the capacity of this deque by at least the given amount.

--- a/src/java.base/share/classes/java/util/BitSet.java
+++ b/src/java.base/share/classes/java/util/BitSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1184,7 +1184,7 @@ public class BitSet implements Cloneable, java.io.Serializable {
     public String toString() {
         checkInvariants();
 
-        final int MAX_INITIAL_CAPACITY = Integer.MAX_VALUE - 8;
+        final int MAX_INITIAL_CAPACITY = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
         int numBits = (wordsInUse > 128) ?
             cardinality() : wordsInUse * BITS_PER_WORD;
         // Avoid overflow in the case of a humongous numBits

--- a/src/java.base/share/classes/java/util/Hashtable.java
+++ b/src/java.base/share/classes/java/util/Hashtable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.function.BiFunction;
 import jdk.internal.access.SharedSecrets;
+import jdk.internal.util.ArraysSupport;
 
 /**
  * This class implements a hash table, which maps keys to values. Any
@@ -390,12 +391,9 @@ public class Hashtable<K,V>
     }
 
     /**
-     * The maximum size of array to allocate.
-     * Some VMs reserve some header words in an array.
-     * Attempts to allocate larger arrays may result in
-     * OutOfMemoryError: Requested array size exceeds VM limit
+     * The maximum size of array to allocate
      */
-    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+    private static final int MAX_ARRAY_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
     /**
      * Increases the capacity of and internally reorganizes this

--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentHashMap.java
@@ -69,6 +69,7 @@ import java.util.function.ToLongBiFunction;
 import java.util.function.ToLongFunction;
 import java.util.stream.Stream;
 import jdk.internal.misc.Unsafe;
+import jdk.internal.util.ArraysSupport;
 
 /**
  * A hash table supporting full concurrency of retrievals and
@@ -517,7 +518,7 @@ public class ConcurrentHashMap<K,V> extends AbstractMap<K,V>
      * The largest possible (non-power of two) array size.
      * Needed by toArray and related methods.
      */
-    static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+    static final int MAX_ARRAY_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
     /**
      * The default concurrency level for this table. Unused but

--- a/src/java.base/share/classes/java/util/regex/Pattern.java
+++ b/src/java.base/share/classes/java/util/regex/Pattern.java
@@ -1502,8 +1502,8 @@ public final class Pattern
             return "\\Q" + s + "\\E";
 
         int lenHint = s.length();
-        lenHint = (lenHint < Integer.MAX_VALUE - 8 - lenHint) ?
-                (lenHint << 1) : (Integer.MAX_VALUE - 8);
+        lenHint = (lenHint < ArraysSupport.SOFT_MAX_ARRAY_LENGTH - lenHint) ?
+                (lenHint << 1) : ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
         StringBuilder sb = new StringBuilder(lenHint);
         sb.append("\\Q");

--- a/src/java.base/share/classes/java/util/stream/Nodes.java
+++ b/src/java.base/share/classes/java/util/stream/Nodes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,6 +23,8 @@
  * questions.
  */
 package java.util.stream;
+
+import jdk.internal.util.ArraysSupport;
 
 import java.util.ArrayDeque;
 import java.util.Arrays;
@@ -57,7 +59,7 @@ final class Nodes {
     /**
      * The maximum size of an array that can be allocated.
      */
-    static final long MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+    static final long MAX_ARRAY_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
     // IllegalArgumentException messages
     static final String BAD_SIZE = "Stream size exceeds max array size";

--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -379,7 +379,7 @@ public abstract sealed class AbstractMemorySegmentImpl
             throw new IllegalStateException(String.format("Segment size is not a multiple of %d. Size: %d", elemSize, length));
         }
         long arraySize = length / elemSize;
-        if (arraySize > (Integer.MAX_VALUE - 8)) { //conservative check
+        if (arraySize > ArraysSupport.SOFT_MAX_ARRAY_LENGTH) { //conservative check
             throw new IllegalStateException(String.format("Segment is too large to wrap as %s. Size: %d", typeName, length));
         }
         return (int)arraySize;

--- a/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
+++ b/src/java.base/share/classes/sun/security/util/SignatureFileVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,6 +36,7 @@ import java.util.*;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
+import jdk.internal.util.ArraysSupport;
 import sun.security.action.GetIntegerAction;
 import sun.security.jca.Providers;
 import sun.security.pkcs.PKCS7;
@@ -87,8 +88,8 @@ public class SignatureFileVerifier {
     // the maximum allowed size in bytes for the signature-related files
     public static final int MAX_SIG_FILE_SIZE = initializeMaxSigFileSize();
 
-    // The maximum size of array to allocate. Some VMs reserve some header words in an array.
-    private static final int MAX_ARRAY_SIZE = Integer.MAX_VALUE - 8;
+    // The maximum size of array to allocate
+    private static final int MAX_ARRAY_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
     /**
      * Create the named SignatureFileVerifier.

--- a/test/jdk/java/lang/StringBuffer/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuffer/HugeCapacity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,14 @@
  * questions.
  */
 
+import jdk.internal.util.ArraysSupport;
+
 /**
  * @test
  * @bug 8218227
  * @summary StringBuilder/StringBuffer constructor throws confusing
  *          NegativeArraySizeException
+ * @modules java.base/jdk.internal.util
  * @requires (sun.arch.data.model == "64" & os.maxMemory >= 8G)
  * @run main/othervm -Xms6G -Xmx6G HugeCapacity
  */
@@ -43,7 +46,9 @@ public class HugeCapacity {
 
     private static void testHugeInitialString() {
         try {
-            String str = "Z".repeat(Integer.MAX_VALUE - 8);
+            // Maximum array length supported by the JVM implementation
+            int maxArrayLength = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
+            String str = "Z".repeat(maxArrayLength);
             StringBuffer sb = new StringBuffer(str);
         } catch (OutOfMemoryError ignore) {
         } catch (Throwable unexpected) {

--- a/test/jdk/java/lang/StringBuffer/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuffer/HugeCapacity.java
@@ -46,9 +46,7 @@ public class HugeCapacity {
 
     private static void testHugeInitialString() {
         try {
-            // Maximum array length supported by the JVM implementation
-            int maxArrayLength = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
-            String str = "Z".repeat(maxArrayLength);
+            String str = "Z".repeat(ArraysSupport.SOFT_MAX_ARRAY_LENGTH);
             StringBuffer sb = new StringBuffer(str);
         } catch (OutOfMemoryError ignore) {
         } catch (Throwable unexpected) {

--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,11 +21,14 @@
  * questions.
  */
 
+import jdk.internal.util.ArraysSupport;
+
 /**
  * @test
  * @bug 8149330 8218227
  * @summary Capacity should not get close to Integer.MAX_VALUE unless
  *          necessary
+ * @modules java.base/jdk.internal.util
  * @requires (sun.arch.data.model == "64" & os.maxMemory >= 8G)
  * @run main/othervm -Xms6G -Xmx6G -XX:+CompactStrings HugeCapacity true
  * @run main/othervm -Xms6G -Xmx6G -XX:-CompactStrings HugeCapacity false
@@ -75,7 +78,9 @@ public class HugeCapacity {
 
     private static void testHugeInitialString() {
         try {
-            String str = "Z".repeat(Integer.MAX_VALUE - 8);
+            // Maximum array length supported by the JVM implementation
+            int maxArrayLength = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
+            String str = "Z".repeat(maxArrayLength);
             StringBuilder sb = new StringBuilder(str);
         } catch (OutOfMemoryError ignore) {
         } catch (Throwable unexpected) {

--- a/test/jdk/java/lang/StringBuilder/HugeCapacity.java
+++ b/test/jdk/java/lang/StringBuilder/HugeCapacity.java
@@ -78,9 +78,7 @@ public class HugeCapacity {
 
     private static void testHugeInitialString() {
         try {
-            // Maximum array length supported by the JVM implementation
-            int maxArrayLength = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
-            String str = "Z".repeat(maxArrayLength);
+            String str = "Z".repeat(ArraysSupport.SOFT_MAX_ARRAY_LENGTH);
             StringBuilder sb = new StringBuilder(str);
         } catch (OutOfMemoryError ignore) {
         } catch (Throwable unexpected) {

--- a/test/jdk/java/nio/charset/CharsetDecoder/XcodeOverflow.java
+++ b/test/jdk/java/nio/charset/CharsetDecoder/XcodeOverflow.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
+import jdk.internal.util.ArraysSupport;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.Arguments;
@@ -44,8 +45,8 @@ import org.junit.jupiter.params.provider.Arguments;
 public class XcodeOverflow {
     private static Stream<Arguments> sizes() {
         return Stream.of(
-            // SOFT_MAX_ARRAY_LENGTH: copied from ArraysSupport. No overflow; no OOME.
-            Arguments.of(Integer.MAX_VALUE - 8),
+            // No overflow; no OOME.
+            Arguments.of(ArraysSupport.SOFT_MAX_ARRAY_LENGTH),
 
             // overflow case: OOME w/ "Java heap space" is thrown on decoding
             Arguments.of(Integer.MAX_VALUE - 1000000)

--- a/test/jdk/java/nio/charset/CharsetDecoder/XcodeOverflow.java
+++ b/test/jdk/java/nio/charset/CharsetDecoder/XcodeOverflow.java
@@ -27,6 +27,7 @@
  * @summary Make sure IAE is not thrown on `int` overflow, turning negative
  *          size. The test should either not throw any Throwable, or an OOME
  *          with real Java heap space error (not "exceeds VM limit").
+ * @modules java.base/jdk.internal.util
  * @requires sun.arch.data.model == "64"
  * @run junit/othervm XcodeOverflow
  */

--- a/test/jdk/java/util/Base64/TestEncodingDecodingLength.java
+++ b/test/jdk/java/util/Base64/TestEncodingDecodingLength.java
@@ -21,6 +21,7 @@
  * questions.
  */
 
+import jdk.internal.util.ArraysSupport;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.InvocationTargetException;
@@ -37,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  *          Base64.Decoder.decode behavior with large, (Integer.MAX_VALUE) sized
  *          input array/buffer. Tests the private methods "encodedOutLength" and
  *          "decodedOutLength".
+ * @modules java.base/jdk.internal.util
  * @run junit/othervm --add-opens java.base/java.util=ALL-UNNAMED TestEncodingDecodingLength
  */
 
@@ -45,7 +47,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 public class TestEncodingDecodingLength {
 
     // A value large enough to test the desired memory conditions in encode and decode
-    private static final int LARGE_MEM_SIZE = Integer.MAX_VALUE - 8;
+    private static final int LARGE_MEM_SIZE = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
     private static final Base64.Decoder DECODER = Base64.getDecoder();
     private static final Base64.Encoder ENCODER = Base64.getEncoder();
 

--- a/test/jdk/java/util/concurrent/tck/ArrayDeque8Test.java
+++ b/test/jdk/java/util/concurrent/tck/ArrayDeque8Test.java
@@ -36,6 +36,7 @@ import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Spliterator;
 
+import jdk.internal.util.ArraysSupport;
 import junit.framework.Test;
 
 public class ArrayDeque8Test extends JSR166TestCase {
@@ -86,7 +87,7 @@ public class ArrayDeque8Test extends JSR166TestCase {
             return;
 
         final Item e = fortytwo;
-        final int maxArraySize = Integer.MAX_VALUE - 8;
+        final int maxArraySize = ArraysSupport.SOFT_MAX_ARRAY_LENGTH;
 
         assertThrows(OutOfMemoryError.class,
                      () -> new ArrayDeque<Item>(Integer.MAX_VALUE));

--- a/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
+++ b/test/jdk/java/util/concurrent/tck/JSR166TestCase.java
@@ -38,7 +38,7 @@
  * @test id=default
  * @summary Conformance testing variant of JSR-166 tck tests.
  * @build *
- * @modules java.management
+ * @modules java.management java.base/jdk.internal.util
  * @run junit/othervm/timeout=1000 JSR166TestCase
  */
 
@@ -47,7 +47,7 @@
  * @summary Conformance testing variant of JSR-166 tck tests
  *          with java security manager set to allow.
  * @build *
- * @modules java.management
+ * @modules java.management java.base/jdk.internal.util
  * @run junit/othervm/timeout=1000 -Djava.security.manager=allow JSR166TestCase
  */
 
@@ -56,7 +56,7 @@
  * @summary Test implementation details variant of JSR-166
  *          tck tests with ForkJoinPool common parallelism.
  * @build *
- * @modules java.management
+ * @modules java.management java.base/jdk.internal.util
  * @run junit/othervm/timeout=1000
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED
@@ -78,7 +78,7 @@
  *          JSR-166 tck tests apart from ForkJoinPool common
  *          parallelism.
  * @build *
- * @modules java.management
+ * @modules java.management java.base/jdk.internal.util
  * @run junit/othervm/timeout=1000
  *      --add-opens java.base/java.util.concurrent=ALL-UNNAMED
  *      --add-opens java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
Please review this cleanup PR which updates code and tests in `java.base` to consistently use  `jdk.internal.util.ArraySupport.SOFT_MAX_ARRAY_LENGTH` when referring to the JVM's maximum array size implementation limit. Currently, instances of `Integer.MAX_VALUE - 8` are found across the code base, with varying degrees of documentation. It would be good to consolidate on a single source of truth, with proper documentation.

This PR is a follow-up to #20905 where the same change was requested in `java.util.zip`.

My understanding is that javac will fold this constant value into the byte code of the compiled use sites, as such this change should not affect class loading or cause startup issues. 

Instances selected for this PR were found searching for "Integer.MAX_VALUE - 8". The PR replaces these with `ArraySupport.SOFT_MAX_ARRAY_LENGTH`, while trimming or amending some code comments where appropriate. (`SOFT_MAX_ARRAY_LENGTH` already has a good explainer which does not need repetition at each use site).

I also searched for instances of `Integer.MAX_VALUE - 1` and `Integer.MAX_VALUE - 2`, no convincing candidates were found.

Instances outside `java.base` were deliberately left out to limit the scope and review cost of this PR.

Tests updated to use `SOFT_MAX_ARRAY_LENGTH` are updated with the jtreg tag `@modules java.base/jdk.internal.util`.

Testing: No new tests are added in this PR, the `noreg-cleanup` label is added to the JBS. The five affected tests have been run manually. GHA tests run green.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341243](https://bugs.openjdk.org/browse/JDK-8341243): Use ArraySupport.SOFT_MAX_ARRAY_LENGTH for max array size in java.base (**Enhancement** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Stuart Marks](https://openjdk.org/census#smarks) (@stuart-marks - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21268/head:pull/21268` \
`$ git checkout pull/21268`

Update a local copy of the PR: \
`$ git checkout pull/21268` \
`$ git pull https://git.openjdk.org/jdk.git pull/21268/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21268`

View PR using the GUI difftool: \
`$ git pr show -t 21268`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21268.diff">https://git.openjdk.org/jdk/pull/21268.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21268#issuecomment-2383968473)