### PR TITLE
8341443: [macos] AppContentTest and SigningOptionsTest failed due to "codesign" does not fails with "--app-content" on macOS 15

### DIFF
--- a/test/jdk/tools/jpackage/macosx/SigningOptionsTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningOptionsTest.java
@@ -91,8 +91,17 @@ public final class SigningOptionsTest {
                     new String[]{"--type"},
                     "Option [--mac-installer-sign-identity] is not valid with type"},
             // --app-content and --type app-image
+            // JDK-8340802: "codesign" may or may not fail if additional
+            // content is specified based on macOS version. For example on
+            // macOS 15 aarch64 "codesign" will not fail with additional content.
+            // Since we only need to check that warning is displayed when
+            // "codesign" fails and "--app-content" is provided, lets fail
+            // "codesign" for some better reason like identity which does not
+            // exists.
             {"Hello",
-                    new String[]{"--app-content", TEST_DUKE},
+                    new String[]{"--app-content", TEST_DUKE,
+                                 "--mac-sign",
+                                 "--mac-app-image-sign-identity", "test-identity"},
                     null,
                     "\"codesign\" failed and additional application content" +
                     " was supplied via the \"--app-content\" parameter."},


### PR DESCRIPTION
- `AppContentTest` and `SigningOptionsTest` failed on macOS 15 due to `codesign` no longer fails if additional content is added to app image.
- `SigningOptionsTest` fixed by failing `codesign` due to missing identity, since we only need to check that warning message is displayed when codesign fails and `--app-content` is specified.
- `AppContentTest` is fixed by setting expected exit code based on macOS version.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341443](https://bugs.openjdk.org/browse/JDK-8341443): [macos] AppContentTest and SigningOptionsTest failed due to "codesign" does not fails with "--app-content" on macOS 15 (**Bug** - P3)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21313/head:pull/21313` \
`$ git checkout pull/21313`

Update a local copy of the PR: \
`$ git checkout pull/21313` \
`$ git pull https://git.openjdk.org/jdk.git pull/21313/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21313`

View PR using the GUI difftool: \
`$ git pr show -t 21313`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21313.diff">https://git.openjdk.org/jdk/pull/21313.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21313#issuecomment-2389653967)