### PR TITLE
8341316: [macos] javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java fails sometimes in macos

### DIFF
--- a/test/jdk/javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java
+++ b/test/jdk/javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java
@@ -78,15 +78,15 @@ public class ProgressMonitorEscapeKeyPress {
         }
     }
 
-     private static void createTestUI() throws Exception {
+    private static void createTestUI() throws Exception {
         SwingUtilities.invokeAndWait(() -> {
-             frame = new JFrame("Test");
-             frame.setSize(300, 300);
+            frame = new JFrame("Test");
+            frame.setSize(300, 300);
             monitor = new ProgressMonitor(frame, "Progress", "1", 0, 100);
             frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
             frame.setLocationByPlatform(true);
-           });
-     }
+        });
+    }
 
 
      private static void disposeTestUI() throws Exception {
@@ -101,14 +101,17 @@ class TestThread extends Thread {
     @Override
     public void run() {
         System.out.println("TestThread started.........");
-        for (ProgressMonitorEscapeKeyPress.counter = 0; ProgressMonitorEscapeKeyPress.counter <= 100; ProgressMonitorEscapeKeyPress.counter += 1) {
+        for (ProgressMonitorEscapeKeyPress.counter = 0;
+             ProgressMonitorEscapeKeyPress.counter <= 100;
+             ProgressMonitorEscapeKeyPress.counter += 1) {
             ProgressMonitorEscapeKeyPress.robot.delay(100);
             ProgressMonitor monitor = ProgressMonitorEscapeKeyPress.monitor;
             if (!monitor.isCanceled()) {
-                monitor.setNote(""+ProgressMonitorEscapeKeyPress.counter);
+                monitor.setNote("" + ProgressMonitorEscapeKeyPress.counter);
                 monitor.setProgress(ProgressMonitorEscapeKeyPress.counter);
                 ProgressMonitorEscapeKeyPress.progressLatch.countDown();
-                System.out.println("Progress bar is in progress....."+ ProgressMonitorEscapeKeyPress.counter+"%");
+                System.out.println("Progress bar is in progress....."
+                        + ProgressMonitorEscapeKeyPress.counter + "%");
             }
             if (monitor.isCanceled()) {
                 System.out.println("$$$$$$$$$$$$$$$ Monitor canceled");

--- a/test/jdk/javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java
+++ b/test/jdk/javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java
@@ -29,65 +29,63 @@
  * @run main ProgressMonitorEscapeKeyPress
  */
 
-import java.awt.AWTException;
-import java.awt.EventQueue;
-import java.awt.Robot;
-import java.awt.event.KeyEvent;
+
 import javax.swing.JFrame;
 import javax.swing.ProgressMonitor;
 import javax.swing.SwingUtilities;
+import java.awt.Robot;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class ProgressMonitorEscapeKeyPress {
 
+    static volatile int counter = 0;
     static ProgressMonitor monitor;
-    static int counter = 0;
-    static TestThread robotThread;
+    static TestThread testThread;
     static JFrame frame;
+    static CountDownLatch progressLatch;
+    static Robot robot;
 
 
     public static void main(String[] args) throws Exception {
-
-        createTestUI();
-
-        monitor = new ProgressMonitor(frame, "Progress", null, 0, 100);
-
-        robotThread = new TestThread();
-        robotThread.start();
-
-        for (counter = 0; counter <= 100; counter += 10) {
-            Thread.sleep(1000);
-
-            EventQueue.invokeAndWait(new Runnable() {
-                @Override
-                public void run() {
-                    if (!monitor.isCanceled()) {
-                        monitor.setProgress(counter);
-                        System.out.println("Progress bar is in progress");
-                    }
-                }
-            });
-
-            if (monitor.isCanceled()) {
-                break;
+        try {
+            progressLatch = new CountDownLatch(20);
+            createTestUI();
+            robot = new Robot();
+            robot.setAutoDelay(50);
+            robot.setAutoWaitForIdle(true);
+            testThread = new TestThread();
+            testThread.start();
+            Thread.sleep(100);
+            if (progressLatch.await(15, TimeUnit.SECONDS)) {
+                System.out.println("Progress monitor completed 20%, lets press Esc...");
+                robot.keyPress(KeyEvent.VK_ESCAPE);
+                robot.keyRelease(KeyEvent.VK_ESCAPE);
+                System.out.println("ESC pressed....");
+            } else {
+                System.out.println("Failure : No status available from Progress monitor...");
+                throw new RuntimeException(
+                        "Can't get the status from Progress monitor even after waiting too long..");
             }
-        }
 
-        disposeTestUI();
-
-        if (counter >= monitor.getMaximum()) {
-            throw new RuntimeException("Escape key did not cancel the ProgressMonitor");
+            if (counter >= monitor.getMaximum()) {
+                throw new RuntimeException("Escape key did not cancel the ProgressMonitor");
+            }
+            System.out.println("Test Passed...");
+        } finally {
+            disposeTestUI();
         }
     }
 
      private static void createTestUI() throws Exception {
-        SwingUtilities.invokeAndWait(new Runnable() {
-           @Override
-           public void run() {
-                frame = new JFrame("Test");
-                frame.setSize(300, 300);
-                frame.setLocationByPlatform(true);
-                frame.setVisible(true);
-              }});
+        SwingUtilities.invokeAndWait(() -> {
+             frame = new JFrame("Test");
+             frame.setSize(300, 300);
+            monitor = new ProgressMonitor(frame, "Progress", "1", 0, 100);
+            frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+            frame.setLocationByPlatform(true);
+           });
      }
 
 
@@ -100,26 +98,22 @@ public class ProgressMonitorEscapeKeyPress {
 
 
 class TestThread extends Thread {
-
-    Robot testRobot;
-
-    TestThread() throws AWTException {
-        super();
-        testRobot = new Robot();
-    }
-
     @Override
     public void run() {
-        try {
-            // Sleep for 5 seconds - so that the ProgressMonitor starts
-            Thread.sleep(5000);
-
-            // Press and release Escape key
-            testRobot.keyPress(KeyEvent.VK_ESCAPE);
-            testRobot.delay(20);
-            testRobot.keyRelease(KeyEvent.VK_ESCAPE);
-        } catch (InterruptedException ex) {
-            throw new RuntimeException("Exception in TestThread");
+        System.out.println("TestThread started.........");
+        for (ProgressMonitorEscapeKeyPress.counter = 0; ProgressMonitorEscapeKeyPress.counter <= 100; ProgressMonitorEscapeKeyPress.counter += 1) {
+            ProgressMonitorEscapeKeyPress.robot.delay(100);
+            ProgressMonitor monitor = ProgressMonitorEscapeKeyPress.monitor;
+            if (!monitor.isCanceled()) {
+                monitor.setNote(""+ProgressMonitorEscapeKeyPress.counter);
+                monitor.setProgress(ProgressMonitorEscapeKeyPress.counter);
+                ProgressMonitorEscapeKeyPress.progressLatch.countDown();
+                System.out.println("Progress bar is in progress....."+ ProgressMonitorEscapeKeyPress.counter+"%");
+            }
+            if (monitor.isCanceled()) {
+                System.out.println("$$$$$$$$$$$$$$$ Monitor canceled");
+                break;
+            }
         }
     }
 }


### PR DESCRIPTION
javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java fails sometimes in macos.
This could be because of a synchronisation issue in the test.

Fix: I have refactored the test to have a CountDownLatch to monitor the ProgressMonitor and when it reaches 20%, it will be triggered. I have also removed the ProgressMonitor update logic execution from EDT as it would block the EDT sometimes. Also added a proper frame disposal mechanism.

Testing:
This is properly tested multiple times in all available platforms in mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341316](https://bugs.openjdk.org/browse/JDK-8341316): [macos] javax/swing/ProgressMonitor/ProgressMonitorEscapeKeyPress.java fails sometimes in macos (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21293/head:pull/21293` \
`$ git checkout pull/21293`

Update a local copy of the PR: \
`$ git checkout pull/21293` \
`$ git pull https://git.openjdk.org/jdk.git pull/21293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21293`

View PR using the GUI difftool: \
`$ git pr show -t 21293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21293.diff">https://git.openjdk.org/jdk/pull/21293.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21293#issuecomment-2386536312)