### PR TITLE
8341148: Open source several Choice related tests

### DIFF
--- a/test/jdk/java/awt/Choice/ChoiceInLWTest/ChoiceInLWTest.java
+++ b/test/jdk/java/awt/Choice/ChoiceInLWTest/ChoiceInLWTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4130788
+ * @summary Choice components move unexpectedly when in lightweight containers
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ChoiceInLWTest
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Choice;
+import java.awt.Container;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Label;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.lang.reflect.InvocationTargetException;
+
+public class ChoiceInLWTest extends Frame implements Runnable {
+    private final Choice choices;
+    static final String INSTRUCTIONS = """
+            After test starts wait for two seconds and open a choice.
+            If choice's popup obscures the label above it press Fail.
+            Otherwise press Pass.
+            """;
+
+    public ChoiceInLWTest() {
+        setLayout(new BorderLayout());
+        Container lwCont = new Container();
+        lwCont.setLayout(new FlowLayout());
+        choices = new Choice();
+        choices.add("This is just a token item to get a nice width.");
+        lwCont.add(choices);
+        add("Center", lwCont);
+        Label label = new Label("You should see an unobscured Choice below.");
+        label.setAlignment(Label.CENTER);
+        add("North", label);
+        addChoiceItem();
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowOpened(WindowEvent e) {
+                super.windowOpened(e);
+                new Thread(ChoiceInLWTest.this).start();
+            }
+        });
+        pack();
+    }
+
+    private void addChoiceItem() {
+        choices.add("Adding an item used to move the Choice!");
+    }
+
+    public void run() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignore) {
+        }
+        addChoiceItem();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Choice in LW Container Test")
+                .testUI(ChoiceInLWTest::new)
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+
+    }
+}

--- a/test/jdk/java/awt/Choice/MultiItemSelected/MultiItemSelected_DragOut.java
+++ b/test/jdk/java/awt/Choice/MultiItemSelected/MultiItemSelected_DragOut.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6367251
+ * @summary 2 items are highlighted when pressing, dragging the mouse inside the choice, XToolkit
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MultiItemSelected_DragOut
+ */
+
+import java.awt.Choice;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.lang.reflect.InvocationTargetException;
+
+public class MultiItemSelected_DragOut extends Frame {
+    static final String INSTRUCTIONS = """
+            1) Open Choice.
+            2) Start drag from first item to second or third one.
+            3) Without releasing left mouse button
+               press and release right mouse button.
+            4) Release left mouse button.
+            5) Open choice again.
+            6) If there is only one selection cursor
+               in the dropdown list press Pass otherwise press Fail.
+            """;
+
+    public MultiItemSelected_DragOut() {
+        Choice choice = new Choice();
+
+        for (int i = 1; i < 10; i++) {
+            choice.add("item " + i);
+        }
+        add(choice);
+        choice.addItemListener(ie -> System.out.println(ie));
+
+        setLayout(new FlowLayout());
+        setSize(200, 200);
+        validate();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("MultiItemSelected Drag Out Test")
+                .testUI(MultiItemSelected_DragOut::new)
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/Choice/MultiItemSelected/MultiItemSelected_KeySelect.java
+++ b/test/jdk/java/awt/Choice/MultiItemSelected/MultiItemSelected_KeySelect.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6367251
+ * @summary 2 items are highlighted when dragging inside and press ESC or ENTER
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MultiItemSelected_KeySelect
+ */
+
+import java.awt.Choice;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.lang.reflect.InvocationTargetException;
+
+public class MultiItemSelected_KeySelect extends Frame {
+    static final String INSTRUCTIONS = """
+            1) Open Choice.
+            2) Start drag from first item to another one.
+            3) Without releasing the mouse button press ESC key.
+            4) Open choice again.
+            5) Verify that there is only one
+               selection cursor in the dropdown list.
+            6) Repeat steps 2-5 once again but  this time
+               press ENTER key instead of ESC.
+            7) If in both scenarios there is only one selection cursor
+               press Pass otherwise press Fail.
+            """;
+
+    public MultiItemSelected_KeySelect() {
+        Choice choice = new Choice();
+
+        for (int i = 1; i < 10; i++) {
+            choice.add("item " + i);
+        }
+        add(choice);
+        choice.addItemListener(ie -> System.out.println(ie));
+        setLayout(new FlowLayout());
+        setSize(200, 200);
+        validate();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("MultiItemSelected Key Select Test")
+                .testUI(MultiItemSelected_KeySelect::new)
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/Choice/MultiItemSelected/MultiItemSelected_UpDown.java
+++ b/test/jdk/java/awt/Choice/MultiItemSelected/MultiItemSelected_UpDown.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6367251
+ * @summary 2 items are highlighted when dragging outside and press UP or DOWN
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MultiItemSelected_UpDown
+ */
+
+import java.awt.Choice;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.lang.reflect.InvocationTargetException;
+
+public class MultiItemSelected_UpDown extends Frame {
+    static final String INSTRUCTIONS = """
+            1) Open Choice.
+            2) Start drag from first item to another one.
+            3) Without interrupting drag
+               move mouse cursor outside the choice popup.
+            4) Press UP, DOWN key several times to position
+               selection cursor to a different item.
+            5) Release mouse button.
+            6) If popup is closed upon mouse button release open Choice again.
+            7) Verify that there is only one
+               selection cursor in the dropdown list.
+            8) If true then press Pass, otherwise press Fail.
+            """;
+
+    public MultiItemSelected_UpDown() {
+        Choice choice = new Choice();
+
+        for (int i = 1; i < 20; i++) {
+            choice.add(" item " + i);
+        }
+        add(choice);
+        choice.addItemListener(ie -> System.out.println(ie));
+        setLayout(new FlowLayout());
+        setSize(200, 200);
+        validate();
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("MultiItemSelected Up/Down Test")
+                .testUI(MultiItemSelected_UpDown::new)
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
+}

--- a/test/jdk/java/awt/Choice/RepaintAfterRemoveLastItemTest/RepaintAfterRemoveLastItemTest.java
+++ b/test/jdk/java/awt/Choice/RepaintAfterRemoveLastItemTest/RepaintAfterRemoveLastItemTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6292186
+ * @summary Choice is not refreshed properly when the last item gets removed
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual RepaintAfterRemoveLastItemTest
+ */
+
+import java.awt.Button;
+import java.awt.Choice;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.lang.reflect.InvocationTargetException;
+
+public class RepaintAfterRemoveLastItemTest extends Frame implements ActionListener {
+    Choice ch = new Choice();
+
+    static final String INSTRUCTIONS = """
+            Press on the 'remove' button after that if the choice does not display
+            'only item' press Pass. If 'only item' is still displayed press Fail.
+            """;
+
+    public RepaintAfterRemoveLastItemTest() {
+        ch.add("only item");
+        add(ch);
+
+        Button b = new Button("remove");
+        add(b);
+        b.addActionListener(this);
+        setLayout(new FlowLayout());
+        setSize(200, 200);
+        validate();
+    }
+
+    public void actionPerformed(ActionEvent ae) {
+        if (ch.getItemCount() != 0) {
+            ch.remove(0);
+        }
+    }
+
+    public static void main(String[] args) throws InterruptedException,
+            InvocationTargetException {
+        PassFailJFrame.builder()
+                .title("Repaint After Remove Test")
+                .testUI(RepaintAfterRemoveLastItemTest::new)
+                .instructions(INSTRUCTIONS)
+                .columns(40)
+                .build()
+                .awaitAndCheck();
+    }
+}


### PR DESCRIPTION
Clean up and open source five tests related to the AWT Choice component

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341148](https://bugs.openjdk.org/browse/JDK-8341148): Open source several Choice related tests (**Bug** - P4)


### Reviewers
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21318/head:pull/21318` \
`$ git checkout pull/21318`

Update a local copy of the PR: \
`$ git checkout pull/21318` \
`$ git pull https://git.openjdk.org/jdk.git pull/21318/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21318`

View PR using the GUI difftool: \
`$ git pr show -t 21318`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21318.diff">https://git.openjdk.org/jdk/pull/21318.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21318#issuecomment-2390658284)