### PR TITLE
8341134: Deprecate for removal the jrunscript tool

### DIFF
--- a/src/java.scripting/share/classes/com/sun/tools/script/shell/Main.java
+++ b/src/java.scripting/share/classes/com/sun/tools/script/shell/Main.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,10 @@ public class Main {
      * @param args command line argument array
      */
     public static void main(String[] args) {
+        // print deprecation warning
+        getError().println(getMessage("deprecated.warning",
+                new Object[] { PROGRAM_NAME }));
+
         // parse command line options
         String[] scriptArgs = processOptions(args);
 

--- a/src/java.scripting/share/classes/com/sun/tools/script/shell/messages.properties
+++ b/src/java.scripting/share/classes/com/sun/tools/script/shell/messages.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2005, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -63,3 +63,6 @@ argument is script file and the rest of the arguments, if any, are passed\n\
 as script arguments. If [arguments..] and -e or -f option is used, then all\n\
 [arguments..] are passed as script arguments. If [arguments..], -e, -f are\n\
 missing, then interactive mode is used.
+
+deprecated.warning=\
+        Warning: {0} is deprecated and will be removed in a future release.

--- a/src/java.scripting/share/classes/module-info.java
+++ b/src/java.scripting/share/classes/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,10 +26,9 @@
 /**
  * Defines the Scripting API.
  *
- * <p> The JDK implementation of this module includes a language-independent
- * command-line script shell, <em>{@index jrunscript jrunscript tool}</em>,
- * that supports executing JavaScript and other languages if its corresponding
- * script engine is installed.
+ * <p> The <em>{@index jrunscript jrunscript tool}</em> included in the JDK
+ * implementation of this module, has been deprecated for removal since
+ * JDK 24 and will be removed in a future release.
  *
  * @toolGuide jrunscript
  *

--- a/src/java.scripting/share/classes/module-info.java
+++ b/src/java.scripting/share/classes/module-info.java
@@ -30,8 +30,8 @@
  * command-line script shell, <em>{@index jrunscript jrunscript tool}</em>,
  * that supports executing JavaScript and other languages if its corresponding
  * script engine is installed.
- * <p> The {@code jrunscript} tool is deprecated for removal since JDK 24
- * and will be removed in a future release.
+ * <p> The {@code jrunscript} tool is deprecated and will be removed
+ * in a future release.
  *
  * @toolGuide jrunscript
  *

--- a/src/java.scripting/share/classes/module-info.java
+++ b/src/java.scripting/share/classes/module-info.java
@@ -26,9 +26,12 @@
 /**
  * Defines the Scripting API.
  *
- * <p> The <em>{@index jrunscript jrunscript tool}</em> included in the JDK
- * implementation of this module, has been deprecated for removal since
- * JDK 24 and will be removed in a future release.
+ * <p> The JDK implementation of this module includes a language-independent
+ * command-line script shell, <em>{@index jrunscript jrunscript tool}</em>,
+ * that supports executing JavaScript and other languages if its corresponding
+ * script engine is installed.
+ * <p> The {@code jrunscript} tool is deprecated for removal since JDK 24
+ * and will be removed in a future release.
  *
  * @toolGuide jrunscript
  *

--- a/src/java.scripting/share/man/jrunscript.1
+++ b/src/java.scripting/share/man/jrunscript.1
@@ -45,7 +45,8 @@ and batch modes
 .PP
 \f[B]Note:\f[R]
 .PP
-This tool is deprecated and will be removed in a future release.
+This tool is \f[B]experimental\f[R] and unsupported.
+It is deprecated and will be removed in a future release.
 .PP
 \f[V]jrunscript\f[R] [\f[I]options\f[R]] [\f[I]arguments\f[R]]
 .TP

--- a/src/java.scripting/share/man/jrunscript.1
+++ b/src/java.scripting/share/man/jrunscript.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 2006, 2018, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ and batch modes
 .PP
 \f[B]Note:\f[R]
 .PP
-This tool is \f[B]experimental\f[R] and unsupported.
+This tool is deprecated and will be removed in a future release.
 .PP
 \f[V]jrunscript\f[R] [\f[I]options\f[R]] [\f[I]arguments\f[R]]
 .TP


### PR DESCRIPTION
Can I please get  a review for this change which proposes to deprecate for removal the `jrunscript` tool?

The `jrunscript` tool as documented in its specification https://docs.oracle.com/en/java/javase/23/docs/specs/man/jrunscript.html was an experimental and unsupported tool. Ever since the script engine implementations have been removed from the JDK, the default usage of this tool has been non-functional:

```
$> jrunscript
script engine for language js can not be found
```

The tool itself could be launched by specifying a script engine implementation in the classpath, in which case it will use that script engine implementation. However, given that the JDK itself ships no such engines anymore and since there are no plans to continue support for this tool, the tool will now print a deprecation warning in preparation for its removal from a future release.

No new tests have been added and existing tests in tier1, tier2 and tier3 continue to pass. I will draft a CSR (and a release note) shortly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8341610](https://bugs.openjdk.org/browse/JDK-8341610) to be approved

### Issues
 * [JDK-8341134](https://bugs.openjdk.org/browse/JDK-8341134): Deprecate for removal the jrunscript tool (**Bug** - P4)
 * [JDK-8341610](https://bugs.openjdk.org/browse/JDK-8341610): Deprecate for removal the jrunscript tool (**CSR**)


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**) Review applies to [65c2ec8f](https://git.openjdk.org/jdk/pull/21380/files/65c2ec8f481307856da7ef4e129c567294402316)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21380/head:pull/21380` \
`$ git checkout pull/21380`

Update a local copy of the PR: \
`$ git checkout pull/21380` \
`$ git pull https://git.openjdk.org/jdk.git pull/21380/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21380`

View PR using the GUI difftool: \
`$ git pr show -t 21380`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21380.diff">https://git.openjdk.org/jdk/pull/21380.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21380#issuecomment-2395874246)