### PR TITLE
8340203: Link color is hard to distinguish from text color in API documentation

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/stylesheet.css
@@ -28,8 +28,8 @@
     /* Line height for continuous text blocks */
     --block-line-height: 1.4em;
     /* Text colors for body and block elements */
-    --body-text-color: #353833;
-    --block-text-color: #474747;
+    --body-text-color: #282828;
+    --block-text-color: #282828;
     /* Background colors for various structural elements */
     --body-background-color: #ffffff;
     --section-background-color: #f8f8f8;
@@ -49,8 +49,11 @@
     /* Text color for page title */
     --title-color: #2c4557;
     /* Text colors for links */
-    --link-color: #4A6782;
+    --link-color: #437291;
     --link-color-active: #bb7a2a;
+    /* Table of contents */
+    --toc-background-color: var(--section-background-color);
+    --toc-link-color: #4a698a;
     /* Snippet colors */
     --snippet-background-color: #ebecee;
     --snippet-text-color: var(--block-text-color);
@@ -98,6 +101,9 @@ main [id] {
 a:link, a:visited {
     text-decoration:none;
     color:var(--link-color);
+}
+nav a:link, nav a:visited {
+    color: var(--toc-link-color);
 }
 a[href]:hover, a[href]:active {
     text-decoration:none;
@@ -398,7 +404,7 @@ dl.name-value > dd {
  * Styles for table of contents.
  */
 .main-grid nav.toc {
-    background-color: var(--section-background-color);
+    background-color: var(--toc-background-color);
     border-right: 1px solid var(--border-color);
     position: sticky;
     top: calc(var(--nav-height));
@@ -409,8 +415,6 @@ dl.name-value > dd {
     z-index: 1;
 }
 .main-grid nav.toc div.toc-header {
-    background-color: var(--section-background-color);
-    border-right: 1px solid var(--border-color);
     top: var(--nav-height);
     z-index: 1;
     padding: 15px 20px;
@@ -473,7 +477,6 @@ nav.toc div.toc-header {
     display: inline-flex;
     align-items: center;
     color: var(--body-text-color);
-    background-color: var(--body-background-color);
     font-size: 0.856em;
     font-weight: bold;
     white-space: nowrap;


### PR DESCRIPTION
Please review a CSS-only change to make it easier to recognize links in API documentation with the default stylesheet. 

This subtle change makes the link color a bit lighter and more saturated and normal text a bit darker. The new link color is `#437291` which is the same color used for links on [openjdk.org](https://openjdk.org/) and other OpenJDK sites. 

The table of contents and breadcrumb-navigation uses a slightly darker color closer to the original one, which works better with the gray background and the large amount of links.

The change also introduces CSS variables (aka custom properties) for the TOC colors which have been missing, and removes some redundant CSS rules for the TOC header.

I've uploaded API docs for `java.base` to compare the changes:

New colors: https://cr.openjdk.org/~hannesw/8340203/api.00/java.base/java/lang/Thread.html
Old colors: https://download.java.net/java/early_access/jdk24/docs/api/java.base/java/lang/Thread.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340203](https://bugs.openjdk.org/browse/JDK-8340203): Link color is hard to distinguish from text color in API documentation (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21409/head:pull/21409` \
`$ git checkout pull/21409`

Update a local copy of the PR: \
`$ git checkout pull/21409` \
`$ git pull https://git.openjdk.org/jdk.git pull/21409/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21409`

View PR using the GUI difftool: \
`$ git pr show -t 21409`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21409.diff">https://git.openjdk.org/jdk/pull/21409.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21409#issuecomment-2400029049)