### PR TITLE
8341708: Optimize safepoint poll encoding with smaller poll data offset

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -241,7 +241,6 @@
   nonstatic_field(JavaThread,                  _jvmci_reserved_oop0,                          oop)                                   \
   nonstatic_field(JavaThread,                  _should_post_on_exceptions_flag,               int)                                   \
   nonstatic_field(JavaThread,                  _jni_environment,                              JNIEnv)                                \
-  nonstatic_field(JavaThread,                  _poll_data,                                    SafepointMechanism::ThreadData)        \
   nonstatic_field(JavaThread,                  _stack_overflow_state._reserved_stack_activation, address)                            \
   nonstatic_field(JavaThread,                  _held_monitor_count,                           intx)                                  \
   nonstatic_field(JavaThread,                  _lock_stack,                                   LockStack)                             \
@@ -409,6 +408,7 @@
   static_field(StubRoutines,                _cont_thaw,                                       address)                               \
   static_field(StubRoutines,                _lookup_secondary_supers_table_slow_path_stub,    address)                               \
                                                                                                                                      \
+  nonstatic_field(Thread,                   _poll_data,                                       SafepointMechanism::ThreadData)        \
   nonstatic_field(Thread,                   _tlab,                                            ThreadLocalAllocBuffer)                \
   nonstatic_field(Thread,                   _allocated_bytes,                                 jlong)                                 \
   JFR_ONLY(nonstatic_field(Thread,          _jfr_thread_local,                                JfrThreadLocal))                       \

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -594,6 +594,24 @@ private:
   bool do_not_unlock_if_synchronized()             { return _do_not_unlock_if_synchronized; }
   void set_do_not_unlock_if_synchronized(bool val) { _do_not_unlock_if_synchronized = val; }
 
+  SafepointMechanism::ThreadData* poll_data() { return &_poll_data; }
+
+  static ByteSize polling_word_offset() {
+    ByteSize offset = byte_offset_of(Thread, _poll_data) +
+                      byte_offset_of(SafepointMechanism::ThreadData, _polling_word);
+    // At least on x86_64, safepoint polls encode the offset as disp8 imm.
+    assert(in_bytes(offset) < 128, "Offset >= 128");
+    return offset;
+  }
+
+  static ByteSize polling_page_offset() {
+    ByteSize offset = byte_offset_of(Thread, _poll_data) +
+                      byte_offset_of(SafepointMechanism::ThreadData, _polling_page);
+    // At least on x86_64, safepoint polls encode the offset as disp8 imm.
+    assert(in_bytes(offset) < 128, "Offset >= 128");
+    return offset;
+  }
+
   void set_requires_cross_modify_fence(bool val) PRODUCT_RETURN NOT_PRODUCT({ _requires_cross_modify_fence = val; })
 
   // Continuation support

--- a/src/hotspot/share/runtime/javaThread.hpp
+++ b/src/hotspot/share/runtime/javaThread.hpp
@@ -238,8 +238,6 @@ class JavaThread: public Thread {
   // Safepoint support
  public:                                                        // Expose _thread_state for SafeFetchInt()
   volatile JavaThreadState _thread_state;
- private:
-  SafepointMechanism::ThreadData _poll_data;
   ThreadSafepointState*          _safepoint_state;              // Holds information about a thread during a safepoint
   address                        _saved_exception_pc;           // Saved pc of instruction where last implicit exception happened
   NOT_PRODUCT(bool               _requires_cross_modify_fence;) // State used by VerifyCrossModifyFence
@@ -596,8 +594,6 @@ private:
   bool do_not_unlock_if_synchronized()             { return _do_not_unlock_if_synchronized; }
   void set_do_not_unlock_if_synchronized(bool val) { _do_not_unlock_if_synchronized = val; }
 
-  SafepointMechanism::ThreadData* poll_data() { return &_poll_data; }
-
   void set_requires_cross_modify_fence(bool val) PRODUCT_RETURN NOT_PRODUCT({ _requires_cross_modify_fence = val; })
 
   // Continuation support
@@ -787,8 +783,6 @@ private:
   static ByteSize vm_result_offset()             { return byte_offset_of(JavaThread, _vm_result); }
   static ByteSize vm_result_2_offset()           { return byte_offset_of(JavaThread, _vm_result_2); }
   static ByteSize thread_state_offset()          { return byte_offset_of(JavaThread, _thread_state); }
-  static ByteSize polling_word_offset()          { return byte_offset_of(JavaThread, _poll_data) + byte_offset_of(SafepointMechanism::ThreadData, _polling_word);}
-  static ByteSize polling_page_offset()          { return byte_offset_of(JavaThread, _poll_data) + byte_offset_of(SafepointMechanism::ThreadData, _polling_page);}
   static ByteSize saved_exception_pc_offset()    { return byte_offset_of(JavaThread, _saved_exception_pc); }
   static ByteSize osthread_offset()              { return byte_offset_of(JavaThread, _osthread); }
 #if INCLUDE_JVMCI

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -110,6 +110,7 @@ class Thread: public ThreadShadow {
   friend class VMErrorCallbackMark;
   friend class VMStructs;
   friend class JVMCIVMStructs;
+  friend class JavaThread;
  private:
 
 #ifndef USE_LIBRARY_BASED_TLS_ONLY
@@ -135,30 +136,12 @@ class Thread: public ThreadShadow {
     return offset;
   }
 
- protected:
+ private:
   // Poll data is used in generated code for safepoint polls.
+  // It is important for performance to put this at lower offset
+  // in Thread. The accessors are in JavaThread.
   SafepointMechanism::ThreadData _poll_data;
 
- public:
-  SafepointMechanism::ThreadData* poll_data()  { return &_poll_data; }
-
-  static ByteSize polling_word_offset() {
-    ByteSize offset = byte_offset_of(Thread, _poll_data) +
-                      byte_offset_of(SafepointMechanism::ThreadData, _polling_word);
-    // At least on x86_64, safepoint polls encode the offset as disp8 imm.
-    assert(in_bytes(offset) < 128, "Offset >= 128");
-    return offset;
-  }
-
-  static ByteSize polling_page_offset() {
-    ByteSize offset = byte_offset_of(Thread, _poll_data) +
-                      byte_offset_of(SafepointMechanism::ThreadData, _polling_page);
-    // At least on x86_64, safepoint polls encode the offset as disp8 imm.
-    assert(in_bytes(offset) < 128, "Offset >= 128");
-    return offset;
-  }
-
- private:
   // Thread local data area available to the GC. The internal
   // structure and contents of this data area is GC-specific.
   // Only GC and GC barrier code should access this data area.

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestPadding.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestPadding.java
@@ -48,7 +48,7 @@ public class TestPadding {
     }
 
     @Test
-    @IR(counts = { IRNode.NOP, "1" })
+    @IR(counts = { IRNode.NOP, "<=1" })
     static int test(int i) {
         TestPadding tp = tpf;
         if (tp.b1 > 42) { // Big 'cmpb' instruction at offset 0x30


### PR DESCRIPTION
See the bug for discussion. We can optimize the encoding for safepoint polls by making sure the polling data is at small offset in `Thread`. There is already the area where we pull data like this for better encoding.

Code density improves on x86_64, can be seen with just `-Xcomp -XX:+CITime`:

```
# Before
  nmethod code size         :  7107136 bytes
  nmethod code size         :  7107120 bytes
  nmethod code size         :  7107136 bytes

# After (-0.25%)
  nmethod code size         :  7088896 bytes
  nmethod code size         :  7088896 bytes
  nmethod code size         :  7088864 bytes
```

Additional testing:
 - [x] Ad-hoc code density checks
 - [x] Linux x86_64 server fastdebug, `all`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341708](https://bugs.openjdk.org/browse/JDK-8341708): Optimize safepoint poll encoding with smaller poll data offset (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21405/head:pull/21405` \
`$ git checkout pull/21405`

Update a local copy of the PR: \
`$ git checkout pull/21405` \
`$ git pull https://git.openjdk.org/jdk.git pull/21405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21405`

View PR using the GUI difftool: \
`$ git pr show -t 21405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21405.diff">https://git.openjdk.org/jdk/pull/21405.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21405#issuecomment-2401671270)