### PR TITLE
8339730: Windows regression after removing ObjectMonitor Responsible

### DIFF
--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -5691,7 +5691,15 @@ void PlatformEvent::park() {
   // TODO: consider a brief spin here, gated on the success of recent
   // spin attempts by this thread.
   while (_Event < 0) {
+    // The following code is only here to maintain the
+    // characteristics/performance from when an ObjectMonitor
+    // "responsible" thread used to issue timed parks.
+    HighResolutionInterval *phri = nullptr;
+    if (!ForceTimeHighResolution) {
+      phri = new HighResolutionInterval((jlong)1);
+    }
     DWORD rv = ::WaitForSingleObject(_ParkHandle, INFINITE);
+    delete phri; // if it is null, harmless
     assert(rv != WAIT_FAILED,   "WaitForSingleObject failed with error code: %lu", GetLastError());
     assert(rv == WAIT_OBJECT_0, "WaitForSingleObject failed with return value: %lu", rv);
   }


### PR DESCRIPTION
In order to mitigate the regression seen on windows I added calls to enable hi res timer resolution around the call to WaitForSingleObject, when doing infinite parking. Got some good results, like these:

DaCapo23-tomcat-large 87.11%
DaCapo23-spring-large 38.25%
Renaissance-Reactors 10.34%
DaCapo-h2-large 10.00%

Tested ok on tier1-7 on windows-x64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339730](https://bugs.openjdk.org/browse/JDK-8339730): Windows regression after removing ObjectMonitor Responsible (**Bug** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21357/head:pull/21357` \
`$ git checkout pull/21357`

Update a local copy of the PR: \
`$ git checkout pull/21357` \
`$ git pull https://git.openjdk.org/jdk.git pull/21357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21357`

View PR using the GUI difftool: \
`$ git pr show -t 21357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21357.diff">https://git.openjdk.org/jdk/pull/21357.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21357#issuecomment-2394008366)