### PR TITLE
8341444: Unnecessary check for JSRs in CDS

### DIFF
--- a/src/hotspot/share/interpreter/bytecodeStream.hpp
+++ b/src/hotspot/share/interpreter/bytecodeStream.hpp
@@ -195,7 +195,7 @@ class BytecodeStream: public BaseBytecodeStream {
       int len = Bytecodes::length_for(code);
       if (len == 0) len = Bytecodes::length_at(_method(), bcp);
       if (len <= 0 || (_bci > _end_bci - len) || (_bci - len >= _next_bci)) {
-        raw_code = code = Bytecodes::_illegal;
+        fatal("Should have been caught by verifier");
       } else {
         _next_bci  += len;
         assert(_bci < _next_bci, "length must be > 0");

--- a/src/hotspot/share/interpreter/bytecodeStream.hpp
+++ b/src/hotspot/share/interpreter/bytecodeStream.hpp
@@ -195,7 +195,7 @@ class BytecodeStream: public BaseBytecodeStream {
       int len = Bytecodes::length_for(code);
       if (len == 0) len = Bytecodes::length_at(_method(), bcp);
       if (len <= 0 || (_bci > _end_bci - len) || (_bci - len >= _next_bci)) {
-        fatal("Should have been caught by verifier");
+        raw_code = code = Bytecodes::_illegal;
       } else {
         _next_bci  += len;
         assert(_bci < _next_bci, "length must be > 0");

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2455,8 +2455,7 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
   // be rewritten during runtime (see Rewriter::rewrite_jsrs()). So setting the _methods to
   // be writable. The length check on the _methods is necessary because classes which
   // don't have any methods share the Universe::_the_empty_method_array which is in the RO region.
-  if (_methods != nullptr && _methods->length() > 0 &&
-      !can_be_verified_at_dumptime() && methods_contain_jsr_bytecode()) {
+  if (_methods != nullptr && _methods->length() > 0 && !can_be_verified_at_dumptime()) {
     // To handle jsr bytecode, new Method* maybe stored into _methods
     it->push(&_methods, MetaspaceClosure::_writable);
   } else {
@@ -2696,21 +2695,6 @@ bool InstanceKlass::can_be_verified_at_dumptime() const {
     }
   }
   return true;
-}
-
-bool InstanceKlass::methods_contain_jsr_bytecode() const {
-  Thread* thread = Thread::current();
-  for (int i = 0; i < _methods->length(); i++) {
-    methodHandle m(thread, _methods->at(i));
-    BytecodeStream bcs(m);
-    while (!bcs.is_last_bytecode()) {
-      Bytecodes::Code opcode = bcs.next();
-      if (opcode == Bytecodes::_jsr || opcode == Bytecodes::_jsr_w) {
-        return true;
-      }
-    }
-  }
-  return false;
 }
 #endif // INCLUDE_CDS
 

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2452,9 +2452,10 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
 #endif
 #if INCLUDE_CDS
   // For "old" classes with methods containing the jsr bytecode, the _methods array will
-  // be rewritten during runtime (see Rewriter::rewrite_jsrs()). So setting the _methods to
-  // be writable. The length check on the _methods is necessary because classes which
-  // don't have any methods share the Universe::_the_empty_method_array which is in the RO region.
+  // be rewritten during runtime (see Rewriter::rewrite_jsrs()) but they cannot be safely
+  // checked here. All the _methods that can't be verified are made writable. The length
+  // check on the _methods is necessary because classes which don't have any methods share
+  // the Universe::_the_empty_method_array which is in the RO region.
   if (_methods != nullptr && _methods->length() > 0 && !can_be_verified_at_dumptime()) {
     // To handle jsr bytecode, new Method* maybe stored into _methods
     it->push(&_methods, MetaspaceClosure::_writable);

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -2453,9 +2453,9 @@ void InstanceKlass::metaspace_pointers_do(MetaspaceClosure* it) {
 #if INCLUDE_CDS
   // For "old" classes with methods containing the jsr bytecode, the _methods array will
   // be rewritten during runtime (see Rewriter::rewrite_jsrs()) but they cannot be safely
-  // checked here. All the _methods that can't be verified are made writable. The length
-  // check on the _methods is necessary because classes which don't have any methods share
-  // the Universe::_the_empty_method_array which is in the RO region.
+  // checked here with ByteCodeStream. All methods that can't be verified are made writable.
+  // The length check on the _methods is necessary because classes which don't have any
+  // methods share the Universe::_the_empty_method_array which is in the RO region.
   if (_methods != nullptr && _methods->length() > 0 && !can_be_verified_at_dumptime()) {
     // To handle jsr bytecode, new Method* maybe stored into _methods
     it->push(&_methods, MetaspaceClosure::_writable);

--- a/src/hotspot/share/oops/instanceKlass.hpp
+++ b/src/hotspot/share/oops/instanceKlass.hpp
@@ -1116,7 +1116,6 @@ public:
   void restore_unshareable_info(ClassLoaderData* loader_data, Handle protection_domain, PackageEntry* pkg_entry, TRAPS);
   void init_shared_package_entry();
   bool can_be_verified_at_dumptime() const;
-  bool methods_contain_jsr_bytecode() const;
   void compute_has_loops_flag_for_methods();
 #endif
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341444](https://bugs.openjdk.org/browse/JDK-8341444): Unnecessary check for JSRs in CDS (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [8b599317](https://git.openjdk.org/jdk/pull/21330/files/8b599317fe6f1430bd19b06c5a511cf39453d439)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21330/head:pull/21330` \
`$ git checkout pull/21330`

Update a local copy of the PR: \
`$ git checkout pull/21330` \
`$ git pull https://git.openjdk.org/jdk.git pull/21330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21330`

View PR using the GUI difftool: \
`$ git pr show -t 21330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21330.diff">https://git.openjdk.org/jdk/pull/21330.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21330#issuecomment-2392254929)