### PR TITLE
8341585: Test java/foreign/TestUpcallStress.java should mark as /native

### DIFF
--- a/test/jdk/java/foreign/TestUpcallStress.java
+++ b/test/jdk/java/foreign/TestUpcallStress.java
@@ -30,7 +30,7 @@
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  * @bug 8337753
  *
- * @run testng/othervm/timeout=3200
+ * @run testng/native/othervm/timeout=3200
  *   -Xcheck:jni
  *   -XX:+IgnoreUnrecognizedVMOptions
  *   -XX:-VerifyDependencies


### PR DESCRIPTION
Hi all,
The newly added test `java/foreign/TestUpcallStress.java` call `System.loadLibrary("TestUpcall")` load native library, so this test should mark as `/native`.
The change has been verified locally, trivial fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341585](https://bugs.openjdk.org/browse/JDK-8341585): Test java/foreign/TestUpcallStress.java should mark as /native (**Bug** - P4)


### Reviewers
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21374/head:pull/21374` \
`$ git checkout pull/21374`

Update a local copy of the PR: \
`$ git checkout pull/21374` \
`$ git pull https://git.openjdk.org/jdk.git pull/21374/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21374`

View PR using the GUI difftool: \
`$ git pr show -t 21374`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21374.diff">https://git.openjdk.org/jdk/pull/21374.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21374#issuecomment-2395267816)
</details>
