### PR TITLE
8341593: Problemlist java/foreign/TestUpcallStress.java in Xcomp mode

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -29,4 +29,5 @@
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java          8146623 generic-all
 java/lang/management/MemoryMXBean/CollectionUsageThreshold.java 8318668 generic-all
+java/foreign/TestUpcallStress.java                              8341584 generic-all
 com/sun/jdi/InterruptHangTest.java                              8043571 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList `java/foreign/TestUpcallStress.java` in Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341593](https://bugs.openjdk.org/browse/JDK-8341593): Problemlist java/foreign/TestUpcallStress.java in Xcomp mode (**Sub-task** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21375/head:pull/21375` \
`$ git checkout pull/21375`

Update a local copy of the PR: \
`$ git checkout pull/21375` \
`$ git pull https://git.openjdk.org/jdk.git pull/21375/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21375`

View PR using the GUI difftool: \
`$ git pr show -t 21375`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21375.diff">https://git.openjdk.org/jdk/pull/21375.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21375#issuecomment-2395365668)