### PR TITLE
8341489: ProblemList runtime/cds/appcds/DumpRuntimeClassesTest.java in Xcomp mode

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -54,4 +54,6 @@ compiler/cha/TypeProfileFinalMethod.java 8341039 generic-all
 
 gc/arguments/TestNewSizeFlags.java 8299116 macosx-aarch64
 
+runtime/cds/appcds/DumpRuntimeClassesTest.java 8341452 generic-all
+
 runtime/condy/escapeAnalysis/TestEscapeCondy.java 8339694 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList runtime/cds/appcds/DumpRuntimeClassesTest.java in Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341489](https://bugs.openjdk.org/browse/JDK-8341489): ProblemList runtime/cds/appcds/DumpRuntimeClassesTest.java in Xcomp mode (**Sub-task** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21333/head:pull/21333` \
`$ git checkout pull/21333`

Update a local copy of the PR: \
`$ git checkout pull/21333` \
`$ git pull https://git.openjdk.org/jdk.git pull/21333/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21333`

View PR using the GUI difftool: \
`$ git pr show -t 21333`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21333.diff">https://git.openjdk.org/jdk/pull/21333.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21333#issuecomment-2392243385)