### PR TITLE
8341637: java/net/Socket/UdpSocket.java fails with "java.net.BindException: Address already in use" (macos-aarch64)

### DIFF
--- a/test/jdk/java/net/Socket/UdpSocket.java
+++ b/test/jdk/java/net/Socket/UdpSocket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,6 +46,8 @@ import static org.testng.Assert.*;
 
 @Test
 public class UdpSocket {
+
+    private static final int MAX_RETRIES = 3;
 
     /**
      * Test using the Socket API to send/receive datagrams
@@ -133,16 +135,19 @@ public class UdpSocket {
     }
 
 
-    private Socket newUdpSocket() throws IOException {
-        Socket s = null;
-
-        try {
-            s = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
-        } catch (BindException unexpected) {
-            System.out.println("BindException caught retry Socket creation");
-            s = new Socket(InetAddress.getLoopbackAddress(), 8000, false);
+    private Socket newUdpSocket() throws IOException, InterruptedException {
+        BindException unexpected = null;
+        for (int i=0; i < MAX_RETRIES; i++) {
+            try {
+                return new Socket(InetAddress.getLoopbackAddress(), 8000, false);
+            } catch (BindException be) {
+                unexpected = be;
+                System.out.printf("BindException caught: retry Socket creation [%s/%s]%n",
+                        i+1, MAX_RETRIES);
+                Thread.sleep(10 + 10 * i);
+            }
         }
-        return s;
+        throw unexpected;
     }
 
     private void closeAll(Deque<Socket> sockets) throws IOException {

--- a/test/jdk/java/net/Socket/UdpSocket.java
+++ b/test/jdk/java/net/Socket/UdpSocket.java
@@ -142,9 +142,11 @@ public class UdpSocket {
                 return new Socket(InetAddress.getLoopbackAddress(), 8000, false);
             } catch (BindException be) {
                 unexpected = be;
-                System.out.printf("BindException caught: retry Socket creation [%s/%s]%n",
-                        i+1, MAX_RETRIES);
-                Thread.sleep(10 + 10 * i);
+                if (i != MAX_RETRIES - 1) {
+                    System.out.printf("BindException caught: retry Socket creation [%s/%s]%n",
+                            i + 1, MAX_RETRIES);
+                    Thread.sleep(10 + 10 * i);
+                }
             }
         }
         throw unexpected;


### PR DESCRIPTION
UdpSocket has been observed failing again in the CI.
[JDK-8265362](https://bugs.openjdk.org/browse/JDK-8265362) added a retry-once policy. 
This fix proposes to retry once more, and adds a bit of delay between retries.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341637](https://bugs.openjdk.org/browse/JDK-8341637): java/net/Socket/UdpSocket.java fails with "java.net.BindException: Address already in use" (macos-aarch64) (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21388/head:pull/21388` \
`$ git checkout pull/21388`

Update a local copy of the PR: \
`$ git checkout pull/21388` \
`$ git pull https://git.openjdk.org/jdk.git pull/21388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21388`

View PR using the GUI difftool: \
`$ git pr show -t 21388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21388.diff">https://git.openjdk.org/jdk/pull/21388.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21388#issuecomment-2396916249)