### PR TITLE
8340445: [PPC64] Wrong ConditionRegister used in ppc64.ad: flagsRegCR0 cr1

### DIFF
--- a/src/hotspot/cpu/ppc/ppc.ad
+++ b/src/hotspot/cpu/ppc/ppc.ad
@@ -12281,7 +12281,7 @@ instruct string_equalsL(rarg1RegP str1, rarg2RegP str2, rarg3RegI cnt, iRegIdst 
 %}
 
 instruct array_equalsB(rarg1RegP ary1, rarg2RegP ary2, iRegIdst result,
-                       iRegIdst tmp1, iRegIdst tmp2, regCTR ctr, flagsRegCR0 cr0, flagsRegCR0 cr1) %{
+                       iRegIdst tmp1, iRegIdst tmp2, regCTR ctr, flagsRegCR0 cr0, flagsRegCR1 cr1) %{
   predicate(((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (AryEq ary1 ary2));
   effect(TEMP_DEF result, USE_KILL ary1, USE_KILL ary2, TEMP tmp1, TEMP tmp2, KILL ctr, KILL cr0, KILL cr1);
@@ -12296,7 +12296,7 @@ instruct array_equalsB(rarg1RegP ary1, rarg2RegP ary2, iRegIdst result,
 %}
 
 instruct array_equalsC(rarg1RegP ary1, rarg2RegP ary2, iRegIdst result,
-                       iRegIdst tmp1, iRegIdst tmp2, regCTR ctr, flagsRegCR0 cr0, flagsRegCR0 cr1) %{
+                       iRegIdst tmp1, iRegIdst tmp2, regCTR ctr, flagsRegCR0 cr0, flagsRegCR1 cr1) %{
   predicate(((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (AryEq ary1 ary2));
   effect(TEMP_DEF result, USE_KILL ary1, USE_KILL ary2, TEMP tmp1, TEMP tmp2, KILL ctr, KILL cr0, KILL cr1);


### PR DESCRIPTION
This PR changes array_equalsB and array_equalsC to use flagsRegCR1 instead of flagsRegCR0 for KILL effects. This change enhances clarity while maintaining current functionality.

Build(release debug level) and tier1 testing are successful 

JBS Issue: [JDK-8340445](https://bugs.openjdk.org/browse/JDK-8340445)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340445](https://bugs.openjdk.org/browse/JDK-8340445): [PPC64] Wrong ConditionRegister used in ppc64.ad: flagsRegCR0 cr1 (**Bug** - P5)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21353/head:pull/21353` \
`$ git checkout pull/21353`

Update a local copy of the PR: \
`$ git checkout pull/21353` \
`$ git pull https://git.openjdk.org/jdk.git pull/21353/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21353`

View PR using the GUI difftool: \
`$ git pr show -t 21353`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21353.diff">https://git.openjdk.org/jdk/pull/21353.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21353#issuecomment-2429975138)