### PR TITLE
8341310: Test TestJcmdWithSideCar.java should skip ACCESS_TMP_VIA_PROC_ROOT (after JDK-8327114)

### DIFF
--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -42,8 +42,8 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
@@ -52,7 +52,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
 import jdk.test.lib.Container;
+import jdk.test.lib.Platform;
 import jdk.test.lib.Utils;
 import jdk.test.lib.containers.docker.Common;
 import jdk.test.lib.containers.docker.DockerRunOptions;
@@ -108,6 +110,11 @@ public class TestJcmdWithSideCar {
                 mainContainer.waitForMainMethodStart(TIME_TO_WAIT_FOR_MAIN_METHOD_START);
 
                 for (AttachStrategy attachStrategy : EnumSet.allOf(AttachStrategy.class)) {
+                    if (attachStrategy == AttachStrategy.ACCESS_TMP_VIA_PROC_ROOT &&
+                        elevated && !Platform.isRoot()) {
+                        // Elevated attach via proc/root not yet supported.
+                        continue;
+                    }
                     long mainProcPid = testCase01(attachStrategy, elevated);
 
                     // Excluding the test case below until JDK-8228850 is fixed

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -247,13 +247,6 @@ public class TestJcmdWithSideCar {
         };
 
         public Process start(final boolean elevated) throws Exception {
-            // Be sure no main container with the same name already exists
-            OutputAnalyzer out = DockerTestUtils.execute(Container.ENGINE_COMMAND, "ps")
-                .shouldHaveExitValue(0);
-            if (out.contains(MAIN_CONTAINER_NAME)) {
-                DockerTestUtils.execute(Container.ENGINE_COMMAND, "rm", MAIN_CONTAINER_NAME)
-                   .shouldHaveExitValue(0);
-            }
             // start "main" container (the observee)
             DockerRunOptions opts = commonDockerOpts("EventGeneratorLoop");
 

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -247,6 +247,13 @@ public class TestJcmdWithSideCar {
         };
 
         public Process start(final boolean elevated) throws Exception {
+            // Be sure no main container with the same name already exists
+            OutputAnalyzer out = DockerTestUtils.execute(Container.ENGINE_COMMAND, "ps")
+                .shouldHaveExitValue(0);
+            if (out.contains(MAIN_CONTAINER_NAME)) {
+                DockerTestUtils.execute(Container.ENGINE_COMMAND, "rm", MAIN_CONTAINER_NAME)
+                   .shouldHaveExitValue(0);
+            }
             // start "main" container (the observee)
             DockerRunOptions opts = commonDockerOpts("EventGeneratorLoop");
 

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -301,9 +301,6 @@ public class TestJcmdWithSideCar {
             int retryCount = 3;
 
             do {
-                // Kill the process, so as to speed up overall time of the
-                // test
-                p.destroy();
                 waitFor(timeout);
                 try {
                     exitValue = p.exitValue();
@@ -313,6 +310,9 @@ public class TestJcmdWithSideCar {
                 }
             } while (exitValue == -1 && retryCount > 0);
 
+            if (exitValue != 0) {
+                throw new RuntimeException("DockerThread stopped unexpectedly, non-zero exit value is " + exitValue);
+            }
         }
 
     }

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -301,6 +301,9 @@ public class TestJcmdWithSideCar {
             int retryCount = 3;
 
             do {
+                // Kill the process, so as to speed up overall time of the
+                // test
+                p.destroy();
                 waitFor(timeout);
                 try {
                     exitValue = p.exitValue();
@@ -310,9 +313,6 @@ public class TestJcmdWithSideCar {
                 }
             } while (exitValue == -1 && retryCount > 0);
 
-            if (exitValue != 0) {
-                throw new RuntimeException("DockerThread stopped unexpectedly, non-zero exit value is " + exitValue);
-            }
         }
 
     }


### PR DESCRIPTION
The change of [JDK-8327114](https://bugs.openjdk.org/browse/JDK-8327114) also increased test coverage. In particular, the `TestJcmdWithSideCar.java` test got enhanced to cover these cases (prior to [JDK-8327114](https://bugs.openjdk.org/browse/JDK-8327114) only case 1 was tested):

1. Shared volumes between attachee and attacher and shared pid namespace
2. Shared volumes between attachee and attacher and shared pid namespace, both running with elevated privileges
3. Shared pid namespace between attachee and attacher only
4. Shared pid namespace between attachee and attacher, both running with elevated privileges

The OpenJDK attach code is able to handle cases 1 through 3 which pass, but the last case, `4`, hasn't been implemented yet when running as regular user and directing the container runtime to map the container user to that user as well. Thus, the test fails. For now I propose to disable the 4th test case. It can get re-enabled once the product code got updated to account for this case (tracked in https://bugs.openjdk.org/browse/JDK-8341349).

Thoughts? Could somebody please run this through Oracle's test system in order to see if this fixes the issue? Thank you!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341310](https://bugs.openjdk.org/browse/JDK-8341310): Test TestJcmdWithSideCar.java should skip ACCESS_TMP_VIA_PROC_ROOT (after JDK-8327114) (**Bug** - P4)


### Reviewers
 * @slovdahl (no known openjdk.org user name / role)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21289/head:pull/21289` \
`$ git checkout pull/21289`

Update a local copy of the PR: \
`$ git checkout pull/21289` \
`$ git pull https://git.openjdk.org/jdk.git pull/21289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21289`

View PR using the GUI difftool: \
`$ git pr show -t 21289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21289.diff">https://git.openjdk.org/jdk/pull/21289.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21289#issuecomment-2386461103)