### PR TITLE
8340109: Ubsan: ciEnv.cpp:1660:65: runtime error: member call on null pointer of type 'struct CompileTask'

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1616,7 +1616,10 @@ void ciEnv::dump_replay_data_helper(outputStream* out) {
   for (int i = 0; i < objects->length(); i++) {
     objects->at(i)->dump_replay_data(out);
   }
-  dump_compile_data(out);
+
+  if (this->task() != nullptr) {
+    dump_compile_data(out);
+  }
   out->flush();
 }
 


### PR DESCRIPTION
When running ubsan-enabled optimized binaries on Linux x86_64, test
compiler/startup/StartupOutput.java
triggers this ubsan issue :

```
jdk/src/hotspot/share/ci/ciEnv.cpp:1660:65: runtime error: member call on null pointer of type 'struct CompileTask'
    #0 0x7fe7443fc88d in ciEnv::dump_replay_data_helper(outputStream*) src/hotspot/share/ci/ciEnv.cpp:1660
    #1 0x7fe746c22047 in VMError::report_and_die(int, char const*, char const*, __va_list_tag*, Thread*, unsigned char*, void*, void*, char const*, int, unsigned long) src/hotspot/share/utilities/vmError.cpp:1872
    #2 0x7fe7447dd429 in report_fatal(VMErrorType, char const*, int, char const*, ...) src/hotspot/share/utilities/debug.cpp:214
    #3 0x7fe7445c614d in RuntimeStub::new_runtime_stub(char const*, CodeBuffer*, short, int, OopMapSet*, bool, bool) src/hotspot/share/code/codeBlob.cpp:413
    #4 0x7fe744259ceb in Runtime1::generate_blob(BufferBlob*, int, char const*, bool, StubAssemblerCodeGenClosure*) src/hotspot/share/c1/c1_Runtime1.cpp:230
    #5 0x7fe74425a273 in Runtime1::generate_blob_for(BufferBlob*, Runtime1::StubID) src/hotspot/share/c1/c1_Runtime1.cpp:259
    #6 0x7fe74425a273 in Runtime1::initialize(BufferBlob*) src/hotspot/share/c1/c1_Runtime1.cpp:268
    #7 0x7fe743fc04a1 in Compiler::init_c1_runtime() src/hotspot/share/c1/c1_Compiler.cpp:53
    #8 0x7fe743fc04a1 in Compiler::initialize() src/hotspot/share/c1/c1_Compiler.cpp:74
    #9 0x7fe7446aaad7 in CompileBroker::init_compiler_runtime() src/hotspot/share/compiler/compileBroker.cpp:1771
    #10 0x7fe7446b83cf in CompileBroker::compiler_thread_loop() src/hotspot/share/compiler/compileBroker.cpp:1913
    #11 0x7fe74516edca in JavaThread::thread_main_inner() src/hotspot/share/runtime/javaThread.cpp:758
    #12 0x7fe7469d3c9a in Thread::call_run() src/hotspot/share/runtime/thread.cpp:225
    #13 0x7fe746048cd1 in thread_native_entry src/hotspot/os/linux/os_linux.cpp:858
    #14 0x7fe74b1e66e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 052f7e2a0045f08cb7e7a291f8066a4b7be2521d)
    #15 0x7fe74aaf158e in clone (/lib64/libc.so.6+0x11858e) (BuildId: cfb059a57e69ac95d5dadab831626b3bd48a4309)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340109](https://bugs.openjdk.org/browse/JDK-8340109): Ubsan: ciEnv.cpp:1660:65: runtime error: member call on null pointer of type 'struct CompileTask' (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21288/head:pull/21288` \
`$ git checkout pull/21288`

Update a local copy of the PR: \
`$ git checkout pull/21288` \
`$ git pull https://git.openjdk.org/jdk.git pull/21288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21288`

View PR using the GUI difftool: \
`$ git pr show -t 21288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21288.diff">https://git.openjdk.org/jdk/pull/21288.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21288#issuecomment-2386196718)