### PR TITLE
8341558: [AIX] build broken after 8341413

### DIFF
--- a/src/hotspot/os/aix/osThread_aix.cpp
+++ b/src/hotspot/os/aix/osThread_aix.cpp
@@ -40,7 +40,6 @@ OSThread::OSThread()
     _ucontext(nullptr),
     _expanding_stack(0),
     _alt_sig_stack(nullptr),
-    _last_cpu_times(),
     _startThread_lock(new Monitor(Mutex::event, "startThread_lock")) {
   sigemptyset(&_caller_sigmask);
 }

--- a/src/hotspot/os/aix/osThread_aix.hpp
+++ b/src/hotspot/os/aix/osThread_aix.hpp
@@ -131,13 +131,6 @@ class OSThread : public OSThreadBase {
     return _startThread_lock;
   }
 
-  // The last measured values of cpu timing to prevent the "stale
-  // value return" bug in thread_cpu_time.
-  volatile struct {
-    jlong sys;
-    jlong user;
-  } _last_cpu_times;
-
   // Printing
   uintx thread_id_for_printing() const override {
     return (uintx)_thread_id;


### PR DESCRIPTION
The AIX build is currently broken due to a build warning caused by [JDK-8341413](https://bugs.openjdk.org/browse/JDK-8341413):
osThread_aix.cpp:43:5: error: field '_last_cpu_times' will be initialized after field '_startThread_lock' [-Werror,-Wreorder-ctor]

It turns out that `_last_cpu_times` is unused and can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341558](https://bugs.openjdk.org/browse/JDK-8341558): [AIX] build broken after 8341413 (**Bug** - P1)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21369/head:pull/21369` \
`$ git checkout pull/21369`

Update a local copy of the PR: \
`$ git checkout pull/21369` \
`$ git pull https://git.openjdk.org/jdk.git pull/21369/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21369`

View PR using the GUI difftool: \
`$ git pr show -t 21369`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21369.diff">https://git.openjdk.org/jdk/pull/21369.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21369#issuecomment-2395003569)