### PR TITLE
8341597: ZipFileInflaterInputStream input buffer size uses uncompressed size

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -411,12 +411,9 @@ public class ZipFile implements ZipConstants, Closeable {
                 case DEFLATED:
                     // Inflater likes a bit of slack
                     // MORE: Compute good size for inflater stream:
-                    long size = CENLEN(zsrc.cen, pos) + 2;
+                    long size = CENSIZ(zsrc.cen, pos);
                     if (size > 65536) {
                         size = 8192;
-                    }
-                    if (size <= 0) {
-                        size = 4096;
                     }
                     InputStream is = new ZipFileInflaterInputStream(in, res, (int) size);
                     synchronized (istreams) {


### PR DESCRIPTION
Please review this PR which proposes to change the input buffer size of `ZipFileInflaterInputStream` to be based on the _compressed_ size of a ZIP entry instead of the _uncompressed_ size. This saves allocation since buffers will no longer be oversized:

* The `size` parameter passed to the `ZipFileInflaterInputStream` constructor is passed on to the superclass `InflaterInputStream` where it determines the size of the input buffer. This buffer is used to read compressed data and pass it on to the `Inflater`.
* `ZipFile:getInputStream` currently looks at the _uncompressed_ size when determining the input buffer size. It should instead use the _compressed_ size, since this buffer is used for compressed, not uncompressed data.
* The current implementation somewhat mysteriously adds 2 to the uncompressed size. My guess is that this is to allow fitting a two-byte DEFLATE header for empty files (where the uncompressed size is 0 and the compressed size is 2).
* There is a check for `size <= 0`. This condition is unreachable in the current code and in the PR as well, since the compressed size will always be `>= 2`. I propose we remove this check.

Performance: A benchmark which measures the cost of opening and closing input streams using `ZipFile::getInputStream` shows a modest improvement of ~5%, consistent with less allocation of unused buffer space.

Testing: No tests are added in this PR. The `noreg-cleanup` label is added in JBS. GHA testing is currently pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341597](https://bugs.openjdk.org/browse/JDK-8341597): ZipFileInflaterInputStream input buffer size uses uncompressed size (**Enhancement** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21379/head:pull/21379` \
`$ git checkout pull/21379`

Update a local copy of the PR: \
`$ git checkout pull/21379` \
`$ git pull https://git.openjdk.org/jdk.git pull/21379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21379`

View PR using the GUI difftool: \
`$ git pr show -t 21379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21379.diff">https://git.openjdk.org/jdk/pull/21379.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21379#issuecomment-2395533816)