### PR TITLE
8341541: Wrong anchor in wrapper classes links

### DIFF
--- a/src/java.base/share/classes/java/lang/package-info.java
+++ b/src/java.base/share/classes/java/lang/package-info.java
@@ -29,8 +29,8 @@
  * Object}, which is the root of the class hierarchy, and {@link
  * Class}, instances of which represent classes at run time.
  *
- * <p>Frequently it is necessary to represent a value of primitive
- * type as if it were an object.The <dfn id=wrapperClasses>{@index
+ * <p id=wrapperClass>Frequently it is necessary to represent a
+ * value of primitive type as if it were an object.The <dfn>{@index
  * "wrapper classes"}</dfn> {@link Boolean}, {@link Byte}, {@link
  * Character}, {@link Short}, {@link Integer}, {@link Long}, {@link
  * Float}, and {@link Double} serve this purpose.  An object of type

--- a/src/java.compiler/share/classes/javax/lang/model/util/Types.java
+++ b/src/java.compiler/share/classes/javax/lang/model/util/Types.java
@@ -206,7 +206,7 @@ public interface Types {
      *
      * @throws IllegalArgumentException if the given type has no
      *         unboxing conversion. Only types for the {@linkplain
-     *         java.lang##wrapperClasses wrapper classes} have an
+     *         java.lang##wrapperClass wrapper classes} have an
      *         unboxing conversion.
      * @jls 5.1.8 Unboxing Conversion
      */


### PR DESCRIPTION
Fix broken links.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341541](https://bugs.openjdk.org/browse/JDK-8341541): Wrong anchor in wrapper classes links (**Sub-task** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21360/head:pull/21360` \
`$ git checkout pull/21360`

Update a local copy of the PR: \
`$ git checkout pull/21360` \
`$ git pull https://git.openjdk.org/jdk.git pull/21360/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21360`

View PR using the GUI difftool: \
`$ git pr show -t 21360`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21360.diff">https://git.openjdk.org/jdk/pull/21360.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21360#issuecomment-2394195584)