### PR TITLE
8341334: CDS: Parallel pretouch and relocation

### DIFF
--- a/src/hotspot/share/cds/archiveUtils.cpp
+++ b/src/hotspot/share/cds/archiveUtils.cpp
@@ -390,3 +390,118 @@ size_t HeapRootSegments::segment_offset(size_t seg_idx) {
   return _base_offset + seg_idx * _max_size_in_bytes;
 }
 
+ArchiveWorkers::ArchiveWorkers() :
+        _start_semaphore(0),
+        _end_semaphore(0),
+        _num_workers(MAX2(1, os::active_processor_count() / cpus_per_worker - 1)),
+        _started_workers(0),
+        _running_workers(0),
+        _in_shutdown(false),
+        _task(nullptr) {
+  // Kick off pool startup by creating a single worker.
+  start_worker_if_needed();
+}
+
+void ArchiveWorkers::shutdown() {
+  if (Atomic::cmpxchg(&_in_shutdown, false, true) == false) {
+    // Execute a shutdown task and block until all workers respond.
+    run_task(&_shutdown_task);
+  }
+}
+
+void ArchiveWorkers::start_worker_if_needed() {
+  while (true) {
+    int cur = Atomic::load(&_started_workers);
+    if (cur >= _num_workers) {
+      return;
+    }
+    if (Atomic::cmpxchg(&_started_workers, cur, cur + 1) == cur) {
+      break;
+    }
+  }
+
+  new ArchiveWorkerThread(this);
+}
+
+void ArchiveWorkers::run_task(ArchiveWorkerTask* task) {
+  assert(task == &_shutdown_task || !_in_shutdown, "Should not be shutdown");
+  assert(_task == nullptr, "Should not have running tasks");
+
+  // If max chunks is not set, put our guess there.
+  task->maybe_override_max_chunks(_num_workers * chunks_per_worker);
+
+  // Publish the task.
+  Atomic::release_store(&_task, task);
+  Atomic::store(&_running_workers, _num_workers);
+
+  // Signal workers to pick up work.
+  _start_semaphore.signal(_num_workers);
+
+  // Start executing the task ourselves, waiting for workers to catch up.
+  task->run();
+
+  // Done with our task, wait for workers to complete.
+  _end_semaphore.wait();
+
+  // All done.
+  Atomic::store(&_task, (ArchiveWorkerTask*)nullptr);
+
+  // All work done in threads should be visible to caller.
+  OrderAccess::fence();
+}
+
+void ArchiveWorkerTask::run() {
+  while (true) {
+    int chunk = Atomic::load(&_chunk);
+    if (chunk >= _max_chunks) {
+      return;
+    }
+    if (Atomic::cmpxchg(&_chunk, chunk, chunk + 1, memory_order_relaxed) == chunk) {
+      assert(0 <= chunk && chunk < _max_chunks, "Sanity");
+      work(chunk, _max_chunks);
+    }
+  }
+}
+
+void ArchiveWorkerTask::maybe_override_max_chunks(int max_chunks) {
+  if (_max_chunks == -1) {
+    _max_chunks = max_chunks;
+  }
+}
+
+bool ArchiveWorkers::run_as_worker() {
+  _start_semaphore.wait();
+
+  ArchiveWorkerTask* task = Atomic::load_acquire(&_task);
+  task->run();
+
+  // Signal the pool the tasks are complete, if this is the last worker.
+  if (Atomic::sub(&_running_workers, 1) == 0) {
+    _end_semaphore.signal();
+  }
+
+  // Continue if task was not a termination task.
+  return (task != &_shutdown_task);
+}
+
+ArchiveWorkerThread::ArchiveWorkerThread(ArchiveWorkers* pool) : NamedThread(), _pool(pool) {
+  set_name("ArchiveWorkerThread");
+  os::create_thread(this, os::os_thread);
+  os::start_thread(this);
+}
+
+void ArchiveWorkerThread::run() {
+  // Avalanche thread startup: each starting worker starts two others.
+  _pool->start_worker_if_needed();
+  _pool->start_worker_if_needed();
+
+  // Set ourselves up.
+  os::set_priority(this, NearMaxPriority);
+
+  while (_pool->run_as_worker()) {
+    // Work until terminated.
+  }
+
+  // All work done in threads should be visible to caller.
+  OrderAccess::fence();
+}

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -31,6 +31,8 @@
 #include "utilities/bitMap.hpp"
 #include "utilities/exceptions.hpp"
 #include "utilities/macros.hpp"
+#include "runtime/nonJavaThread.hpp"
+#include "runtime/semaphore.hpp"
 
 class BootstrapInfo;
 class ReservedSpace;
@@ -289,6 +291,81 @@ public:
   // This class is trivially copyable and assignable.
   HeapRootSegments(const HeapRootSegments&) = default;
   HeapRootSegments& operator=(const HeapRootSegments&) = default;
+};
+
+class ArchiveWorkers;
+
+// A task to be worked on by worker threads
+class ArchiveWorkerTask : public CHeapObj<mtInternal> {
+  friend class ArchiveWorkers;
+private:
+  const char* _name;
+  int _max_chunks;
+  volatile int _chunk;
+
+  void run();
+
+  void maybe_override_max_chunks(int max_chunks);
+
+public:
+  ArchiveWorkerTask(const char* name, int max_chunks = -1) :
+      _name(name), _max_chunks(max_chunks), _chunk(0) {}
+  const char* name() const { return _name; }
+  virtual void work(int chunk, int max_chunks) = 0;
+};
+
+class ArchiveWorkerThread : public NamedThread {
+  friend class ArchiveWorkers;
+private:
+  ArchiveWorkers* const _pool;
+
+public:
+  ArchiveWorkerThread(ArchiveWorkers* pool);
+  const char* type_name() const override { return "Archive Worker Thread"; }
+  void run() override;
+};
+
+class ArchiveWorkerShutdownTask : public ArchiveWorkerTask {
+public:
+  ArchiveWorkerShutdownTask() : ArchiveWorkerTask("Archive Worker Shutdown", 1) {}
+  void work(int chunk, int max_chunks) override {
+    // Do nothing.
+  }
+};
+
+// Special worker pool for archive workers. The goal for this pool is to
+// startup fast, distribute spiky workloads efficiently, and being able to
+// shutdown after use. This makes the implementation quite different from
+// the normal GC worker pool.
+class ArchiveWorkers {
+  friend class ArchiveWorkerThread;
+private:
+  // The reciprocal ratio for number of workers per CPU. We are targeting
+  // to take 1/4 CPUs to provide decent parallelism without letting workers
+  // stumble over each other.
+  static constexpr int cpus_per_worker = 4;
+
+  // Target number of chunks per worker. This should be large enough to even
+  // out work imbalance, and small enough to keep bookkeeping overheads low.
+  static constexpr int chunks_per_worker = 4;
+
+  ArchiveWorkerShutdownTask _shutdown_task;
+  Semaphore _start_semaphore;
+  Semaphore _end_semaphore;
+
+  int _num_workers;
+  int _started_workers;
+  int _running_workers;
+  bool _in_shutdown;
+  ArchiveWorkerTask* _task;
+
+  bool run_as_worker();
+  void start_worker_if_needed();
+
+public:
+  ArchiveWorkers();
+  void shutdown();
+  void run_task(ArchiveWorkerTask* task);
 };
 
 #endif // SHARE_CDS_ARCHIVEUTILS_HPP

--- a/src/hotspot/share/cds/filemap.cpp
+++ b/src/hotspot/share/cds/filemap.cpp
@@ -1708,19 +1708,39 @@ void FileMapInfo::close() {
     _file_open = false;
     _fd = -1;
   }
+
+  // Workers are no longer needed.
+  _archive_workers.shutdown();
 }
 
+class ArchiveRegionPretouchTask : public ArchiveWorkerTask {
+private:
+  char* const _from;
+  size_t const _bytes;
+
+public:
+  ArchiveRegionPretouchTask(char* from, size_t bytes) :
+    ArchiveWorkerTask("Archive Regions Pretouch"), _from(from), _bytes(bytes) {}
+
+  void work(int chunk, int max_chunks) override {
+    char* start = _from + MIN2(_bytes, _bytes * chunk / max_chunks);
+    char* end   = _from + MIN2(_bytes, _bytes * (chunk + 1) / max_chunks);
+    os::pretouch_memory(start, end);
+  }
+};
+
 /*
- * Same as os::map_memory() but also pretouches if AlwaysPreTouch is enabled.
+ * Same as os::map_memory() but also pretouches memory unconditionally,
+ * as we are very likely to start writing into that memory during archive load.
  */
-static char* map_memory(int fd, const char* file_name, size_t file_offset,
-                        char *addr, size_t bytes, bool read_only,
-                        bool allow_exec, MemTag mem_tag = mtNone) {
+char* FileMapInfo::map_memory(int fd, const char* file_name, size_t file_offset,
+                              char *addr, size_t bytes, bool read_only, bool allow_exec) {
   char* mem = os::map_memory(fd, file_name, file_offset, addr, bytes,
-                             AlwaysPreTouch ? false : read_only,
-                             allow_exec, mem_tag);
-  if (mem != nullptr && AlwaysPreTouch) {
-    os::pretouch_memory(mem, mem + bytes);
+                             false, // Pretouch cannot work with read-only memory.
+                             allow_exec, mtClassShared);
+  if (mem != nullptr) {
+    ArchiveRegionPretouchTask pretouch(mem, bytes);
+    _archive_workers.run_task(&pretouch);
   }
   return mem;
 }
@@ -1865,7 +1885,7 @@ MapArchiveResult FileMapInfo::map_region(int i, intx addr_delta, char* mapped_ba
     // space (Posix). See also comment in MetaspaceShared::map_archives().
     char* base = map_memory(_fd, _full_path, r->file_offset(),
                             requested_addr, size, r->read_only(),
-                            r->allow_exec(), mtClassShared);
+                            r->allow_exec());
     if (base != requested_addr) {
       log_info(cds)("Unable to map %s shared space at " INTPTR_FORMAT,
                     shared_region_name[i], p2i(requested_addr));
@@ -1893,7 +1913,7 @@ char* FileMapInfo::map_bitmap_region() {
   bool read_only = true, allow_exec = false;
   char* requested_addr = nullptr; // allow OS to pick any location
   char* bitmap_base = map_memory(_fd, _full_path, r->file_offset(),
-                                 requested_addr, r->used_aligned(), read_only, allow_exec, mtClassShared);
+                                 requested_addr, r->used_aligned(), read_only, allow_exec);
   if (bitmap_base == nullptr) {
     log_info(cds)("failed to map relocation bitmap");
     return nullptr;
@@ -1915,6 +1935,43 @@ char* FileMapInfo::map_bitmap_region() {
                 shared_region_name[MetaspaceShared::bm]);
   return bitmap_base;
 }
+
+class SharedDataRelocationTask : public ArchiveWorkerTask {
+private:
+  BitMapView* const _rw_bm;
+  BitMapView* const _ro_bm;
+  SharedDataRelocator* const _rw_reloc;
+  SharedDataRelocator* const _ro_reloc;
+
+public:
+  SharedDataRelocationTask(BitMapView* rw_bm, BitMapView* ro_bm, SharedDataRelocator* rw_reloc, SharedDataRelocator* ro_reloc) :
+                           ArchiveWorkerTask("Shared Data Relocation"),
+                           _rw_bm(rw_bm), _ro_bm(ro_bm), _rw_reloc(rw_reloc), _ro_reloc(ro_reloc) {}
+
+  void work(int chunk, int max_chunks) override {
+    BitMapView* bm;
+    SharedDataRelocator* reloc;
+    int bitmap_chunk;
+
+    // Pick up the slice from one of the bitmaps.
+    int chunks_per_bitmap = max_chunks / 2;
+    if (chunk < chunks_per_bitmap) {
+      bm = _rw_bm;
+      reloc = _rw_reloc;
+      bitmap_chunk = chunk;
+    } else {
+      // Processing RO bitmap
+      bm = _ro_bm;
+      reloc = _ro_reloc;
+      bitmap_chunk = chunk - chunks_per_bitmap;
+    }
+
+    // Process the slice.
+    BitMap::idx_t start = MIN2(bm->size(), bm->size() * bitmap_chunk / chunks_per_bitmap);
+    BitMap::idx_t end   = MIN2(bm->size(), bm->size() * (bitmap_chunk + 1) / chunks_per_bitmap);
+    bm->iterate(reloc, start, end);
+  }
+};
 
 // This is called when we cannot map the archive at the requested[ base address (usually 0x800000000).
 // We relocate all pointers in the 2 core regions (ro, rw).
@@ -1954,8 +2011,9 @@ bool FileMapInfo::relocate_pointers_in_core_regions(intx addr_delta) {
                                 valid_new_base, valid_new_end, addr_delta);
     SharedDataRelocator ro_patcher((address*)ro_patch_base + header()->ro_ptrmap_start_pos(), (address*)ro_patch_end, valid_old_base, valid_old_end,
                                 valid_new_base, valid_new_end, addr_delta);
-    rw_ptrmap.iterate(&rw_patcher);
-    ro_ptrmap.iterate(&ro_patcher);
+
+    SharedDataRelocationTask task(&rw_ptrmap, &ro_ptrmap, &rw_patcher, &ro_patcher);
+    _archive_workers.run_task(&task);
 
     // The MetaspaceShared::bm region will be unmapped in MetaspaceShared::initialize_shared_spaces().
 

--- a/src/hotspot/share/cds/filemap.hpp
+++ b/src/hotspot/share/cds/filemap.hpp
@@ -341,6 +341,8 @@ private:
   const char*    _base_archive_name;
   FileMapHeader* _header;
 
+  ArchiveWorkers _archive_workers;
+
   static SharedPathTable       _shared_path_table;
   static bool                  _validating_shared_path_table;
 
@@ -466,6 +468,9 @@ public:
   void  close();
   bool  is_open() { return _file_open; }
   ReservedSpace reserve_shared_memory();
+
+  char* map_memory(int fd, const char* file_name, size_t file_offset,
+                   char *addr, size_t bytes, bool read_only, bool allow_exec);
 
   // JVM/TI RedefineClasses() support:
   // Remap the shared readonly space to shared readwrite, private.


### PR DESCRIPTION
See the symptoms of the problem we are facing in bug description.

This PR implements the infrastructure for fast archive workers, and leverages it to do two things: 
1. Parallel pretouch of mmap-ed regions. This causes the faults we would otherwise process in a single thread to be processed in multiple threads. This gives the biggest bang in both `ArchiveRelocationMode`-s.
2. Parallel core regions relocation. The RW/RO regions this code traverses is large, and we can squeeze more performance by parallelizing it. Without pretouch from (1), this step serves as one for RW/RO regions. We can, in principle, only do the pretouch in (1), and have only a few hundred microseconds of unrealized gain.

(I'll put some performance data in the comments to show how these interact)

I think we can do parallelism for heap region relocations as well, but so far I see it is a very small fraction of time spent in loading, so I left it for future work. I think (1) covers a lot of ground for heap region relocations already.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`
 - [ ] Linux x86_64 server fastdebug, `all`