### PR TITLE
8341127: Extra call to MethodHandle::asType from memory segment var handles fails to inline

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -27,6 +27,7 @@ package java.lang.invoke;
 
 
 import jdk.internal.loader.ClassLoaders;
+import jdk.internal.vm.annotation.DontInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import java.lang.constant.ClassDesc;
@@ -867,7 +868,7 @@ public abstract sealed class MethodHandle implements Constable
         if (at != null) {
             return at;
         }
-        return setAsTypeCache(asTypeUncached(newType));
+        return setAsTypeCache(newType);
     }
 
     private MethodHandle asTypeCached(MethodType newType) {
@@ -885,7 +886,9 @@ public abstract sealed class MethodHandle implements Constable
         return null;
     }
 
-    private MethodHandle setAsTypeCache(MethodHandle at) {
+    @DontInline
+    private MethodHandle setAsTypeCache(MethodType newType) {
+        MethodHandle at = asTypeUncached(newType);
         // Don't introduce a strong reference in the cache if newType depends on any class loader other than
         // current method handle already does to avoid class loader leaks.
         if (isSafeToCache(at.type)) {

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -886,6 +886,13 @@ public abstract sealed class MethodHandle implements Constable
         return null;
     }
 
+    /*
+     * We disable inlining here to prevent complex code in the slow path
+     * of MethodHandle::asType from being inlined into that method.
+     * Excessive inlining into MethodHandle::asType can cause that method
+     * to become too big, which will then cause performance issues during
+     * var handle and method handle calls.
+     */
     @DontInline
     private MethodHandle setAsTypeCache(MethodType newType) {
         MethodHandle at = asTypeUncached(newType);

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandle.java
@@ -28,6 +28,7 @@ package java.lang.invoke;
 
 import jdk.internal.loader.ClassLoaders;
 import jdk.internal.vm.annotation.DontInline;
+import jdk.internal.vm.annotation.ForceInline;
 import jdk.internal.vm.annotation.IntrinsicCandidate;
 
 import java.lang.constant.ClassDesc;
@@ -857,6 +858,7 @@ public abstract sealed class MethodHandle implements Constable
      * @throws WrongMethodTypeException if the conversion cannot be made
      * @see MethodHandles#explicitCastArguments
      */
+    @ForceInline
     public final MethodHandle asType(MethodType newType) {
         // Fast path alternative to a heavyweight {@code asType} call.
         // Return 'this' if the conversion will be a no-op.

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
@@ -54,7 +54,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(3)
+@Fork(value = 3, jvmArgsAppend = { "-XX:-TieredCompilation" })
 public class LoopOverNonConstantAsType extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
@@ -51,7 +51,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(3)
+@Fork(value = 3, jvmArgsAppend = { "-XX:-TieredCompilation" })
 public class LoopOverNonConstantAsType extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
@@ -100,7 +100,6 @@ public class LoopOverNonConstantAsType extends JavaLayouts {
         }
     }
 
-    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
     void compileAsType() {
         for (Class<?> type : types) {
             MethodHandle handle = MethodHandles.zero(Object.class);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
@@ -133,7 +133,6 @@ public class LoopOverNonConstantAsType extends JavaLayouts {
         long sum = 0;
         for (int i = 0; i < ELEM_SIZE; i++) {
             sum += segment.get(JAVA_LONG, i * CARRIER_SIZE);
-
         }
         return sum;
     }

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.foreign;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import sun.misc.Unsafe;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.foreign.ValueLayout.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(3)
+public class LoopOverNonConstantAsType extends JavaLayouts {
+
+    static final Unsafe unsafe = Utils.unsafe;
+
+    static final int ELEM_SIZE = 1_000_000;
+    static final int CARRIER_SIZE = (int)JAVA_LONG.byteSize();
+    static final int ALLOC_SIZE = ELEM_SIZE * CARRIER_SIZE;
+
+    @Param({"false", "true"})
+    public boolean asTypeCompiled;
+
+    Arena arena;
+    MemorySegment segment;
+    long unsafe_addr;
+
+    @Setup
+    public void setup() {
+        unsafe_addr = unsafe.allocateMemory(ALLOC_SIZE);
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            unsafe.putInt(unsafe_addr + (i * CARRIER_SIZE) , i);
+        }
+        arena = Arena.ofConfined();
+        segment = arena.allocate(ALLOC_SIZE, 1);
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            VH_INT.set(segment, (long) i, i);
+        }
+        if (asTypeCompiled) {
+            compileAsType();
+        }
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    void compileAsType() {
+        Class<?>[] types = new Class<?>[] { byte.class, short.class, int.class, long.class };
+        for (int i = 0 ; i < 40 ; i++) {
+            for (Class<?> type : types) {
+                MethodHandle handle = MethodHandles.zero(Object.class);
+                Class<?>[] args = new Class<?>[127];
+                Arrays.fill(args, long.class);
+                handle = MethodHandles.dropArguments(handle, 0, args);
+                for (int j = 0; j < args.length ; j++) {
+                    handle = handle.asType(handle.type().changeParameterType(j, type));
+                }
+            }
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        arena.close();
+        unsafe.freeMemory(unsafe_addr);
+    }
+
+    @Benchmark
+    public long unsafe_loop() {
+        long res = 0;
+        for (int i = 0; i < ELEM_SIZE; i ++) {
+            res += unsafe.getLong(unsafe_addr + (i * CARRIER_SIZE));
+        }
+        return res;
+    }
+
+    @Benchmark
+    public long segment_loop() {
+        long sum = 0;
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            sum += segment.get(JAVA_LONG, i * CARRIER_SIZE);
+
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION
The fix for JDK-8331865 introduced an accidental performance regression.
The main issue is that now *all* memory segment var handles go through some round of adaptation.
Adapting a var handle results in a so called *indirect* var handle.
When an indirect var handle is called through a *var handle guard*, an extra `MethodHandle::asType` call is triggered.
In some cases, if `asType` has already been compiled into a big method, it cannot be inlined into the caller, which then results in a failure to inline through the var handle call, resulting in a big performance regression.

The solution is to make sure that the compiled size of `MethodHandle::asType` stays small: this is done by making sure that the slowpath (the one which populates the cache used by `asType`) is not inlined by the JVM. This is done by consolidating the slow path into a separate method, which is annotated with the internal `@DontInline` annotation.

This problem was originally reported here:
https://mail.openjdk.org/pipermail/panama-dev/2024-September/020643.html

While we did not test this fix directly, we have made sure that running the problematic benchmark with the flags:

```
-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.setAsTypeCache
-XX:CompileCommand=dontinline,java/lang/invoke/MethodHandle.asTypeUncached
```

Solves the performance regression. The fix in this PR is just a programmatic way to achieve the same results w/o the need of command line flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341127](https://bugs.openjdk.org/browse/JDK-8341127): Extra call to MethodHandle::asType from memory segment var handles fails to inline (**Enhancement** - P2)


### Reviewers
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**) Review applies to [f644d52d](https://git.openjdk.org/jdk/pull/21283/files/f644d52defecf82f9405046f981aa69a2176a0a3)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**) Review applies to [964a273f](https://git.openjdk.org/jdk/pull/21283/files/964a273f73636b7a45417d30f2756403b0c21323)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21283/head:pull/21283` \
`$ git checkout pull/21283`

Update a local copy of the PR: \
`$ git checkout pull/21283` \
`$ git pull https://git.openjdk.org/jdk.git pull/21283/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21283`

View PR using the GUI difftool: \
`$ git pr show -t 21283`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21283.diff">https://git.openjdk.org/jdk/pull/21283.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21283#issuecomment-2385386109)