### PR TITLE
8341668: Shenandoah: assert(tail_bits < (idx_t)BitsPerWord) failed: precondition

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.hpp
@@ -80,6 +80,8 @@ private:
   bool is_forward_consecutive_ones(idx_t start_idx, idx_t count) const;
   bool is_backward_consecutive_ones(idx_t last_idx, idx_t count) const;
 
+  static inline uintx tail_mask(uintx bit_number);
+
 public:
 
   inline idx_t aligned_index(idx_t idx) const {

--- a/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.inline.hpp
@@ -27,7 +27,7 @@
 
 #include "gc/shenandoah/shenandoahSimpleBitMap.hpp"
 
-inline uintx tail_mask(uintx bit_number) {
+inline uintx ShenandoahSimpleBitMap::tail_mask(uintx bit_number) {
   if (bit_number >= BitsPerWord) {
     return -1;
   }


### PR DESCRIPTION
`tail_mask` function should not be in the global scope. Stack traces in incremental build shows `shenandoahSimpleBitMap` calling a function with the same name defined in `bitMap.cpp`:

```
    #8 0x7f5e08a2c4d4 in tail_mask(unsigned long) src/hotspot/share/utilities/bitMap.cpp:431
    #9 0x7f5e0a951144 in ShenandoahSimpleBitMap::count_trailing_ones(long) const src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.cpp:75
    #10 0x7f5e0a951b42 in ShenandoahSimpleBitMap::find_first_consecutive_set_bits(long, long, unsigned long) const src/hotspot/share/gc/shenandoah/shenandoahSimpleBitMap.cpp:215
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341668](https://bugs.openjdk.org/browse/JDK-8341668): Shenandoah: assert(tail_bits &lt; (idx_t)BitsPerWord) failed: precondition (**Bug** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21395/head:pull/21395` \
`$ git checkout pull/21395`

Update a local copy of the PR: \
`$ git checkout pull/21395` \
`$ git pull https://git.openjdk.org/jdk.git pull/21395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21395`

View PR using the GUI difftool: \
`$ git pr show -t 21395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21395.diff">https://git.openjdk.org/jdk/pull/21395.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21395#issuecomment-2397644848)