### PR TITLE
8341162: Open source some of the AWT window test

### DIFF
--- a/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
+++ b/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 6318630
  * @summary Test that location by platform works
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual TestLocationByPlatform
 */

--- a/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
+++ b/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6318630
+ * @summary Test that location by platform works
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestLocationByPlatform
+*/
+
+import java.awt.BorderLayout;
+import java.awt.Canvas;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.Frame;
+import java.awt.Graphics;
+
+public class TestLocationByPlatform {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            You should see two frames. One has locationByPlatform set, it
+            should be displayed somewhere on the screen most probably without
+            intersecting other Frames or stacked over normal frame with some
+            offset. Another has its location explicitly set to (0, 450).
+            Please verify that the frames are situated correctly.
+            Also, please verify that the picture inside of frames looks the same
+            and consists of red descending triangle occupying exactly the bottom
+            half of the frame. Also, that there is a blue rect exactly
+            surrounding the client area of frame with no pixels between it and
+            the frame's decorations. Press Pass if this all is true,
+            otherwise press Fail.
+            """;
+
+        PassFailJFrame passFailJFrame = PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .rows(13)
+            .columns(40)
+            .build();
+        EventQueue.invokeAndWait(() -> createUI());
+        passFailJFrame.awaitAndCheck();
+    }
+    private static void createUI() {
+        Frame frame = new Frame("Normal");
+        frame.setLocation(0, 450);
+        Canvas c = new Canvas() {
+            public Dimension getPreferredSize() {
+                return new Dimension(400, 400);
+            }
+
+            public void paint(Graphics g) {
+                g.setColor(Color.red);
+                for (int i = 399; i >= 0; i--) {
+                    g.drawLine(400 - i - 1, 400 - i - 1,
+                        400 - i - 1, 399);
+                }
+                g.setColor(Color.blue);
+                g.drawLine(0, 0, 399, 0);
+                g.drawLine(0, 0, 0, 399);
+                g.drawLine(0, 399, 399, 399);
+                g.drawLine(399, 0, 399, 399);
+            }
+        };
+        frame.add(c, BorderLayout.CENTER);
+        frame.pack();
+        PassFailJFrame.addTestWindow(frame);
+        frame.setVisible(true);
+
+        frame = new Frame("Location by platform");
+        frame.setLocationByPlatform(true);
+        c = new Canvas() {
+            public Dimension getPreferredSize() {
+                return new Dimension(400, 400);
+            }
+
+            public void paint(Graphics g) {
+                g.setColor(Color.red);
+                for (int i = 399; i >= 0; i--) {
+                    g.drawLine(400 - i - 1, 400 - i - 1,
+                        400 - i - 1, 399);
+                }
+                g.setColor(Color.blue);
+                g.drawLine(0, 0, 399, 0);
+                g.drawLine(0, 0, 0, 399);
+                g.drawLine(0, 399, 399, 399);
+                g.drawLine(399, 0, 399, 399);
+            }
+        };
+        frame.add(c, BorderLayout.CENTER);
+        frame.pack();
+        PassFailJFrame.addTestWindow(frame);
+        frame.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
+++ b/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
@@ -81,25 +81,25 @@ public class TestLocationByPlatform {
         PassFailJFrame.addTestWindow(frame);
         frame.setVisible(true);
     }
-}
 
-class MyCanvas extends Canvas {
-    @Override
-    public Dimension getPreferredSize() {
-        return new Dimension(400, 400);
-    }
-
-    @Override
-    public void paint(Graphics g) {
-        g.setColor(Color.red);
-        for (int i = 399; i >= 0; i--) {
-            g.drawLine(400 - i - 1, 400 - i - 1,
-                400 - i - 1, 399);
+    static class MyCanvas extends Canvas {
+        @Override
+        public Dimension getPreferredSize() {
+            return new Dimension(400, 400);
         }
-        g.setColor(Color.blue);
-        g.drawLine(0, 0, 399, 0);
-        g.drawLine(0, 0, 0, 399);
-        g.drawLine(0, 399, 399, 399);
-        g.drawLine(399, 0, 399, 399);
+
+        @Override
+        public void paint(Graphics g) {
+            g.setColor(Color.red);
+            for (int i = 399; i >= 0; i--) {
+                g.drawLine(400 - i - 1, 400 - i - 1,
+                    400 - i - 1, 399);
+            }
+            g.setColor(Color.blue);
+            g.drawLine(0, 0, 399, 0);
+            g.drawLine(0, 0, 0, 399);
+            g.drawLine(0, 399, 399, 399);
+            g.drawLine(399, 0, 399, 399);
+        }
     }
 }

--- a/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
+++ b/test/jdk/java/awt/Window/LocationByPlatform/TestLocationByPlatform.java
@@ -28,7 +28,7 @@
  * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual TestLocationByPlatform
-*/
+ */
 
 import java.awt.BorderLayout;
 import java.awt.Canvas;
@@ -45,10 +45,11 @@ public class TestLocationByPlatform {
             should be displayed somewhere on the screen most probably without
             intersecting other Frames or stacked over normal frame with some
             offset. Another has its location explicitly set to (0, 450).
-            Please verify that the frames are situated correctly.
-            Also, please verify that the picture inside of frames looks the same
+            Please verify that the frames are located correctly on the screen.
+
+            Also verify that the picture inside of frames looks the same
             and consists of red descending triangle occupying exactly the bottom
-            half of the frame. Also, that there is a blue rect exactly
+            half of the frame. Make sure that there is a blue rectangle exactly
             surrounding the client area of frame with no pixels between it and
             the frame's decorations. Press Pass if this all is true,
             otherwise press Fail.
@@ -60,30 +61,13 @@ public class TestLocationByPlatform {
             .rows(13)
             .columns(40)
             .build();
-        EventQueue.invokeAndWait(() -> createUI());
+        EventQueue.invokeAndWait(TestLocationByPlatform::createUI);
         passFailJFrame.awaitAndCheck();
     }
     private static void createUI() {
         Frame frame = new Frame("Normal");
         frame.setLocation(0, 450);
-        Canvas c = new Canvas() {
-            public Dimension getPreferredSize() {
-                return new Dimension(400, 400);
-            }
-
-            public void paint(Graphics g) {
-                g.setColor(Color.red);
-                for (int i = 399; i >= 0; i--) {
-                    g.drawLine(400 - i - 1, 400 - i - 1,
-                        400 - i - 1, 399);
-                }
-                g.setColor(Color.blue);
-                g.drawLine(0, 0, 399, 0);
-                g.drawLine(0, 0, 0, 399);
-                g.drawLine(0, 399, 399, 399);
-                g.drawLine(399, 0, 399, 399);
-            }
-        };
+        Canvas c = new MyCanvas();
         frame.add(c, BorderLayout.CENTER);
         frame.pack();
         PassFailJFrame.addTestWindow(frame);
@@ -91,27 +75,31 @@ public class TestLocationByPlatform {
 
         frame = new Frame("Location by platform");
         frame.setLocationByPlatform(true);
-        c = new Canvas() {
-            public Dimension getPreferredSize() {
-                return new Dimension(400, 400);
-            }
-
-            public void paint(Graphics g) {
-                g.setColor(Color.red);
-                for (int i = 399; i >= 0; i--) {
-                    g.drawLine(400 - i - 1, 400 - i - 1,
-                        400 - i - 1, 399);
-                }
-                g.setColor(Color.blue);
-                g.drawLine(0, 0, 399, 0);
-                g.drawLine(0, 0, 0, 399);
-                g.drawLine(0, 399, 399, 399);
-                g.drawLine(399, 0, 399, 399);
-            }
-        };
+        c = new MyCanvas();
         frame.add(c, BorderLayout.CENTER);
         frame.pack();
         PassFailJFrame.addTestWindow(frame);
         frame.setVisible(true);
+    }
+}
+
+class MyCanvas extends Canvas {
+    @Override
+    public Dimension getPreferredSize() {
+        return new Dimension(400, 400);
+    }
+
+    @Override
+    public void paint(Graphics g) {
+        g.setColor(Color.red);
+        for (int i = 399; i >= 0; i--) {
+            g.drawLine(400 - i - 1, 400 - i - 1,
+                400 - i - 1, 399);
+        }
+        g.setColor(Color.blue);
+        g.drawLine(0, 0, 399, 0);
+        g.drawLine(0, 0, 0, 399);
+        g.drawLine(0, 399, 399, 399);
+        g.drawLine(399, 0, 399, 399);
     }
 }

--- a/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
+++ b/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
@@ -35,8 +35,8 @@ import java.awt.Frame;
 import java.awt.Window;
 
 public class OwnedWindowShowTest {
-    public static void main(String args[]) throws Exception {
-        EventQueue.invokeAndWait(() -> runTest());
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(OwnedWindowShowTest::runTest);
     }
 
     static void runTest() {
@@ -44,11 +44,11 @@ public class OwnedWindowShowTest {
         try {
             Window owner = new Window(parent);
             Window window = new Window(owner);
+            // Showing a window with multiple level of ownership
+            // should not throw NullPointerException
             window.setVisible(true);
         } finally {
-            if (parent != null) {
-                parent.dispose();
-            }
+            parent.dispose();
         }
     }
 }

--- a/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
+++ b/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
@@ -44,7 +44,7 @@ public class OwnedWindowShowTest {
         try {
             Window owner = new Window(parent);
             Window window = new Window(owner);
-            // Showing a window with multiple level of ownership
+            // Showing a window with multiple levels of ownership
             // should not throw NullPointerException
             window.setVisible(true);
         } finally {

--- a/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
+++ b/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
@@ -30,22 +30,21 @@
  * @run main OwnedWindowShowTest
  */
 
+import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Window;
 
 public class OwnedWindowShowTest {
-    public static void main(String args[])
-    {
+    public static void main(String args[]) throws Exception {
+        EventQueue.invokeAndWait(() -> runTest());
+    }
+
+    static void runTest() {
         Frame parent = new Frame("OwnedWindowShowTest");
-        try
-        {
+        try {
             Window owner = new Window(parent);
             Window window = new Window(owner);
-            try {
-                window.setVisible(true);
-            } catch (NullPointerException npe) {
-                throw new RuntimeException("Got Null pointer exception");
-            }
+            window.setVisible(true);
         } finally {
             if (parent != null) {
                 parent.dispose();

--- a/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
+++ b/test/jdk/java/awt/Window/OwnedWindowShowTest/OwnedWindowShowTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4177156
+ * @key headful
+ * @summary Tests that multiple level of window ownership doesn't cause
+ * NullPointerException when showing a Window
+ * @run main OwnedWindowShowTest
+ */
+
+import java.awt.Frame;
+import java.awt.Window;
+
+public class OwnedWindowShowTest {
+    public static void main(String args[])
+    {
+        Frame parent = new Frame("OwnedWindowShowTest");
+        try
+        {
+            Window owner = new Window(parent);
+            Window window = new Window(owner);
+            try {
+                window.setVisible(true);
+            } catch (NullPointerException npe) {
+                throw new RuntimeException("Got Null pointer exception");
+            }
+        } finally {
+            if (parent != null) {
+                parent.dispose();
+            }
+        }
+    }
+}

--- a/test/jdk/java/awt/Window/ResizeTest/ResizeTest.java
+++ b/test/jdk/java/awt/Window/ResizeTest/ResizeTest.java
@@ -26,7 +26,7 @@
  * @bug 4225955
  * @summary Tests that focus lost is delivered to a lightweight component
  * in a disposed window
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual ResizeTest
  */

--- a/test/jdk/java/awt/Window/ResizeTest/ResizeTest.java
+++ b/test/jdk/java/awt/Window/ResizeTest/ResizeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4225955
+ * @summary Tests that focus lost is delivered to a lightweight component
+ * in a disposed window
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ResizeTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+
+public class ResizeTest
+{
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            1) Push button A to create modal dialog 2.
+            2) Resize dialog 2, then click button B to hide it.
+            3) Push button A again. Dialog B should be packed to its original
+            size.
+            4) Push button B again to hide, and A to reshow.
+            Dialog B should still be the same size, then test is passed,
+            otherwise failed.
+            5) Push button B to hide the modal dialog and then select pass/fail.
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(ResizeTest::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame f = new Frame("1");
+        Dialog d = new Dialog(f, "2", true);
+        d.setLocationRelativeTo(null);
+        Button b2 = new Button("B");
+        b2.addActionListener(e -> d.setVisible(false));
+        d.setLayout(new BorderLayout());
+        d.add(b2, BorderLayout.CENTER);
+
+        Button b = new Button("A");
+        f.add(b, BorderLayout.CENTER);
+        b.addActionListener(e -> {
+            d.pack();
+            d.setVisible(true);
+        });
+        f.pack();
+        f.setVisible(true);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Window/ResizeTest/ResizeTest.java
+++ b/test/jdk/java/awt/Window/ResizeTest/ResizeTest.java
@@ -75,7 +75,6 @@ public class ResizeTest
             d.setVisible(true);
         });
         f.pack();
-        f.setVisible(true);
         return f;
     }
 }

--- a/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
+++ b/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4084997
+ * @summary See if Window can be created without its size explicitly set
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ShowWindowTest
+ */
+
+import java.awt.Button;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+public class ShowWindowTest implements ActionListener
+{
+    private static Window win;
+    private static Button showButton;
+    private static Button hideButton;
+
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+            1. You should see a Frame with a "Show" and a "Hide" button in it.
+            2. Click on the "Show" button. A Window with a "Hello World" Label
+            should appear
+            3. If a Window does not appear, the test failed.
+            """;
+
+        PassFailJFrame.builder()
+            .title("Test Instructions")
+            .instructions(INSTRUCTIONS)
+            .columns(40)
+            .testUI(ShowWindowTest::createUI)
+            .build()
+            .awaitAndCheck();
+    }
+
+    private static Frame createUI() {
+        Frame frame = new Frame("ShowWindowTest");
+        frame.setLayout(new FlowLayout());
+        frame.setSize(100,100);
+        frame.add(showButton = new Button("Show"));
+        frame.add(hideButton = new Button("Hide"));
+        showButton.addActionListener(new ShowWindowTest());
+        hideButton.addActionListener(new ShowWindowTest());
+
+        win = new Window(frame);
+        win.add("Center", new Label("Hello World"));
+        win.setLocationRelativeTo(null);
+
+        frame.setVisible(true);
+        return frame;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        if (e.getSource() == showButton) {
+            win.pack();
+            win.setVisible(true);
+        } else if (e.getSource() == hideButton)
+            win.setVisible(false);
+    }
+}

--- a/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
+++ b/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 4084997
  * @summary See if Window can be created without its size explicitly set
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual ShowWindowTest
  */

--- a/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
+++ b/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
@@ -40,7 +40,7 @@ import java.awt.event.ActionListener;
 
 public class ShowWindowTest implements ActionListener
 {
-    private static Window win;
+    private static Window window;
     private static Button showButton;
     private static Button hideButton;
 
@@ -49,7 +49,7 @@ public class ShowWindowTest implements ActionListener
             1. You should see a Frame with a "Show" and a "Hide" button in it.
             2. Click on the "Show" button. A window with a "Hello World" Label
             should appear
-            3. If the window does not appear the test failed, otherwise passed.
+            3. If the window does not appear, the test failed, otherwise passed.
             """;
 
         PassFailJFrame.builder()
@@ -72,17 +72,17 @@ public class ShowWindowTest implements ActionListener
         showButton.addActionListener(handler);
         hideButton.addActionListener(handler);
 
-        win = new Window(frame);
-        win.add("Center", new Label("Hello World"));
-        win.setLocationRelativeTo(null);
+        window = new Window(frame);
+        window.add("Center", new Label("Hello World"));
+        window.setLocationRelativeTo(null);
         return frame;
     }
 
     public void actionPerformed(ActionEvent e) {
         if (e.getSource() == showButton) {
-            win.pack();
-            win.setVisible(true);
+            window.pack();
+            window.setVisible(true);
         } else if (e.getSource() == hideButton)
-            win.setVisible(false);
+            window.setVisible(false);
     }
 }

--- a/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
+++ b/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
@@ -73,8 +73,6 @@ public class ShowWindowTest implements ActionListener
         win = new Window(frame);
         win.add("Center", new Label("Hello World"));
         win.setLocationRelativeTo(null);
-
-        frame.setVisible(true);
         return frame;
     }
 

--- a/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
+++ b/test/jdk/java/awt/Window/ShowWindowTest/ShowWindowTest.java
@@ -47,9 +47,9 @@ public class ShowWindowTest implements ActionListener
     public static void main(String[] args) throws Exception {
         String INSTRUCTIONS = """
             1. You should see a Frame with a "Show" and a "Hide" button in it.
-            2. Click on the "Show" button. A Window with a "Hello World" Label
+            2. Click on the "Show" button. A window with a "Hello World" Label
             should appear
-            3. If a Window does not appear, the test failed.
+            3. If the window does not appear the test failed, otherwise passed.
             """;
 
         PassFailJFrame.builder()
@@ -67,8 +67,10 @@ public class ShowWindowTest implements ActionListener
         frame.setSize(100,100);
         frame.add(showButton = new Button("Show"));
         frame.add(hideButton = new Button("Hide"));
-        showButton.addActionListener(new ShowWindowTest());
-        hideButton.addActionListener(new ShowWindowTest());
+
+        ActionListener handler = new ShowWindowTest();
+        showButton.addActionListener(handler);
+        hideButton.addActionListener(handler);
 
         win = new Window(frame);
         win.add("Center", new Label("Hello World"));


### PR DESCRIPTION
Clean up and open source some of the AWT window tests.
Automated test `OwnedWindowShowTest.java` is verified in our CI also and it passes on all platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341162](https://bugs.openjdk.org/browse/JDK-8341162): Open source some of the AWT window test (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21284/head:pull/21284` \
`$ git checkout pull/21284`

Update a local copy of the PR: \
`$ git checkout pull/21284` \
`$ git pull https://git.openjdk.org/jdk.git pull/21284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21284`

View PR using the GUI difftool: \
`$ git pr show -t 21284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21284.diff">https://git.openjdk.org/jdk/pull/21284.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21284#issuecomment-2385437426)