### PR TITLE
8341293: Split field loads through Nested Phis

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -602,7 +602,7 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint phi_nest_level) const
           if (!can_reduce) {
 #ifndef PRODUCT
             if (TraceReduceAllocationMerges) {
-                tty->print_cr("Cannot reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);
+              tty->print_cr("Cannot reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);
               n->dump(5);
             }
 #endif

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -463,8 +463,15 @@ bool ConnectionGraph::compute_escape() {
 // if at least one scalar replaceable allocation participates in the merge.
 bool ConnectionGraph::can_reduce_phi_check_inputs(PhiNode* ophi) const {
   bool found_sr_allocate = false;
-
+  int nof_input_phi_nodes = 0;
   for (uint i = 1; i < ophi->req(); i++) {
+    if (ophi->in(i)->is_Phi()) {
+      // ignore phi node with more than one input phi node
+      if (++nof_input_phi_nodes > 1) {
+        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Cannot reduce Phi %d. More than one input phi node.", ophi->_idx);)
+        return false;
+      }
+    }
     JavaObjectNode* ptn = unique_java_object(ophi->in(i));
     if (ptn != nullptr && ptn->scalar_replaceable()) {
       AllocateNode* alloc = ptn->ideal_node()->as_Allocate();
@@ -484,7 +491,7 @@ bool ConnectionGraph::can_reduce_phi_check_inputs(PhiNode* ophi) const {
     }
   }
 
-  NOT_PRODUCT(if (TraceReduceAllocationMerges && !found_sr_allocate) tty->print_cr("Can NOT reduce Phi %d on invocation %d. No SR Allocate as input.", ophi->_idx, _invocation);)
+  NOT_PRODUCT(if (TraceReduceAllocationMerges && !found_sr_allocate) tty->print_cr("Cannot reduce Phi %d on invocation %d. No SR Allocate as input.", ophi->_idx, _invocation);)
   return found_sr_allocate;
 }
 
@@ -527,41 +534,50 @@ bool ConnectionGraph::has_been_reduced(PhiNode* n, SafePointNode* sfpt) const {
 //  - Phi -> AddP -> Load
 //  - Phi -> CastPP -> SafePoints
 //  - Phi -> CastPP -> AddP -> Load
-bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
+//  - Phi -> Phi -> AddP -> Load
+bool ConnectionGraph::can_reduce_check_users(Node* n, uint phi_nest_level) const {
   for (DUIterator_Fast imax, i = n->fast_outs(imax); i < imax; i++) {
     Node* use = n->fast_out(i);
-
-    if (use->is_SafePoint()) {
+    // Skip Phi -> Phi -> SafePoints and allow only Phi -> SafePoints and Phi -> CastPP -> SafePoints
+    if (use->is_SafePoint() && (!n->is_Phi() || phi_nest_level < 1)) {
       if (use->is_Call() && use->as_Call()->has_non_debug_use(n)) {
-        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. Call has non_debug_use().", n->_idx, _invocation);)
+        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Cannot reduce Phi %d on invocation %d. Call has non_debug_use().", n->_idx, _invocation);)
         return false;
       } else if (has_been_reduced(n->is_Phi() ? n->as_Phi() : n->as_CastPP()->in(1)->as_Phi(), use->as_SafePoint())) {
-        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. It has already been reduced.", n->_idx, _invocation);)
+        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Cannot reduce Phi %d on invocation %d. It has already been reduced.", n->_idx, _invocation);)
         return false;
       }
     } else if (use->is_AddP()) {
+      assert(phi_nest_level <= 1, "unexpected nesting level");
       Node* addp = use;
       for (DUIterator_Fast jmax, j = addp->fast_outs(jmax); j < jmax; j++) {
         Node* use_use = addp->fast_out(j);
         const Type* load_type = _igvn->type(use_use);
 
-        if (!use_use->is_Load() || !use_use->as_Load()->can_split_through_phi_base(_igvn)) {
-          NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. AddP user isn't a [splittable] Load(): %s", n->_idx, _invocation, use_use->Name());)
+        if (!use_use->is_Load() || !use_use->as_Load()->can_split_through_phi_base(_igvn, (phi_nest_level > 0))) {
+          NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Cannot reduce %s Phi %d on invocation %d. AddP user isn't a [splittable] Load(): %s", (phi_nest_level > 0)?"nested":"", n->_idx, _invocation, use_use->Name());)
           return false;
         } else if (load_type->isa_narrowklass() || load_type->isa_klassptr()) {
-          NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. [Narrow] Klass Load: %s", n->_idx, _invocation, use_use->Name());)
+          NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Cannot reduce %s Phi %d on invocation %d. [Narrow] Klass Load: %s", (phi_nest_level > 0)?"nested":"", n->_idx, _invocation, use_use->Name());)
           return false;
         }
       }
-    } else if (nesting > 0) {
-      NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. Unsupported user %s at nesting level %d.", n->_idx, _invocation, use->Name(), nesting);)
+    } else if (phi_nest_level > 0) {
+      NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Cannot reduce Phi %d on invocation %d. Unsupported user %s at nesting level %d.", n->_idx, _invocation, use->Name(), phi_nest_level);)
       return false;
+    } else if (use->is_Phi()) {
+      if (n->_idx == use->_idx) {
+        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Cannot reduce Self loop nested Phi");)
+        return false;
+      } else if (!can_reduce_phi_check_inputs(use->as_Phi()) || !can_reduce_check_users(use->as_Phi(), phi_nest_level+1)) {
+        return false;
+      }
     } else if (use->is_CastPP()) {
       const Type* cast_t = _igvn->type(use);
       if (cast_t == nullptr || cast_t->make_ptr()->isa_instptr() == nullptr) {
 #ifndef PRODUCT
         if (TraceReduceAllocationMerges) {
-          tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP is not to an instance.", n->_idx, _invocation);
+          tty->print_cr("Cannot reduce Phi %d on invocation %d. CastPP is not to an instance.", n->_idx, _invocation);
           use->dump();
         }
 #endif
@@ -586,7 +602,7 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
           if (!can_reduce) {
 #ifndef PRODUCT
             if (TraceReduceAllocationMerges) {
-              tty->print_cr("Can NOT reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);
+                tty->print_cr("Cannot reduce Phi %d on invocation %d. CastPP %d doesn't have simple control.", n->_idx, _invocation, use->_idx);
               n->dump(5);
             }
 #endif
@@ -595,16 +611,16 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
         }
       }
 
-      if (!can_reduce_check_users(use, nesting+1)) {
+      if (!can_reduce_check_users(use, phi_nest_level+1)) {
         return false;
       }
     } else if (use->Opcode() == Op_CmpP || use->Opcode() == Op_CmpN) {
       if (!can_reduce_cmp(n, use)) {
-        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. CmpP/N %d isn't reducible.", n->_idx, _invocation, use->_idx);)
+        NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Cannot reduce Phi %d on invocation %d. CmpP/N %d isn't reducible.", n->_idx, _invocation, use->_idx);)
         return false;
       }
     } else {
-      NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Can NOT reduce Phi %d on invocation %d. One of the uses is: %d %s", n->_idx, _invocation, use->_idx, use->Name());)
+      NOT_PRODUCT(if (TraceReduceAllocationMerges) tty->print_cr("Cannot reduce Phi %d on invocation %d. One of the uses is: %d %s", n->_idx, _invocation, use->_idx, use->Name());)
       return false;
     }
   }
@@ -631,7 +647,7 @@ bool ConnectionGraph::can_reduce_phi(PhiNode* ophi) const {
     return false;
   }
 
-  if (!can_reduce_phi_check_inputs(ophi) || !can_reduce_check_users(ophi, /* nesting: */ 0)) {
+  if (!can_reduce_phi_check_inputs(ophi) || !can_reduce_check_users(ophi, /* phi_nest_level: */ 0)) {
     return false;
   }
 
@@ -738,7 +754,7 @@ Node* ConnectionGraph::specialize_castpp(Node* castpp, Node* base, Node* current
   return _igvn->transform(ConstraintCastNode::make_cast_for_type(not_eq_control, base, _igvn->type(castpp), ConstraintCastNode::UnconditionalDependency, nullptr));
 }
 
-Node* ConnectionGraph::split_castpp_load_through_phi(Node* curr_addp, Node* curr_load, Node* region, GrowableArray<Node*>* bases_for_loads, GrowableArray<Node *>  &alloc_worklist) {
+Node* ConnectionGraph::split_castpp_load_through_phi(Node* curr_addp, Node* curr_load, Node* region, GrowableArray<Node*>* bases_for_loads, GrowableArray<Node *>  &alloc_worklist, Unique_Node_List &reducible_merges) {
   const Type* load_type = _igvn->type(curr_load);
   Node* nsr_value = _igvn->zerocon(load_type->basic_type());
   Node* memory = curr_load->in(MemNode::Memory);
@@ -788,7 +804,7 @@ Node* ConnectionGraph::split_castpp_load_through_phi(Node* curr_addp, Node* curr
 
   // Takes care of updating CG and split_unique_types worklists due
   // to cloned AddP->Load.
-  updates_after_load_split(data_phi, curr_load, alloc_worklist);
+  updates_after_load_split(data_phi, curr_load, alloc_worklist, reducible_merges);
 
   return _igvn->transform(data_phi);
 }
@@ -865,7 +881,7 @@ Node* ConnectionGraph::split_castpp_load_through_phi(Node* curr_addp, Node* curr
 //                      \|/
 //                      Phi        # "Field" Phi
 //
-void ConnectionGraph::reduce_phi_on_castpp_field_load(Node* curr_castpp, GrowableArray<Node *>  &alloc_worklist, GrowableArray<Node *>  &memnode_worklist) {
+void ConnectionGraph::reduce_phi_on_castpp_field_load(Node* curr_castpp, GrowableArray<Node *>  &alloc_worklist, GrowableArray<Node *>  &memnode_worklist, Unique_Node_List &reducible_merges) {
   Node* ophi = curr_castpp->in(1);
   assert(ophi->is_Phi(), "Expected this to be a Phi node.");
 
@@ -913,7 +929,7 @@ void ConnectionGraph::reduce_phi_on_castpp_field_load(Node* curr_castpp, Growabl
         // 'split_castpp_load_through_phi` method will add an
         // 'If-Then-Else-Region` around nullable bases and only load from them
         // when the input is not null.
-        Node* phi = split_castpp_load_through_phi(use, use_use, ophi->in(0), &bases_for_loads, alloc_worklist);
+        Node* phi = split_castpp_load_through_phi(use, use_use, ophi->in(0), &bases_for_loads, alloc_worklist, reducible_merges);
         _igvn->replace_node(use_use, phi);
 
         --j;
@@ -1014,7 +1030,7 @@ void ConnectionGraph::reduce_phi_on_cmp(Node* cmp) {
 // the connection graph. Note that the changes in the CG below
 // won't affect the ES of objects since the new nodes have the
 // same status as the old ones.
-void ConnectionGraph::updates_after_load_split(Node* data_phi, Node* previous_load, GrowableArray<Node *>  &alloc_worklist) {
+void ConnectionGraph::updates_after_load_split(Node* data_phi, Node* previous_load, GrowableArray<Node *>  &alloc_worklist, Unique_Node_List &reducible_merges) {
   assert(data_phi != nullptr, "Output of split_through_phi is null.");
   assert(data_phi != previous_load, "Output of split_through_phi is same as input.");
   assert(data_phi->is_Phi(), "Output of split_through_phi isn't a Phi.");
@@ -1043,8 +1059,14 @@ void ConnectionGraph::updates_after_load_split(Node* data_phi, Node* previous_lo
       // The base might not be something that we can create an unique
       // type for. If that's the case we are done with that input.
       PointsToNode* jobj_ptn = unique_java_object(base);
-      if (jobj_ptn == nullptr || !jobj_ptn->scalar_replaceable()) {
-        continue;
+      if (base->is_Phi()) {
+        if (!reducible_merges.member(base)) {
+          continue;
+        }
+      } else {
+        if (jobj_ptn == nullptr || !jobj_ptn->scalar_replaceable()) {
+          continue;
+        }
       }
 
       // Push to alloc_worklist since the base has an unique_type
@@ -1067,7 +1089,7 @@ void ConnectionGraph::updates_after_load_split(Node* data_phi, Node* previous_lo
   }
 }
 
-void ConnectionGraph::reduce_phi_on_field_access(Node* previous_addp, GrowableArray<Node *>  &alloc_worklist) {
+void ConnectionGraph::reduce_phi_on_field_access(Node* previous_addp, GrowableArray<Node *>  &alloc_worklist, Unique_Node_List &reducible_merges) {
   // We'll pass this to 'split_through_phi' so that it'll do the split even
   // though the load doesn't have an unique instance type.
   bool ignore_missing_instance_id = true;
@@ -1083,7 +1105,7 @@ void ConnectionGraph::reduce_phi_on_field_access(Node* previous_addp, GrowableAr
 
       // Takes care of updating CG and split_unique_types worklists due to cloned
       // AddP->Load.
-      updates_after_load_split(data_phi, previous_load, alloc_worklist);
+      updates_after_load_split(data_phi, previous_load, alloc_worklist, reducible_merges);
 
       _igvn->replace_node(previous_load, data_phi);
     }
@@ -1274,7 +1296,24 @@ bool ConnectionGraph::reduce_phi_on_safepoints_helper(Node* ophi, Node* cast, No
   return true;
 }
 
-void ConnectionGraph::reduce_phi(PhiNode* ophi, GrowableArray<Node *>  &alloc_worklist, GrowableArray<Node *>  &memnode_worklist) {
+void ConnectionGraph::reduce_phi(PhiNode* ophi, GrowableArray<Node *>  &alloc_worklist, GrowableArray<Node *>  &memnode_worklist, Unique_Node_List &reducible_merges) {
+  Unique_Node_List nested_phis;
+  // Collect nested phi nodes first because the graph will change while splitting the child/nested phi node.
+  for (DUIterator_Fast imax, i = ophi->fast_outs(imax); i < imax; i++) {
+    Node* use = ophi->fast_out(i);
+    if (use->is_Phi()) {
+      assert(use->_idx != ophi->_idx, "Unexpected selfloop Phi.");
+      nested_phis.push(use);
+    }
+  }
+
+  // Splitting through the child phi nodes ahead of parent phi nodes in nested scenarios is crucial.
+  // Ensure that the splits are applied to the load fields of child phi nodes before the parent phi nodes take place.
+  for (uint i = 0; i < nested_phis.size(); i++) {
+    Node *nested_phi = nested_phis.at(i);
+    reduce_phi(nested_phi->as_Phi(), alloc_worklist, memnode_worklist, reducible_merges);
+  }
+
   bool delay = _igvn->delay_transform();
   _igvn->set_delay_transform(true);
   _igvn->hash_delete(ophi);
@@ -1302,14 +1341,14 @@ void ConnectionGraph::reduce_phi(PhiNode* ophi, GrowableArray<Node *>  &alloc_wo
   // splitting CastPPs we make reference to the inputs of the Cmp that is used
   // by the If controlling the CastPP.
   for (uint i = 0; i < castpps.size(); i++) {
-    reduce_phi_on_castpp_field_load(castpps.at(i), alloc_worklist, memnode_worklist);
+    reduce_phi_on_castpp_field_load(castpps.at(i), alloc_worklist, memnode_worklist, reducible_merges);
   }
 
   for (uint i = 0; i < others.size(); i++) {
     Node* use = others.at(i);
 
     if (use->is_AddP()) {
-      reduce_phi_on_field_access(use, alloc_worklist);
+      reduce_phi_on_field_access(use, alloc_worklist, reducible_merges);
     } else if(use->is_Cmp()) {
       reduce_phi_on_cmp(use);
     }
@@ -4461,7 +4500,7 @@ void ConnectionGraph::split_unique_types(GrowableArray<Node *>  &alloc_worklist,
       // finishes. For now we just try to split out the SR inputs of the merge.
       Node* parent = n->in(1);
       if (reducible_merges.member(n)) {
-        reduce_phi(n->as_Phi(), alloc_worklist, memnode_worklist);
+        reduce_phi(n->as_Phi(), alloc_worklist, memnode_worklist, reducible_merges);
 #ifdef ASSERT
         if (VerifyReduceAllocationMerges) {
           reduced_merges.push(n);

--- a/src/hotspot/share/opto/escape.hpp
+++ b/src/hotspot/share/opto/escape.hpp
@@ -592,8 +592,8 @@ private:
   // Methods related to Reduce Allocation Merges
   bool has_non_reducible_merge(FieldNode* field, Unique_Node_List& reducible_merges);
   PhiNode* create_selector(PhiNode* ophi) const;
-  void updates_after_load_split(Node* data_phi, Node* previous_load, GrowableArray<Node *>  &alloc_worklist);
-  Node* split_castpp_load_through_phi(Node* curr_addp, Node* curr_load, Node* region, GrowableArray<Node*>* bases_for_loads, GrowableArray<Node *>  &alloc_worklist);
+  void updates_after_load_split(Node* data_phi, Node* previous_load, GrowableArray<Node *>  &alloc_worklist, Unique_Node_List &reducible_merges);
+  Node* split_castpp_load_through_phi(Node* curr_addp, Node* curr_load, Node* region, GrowableArray<Node*>* bases_for_loads, GrowableArray<Node *>  &alloc_worklist, Unique_Node_List &reducible_merges);
   void reset_scalar_replaceable_entries(PhiNode* ophi);
   bool has_reducible_merge_base(AddPNode* n, Unique_Node_List &reducible_merges);
   Node* specialize_cmp(Node* base, Node* curr_ctrl);
@@ -602,15 +602,15 @@ private:
   bool can_reduce_cmp(Node* n, Node* cmp) const;
   bool has_been_reduced(PhiNode* n, SafePointNode* sfpt) const;
   bool can_reduce_phi(PhiNode* ophi) const;
-  bool can_reduce_check_users(Node* n, uint nesting) const;
+  bool can_reduce_check_users(Node* n, uint phi_nest_level) const;
   bool can_reduce_phi_check_inputs(PhiNode* ophi) const;
 
-  void reduce_phi_on_field_access(Node* previous_addp, GrowableArray<Node *>  &alloc_worklist);
-  void reduce_phi_on_castpp_field_load(Node* castpp, GrowableArray<Node *>  &alloc_worklist, GrowableArray<Node *>  &memnode_worklist);
+  void reduce_phi_on_field_access(Node* previous_addp, GrowableArray<Node *>  &alloc_worklist, Unique_Node_List &reducible_merges);
+  void reduce_phi_on_castpp_field_load(Node* castpp, GrowableArray<Node *>  &alloc_worklist, GrowableArray<Node *>  &memnode_worklist, Unique_Node_List &reducible_merges);
   void reduce_phi_on_cmp(Node* cmp);
   bool reduce_phi_on_safepoints(PhiNode* ophi);
   bool reduce_phi_on_safepoints_helper(Node* ophi, Node* cast, Node* selector, Unique_Node_List& safepoints);
-  void reduce_phi(PhiNode* ophi, GrowableArray<Node *>  &alloc_worklist, GrowableArray<Node *>  &memnode_worklist);
+  void reduce_phi(PhiNode* ophi, GrowableArray<Node *>  &alloc_worklist, GrowableArray<Node *>  &memnode_worklist, Unique_Node_List &reducible_merges);
 
   void set_not_scalar_replaceable(PointsToNode* ptn NOT_PRODUCT(COMMA const char* reason)) const {
 #ifndef PRODUCT

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1564,14 +1564,83 @@ static bool stable_phi(PhiNode* phi, PhaseGVN *phase) {
   return true;
 }
 
+//------------------------------get_region_of_split_through_phi------------------------------
+// Given a base node and a memory node, this function determines the region of split through phi.
+// If the base node is not a phi node, it returns nullptr.
+Node* LoadNode::get_region_of_split_through_base_phi(PhaseGVN* phase, Node *base) {
+  Node* mem        = in(Memory);
+  Node* address    = in(Address);
+  bool base_is_phi = (base != nullptr) && base->is_Phi();
+  Node* region = nullptr;  
+  DomResult dom_result = DomResult::Dominate;
+  if (!base_is_phi) {
+    assert(mem->is_Phi(), "memory node should be a Phi");
+    region = mem->in(0);
+    // Skip if the region dominates some control edge of the address.
+    // We will check `dom_result` later.
+    dom_result = MemNode::maybe_all_controls_dominate(address, region);
+  } else if (!mem->is_Phi()) {
+    assert(base_is_phi, "base node should be a Phi");
+    region = base->in(0);
+    // Skip if the region dominates some control edge of the memory.
+    // We will check `dom_result` later.
+    dom_result = MemNode::maybe_all_controls_dominate(mem, region);
+  } else if (base->in(0) != mem->in(0)) {
+    assert(base_is_phi && mem->is_Phi(), "base and memory nodes should be Phi");
+    dom_result = MemNode::maybe_all_controls_dominate(mem, base->in(0));
+    if (dom_result == DomResult::Dominate) {
+      region = base->in(0);
+    } else {
+      dom_result = MemNode::maybe_all_controls_dominate(address, mem->in(0));
+      if (dom_result == DomResult::Dominate) {
+        region = mem->in(0);
+      }
+      // Otherwise we encountered a complex graph.
+    }
+  } else {
+    assert(base->in(0) == mem->in(0), "base and memory nodes should have the same region");
+    region = mem->in(0);
+  }
+
+  PhaseIterGVN* igvn = phase->is_IterGVN();
+  if (dom_result != DomResult::Dominate) {
+    if (dom_result == DomResult::EncounteredDeadCode) {
+      // There is some dead code which eventually will be removed in IGVN.
+      // Once this is the case, we get an unambiguous dominance result.
+      // Push the node to the worklist again until the dead code is removed.
+      igvn->_worklist.push(this);
+    }
+    return nullptr;
+  }
+  return region;
+}
+
+static bool can_split_through_phi_helper(Node *base, Node *mem) {
+  if (base == nullptr || !base->is_Phi()) {
+    return false;
+  }
+
+  if (!mem->is_Phi()) {
+    // Skip if the region dominates some control edge of the memory.
+    if (!MemNode::all_controls_dominate(mem, base->in(0)))
+      return false;
+  } else if (base->in(0) != mem->in(0)) {
+    // Skip if the region dominates some control edge of the memory.
+    if (!MemNode::all_controls_dominate(mem, base->in(0))) {
+      return false; // complex graph
+    }
+  }
+  return true;
+}
+
 //------------------------------split_through_phi------------------------------
 // Check whether a call to 'split_through_phi' would split this load through the
 // Phi *base*. This method is essentially a copy of the validations performed
 // by 'split_through_phi'. The first use of this method was in EA code as part
 // of simplification of allocation merges.
-// Some differences from original method (split_through_phi):
+// The difference from the original method (split_through_phi) is:
 //  - If base->is_CastPP(): base = base->in(1)
-bool LoadNode::can_split_through_phi_base(PhaseGVN* phase) {
+bool LoadNode::can_split_through_phi_base(PhaseGVN* phase, bool nested) {
   Node* mem        = in(Memory);
   Node* address    = in(Address);
   intptr_t ignore  = 0;
@@ -1581,21 +1650,50 @@ bool LoadNode::can_split_through_phi_base(PhaseGVN* phase) {
     base = base->in(1);
   }
 
-  if (req() > 3 || base == nullptr || !base->is_Phi()) {
+  if (req() > 3 || !can_split_through_phi_helper(base, mem)) {
     return false;
   }
 
-  if (!mem->is_Phi()) {
-    if (!MemNode::all_controls_dominate(mem, base->in(0))) {
-      return false;
-    }
-  } else if (base->in(0) != mem->in(0)) {
-    if (!MemNode::all_controls_dominate(mem, base->in(0))) {
-      return false;
+  if (nested) {
+    for (uint i = 1; i < base->req(); i++) {
+      if (base->in(i)->is_Phi()) {
+        // base->in(i) is the parent phi node for base node.
+        Node *mem_node_for_load_after_opt = get_memory_node_for_nestedphi_after_split(phase, base, i);
+        if (!mem_node_for_load_after_opt || !can_split_through_phi_helper(base->in(i), mem_node_for_load_after_opt)) {
+          return false;
+        }
+      }
     }
   }
-
   return true;
+}
+
+//------------------------------get_memory_node_for_nestedphi_after_split------------------------------
+// Given a nestedphi node and its parentphi node, this function pretends that a split has occurred on a load field 
+// and returns the memory node of the new load field node that is attached to the parentphi node.
+// Note that this function doesn't actually perform the split.
+// If a split is impossible, it returns nullptr.
+Node* LoadNode::get_memory_node_for_nestedphi_after_split(PhaseGVN* phase, Node *base, uint parent_idx) {
+  Node* mem        = in(Memory);
+  Node* region = get_region_of_split_through_base_phi(phase, base);
+  if (region == nullptr) {
+    return nullptr;
+  }
+  
+  Node* in = region->in(parent_idx);
+  if (region->is_CountedLoop() && region->as_Loop()->is_strip_mined() && parent_idx == LoopNode::EntryControl &&
+    in != nullptr && in->is_OuterStripMinedLoop()) {
+    // No node should go in the outer strip mined loop
+    in = in->in(LoopNode::EntryControl);
+  }
+  if (in == nullptr || in == phase->C->top()) {
+    // Dead path?  Use a dead data op    
+    return phase->C->top()->in(Memory);
+  } else if (mem->is_Phi() && (mem->in(0) == region)) {
+    return mem->in(parent_idx);
+  }
+
+  return mem;
 }
 
 //------------------------------split_through_phi------------------------------
@@ -1634,7 +1732,7 @@ Node* LoadNode::split_through_phi(PhaseGVN* phase, bool ignore_missing_instance_
     }
     uint cnt = mem->req();
     // Check for loop invariant memory.
-    if (cnt == 3) {
+    if (cnt == 3 && !ignore_missing_instance_id) {
       for (uint i = 1; i < cnt; i++) {
         Node* in = mem->in(i);
         Node*  m = optimize_memory_chain(in, t_oop, this, phase);
@@ -1678,50 +1776,14 @@ Node* LoadNode::split_through_phi(PhaseGVN* phase, bool ignore_missing_instance_
   }
 
   // Select Region to split through.
-  Node* region;
-  DomResult dom_result = DomResult::Dominate;
-  if (!base_is_phi) {
-    assert(mem->is_Phi(), "sanity");
-    region = mem->in(0);
-    // Skip if the region dominates some control edge of the address.
-    // We will check `dom_result` later.
-    dom_result = MemNode::maybe_all_controls_dominate(address, region);
-  } else if (!mem->is_Phi()) {
-    assert(base_is_phi, "sanity");
-    region = base->in(0);
-    // Skip if the region dominates some control edge of the memory.
-    // We will check `dom_result` later.
-    dom_result = MemNode::maybe_all_controls_dominate(mem, region);
-  } else if (base->in(0) != mem->in(0)) {
-    assert(base_is_phi && mem->is_Phi(), "sanity");
-    dom_result = MemNode::maybe_all_controls_dominate(mem, base->in(0));
-    if (dom_result == DomResult::Dominate) {
-      region = base->in(0);
-    } else {
-      dom_result = MemNode::maybe_all_controls_dominate(address, mem->in(0));
-      if (dom_result == DomResult::Dominate) {
-        region = mem->in(0);
-      }
-      // Otherwise we encountered a complex graph.
-    }
-  } else {
-    assert(base->in(0) == mem->in(0), "sanity");
-    region = mem->in(0);
-  }
-
-  PhaseIterGVN* igvn = phase->is_IterGVN();
-  if (dom_result != DomResult::Dominate) {
-    if (dom_result == DomResult::EncounteredDeadCode) {
-      // There is some dead code which eventually will be removed in IGVN.
-      // Once this is the case, we get an unambiguous dominance result.
-      // Push the node to the worklist again until the dead code is removed.
-      igvn->_worklist.push(this);
-    }
+  Node* region = get_region_of_split_through_base_phi(phase, base);
+  if (region == nullptr) {
     return nullptr;
   }
 
   Node* phi = nullptr;
   const Type* this_type = this->bottom_type();
+  PhaseIterGVN* igvn = phase->is_IterGVN();
   if (t_oop != nullptr && (t_oop->is_known_instance_field() || load_boxed_values)) {
     int this_index = C->get_alias_index(t_oop);
     int this_offset = t_oop->offset();

--- a/src/hotspot/share/opto/memnode.cpp
+++ b/src/hotspot/share/opto/memnode.cpp
@@ -1571,7 +1571,7 @@ Node* LoadNode::get_region_of_split_through_base_phi(PhaseGVN* phase, Node *base
   Node* mem        = in(Memory);
   Node* address    = in(Address);
   bool base_is_phi = (base != nullptr) && base->is_Phi();
-  Node* region = nullptr;  
+  Node* region = nullptr;
   DomResult dom_result = DomResult::Dominate;
   if (!base_is_phi) {
     assert(mem->is_Phi(), "memory node should be a Phi");
@@ -1669,7 +1669,7 @@ bool LoadNode::can_split_through_phi_base(PhaseGVN* phase, bool nested) {
 }
 
 //------------------------------get_memory_node_for_nestedphi_after_split------------------------------
-// Given a nestedphi node and its parentphi node, this function pretends that a split has occurred on a load field 
+// Given a nestedphi node and its parentphi node, this function pretends that a split has occurred on a load field
 // and returns the memory node of the new load field node that is attached to the parentphi node.
 // Note that this function doesn't actually perform the split.
 // If a split is impossible, it returns nullptr.
@@ -1679,7 +1679,7 @@ Node* LoadNode::get_memory_node_for_nestedphi_after_split(PhaseGVN* phase, Node 
   if (region == nullptr) {
     return nullptr;
   }
-  
+
   Node* in = region->in(parent_idx);
   if (region->is_CountedLoop() && region->as_Loop()->is_strip_mined() && parent_idx == LoopNode::EntryControl &&
     in != nullptr && in->is_OuterStripMinedLoop()) {
@@ -1687,7 +1687,7 @@ Node* LoadNode::get_memory_node_for_nestedphi_after_split(PhaseGVN* phase, Node 
     in = in->in(LoopNode::EntryControl);
   }
   if (in == nullptr || in == phase->C->top()) {
-    // Dead path?  Use a dead data op    
+    // Dead path?  Use a dead data op
     return phase->C->top()->in(Memory);
   } else if (mem->is_Phi() && (mem->in(0) == region)) {
     return mem->in(parent_idx);

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -253,7 +253,12 @@ public:
   virtual Node *Ideal(PhaseGVN *phase, bool can_reshape);
 
   // Return true if it's possible to split the Load through a Phi merging the bases
-  bool can_split_through_phi_base(PhaseGVN *phase);
+  bool can_split_through_phi_base(PhaseGVN *phase, bool nested = false);
+
+  // Returns a memory node for load node after splitting through nestedphi node
+  // Calling code is responsible to clean up (remove_dead_node) after use
+  Node* get_memory_node_for_nestedphi_after_split(PhaseGVN* phase, Node *base, uint parent_idx);
+  Node* get_region_of_split_through_base_phi(PhaseGVN* phase, Node *base);
 
   // Split instance field load through Phi.
   Node* split_through_phi(PhaseGVN *phase, bool ignore_missing_instance_id = false);

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
@@ -28,7 +28,7 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
- * @bug 8281429
+ * @bug 8341293
  * @summary Tests that C2 can correctly scalar replace some object allocation merges.
  * @library /test/lib /
  * @requires vm.debug == true & vm.flagless & vm.bits == 64 & vm.compiler2.enabled & vm.opt.final.EliminateAllocations

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -264,7 +264,7 @@ public class AllocationMergesNestedPhiTests {
     int testGlobalEscapeInThread_Intrep(boolean cond1, int n, int x, int y) { return testGlobalEscapeInThread(cond1, n, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, ">=5"}, phase= CompilePhase.ITER_GVN_AFTER_EA)
+    @IR(counts = { IRNode.ALLOC, ">=4"}, phase= CompilePhase.ITER_GVN_AFTER_EA)
     int testGlobalEscapeInThread_C2(boolean cond1, int n, int x, int y) { return testGlobalEscapeInThread(cond1, n, x, y); }
 
     //--------------------------------------------------------------------------------------------------------------------------------------------

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
@@ -31,7 +31,7 @@ import compiler.lib.ir_framework.*;
  * @bug 8341293
  * @summary Tests that C2 can correctly scalar replace some object allocation merges.
  * @library /test/lib /
- * @requires vm.debug == true & vm.flagless & vm.bits == 64 & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
+ * @requires vm.debug == true & vm.compiler2.enabled
  * @run driver compiler.c2.irTests.scalarReplacement.AllocationMergesNestedPhiTests
  */
 public class AllocationMergesNestedPhiTests {
@@ -149,7 +149,10 @@ public class AllocationMergesNestedPhiTests {
     }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, ">=1", IRNode.SAFEPOINT_SCALAR_MERGE, ">=1"}, phase = CompilePhase.ITER_GVN_AFTER_EA)
+    @IR(counts = { IRNode.ALLOC, ">=1", IRNode.SAFEPOINT_SCALAR_MERGE, ">=1"},
+        phase = CompilePhase.ITER_GVN_AFTER_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testRematerialize_SingleObj_C2(boolean cond1,int x, int y) throws Exception { return testRematerialize_SingleObj(cond1, x, y); }
 
     @DontCompile
@@ -172,7 +175,10 @@ public class AllocationMergesNestedPhiTests {
     }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, ">=1", IRNode.SAFEPOINT_SCALAR_MERGE, ">=1",  IRNode.SAFEPOINT_SCALAR_OBJECT, ">=2"}, phase = CompilePhase.ITER_GVN_AFTER_EA)
+    @IR(counts = { IRNode.ALLOC, ">=1", IRNode.SAFEPOINT_SCALAR_MERGE, ">=1",  IRNode.SAFEPOINT_SCALAR_OBJECT, ">=2"},
+        phase = CompilePhase.ITER_GVN_AFTER_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testRematerialize_TryCatch_C2(boolean cond1, int n, int x, int y) { return testRematerialize_TryCatch(cond1, n, x, y); }
 
     @DontCompile
@@ -199,7 +205,10 @@ public class AllocationMergesNestedPhiTests {
     }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, ">=2"}, phase = CompilePhase.ITER_GVN_AFTER_EA)
+    @IR(counts = { IRNode.ALLOC, ">=2"},
+        phase = CompilePhase.ITER_GVN_AFTER_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testMerge_TryCatchFinally_C2(boolean cond1, int n, int x, int y) { return testMerge_TryCatchFinally(cond1, n, x, y); }
 
     @DontCompile
@@ -232,7 +241,10 @@ public class AllocationMergesNestedPhiTests {
     }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, ">=1", IRNode.SAFEPOINT_SCALAR_MERGE, ">=1", IRNode.SAFEPOINT_SCALAR_OBJECT, ">=2"}, phase= CompilePhase.ITER_GVN_AFTER_EA)
+    @IR(counts = { IRNode.ALLOC, ">=1", IRNode.SAFEPOINT_SCALAR_MERGE, ">=1", IRNode.SAFEPOINT_SCALAR_OBJECT, ">=2"},
+        phase= CompilePhase.ITER_GVN_AFTER_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testRematerialize_MultiObj_C2(boolean cond1, boolean cond2, int x, int y) { return testRematerialize_MultiObj(cond1, cond2, x, y); }
 
     @DontCompile
@@ -264,7 +276,10 @@ public class AllocationMergesNestedPhiTests {
     int testGlobalEscapeInThread_Intrep(boolean cond1, int n, int x, int y) { return testGlobalEscapeInThread(cond1, n, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, ">=4"}, phase= CompilePhase.ITER_GVN_AFTER_EA)
+    @IR(counts = { IRNode.ALLOC, ">=4"},
+        phase= CompilePhase.ITER_GVN_AFTER_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testGlobalEscapeInThread_C2(boolean cond1, int n, int x, int y) { return testGlobalEscapeInThread(cond1, n, x, y); }
 
     //--------------------------------------------------------------------------------------------------------------------------------------------
@@ -306,7 +321,10 @@ public class AllocationMergesNestedPhiTests {
     int testFieldEscapeWithMerge_Intrep(boolean cond1, int x, int y) { return testFieldEscapeWithMerge(cond1, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, ">=1"}, phase= CompilePhase.ITER_GVN_AFTER_EA)
+    @IR(counts = { IRNode.ALLOC, ">=1"},
+        phase= CompilePhase.ITER_GVN_AFTER_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testFieldEscapeWithMerge_C2(boolean cond1, int x, int y) { return testFieldEscapeWithMerge(cond1, x, y); }
 
     //--------------------------------------------------------------------------------------------------------------------------------------------
@@ -325,8 +343,14 @@ public class AllocationMergesNestedPhiTests {
     }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
-    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    @IR(counts = { IRNode.ALLOC, "3" },
+        phase = CompilePhase.PHASEIDEAL_BEFORE_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
+    @IR(counts = { IRNode.ALLOC, "0" },
+        phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testNestedPhi_FieldLoad_C2(boolean cond1, boolean cond2, int x, int y) {
        return testNestedPhi_FieldLoad(cond1, cond2, x, y);
     }
@@ -342,8 +366,14 @@ public class AllocationMergesNestedPhiTests {
     int testThreeLevelNestedPhi_Interp(boolean cond1, boolean cond2, int x, int y) { return testThreeLevelNestedPhi(cond1, cond2, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
-    @IR(counts = { IRNode.ALLOC, "2" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    @IR(counts = { IRNode.ALLOC, "3" },
+        phase = CompilePhase.PHASEIDEAL_BEFORE_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
+    @IR(counts = { IRNode.ALLOC, "2" },
+        phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testThreeLevelNestedPhi_C2(boolean cond1, boolean cond2, int x, int y) { return testThreeLevelNestedPhi(cond1, cond2, x, y); }
 
     @ForceInline
@@ -372,8 +402,14 @@ public class AllocationMergesNestedPhiTests {
     int testNestedPhiProcessOrder_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiProcessOrder(cond1, cond2, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, "2" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
-    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    @IR(counts = { IRNode.ALLOC, "2" },
+        phase = CompilePhase.PHASEIDEAL_BEFORE_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
+    @IR(counts = { IRNode.ALLOC, "0" },
+        phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testNestedPhiProcessOrder_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiProcessOrder(cond1, cond2, x, y); }
 
     @ForceInline
@@ -396,8 +432,14 @@ public class AllocationMergesNestedPhiTests {
     int testNestedPhi_TryCatch_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhi_TryCatch(cond1, cond2, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, "2" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
-    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    @IR(counts = { IRNode.ALLOC, "2" },
+        phase = CompilePhase.PHASEIDEAL_BEFORE_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
+    @IR(counts = { IRNode.ALLOC, "0" },
+        phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testNestedPhi_TryCatch_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhi_TryCatch(cond1, cond2, x, y); }
 
     @ForceInline
@@ -421,8 +463,14 @@ public class AllocationMergesNestedPhiTests {
     int testBailOut_Interp(boolean cond1, boolean cond2, int x, int y) { return testBailOut(cond1, cond2, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
-    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    @IR(counts = { IRNode.ALLOC, "3" },
+        phase = CompilePhase.PHASEIDEAL_BEFORE_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
+    @IR(counts = { IRNode.ALLOC, "0" },
+        phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testBailOut_C2(boolean cond1, boolean cond2, int x, int y) { return testBailOut(cond1, cond2, x, y); }
 
     @ForceInline
@@ -449,8 +497,14 @@ public class AllocationMergesNestedPhiTests {
     int testNestedPhiPolymorphic_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiPolymorphic(cond1, cond2, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
-    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    @IR(counts = { IRNode.ALLOC, "3" },
+        phase = CompilePhase.PHASEIDEAL_BEFORE_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
+    @IR(counts = { IRNode.ALLOC, "0" },
+        phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testNestedPhiPolymorphic_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiPolymorphic(cond1, cond2, x, y); }
 
     @ForceInline
@@ -470,8 +524,14 @@ public class AllocationMergesNestedPhiTests {
     int testNestedPhiWithTrap_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiWithTrap(cond1, cond2, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
-    @IR(counts = { IRNode.ALLOC, "2" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    @IR(counts = { IRNode.ALLOC, "3" },
+        phase = CompilePhase.PHASEIDEAL_BEFORE_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
+    @IR(counts = { IRNode.ALLOC, "2" },
+        phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testNestedPhiWithTrap_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiWithTrap(cond1, cond2, x, y); }
 
     @ForceInline
@@ -494,8 +554,14 @@ public class AllocationMergesNestedPhiTests {
     int testNestedPhiWithLambda_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiWithLambda(cond1, cond2, x, y); }
 
     @Test
-    @IR(counts = { IRNode.ALLOC, "4" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
-    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    @IR(counts = { IRNode.ALLOC, "4" },
+        phase = CompilePhase.PHASEIDEAL_BEFORE_EA,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
+    @IR(counts = { IRNode.ALLOC, "0" },
+        phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION,
+        applyIfPlatform = {"64-bit", "true"},
+        applyIf = {"EliminateAllocations", "true"})
     int testNestedPhiWithLambda_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiWithLambda(cond1, cond2, x, y); }
 
     @ForceInline

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
@@ -31,7 +31,6 @@ import compiler.lib.ir_framework.*;
  * @bug 8341293
  * @summary Tests that C2 can correctly scalar replace some object allocation merges.
  * @library /test/lib /
- * @requires vm.debug == true & vm.compiler2.enabled
  * @run driver compiler.c2.irTests.scalarReplacement.AllocationMergesNestedPhiTests
  */
 public class AllocationMergesNestedPhiTests {
@@ -41,7 +40,8 @@ public class AllocationMergesNestedPhiTests {
     public static void main(String[] args) {
         TestFramework framework = new TestFramework();
 
-        Scenario scenario0 = new Scenario(0, "-XX:+UnlockDiagnosticVMOptions",
+        Scenario scenario0 = new Scenario(0, "-XX:+IgnoreUnrecognizedVMOptions",
+                                             "-XX:+UnlockDiagnosticVMOptions",
                                              "-XX:+ReduceAllocationMerges",
                                              "-XX:+TraceReduceAllocationMerges",
                                              "-XX:+DeoptimizeALot",
@@ -53,7 +53,8 @@ public class AllocationMergesNestedPhiTests {
                                              "-XX:CompileCommand=inline,*Nested::*",
                                              "-XX:CompileCommand=exclude,*::dummy*");
 
-        Scenario scenario1 = new Scenario(1, "-XX:+UnlockDiagnosticVMOptions",
+        Scenario scenario1 = new Scenario(1, "-XX:+IgnoreUnrecognizedVMOptions",
+                                             "-XX:+UnlockDiagnosticVMOptions",
                                              "-XX:+ReduceAllocationMerges",
                                              "-XX:+TraceReduceAllocationMerges",
                                              "-XX:+DeoptimizeALot",
@@ -65,7 +66,8 @@ public class AllocationMergesNestedPhiTests {
                                              "-XX:CompileCommand=inline,*Nested::*",
                                              "-XX:CompileCommand=exclude,*::dummy*");
 
-        Scenario scenario2 = new Scenario(2, "-XX:+UnlockDiagnosticVMOptions",
+        Scenario scenario2 = new Scenario(2, "-XX:+IgnoreUnrecognizedVMOptions",
+                                             "-XX:+UnlockDiagnosticVMOptions",
                                              "-XX:+ReduceAllocationMerges",
                                              "-XX:+TraceReduceAllocationMerges",
                                              "-XX:+DeoptimizeALot",

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
@@ -1,0 +1,753 @@
+/*
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests.scalarReplacement;
+
+import java.util.Random;
+import jdk.test.lib.Asserts;
+import compiler.lib.ir_framework.*;
+
+/*
+ * @test
+ * @bug 8281429
+ * @summary Tests that C2 can correctly scalar replace some object allocation merges.
+ * @library /test/lib /
+ * @requires vm.debug == true & vm.flagless & vm.bits == 64 & vm.compiler2.enabled & vm.opt.final.EliminateAllocations
+ * @run driver compiler.c2.irTests.scalarReplacement.AllocationMergesNestedPhiTests
+ */
+public class AllocationMergesNestedPhiTests {
+    private int invocations = 0;
+    private static Point global_escape = new Point(2022, 2023);
+
+    public static void main(String[] args) {
+        TestFramework framework = new TestFramework();
+
+        Scenario scenario0 = new Scenario(0, "-XX:+UnlockDiagnosticVMOptions",
+                                             "-XX:+ReduceAllocationMerges",
+                                             "-XX:+TraceReduceAllocationMerges",
+                                             "-XX:+DeoptimizeALot",
+                                             "-XX:+UseCompressedOops",
+                                             "-XX:+UseCompressedClassPointers",
+                                             "-XX:CompileCommand=inline,*::charAt*",
+                                             "-XX:CompileCommand=inline,*PicturePositions::*",
+                                             "-XX:CompileCommand=inline,*Point::*",
+                                             "-XX:CompileCommand=inline,*Nested::*",
+                                             "-XX:CompileCommand=exclude,*::dummy*");
+
+        Scenario scenario1 = new Scenario(1, "-XX:+UnlockDiagnosticVMOptions",
+                                             "-XX:+ReduceAllocationMerges",
+                                             "-XX:+TraceReduceAllocationMerges",
+                                             "-XX:+DeoptimizeALot",
+                                             "-XX:+UseCompressedOops",
+                                             "-XX:-UseCompressedClassPointers",
+                                             "-XX:CompileCommand=inline,*::charAt*",
+                                             "-XX:CompileCommand=inline,*PicturePositions::*",
+                                             "-XX:CompileCommand=inline,*Point::*",
+                                             "-XX:CompileCommand=inline,*Nested::*",
+                                             "-XX:CompileCommand=exclude,*::dummy*");
+
+        Scenario scenario2 = new Scenario(2, "-XX:+UnlockDiagnosticVMOptions",
+                                             "-XX:+ReduceAllocationMerges",
+                                             "-XX:+TraceReduceAllocationMerges",
+                                             "-XX:+DeoptimizeALot",
+                                             "-XX:-UseCompressedOops",
+                                             "-XX:CompileCommand=inline,*::charAt*",
+                                             "-XX:CompileCommand=inline,*PicturePositions::*",
+                                             "-XX:CompileCommand=inline,*Point::*",
+                                             "-XX:CompileCommand=inline,*Nested::*",
+                                             "-XX:CompileCommand=exclude,*::dummy*");
+
+        framework.addScenarios(scenario0, scenario1, scenario2).start();
+    }
+
+    // ------------------ No Scalar Replacement Should Happen in The Tests Below ------------------- //
+
+    @Run(test = {
+                 "testRematerialize_SingleObj_C2",
+                 "testRematerialize_TryCatch_C2",
+                 "testMerge_TryCatchFinally_C2",
+                 "testRematerialize_MultiObj_C2",
+                 "testGlobalEscapeInThread_C2",
+                 "testGlobalEscapeInThreadWithSync_C2",
+                 "testFieldEscapeWithMerge_C2",
+                 "testNestedPhi_FieldLoad_C2",
+                 "testThreeLevelNestedPhi_C2",
+                 "testNestedPhiProcessOrder_C2",
+                 "testNestedPhi_TryCatch_C2",
+                 "testBailOut_C2",
+                 "testNestedPhiPolymorphic_C2",
+                 "testNestedPhiWithTrap_C2",
+                 "testNestedPhiWithLambda_C2",
+                 "testMultiParentPhi_C2"
+                })
+    public void runner(RunInfo info) {
+        invocations++;
+
+        Random random = info.getRandom();
+        boolean cond1 = invocations % 2 == 0;
+        boolean cond2 = !cond1;
+
+        int l = random.nextInt();
+        int w = random.nextInt();
+        int x = random.nextInt();
+        int y = random.nextInt();
+        int z = random.nextInt(); 
+        try {
+            Asserts.assertEQ(testRematerialize_SingleObj_Interp(cond1, x, y),       testRematerialize_SingleObj_C2(cond1, x, y));
+        } catch (Exception e) {}
+        Asserts.assertEQ(testRematerialize_TryCatch_Interp(cond1, l, x, y),         testRematerialize_TryCatch_C2(cond1, l, x, y));
+        Asserts.assertEQ(testMerge_TryCatchFinally_Interp(cond1, l, x, y),          testMerge_TryCatchFinally_C2(cond1, l, x, y));
+        Asserts.assertEQ(testRematerialize_MultiObj_Interp(cond1, cond2, x, y),     testRematerialize_MultiObj_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testGlobalEscapeInThread_Intrep(cond1, l, x, y),           testGlobalEscapeInThread_C2(cond1, l, x, y));
+        Asserts.assertEQ(testGlobalEscapeInThreadWithSync_Intrep(cond1, x, y),      testGlobalEscapeInThreadWithSync_C2(cond1, x, y));
+        Asserts.assertEQ(testFieldEscapeWithMerge_Intrep(cond1, x, y),              testFieldEscapeWithMerge_C2(cond1, x, y));
+        Asserts.assertEQ(testNestedPhi_FieldLoad_Interp(cond1, cond2, x, y),        testNestedPhi_FieldLoad_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testThreeLevelNestedPhi_Interp(cond1, cond2, x, y),        testThreeLevelNestedPhi_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testNestedPhiProcessOrder_Interp(cond1, cond2, x, y),      testNestedPhiProcessOrder_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testNestedPhi_TryCatch_Interp(cond1, cond2, x, y),         testNestedPhi_TryCatch_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testBailOut_Interp(cond1, cond2, x, y),                    testBailOut_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testNestedPhiPolymorphic_Interp(cond1, cond2, x, y),       testNestedPhiPolymorphic_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testNestedPhiWithTrap_Interp(cond1, cond2, x, y),          testNestedPhiWithTrap_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testNestedPhiWithLambda_Interp(cond1, cond2, x, y),        testNestedPhiWithLambda_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testMultiParentPhi_Interp(cond1, cond2, x, y),             testMultiParentPhi_C2(cond1, cond2, x, y));
+    }
+
+    // -------------------------------------------------------------------------
+
+    @ForceInline
+    int testRematerialize_SingleObj(boolean cond1, int x, int y) throws Exception {
+        Point p = new Point(x, y);
+
+        if (cond1) {
+            p = new Point(x+1, y+1);
+            global_escape = p;
+        }
+
+        if (!cond1)
+            throw new Exception();
+
+        return p.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, ">=1", IRNode.SAFEPOINT_SCALAR_MERGE, ">=1"}, phase = CompilePhase.ITER_GVN_AFTER_EA)
+    int testRematerialize_SingleObj_C2(boolean cond1,int x, int y) throws Exception { return testRematerialize_SingleObj(cond1, x, y); }
+
+    @DontCompile
+    int testRematerialize_SingleObj_Interp(boolean cond1, int x, int y) throws Exception { return testRematerialize_SingleObj(cond1, x, y); }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @ForceInline
+    int testRematerialize_TryCatch(boolean cond1, int n, int x, int y) {
+        Point p = new Point(x, y);
+        if (cond1) {
+            p = new Point(x+1, y+1);
+            global_escape = p;
+        }
+        try {
+            p.y = n/0;
+        } catch (Exception e) {}
+
+        return p.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, ">=1", IRNode.SAFEPOINT_SCALAR_MERGE, ">=1",  IRNode.SAFEPOINT_SCALAR_OBJECT, ">=2"}, phase = CompilePhase.ITER_GVN_AFTER_EA)
+    int testRematerialize_TryCatch_C2(boolean cond1, int n, int x, int y) { return testRematerialize_TryCatch(cond1, n, x, y); }
+
+    @DontCompile
+    int testRematerialize_TryCatch_Interp(boolean cond1, int n, int x, int y) { return testRematerialize_TryCatch(cond1, n, x, y); }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @ForceInline
+    int testMerge_TryCatchFinally(boolean cond1, int n, int x, int y) {
+
+        Point p = new Point(x, y);
+        try {
+            if (cond1) {
+                p = new Point(x+1, y+1);
+            }
+        } catch (Exception e) {
+            p.y = n;
+        } finally {
+            dummy_defaults();
+            p = new Point(n, x+y);
+        }
+
+        return p.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, ">=2"}, phase = CompilePhase.ITER_GVN_AFTER_EA)
+    int testMerge_TryCatchFinally_C2(boolean cond1, int n, int x, int y) { return testMerge_TryCatchFinally(cond1, n, x, y); }
+
+    @DontCompile
+    int testMerge_TryCatchFinally_Interp(boolean cond1, int n, int x, int y) { return testMerge_TryCatchFinally(cond1, n, x, y); }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @ForceInline
+    int testRematerialize_MultiObj(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x+2, y+4);
+
+        if (cond1) {
+            p1 = new Point(x+1, y+1);
+            global_escape = p1;
+        }
+
+        if (x%2 == 1) {
+            p2 = new Point(x*2, y/4);
+        }
+
+        try {
+            String s = null;
+            s.length();
+        } catch (Exception e) {}
+
+        if (cond2)
+            return p1.y;
+        return p2.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, ">=1", IRNode.SAFEPOINT_SCALAR_MERGE, ">=1", IRNode.SAFEPOINT_SCALAR_OBJECT, ">=2"}, phase= CompilePhase.ITER_GVN_AFTER_EA)
+    int testRematerialize_MultiObj_C2(boolean cond1, boolean cond2, int x, int y) { return testRematerialize_MultiObj(cond1, cond2, x, y); }
+
+    @DontCompile
+    int testRematerialize_MultiObj_Interp(boolean cond1, boolean cond2, int x, int y) { return testRematerialize_MultiObj(cond1, cond2, x, y); }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @ForceInline
+    public int testGlobalEscapeInThread(boolean cond, int n, int x, int y) {
+        Point p = new Point(x, y);
+        Object syncObject = new Object();
+        Runnable threadLoop = () -> {
+            if (cond)
+                global_escape = new Point( x+n, y+n);
+        };
+        Thread thLoop = new Thread(threadLoop);
+        thLoop.start();
+        try {
+            thLoop.join();
+        } catch (InterruptedException e) {}
+
+        if (cond && n % 2 == 1)
+            p.x = global_escape.x;
+
+        return p.y;
+    }
+
+    @DontCompile
+    int testGlobalEscapeInThread_Intrep(boolean cond1, int n, int x, int y) { return testGlobalEscapeInThread(cond1, n, x, y); }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, ">=5"}, phase= CompilePhase.ITER_GVN_AFTER_EA)
+    int testGlobalEscapeInThread_C2(boolean cond1, int n, int x, int y) { return testGlobalEscapeInThread(cond1, n, x, y); }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @ForceInline
+    public int testGlobalEscapeInThreadWithSync(boolean cond, int x, int y) {
+        Point p = new Point(x, y);
+        for (int i = 0; i < 2; i++) {
+            if (cond)
+                p = new Point(x+i, y+i);
+            TestThread th = new TestThread(p);
+            th.start();
+        }
+        return p.y;
+    }
+
+    @DontCompile
+    int testGlobalEscapeInThreadWithSync_Intrep(boolean cond1, int x, int y) { return testGlobalEscapeInThreadWithSync(cond1, x, y); }
+
+    @Test
+    int testGlobalEscapeInThreadWithSync_C2(boolean cond1, int x, int y) { return testGlobalEscapeInThreadWithSync(cond1, x, y); }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @ForceInline
+    public int testFieldEscapeWithMerge(boolean cond, int x, int y) {
+
+        Point p1 = new Point(x, y);
+        Point p2 = new Point(x+y, x*y);
+        Line ln = new Line(p1, p2);
+        if (cond) {
+            ln.p1 = new Point(x-y, x/y);
+            global_escape = ln.p2;
+        }
+        return ln.p1.y;
+    }
+
+    @DontCompile
+    int testFieldEscapeWithMerge_Intrep(boolean cond1, int x, int y) { return testFieldEscapeWithMerge(cond1, x, y); }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, ">=1"}, phase= CompilePhase.ITER_GVN_AFTER_EA)
+    int testFieldEscapeWithMerge_C2(boolean cond1, int x, int y) { return testFieldEscapeWithMerge(cond1, x, y); }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @ForceInline
+    int testNestedPhi_FieldLoad(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        if (cond1) {
+            p1 = new Point(x+30, y+40);
+        }
+        Point p2 = p1;
+        if (cond2) {
+          p2 = new Point(x+50, y+60);
+        }
+        return  p2.x + p2.y;
+    }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
+    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    int testNestedPhi_FieldLoad_C2(boolean cond1, boolean cond2, int x, int y) {
+       return testNestedPhi_FieldLoad(cond1, cond2, x, y);
+    }
+
+    @DontCompile
+    int testNestedPhi_FieldLoad_Interp(boolean cond1, boolean cond2, int x, int y) {
+       return testNestedPhi_FieldLoad(cond1, cond2, x, y);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @DontCompile
+    int testThreeLevelNestedPhi_Interp(boolean cond1, boolean cond2, int x, int y) { return testThreeLevelNestedPhi(cond1, cond2, x, y); }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
+    @IR(counts = { IRNode.ALLOC, "2" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    int testThreeLevelNestedPhi_C2(boolean cond1, boolean cond2, int x, int y) { return testThreeLevelNestedPhi(cond1, cond2, x, y); }
+
+    @ForceInline
+    int testThreeLevelNestedPhi(boolean cond1, boolean cond2, int x, int y) {
+
+        Point p1 = new Point(x, y);
+        if (cond1) {
+            p1 = new Point(x, y);
+        }
+
+        Point p2 = p1;
+        if (cond2) {
+            p2 = new Point(x, y);
+        }
+
+        Point p3 = p2;
+        if (cond1 && cond2) {
+            p3 = new Point(x, y);
+        }
+        return  p3.x + p3.y;
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @DontCompile
+    int testNestedPhiProcessOrder_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiProcessOrder(cond1, cond2, x, y); }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
+    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    int testNestedPhiProcessOrder_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiProcessOrder(cond1, cond2, x, y); }
+
+    @ForceInline
+    // make sure the child phis are processed fist
+    int testNestedPhiProcessOrder(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = p1;
+        if (cond1)
+            p1 = new Point(x, y);
+
+        if (cond2)
+            p2 = p1;
+
+       return p2.x;
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @DontCompile
+    int testNestedPhi_TryCatch_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhi_TryCatch(cond1, cond2, x, y); }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "2" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
+    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    int testNestedPhi_TryCatch_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhi_TryCatch(cond1, cond2, x, y); }
+
+    @ForceInline
+    int testNestedPhi_TryCatch(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = p1;
+        try {
+            if (cond1)
+            p1 = new Point(x, y);
+            if (cond2)
+                p2 = p1;
+        } catch (Exception e) {
+            p2 = new Point (x, y);
+        }
+        return p2.x;
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @DontCompile
+    int testBailOut_Interp(boolean cond1, boolean cond2, int x, int y) { return testBailOut(cond1, cond2, x, y); }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
+    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    int testBailOut_C2(boolean cond1, boolean cond2, int x, int y) { return testBailOut(cond1, cond2, x, y); }
+
+    @ForceInline
+    int testBailOut(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = p1;
+        if (cond1)
+          p1 = new Point(x, y);
+
+        if (cond2)
+          p2 = new Point(x, y);
+
+        try {
+            if (cond1 && cond2)
+                throw new Exception();
+        } catch (Exception e) {}
+
+        return p2.getX();
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @DontCompile
+    int testNestedPhiPolymorphic_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiPolymorphic(cond1, cond2, x, y); }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
+    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    int testNestedPhiPolymorphic_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiPolymorphic(cond1, cond2, x, y); }
+
+    @ForceInline
+    int testNestedPhiPolymorphic(boolean cond1, boolean cond2, int x, int l) {
+        Shape obj1 = new Square(l);
+        if (cond1)
+            obj1 = new Circle(l);
+        Shape obj2 = obj1;
+        if (cond2)
+            obj2 = new Circle(x + l/5);
+        return obj2.l;
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @DontCompile
+    int testNestedPhiWithTrap_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiWithTrap(cond1, cond2, x, y); }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "3" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
+    @IR(counts = { IRNode.ALLOC, "2" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    int testNestedPhiWithTrap_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiWithTrap(cond1, cond2, x, y); }
+
+    @ForceInline
+    int testNestedPhiWithTrap(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        if (cond1)
+            p1 = new Point(x, y);
+
+        Point p2 = p1;
+        dummy();
+        if (cond2)
+            p2 = new Point(x, y);
+
+        return p2.x;
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+   @DontCompile
+    int testNestedPhiWithLambda_Interp(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiWithLambda(cond1, cond2, x, y); }
+
+    @Test
+    @IR(counts = { IRNode.ALLOC, "4" }, phase = CompilePhase.PHASEIDEAL_BEFORE_EA)
+    @IR(counts = { IRNode.ALLOC, "0" }, phase = CompilePhase.ITER_GVN_AFTER_ELIMINATION)
+    int testNestedPhiWithLambda_C2(boolean cond1, boolean cond2, int x, int y) { return testNestedPhiWithLambda(cond1, cond2, x, y); }
+
+    @ForceInline
+    public int testNestedPhiWithLambda(boolean cond1, boolean cond2, int x, int y) {
+        Point1 p1 = new Point1(x, y);
+        if (cond1)
+            p1 = new Point1(x, y);
+
+        Point1 p2 = p1;
+        PointSupplier ps = () -> (cond2? (new Point1(x, y)) : (new Point1(x+70, y+80)));
+        if (cond2)
+            p2 = ps.getPoint();
+        return p2.x;
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+    @DontCompile
+    int testMultiParentPhi_Interp(boolean cond1, int x, int y) { return testMultiParentPhi(cond1, x, y); }
+
+    @Test    
+    int testMultiParentPhi_C2(boolean cond1, int x, int y) { return testMultiParentPhi(cond1, x, y); }
+
+    @ForceInline
+    public static int testMultiParentPhi(boolean cond1, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p3 = new Point(x+30, y+31);
+        if (cond1) {
+          p1 = new Point(x+12, y+13);
+          p3 = new Point(x+32, y+33);
+        }
+        Point p2 = new Point(x+20, y+21);
+        try {
+           Point p4 = new Point(x+40, y+41);
+        } catch (NullPointerException ne) {
+            p2 = p3;
+        } catch (Exception e) {
+            p2 = p1;
+        }
+        return p2.x;
+    }
+
+   // ------------------ Utility for Testing ------------------- //
+
+    @DontCompile
+    static void dummy() {
+    }
+
+    @DontCompile
+    static int dummy(Point p) {
+        return p.x * p.y;
+    }
+
+    @DontCompile
+    static int dummy(int x) {
+        return x;
+    }
+
+    @DontCompile
+    static Point dummy(int x, int y) {
+        return new Point(x, y);
+    }
+
+    @DontCompile
+    static String dummy(String str) {
+        return str;
+    }
+
+    @DontCompile
+    static ADefaults dummy_defaults() {
+        return new ADefaults();
+    }
+
+    static class Nested {
+        int x, y;
+        Nested other;
+        Nested(int x, int y) {
+            this.x = x;
+            this.y = y;
+            this.other = null;
+        }
+    }
+
+    static class Point {
+        int x, y;
+        Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (!(o instanceof Point)) return false;
+            Point p = (Point) o;
+            return (p.x == x) && (p.y == y);
+        }
+
+        int getX() {
+            return x;
+        }
+    }
+
+   class Line {
+       Point p1, p2;
+       Line(Point p1, Point p2) {
+           this.p1 = p1;
+           this.p2 = p2;
+       }
+    }
+
+    interface PointSupplier {
+        Point1 getPoint();
+    }
+
+   class Point1 implements PointSupplier {
+       int x, y;
+       Point1(int x, int y) {
+           this.x = x;
+           this.y = y;
+       }
+       public Point1 getPoint() {
+           return this;
+       }
+    }
+
+    class Shape {
+        int x, y, l;
+        Shape(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    class Square extends Shape {
+        Square(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    class Circle extends Shape {
+        Circle(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    static class ADefaults {
+        static int ble;
+        int i;
+        @DontCompile
+        ADefaults(int i) { this.i = i; }
+        @DontCompile
+        ADefaults() { }
+    }
+
+    static class Picture {
+        public int id;
+        public Point position;
+
+        public Picture(int id, int x, int y) {
+            this.id = id;
+            this.position = new Point(x, y);
+        }
+    }
+
+    static class PicturePositions {
+        public int id;
+        public Point[] positions;
+
+        public PicturePositions(int id, int x, int y) {
+            this.id = id;
+            this.positions = new Point[] { new Point(x, y), new Point(y, x) };
+        }
+    }
+
+    class Root {
+        public int a;
+        public int b;
+        public int c;
+        public int d;
+        public int e;
+
+        public Root(int a, int b, int c, int d, int e) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+            this.e = e;
+        }
+    }
+
+    class Usr extends Root {
+        public float flt;
+
+        public Usr(float a, float b, float c) {
+            super((int)a, (int)b, (int)c, 0, 0);
+            this.flt = a;
+        }
+    }
+
+    class Home extends Root {
+        public double[] arr;
+
+        public Home(double a, double b) {
+            super((int)a, (int)b, 0, 0, 0);
+            this.arr = new double[] {a, b};
+        }
+
+    }
+
+    class Tmp extends Root {
+        public String s;
+
+        public Tmp(String s) {
+            super((int)s.length(), 0, 0, 0, 0);
+            this.s = s;
+        }
+    }
+
+    class Etc extends Root {
+        public String a;
+
+        public Etc(String s) {
+            super((int)s.length(), 0, 0, 0, 0);
+            this.a = s;
+        }
+    }
+
+    class TestThread extends Thread {
+        private static Object syncObject = new Object();
+        Point p;
+
+        TestThread(Point p) {
+            this.p = p;
+        }
+
+        public void run() {
+            try {
+                synchronized(syncObject) {
+                    p = new Point(1,1);
+                    global_escape = p;
+                }
+            } catch(Exception e){}
+        }
+    }
+
+    class A { }
+    class B { }
+    class C { }
+    class D { }
+    class E { }
+    class F { }
+    class G { }
+}

--- a/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/scalarReplacement/AllocationMergesNestedPhiTests.java
@@ -110,7 +110,7 @@ public class AllocationMergesNestedPhiTests {
         int w = random.nextInt();
         int x = random.nextInt();
         int y = random.nextInt();
-        int z = random.nextInt(); 
+        int z = random.nextInt();
         try {
             Asserts.assertEQ(testRematerialize_SingleObj_Interp(cond1, x, y),       testRematerialize_SingleObj_C2(cond1, x, y));
         } catch (Exception e) {}
@@ -128,7 +128,7 @@ public class AllocationMergesNestedPhiTests {
         Asserts.assertEQ(testNestedPhiPolymorphic_Interp(cond1, cond2, x, y),       testNestedPhiPolymorphic_C2(cond1, cond2, x, y));
         Asserts.assertEQ(testNestedPhiWithTrap_Interp(cond1, cond2, x, y),          testNestedPhiWithTrap_C2(cond1, cond2, x, y));
         Asserts.assertEQ(testNestedPhiWithLambda_Interp(cond1, cond2, x, y),        testNestedPhiWithLambda_C2(cond1, cond2, x, y));
-        Asserts.assertEQ(testMultiParentPhi_Interp(cond1, cond2, x, y),             testMultiParentPhi_C2(cond1, cond2, x, y));
+        Asserts.assertEQ(testMultiParentPhi_Interp(cond1, x, y),             testMultiParentPhi_C2(cond1, x, y));
     }
 
     // -------------------------------------------------------------------------
@@ -515,7 +515,7 @@ public class AllocationMergesNestedPhiTests {
     @DontCompile
     int testMultiParentPhi_Interp(boolean cond1, int x, int y) { return testMultiParentPhi(cond1, x, y); }
 
-    @Test    
+    @Test
     int testMultiParentPhi_C2(boolean cond1, int x, int y) { return testMultiParentPhi(cond1, x, y); }
 
     @ForceInline

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1362,6 +1362,16 @@ public class IRNode {
         vectorNode(RSHIFT_VI, "RShiftVI", TYPE_INT);
     }
 
+    public static final String SAFEPOINT_SCALAR_MERGE = PREFIX + "SAFEPOINT_SCALAR_MERGE" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(SAFEPOINT_SCALAR_MERGE, "SafePointScalarMerge");
+    }
+
+    public static final String SAFEPOINT_SCALAR_OBJECT = PREFIX + "SAFEPOINT_SCALAR_OBJECT" + POSTFIX;
+    static {
+        beforeMatchingNameRegex(SAFEPOINT_SCALAR_OBJECT, "SafePointScalarObject");
+    }
+
     public static final String RSHIFT_VL = VECTOR_PREFIX + "RSHIFT_VL" + POSTFIX;
     static {
         vectorNode(RSHIFT_VL, "RShiftVL", TYPE_LONG);

--- a/test/micro/org/openjdk/bench/vm/compiler/AllocationMergesNestedPhi.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AllocationMergesNestedPhi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/vm/compiler/AllocationMergesNestedPhi.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AllocationMergesNestedPhi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/vm/compiler/AllocationMergesNestedPhi.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AllocationMergesNestedPhi.java
@@ -1,0 +1,691 @@
+/*
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.*;
+import java.util.concurrent.TimeUnit;
+import java.util.random.RandomGenerator;
+import java.util.random.RandomGeneratorFactory;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
+@Fork(value = 3)
+public abstract class AllocationMergesNestedPhi {
+    private static final int SIZE        = 1000000;
+    private static final boolean cond1[] = new boolean[SIZE];
+    private static final boolean cond2[] = new boolean[SIZE];
+    private static final int ws[]        = new int[SIZE];
+    private static final int xs[]        = new int[SIZE];
+    private static final int ys[]        = new int[SIZE];
+    private static final int zs[]        = new int[SIZE];
+    private static Load global_escape   = new Load(2022, 2023);
+    private RandomGenerator rng          = RandomGeneratorFactory.getDefault().create();
+
+    // -------------------------------------------------------------------------
+
+    @Setup
+    public void setup() {
+        for (int i = 0; i < SIZE; i++) {
+            cond1[i] = i % 2 == 0;
+            cond2[i] = i % 2 == 1;
+
+            ws[i] = rng.nextInt();
+            xs[i] = rng.nextInt();
+            ys[i] = rng.nextInt();
+            zs[i] = rng.nextInt();
+        }
+    }
+
+    // -------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testRematerialize_SingleObj(boolean cond1, int x, int y) throws Exception {
+        Load p = new Load(x, y);
+
+        if (cond1) {
+            p = new Load(x+1, y+1);
+            global_escape = p;
+        }
+
+        if (!cond1)
+            throw new Exception();
+
+        return p.y;
+    }
+
+    @Benchmark
+    public void testRematerialize_SingleObj_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            try {
+                result += testRematerialize_SingleObj(cond1[i], xs[i], ys[i]);
+            } catch (Exception e) {}
+        }
+        bh.consume(result);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testRematerialize_TryCatch(boolean cond1, int n, int x, int y) {
+        Load p = new Load(x, y);
+        int a = 5;
+        int b = 10-5;
+        if (cond1) {
+            p = new Load(x+1, y+1);
+            global_escape = p;
+        }
+        try {
+            p.y = n/(a-b);
+        } catch (Exception e) {}
+
+        return p.y;
+    }
+
+    @Benchmark
+    public void testRematerialize_TryCatch_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testRematerialize_TryCatch(cond1[i], xs[i], ys[i], zs[i]);
+        }
+        bh.consume(result);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testMerge_TryCatchFinally(boolean cond1, int n, int x, int y) {
+
+        Point p = new Point(x, y);
+        try {
+            if (cond1) {
+                p = new Point(x+1, y+1);
+            }
+        } catch (Exception e) {
+            p.y = n;
+        } finally {
+            dummy_defaults();
+            p = new Point(n, x+y);
+        }
+
+        return p.y;
+    }
+
+    @Benchmark
+    public void testMerge_TryCatchFinally_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testMerge_TryCatchFinally(cond1[i], xs[i], ys[i], zs[i]);
+        }
+        bh.consume(result);
+    }
+
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testRematerialize_MultiObj(boolean cond1, boolean cond2, int x, int y) {
+        Load p1 = new Load(x, y);
+        Load p2 = new Load(x+2, y+4);
+
+        if (cond1) {
+            p1 = new Load(x+1, y+1);
+            global_escape = p1;
+        }
+
+        if (x%2 == 1) {
+            p2 = new Load(x*2, y/4);
+        }
+
+        try {
+            String s = null;
+            s.length();
+        } catch (Exception e) {}
+
+        if (cond2)
+            return p1.y;
+        return p2.y;
+    }
+
+    @Benchmark
+    public void testRematerialize_MultiObj_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testRematerialize_MultiObj(cond1[i], cond2[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public int testFieldEscapeWithMerge(boolean cond, int x, int y) {
+
+        Load p1 = new Load(x, y);
+        Load p2 = new Load(x+y, x*y);
+        Line ln = new Line(p1, p2);
+        if (cond) {
+            ln.p1 = new Load(x-y, x/y);
+            global_escape = ln.p2;
+        }
+        return ln.p1.y;
+    }
+
+    @Benchmark
+    public void testFieldEscapeWithMerge_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testFieldEscapeWithMerge(cond1[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testNestedPhi_FieldLoad(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        if (cond1) {
+            p1 = new Point(x+30, y+40);
+        }
+        Point p2 = p1;
+        if (cond2) {
+          p2 = new Point(x+50, y+60);
+        }
+        return  p2.x + p2.y;
+    }
+
+    @Benchmark
+    public void testNestedPhi_FieldLoad_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testNestedPhi_FieldLoad(cond1[i], cond2[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testThreeLevelNestedPhi(boolean cond1, boolean cond2, int x, int y) {
+
+        Point p1 = new Point(x, y);
+        if (cond1) {
+            p1 = new Point(x, y);
+        }
+
+        Point p2 = p1;
+        if (cond2) {
+            p2 = new Point(x, y);
+        }
+
+        Point p3 = p2;
+        if (cond1 && cond2) {
+            p3 = new Point(x, y);
+        }
+        return  p3.x + p3.y;
+    }
+
+    @Benchmark
+    public void testThreeLevelNestedPhi_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testThreeLevelNestedPhi(cond1[i], cond2[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    // make sure the child phis are processed fist
+    int testNestedPhiProcessOrder(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = p1;
+        if (cond1)
+            p1 = new Point(x, y);
+
+        if (cond2)
+            p2 = p1;
+
+       return p2.x;
+    }
+
+    @Benchmark
+    public void testNestedPhiProcessOrder_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testNestedPhiProcessOrder(cond1[i], cond2[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testNestedPhi_TryCatch(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = p1;
+        try {
+            if (cond1)
+            p1 = new Point(x, y);
+            if (cond2)
+                p2 = p1;
+        } catch (Exception e) {
+            p2 = new Point (x, y);
+        }
+        return p2.x;
+    }
+
+    @Benchmark
+    public void testNestedPhi_TryCatch_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testNestedPhi_TryCatch(cond1[i], cond2[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testBailOut(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p2 = p1;
+        if (cond1)
+          p1 = new Point(x, y);
+
+        if (cond2)
+          p2 = new Point(x, y);
+
+        try {
+            if (cond1 && cond2)
+                throw new Exception();
+        } catch (Exception e) {}
+
+        return p2.getX();
+    }
+
+    @Benchmark
+    public void testBailOut_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testBailOut(cond1[i], cond2[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testNestedPhiPolymorphic(boolean cond1, boolean cond2, int x, int l) {
+        Shape obj1 = new Square(l);
+        if (cond1)
+            obj1 = new Circle(l);
+        Shape obj2 = obj1;
+        if (cond2)
+            obj2 = new Circle(x + l/5);
+        return obj2.l;
+    }
+
+    @Benchmark
+    public void testNestedPhiPolymorphic_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testNestedPhiPolymorphic(cond1[i], cond2[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    int testNestedPhiWithTrap(boolean cond1, boolean cond2, int x, int y) {
+        Point p1 = new Point(x, y);
+        if (cond1)
+            p1 = new Point(x, y);
+
+        Point p2 = p1;
+        dummy();
+        if (cond2)
+            p2 = new Point(x, y);
+
+        return p2.x;
+    }
+
+    @Benchmark
+    public void testNestedPhiWithTrap_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testNestedPhiWithTrap(cond1[i], cond2[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public int testNestedPhiWithLambda(boolean cond1, boolean cond2, int x, int y) {
+        Point1 p1 = new Point1(x, y);
+        if (cond1)
+            p1 = new Point1(x, y);
+
+        Point1 p2 = p1;
+        PointSupplier ps = () -> (cond2? (new Point1(x, y)) : (new Point1(x+70, y+80)));
+        if (cond2)
+            p2 = ps.getPoint();
+        return p2.x;
+    }
+
+    @Benchmark
+    public void testNestedPhiWithLambda_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testNestedPhiWithLambda(cond1[i], cond2[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+
+    //--------------------------------------------------------------------------------------------------------------------------------------------
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public static int testMultiParentPhi(boolean cond1, int x, int y) {
+        Point p1 = new Point(x, y);
+        Point p3 = new Point(x+30, y+31);
+        if (cond1) {
+          p1 = new Point(x+12, y+13);
+          p3 = new Point(x+32, y+33);
+        }
+        Point p2 = new Point(x+20, y+21);
+        try {
+           Point p4 = new Point(x+40, y+41);
+        } catch (NullPointerException ne) {
+            p2 = p3;
+        } catch (Exception e) {
+            p2 = p1;
+        }
+        return p2.x;
+    }
+
+    @Benchmark
+    public void testMultiParentPhi_runner(Blackhole bh) {
+        int result = 0;
+        for (int i = 0 ; i < SIZE; i++) {
+            result += testMultiParentPhi(cond1[i], xs[i], ys[i]);
+        }
+        bh.consume(result);
+    }
+
+
+   // ------------------ Utility for Testing ------------------- //
+
+
+    @Fork(value = 3, jvmArgsPrepend = {
+        "-XX:+UnlockDiagnosticVMOptions",
+        "-XX:+UseTLAB",
+        "-XX:-ReduceAllocationMerges",
+    })
+    public static class NopRAM extends AllocationMergesNestedPhi {
+    }
+
+    @Fork(value = 3, jvmArgsPrepend = {
+        "-XX:+UnlockDiagnosticVMOptions",
+        "-XX:+ReduceAllocationMerges",
+    })
+    public static class YesRAM extends AllocationMergesNestedPhi {
+    }
+
+
+    @CompilerControl(CompilerControl.Mode.EXCLUDE)
+    static void dummy() {
+    }
+
+    @CompilerControl(CompilerControl.Mode.EXCLUDE)
+    static int dummy(Point p) {
+        return p.x * p.y;
+    }
+
+    @CompilerControl(CompilerControl.Mode.EXCLUDE)
+    static int dummy(int x) {
+        return x;
+    }
+
+    @CompilerControl(CompilerControl.Mode.EXCLUDE)
+    static Point dummy(int x, int y) {
+        return new Point(x, y);
+    }
+
+    @CompilerControl(CompilerControl.Mode.EXCLUDE)
+    static String dummy(String str) {
+        return str;
+    }
+
+    @CompilerControl(CompilerControl.Mode.EXCLUDE)
+    static ADefaults dummy_defaults() {
+        return new ADefaults();
+    }
+
+    static class Nested {
+        int x, y;
+        Nested other;
+        Nested(int x, int y) {
+            this.x = x;
+            this.y = y;
+            this.other = null;
+        }
+    }
+
+    static class Point {
+        int x, y;
+        Point(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (!(o instanceof Point)) return false;
+            Point p = (Point) o;
+            return (p.x == x) && (p.y == y);
+        }
+
+        @Override
+        public int hashCode() {
+            return x + y;
+        }
+
+        int getX() {
+            return x;
+        }
+    }
+
+   class Line {
+       Load p1, p2;
+       Line(Load p1, Load p2) {
+           this.p1 = p1;
+           this.p2 = p2;
+       }
+    }
+
+    interface PointSupplier {
+        Point1 getPoint();
+    }
+
+   class Point1 implements PointSupplier {
+       int x, y;
+       Point1(int x, int y) {
+           this.x = x;
+           this.y = y;
+       }
+       public Point1 getPoint() {
+           return this;
+       }
+    }
+
+    class Shape {
+        int x, y, l;
+        Shape(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+
+    class Square extends Shape {
+        Square(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    class Circle extends Shape {
+        Circle(int l) {
+            super(0, 0);
+            this.l = l;
+        }
+    }
+
+    static class ADefaults {
+        static int ble;
+        int i;
+        @CompilerControl(CompilerControl.Mode.EXCLUDE)
+        ADefaults(int i) { this.i = i; }
+        @CompilerControl(CompilerControl.Mode.EXCLUDE)
+        ADefaults() { }
+    }
+
+     static class Load {
+        long id;
+        String name;
+        Integer[] values = new Integer[10];
+        int x, y;
+
+        @CompilerControl(CompilerControl.Mode.INLINE)
+        Load(int x, int y) {
+            this.x = x;
+            this.y = y;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == this) return true;
+            if (!(o instanceof Load)) return false;
+            Load p = (Load) o;
+            return (p.x == x) && (p.y == y);
+        }
+
+        @Override
+        public int hashCode() {
+            return x + y;
+        }
+    }
+
+    static class Picture {
+        public int id;
+        public Point position;
+
+        public Picture(int id, int x, int y) {
+            this.id = id;
+            this.position = new Point(x, y);
+        }
+    }
+
+    static class PicturePositions {
+        public int id;
+        public Point[] positions;
+
+        public PicturePositions(int id, int x, int y) {
+            this.id = id;
+            this.positions = new Point[] { new Point(x, y), new Point(y, x) };
+        }
+    }
+
+    class Root {
+        public int a;
+        public int b;
+        public int c;
+        public int d;
+        public int e;
+
+        public Root(int a, int b, int c, int d, int e) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+            this.d = d;
+            this.e = e;
+        }
+    }
+
+    class Usr extends Root {
+        public float flt;
+
+        public Usr(float a, float b, float c) {
+            super((int)a, (int)b, (int)c, 0, 0);
+            this.flt = a;
+        }
+    }
+
+    class Home extends Root {
+        public double[] arr;
+
+        public Home(double a, double b) {
+            super((int)a, (int)b, 0, 0, 0);
+            this.arr = new double[] {a, b};
+        }
+
+    }
+
+    class Tmp extends Root {
+        public String s;
+
+        public Tmp(String s) {
+            super((int)s.length(), 0, 0, 0, 0);
+            this.s = s;
+        }
+    }
+
+    class Etc extends Root {
+        public String a;
+
+        public Etc(String s) {
+            super((int)s.length(), 0, 0, 0, 0);
+            this.a = s;
+        }
+    }
+
+    class A { }
+    class B { }
+    class C { }
+    class D { }
+    class E { }
+    class F { }
+    class G { }
+}


### PR DESCRIPTION
As an extension of the work done as part of https://github.com/openjdk/jdk/pull/12897, split the field loads (AddP -> Load*) with nested phi parent nodes to enable more scalar replacements, thereby reducing memory allocation.


Here are the sequence of Ideal graph transformations for Nested phi:

 
![image](https://github.com/user-attachments/assets/c18e5ca0-c554-475c-814a-7cb288d96569)

![image](https://github.com/user-attachments/assets/b279b5f2-9ec6-4d9b-a627-506451f1cf81)

![image](https://github.com/user-attachments/assets/f506b918-2dd0-4dbe-a440-ff253afa3961)

JMH results:
with disabled RAM

Benchmark Mode Cnt Score Error Units
NestedPhiAndRematerialize.NopRAM.testBailOut_runner avgt 15 13.969 ± 0.248 ms/op
NestedPhiAndRematerialize.NopRAM.testFieldEscapeWithMerge_runner avgt 15 80.300 ± 4.306 ms/op
NestedPhiAndRematerialize.NopRAM.testMerge_TryCatchFinally_runner avgt 15 72.182 ± 1.781 ms/op
NestedPhiAndRematerialize.NopRAM.testMultiParentPhi_runner avgt 15 2.983 ± 0.001 ms/op
NestedPhiAndRematerialize.NopRAM.testNestedPhiPolymorphic_runner avgt 15 18.342 ± 0.731 ms/op
NestedPhiAndRematerialize.NopRAM.testNestedPhiProcessOrder_runner avgt 15 14.315 ± 0.443 ms/op
NestedPhiAndRematerialize.NopRAM.testNestedPhiWithLambda_runner avgt 15 18.511 ± 1.212 ms/op
NestedPhiAndRematerialize.NopRAM.testNestedPhiWithTrap_runner avgt 15 66.277 ± 1.478 ms/op
NestedPhiAndRematerialize.NopRAM.testNestedPhi_FieldLoad_runner avgt 15 17.968 ± 0.306 ms/op
NestedPhiAndRematerialize.NopRAM.testNestedPhi_TryCatch_runner avgt 15 14.186 ± 0.247 ms/op
NestedPhiAndRematerialize.NopRAM.testRematerialize_MultiObj_runner avgt 15 88.435 ± 4.869 ms/op
NestedPhiAndRematerialize.NopRAM.testRematerialize_SingleObj_runner avgt 15 29560.130 ± 48.797 ms/op
NestedPhiAndRematerialize.NopRAM.testRematerialize_TryCatch_runner avgt 15 49.150 ± 2.307 ms/op
NestedPhiAndRematerialize.NopRAM.testThreeLevelNestedPhi_runner avgt 15 18.236 ± 0.308 ms/op

with enabled RAM
Benchmark Mode Cnt Score Error Units
NestedPhiAndRematerialize.YesRAM.testBailOut_runner avgt 15 3.257 ± 0.423 ms/op
NestedPhiAndRematerialize.YesRAM.testFieldEscapeWithMerge_runner avgt 15 79.916 ± 3.477 ms/op
NestedPhiAndRematerialize.YesRAM.testMerge_TryCatchFinally_runner avgt 15 72.053 ± 1.916 ms/op
NestedPhiAndRematerialize.YesRAM.testMultiParentPhi_runner avgt 15 2.984 ± 0.001 ms/op
NestedPhiAndRematerialize.YesRAM.testNestedPhiPolymorphic_runner avgt 15 18.309 ± 0.706 ms/op
NestedPhiAndRematerialize.YesRAM.testNestedPhiProcessOrder_runner avgt 15 3.254 ± 0.001 ms/op
NestedPhiAndRematerialize.YesRAM.testNestedPhiWithLambda_runner avgt 15 3.535 ± 0.421 ms/op
NestedPhiAndRematerialize.YesRAM.testNestedPhiWithTrap_runner avgt 15 62.742 ± 1.415 ms/op
NestedPhiAndRematerialize.YesRAM.testNestedPhi_FieldLoad_runner avgt 15 18.030 ± 0.494 ms/op
NestedPhiAndRematerialize.YesRAM.testNestedPhi_TryCatch_runner avgt 15 3.254 ± 0.001 ms/op
NestedPhiAndRematerialize.YesRAM.testRematerialize_MultiObj_runner avgt 15 23.091 ± 1.223 ms/op
NestedPhiAndRematerialize.YesRAM.testRematerialize_SingleObj_runner avgt 15 29509.152 ± 42.556 ms/op
NestedPhiAndRematerialize.YesRAM.testRematerialize_TryCatch_runner avgt 15 21.708 ± 1.099 ms/op
NestedPhiAndRematerialize.YesRAM.testThreeLevelNestedPhi_runner avgt 15 18.227 ± 0.307 ms/op

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8341293](https://bugs.openjdk.org/browse/JDK-8341293): Split field loads through Nested Phis (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21270/head:pull/21270` \
`$ git checkout pull/21270`

Update a local copy of the PR: \
`$ git checkout pull/21270` \
`$ git pull https://git.openjdk.org/jdk.git pull/21270/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21270`

View PR using the GUI difftool: \
`$ git pr show -t 21270`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21270.diff">https://git.openjdk.org/jdk/pull/21270.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21270#issuecomment-2486360565)
</details>
