### PR TITLE
8341366: Suspicious check in Locale.getDisplayName(Locale inLocale)

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -2324,11 +2324,10 @@ public final class Locale implements Cloneable, Serializable {
             // If we cannot get the message format pattern, then we use a simple
             // hard-coded pattern.  This should not occur in practice unless the
             // installation is missing some core files (FormatData etc.).
-            StringBuilder result = new StringBuilder();
-            result.append((String)displayNames[1]);
-            if (displayNames.length > 2) {
+            StringBuilder result = new StringBuilder((String) displayNames[1]);
+            if (displayNames[2] != null) {
                 result.append(" (");
-                result.append((String)displayNames[2]);
+                result.append((String) displayNames[2]);
                 result.append(')');
             }
             return result.toString();

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -2326,9 +2326,9 @@ public final class Locale implements Cloneable, Serializable {
             // installation is missing some core files (FormatData etc.).
             StringBuilder result = new StringBuilder((String) displayNames[1]);
             if (displayNames[2] != null) {
-                result.append(" (");
-                result.append((String) displayNames[2]);
-                result.append(')');
+                result.append(" (")
+                        .append((String) displayNames[2])
+                        .append(')');
             }
             return result.toString();
         }


### PR DESCRIPTION
Please review this PR which modifies a suspicious check in the fallback of `Locale.getDisplayName(Locale inLocale)`.

As a fallback, a hard coded pattern is used. The previous code outputted the qualifiers if the `displayNames` array had length greater than 2. Just a few lines above, the array is initialized with a length of 3 and so the check is pointless.

It would be better, if replaced with a null check for the last element of the `displayNames` array, as that element may be null if there are no qualifiers. See L2317 ,

`qualifierNames.length != 0 ? formatList(qualifierNames, listCompositionPattern) : null`

For example, now a fallback (with no qualifiers) might look like: `German` instead of `German (null)`.
But will remain the same (with qualifiers): `German (Germany)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341366](https://bugs.openjdk.org/browse/JDK-8341366): Suspicious check in Locale.getDisplayName(Locale inLocale) (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21298/head:pull/21298` \
`$ git checkout pull/21298`

Update a local copy of the PR: \
`$ git checkout pull/21298` \
`$ git pull https://git.openjdk.org/jdk.git pull/21298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21298`

View PR using the GUI difftool: \
`$ git pr show -t 21298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21298.diff">https://git.openjdk.org/jdk/pull/21298.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21298#issuecomment-2387160721)