### PR TITLE
8341135: Incorrect format string after JDK-8339475

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -312,12 +312,12 @@ static void MacOSXStartup(int argc, char *argv[]) {
     pthread_t main_thr;
     rc = pthread_create(&main_thr, NULL, &apple_main, &args);
     if (rc != 0) {
-        JLI_ReportErrorMessageSys("Could not create main thread, return code: %s\n", rc);
+        JLI_ReportErrorMessageSys("Could not create main thread, return code:%d\n", rc);
         exit(1);
     }
     rc = pthread_detach(main_thr);
     if (rc != 0) {
-        JLI_ReportErrorMessage("pthread_detach() failed, return code: %s\n", rc);
+        JLI_ReportErrorMessage("pthread_detach() failed, return code:%d\n", rc);
         exit(1);
     }
 

--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -312,12 +312,12 @@ static void MacOSXStartup(int argc, char *argv[]) {
     pthread_t main_thr;
     rc = pthread_create(&main_thr, NULL, &apple_main, &args);
     if (rc != 0) {
-        JLI_ReportErrorMessageSys("Could not create main thread, return code:%d\n", rc);
+        JLI_ReportErrorMessageSys("Could not create main thread, return code: %d\n", rc);
         exit(1);
     }
     rc = pthread_detach(main_thr);
     if (rc != 0) {
-        JLI_ReportErrorMessage("pthread_detach() failed, return code:%d\n", rc);
+        JLI_ReportErrorMessage("pthread_detach() failed, return code: %d\n", rc);
         exit(1);
     }
 


### PR DESCRIPTION
This fixes a format string issue.

In the error report it was reported : 'The compiler should be able to catch this if JLI_ReportErrorMessageSys was declared with something like __attribute__ ((format (printf, 1, 2))).'
Should we maybe adjust  JLI_ReportErrorMessageSys , JLI_ReportErrorMessage  and related functions/methods  using a format string so that such errors can be found already at build time ?

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341135](https://bugs.openjdk.org/browse/JDK-8341135): Incorrect format string after JDK-8339475 (**Bug** - P3)


### Reviewers
 * [Christoph Langer](https://openjdk.org/census#clanger) (@RealCLanger - **Reviewer**) Review applies to [1d649c89](https://git.openjdk.org/jdk/pull/21278/files/1d649c89a80fc947ffb4cda13a5e85f7f93afa78)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [1d649c89](https://git.openjdk.org/jdk/pull/21278/files/1d649c89a80fc947ffb4cda13a5e85f7f93afa78)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21278/head:pull/21278` \
`$ git checkout pull/21278`

Update a local copy of the PR: \
`$ git checkout pull/21278` \
`$ git pull https://git.openjdk.org/jdk.git pull/21278/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21278`

View PR using the GUI difftool: \
`$ git pr show -t 21278`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21278.diff">https://git.openjdk.org/jdk/pull/21278.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21278#issuecomment-2385000130)