### PR TITLE
8341191: Open source few more AWT FileDialog tests

### DIFF
--- a/test/jdk/java/awt/FileDialog/KeyboardInteractionTest.java
+++ b/test/jdk/java/awt/FileDialog/KeyboardInteractionTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.FileDialog;
+import java.awt.Frame;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 6259434
+ * @summary PIT: Choice in FileDialog is not responding to keyboard interactions, XToolkit
+ * @requires (os.family == "linux")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual KeyboardInteractionTest
+ */
+
+public class KeyboardInteractionTest {
+    public static void main(String[] args) throws Exception {
+        System.setProperty("sun.awt.disableGtkFileDialogs", "true");
+        String INSTRUCTIONS = """
+                1) Click on 'Show File Dialog' button to bring up the FileDialog window.
+                   A file dialog will come up.
+                2) You will see a text field 'Enter full path or filename'.
+                   Right next to it, you will see a button.
+                   Transfer the focus on this button using 'TAB'.
+                   Make sure that the popup choice is not shown.
+                3) Press 'ESC'. If file dialog isn't disposed, then the test failed.
+                4) Again, click on 'Show File Dialog' to bring up the file dialog.
+                   A file dialog will come up.
+                5) You will see a text field 'Enter full path or filename'.
+                   Right next to it, you will see a button.
+                   Click on this button. The popup choice will appear.
+                6) Look at the popup choice. Change the current item in the popup
+                   choice by the arrow keys.
+                   If the text in the 'Enter full path or filename' text field isn't
+                   changed, then the test failed.
+                7) The test passed.
+                """;
+
+        PassFailJFrame.builder()
+                .title("KeyboardInteractionTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(KeyboardInteractionTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("KeyboardInteractionTest Test");
+        Button b = new Button("Show File Dialog");
+        FileDialog fd = new FileDialog(f);
+        b.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                fd.setVisible(true);
+            }
+        });
+        f.add(b);
+        f.setSize(300, 200);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/FileDialog/PathChoiceDisposeTest.java
+++ b/test/jdk/java/awt/FileDialog/PathChoiceDisposeTest.java
@@ -40,7 +40,7 @@ import java.awt.event.ActionListener;
 
 public class PathChoiceDisposeTest {
     public static void main(String[] args) throws Exception {
-        System.setProperty("sun.awt.disableGtkFileDialogs","true");
+        System.setProperty("sun.awt.disableGtkFileDialogs", "true");
         String INSTRUCTIONS = """
                 1) Click on 'Show File Dialog' button to bring up the FileDialog window.
                 2) Open the directory selection choice by clicking button next to

--- a/test/jdk/java/awt/FileDialog/PathChoiceDisposeTest.java
+++ b/test/jdk/java/awt/FileDialog/PathChoiceDisposeTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.FileDialog;
+import java.awt.Frame;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 6240084
+ * @summary Test that disposing unfurled list by the pressing ESC
+ *          in FileDialog is working properly on XToolkit
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PathChoiceDisposeTest
+ */
+
+public class PathChoiceDisposeTest {
+    public static void main(String[] args) throws Exception {
+        System.setProperty("sun.awt.disableGtkFileDialogs","true");
+        String INSTRUCTIONS = """
+                1) Click on 'Show File Dialog' button to bring up the FileDialog window.
+                2) Open the directory selection choice by clicking button next to
+                   'Enter Path or Folder Name'. A drop-down will appear.
+                3) Press 'ESC'.
+                4) If you see that the dialog gets disposed and the popup
+                   still remains on the screen, the test failed, otherwise passed.
+                """;
+
+        PassFailJFrame.builder()
+                .title("PathChoiceDisposeTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(PathChoiceDisposeTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("PathChoiceDisposeTest Test");
+        Button b = new Button("Show File Dialog");
+        FileDialog fd = new FileDialog(f);
+        b.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                fd.setVisible(true);
+            }
+        });
+        f.add(b);
+        f.setSize(300, 200);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/FileDialog/PathChoiceWorkArrowsTest.java
+++ b/test/jdk/java/awt/FileDialog/PathChoiceWorkArrowsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.FileDialog;
+import java.awt.Frame;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 6240074
+ * @summary Test that file drop-down field in FileDialog is working properly on XToolkit
+ * @requires (os.family == "linux")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PathChoiceWorkArrowsTest
+ */
+
+public class PathChoiceWorkArrowsTest {
+    public static void main(String[] args) throws Exception {
+        System.setProperty("sun.awt.disableGtkFileDialogs", "true");
+        String INSTRUCTIONS = """
+                This is only XAWT test.
+
+                1) Click on 'Show File Dialog' to bring up the FileDialog window.
+                   A file dialog would come up.
+                2) Click on the button next to 'Enter folder name' field.
+                   A drop-down will appear. After this, there are 2 scenarios.
+                3) Press the down arrow one by one. You will see a '/' being
+                   appended as soon as the current entry is removed.
+                   Keep pressing till the last entry is reached. Now the drop-down
+                   will stop responding to arrow keys. If yes, the test failed.
+                4) Press the up arrow. The cursor will directly go to the last
+                   entry ('/') and navigation will stop there. You will see 2
+                   entries being selected at the same time.
+                   If yes, the test failed.
+                """;
+
+        PassFailJFrame.builder()
+                .title("PathChoiceWorkArrowsTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(PathChoiceWorkArrowsTest::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("PathChoiceWorkArrowsTest Test");
+        Button b = new Button("Show File Dialog");
+        FileDialog fd = new FileDialog(f);
+        b.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                fd.setSize(200, 200);
+                fd.setLocation(200, 200);
+                fd.setVisible(true);
+            }
+        });
+        f.add(b);
+        f.setSize(300, 200);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/FileDialog/SavedDirInitTest.java
+++ b/test/jdk/java/awt/FileDialog/SavedDirInitTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.FileDialog;
+import java.awt.Frame;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+import java.awt.Component;
+
+/*
+ * @test
+ * @bug 6260650
+ * @summary FileDialog.getDirectory() does not return null when file dialog is cancelled
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual SavedDirInitTest
+ */
+
+public class SavedDirInitTest {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                Click on 'Show File Dialog' button to bring up the FileDialog window.
+                1) A file dialog will come up.
+                2) Press 'Cancel' button to cancel the file dialog.
+                3) The result (passed or failed) will be shown in the message window below.
+                """;
+
+        PassFailJFrame.builder()
+                .title("SavedDirInitTest Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(SavedDirInitTest::createUI)
+                .logArea(2)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame f = new Frame("SavedDirInitTest Test");
+        Button b = new Button("Show File Dialog");
+        FileDialog fd = new FileDialog(f);
+        b.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                fd.setVisible(true);
+                if (fd.getDirectory() == null && fd.getFile() == null) {
+                    PassFailJFrame.log("TEST PASSED");
+                } else {
+                    PassFailJFrame.log("TEST FAILED. dir = " + fd.getDirectory()
+                            + " , file = " + fd.getFile());
+                }
+                System.out.println("fd components count: "+fd.getComponentCount());
+                System.out.println("fd components: "+fd.getComponents());
+
+                for (Component c : fd.getComponents()) {
+                    System.out.println("1. fd components: "+fd.getComponents());
+                }
+            }
+        });
+        f.add(b);
+        f.setSize(300, 200);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/FileDialog/SavedDirInitTest.java
+++ b/test/jdk/java/awt/FileDialog/SavedDirInitTest.java
@@ -28,8 +28,6 @@ import java.awt.Frame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 
-import java.awt.Component;
-
 /*
  * @test
  * @bug 6260650
@@ -71,12 +69,6 @@ public class SavedDirInitTest {
                 } else {
                     PassFailJFrame.log("TEST FAILED. dir = " + fd.getDirectory()
                             + " , file = " + fd.getFile());
-                }
-                System.out.println("fd components count: "+fd.getComponentCount());
-                System.out.println("fd components: "+fd.getComponents());
-
-                for (Component c : fd.getComponents()) {
-                    System.out.println("1. fd components: "+fd.getComponents());
                 }
             }
         });


### PR DESCRIPTION
AWT File Dialog related tests are converted from applet to manual and moved to open.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341191](https://bugs.openjdk.org/browse/JDK-8341191): Open source few more AWT FileDialog tests (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**) Review applies to [872bae22](https://git.openjdk.org/jdk/pull/21277/files/872bae2297f7387b91c6bdc0a40c88f192866a75)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21277/head:pull/21277` \
`$ git checkout pull/21277`

Update a local copy of the PR: \
`$ git checkout pull/21277` \
`$ git pull https://git.openjdk.org/jdk.git pull/21277/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21277`

View PR using the GUI difftool: \
`$ git pr show -t 21277`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21277.diff">https://git.openjdk.org/jdk/pull/21277.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21277#issuecomment-2384803279)