### PR TITLE
8336911: ZGC: Division by zero in heuristics after JDK-8332717

### DIFF
--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -535,7 +535,8 @@ static double calculate_young_to_old_worker_ratio(const ZDirectorStats& stats) {
   const size_t reclaimed_per_old_gc = stats._old_stats._stat_heap._reclaimed_avg;
   const double current_young_bytes_freed_per_gc_time = double(reclaimed_per_young_gc) / double(young_gc_time);
   const double current_old_bytes_freed_per_gc_time = double(reclaimed_per_old_gc) / double(old_gc_time);
-  const double old_vs_young_efficiency_ratio = current_old_bytes_freed_per_gc_time / current_young_bytes_freed_per_gc_time;
+  const double old_vs_young_efficiency_ratio = current_young_bytes_freed_per_gc_time == 0 ? std::numeric_limits<double>::infinity()
+                                                                                          : current_old_bytes_freed_per_gc_time / current_young_bytes_freed_per_gc_time;
 
   return old_vs_young_efficiency_ratio;
 }

--- a/src/hotspot/share/gc/z/zDirector.cpp
+++ b/src/hotspot/share/gc/z/zDirector.cpp
@@ -535,8 +535,20 @@ static double calculate_young_to_old_worker_ratio(const ZDirectorStats& stats) {
   const size_t reclaimed_per_old_gc = stats._old_stats._stat_heap._reclaimed_avg;
   const double current_young_bytes_freed_per_gc_time = double(reclaimed_per_young_gc) / double(young_gc_time);
   const double current_old_bytes_freed_per_gc_time = double(reclaimed_per_old_gc) / double(old_gc_time);
-  const double old_vs_young_efficiency_ratio = current_young_bytes_freed_per_gc_time == 0 ? std::numeric_limits<double>::infinity()
-                                                                                          : current_old_bytes_freed_per_gc_time / current_young_bytes_freed_per_gc_time;
+
+  if (current_young_bytes_freed_per_gc_time == 0.0) {
+    if (current_old_bytes_freed_per_gc_time == 0.0) {
+      // Neither young nor old collections have reclaimed any memory.
+      // Give them equal priority.
+      return 1.0;
+    }
+
+    // Only old collections have reclaimed memory.
+    // Prioritize old.
+    return ZOldGCThreads;
+  }
+
+  const double old_vs_young_efficiency_ratio = current_old_bytes_freed_per_gc_time / current_young_bytes_freed_per_gc_time;
 
   return old_vs_young_efficiency_ratio;
 }


### PR DESCRIPTION
When running with ubsan enabled binaries, the following issue is reported,
e.g. in test
compiler/uncommontrap/TestDeoptOOM_ZGenerational.jtr
also in gc/z/TestSmallHeap.jtr

```
jdk/src/hotspot/share/gc/z/zDirector.cpp:537:84: runtime error: division by zero
    #0 0x7f422495bd1f in calculate_young_to_old_worker_ratio src/hotspot/share/gc/z/zDirector.cpp:537
    #1 0x7f422495bd1f in select_worker_threads src/hotspot/share/gc/z/zDirector.cpp:694
    #2 0x7f42282a0d97 in select_worker_threads src/hotspot/share/gc/z/zDirector.cpp:689
    #3 0x7f42282a0d97 in initial_workers src/hotspot/share/gc/z/zDirector.cpp:784
    #4 0x7f42282a2485 in initial_workers src/hotspot/share/gc/z/zDirector.cpp:795
    #5 0x7f42282a2485 in start_minor_gc src/hotspot/share/gc/z/zDirector.cpp:797
    #6 0x7f42282a2485 in start_gc src/hotspot/share/gc/z/zDirector.cpp:826
    #7 0x7f42282a2485 in ZDirector::run_thread() src/hotspot/share/gc/z/zDirector.cpp:912
    #8 0x7f422840bdd8 in ZThread::run_service() src/hotspot/share/gc/z/zThread.cpp:29
    #9 0x7f4225ab6979 in ConcurrentGCThread::run() src/hotspot/share/gc/shared/concurrentGCThread.cpp:48
    #10 0x7f4227e1137a in Thread::call_run() src/hotspot/share/runtime/thread.cpp:225
    #11 0x7f42274619b1 in thread_native_entry src/hotspot/os/linux/os_linux.cpp:858
    #12 0x7f422c8d36e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 9a146bd267419cb6a8cf08d7c602953a0f2e12c5)
    #13 0x7f422c1dc58e in clone (/lib64/libc.so.6+0x11858e) (BuildId: f2d1cb1ef49f8c47d43a4053910ba6137673ccce)
```

The division by 0 leads to  'infinity'  on most of our platforms. So instead of relying on this behavior, we can add a small check and  set 'infinity'  for divisor == 0.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336911](https://bugs.openjdk.org/browse/JDK-8336911): ZGC: Division by zero in heuristics after JDK-8332717 (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21304/head:pull/21304` \
`$ git checkout pull/21304`

Update a local copy of the PR: \
`$ git checkout pull/21304` \
`$ git pull https://git.openjdk.org/jdk.git pull/21304/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21304`

View PR using the GUI difftool: \
`$ git pr show -t 21304`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21304.diff">https://git.openjdk.org/jdk/pull/21304.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21304#issuecomment-2388474832)