### PR TITLE
8341540: Harmonize source code of sun.net.w.p.file.Handler between unix and windows

### DIFF
--- a/src/java.base/windows/classes/sun/net/www/protocol/file/Handler.java
+++ b/src/java.base/windows/classes/sun/net/www/protocol/file/Handler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,40 +64,34 @@ public class Handler extends URLStreamHandler {
     public URLConnection openConnection(URL url, Proxy p)
            throws IOException {
 
-        String path;
         String file = url.getFile();
+        String path = ParseUtil.decode(file).replace('/', '\\').replace('|', ':');
         String host = url.getHost();
 
-        path = ParseUtil.decode(file);
-        path = path.replace('/', '\\');
-        path = path.replace('|', ':');
-
-        if ((host == null) || host.isEmpty() ||
+        if (host == null || host.isEmpty() ||
                 host.equalsIgnoreCase("localhost") ||
                 host.equals("~")) {
-           return createFileURLConnection(url, new File(path));
+            return createFileURLConnection(url, new File(path));
         }
 
-        /*
-         * attempt to treat this as a UNC path. See 4180841
-         */
+        URLConnection uc;
+
+        // attempt to treat this as a UNC path. See 4180841
         path = "\\\\" + host + path;
         File f = new File(path);
         if (f.exists()) {
             return new UNCFileURLConnection(url, f, path);
         }
 
-        /*
-         * Now attempt an ftp connection.
-         */
-        URLConnection uc;
+        // If you reach here, it implies that you have a hostname
+        // so attempt an ftp connection.
+
         URL newurl;
 
         try {
             @SuppressWarnings("deprecation")
             var _unused = newurl = new URL("ftp", host, file +
-                            (url.getRef() == null ? "":
-                            "#" + url.getRef()));
+                    (url.getRef() == null ? "": "#" + url.getRef()));
             if (p != null) {
                 uc = newurl.openConnection(p);
             } else {
@@ -108,7 +102,7 @@ public class Handler extends URLStreamHandler {
         }
         if (uc == null) {
             throw new IOException("Unable to connect to: " +
-                                        url.toExternalForm());
+                    url.toExternalForm());
         }
         return uc;
     }


### PR DESCRIPTION
Please review this cleanup PR which harmonizes the code style and organization of unix and windows source code files for `sun.net.www.protocol.file.Handler`. These files are mostly equal, but have drifted a bit in terms of code style, variable names, comments and organization of the code.

Harmonizing on one code style makes the actual semantic differences easier to spot when diffing the files side by side. Diffing the files after this PR clearly shows the differences between the platforms: (See first PR comment for actual diff)

* unix uses `URL::getPath` to get the file path, while windows uses `URL::getFile`.
* windows replaces the '/' and '|' chars using `replace('/', '\\').replace('|', ':')`
* windows has an extra check for UNC file paths before falling back to FTP.


Two open questions:

* The protected method createFileURLConnection has the comment `// Template method to be overridden by Java Plug-in. [stanleyh]`. If this is related to Applets,  perhaps we should make this method private and remove the comment? 
* I'm wondering if the difference in using `URL::getPath` vs. `URL::getFile` is intentional? If not, should we harmoize on one or the other? (`URL::getPath` includes `URL::getQuery`, while `URL::getFile` does not)
* Should we go one step further and consolidate this to a single source code file, as suggested in #21245?

Testing: No tests are updated in this PR, the label `noreg-cleanup` is added to the JBS. GHA results are currently pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341540](https://bugs.openjdk.org/browse/JDK-8341540): Harmonize source code of sun.net.w.p.file.Handler between unix and windows (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21359/head:pull/21359` \
`$ git checkout pull/21359`

Update a local copy of the PR: \
`$ git checkout pull/21359` \
`$ git pull https://git.openjdk.org/jdk.git pull/21359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21359`

View PR using the GUI difftool: \
`$ git pr show -t 21359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21359.diff">https://git.openjdk.org/jdk/pull/21359.diff</a>

</details>
