### PR TITLE
8341053: Two CDS tests fail again with -UseCompressedOops and UseSerialGC/UseParallelGC

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -2159,7 +2159,8 @@ WB_ENTRY(jboolean, WB_IsJVMCISupportedByGC(JNIEnv* env))
 WB_END
 
 WB_ENTRY(jboolean, WB_CanWriteJavaHeapArchive(JNIEnv* env))
-  return HeapShared::can_write();
+  return HeapShared::can_write()
+      && ArchiveHeapLoader::can_use(); // work-around JDK-8341371
 WB_END
 
 


### PR DESCRIPTION
A small fix to add a check in WB_CanWriteJavaHeapArchive to allow CDS tests to run with Parallel and Serial GC. However, if compressed oops is disabled (`-XX:-UseCompressedOops`) and specified with `-XX:+UseParallelGC `or `-XX:+UseSerialGC`, the test will be skipped.

Testing:
- [x] CDS tests with `-XX:+ParallelGC`
- [x] CDS tests with `-XX:+SerialGC`
- [x] test group `open/test/hotspot/jtreg/:hotspot_cds_only` with `-XX:-UseCompressedOops`
- [x] manually checks that the failed tests in the bug report were not run with `-XX:-UseCompressedOops -XX:+UseParallel`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341053](https://bugs.openjdk.org/browse/JDK-8341053): Two CDS tests fail again with -UseCompressedOops and UseSerialGC/UseParallelGC (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21314/head:pull/21314` \
`$ git checkout pull/21314`

Update a local copy of the PR: \
`$ git checkout pull/21314` \
`$ git pull https://git.openjdk.org/jdk.git pull/21314/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21314`

View PR using the GUI difftool: \
`$ git pr show -t 21314`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21314.diff">https://git.openjdk.org/jdk/pull/21314.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21314#issuecomment-2389763847)