### PR TITLE
8341566: Add Reader.of(CharSequence)

### DIFF
--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -145,15 +145,15 @@ public abstract class Reader implements Readable, Closeable {
      * {@code CharSequence}. The reader is initially open and reading starts at
      * the first character in the sequence.
      *
+     * <p> The returned reader supports the {@link #mark mark()} and
+     * {@link #reset reset()} operations.
+     *
      * <p> The resulting reader is not safe for use by multiple
      * concurrent threads. If the reader is to be used by more than one
      * thread it should be controlled by appropriate synchronization.
      *
      * <p> If the sequence changes while the reader is open, e.g. the length
      * changes, the behavior is undefined.
-     *
-     * <p> The returned reader supports the {@link #mark mark()} and
-     * {@link #reset reset()} operations.
      *
      * @param cs {@code CharSequence} providing the character stream.
      * @return a {@code Reader} which reads characters from {@code cs}

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -208,8 +208,8 @@ public abstract class Reader implements Readable, Closeable {
                     case StringBuffer sb -> sb.getChars(next, next + n, cbuf, off);
                     case CharBuffer cb -> cb.get(next, cbuf, off, n);
                     default -> {
-                        for (int i = next, j = next + n; i < j;)
-                            cbuf[off++] = cs.charAt(i++);
+                        for (int i = 0; i < n; i++)
+                            cbuf[off + i] = cs.charAt(next + i);
                     }
                 }
                 next += n;

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -144,7 +144,8 @@ public abstract class Reader implements Readable, Closeable {
      * Returns a {@code Reader} that reads characters from a
      * {@code CharSequence}.
      *
-     * Reading starts at the first character in the sequence.
+     * The reader is initially opened and reading starts at the
+     * first character in the sequence.
      *
      * <p> The resulting reader is not safe for use by multiple
      * concurrent threads. If the reader is to be used by more than one

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -144,7 +144,7 @@ public abstract class Reader implements Readable, Closeable {
      * Returns a {@code Reader} that reads characters from a
      * {@code CharSequence}.
      *
-     * The reader is initially opened and reading starts at the
+     * <p> The reader is initially open and reading starts at the
      * first character in the sequence.
      *
      * <p> The resulting reader is not safe for use by multiple

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -153,13 +153,6 @@ public abstract class Reader implements Readable, Closeable {
      * <p> If the sequence changes while the reader is open, e.g. the length
      * changes, the behavior is undefined.
      *
-     * <p> The returned reader is initially open. The reader is closed by
-     * calling the {@code close()} method. Subsequent calls to {@code close()}
-     * have no effect. After the reader has been closed, the {@code read()},
-     * {@code read(char[])}, {@code read(char[], int, int)},
-     * {@code read(CharBuffer)}, {@code ready()}, {@code skip(long)}, and
-     * {@code transferTo()} methods all throw {@code IOException}.
-     *
      * <p> The returned reader supports the {@link #mark mark()} and
      * {@link #reset reset()} operations.
      *

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -142,10 +142,8 @@ public abstract class Reader implements Readable, Closeable {
 
     /**
      * Returns a {@code Reader} that reads characters from a
-     * {@code CharSequence}.
-     *
-     * <p> The reader is initially open and reading starts at the
-     * first character in the sequence.
+     * {@code CharSequence}. The reader is initially open and reading starts at
+     * the first character in the sequence.
      *
      * <p> The resulting reader is not safe for use by multiple
      * concurrent threads. If the reader is to be used by more than one

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -141,7 +141,8 @@ public abstract class Reader implements Readable, Closeable {
     }
 
     /**
-     * Returns a new {@code Reader} whose source is a {@link CharSequence}.
+     * Returns a {@code Reader} that reads characters from a
+     * {@code CharSequence}, starting at the first character in the sequence.
      *
      * <p> The resulting reader is not safe for use by multiple
      * concurrent threads. If the reader is to be used by more than one

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -148,7 +148,8 @@ public abstract class Reader implements Readable, Closeable {
      * concurrent threads. If the reader is to be used by more than one
      * thread it should be controlled by appropriate synchronization.
      *
-     * <p> If the sequence is concurrently modified then the result is undefined.
+     * <p> If the sequence changes while the reader is open, e.g. the length
+     * changes, the behavior is undefined.
      *
      * <p> The returned reader is initially open. The reader is closed by
      * calling the {@code close()} method. Subsequent calls to {@code close()}

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -157,7 +157,7 @@ public abstract class Reader implements Readable, Closeable {
      * {@code read(CharBuffer)}, {@code ready()}, {@code skip(long)}, and
      * {@code transferTo()} methods all throw {@code IOException}.
      *
-     * <p> The {@code markSupported()} method returns {@code true}.
+     * <p> The returned reader supports the {@link #mark mark()} operation.
      *
      * @param source {@code CharSequence} providing the character stream.
      *

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -181,14 +181,6 @@ public abstract class Reader implements Readable, Closeable {
                     throw new IOException("Stream closed");
             }
 
-            /**
-             * Reads a single character.
-             *
-             * @return     The character read, or -1 if the end of the stream has been
-             *             reached
-             *
-             * @throws     IOException  If an I/O error occurs
-             */
             @Override
             public int read() throws IOException {
                 ensureOpen();
@@ -197,24 +189,6 @@ public abstract class Reader implements Readable, Closeable {
                 return cs.charAt(next++);
             }
 
-            /**
-             * Reads characters into a portion of an array.
-             *
-             * <p> If {@code len} is zero, then no characters are read and {@code 0} is
-             * returned; otherwise, there is an attempt to read at least one character.
-             * If no character is available because the stream is at its end, the value
-             * {@code -1} is returned; otherwise, at least one character is read and
-             * stored into {@code cbuf}.
-             *
-             * @param      cbuf  {@inheritDoc}
-             * @param      off   {@inheritDoc}
-             * @param      len   {@inheritDoc}
-             *
-             * @return     {@inheritDoc}
-             *
-             * @throws     IndexOutOfBoundsException  {@inheritDoc}
-             * @throws     IOException  {@inheritDoc}
-             */
             @Override
             public int read(char[] cbuf, int off, int len) throws IOException {
                 ensureOpen();
@@ -239,26 +213,6 @@ public abstract class Reader implements Readable, Closeable {
                 return n;
             }
 
-            /**
-             * Skips characters. If the stream is already at its end before this method
-             * is invoked, then no characters are skipped and zero is returned.
-             *
-             * <p>The {@code n} parameter may be negative, even though the
-             * {@code skip} method of the {@link Reader} superclass throws
-             * an exception in this case. Negative values of {@code n} cause the
-             * stream to skip backwards. Negative return values indicate a skip
-             * backwards. It is not possible to skip backwards past the beginning of
-             * the string.
-             *
-             * <p>If the entire string has been read or skipped, then this method has
-             * no effect and always returns {@code 0}.
-             *
-             * @param n {@inheritDoc}
-             *
-             * @return {@inheritDoc}
-             *
-             * @throws IOException {@inheritDoc}
-             */
             @Override
             public long skip(long n) throws IOException {
                 ensureOpen();
@@ -271,40 +225,17 @@ public abstract class Reader implements Readable, Closeable {
                 return r;
             }
 
-            /**
-             * Tells whether this stream is ready to be read.
-             *
-             * @return True if the next read() is guaranteed not to block for input
-             *
-             * @throws     IOException  If the stream is closed
-             */
             @Override
             public boolean ready() throws IOException {
                 ensureOpen();
                 return true;
             }
 
-            /**
-             * Tells whether this stream supports the mark() operation, which it does.
-             */
             @Override
             public boolean markSupported() {
                 return true;
             }
 
-            /**
-             * Marks the present position in the stream.  Subsequent calls to reset()
-             * will reposition the stream to this point.
-             *
-             * @param  readAheadLimit  Limit on the number of characters that may be
-             *                         read while still preserving the mark.  Because
-             *                         the stream's input comes from a string, there
-             *                         is no actual limit, so this argument must not
-             *                         be negative, but is otherwise ignored.
-             *
-             * @throws     IllegalArgumentException  If {@code readAheadLimit < 0}
-             * @throws     IOException  If an I/O error occurs
-             */
             @Override
             public void mark(int readAheadLimit) throws IOException {
                 if (readAheadLimit < 0){
@@ -314,24 +245,12 @@ public abstract class Reader implements Readable, Closeable {
                 mark = next;
             }
 
-            /**
-             * Resets the stream to the most recent mark, or to the beginning of the
-             * string if it has never been marked.
-             *
-             * @throws     IOException  If an I/O error occurs
-             */
             @Override
             public void reset() throws IOException {
                 ensureOpen();
                 next = mark;
             }
 
-            /**
-             * Closes the stream and releases any system resources associated with
-             * it. Once the stream has been closed, further read(),
-             * ready(), mark(), or reset() invocations will throw an IOException.
-             * Closing a previously closed stream has no effect.
-             */
             @Override
             public void close() {
                 cs = null;

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -142,7 +142,9 @@ public abstract class Reader implements Readable, Closeable {
 
     /**
      * Returns a {@code Reader} that reads characters from a
-     * {@code CharSequence}, starting at the first character in the sequence.
+     * {@code CharSequence}.
+     *
+     * Reading starts at the first character in the sequence.
      *
      * <p> The resulting reader is not safe for use by multiple
      * concurrent threads. If the reader is to be used by more than one
@@ -158,12 +160,11 @@ public abstract class Reader implements Readable, Closeable {
      * {@code read(CharBuffer)}, {@code ready()}, {@code skip(long)}, and
      * {@code transferTo()} methods all throw {@code IOException}.
      *
-     * <p> The returned reader supports the {@link #mark mark()} operation.
+     * <p> The returned reader supports the {@link #mark mark()} and
+     * {@link #reset reset()} operations.
      *
      * @param cs {@code CharSequence} providing the character stream.
-     *
      * @return a {@code Reader} which reads characters from {@code cs}
-     *
      * @throws NullPointerException if {@code cs} is {@code null}
      *
      * @since 24
@@ -197,9 +198,10 @@ public abstract class Reader implements Readable, Closeable {
                 if (len == 0) {
                     return 0;
                 }
-                if (next >= cs.length())
+                int length = cs.length();
+                if (next >= length)
                     return -1;
-                int n = Math.min(cs.length() - next, len);
+                int n = Math.min(length - next, len);
                 switch (cs) {
                     case String s -> s.getChars(next, next + n, cbuf, off);
                     case StringBuilder sb -> sb.getChars(next, next + n, cbuf, off);

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -150,9 +150,7 @@ public abstract class Reader implements Readable, Closeable {
      *
      * <p> The returned reader is initially open. The reader is closed by
      * calling the {@code close()} method. Subsequent calls to {@code close()}
-     * have no effect.
-     *
-     * <p> After the reader has been closed, the {@code read()},
+     * have no effect. After the reader has been closed, the {@code read()},
      * {@code read(char[])}, {@code read(char[], int, int)},
      * {@code read(CharBuffer)}, {@code ready()}, {@code skip(long)}, and
      * {@code transferTo()} methods all throw {@code IOException}.

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -159,26 +159,26 @@ public abstract class Reader implements Readable, Closeable {
      *
      * <p> The returned reader supports the {@link #mark mark()} operation.
      *
-     * @param source {@code CharSequence} providing the character stream.
+     * @param cs {@code CharSequence} providing the character stream.
      *
-     * @return a {@code Reader} which reads characters from {@code source}
+     * @return a {@code Reader} which reads characters from {@code cs}
      *
-     * @throws NullPointerException if {@code source} is {@code null}
+     * @throws NullPointerException if {@code cs} is {@code null}
      *
      * @since 24
      */
-    public static Reader of(CharSequence source) {
-        Objects.requireNonNull(source);
+    public static Reader of(final CharSequence cs) {
+        Objects.requireNonNull(cs);
 
         return new Reader() {
-            private final int length = source.length();
-            private CharSequence cs = source;
+            private final int length = cs.length();
+            private boolean isClosed;
             private int next = 0;
             private int mark = 0;
 
             /** Check to make sure that the stream has not been closed */
             private void ensureOpen() throws IOException {
-                if (cs == null)
+                if (isClosed)
                     throw new IOException("Stream closed");
             }
 
@@ -254,7 +254,7 @@ public abstract class Reader implements Readable, Closeable {
 
             @Override
             public void close() {
-                cs = null;
+                isClosed = true;
             }
         };
     }

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -143,38 +143,35 @@ public abstract class Reader implements Readable, Closeable {
     /**
      * Returns a new {@code Reader} whose source is a {@link CharSequence}.
      *
-     * <p> The returned reader's class provides an API compatible with
-     * {@link StringReader}, but with no guarantee of synchronization, and
-     * without limitation to {@code String} sources. This class is designed for
-     * use as a drop-in replacement for {@code StringReader} in places where the
-     * reader was being used by a single thread (as is generally the case).
-     * Where possible, it is recommended that this class be used in preference
-     * to {@code StringReader} as it will be faster under most implementations.
+     * <p> The resulting reader is not safe for use by multiple
+     * concurrent threads. If the reader is to be used by more than one
+     * thread it should be controlled by appropriate synchronization.
      *
-     * <p> The returned stream is initially open. The stream is closed by
+     * <p> The returned reader is initially open. The reader is closed by
      * calling the {@code close()} method. Subsequent calls to {@code close()}
      * have no effect.
      *
-     * <p> After the stream has been closed, the {@code read()},
+     * <p> After the reader has been closed, the {@code read()},
      * {@code read(char[])}, {@code read(char[], int, int)},
      * {@code read(CharBuffer)}, {@code ready()}, {@code skip(long)}, and
      * {@code transferTo()} methods all throw {@code IOException}.
      *
      * <p> The {@code markSupported()} method returns {@code true}.
      *
-     * <p> The {@link #lock object} used to synchronize operations on the
-     * returned {@code Reader} is not specified.
+     * @param source {@code CharSequence} providing the character stream.
      *
-     * @param c {@code CharSequence} providing the character stream.
+     * @return a {@code Reader} which reads characters from {@code source}
      *
-     * @return a {@code Reader} which reads characters from {@code c}
+     * @throws NullPointerException if {@code source} is {@code null}
      *
      * @since 24
      */
-    public static Reader of(CharSequence c) {
+    public static Reader of(CharSequence source) {
+        Objects.requireNonNull(source);
+
         return new Reader() {
-            private final int length = c.length();
-            private CharSequence cs = c;
+            private final int length = source.length();
+            private CharSequence cs = source;
             private int next = 0;
             private int mark = 0;
 

--- a/src/java.base/share/classes/java/io/Reader.java
+++ b/src/java.base/share/classes/java/io/Reader.java
@@ -208,8 +208,8 @@ public abstract class Reader implements Readable, Closeable {
                     case StringBuffer sb -> sb.getChars(next, next + n, cbuf, off);
                     case CharBuffer cb -> cb.get(next, cbuf, off, n);
                     default -> {
-                        for (int i = 0; i < n; i++)
-                            cbuf[off + i] = cs.charAt(next + i);
+                        for (int i = next, j = next + n; i < j;)
+                            cbuf[off++] = cs.charAt(i++);
                     }
                 }
                 next += n;

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -31,11 +31,8 @@ import java.util.Objects;
  * A character stream whose source is a string.
  *
  * @apiNote
- * As of release JDK 24, this class has been supplemented with an equivalent
- * API designed for use by a single thread, {@link Reader#of(CharSequence)}.
- * {@code Reader.of(String)} should generally be used in preference to this one,
- * as it supports all of the same operations but it is faster, as it performs no
- * synchronization.
+ * {@link Reader#of(CharSequence)} provides a method to read from any
+ * {@link CharSequence} that may be more efficient than {@code StringReader}.
  *
  * @author      Mark Reinhold
  * @since       1.1

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,16 +30,19 @@ import java.util.Objects;
 /**
  * A character stream whose source is a string.
  *
+ * As of release JDK 24, this class has been supplemented with an equivalent
+ * API designed for use by a single thread, {@link Reader#of(CharSequence)}.
+ * {@code Reader.of(String)} should generally be used in preference to this one,
+ * as it supports all of the same operations but it is faster, as it performs no
+ * synchronization.
+ *
  * @author      Mark Reinhold
  * @since       1.1
  */
 
 public class StringReader extends Reader {
 
-    private final int length;
-    private String str;
-    private int next = 0;
-    private int mark = 0;
+    private final Reader r;
 
     /**
      * Creates a new string reader.
@@ -47,14 +50,7 @@ public class StringReader extends Reader {
      * @param s  String providing the character stream.
      */
     public StringReader(String s) {
-        this.length = s.length();
-        this.str = s;
-    }
-
-    /** Check to make sure that the stream has not been closed */
-    private void ensureOpen() throws IOException {
-        if (str == null)
-            throw new IOException("Stream closed");
+        r = Reader.of(s);
     }
 
     /**
@@ -67,10 +63,7 @@ public class StringReader extends Reader {
      */
     public int read() throws IOException {
         synchronized (lock) {
-            ensureOpen();
-            if (next >= length)
-                return -1;
-            return str.charAt(next++);
+            return r.read();
         }
     }
 
@@ -94,17 +87,7 @@ public class StringReader extends Reader {
      */
     public int read(char[] cbuf, int off, int len) throws IOException {
         synchronized (lock) {
-            ensureOpen();
-            Objects.checkFromIndexSize(off, len, cbuf.length);
-            if (len == 0) {
-                return 0;
-            }
-            if (next >= length)
-                return -1;
-            int n = Math.min(length - next, len);
-            str.getChars(next, next + n, cbuf, off);
-            next += n;
-            return n;
+            return r.read(cbuf, off, len);
         }
     }
 
@@ -130,14 +113,7 @@ public class StringReader extends Reader {
      */
     public long skip(long n) throws IOException {
         synchronized (lock) {
-            ensureOpen();
-            if (next >= length)
-                return 0;
-            // Bound skip by beginning and end of the source
-            long r = Math.min(length - next, n);
-            r = Math.max(-next, r);
-            next += (int)r;
-            return r;
+            return r.skip(n);
         }
     }
 
@@ -150,8 +126,7 @@ public class StringReader extends Reader {
      */
     public boolean ready() throws IOException {
         synchronized (lock) {
-            ensureOpen();
-            return true;
+            return r.ready();
         }
     }
 
@@ -176,12 +151,8 @@ public class StringReader extends Reader {
      * @throws     IOException  If an I/O error occurs
      */
     public void mark(int readAheadLimit) throws IOException {
-        if (readAheadLimit < 0){
-            throw new IllegalArgumentException("Read-ahead limit < 0");
-        }
         synchronized (lock) {
-            ensureOpen();
-            mark = next;
+            r.mark(readAheadLimit);
         }
     }
 
@@ -193,8 +164,7 @@ public class StringReader extends Reader {
      */
     public void reset() throws IOException {
         synchronized (lock) {
-            ensureOpen();
-            next = mark;
+            r.reset();
         }
     }
 
@@ -207,7 +177,11 @@ public class StringReader extends Reader {
      */
     public void close() {
         synchronized (lock) {
-            str = null;
+            try {
+                r.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
         }
     }
 }

--- a/src/java.base/share/classes/java/io/StringReader.java
+++ b/src/java.base/share/classes/java/io/StringReader.java
@@ -30,6 +30,7 @@ import java.util.Objects;
 /**
  * A character stream whose source is a string.
  *
+ * @apiNote
  * As of release JDK 24, this class has been supplemented with an equivalent
  * API designed for use by a single thread, {@link Reader#of(CharSequence)}.
  * {@code Reader.of(String)} should generally be used in preference to this one,

--- a/test/jdk/java/io/Reader/Of.java
+++ b/test/jdk/java/io/Reader/Of.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.ReadOnlyBufferException;
+
+import org.testng.annotations.*;
+
+import static org.testng.Assert.*;
+
+/*
+ * @test
+ * @bug 8341566
+ * @run testng Of
+ * @summary Check for expected behavior of Reader.of().
+ */
+public class Of {
+    final static String CONTENT = "Some Reader Test";
+
+    /*
+     * Readers to be tested.
+     */
+    @DataProvider
+    public static Reader[] readers() {
+        return new Reader[] {
+            new StringReader(CONTENT),
+            Reader.of(CONTENT),
+            Reader.of(new StringBuffer(CONTENT)),
+            Reader.of(new StringBuilder(CONTENT)),
+            Reader.of(ByteBuffer.allocateDirect(CONTENT.length() * 2)
+                    .asCharBuffer().put(CONTENT).flip()),
+            Reader.of(CharBuffer.wrap(CONTENT.toCharArray()))
+        };
+    }
+
+    @Test(dataProvider = "readers")
+    public void testOpen(Reader reader) {
+        assertNotNull(reader, "Reader.of(String) returned null");
+    }
+
+    @Test(dataProvider = "readers")
+    public void testRead(Reader reader) throws IOException {
+        String s = "";
+        for (int c; (c = reader.read()) != -1; s += (char) c);
+        assertEquals(s, CONTENT, "read() returned wrong value");
+    }
+
+    @Test(dataProvider = "readers")
+    public void testReadBII(Reader reader) throws IOException {
+        char[] c = new char[16];
+        assertEquals(reader.read(c, 8, 8), 8,
+                "read(char[],int,int) does not respect given start or end");
+        assertEquals(reader.read(c, 0, 16), 8,
+                "read(char[],int,int) does not respect end of stream");
+        assertEquals(new String(c),
+                CONTENT.substring(8, 16) + CONTENT.substring(0, 8),
+                "read(char[],int,int) provides wrong content");
+    }
+
+    @Test(dataProvider = "readers")
+    public void testReadBIILenZero(Reader reader) throws IOException {
+        assertEquals(reader.read(new char[1], 0, 0), 0,
+                "read(char[],int,int) != 0");
+    }
+
+    @Test(dataProvider = "readers")
+    public void testReadDirectCharBuffer(Reader reader) throws IOException {
+        CharBuffer charBuffer = ByteBuffer.allocateDirect(32).asCharBuffer();
+        charBuffer.position(8);
+        assertEquals(reader.read(charBuffer), 8,
+                "read(CharBuffer) does not respect position or limit");
+        charBuffer.rewind();
+        assertEquals(reader.read(charBuffer), 8,
+                "read(CharBuffer) does not respect end of stream");
+        charBuffer.rewind();
+        assertEquals(charBuffer.toString(),
+                // last part first proofs that copy loops correctly stopped
+                CONTENT.substring(8, 16) + CONTENT.substring(0, 8),
+                "read(CharBuffer) provides wrong content");
+    }
+
+    @Test(dataProvider = "readers")
+    public void testReadNonDirectCharBuffer(Reader reader) throws IOException {
+        CharBuffer charBuffer = CharBuffer.allocate(16);
+        charBuffer.position(8);
+        assertEquals(reader.read(charBuffer), 8,
+                "read(CharBuffer) does not respect position or limit");
+        charBuffer.rewind();
+        assertEquals(reader.read(charBuffer), 8,
+                "read(CharBuffer) does not respect end of stream");
+        charBuffer.rewind();
+        assertEquals(charBuffer.toString(),
+                CONTENT.substring(8, 16) + CONTENT.substring(0, 8),
+                "read(CharBuffer) provides wrong content");
+    }
+
+    @Test(dataProvider = "readers")
+    public void testReadCharBufferZeroRemaining(Reader reader) throws IOException {
+        CharBuffer charBuffer = CharBuffer.allocate(0);
+        assertEquals(reader.read(charBuffer), 0, "read(CharBuffer) != 0");
+    }
+
+    @Test(dataProvider = "readers")
+    public void testReady(Reader reader) throws IOException {
+        assertTrue(reader.ready());
+    }
+
+    @Test(dataProvider = "readers")
+    public void testSkip(Reader reader) throws IOException {
+        assertEquals(reader.skip(8), 8, "skip() does not respect limit");
+        assertEquals(reader.skip(9), 8, "skip() does not respect end of stream");
+        assertEquals(reader.skip(1), 0, "skip() does not respect empty stream");
+    }
+
+    @Test(dataProvider = "readers")
+    public void testTransferTo(Reader reader) throws IOException {
+        StringWriter sw = new StringWriter(16);
+        assertEquals(reader.transferTo(sw), 16, "transferTo() != 16");
+        assertEquals(reader.transferTo(sw), 0,
+                "transferTo() does not resect empty stream");
+        assertEquals(sw.toString(), CONTENT,
+                "transferTo() provides wrong content");
+    }
+
+    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    public void testReadClosed(Reader reader) throws IOException {
+        reader.close();
+        reader.read();
+    }
+
+    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    public void testReadBIIClosed(Reader reader) throws IOException {
+        reader.close();
+        reader.read(new char[1], 0, 1);
+    }
+
+    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    public void testReadCharBufferClosed(Reader reader) throws IOException {
+        CharBuffer charBuffer = CharBuffer.allocate(1);
+        reader.close();
+        reader.read(charBuffer);
+    }
+
+    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    public void testReadCharBufferZeroRemainingClosed(Reader reader) throws IOException {
+        CharBuffer charBuffer = CharBuffer.allocate(0);
+        reader.close();
+        reader.read(charBuffer);
+    }
+
+    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    public void testReadyClosed(Reader reader) throws IOException {
+        reader.close();
+        reader.ready();
+    }
+
+    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    public void testSkipClosed(Reader reader) throws IOException {
+        reader.close();
+        reader.skip(1);
+    }
+
+    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    public void testTransferToClosed(Reader reader) throws IOException {
+        reader.close();
+        reader.transferTo(new StringWriter(1));
+    }
+
+    @Test(dataProvider = "readers")
+    public void testCloseClosed(Reader reader) throws IOException {
+        reader.close();
+        reader.close();
+    }
+}

--- a/test/jdk/java/io/Reader/Of.java
+++ b/test/jdk/java/io/Reader/Of.java
@@ -36,8 +36,8 @@ import static org.testng.Assert.*;
 /*
  * @test
  * @bug 8341566
- * @run testng Of
  * @summary Check for expected behavior of Reader.of().
+ * @run testng Of
  */
 public class Of {
     final static String CONTENT = "Some Reader Test";

--- a/test/jdk/java/io/Reader/Of.java
+++ b/test/jdk/java/io/Reader/Of.java
@@ -59,11 +59,6 @@ public class Of {
     }
 
     @Test(dataProvider = "readers")
-    public void testOpen(Reader reader) {
-        assertNotNull(reader, "Reader.of(String) returned null");
-    }
-
-    @Test(dataProvider = "readers")
     public void testRead(Reader reader) throws IOException {
         String s = "";
         for (int c; (c = reader.read()) != -1; s += (char) c);

--- a/test/jdk/java/io/Reader/Of.java
+++ b/test/jdk/java/io/Reader/Of.java
@@ -54,7 +54,30 @@ public class Of {
             Reader.of(new StringBuilder(CONTENT)),
             Reader.of(ByteBuffer.allocateDirect(CONTENT.length() * 2)
                     .asCharBuffer().put(CONTENT).flip()),
-            Reader.of(CharBuffer.wrap(CONTENT.toCharArray()))
+            Reader.of(CharBuffer.wrap(CONTENT.toCharArray())),
+            Reader.of(new CharSequence() {
+                @Override
+                public char charAt(int index) {
+                    return CONTENT.charAt(index);
+                }
+
+                @Override
+                public int length() {
+                    return CONTENT.length();
+                }
+
+                @Override
+                public CharSequence subSequence(int start, int end) {
+                    // unused by Reader.Of's result
+                    throw new UnsupportedOperationException();
+                }
+
+                @Override
+                public String toString() {
+                    // Reader.Of's result SHALL NOT convert to String
+                    throw new UnsupportedOperationException();
+                }
+            })
         };
     }
 

--- a/test/jdk/java/io/Reader/Of.java
+++ b/test/jdk/java/io/Reader/Of.java
@@ -160,7 +160,7 @@ public class Of {
         StringWriter sw = new StringWriter(16);
         assertEquals(reader.transferTo(sw), 16, "transferTo() != 16");
         assertEquals(reader.transferTo(sw), 0,
-                "transferTo() does not resect empty stream");
+                "transferTo() does not respect empty stream");
         assertEquals(sw.toString(), CONTENT,
                 "transferTo() provides wrong content");
     }

--- a/test/jdk/java/io/Reader/Of.java
+++ b/test/jdk/java/io/Reader/Of.java
@@ -165,48 +165,48 @@ public class Of {
                 "transferTo() provides wrong content");
     }
 
-    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    @Test(dataProvider = "readers")
     public void testReadClosed(Reader reader) throws IOException {
         reader.close();
-        reader.read();
+        assertThrows(IOException.class, () -> {reader.read();});
     }
 
-    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    @Test(dataProvider = "readers")
     public void testReadBIIClosed(Reader reader) throws IOException {
         reader.close();
-        reader.read(new char[1], 0, 1);
+        assertThrows(IOException.class, () -> reader.read(new char[1], 0, 1));
     }
 
-    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    @Test(dataProvider = "readers")
     public void testReadCharBufferClosed(Reader reader) throws IOException {
         CharBuffer charBuffer = CharBuffer.allocate(1);
         reader.close();
-        reader.read(charBuffer);
+        assertThrows(IOException.class, () -> reader.read(charBuffer));
     }
 
-    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    @Test(dataProvider = "readers")
     public void testReadCharBufferZeroRemainingClosed(Reader reader) throws IOException {
         CharBuffer charBuffer = CharBuffer.allocate(0);
         reader.close();
-        reader.read(charBuffer);
+        assertThrows(IOException.class, () -> reader.read(charBuffer));
     }
 
-    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    @Test(dataProvider = "readers")
     public void testReadyClosed(Reader reader) throws IOException {
         reader.close();
-        reader.ready();
+        assertThrows(IOException.class, () -> reader.ready());
     }
 
-    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    @Test(dataProvider = "readers")
     public void testSkipClosed(Reader reader) throws IOException {
         reader.close();
-        reader.skip(1);
+        assertThrows(IOException.class, () -> reader.skip(1));
     }
 
-    @Test(dataProvider = "readers", expectedExceptions = IOException.class)
+    @Test(dataProvider = "readers")
     public void testTransferToClosed(Reader reader) throws IOException {
         reader.close();
-        reader.transferTo(new StringWriter(1));
+        assertThrows(IOException.class, () -> reader.transferTo(new StringWriter(1)));
     }
 
     @Test(dataProvider = "readers")


### PR DESCRIPTION
This Pull Requests proposes an implementation for [JDK-8341566](https://bugs.openjdk.org/browse/JDK-8341566): Adding the new method `public static Reader Reader.of(CharSequence)` will return an anonymous, non-synchronized implementation of a `Reader` for each kind of `CharSequence` implementation. It is optimized for `String`, `StringBuilder`, `StringBuffer` and `CharBuffer`.

In addition, this Pull Request proposes to replace the implementation of `StringReader` to become a simple synchronized wrapper around `Reader.of(CharSequence)` for the case of `String` sources. To ensure correctness, this PR...
* ...simply moved the **original code** of `StringBuilder` to become the de-facto implementation of `Reader.of()`, then stripped synchronized from it on the left hand, but kept just a synchronized wrapper on the right hand. Then added a `switch` for optimizations within the original code, at the exact location where previously just an optimization for `String` lived in.
* ...added tests for all methods (`Of.java`), and applied that test upon the modified `StringBuilder`.

Wherever new JavaDocs were added, existing phrases from other code locations have been copied and adapted, to best match the same wording.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8341596](https://bugs.openjdk.org/browse/JDK-8341596) to be approved
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issues
 * [JDK-8341566](https://bugs.openjdk.org/browse/JDK-8341566): Add Reader.of(CharSequence) (**Enhancement** - P4)
 * [JDK-8341596](https://bugs.openjdk.org/browse/JDK-8341596): Add Reader.of(CharSequence) (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21371/head:pull/21371` \
`$ git checkout pull/21371`

Update a local copy of the PR: \
`$ git checkout pull/21371` \
`$ git pull https://git.openjdk.org/jdk.git pull/21371/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21371`

View PR using the GUI difftool: \
`$ git pr show -t 21371`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21371.diff">https://git.openjdk.org/jdk/pull/21371.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21371#issuecomment-2395111947)