### PR TITLE
8341644: Compile error in cgroup coding when using toolchain clang

### DIFF
--- a/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
+++ b/src/hotspot/os/linux/cgroupV2Subsystem_linux.hpp
@@ -64,16 +64,16 @@ class CgroupV2CpuController: public CgroupCpuController {
     bool is_read_only() override {
       return reader()->is_read_only();
     }
-    const char* subsystem_path() {
+    const char* subsystem_path() override {
       return reader()->subsystem_path();
     }
     bool needs_hierarchy_adjustment() override {
       return reader()->needs_hierarchy_adjustment();
     }
-    void set_subsystem_path(const char* cgroup_path) {
+    void set_subsystem_path(const char* cgroup_path) override {
       reader()->set_subsystem_path(cgroup_path);
     }
-    const char* mount_point() { return reader()->mount_point(); }
+    const char* mount_point() override { return reader()->mount_point(); }
     const char* cgroup_path() override { return reader()->cgroup_path(); }
 };
 
@@ -97,16 +97,16 @@ class CgroupV2MemoryController final: public CgroupMemoryController {
     bool is_read_only() override {
       return reader()->is_read_only();
     }
-    const char* subsystem_path() {
+    const char* subsystem_path() override {
       return reader()->subsystem_path();
     }
     bool needs_hierarchy_adjustment() override {
       return reader()->needs_hierarchy_adjustment();
     }
-    void set_subsystem_path(const char* cgroup_path) {
+    void set_subsystem_path(const char* cgroup_path) override {
       reader()->set_subsystem_path(cgroup_path);
     }
-    const char* mount_point() { return reader()->mount_point(); }
+    const char* mount_point() override { return reader()->mount_point(); }
     const char* cgroup_path() override { return reader()->cgroup_path(); }
 };
 


### PR DESCRIPTION
When building on Linux but with toolchain-type clang , I run into a couple of errors because of missing override .

We use this clang on the build machine
clang --version
clang version 15.0.7
Target: x86_64-suse-linux

The issue seems to be similar to JDK-8338236 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341644](https://bugs.openjdk.org/browse/JDK-8341644): Compile error in cgroup coding when using toolchain clang (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21391/head:pull/21391` \
`$ git checkout pull/21391`

Update a local copy of the PR: \
`$ git checkout pull/21391` \
`$ git pull https://git.openjdk.org/jdk.git pull/21391/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21391`

View PR using the GUI difftool: \
`$ git pr show -t 21391`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21391.diff">https://git.openjdk.org/jdk/pull/21391.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21391#issuecomment-2397416534)