### PR TITLE
8340802: [macos] AppContentTest and SigningOptionsTest failed due to "codesign" does not fails with "--app-content" on macOS 15

### DIFF
--- a/test/jdk/tools/jpackage/macosx/SigningOptionsTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningOptionsTest.java
@@ -91,8 +91,17 @@ public final class SigningOptionsTest {
                     new String[]{"--type"},
                     "Option [--mac-installer-sign-identity] is not valid with type"},
             // --app-content and --type app-image
+            // JDK-8340802: "codesign" may or may not fail if additional
+            // content is specified based on macOS version. For example on
+            // macOS 15 aarch64 "codesign" will not fail with additional content.
+            // Since we only need to check that warning is displayed when
+            // "codesign" fails and "--app-content" is provided, lets fail
+            // "codesign" for some better reason like identity which does not
+            // exists.
             {"Hello",
-                    new String[]{"--app-content", TEST_DUKE},
+                    new String[]{"--app-content", TEST_DUKE,
+                                 "--mac-sign",
+                                 "--mac-app-image-sign-identity", "test-identity"},
                     null,
                     "\"codesign\" failed and additional application content" +
                     " was supplied via the \"--app-content\" parameter."},


### PR DESCRIPTION
- `AppContentTest` and `SigningOptionsTest` failed on macOS 15 due to `codesign` no longer fails if additional content is added to app image.
-  `SigningOptionsTest` fixed by failing `codesign` due to missing identity, since we only need to check that warning message is displayed when `codesign` fails and `--app-content` is specified.
- `AppContentTest` is fixed by setting expected exit code based on macOS version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Failed to retrieve information on issue `8340802`. Please make sure it exists and is accessible.

### Issue
 * ⚠️ Failed to retrieve information on issue `8340802`.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21311/head:pull/21311` \
`$ git checkout pull/21311`

Update a local copy of the PR: \
`$ git checkout pull/21311` \
`$ git pull https://git.openjdk.org/jdk.git pull/21311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21311`

View PR using the GUI difftool: \
`$ git pr show -t 21311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21311.diff">https://git.openjdk.org/jdk/pull/21311.diff</a>

</details>
