### PR TITLE
8341722: Fix some warnings as errors when building on Linux with toolchain clang

### DIFF
--- a/make/modules/jdk.hotspot.agent/Lib.gmk
+++ b/make/modules/jdk.hotspot.agent/Lib.gmk
@@ -59,9 +59,7 @@ $(eval $(call SetupJdkLibrary, BUILD_LIBSAPROC, \
     OPTIMIZATION := HIGH, \
     EXTRA_HEADER_DIRS := java.base:libjvm, \
     DISABLED_WARNINGS_gcc := sign-compare, \
-    DISABLED_WARNINGS_gcc_LinuxDebuggerLocal.cpp := unused-variable, \
     DISABLED_WARNINGS_gcc_ps_core.c := pointer-arith, \
-    DISABLED_WARNINGS_gcc_symtab.c := unused-but-set-variable, \
     DISABLED_WARNINGS_clang := sign-compare, \
     DISABLED_WARNINGS_clang_libproc_impl.c := format-nonliteral, \
     DISABLED_WARNINGS_clang_MacosxDebuggerLocal.m := unused-variable, \

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -420,7 +420,6 @@ JNIEXPORT jlongArray JNICALL Java_sun_jvm_hotspot_debugger_linux_LinuxDebuggerLo
   jboolean isCopy;
   jlongArray array;
   jlong *regs;
-  int i;
 
   struct ps_prochandle* ph = get_proc_handle(env, this_obj);
   if (get_lwp_regs(ph, lwp_id, &gregs) != true) {

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
@@ -389,6 +389,7 @@ static struct symtab* build_symtab_internal(int fd, const char *filename, bool t
         goto bad;
       }
 
+      // int rslt =
       hcreate_r(htab_sz, symtab->hash_table);
       // guarantee(rslt, "unexpected failure: hcreate_r");
 

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
@@ -356,7 +356,6 @@ static struct symtab* build_symtab_internal(int fd, const char *filename, bool t
 
     if (shdr->sh_type == sym_section) {
       ELF_SYM  *syms;
-      int rslt;
       size_t size, n, j, htab_sz;
 
       // FIXME: there could be multiple data buffers associated with the
@@ -390,7 +389,7 @@ static struct symtab* build_symtab_internal(int fd, const char *filename, bool t
         goto bad;
       }
 
-      rslt = hcreate_r(htab_sz, symtab->hash_table);
+      hcreate_r(htab_sz, symtab->hash_table);
       // guarantee(rslt, "unexpected failure: hcreate_r");
 
       // shdr->sh_link points to the section that contains the actual strings

--- a/src/jdk.jpackage/share/native/common/Log.cpp
+++ b/src/jdk.jpackage/share/native/common/Log.cpp
@@ -40,10 +40,6 @@ namespace {
     // variables are initialized if any. This will result in AV. To avoid such
     // use cases keep logging module free from static variables that require
     // initialization with functions called by CRT.
-    //
-
-    // by default log everything
-    const Logger::LogLevel defaultLogLevel = Logger::LOG_TRACE;
 
     char defaultLogAppenderMemory[sizeof(StreamLogAppender)] = {};
 

--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -360,10 +360,10 @@ TEST_VM(os_linux, pretouch_thp_and_use_concurrent) {
   EXPECT_TRUE(os::commit_memory(heap, size, false));
 
   {
-    auto pretouch = [heap, size](Thread*, int) {
+    auto pretouch = [heap](Thread*, int) {
       os::pretouch_memory(heap, heap + size, os::vm_page_size());
     };
-    auto useMemory = [heap, size](Thread*, int) {
+    auto useMemory = [heap](Thread*, int) {
       int* iptr = reinterpret_cast<int*>(heap);
       for (int i = 0; i < 1000; i++) *iptr++ = i;
     };


### PR DESCRIPTION
There are a few warnings as errors occurring when building on Linux with clang (clang15). Mostly these are some kind of 'unused' warnings.
Might be related to https://bugs.openjdk.org/browse/JDK-8339156 .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341722](https://bugs.openjdk.org/browse/JDK-8341722): Fix some warnings as errors when building on Linux with toolchain clang (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21407/head:pull/21407` \
`$ git checkout pull/21407`

Update a local copy of the PR: \
`$ git checkout pull/21407` \
`$ git pull https://git.openjdk.org/jdk.git pull/21407/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21407`

View PR using the GUI difftool: \
`$ git pr show -t 21407`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21407.diff">https://git.openjdk.org/jdk/pull/21407.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21407#issuecomment-2399891327)