### PR TITLE
8341586: RISC-V: build fail with gcc9

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_flush_icache.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_flush_icache.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2023, Rivos Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -48,7 +48,7 @@ static long sys_flush_icache(uintptr_t start, uintptr_t end , uintptr_t flags) {
 }
 
 bool RiscvFlushIcache::test() {
-  alignas(64) char memory[64];
+  alignas(16) char memory[64];
   long ret = sys_flush_icache((uintptr_t)&memory[0],
                               (uintptr_t)&memory[sizeof(memory) - 1],
                               SYS_RISCV_FLUSH_ICACHE_ALL);


### PR DESCRIPTION
Hi all,
The `src/hotspot/cpu/riscv/icache_riscv.cpp` build fails `riscv_flush_icache.cpp:51:29: error: requested alignment 64 is larger than 16 [-Werror=attributes]` with gcc9. Alignment 16 will be enough, though the [NR_riscv_flush_icache syscall](https://github.com/torvalds/linux/blob/master/tools/arch/riscv/include/uapi/asm/unistd.h) doesn't reqiure alignment.

Addiontional testing:

- [x] riscv native build with release conf and slowdebug conf
- [ ] jtreg tier1 tests with release build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341586](https://bugs.openjdk.org/browse/JDK-8341586): RISC-V: build fail with gcc9 (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21376/head:pull/21376` \
`$ git checkout pull/21376`

Update a local copy of the PR: \
`$ git checkout pull/21376` \
`$ git pull https://git.openjdk.org/jdk.git pull/21376/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21376`

View PR using the GUI difftool: \
`$ git pr show -t 21376`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21376.diff">https://git.openjdk.org/jdk/pull/21376.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21376#issuecomment-2395442808)