### PR TITLE
8341554: Shenandoah: Missing heap lock when updating usage for soft ref policy

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahControlThread.cpp
@@ -177,10 +177,13 @@ void ShenandoahControlThread::run_service() {
       // it is a normal completion, or the abort.
       heap->free_set()->log_status_under_lock();
 
-      // Notify Universe about new heap usage. This has implications for
-      // global soft refs policy, and we better report it every time heap
-      // usage goes down.
-      heap->update_capacity_and_used_at_gc();
+      {
+        // Notify Universe about new heap usage. This has implications for
+        // global soft refs policy, and we better report it every time heap
+        // usage goes down.
+        ShenandoahHeapLocker locker(heap->lock());
+        heap->update_capacity_and_used_at_gc();
+      }
 
       // Signal that we have completed a visit to all live objects.
       heap->record_whole_heap_examined_timestamp();


### PR DESCRIPTION
A recent change to avoid checking the log level under the lock inadvertently removed the lock from an operation that needs it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341554](https://bugs.openjdk.org/browse/JDK-8341554): Shenandoah: Missing heap lock when updating usage for soft ref policy (**Bug** - P4)


### Reviewers
 * [Kelvin Nilsen](https://openjdk.org/census#kdnilsen) (@kdnilsen - Author)
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21362/head:pull/21362` \
`$ git checkout pull/21362`

Update a local copy of the PR: \
`$ git checkout pull/21362` \
`$ git pull https://git.openjdk.org/jdk.git pull/21362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21362`

View PR using the GUI difftool: \
`$ git pr show -t 21362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21362.diff">https://git.openjdk.org/jdk/pull/21362.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21362#issuecomment-2394440335)