### PR TITLE
8341581: Optimize BytecodeHelpers validate slot

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
@@ -377,8 +377,8 @@ public class BytecodeHelpers {
     public static void validateSlot(Opcode opcode, int slot, boolean load) {
         int size = opcode.sizeIfFixed();
         if (size == 1 && slot == (load ? intrinsicLoadSlot(opcode) : intrinsicStoreSlot(opcode)) ||
-                size == 2 && 0 == (slot & ~0xFF) ||
-                size == 4 && 0 == (slot & ~0xFFFF))
+                size == 2 && (slot & ~0xFF) == 0 ||
+                size == 4 && (slot & ~0xFFFF) == 0)
             return;
         throw slotOutOfBounds(opcode, slot);
     }
@@ -404,8 +404,8 @@ public class BytecodeHelpers {
     }
 
     public static void validateRet(Opcode opcode, int slot) {
-        if (opcode == Opcode.RET && 0 == (slot & ~0xFF) ||
-                opcode == Opcode.RET_W && 0 == (slot & ~0xFFFF))
+        if (opcode == Opcode.RET && (slot & ~0xFF) == 0 ||
+                opcode == Opcode.RET_W && (slot & ~0xFFFF) == 0)
             return;
         Objects.requireNonNull(opcode);
         throw slotOutOfBounds(opcode, slot);

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/BytecodeHelpers.java
@@ -88,9 +88,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.ALOAD_2;
             case 3 -> Opcode.ALOAD_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.ALOAD;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.ALOAD_W;
                 throw slotOutOfBounds(slot);
             }
@@ -104,9 +104,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.FLOAD_2;
             case 3 -> Opcode.FLOAD_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.FLOAD;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.FLOAD_W;
                 throw slotOutOfBounds(slot);
             }
@@ -120,9 +120,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.DLOAD_2;
             case 3 -> Opcode.DLOAD_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.DLOAD;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.DLOAD_W;
                 throw slotOutOfBounds(slot);
             }
@@ -136,9 +136,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.LLOAD_2;
             case 3 -> Opcode.LLOAD_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.LLOAD;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.LLOAD_W;
                 throw slotOutOfBounds(slot);
             }
@@ -152,9 +152,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.ILOAD_2;
             case 3 -> Opcode.ILOAD_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.ILOAD;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.ILOAD_W;
                 throw slotOutOfBounds(slot);
             }
@@ -180,9 +180,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.ASTORE_2;
             case 3 -> Opcode.ASTORE_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.ASTORE;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.ASTORE_W;
                 throw slotOutOfBounds(slot);
             }
@@ -196,9 +196,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.FSTORE_2;
             case 3 -> Opcode.FSTORE_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.FSTORE;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.FSTORE_W;
                 throw slotOutOfBounds(slot);
             }
@@ -212,9 +212,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.DSTORE_2;
             case 3 -> Opcode.DSTORE_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.DSTORE;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.DSTORE_W;
                 throw slotOutOfBounds(slot);
             }
@@ -228,9 +228,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.LSTORE_2;
             case 3 -> Opcode.LSTORE_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.LSTORE;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.LSTORE_W;
                 throw slotOutOfBounds(slot);
             }
@@ -244,9 +244,9 @@ public class BytecodeHelpers {
             case 2 -> Opcode.ISTORE_2;
             case 3 -> Opcode.ISTORE_3;
             default -> {
-                if ((slot & 0xFF) == slot)
+                if ((slot & ~0xFF) == 0)
                     yield Opcode.ISTORE;
-                if ((slot & 0xFFFF) == slot)
+                if ((slot & ~0xFFFF) == 0)
                     yield Opcode.ISTORE_W;
                 throw slotOutOfBounds(slot);
             }
@@ -377,20 +377,20 @@ public class BytecodeHelpers {
     public static void validateSlot(Opcode opcode, int slot, boolean load) {
         int size = opcode.sizeIfFixed();
         if (size == 1 && slot == (load ? intrinsicLoadSlot(opcode) : intrinsicStoreSlot(opcode)) ||
-                size == 2 && slot == (slot & 0xFF) ||
-                size == 4 && slot == (slot & 0xFFFF))
+                size == 2 && 0 == (slot & ~0xFF) ||
+                size == 4 && 0 == (slot & ~0xFFFF))
             return;
         throw slotOutOfBounds(opcode, slot);
     }
 
     public static void validateSlot(int slot) {
-        if ((slot & 0xFFFF) != slot)
+        if ((slot & ~0xFFFF) != 0)
             throw slotOutOfBounds(slot);
     }
 
     public static boolean validateAndIsWideIinc(int slot, int val) {
         var ret = false;
-        if ((slot & 0xFF) != slot) {
+        if ((slot & ~0xFF) != 0) {
             validateSlot(slot);
             ret = true;
         }
@@ -404,8 +404,8 @@ public class BytecodeHelpers {
     }
 
     public static void validateRet(Opcode opcode, int slot) {
-        if (opcode == Opcode.RET && slot == (slot & 0xFF) ||
-                opcode == Opcode.RET_W && slot == (slot & 0xFFFF))
+        if (opcode == Opcode.RET && 0 == (slot & ~0xFF) ||
+                opcode == Opcode.RET_W && 0 == (slot & ~0xFFFF))
             return;
         Objects.requireNonNull(opcode);
         throw slotOutOfBounds(opcode, slot);


### PR DESCRIPTION
Use `slot & ~0xFF == 0` instead of `(slot & 0xFF) == slot` to reduce codeSize.

The following is a comparison of the bytecode before and after the modification. It can be seen that using `slot & ~0xFF == 0` will reduce one iload operation.

```
// (slot & 0xFF) == slot
56: iload_0
57: sipush        255
60: iand
61: iload_0
62: if_icmpne     71

// slot & ~0xFF == 0
56: iload_0
57: sipush        -256
60: iand
61: ifne          70
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341581](https://bugs.openjdk.org/browse/JDK-8341581): Optimize BytecodeHelpers validate slot (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21367/head:pull/21367` \
`$ git checkout pull/21367`

Update a local copy of the PR: \
`$ git checkout pull/21367` \
`$ git pull https://git.openjdk.org/jdk.git pull/21367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21367`

View PR using the GUI difftool: \
`$ git pr show -t 21367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21367.diff">https://git.openjdk.org/jdk/pull/21367.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21367#issuecomment-2395127458)