### PR TITLE
8341451: Remove C2HandleAnonOMOwnerStub

### DIFF
--- a/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/c2_CodeStubs_aarch64.cpp
@@ -64,31 +64,4 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ emit_int32(0);   // nmethod guard value
 }
 
-int C2HandleAnonOMOwnerStub::max_size() const {
-  // Max size of stub has been determined by testing with 0, in which case
-  // C2CodeStubList::emit() will throw an assertion and report the actual size that
-  // is needed.
-  return 24;
-}
-
-void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
-  __ bind(entry());
-  Register mon = monitor();
-  Register t = tmp();
-  assert(t != noreg, "need tmp register");
-
-  // Fix owner to be the current thread.
-  __ str(rthread, Address(mon, ObjectMonitor::owner_offset()));
-
-  // Pop owner object from lock-stack.
-  __ ldrw(t, Address(rthread, JavaThread::lock_stack_top_offset()));
-  __ subw(t, t, oopSize);
-#ifdef ASSERT
-  __ str(zr, Address(rthread, t));
-#endif
-  __ strw(t, Address(rthread, JavaThread::lock_stack_top_offset()));
-
-  __ b(continuation());
-}
-
 #undef __

--- a/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
@@ -71,32 +71,4 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   __ emit_int32(0);  // nmethod guard value
 }
 
-int C2HandleAnonOMOwnerStub::max_size() const {
-  // Max size of stub has been determined by testing with 0 without using RISC-V compressed
-  // instruction-set extension, in which case C2CodeStubList::emit() will throw an assertion
-  // and report the actual size that is needed.
-  return 20 DEBUG_ONLY(+8);
-}
-
-void C2HandleAnonOMOwnerStub::emit(C2_MacroAssembler& masm) {
-  __ bind(entry());
-  Register mon = monitor();
-  Register t = tmp();
-  assert(t != noreg, "need tmp register");
-
-  // Fix owner to be the current thread.
-  __ sd(xthread, Address(mon, ObjectMonitor::owner_offset()));
-
-  // Pop owner object from lock-stack.
-  __ lwu(t, Address(xthread, JavaThread::lock_stack_top_offset()));
-  __ subw(t, t, oopSize);
-#ifdef ASSERT
-  __ add(t0, xthread, t);
-  __ sd(zr, Address(t0, 0));
-#endif
-  __ sw(t, Address(xthread, JavaThread::lock_stack_top_offset()));
-
-  __ j(continuation());
-}
-
 #undef __

--- a/src/hotspot/share/opto/c2_CodeStubs.hpp
+++ b/src/hotspot/share/opto/c2_CodeStubs.hpp
@@ -117,21 +117,6 @@ public:
   Label& slow_path_continuation() { return continuation(); }
 };
 
-#ifdef _LP64
-class C2HandleAnonOMOwnerStub : public C2CodeStub {
-private:
-  Register _monitor;
-  Register _tmp;
-public:
-  C2HandleAnonOMOwnerStub(Register monitor, Register tmp = noreg) : C2CodeStub(),
-    _monitor(monitor), _tmp(tmp) {}
-  Register monitor() { return _monitor; }
-  Register tmp() { return _tmp; }
-  int max_size() const;
-  void emit(C2_MacroAssembler& masm);
-};
-#endif
-
 //-----------------------------C2GeneralStub-----------------------------------
 // A generalized stub that can be used to implement an arbitrary stub in a
 // type-safe manner. An example:


### PR DESCRIPTION
[JDK-8319796](https://bugs.openjdk.org/browse/JDK-8319796) has been implemented on all platforms which had previous C2 implementations of LM_LIGHTWEIGHT that made use of C2HandleAnonOMOwnerStub.

The declaration is still left in the shared code, an a couple of platforms have the definitions still lingering. I propose we remove them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341451](https://bugs.openjdk.org/browse/JDK-8341451): Remove C2HandleAnonOMOwnerStub (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21319/head:pull/21319` \
`$ git checkout pull/21319`

Update a local copy of the PR: \
`$ git checkout pull/21319` \
`$ git pull https://git.openjdk.org/jdk.git pull/21319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21319`

View PR using the GUI difftool: \
`$ git pr show -t 21319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21319.diff">https://git.openjdk.org/jdk/pull/21319.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21319#issuecomment-2390693754)