### PR TITLE
8341412: Various test failures after JDK-8334305

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/Log.java
@@ -171,6 +171,7 @@ public class Log {
      * the given <code>argsHandler</code>.
      */
     public Log(PrintStream stream, ArgumentParser argsParser) {
+        this(stream);
         traceLevel = argsParser.getTraceLevel();
     }
 


### PR DESCRIPTION
PrintStream passed in the constructor of nsk.share.Log was accidentally deleted while cleaning up verbose related code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341412](https://bugs.openjdk.org/browse/JDK-8341412): Various test failures after JDK-8334305 (**Bug** - P1)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21307/head:pull/21307` \
`$ git checkout pull/21307`

Update a local copy of the PR: \
`$ git checkout pull/21307` \
`$ git pull https://git.openjdk.org/jdk.git pull/21307/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21307`

View PR using the GUI difftool: \
`$ git pr show -t 21307`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21307.diff">https://git.openjdk.org/jdk/pull/21307.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21307#issuecomment-2388829384)