### PR TITLE
8341178: TypeRawPtr::add_offset may be "miscompiled" due to UB

### DIFF
--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3222,8 +3222,6 @@ const TypePtr* TypeRawPtr::add_offset(intptr_t offset) const {
   case TypePtr::BotPTR:
   case TypePtr::NotNull:
     return this;
-  case TypePtr::Null:
-    return make( (address)offset );
   case TypePtr::Constant: {
     uintptr_t bits = (uintptr_t)_bits;
     uintptr_t sum = bits + offset;

--- a/src/hotspot/share/opto/type.cpp
+++ b/src/hotspot/share/opto/type.cpp
@@ -3132,8 +3132,8 @@ const TypeRawPtr *TypeRawPtr::make( enum PTR ptr ) {
   return (TypeRawPtr*)(new TypeRawPtr(ptr,nullptr))->hashcons();
 }
 
-const TypeRawPtr *TypeRawPtr::make( address bits ) {
-  assert( bits != nullptr, "Use TypePtr for null" );
+const TypeRawPtr *TypeRawPtr::make(address bits) {
+  assert(bits != nullptr, "Use TypePtr for null");
   return (TypeRawPtr*)(new TypeRawPtr(Constant,bits))->hashcons();
 }
 


### PR DESCRIPTION
Please review this change to TypeRawPtr::add_offset to prevent a compiler from
inferring things based on prior pointer arithmetic not invoking UB.  As noted in
the bug report, clang is actually doing this.

To accomplish this, changed to integral arithmetic.  Also added over/underflow
checks.

Also made a couple of minor touchups.  Replaced an implicit conversion to bool
with an explicit compare to nullptr (per style guide).  Removed a no longer
needed dummy return after a (now) noreturn function.

Testing: mach5 tier1-7
That testing was with calls to "fatal" for the over/underflow cases and the
sum==0 case.  There were no hits.  I'm not sure how to construct a test that
would hit those.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341178](https://bugs.openjdk.org/browse/JDK-8341178): TypeRawPtr::add_offset may be "miscompiled" due to UB (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [cc1f2ac8](https://git.openjdk.org/jdk/pull/21324/files/cc1f2ac8b0ea234feef5f58f7a01e93290b14735)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21324/head:pull/21324` \
`$ git checkout pull/21324`

Update a local copy of the PR: \
`$ git checkout pull/21324` \
`$ git pull https://git.openjdk.org/jdk.git pull/21324/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21324`

View PR using the GUI difftool: \
`$ git pr show -t 21324`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21324.diff">https://git.openjdk.org/jdk/pull/21324.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21324#issuecomment-2391355195)