### PR TITLE
8341484: TimeZone.toZoneId() throws exception when using old mapping for "HST"

### DIFF
--- a/src/java.base/share/classes/java/util/TimeZone.java
+++ b/src/java.base/share/classes/java/util/TimeZone.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -600,7 +600,7 @@ public abstract class TimeZone implements Serializable, Cloneable {
             if ("MST".equals(id))
                 return ZoneId.of("America/Denver");
             if ("HST".equals(id))
-                return ZoneId.of("America/Honolulu");
+                return ZoneId.of("Pacific/Honolulu");
         }
         return ZoneId.of(id, ZoneId.SHORT_IDS);
     }


### PR DESCRIPTION
Please review this PR which fixes an unexpected exception for `TimeZone.toZoneId("HST")` when the old mapping system property is used.

The culprit is in `TimeZone.toZoneId0()`.

This method provides workarounds for "EST", "MST", and "HST" when the old mapping system property is true. However, it seems that "HST" was added with "America/Honolulu" when it should have been "Pacific/Honolulu".

Added a basic test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341484](https://bugs.openjdk.org/browse/JDK-8341484): TimeZone.toZoneId() throws exception when using old mapping for "HST" (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21332/head:pull/21332` \
`$ git checkout pull/21332`

Update a local copy of the PR: \
`$ git checkout pull/21332` \
`$ git pull https://git.openjdk.org/jdk.git pull/21332/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21332`

View PR using the GUI difftool: \
`$ git pr show -t 21332`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21332.diff">https://git.openjdk.org/jdk/pull/21332.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21332#issuecomment-2392214155)