### PR TITLE
8341705: C2: (x86) Restrict poll addresses to rax register

### DIFF
--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -12401,7 +12401,7 @@ instruct cmpFastUnlockLightweight(rFlagsReg cr, rRegP object, rax_RegP rax_reg, 
 
 // ============================================================================
 // Safepoint Instructions
-instruct safePoint_poll_tls(rFlagsReg cr, rRegP poll)
+instruct safePoint_poll_tls(rFlagsReg cr, rax_RegP poll)
 %{
   match(SafePoint poll);
   effect(KILL cr, USE poll);


### PR DESCRIPTION
WIP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341705](https://bugs.openjdk.org/browse/JDK-8341705): C2: (x86) Restrict poll addresses to rax register (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21403/head:pull/21403` \
`$ git checkout pull/21403`

Update a local copy of the PR: \
`$ git checkout pull/21403` \
`$ git pull https://git.openjdk.org/jdk.git pull/21403/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21403`

View PR using the GUI difftool: \
`$ git pr show -t 21403`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21403.diff">https://git.openjdk.org/jdk/pull/21403.diff</a>

</details>
