### PR TITLE
8341643: G1: Merged cards counter skewed by merge cards cache

### DIFF
--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -1097,9 +1097,8 @@ class G1MergeHeapRootsTask : public WorkerTask {
       _merge_card_set_cache.flush();
       // Compensation for the dummy cards that were initially pushed into the
       // card cache.
-      // We do not need to compensate for the MergeRSFromRemSetCards counter
-      // because the dummy card mark will always fail because it is initally
-      // "dirty".
+      // We do not need to compensate for the other counters because the dummy
+      // card mark will never update another counter because it is initally "dirty".
       _stats.dec_remset_cards(G1MergeCardSetCache::CacheSize);
       return _stats;
     }

--- a/src/hotspot/share/gc/g1/g1RemSet.cpp
+++ b/src/hotspot/share/gc/g1/g1RemSet.cpp
@@ -967,6 +967,10 @@ class G1MergeHeapRootsTask : public WorkerTask {
       _merged[G1GCPhaseTimes::MergeRSCards] += increment;
     }
 
+    void dec_remset_cards(size_t decrement) {
+      _merged[G1GCPhaseTimes::MergeRSCards] -= decrement;
+    }
+
     size_t merged(uint i) const { return _merged[i]; }
   };
 
@@ -1091,6 +1095,12 @@ class G1MergeHeapRootsTask : public WorkerTask {
 
     G1MergeCardSetStats stats() {
       _merge_card_set_cache.flush();
+      // Compensation for the dummy cards that were initially pushed into the
+      // card cache.
+      // We do not need to compensate for the MergeRSFromRemSetCards counter
+      // because the dummy card mark will always fail because it is initally
+      // "dirty".
+      _stats.dec_remset_cards(G1MergeCardSetCache::CacheSize);
       return _stats;
     }
   };


### PR DESCRIPTION
Hi all,

   please review this change that subtracts the dummy cards from the merge cards counter at the end of the phase to keep its value correct.

E.g. previously log output with no actual cards being merged looks as follows:
```
 [0.991s][debug][gc,phases ] GC(11) Remembered Sets (ms): Min: 0.03, Avg: 0.03, Max: 0.03, Diff: 0.01, Sum: 0.11, Workers: 4
[0.991s][debug][gc,phases ] GC(11) Eager Reclaim (ms): skipped
[0.991s][debug][gc,phases ] GC(11) Merged Inline: Min: 0, Avg: 0.0, Max: 0, Diff: 0, Sum: 0, Workers: 4
[0.991s][debug][gc,phases ] GC(11) Merged ArrayOfCards: Min: 0, Avg: 0.0, Max: 0, Diff: 0, Sum: 0, Workers: 4
[0.991s][debug][gc,phases ] GC(11) Merged Howl: Min: 0, Avg: 0.0, Max: 0, Diff: 0, Sum: 0, Workers: 4
[0.991s][debug][gc,phases ] GC(11) Merged Full: Min: 0, Avg: 0.0, Max: 0, Diff: 0, Sum: 0, Workers: 4
[0.991s][debug][gc,phases ] GC(11) Merged Howl Inline: Min: 0, Avg: 0.0, Max: 0, Diff: 0, Sum: 0, Workers: 4
[0.991s][debug][gc,phases ] GC(11) Merged Howl ArrayOfCards: Min: 0, Avg: 0.0, Max: 0, Diff: 0, Sum: 0, Workers: 4
[0.991s][debug][gc,phases ] GC(11) Merged Howl BitMap: Min: 0, Avg: 0.0, Max: 0, Diff: 0, Sum: 0, Workers: 4
[0.991s][debug][gc,phases ] GC(11) Merged Howl Full: Min: 0, Avg: 0.0, Max: 0, Diff: 0, Sum: 0, Workers: 4
[0.991s][debug][gc,phases ] GC(11) Merged Cards: Min: 8, Avg: 8.0, Max: 8, Diff: 0, Sum: 32, Workers: 4
```
(Note that none of the other categories have non-zero values)
to
```
[0.991s][debug][gc,phases ] GC(11) Merged Cards: Min: 0, Avg: 0.0, Max: 0, Diff: 0, Sum: 0, Workers: 4
```

For the same test (gcbasher in this case).

Testing: gha, log messages

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341643](https://bugs.openjdk.org/browse/JDK-8341643): G1: Merged cards counter skewed by merge cards cache (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21390/head:pull/21390` \
`$ git checkout pull/21390`

Update a local copy of the PR: \
`$ git checkout pull/21390` \
`$ git pull https://git.openjdk.org/jdk.git pull/21390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21390`

View PR using the GUI difftool: \
`$ git pr show -t 21390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21390.diff">https://git.openjdk.org/jdk/pull/21390.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21390#issuecomment-2396988639)