### PR TITLE
8341246: Test com/sun/tools/attach/PermissionTest.java fails access denied

### DIFF
--- a/test/jdk/com/sun/tools/attach/java.policy.allow
+++ b/test/jdk/com/sun/tools/attach/java.policy.allow
@@ -1,6 +1,4 @@
 /*
- *
- *
  * Policy file used by unit tests for attach API
  */
 grant {
@@ -16,6 +14,7 @@ grant {
     permission java.util.PropertyPermission "sun.jvmstat.*", "read";
 
     /* to read configuration file in META-INF/services, and write/delete .attach_pid<pid> */
-    permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete";
+    /* to read symbol link in /proc/self/ns/mnt */
+    permission java.io.FilePermission "<<ALL FILES>>", "read,write,delete,readlink";
 };
 


### PR DESCRIPTION
Hi all,
Test `com/sun/tools/attach/PermissionTest.java` fails access denied after [JDK-8327114](https://bugs.openjdk.org/browse/JDK-8327114). This testcase need the `readlink` permission of file `/proc/self/ns/mnt` after [JDK-8327114](https://bugs.openjdk.org/browse/JDK-8327114).
So this PR add `readlink` permission to make this test work normally.
Before this PR, test run failed, after this PR, test run success. Test fix only, no risk.