### PR TITLE
8341633: StatSampler::assert_system_property: Print the keys and values of the assert

### DIFF
--- a/src/hotspot/share/runtime/statSampler.cpp
+++ b/src/hotspot/share/runtime/statSampler.cpp
@@ -201,7 +201,8 @@ void StatSampler::assert_system_property(const char* name, const char* value, TR
   // convert Java String to utf8 string
   char* system_value = java_lang_String::as_utf8_string(value_oop);
 
-  assert(strcmp(value, system_value) == 0, "property value mustn't differ from System.getProperty");
+  assert(strcmp(value, system_value) == 0, "property value mustn't differ from System.getProperty. Our value is: %s, System.getProperty is: %s",
+         value, system_value);
 #endif // ASSERT
 }
 


### PR DESCRIPTION
Hi,

This trivial PR adds that the failing assert also prints the differing values so that we can more easily debug what's wrong when this assert is triggered.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341633](https://bugs.openjdk.org/browse/JDK-8341633): StatSampler::assert_system_property: Print the keys and values of the assert (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21386/head:pull/21386` \
`$ git checkout pull/21386`

Update a local copy of the PR: \
`$ git checkout pull/21386` \
`$ git pull https://git.openjdk.org/jdk.git pull/21386/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21386`

View PR using the GUI difftool: \
`$ git pr show -t 21386`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21386.diff">https://git.openjdk.org/jdk/pull/21386.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21386#issuecomment-2396705733)