### PR TITLE
8340488: Clarify LocaleServiceProvider deployment on application module path

### DIFF
--- a/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
+++ b/src/java.base/share/classes/java/util/spi/LocaleServiceProvider.java
@@ -41,19 +41,36 @@ import java.util.Locale;
  * and methods for name retrieval in the {@code java.text} and
  * {@code java.util} packages use implementations of the provider
  * interfaces to offer support for locales beyond the set of locales
- * supported by the Java runtime environment itself.
+ * supported by the Java runtime environment itself. Locale sensitive service
+ * providers are deployed on the application module path or the application class
+ * path. In order to be looked up, providers must be visible to the {@link
+ * ClassLoader#getSystemClassLoader() system class loader}.
+ * See {@link java.util.ServiceLoader##developing-service-providers Deploying
+ * Service Providers} for further detail on deploying a locale sensitive service
+ * provider as a module or on the class path.
  *
  * <h2>Packaging of Locale Sensitive Service Provider Implementations</h2>
- * Implementations of these locale sensitive services can be made available
- * by adding them to the application's class path. A provider identifies itself with a
- * provider-configuration file in the resource directory META-INF/services,
- * using the fully qualified provider interface class name as the file name.
- * The file should contain a list of fully-qualified concrete provider class names,
- * one per line. A line is terminated by any one of a line feed ('\n'), a carriage
- * return ('\r'), or a carriage return followed immediately by a line feed. Space
- * and tab characters surrounding each name, as well as blank lines, are ignored.
- * The comment character is '#' ('\u0023'); on each line all characters following
- * the first comment character are ignored. The file must be encoded in UTF-8.
+ *
+ * <p> For a locale sensitive service provider deployed in a module, the <i>provides</i>
+ * directive must be specified in the module declaration. The <i>provides</i>
+ * directive specifies both the service and the service provider.
+ *
+ * <p> For example, an implementation of the {@link java.text.spi.DateFormatProvider
+ * DateFormatProvider} class deployed as a module might specify the following directive:
+ * <pre>{@code
+ *     provides java.text.spi.DateFormatProvider with com.example.ExternalDateFormatProvider;
+ * }</pre>
+ *
+ * <p> For a Locale Service Provider deployed on the class path, the provider
+ * identifies itself with a provider-configuration file in the resource directory
+ * META-INF/services. The file name should be the fully fully qualified provider
+ * interface class name. The file should contain a list of fully-qualified concrete
+ * provider class names, one per line. A line is terminated by any one of a line
+ * feed ('\n'), a carriage return ('\r'), or a carriage return followed immediately
+ * by a line feed. Space and tab characters surrounding each name, as well as
+ * blank lines, are ignored. The comment character is '#' ('\u0023'); on each line
+ * all characters following the first comment character are ignored. The file must
+ * be encoded in UTF-8.
  * <p>
  * If a particular concrete provider class is named in more than one configuration
  * file, or is named in the same configuration file more than once, then the
@@ -88,8 +105,8 @@ import java.util.Locale;
  * supports the requested locale. If such a provider is found, its other
  * methods are called to obtain the requested object or name.  When checking
  * whether a locale is supported, the {@linkplain Locale##def_extensions
- * locale's extensions} are ignored by default. (If locale's extensions should
- * also be checked, the {@code isSupportedLocale} method must be overridden.)
+ * locale's extensions} are ignored by default. (If a locale's extensions should
+ * also be checked, the {@code isSupportedLocale} method must be overridden).
  * If neither the Java runtime environment itself nor an installed provider
  * supports the requested locale, the methods go through a list of candidate
  * locales and repeat the availability check for each until a match is found.


### PR DESCRIPTION
Please review this PR and [CSR](https://bugs.openjdk.org/browse/JDK-8341285) which clarifies that a Locale sensitive service provider can be deployed as a module.

This mainly follows the same format as the work done for [JDK-8340404](https://bugs.openjdk.org/browse/JDK-8340404), by providing a brief example, and pointing to the Deploying Service Providers section under ServiceLoader.

There is no test added, since there already exists java.text tests that deploy SPIs as a module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8341285](https://bugs.openjdk.org/browse/JDK-8341285) to be approved

### Issues
 * [JDK-8340488](https://bugs.openjdk.org/browse/JDK-8340488): Clarify LocaleServiceProvider deployment on application module path (**Bug** - P4)
 * [JDK-8341285](https://bugs.openjdk.org/browse/JDK-8341285): Clarify LocaleServiceProvider deployment on application module path (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21294/head:pull/21294` \
`$ git checkout pull/21294`

Update a local copy of the PR: \
`$ git checkout pull/21294` \
`$ git pull https://git.openjdk.org/jdk.git pull/21294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21294`

View PR using the GUI difftool: \
`$ git pr show -t 21294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21294.diff">https://git.openjdk.org/jdk/pull/21294.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21294#issuecomment-2386583280)