### PR TITLE
8337493: [JVMCI] Number of libgraal threads might be too low

### DIFF
--- a/src/hotspot/share/jvmci/jvmci_globals.hpp
+++ b/src/hotspot/share/jvmci/jvmci_globals.hpp
@@ -143,9 +143,11 @@ class fileStream;
           "on the HotSpot heap. Defaults to true if UseJVMCICompiler or "   \
           "EnableJVMCI is true and a JVMCI native library is available.")   \
                                                                             \
-  product(double, JVMCINativeLibraryThreadFraction, 0.33, EXPERIMENTAL,     \
+  product(double, JVMCINativeLibraryThreadFraction, 0.66, EXPERIMENTAL,     \
           "The fraction of compiler threads used by libjvmci. "             \
-          "The remaining compiler threads are used by C1.")                 \
+          "The remaining compiler threads are used by C1. "                 \
+          "Reducing this value could reduce the max RSS but "               \
+          "also increase the warmup time.")                                 \
           range(0.0, 1.0)                                                   \
                                                                             \
   product(ccstr, JVMCINativeLibraryErrorFile, nullptr, EXPERIMENTAL,        \


### PR DESCRIPTION
The `-XX:JVMCINativeLibraryThreadFraction` flag defines the ratio between JVMCI threads and C1 threads.
With a default value of 0.33 the number of JVMCI threads is significantly smaller than the number of C2 threads would be.

This can lead to unexpected warmup behavior with `-XX:+UseJVMCICompiler`. This PR changes the default value of `-XX:JVMCINativeLibraryThreadFraction` to yield the same number of JVMCI threads as C2 threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337493](https://bugs.openjdk.org/browse/JDK-8337493): [JVMCI] Number of libgraal threads might be too low (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21279/head:pull/21279` \
`$ git checkout pull/21279`

Update a local copy of the PR: \
`$ git checkout pull/21279` \
`$ git pull https://git.openjdk.org/jdk.git pull/21279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21279`

View PR using the GUI difftool: \
`$ git pr show -t 21279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21279.diff">https://git.openjdk.org/jdk/pull/21279.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21279#issuecomment-2385148685)