### PR TITLE
8341483: Clarify special case handling of Types.getArrayType

### DIFF
--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -263,7 +263,9 @@ public interface Types {
      *
      * @param componentType  the component type
      * @throws IllegalArgumentException if the component type is not valid for
-     *          an array, including executable, package, module, and wildcard types
+     *          an array. All valid types are {@linkplain ReferenceType
+     *          reference types} or {@linkplain PrimitiveType primitive types}.
+     *          Invalid types include null, executable, package, module, and wildcard types.
      * @jls 10.1 Array Types
      */
     ArrayType getArrayType(TypeMirror componentType);

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -265,7 +265,8 @@ public interface Types {
      * @throws IllegalArgumentException if the component type is not valid for
      *          an array. All valid types are {@linkplain ReferenceType
      *          reference types} or {@linkplain PrimitiveType primitive types}.
-     *          Invalid types include null, executable, package, module, and wildcard types.
+     *          Invalid types include {@linkplain NullType null}, executable, package,
+     *          module, and wildcard types.
      * @jls 10.1 Array Types
      */
     ArrayType getArrayType(TypeMirror componentType);

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/model/JavacTypes.java
@@ -193,10 +193,14 @@ public class JavacTypes implements javax.lang.model.util.Types {
     public ArrayType getArrayType(TypeMirror componentType) {
         switch (componentType.getKind()) {
         case VOID:
+        case NONE:
+        case NULL:
         case EXECUTABLE:
         case WILDCARD:  // heh!
         case PACKAGE:
         case MODULE:
+        case UNION:
+        case INTERSECTION:
             throw new IllegalArgumentException(componentType.toString());
         }
         return new Type.ArrayType((Type) componentType, syms.arrayClass);


### PR DESCRIPTION
Add specification and tests for invalid inputs to getArrayType that generation an exception. As initially written, this PR changes the behavior on NONE and the null type.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change requires CSR request [JDK-8341511](https://bugs.openjdk.org/browse/JDK-8341511) to be approved
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8341483](https://bugs.openjdk.org/browse/JDK-8341483): Clarify special case handling of Types.getArrayType (**Sub-task** - P4)
 * [JDK-8341511](https://bugs.openjdk.org/browse/JDK-8341511): Clarify special case handling of Types.getArrayType (**CSR**)


### Reviewers
 * [Dan Smith](https://openjdk.org/census#dlsmith) (@dansmithcode - Committer) Review applies to [222cfa97](https://git.openjdk.org/jdk/pull/21346/files/222cfa97aa0a8690436dfcf037fed7c749f514f1)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21346/head:pull/21346` \
`$ git checkout pull/21346`

Update a local copy of the PR: \
`$ git checkout pull/21346` \
`$ git pull https://git.openjdk.org/jdk.git pull/21346/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21346`

View PR using the GUI difftool: \
`$ git pr show -t 21346`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21346.diff">https://git.openjdk.org/jdk/pull/21346.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21346#issuecomment-2392756393)