### PR TITLE
8341658: RISC-V: Test DateFormatProviderTest.java run timeouted

### DIFF
--- a/test/jdk/java/util/PluggableLocale/DateFormatProviderTest.java
+++ b/test/jdk/java/util/PluggableLocale/DateFormatProviderTest.java
@@ -31,7 +31,7 @@
  *          java.base/sun.util.resources
  * @build com.foobar.Utils
  *        com.foo.*
- * @run main/othervm -Djava.locale.providers=CLDR,SPI DateFormatProviderTest
+ * @run main/othervm/timeout=300 -Djava.locale.providers=CLDR,SPI DateFormatProviderTest
  */
 
 import java.text.DateFormat;


### PR DESCRIPTION
Hi all,
The test `java/util/PluggableLocale/DateFormatProviderTest.java` run timeout on riscv64 physic machine. This test has 4496 sub-tests, and riscv64 has poor single core performance, so this test run timeouted on riscv64 seems acceptable.
Thus, to make less test noisy, I think we should add more timeout value for this test.
Test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341658](https://bugs.openjdk.org/browse/JDK-8341658): RISC-V: Test DateFormatProviderTest.java run timeouted (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21393/head:pull/21393` \
`$ git checkout pull/21393`

Update a local copy of the PR: \
`$ git checkout pull/21393` \
`$ git pull https://git.openjdk.org/jdk.git pull/21393/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21393`

View PR using the GUI difftool: \
`$ git pr show -t 21393`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21393.diff">https://git.openjdk.org/jdk/pull/21393.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21393#issuecomment-2397409221)