### PR TITLE
8341510: Optimize StackMapGenerator::processFieldInstructions

### DIFF
--- a/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantDynamicEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/ConstantDynamicEntry.java
@@ -50,7 +50,7 @@ public sealed interface ConstantDynamicEntry
      * {@return a symbolic descriptor for the dynamic constant's type}
      */
     default ClassDesc typeSymbol() {
-        return Util.fieldTypeSymbol(nameAndType());
+        return Util.fieldTypeSymbol(type());
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/classfile/constantpool/FieldRefEntry.java
+++ b/src/java.base/share/classes/java/lang/classfile/constantpool/FieldRefEntry.java
@@ -44,6 +44,6 @@ public sealed interface FieldRefEntry extends MemberRefEntry
      * {@return a symbolic descriptor for the field's type}
      */
     default ClassDesc typeSymbol() {
-        return Util.fieldTypeSymbol(nameAndType());
+        return Util.fieldTypeSymbol(type());
     }
 }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -756,22 +756,20 @@ public final class StackMapGenerator {
     }
 
     private void processFieldInstructions(RawBytecodeHelper bcs) {
-        var desc = Util.fieldTypeSymbol(cp.entryByIndex(bcs.getIndexU2(), MemberRefEntry.class).nameAndType());
+        var desc = Util.fieldTypeSymbol(cp.entryByIndex(bcs.getIndexU2(), MemberRefEntry.class).type());
+        var currentFrame = this.currentFrame;
         switch (bcs.opcode()) {
             case GETSTATIC ->
                 currentFrame.pushStack(desc);
             case PUTSTATIC -> {
-                currentFrame.popStack();
-                if (Util.isDoubleSlot(desc)) currentFrame.popStack();
+                currentFrame.decStack(Util.isDoubleSlot(desc) ? 2 : 1);
             }
             case GETFIELD -> {
-                currentFrame.popStack();
+                currentFrame.decStack(1);
                 currentFrame.pushStack(desc);
             }
             case PUTFIELD -> {
-                currentFrame.popStack();
-                currentFrame.popStack();
-                if (Util.isDoubleSlot(desc)) currentFrame.popStack();
+                currentFrame.decStack(Util.isDoubleSlot(desc) ? 3 : 2);
             }
             default -> throw new AssertionError("Should not reach here");
         }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/Util.java
@@ -231,10 +231,6 @@ public class Util {
         return ((AbstractPoolEntry.Utf8EntryImpl) utf8).methodTypeSymbol();
     }
 
-    public static ClassDesc fieldTypeSymbol(NameAndTypeEntry nat) {
-        return fieldTypeSymbol(nat.type());
-    }
-
     public static MethodTypeDesc methodTypeSymbol(NameAndTypeEntry nat) {
         return methodTypeSymbol(nat.type());
     }


### PR DESCRIPTION
A small optimization to reduce CodeSize, codeSize reduced from 164 to 140.

1. Use local currentFrame to avoid multiple getfields
2. Use decStack instead of popStack to reduce array access in popStack
3. Call Util.fieldTypeSymbol to pass in type instead of nameAndType

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341510](https://bugs.openjdk.org/browse/JDK-8341510): Optimize StackMapGenerator::processFieldInstructions (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21345/head:pull/21345` \
`$ git checkout pull/21345`

Update a local copy of the PR: \
`$ git checkout pull/21345` \
`$ git pull https://git.openjdk.org/jdk.git pull/21345/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21345`

View PR using the GUI difftool: \
`$ git pr show -t 21345`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21345.diff">https://git.openjdk.org/jdk/pull/21345.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21345#issuecomment-2392733376)