### PR TITLE
8341525: G1: use bit clearing to remove tightly-coupled initialization store pre-barriers

### DIFF
--- a/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
+++ b/src/hotspot/share/gc/g1/c2/g1BarrierSetC2.cpp
@@ -332,7 +332,8 @@ Node* G1BarrierSetC2::store_at_resolved(C2Access& access, C2AccessValue& val) co
     if (tightly_coupled_alloc) {
       assert(!use_ReduceInitialCardMarks(),
              "post-barriers are only needed for tightly-coupled initialization stores when ReduceInitialCardMarks is disabled");
-      access.set_barrier_data(access.barrier_data() ^ G1C2BarrierPre);
+      // Pre-barriers are unnecessary for tightly-coupled initialization stores.
+      access.set_barrier_data(access.barrier_data() & ~G1C2BarrierPre);
     }
   }
   return BarrierSetC2::store_at_resolved(access, val);


### PR DESCRIPTION
This cleanup applies bit clearing rather than bit toggling to clear the G1 pre-barrier bit of tightly-coupled initializing stores when `ReduceInitialCardMarks` is disabled. Although using bit toggling is correct in this context (see [JBS issue description](https://bugs.openjdk.org/browse/JDK-8341525)), bit clearing communicates more clearly (no pun intended) the intent of setting the pre-barrier bit to zero regardless of its previous value. No new tests are added because there already exist tests that exercise this case, for example `testCloneObjectWithFewFields` in `test/hotspot/jtreg/compiler/gcbarriers/TestG1BarrierGeneration.java`.

Thanks to @shipilev for [reporting](https://github.com/openjdk/jdk/pull/19746#discussion_r1786573527) this maintainability issue.

#### Testing
- tier1-5 (linux-x64, linux-aarch64, windows-x64, macosx-x64, and macosx-aarch64; release and debug mode).
- tier1-3 with `-XX:-ReduceInitialCardMarks` (linux-x64; debug mode).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341525](https://bugs.openjdk.org/browse/JDK-8341525): G1: use bit clearing to remove tightly-coupled initialization store pre-barriers (**Enhancement** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21356/head:pull/21356` \
`$ git checkout pull/21356`

Update a local copy of the PR: \
`$ git checkout pull/21356` \
`$ git pull https://git.openjdk.org/jdk.git pull/21356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21356`

View PR using the GUI difftool: \
`$ git pr show -t 21356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21356.diff">https://git.openjdk.org/jdk/pull/21356.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21356#issuecomment-2393796220)