### PR TITLE
8341004: Open source AWT FileDialog related tests

### DIFF
--- a/test/jdk/java/awt/FileDialog/DoubleActionCloseX.java
+++ b/test/jdk/java/awt/FileDialog/DoubleActionCloseX.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.FileDialog;
+import java.awt.Frame;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 6227750
+ * @summary Tests that FileDialog can be closed by clicking the 'close' (X) button
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual DoubleActionCloseX
+ */
+
+public class DoubleActionCloseX {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                NOTE: On Linux and Mac, there is no 'close'(X) button
+                      when file dialog is visible, press Pass.
+
+                Click the 'Open File Dialog' button to open FileDialog.
+                A file dialog will appear on the screen.
+                Click on the 'close'(X) button.
+                The dialog should be closed.
+                If not, the test failed, press Fail otherwise press Pass.
+                """;
+
+        PassFailJFrame.builder()
+                .title("DoubleActionCloseX Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(DoubleActionCloseX::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+    public static Frame createUI() {
+        Frame f = new Frame("DoubleActionCloseX Test");
+        Button b = new Button("Open File Dialog");
+        FileDialog fd = new FileDialog(f);
+        b.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                fd.setVisible(true);
+            }
+        });
+        f.add(b);
+        f.setSize(300, 200);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/FileDialog/DoubleActionESC.java
+++ b/test/jdk/java/awt/FileDialog/DoubleActionESC.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+
+/*
+ * @test
+ * @bug 5097243
+ * @summary Tests that FileDialog can be closed by ESC any time
+ * @key headful
+ * @run main DoubleActionESC
+ */
+
+public class DoubleActionESC {
+    private static Frame f;
+    private static Button showBtn;
+    private static FileDialog fd;
+    private static Robot robot;
+    private static volatile Point p;
+    private static volatile Dimension d;
+    private static volatile CountDownLatch latch;
+    private static final int REPEAT_COUNT = 2;
+
+    public static void main(String[] args) throws Exception {
+        latch = new CountDownLatch(1);
+
+        robot = new Robot();
+        robot.setAutoDelay(100);
+        try {
+            EventQueue.invokeAndWait(() -> {
+                createAndShowUI();
+            });
+
+            robot.delay(1000);
+            EventQueue.invokeAndWait(() -> {
+                p = showBtn.getLocationOnScreen();
+                d = showBtn.getSize();
+            });
+
+            for (int i = 0; i < REPEAT_COUNT; ++i) {
+                Thread thread = new Thread(() -> {
+                    robot.mouseMove(p.x + d.width / 2, p.y + d.height / 2);
+                    robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+                });
+                thread.start();
+                robot.delay(3000);
+
+                Thread thread1 = new Thread(() -> {
+                    robot.keyPress(KeyEvent.VK_ESCAPE);
+                    robot.keyRelease(KeyEvent.VK_ESCAPE);
+                    robot.waitForIdle();
+                });
+                thread1.start();
+                robot.delay(3000);
+            }
+
+            latch.await();
+            if (fd.isVisible()) {
+                throw new RuntimeException("File Dialog is not closed");
+            }
+        } finally {
+            EventQueue.invokeAndWait(() -> {
+                if (f != null) {
+                    f.dispose();
+                }
+            });
+        }
+    }
+
+    public static void createAndShowUI() {
+        f = new Frame("DoubleActionESC Test");
+        showBtn = new Button("Show File Dialog");
+        fd = new FileDialog(f);
+        showBtn.addActionListener(new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                if (e.getSource() == showBtn) {
+                    fd.setSize(200, 200);
+                    fd.setLocation(200, 200);
+                    fd.setVisible(true);
+                    latch.countDown();
+                }
+            }
+        });
+        f.add(showBtn);
+        f.setSize(300, 200);
+        f.setLocationRelativeTo(null);
+        f.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/FileDialog/TestFileDialogDupJNIRef.java
+++ b/test/jdk/java/awt/FileDialog/TestFileDialogDupJNIRef.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.FileDialog;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4906972
+ * @summary Tests using of JNI reference to peer object.
+ * @requires (os.family == "windows")
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual TestFileDialogDupJNIRef
+ */
+
+public class TestFileDialogDupJNIRef {
+    public static void main(String[] args) throws Exception {
+        String INSTRUCTIONS = """
+                This is a crash test.
+                After test started you will see 'Test Frame' with one button.
+                1. Click the button to open FileDialog.
+                2. Go to the dialog and choose any directory with some files in it..
+                3. Click on any file to highlight it.
+                4. Click on the file again to rename.
+                5. Leave the file in edit mode and click Open button
+
+                If there was no crash the test passed, Press Pass.
+                """;
+
+        PassFailJFrame.builder()
+                .title("TestFileDialogDupJNIRef Instruction")
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .testUI(TestFileDialogDupJNIRef::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createUI() {
+        Frame frame = new Frame("TestFileDialogDupJNIRef Test Frame");
+        Button open = new Button("Open File Dialog");
+
+        open.addActionListener(new ActionListener() {
+                public void actionPerformed(ActionEvent e) {
+                    FileDialog fd = new FileDialog(frame);
+                    fd.setVisible(true);
+                }
+            });
+
+        frame.setLayout(new FlowLayout());
+        frame.add(open);
+        frame.setSize(250, 70);
+        return frame;
+    }
+}


### PR DESCRIPTION
AWT File Dialog related tests are converted from applet to automated/manual and moved to open.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341004](https://bugs.openjdk.org/browse/JDK-8341004): Open source AWT FileDialog related tests (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21316/head:pull/21316` \
`$ git checkout pull/21316`

Update a local copy of the PR: \
`$ git checkout pull/21316` \
`$ git pull https://git.openjdk.org/jdk.git pull/21316/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21316`

View PR using the GUI difftool: \
`$ git pr show -t 21316`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21316.diff">https://git.openjdk.org/jdk/pull/21316.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21316#issuecomment-2390496311)