### PR TITLE
8340818: Add a new jtreg test root to test the generated documentation

### DIFF
--- a/make/Global.gmk
+++ b/make/Global.gmk
@@ -57,6 +57,7 @@ help:
 	$(info $(_) make test TEST=<t>     # Run test(s) given by TEST specification)
 	$(info $(_) make exploded-test TEST=<t> # Run test(s) on the exploded image instead of)
 	$(info $(_)                        # the full jdk image)
+	$(info $(_) make test-docs TEST=<t> # Run test(s) on the generated documentation)
 	$(info )
 	$(info Targets for troubleshooting)
 	$(info $(_) make help              # Give some help on using make)

--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -788,6 +788,12 @@ $(eval $(call SetupTarget, test, \
     DEPS := jdk-image test-image, \
 ))
 
+$(eval $(call SetupTarget, test-docs, \
+    MAKEFILE := RunTests, \
+    ARGS := TEST="$(TEST)", \
+    DEPS := jdk-image test-image docs-jdk, \
+))
+
 $(eval $(call SetupTarget, exploded-test, \
     MAKEFILE := RunTests, \
     ARGS := TEST="$(TEST)" JDK_IMAGE_DIR=$(JDK_OUTPUTDIR), \
@@ -1334,6 +1340,7 @@ RUN_TEST_TARGETS := $(addprefix run-test-, $(ALL_NAMED_TESTS))
 
 run-test: test
 exploded-run-test: exploded-test
+run-test-docs: test-docs
 
 # "make check" is a common idiom for running basic testing
 check: test-tier1

--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -264,6 +264,7 @@ jaxp_JTREG_PROBLEM_LIST += $(TOPDIR)/test/jaxp/ProblemList.txt
 langtools_JTREG_PROBLEM_LIST += $(TOPDIR)/test/langtools/ProblemList.txt
 hotspot_JTREG_PROBLEM_LIST += $(TOPDIR)/test/hotspot/jtreg/ProblemList.txt
 lib-test_JTREG_PROBLEM_LIST += $(TOPDIR)/test/lib-test/ProblemList.txt
+docs_JTREG_PROBLEM_LIST += $(TOPDIR)/test/docs/ProblemList.txt
 
 ################################################################################
 # Parse test selection

--- a/make/common/FindTests.gmk
+++ b/make/common/FindTests.gmk
@@ -43,7 +43,7 @@ $(eval $(call IncludeCustomExtension, common/FindTests.gmk))
 TEST_BASEDIRS += $(TOPDIR)/test $(TOPDIR)
 
 # JTREG_TESTROOTS might have been set by a custom extension
-JTREG_TESTROOTS += $(addprefix $(TOPDIR)/test/, hotspot/jtreg jdk langtools jaxp lib-test)
+JTREG_TESTROOTS += $(addprefix $(TOPDIR)/test/, hotspot/jtreg jdk langtools jaxp lib-test docs)
 
 # Extract the names of the Jtreg group files from the TEST.ROOT files. The
 # TEST.ROOT files being properties files can be interpreted as makefiles so

--- a/test/docs/ProblemList.txt
+++ b/test/docs/ProblemList.txt
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# ORACLE PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
+#
+
+###########################################################################
+#
+# See doccheck/test/ProblemList.txt for documentation on this file and its purpose.
+#
+#############################################################################

--- a/test/docs/TEST.ROOT
+++ b/test/docs/TEST.ROOT
@@ -1,0 +1,28 @@
+# This file identifies the root of the test-suite hierarchy.
+# It also contains test-suite configuration information.
+
+# The list of keywords supported in the entire test suite.  The
+# "intermittent" keyword marks tests known to fail intermittently.
+# The "randomness" keyword marks tests using randomness with test
+# cases differing from run to run. (A test using a fixed random seed
+# would not count as "randomness" by this definition.) Extra care
+# should be taken to handle test failures of intermittent or
+# randomness tests.
+
+keys=intermittent randomness needs-src needs-src-jdk_javadoc
+
+# Group definitions
+groups=TEST.groups
+
+# Minimum jtreg version
+requiredVersion=7.4+1
+
+# Use new module options
+useNewOptions=true
+
+# Use --patch-module instead of -Xmodule:
+useNewPatchModule=true
+
+# Path to libraries in the topmost test directory. This is needed so @library
+# does not need ../../ notation to reach them
+external.lib.roots = ../../

--- a/test/docs/TEST.groups
+++ b/test/docs/TEST.groups
@@ -1,0 +1,29 @@
+#  Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+#  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+#  This code is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU General Public License version 2 only, as
+#  published by the Free Software Foundation.
+#
+#  This code is distributed in the hope that it will be useful, but WITHOUT
+#  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+#  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+#  version 2 for more details (a copy is included in the LICENSE file that
+#  accompanied this code).
+#
+#  You should have received a copy of the GNU General Public License version
+#  2 along with this work; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+#  Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+#  or visit www.oracle.com if you need additional information or have any
+#  questions.
+#
+
+# Doccheck-specific test groups
+
+docs_all = \
+    /
+
+tier2 = \
+    :docs_all

--- a/test/docs/jdk/javadoc/TestDocs.java
+++ b/test/docs/jdk/javadoc/TestDocs.java
@@ -1,0 +1,61 @@
+/*
+ * @test
+ * @library /test/lib
+ * @build jtreg.SkippedException
+ * @summary example of a test on the generated documentation
+ * @run main TestDocs
+ */
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+import jtreg.SkippedException;
+
+public class TestDocs {
+    private static final Path ROOT_PATH = Path.of(System.getProperty("test.jdk"));
+
+    public static Path resolveDocs() {
+        Path firstCandidate = ROOT_PATH.getParent()
+                .resolve("docs");
+        Path secondCandidate = ROOT_PATH.getParent().getParent()
+                .resolve("docs.doc_api_spec").resolve("docs");
+
+        if (Files.exists(firstCandidate)) {
+            return firstCandidate;
+        } else if (Files.exists(secondCandidate)) {
+            return secondCandidate;
+        } else {
+            throw new SkippedException("docs folder not found in either location");
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        Path docRoot = resolveDocs();
+        System.err.println(docRoot);
+        final List<Path> files=new ArrayList<>();
+        try {
+            Files.walkFileTree(docRoot, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (!attrs.isDirectory()) {
+                        files.add(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        for (var file : files) {
+            if (!Files.isReadable(file)) {
+                throw new Exception("File " + file + " is unreadable");
+            }
+        }
+    }
+}

--- a/test/docs/req.flg
+++ b/test/docs/req.flg
@@ -1,0 +1,1 @@
+echo_file test/TEST.properties


### PR DESCRIPTION
Please review this change that adds a new test root `docs` dedicated to testing the documentation, which has been a work in progress for a while. Testings for links, encoding, HTML, accessibility will be later added in following PRs. 

We also define a new make target `test-docs` meant for local use and depends on the docs.
This also adds the necessary configurations needed at Oracle.

TIA