### PR TITLE
8341541: Wrong anchor in wrapper classes links

### DIFF
--- a/src/java.base/share/classes/java/lang/package-info.java
+++ b/src/java.base/share/classes/java/lang/package-info.java
@@ -29,8 +29,8 @@
  * Object}, which is the root of the class hierarchy, and {@link
  * Class}, instances of which represent classes at run time.
  *
- * <p>Frequently it is necessary to represent a value of primitive
- * type as if it were an object.The <dfn id=wrapperClasses>{@index
+ * <p id="wrapperClass">Frequently it is necessary to represent a
+ * value of primitive type as if it were an object. The <dfn>{@index
  * "wrapper classes"}</dfn> {@link Boolean}, {@link Byte}, {@link
  * Character}, {@link Short}, {@link Integer}, {@link Long}, {@link
  * Float}, and {@link Double} serve this purpose.  An object of type


### PR DESCRIPTION
Please review a doc change to fix the target anchor for the "wrapper class" links added in #21215. 

In addition to changing the anchor to "wrapperClass" (singular) I also moved the id attribute to the `<p>` tag so that browser view is positioned over the whole paragraph instead of just the term "wrapper classes".

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341541](https://bugs.openjdk.org/browse/JDK-8341541): Wrong anchor in wrapper classes links (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21361/head:pull/21361` \
`$ git checkout pull/21361`

Update a local copy of the PR: \
`$ git checkout pull/21361` \
`$ git pull https://git.openjdk.org/jdk.git pull/21361/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21361`

View PR using the GUI difftool: \
`$ git pr show -t 21361`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21361.diff">https://git.openjdk.org/jdk/pull/21361.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21361#issuecomment-2394263826)