### PR TITLE
8340116: test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java can fail due to regex

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java
+++ b/test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java
@@ -243,9 +243,8 @@ public class PreserveRawManifestEntryAndDigest {
      * @see "concise_jarsigner.sh"
      */
     String[] getExpectedJarSignerOutputUpdatedContentNotValidatedBySignerA(
-            String jarFilename, String digestalg,
             String firstAddedFilename, String secondAddedFilename) {
-        final String TS = ".{28,29}"; // matches a timestamp
+        final String TS = ".{28,34}"; // matches a timestamp
         List<String> expLines = new ArrayList<>();
         expLines.add("s k   *\\d+ " + TS + " META-INF/MANIFEST[.]MF");
         expLines.add("      *\\d+ " + TS + " META-INF/B[.]SF");
@@ -347,7 +346,6 @@ public class PreserveRawManifestEntryAndDigest {
         assertMatchByLines(
                 fromFirstToSecondEmptyLine(o.getStdout().split("\\R")),
                 getExpectedJarSignerOutputUpdatedContentNotValidatedBySignerA(
-                        jarFilename4, digestalg,
                         firstAddedFilename, secondAddedFilename));
 
         // double-check reading the files with a verifying JarFile


### PR DESCRIPTION
The test **test/jdk/sun/security/tools/jarsigner/PreserveRawManifestEntryAndDigest.java** may fail with the following exception:

```
test PreserveRawManifestEntryAndDigest.testNameImmediatelyContinued(): failure
java.lang.AssertionError: "s k 300 Tue Jun 25 10:20:16 GMT+07:00 2024 META-INF/MANIFEST.MF" should have matched "s k *\\d+ .{28,29} META-INF/MANIFEST[.]MF" expected [true] but found [false]
```

The failure occurs due to a mismatch in the expected timestamp format. The current regular expression expects a timestamp length of 28 or 29 characters, which works for short timezones like PST or CEST. However, it fails for longer timezone formats such as 'GMT+07:00'.

This PR updates the regular expression ensuring that the test can handle a wider range of timezone strings.