### PR TITLE
8325937: runtime/handshake/HandshakeDirectTest.java causes "monitor end should be strictly below the frame pointer" assertion failure on AArch64

### DIFF
--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -701,6 +701,10 @@ void HandshakeState::do_self_suspend() {
   assert(!_handshakee->has_last_Java_frame() || _handshakee->frame_anchor()->walkable(), "should have walkable stack");
   assert(_handshakee->thread_state() == _thread_blocked, "Caller should have transitioned to _thread_blocked");
 
+  // Separate all the writes above for other threads reading state
+  // set by this suspended thread.
+  OrderAccess::fence();
+
   while (is_suspended()) {
     log_trace(thread, suspend)("JavaThread:" INTPTR_FORMAT " suspended", p2i(_handshakee));
     _lock.wait_without_safepoint_check();

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -257,7 +257,7 @@ class VM_HandshakeAllThreads: public VM_Operation {
     if (UseSystemMemoryBarrier) {
       SystemMemoryBarrier::emit();
     } else {
-      OrderAccess::fence(); // storestore|storeload, global state -> local state
+      OrderAccess::fence();
     }
 
     if (number_of_threads_issued < 1) {
@@ -386,7 +386,7 @@ void Handshake::execute(HandshakeClosure* hs_cl, ThreadsListHandle* tlh, JavaThr
   if (UseSystemMemoryBarrier) {
     SystemMemoryBarrier::emit();
   } else {
-    OrderAccess::fence(); // storestore|storeload, global state -> local state
+    OrderAccess::fence();
   }
 
   // Keeps count on how many of own emitted handshakes

--- a/src/hotspot/share/runtime/handshake.cpp
+++ b/src/hotspot/share/runtime/handshake.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -251,8 +251,13 @@ class VM_HandshakeAllThreads: public VM_Operation {
       thr->handshake_state()->add_operation(_op);
       number_of_threads_issued++;
     }
+
+    // Separate the arming of the poll in add_operation() above from
+    // the read of JavaThread state in the try_process() call below.
     if (UseSystemMemoryBarrier) {
       SystemMemoryBarrier::emit();
+    } else {
+      OrderAccess::fence(); // storestore|storeload, global state -> local state
     }
 
     if (number_of_threads_issued < 1) {
@@ -380,6 +385,8 @@ void Handshake::execute(HandshakeClosure* hs_cl, ThreadsListHandle* tlh, JavaThr
   // the read of JavaThread state in the try_process() call below.
   if (UseSystemMemoryBarrier) {
     SystemMemoryBarrier::emit();
+  } else {
+    OrderAccess::fence(); // storestore|storeload, global state -> local state
   }
 
   // Keeps count on how many of own emitted handshakes


### PR DESCRIPTION
Add missing StoreLoad fences in handshaking code to match safepoint code.  Thanks to @pchilano for finding this bug.

Tested with tier1-4 and tier8 which has Kitchensink in it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8325937](https://bugs.openjdk.org/browse/JDK-8325937): runtime/handshake/HandshakeDirectTest.java causes "monitor end should be strictly below the frame pointer" assertion failure on AArch64 (**Bug** - P2)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) Review applies to [ed17b70f](https://git.openjdk.org/jdk/pull/21295/files/ed17b70fb56ae5c39104b2b0832313d8615da78b)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) Review applies to [ed17b70f](https://git.openjdk.org/jdk/pull/21295/files/ed17b70fb56ae5c39104b2b0832313d8615da78b)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**) Review applies to [ed17b70f](https://git.openjdk.org/jdk/pull/21295/files/ed17b70fb56ae5c39104b2b0832313d8615da78b)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - Committer) Review applies to [63e52fde](https://git.openjdk.org/jdk/pull/21295/files/63e52fde2d4adfec4368fca2fdf2ecb0d96f10bc)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21295/head:pull/21295` \
`$ git checkout pull/21295`

Update a local copy of the PR: \
`$ git checkout pull/21295` \
`$ git pull https://git.openjdk.org/jdk.git pull/21295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21295`

View PR using the GUI difftool: \
`$ git pr show -t 21295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21295.diff">https://git.openjdk.org/jdk/pull/21295.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21295#issuecomment-2386717182)