### PR TITLE
8341377: Update VMProps.isCDSRuntimeOptionsCompatible to include Parallel and Serial GC

### DIFF
--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -478,12 +478,14 @@ public class VMProps implements Callable<Map<String, String>> {
         }
         String CCP_DISABLED = "-XX:-UseCompressedClassPointers";
         String G1GC_ENABLED = "-XX:+UseG1GC";
+        String PARALLELGC_ENABLED = "-XX:+UseParallelGC";
+        String SERIALGC_ENABLED = "-XX:+UseSerialGC";
         for (String opt : jtropts.split(",")) {
             if (opt.equals(CCP_DISABLED)) {
                 return false;
             }
             if (opt.startsWith(GC_PREFIX) && opt.endsWith(GC_SUFFIX) &&
-                !opt.equals(G1GC_ENABLED)) {
+                !opt.equals(G1GC_ENABLED) && !opt.equals(PARALLELGC_ENABLED) && !opt.equals(SERIALGC_ENABLED)) {
                 return false;
             }
         }


### PR DESCRIPTION
After the fix for [JDK-8298614](https://bugs.openjdk.org/browse/JDK-8298614), CDS heap dumping works with Parallel and Serial GC. The `VMProps.isCDSRuntimeOptionsCompatible` method should be updated accordingly so that some CDS tests which requires `vm.cds.write.archived.java.heap` can be run with `-XX:+UseParallelGC` or `-XX:+UseSerialGC`.

Based on my testing, 25 more CDS tests can be run with `-XX:+UseParallelGC` or `-XX:+UseSerialGC`