### PR TITLE
8341548: More concise use of classfile API

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -394,9 +394,8 @@ import sun.invoke.util.Wrapper;
                            .invokespecial(CD_Object, INIT_NAME, MTD_void);
                         int parameterCount = factoryType.parameterCount();
                         for (int i = 0; i < parameterCount; i++) {
-                            cob.aload(0);
-                            Class<?> argType = factoryType.parameterType(i);
-                            cob.loadLocal(TypeKind.from(argType), cob.parameterSlot(i))
+                            cob.aload(0)
+                               .loadLocal(TypeKind.from(factoryType.parameterType(i)), cob.parameterSlot(i))
                                .putfield(pool.fieldRefEntry(lambdaClassEntry, pool.nameAndTypeEntry(argNames[i], argDescs[i])));
                         }
                         cob.return_();

--- a/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
+++ b/src/java.base/share/classes/java/lang/invoke/InnerClassLambdaMetafactory.java
@@ -396,8 +396,8 @@ import sun.invoke.util.Wrapper;
                         for (int i = 0; i < parameterCount; i++) {
                             cob.aload(0);
                             Class<?> argType = factoryType.parameterType(i);
-                            cob.loadLocal(TypeKind.from(argType), cob.parameterSlot(i));
-                            cob.putfield(pool.fieldRefEntry(lambdaClassEntry, pool.nameAndTypeEntry(argNames[i], argDescs[i])));
+                            cob.loadLocal(TypeKind.from(argType), cob.parameterSlot(i))
+                               .putfield(pool.fieldRefEntry(lambdaClassEntry, pool.nameAndTypeEntry(argNames[i], argDescs[i])));
                         }
                         cob.return_();
                     }

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -891,10 +891,9 @@ class InvokerBytecodeGenerator {
         emitStaticInvoke(cob, invokeBasicName);
 
         // goto L_done
-        cob.goto_w(L_done);
-
-        // L_fallback:
-        cob.labelBinding(L_fallback);
+        cob.goto_w(L_done)
+           // L_fallback:
+           .labelBinding(L_fallback);
 
         // invoke selectAlternativeName.arguments[2]
         System.arraycopy(preForkClasses, 0, localClasses, 0, preForkClasses.length);
@@ -945,26 +944,23 @@ class InvokerBytecodeGenerator {
                               .dropParameterTypes(0,1)
                               .changeReturnType(returnType);
 
-        cob.exceptionCatch(L_startBlock, L_endBlock, L_handler, CD_Throwable);
-
-        // Normal case
-        cob.labelBinding(L_startBlock);
+        cob.exceptionCatch(L_startBlock, L_endBlock, L_handler, CD_Throwable)
+           // Normal case
+           .labelBinding(L_startBlock);
         // load target
         emitPushArgument(cob, invoker, 0);
         emitPushArguments(cob, args, 1); // skip 1st argument: method handle
-        cob.invokevirtual(CD_MethodHandle, "invokeBasic", methodDesc(type.basicType()));
-        cob.labelBinding(L_endBlock);
-        cob.goto_w(L_done);
-
-        // Exceptional case
-        cob.labelBinding(L_handler);
-
-        // Check exception's type
-        cob.dup();
+        cob.invokevirtual(CD_MethodHandle, "invokeBasic", methodDesc(type.basicType()))
+           .labelBinding(L_endBlock)
+           .goto_w(L_done)
+           // Exceptional case
+           .labelBinding(L_handler)
+           // Check exception's type
+           .dup();
         // load exception class
         emitPushArgument(cob, invoker, 1);
-        cob.swap();
-        cob.invokevirtual(CD_Class, "isInstance", MTD_boolean_Object);
+        cob.swap()
+           .invokevirtual(CD_Class, "isInstance", MTD_boolean_Object);
         Label L_rethrow = cob.newLabel();
         cob.ifeq(L_rethrow);
 
@@ -974,13 +970,11 @@ class InvokerBytecodeGenerator {
         cob.swap();
         emitPushArguments(cob, args, 1); // skip 1st argument: method handle
         MethodType catcherType = type.insertParameterTypes(0, Throwable.class);
-        cob.invokevirtual(CD_MethodHandle, "invokeBasic", methodDesc(catcherType.basicType()));
-        cob.goto_w(L_done);
-
-        cob.labelBinding(L_rethrow);
-        cob.athrow();
-
-        cob.labelBinding(L_done);
+        cob.invokevirtual(CD_MethodHandle, "invokeBasic", methodDesc(catcherType.basicType()))
+           .goto_w(L_done)
+           .labelBinding(L_rethrow)
+           .athrow()
+           .labelBinding(L_done);
 
         return result;
     }
@@ -1075,8 +1069,8 @@ class InvokerBytecodeGenerator {
         cob.labelBinding(lFrom);
         emitPushArgument(cob, invoker, 0); // load target
         emitPushArguments(cob, args, 1); // load args (skip 0: method handle)
-        cob.invokevirtual(CD_MethodHandle, "invokeBasic", methodDesc(type.basicType()));
-        cob.labelBinding(lTo);
+        cob.invokevirtual(CD_MethodHandle, "invokeBasic", methodDesc(type.basicType()))
+           .labelBinding(lTo);
 
         // FINALLY_NORMAL:
         int index = extendLocalsMap(new Class<?>[]{ returnType });
@@ -1084,17 +1078,16 @@ class InvokerBytecodeGenerator {
             emitStoreInsn(cob, basicReturnType.basicTypeKind(), index);
         }
         emitPushArgument(cob, invoker, 1); // load cleanup
-        cob.loadConstant(null);
+        cob.aconst_null();
         if (isNonVoid) {
             emitLoadInsn(cob, basicReturnType.basicTypeKind(), index);
         }
         emitPushArguments(cob, args, 1); // load args (skip 0: method handle)
-        cob.invokevirtual(CD_MethodHandle, "invokeBasic", cleanupDesc);
-        cob.goto_w(lDone);
-
-        // CATCH:
-        cob.labelBinding(lCatch);
-        cob.dup();
+        cob.invokevirtual(CD_MethodHandle, "invokeBasic", cleanupDesc)
+           .goto_w(lDone)
+           // CATCH:
+           .labelBinding(lCatch)
+           .dup();
 
         // FINALLY_EXCEPTIONAL:
         emitPushArgument(cob, invoker, 1); // load cleanup
@@ -1107,10 +1100,9 @@ class InvokerBytecodeGenerator {
         if (isNonVoid) {
             emitPopInsn(cob, basicReturnType);
         }
-        cob.athrow();
-
-        // DONE:
-        cob.labelBinding(lDone);
+        cob.athrow()
+           // DONE:
+           .labelBinding(lDone);
 
         return result;
     }
@@ -1147,26 +1139,24 @@ class InvokerBytecodeGenerator {
         }
 
         emitPushArgument(cob, invoker, 0); // push switch input
-        cob.tableswitch(0, numCases - 1, defaultLabel, cases);
-
-        cob.labelBinding(defaultLabel);
+        cob.tableswitch(0, numCases - 1, defaultLabel, cases)
+           .labelBinding(defaultLabel);
         emitPushArgument(cob, invoker, 1); // push default handle
         emitPushArguments(cob, args, 1); // again, skip collector
-        cob.invokevirtual(CD_MethodHandle, "invokeBasic", caseDescriptor);
-        cob.goto_(endLabel);
+        cob.invokevirtual(CD_MethodHandle, "invokeBasic", caseDescriptor)
+           .goto_(endLabel);
 
         for (int i = 0; i < numCases; i++) {
             cob.labelBinding(cases.get(i).target());
             // Load the particular case:
             emitLoadInsn(cob, TypeKind.REFERENCE, casesLocal);
-            cob.loadConstant(i);
-            cob.aaload();
+            cob.loadConstant(i)
+               .aaload();
 
             // invoke it:
             emitPushArguments(cob, args, 1); // again, skip collector
-            cob.invokevirtual(CD_MethodHandle, "invokeBasic", caseDescriptor);
-
-            cob.goto_(endLabel);
+            cob.invokevirtual(CD_MethodHandle, "invokeBasic", caseDescriptor)
+               .goto_(endLabel);
         }
 
         cob.labelBinding(endLabel);
@@ -1335,16 +1325,14 @@ class InvokerBytecodeGenerator {
             // invoke fini
             emitLoopHandleInvoke(cob, invoker, finis, c, args, true, finiType, loopLocalStateTypes, clauseDataIndex,
                     firstLoopStateIndex);
-            cob.goto_w(lDone);
-
-            // this is the beginning of the next loop clause
-            cob.labelBinding(lNext);
+            cob.goto_w(lDone)
+               // this is the beginning of the next loop clause
+               .labelBinding(lNext);
         }
 
-        cob.goto_w(lLoop);
-
-        // DONE:
-        cob.labelBinding(lDone);
+        cob.goto_w(lLoop)
+           // DONE:
+           .labelBinding(lDone);
 
         return result;
     }
@@ -1370,8 +1358,8 @@ class InvokerBytecodeGenerator {
                                       int firstLoopStateSlot) {
         // load handle for clause
         emitPushClauseArray(cob, clauseDataSlot, handles);
-        cob.loadConstant(clause);
-        cob.aaload();
+        cob.loadConstant(clause)
+           .aaload();
         // load loop state (preceding the other arguments)
         if (pushLocalState) {
             for (int s = 0; s < loopLocalStateTypes.length; ++s) {
@@ -1385,8 +1373,8 @@ class InvokerBytecodeGenerator {
 
     private void emitPushClauseArray(CodeBuilder cob, int clauseDataSlot, int which) {
         emitLoadInsn(cob, TypeKind.REFERENCE, clauseDataSlot);
-        cob.loadConstant(which - 1);
-        cob.aaload();
+        cob.loadConstant(which - 1)
+           .aaload();
     }
 
     private void emitZero(CodeBuilder cob, BasicType type) {
@@ -1519,14 +1507,14 @@ class InvokerBytecodeGenerator {
                             @Override
                             public void accept(CodeBuilder cob) {
                                 // create parameter array
-                                cob.loadConstant(invokerType.parameterCount());
-                                cob.anewarray(CD_Object);
+                                cob.loadConstant(invokerType.parameterCount())
+                                   .anewarray(CD_Object);
 
                                 // fill parameter array
                                 for (int i = 0; i < invokerType.parameterCount(); i++) {
                                     Class<?> ptype = invokerType.parameterType(i);
-                                    cob.dup();
-                                    cob.loadConstant(i);
+                                    cob.dup()
+                                       .loadConstant(i);
                                     emitLoadInsn(cob, basicType(ptype).basicTypeKind(), i);
                                     // box if primitive type
                                     if (ptype.isPrimitive()) {
@@ -1592,9 +1580,9 @@ class InvokerBytecodeGenerator {
 
                                 // Load arguments from array
                                 for (int i = 0; i < dstType.parameterCount(); i++) {
-                                    cob.aload(1);
-                                    cob.loadConstant(i);
-                                    cob.aaload();
+                                    cob.aload(1)
+                                       .loadConstant(i)
+                                       .aaload();
 
                                     // Maybe unbox
                                     Class<?> dptype = dstType.parameterType(i);
@@ -1645,9 +1633,9 @@ class InvokerBytecodeGenerator {
             clb.withMethodBody("dummy", MTD_void, ACC_STATIC, new Consumer<>() {
                 @Override
                 public void accept(CodeBuilder cob) {
-                    cob.ldc(os.toString());
-                    cob.pop();
-                    cob.return_();
+                    cob.ldc(os.toString())
+                       .pop()
+                       .return_();
                 }
             });
         }

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1523,10 +1523,10 @@ class InvokerBytecodeGenerator {
                                     cob.aastore();
                                 }
                                 // invoke
-                                cob.aload(0);
-                                cob.getfield(CD_MethodHandle, "form", CD_LambdaForm);
-                                cob.swap();  // swap form and array; avoid local variable
-                                cob.invokevirtual(CD_LambdaForm, "interpretWithArguments", MethodTypeDescImpl.ofValidated(CD_Object, CD_Object_array));
+                                cob.aload(0)
+                                   .getfield(CD_MethodHandle, "form", CD_LambdaForm)
+                                   .swap()  // swap form and array; avoid local variable
+                                   .invokevirtual(CD_LambdaForm, "interpretWithArguments", MethodTypeDescImpl.ofValidated(CD_Object, CD_Object_array));
 
                                 // maybe unbox
                                 Class<?> rtype = invokerType.returnType();

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -396,7 +396,7 @@ public class MethodHandleProxies {
                    .invokespecial(CD_Object, INIT_NAME, MTD_void)
                    // call ensureOriginalLookup to verify the given Lookup has access
                    .aload(1)
-                   .invokestatic(proxyDesc, "ensureOriginalLookup", MTD_void_Lookup)
+                   .invokestatic(proxyDesc, ENSURE_ORIGINAL_LOOKUP, MTD_void_Lookup)
                    // this.target = target;
                    .aload(0)
                    .aload(2)

--- a/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandleProxies.java
@@ -373,46 +373,43 @@ public class MethodHandleProxies {
                                          String methodName, List<MethodInfo> methods) {
         return ClassFile.of(ClassHierarchyResolverOption.of(ClassHierarchyResolver.ofClassLoading(loader)))
                         .build(proxyDesc, clb -> {
-            clb.withSuperclass(CD_Object);
-            clb.withFlags(ACC_FINAL | ACC_SYNTHETIC);
-            clb.withInterfaceSymbols(ifaceDesc);
-
-            // static and instance fields
-            clb.withField(TYPE_NAME, CD_Class, ACC_PRIVATE | ACC_STATIC | ACC_FINAL);
-            clb.withField(TARGET_NAME, CD_MethodHandle, ACC_PRIVATE | ACC_FINAL);
+            clb.withSuperclass(CD_Object)
+               .withFlags(ACC_FINAL | ACC_SYNTHETIC)
+               .withInterfaceSymbols(ifaceDesc)
+               // static and instance fields
+               .withField(TYPE_NAME, CD_Class, ACC_PRIVATE | ACC_STATIC | ACC_FINAL)
+               .withField(TARGET_NAME, CD_MethodHandle, ACC_PRIVATE | ACC_FINAL);
             for (var mi : methods) {
                 clb.withField(mi.fieldName, CD_MethodHandle, ACC_PRIVATE | ACC_FINAL);
             }
 
             // <clinit>
             clb.withMethodBody(CLASS_INIT_NAME, MTD_void, ACC_STATIC, cob -> {
-                cob.loadConstant(ifaceDesc);
-                cob.putstatic(proxyDesc, TYPE_NAME, CD_Class);
-                cob.return_();
+                cob.loadConstant(ifaceDesc)
+                   .putstatic(proxyDesc, TYPE_NAME, CD_Class)
+                   .return_();
             });
 
             // <init>(Lookup, MethodHandle target, MethodHandle callerBoundTarget)
             clb.withMethodBody(INIT_NAME, MTD_void_Lookup_MethodHandle_MethodHandle, 0, cob -> {
-                cob.aload(0);
-                cob.invokespecial(CD_Object, INIT_NAME, MTD_void);
-
-                // call ensureOriginalLookup to verify the given Lookup has access
-                cob.aload(1);
-                cob.invokestatic(proxyDesc, "ensureOriginalLookup", MTD_void_Lookup);
-
-                // this.target = target;
-                cob.aload(0);
-                cob.aload(2);
-                cob.putfield(proxyDesc, TARGET_NAME, CD_MethodHandle);
+                cob.aload(0)
+                   .invokespecial(CD_Object, INIT_NAME, MTD_void)
+                   // call ensureOriginalLookup to verify the given Lookup has access
+                   .aload(1)
+                   .invokestatic(proxyDesc, "ensureOriginalLookup", MTD_void_Lookup)
+                   // this.target = target;
+                   .aload(0)
+                   .aload(2)
+                   .putfield(proxyDesc, TARGET_NAME, CD_MethodHandle);
 
                 // method handles adjusted to the method type of each method
                 for (var mi : methods) {
                     // this.m<i> = callerBoundTarget.asType(xxType);
-                    cob.aload(0);
-                    cob.aload(3);
-                    cob.loadConstant(mi.desc);
-                    cob.invokevirtual(CD_MethodHandle, "asType", MTD_MethodHandle_MethodType);
-                    cob.putfield(proxyDesc, mi.fieldName, CD_MethodHandle);
+                    cob.aload(0)
+                       .aload(3)
+                       .loadConstant(mi.desc)
+                       .invokevirtual(CD_MethodHandle, "asType", MTD_MethodHandle_MethodType)
+                       .putfield(proxyDesc, mi.fieldName, CD_MethodHandle);
                 }
 
                 // complete
@@ -425,26 +422,26 @@ public class MethodHandleProxies {
             clb.withMethodBody(ENSURE_ORIGINAL_LOOKUP, MTD_void_Lookup, ACC_PRIVATE | ACC_STATIC, cob -> {
                 var failLabel = cob.newLabel();
                 // check lookupClass
-                cob.aload(0);
-                cob.invokevirtual(CD_MethodHandles_Lookup, "lookupClass", MTD_Class);
-                cob.loadConstant(proxyDesc);
-                cob.if_acmpne(failLabel);
-                // check original access
-                cob.aload(0);
-                cob.invokevirtual(CD_MethodHandles_Lookup, "lookupModes", MTD_int);
-                cob.loadConstant(Lookup.ORIGINAL);
-                cob.iand();
-                cob.ifeq(failLabel);
-                // success
-                cob.return_();
-                // throw exception
-                cob.labelBinding(failLabel);
-                cob.new_(CD_IllegalAccessException);
-                cob.dup();
-                cob.aload(0); // lookup
-                cob.invokevirtual(CD_Object, "toString", MTD_String);
-                cob.invokespecial(CD_IllegalAccessException, INIT_NAME, MTD_void_String);
-                cob.athrow();
+                cob.aload(0)
+                   .invokevirtual(CD_MethodHandles_Lookup, "lookupClass", MTD_Class)
+                   .loadConstant(proxyDesc)
+                   .if_acmpne(failLabel)
+                   // check original access
+                   .aload(0)
+                   .invokevirtual(CD_MethodHandles_Lookup, "lookupModes", MTD_int)
+                   .loadConstant(Lookup.ORIGINAL)
+                   .iand()
+                   .ifeq(failLabel)
+                   // success
+                   .return_()
+                   // throw exception
+                   .labelBinding(failLabel)
+                   .new_(CD_IllegalAccessException)
+                   .dup()
+                   .aload(0) // lookup
+                   .invokevirtual(CD_Object, "toString", MTD_String)
+                   .invokespecial(CD_IllegalAccessException, INIT_NAME, MTD_void_String)
+                   .athrow();
             });
 
             // implementation methods
@@ -453,14 +450,14 @@ public class MethodHandleProxies {
                 clb.withMethodBody(methodName, mi.desc, ACC_PUBLIC, cob -> cob
                         .trying(bcb -> {
                                     // return this.handleField.invokeExact(arguments...);
-                                    bcb.aload(0);
-                                    bcb.getfield(proxyDesc, mi.fieldName, CD_MethodHandle);
+                                    bcb.aload(0)
+                                       .getfield(proxyDesc, mi.fieldName, CD_MethodHandle);
                                     for (int j = 0; j < mi.desc.parameterCount(); j++) {
                                         bcb.loadLocal(TypeKind.from(mi.desc.parameterType(j)),
                                                 bcb.parameterSlot(j));
                                     }
-                                    bcb.invokevirtual(CD_MethodHandle, "invokeExact", mi.desc);
-                                    bcb.return_(TypeKind.from(mi.desc.returnType()));
+                                    bcb.invokevirtual(CD_MethodHandle, "invokeExact", mi.desc)
+                                       .return_(TypeKind.from(mi.desc.returnType()));
                                 }, ctb -> ctb
                                         // catch (Error | RuntimeException | Declared ex) { throw ex; }
                                         .catchingMulti(mi.thrown, CodeBuilder::athrow)

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -193,11 +193,10 @@ public class BindingSpecializer {
                                            CallingSequence callingSequence, ABIDescriptor abi) {
         String className = callingSequence.forDowncall() ? CLASS_NAME_DOWNCALL : CLASS_NAME_UPCALL;
         byte[] bytes = ClassFile.of().build(ClassDesc.ofInternalName(className), clb -> {
-            clb.withFlags(ACC_PUBLIC + ACC_FINAL + ACC_SUPER);
-            clb.withSuperclass(CD_Object);
-            clb.withVersion(CLASSFILE_VERSION, 0);
-
-            clb.withMethodBody(METHOD_NAME, methodTypeDesc(callerMethodType), ACC_PUBLIC | ACC_STATIC,
+            clb.withFlags(ACC_PUBLIC + ACC_FINAL + ACC_SUPER)
+               .withSuperclass(CD_Object)
+               .withVersion(CLASSFILE_VERSION, 0)
+               .withMethodBody(METHOD_NAME, methodTypeDesc(callerMethodType), ACC_PUBLIC | ACC_STATIC,
                     cb -> new BindingSpecializer(cb, callerMethodType, callingSequence, abi, leafType).specialize());
         });
 
@@ -275,8 +274,8 @@ public class BindingSpecializer {
                 if (shouldAcquire(i)) {
                     int scopeLocal = cb.allocateLocal(REFERENCE);
                     initialScopeSlots[numScopes++] = scopeLocal;
-                    cb.loadConstant(null);
-                    cb.storeLocal(REFERENCE, scopeLocal); // need to initialize all scope locals here in case an exception occurs
+                    cb.aconst_null()
+                      .astore(scopeLocal); // need to initialize all scope locals here in case an exception occurs
                 }
             }
             scopeSlots = Arrays.copyOf(initialScopeSlots, numScopes); // fit to size
@@ -285,15 +284,15 @@ public class BindingSpecializer {
 
         // create a Binding.Context for this call
         if (callingSequence.allocationSize() != 0) {
-            cb.loadConstant(callingSequence.allocationSize());
-            cb.invokestatic(CD_SharedUtils, "newBoundedArena", MTD_NEW_BOUNDED_ARENA);
+            cb.loadConstant(callingSequence.allocationSize())
+              .invokestatic(CD_SharedUtils, "newBoundedArena", MTD_NEW_BOUNDED_ARENA);
         } else if (callingSequence.forUpcall() && needsSession()) {
             cb.invokestatic(CD_SharedUtils, "newEmptyArena", MTD_NEW_EMPTY_ARENA);
         } else {
             cb.getstatic(CD_SharedUtils, "DUMMY_ARENA", CD_Arena);
         }
         contextIdx = cb.allocateLocal(REFERENCE);
-        cb.storeLocal(REFERENCE, contextIdx);
+        cb.astore(contextIdx);
 
         // in case the call needs a return buffer, allocate it here.
         // for upcalls the VM wrapper stub allocates the buffer.
@@ -301,7 +300,7 @@ public class BindingSpecializer {
             emitLoadInternalAllocator();
             emitAllocateCall(callingSequence.returnBufferSize(), 1);
             returnBufferIdx = cb.allocateLocal(REFERENCE);
-            cb.storeLocal(REFERENCE, returnBufferIdx);
+            cb.astore(returnBufferIdx);
         }
 
         Label tryStart = cb.newLabel();
@@ -324,7 +323,7 @@ public class BindingSpecializer {
                 // for downcalls, recipes have an input value, which we set up here
                 if (callingSequence.needsReturnBuffer() && i == 0) {
                     assert returnBufferIdx != -1;
-                    cb.loadLocal(REFERENCE, returnBufferIdx);
+                    cb.aload(returnBufferIdx);
                     pushType(MemorySegment.class);
                 } else {
                     emitGetInput();
@@ -340,7 +339,7 @@ public class BindingSpecializer {
                     // return buffer ptr is wrapped in a MemorySegment above, but not passed to the leaf handle
                     popType(MemorySegment.class);
                     returnBufferIdx = cb.allocateLocal(REFERENCE);
-                    cb.storeLocal(REFERENCE, returnBufferIdx);
+                    cb.astore(returnBufferIdx);
                 } else {
                     // for upcalls the recipe result is an argument to the leaf handle
                     emitSetOutput(typeStack.pop());
@@ -355,7 +354,7 @@ public class BindingSpecializer {
         if (callingSequence.forDowncall()) {
             cb.loadConstant(CLASS_DATA_DESC);
         } else {
-            cb.loadLocal(REFERENCE, 0); // load target arg
+            cb.aload(0); // load target arg
         }
         cb.checkcast(CD_MethodHandle);
         // load all the leaf args
@@ -496,8 +495,8 @@ public class BindingSpecializer {
     }
 
     private void emitAcquireScope() {
-        cb.checkcast(CD_AbstractMemorySegmentImpl);
-        cb.invokevirtual(CD_AbstractMemorySegmentImpl, "sessionImpl", MTD_SESSION_IMPL);
+        cb.checkcast(CD_AbstractMemorySegmentImpl)
+          .invokevirtual(CD_AbstractMemorySegmentImpl, "sessionImpl", MTD_SESSION_IMPL);
         Label skipAcquire = cb.newLabel();
         Label end = cb.newLabel();
 
@@ -505,23 +504,22 @@ public class BindingSpecializer {
         assert curScopeLocalIdx != -1;
         boolean hasOtherScopes = curScopeLocalIdx != 0;
         for (int i = 0; i < curScopeLocalIdx; i++) {
-            cb.dup(); // dup for comparison
-            cb.loadLocal(REFERENCE, scopeSlots[i]);
-            cb.if_acmpeq(skipAcquire);
+            cb.dup() // dup for comparison
+              .aload(scopeSlots[i])
+              .if_acmpeq(skipAcquire);
         }
 
         // 1 scope to acquire on the stack
         cb.dup();
         int nextScopeLocal = scopeSlots[curScopeLocalIdx++];
         // call acquire first here. So that if it fails, we don't call release
-        cb.invokevirtual(CD_MemorySessionImpl, "acquire0", MTD_ACQUIRE0); // call acquire on the other
-        cb.storeLocal(REFERENCE, nextScopeLocal); // store off one to release later
+        cb.invokevirtual(CD_MemorySessionImpl, "acquire0", MTD_ACQUIRE0) // call acquire on the other
+          .astore(nextScopeLocal); // store off one to release later
 
         if (hasOtherScopes) { // avoid ASM generating a bunch of nops for the dead code
-            cb.goto_(end);
-
-            cb.labelBinding(skipAcquire);
-            cb.pop(); // drop scope
+            cb.goto_(end)
+              .labelBinding(skipAcquire)
+              .pop(); // drop scope
         }
 
         cb.labelBinding(end);
@@ -529,10 +527,10 @@ public class BindingSpecializer {
 
     private void emitReleaseScopes() {
         for (int scopeLocal : scopeSlots) {
-            cb.loadLocal(REFERENCE, scopeLocal);
-            cb.ifThen(Opcode.IFNONNULL, ifCb -> {
-                ifCb.loadLocal(REFERENCE, scopeLocal);
-                ifCb.invokevirtual(CD_MemorySessionImpl, "release0", MTD_RELEASE0);
+            cb.aload(scopeLocal)
+              .ifThen(Opcode.IFNONNULL, ifCb -> {
+                ifCb.aload(scopeLocal)
+                    .invokevirtual(CD_MemorySessionImpl, "release0", MTD_RELEASE0);
             });
         }
     }
@@ -551,28 +549,28 @@ public class BindingSpecializer {
 
     private void emitLoadInternalSession() {
         assert contextIdx != -1;
-        cb.loadLocal(REFERENCE, contextIdx);
-        cb.checkcast(CD_Arena);
-        cb.invokeinterface(CD_Arena, "scope", MTD_SCOPE);
-        cb.checkcast(CD_MemorySessionImpl);
+        cb.aload(contextIdx)
+          .checkcast(CD_Arena)
+          .invokeinterface(CD_Arena, "scope", MTD_SCOPE)
+          .checkcast(CD_MemorySessionImpl);
     }
 
     private void emitLoadInternalAllocator() {
         assert contextIdx != -1;
-        cb.loadLocal(REFERENCE, contextIdx);
+        cb.aload(contextIdx);
     }
 
     private void emitCloseContext() {
         assert contextIdx != -1;
-        cb.loadLocal(REFERENCE, contextIdx);
-        cb.checkcast(CD_Arena);
-        cb.invokeinterface(CD_Arena, "close", MTD_CLOSE);
+        cb.aload(contextIdx)
+          .checkcast(CD_Arena)
+          .invokeinterface(CD_Arena, "close", MTD_CLOSE);
     }
 
     private void emitBoxAddress(BoxAddress boxAddress) {
         popType(long.class);
-        cb.loadConstant(boxAddress.size());
-        cb.loadConstant(boxAddress.align());
+        cb.loadConstant(boxAddress.size())
+          .loadConstant(boxAddress.align());
         if (needsSession()) {
             emitLoadInternalSession();
             cb.invokestatic(CD_Utils, "longToAddress", MTD_LONG_TO_ADDRESS_SCOPE);
@@ -585,7 +583,7 @@ public class BindingSpecializer {
     private void emitAllocBuffer(Allocate binding) {
         if (callingSequence.forDowncall()) {
             assert returnAllocatorIdx != -1;
-            cb.loadLocal(REFERENCE, returnAllocatorIdx);
+            cb.aload(returnAllocatorIdx);
         } else {
             emitLoadInternalAllocator();
         }
@@ -607,8 +605,8 @@ public class BindingSpecializer {
             cb.storeLocal(storeTypeKind, valueIdx);
 
             ClassDesc valueLayoutType = emitLoadLayoutConstant(storeType);
-            cb.loadConstant(offset);
-            cb.loadLocal(storeTypeKind, valueIdx);
+            cb.loadConstant(offset)
+              .loadLocal(storeTypeKind, valueIdx);
             MethodTypeDesc descriptor = MethodTypeDesc.of(CD_void, valueLayoutType, CD_long, classDesc(storeType));
             cb.invokeinterface(CD_MemorySegment, "set", descriptor);
         } else {
@@ -621,7 +619,7 @@ public class BindingSpecializer {
             int longValueIdx = cb.allocateLocal(LONG);
             cb.storeLocal(LONG, longValueIdx);
             int writeAddrIdx = cb.allocateLocal(REFERENCE);
-            cb.storeLocal(REFERENCE, writeAddrIdx);
+            cb.astore(writeAddrIdx);
 
             int remaining = byteWidth;
             int chunkOffset = 0;
@@ -648,25 +646,25 @@ public class BindingSpecializer {
                 //int writeChunk = (int) (((0xFFFF_FFFFL << shiftAmount) & longValue) >>> shiftAmount);
                 int shiftAmount = chunkOffset * Byte.SIZE;
                 mask = mask << shiftAmount;
-                cb.loadLocal(LONG, longValueIdx);
-                cb.loadConstant(mask);
-                cb.land();
+                cb.loadLocal(LONG, longValueIdx)
+                  .loadConstant(mask)
+                  .land();
                 if (shiftAmount != 0) {
-                    cb.loadConstant(shiftAmount);
-                    cb.lushr();
+                    cb.loadConstant(shiftAmount)
+                      .lushr();
                 }
                 cb.l2i();
                 TypeKind chunkStoreTypeKind = TypeKind.from(chunkStoreType);
                 int chunkIdx = cb.allocateLocal(chunkStoreTypeKind);
-                cb.storeLocal(chunkStoreTypeKind, chunkIdx);
+                cb.storeLocal(chunkStoreTypeKind, chunkIdx)
                 // chunk done, now write it
 
                 //writeAddress.set(JAVA_SHORT_UNALIGNED, offset, writeChunk);
-                cb.loadLocal(REFERENCE, writeAddrIdx);
+                  .aload(writeAddrIdx);
                 ClassDesc valueLayoutType = emitLoadLayoutConstant(chunkStoreType);
                 long writeOffset = offset + SharedUtils.pickChunkOffset(chunkOffset, byteWidth, chunkSize);
-                cb.loadConstant(writeOffset);
-                cb.loadLocal(chunkStoreTypeKind, chunkIdx);
+                cb.loadConstant(writeOffset)
+                  .loadLocal(chunkStoreTypeKind, chunkIdx);
                 MethodTypeDesc descriptor = MethodTypeDesc.of(CD_void, valueLayoutType, CD_long, classDesc(chunkStoreType));
                 cb.invokeinterface(CD_MemorySegment, "set", descriptor);
 
@@ -694,10 +692,10 @@ public class BindingSpecializer {
                 cb.storeLocal(storeTypeKind, valueIdx); // store away the stored value, need it later
 
                 assert returnBufferIdx != -1;
-                cb.loadLocal(REFERENCE, returnBufferIdx);
+                cb.aload(returnBufferIdx);
                 ClassDesc valueLayoutType = emitLoadLayoutConstant(storeType);
-                cb.loadConstant(retBufOffset);
-                cb.loadLocal(storeTypeKind, valueIdx);
+                cb.loadConstant(retBufOffset)
+                  .loadLocal(storeTypeKind, valueIdx);
                 MethodTypeDesc descriptor = MethodTypeDesc.of(CD_void, valueLayoutType, CD_long, classDesc(storeType));
                 cb.invokeinterface(CD_MemorySegment, "set", descriptor);
                 retBufOffset += abi.arch.typeSize(vmStore.storage().type());
@@ -714,7 +712,7 @@ public class BindingSpecializer {
                 emitRestoreReturnValue(loadType);
             } else {
                 assert returnBufferIdx != -1;
-                cb.loadLocal(REFERENCE, returnBufferIdx);
+                cb.aload(returnBufferIdx);
                 ClassDesc valueLayoutType = emitLoadLayoutConstant(loadType);
                 cb.loadConstant(retBufOffset);
                 MethodTypeDesc descriptor = MethodTypeDesc.of(classDesc(loadType), valueLayoutType, CD_long);
@@ -736,15 +734,15 @@ public class BindingSpecializer {
 
     private void emitShiftLeft(ShiftLeft shiftLeft) {
         popType(long.class);
-        cb.loadConstant(shiftLeft.shiftAmount() * Byte.SIZE);
-        cb.lshl();
+        cb.loadConstant(shiftLeft.shiftAmount() * Byte.SIZE)
+          .lshl();
         pushType(long.class);
     }
 
     private void emitShiftRight(ShiftRight shiftRight) {
         popType(long.class);
-        cb.loadConstant(shiftRight.shiftAmount() * Byte.SIZE);
-        cb.lushr();
+        cb.loadConstant(shiftRight.shiftAmount() * Byte.SIZE)
+          .lushr();
         pushType(long.class);
     }
 
@@ -758,11 +756,10 @@ public class BindingSpecializer {
                 // implement least significant byte non-zero test
 
                 // select first byte
-                cb.loadConstant(0xFF);
-                cb.iand();
-
-                // convert to boolean
-                cb.invokestatic(CD_Utils, "byteToBoolean", MTD_BYTE_TO_BOOLEAN);
+                cb.loadConstant(0xFF)
+                  .iand()
+                  // convert to boolean
+                  .invokestatic(CD_Utils, "byteToBoolean", MTD_BYTE_TO_BOOLEAN);
             }
             case INT_TO_BYTE -> cb.i2b();
             case INT_TO_CHAR -> cb.i2c();
@@ -782,8 +779,8 @@ public class BindingSpecializer {
 
     private void emitSegmentBase() {
         popType(MemorySegment.class);
-        cb.checkcast(CD_AbstractMemorySegmentImpl);
-        cb.invokevirtual(CD_AbstractMemorySegmentImpl, "unsafeGetBase", MTD_UNSAFE_GET_BASE);
+        cb.checkcast(CD_AbstractMemorySegmentImpl)
+          .invokevirtual(CD_AbstractMemorySegmentImpl, "unsafeGetBase", MTD_UNSAFE_GET_BASE);
         pushType(Object.class);
     }
 
@@ -791,11 +788,11 @@ public class BindingSpecializer {
         popType(MemorySegment.class);
 
         if (!segmentOffset.allowHeap()) {
-            cb.dup();
-            cb.invokestatic(CD_SharedUtils, "checkNative", MTD_CHECK_NATIVE);
+            cb.dup()
+              .invokestatic(CD_SharedUtils, "checkNative", MTD_CHECK_NATIVE);
         }
-        cb.checkcast(CD_AbstractMemorySegmentImpl);
-        cb.invokevirtual(CD_AbstractMemorySegmentImpl, "unsafeGetOffset", MTD_UNSAFE_GET_OFFSET);
+        cb.checkcast(CD_AbstractMemorySegmentImpl)
+          .invokevirtual(CD_AbstractMemorySegmentImpl, "unsafeGetOffset", MTD_UNSAFE_GET_OFFSET);
 
         pushType(long.class);
     }
@@ -815,9 +812,9 @@ public class BindingSpecializer {
         } else {
             // chunked
             int readAddrIdx = cb.allocateLocal(REFERENCE);
-            cb.storeLocal(REFERENCE, readAddrIdx);
+            cb.astore(readAddrIdx)
 
-            cb.loadConstant(0L); // result
+              .loadConstant(0L); // result
             int resultIdx = cb.allocateLocal(LONG);
             cb.storeLocal(LONG, resultIdx);
 
@@ -848,24 +845,24 @@ public class BindingSpecializer {
                         throw new IllegalStateException("Unexpected chunk size for chunked write: " + chunkSize);
                 }
                 // read from segment
-                cb.loadLocal(REFERENCE, readAddrIdx);
+                cb.aload(readAddrIdx);
                 ClassDesc valueLayoutType = emitLoadLayoutConstant(chunkType);
                 MethodTypeDesc descriptor = MethodTypeDesc.of(classDesc(chunkType), valueLayoutType, CD_long);
                 long readOffset = offset + SharedUtils.pickChunkOffset(chunkOffset, byteWidth, chunkSize);
-                cb.loadConstant(readOffset);
-                cb.invokeinterface(CD_MemorySegment, "get", descriptor);
-                cb.invokestatic(toULongHolder, "toUnsignedLong", toULongDescriptor);
+                cb.loadConstant(readOffset)
+                  .invokeinterface(CD_MemorySegment, "get", descriptor)
+                  .invokestatic(toULongHolder, "toUnsignedLong", toULongDescriptor);
 
                 // shift to right offset
                 int shiftAmount = chunkOffset * Byte.SIZE;
                 if (shiftAmount != 0) {
-                    cb.loadConstant(shiftAmount);
-                    cb.lshl();
+                    cb.loadConstant(shiftAmount)
+                      .lshl();
                 }
                 // add to result
-                cb.loadLocal(LONG, resultIdx);
-                cb.lor();
-                cb.storeLocal(LONG, resultIdx);
+                cb.loadLocal(LONG, resultIdx)
+                  .lor()
+                  .storeLocal(LONG, resultIdx);
 
                 remaining -= chunkSize;
                 chunkOffset += chunkSize;
@@ -898,19 +895,19 @@ public class BindingSpecializer {
         emitAllocateCall(size, alignment);
         cb.dup();
         int storeIdx = cb.allocateLocal(REFERENCE);
-        cb.storeLocal(REFERENCE, storeIdx);
-        cb.loadConstant(0L);
-        cb.loadConstant(size);
-        cb.invokestatic(CD_MemorySegment, "copy", MTD_COPY, true);
+        cb.astore(storeIdx)
+          .loadConstant(0L)
+          .loadConstant(size)
+          .invokestatic(CD_MemorySegment, "copy", MTD_COPY, true)
 
-        cb.loadLocal(REFERENCE, storeIdx);
+          .aload(storeIdx);
         pushType(MemorySegment.class);
     }
 
     private void emitAllocateCall(long size, long alignment) {
-        cb.loadConstant(size);
-        cb.loadConstant(alignment);
-        cb.invokeinterface(CD_SegmentAllocator, "allocate", MTD_ALLOCATE);
+        cb.loadConstant(size)
+          .loadConstant(alignment)
+          .invokeinterface(CD_SegmentAllocator, "allocate", MTD_ALLOCATE);
     }
 
     private ClassDesc emitLoadLayoutConstant(Class<?> type) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -688,16 +688,16 @@ public class BindingSpecializer {
             if (!callingSequence.needsReturnBuffer()) {
                 emitSaveReturnValue(storeType);
             } else {
-                int valueIdx = cb.allocateLocal(storeTypeKind);
-                cb.storeLocal(storeTypeKind, valueIdx); // store away the stored value, need it later
-
                 assert returnBufferIdx != -1;
-                cb.aload(returnBufferIdx);
+                int valueIdx = cb.allocateLocal(storeTypeKind);
+                cb.storeLocal(storeTypeKind, valueIdx) // store away the stored value, need it later
+                  .aload(returnBufferIdx);
                 ClassDesc valueLayoutType = emitLoadLayoutConstant(storeType);
                 cb.loadConstant(retBufOffset)
-                  .loadLocal(storeTypeKind, valueIdx);
-                MethodTypeDesc descriptor = MethodTypeDesc.of(CD_void, valueLayoutType, CD_long, classDesc(storeType));
-                cb.invokeinterface(CD_MemorySegment, "set", descriptor);
+                  .loadLocal(storeTypeKind, valueIdx)
+                  .invokeinterface(CD_MemorySegment,
+                        "set",
+                        MethodTypeDesc.of(CD_void, valueLayoutType, CD_long, classDesc(storeType)));
                 retBufOffset += abi.arch.typeSize(vmStore.storage().type());
             }
         }
@@ -714,9 +714,10 @@ public class BindingSpecializer {
                 assert returnBufferIdx != -1;
                 cb.aload(returnBufferIdx);
                 ClassDesc valueLayoutType = emitLoadLayoutConstant(loadType);
-                cb.loadConstant(retBufOffset);
-                MethodTypeDesc descriptor = MethodTypeDesc.of(classDesc(loadType), valueLayoutType, CD_long);
-                cb.invokeinterface(CD_MemorySegment, "get", descriptor);
+                cb.loadConstant(retBufOffset)
+                  .invokeinterface(CD_MemorySegment,
+                          "get",
+                          MethodTypeDesc.of(classDesc(loadType), valueLayoutType, CD_long));
                 retBufOffset += abi.arch.typeSize(vmLoad.storage().type());
                 pushType(loadType);
             }
@@ -806,9 +807,10 @@ public class BindingSpecializer {
 
         if (SharedUtils.isPowerOfTwo(byteWidth)) {
             ClassDesc valueLayoutType = emitLoadLayoutConstant(loadType);
-            cb.loadConstant(offset);
-            MethodTypeDesc descriptor = MethodTypeDesc.of(classDesc(loadType), valueLayoutType, CD_long);
-            cb.invokeinterface(CD_MemorySegment, "get", descriptor);
+            cb.loadConstant(offset)
+              .invokeinterface(CD_MemorySegment,
+                      "get",
+                      MethodTypeDesc.of(classDesc(loadType), valueLayoutType, CD_long));
         } else {
             // chunked
             int readAddrIdx = cb.allocateLocal(REFERENCE);

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -617,7 +617,7 @@ public class BindingSpecializer {
                 assert storeType == long.class; // chunking only for int and long
             }
             int longValueIdx = cb.allocateLocal(LONG);
-            cb.storeLocal(LONG, longValueIdx);
+            cb.lstore(longValueIdx);
             int writeAddrIdx = cb.allocateLocal(REFERENCE);
             cb.astore(writeAddrIdx);
 
@@ -646,7 +646,7 @@ public class BindingSpecializer {
                 //int writeChunk = (int) (((0xFFFF_FFFFL << shiftAmount) & longValue) >>> shiftAmount);
                 int shiftAmount = chunkOffset * Byte.SIZE;
                 mask = mask << shiftAmount;
-                cb.loadLocal(LONG, longValueIdx)
+                cb.lload(longValueIdx)
                   .loadConstant(mask)
                   .land();
                 if (shiftAmount != 0) {
@@ -816,7 +816,7 @@ public class BindingSpecializer {
 
               .loadConstant(0L); // result
             int resultIdx = cb.allocateLocal(LONG);
-            cb.storeLocal(LONG, resultIdx);
+            cb.lstore(resultIdx);
 
             int remaining = byteWidth;
             int chunkOffset = 0;
@@ -860,15 +860,15 @@ public class BindingSpecializer {
                       .lshl();
                 }
                 // add to result
-                cb.loadLocal(LONG, resultIdx)
+                cb.lload(resultIdx)
                   .lor()
-                  .storeLocal(LONG, resultIdx);
+                  .lstore(resultIdx);
 
                 remaining -= chunkSize;
                 chunkOffset += chunkSize;
             } while (remaining != 0);
 
-            cb.loadLocal(LONG, resultIdx);
+            cb.lload(resultIdx);
             if (loadType == int.class) {
                 cb.l2i();
             } else {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/BindingSpecializer.java
@@ -813,7 +813,6 @@ public class BindingSpecializer {
             // chunked
             int readAddrIdx = cb.allocateLocal(REFERENCE);
             cb.astore(readAddrIdx)
-
               .loadConstant(0L); // result
             int resultIdx = cb.allocateLocal(LONG);
             cb.lstore(resultIdx);
@@ -899,7 +898,6 @@ public class BindingSpecializer {
           .loadConstant(0L)
           .loadConstant(size)
           .invokestatic(CD_MemorySegment, "copy", MTD_COPY, true)
-
           .aload(storeIdx);
         pushType(MemorySegment.class);
     }


### PR DESCRIPTION
java.base should provide best practices for Class File API

1. Use fluent coding style
2. Use aconst_null instead of oadConstant(null)
3. use astore intead of 'storeLocal(REFERENCE'
4. use aload instead of 'loadLocal(REFERENCE'
5. 'lload/lstore' instead of 'loadLocal(LONG)/storeLocal(LONG)'

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341548](https://bugs.openjdk.org/browse/JDK-8341548): More concise use of classfile API (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21355/head:pull/21355` \
`$ git checkout pull/21355`

Update a local copy of the PR: \
`$ git checkout pull/21355` \
`$ git pull https://git.openjdk.org/jdk.git pull/21355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21355`

View PR using the GUI difftool: \
`$ git pr show -t 21355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21355.diff">https://git.openjdk.org/jdk/pull/21355.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21355#issuecomment-2394168779)