### PR TITLE
8340133: Investigate if the java launcher could give hints about JShell

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -2799,6 +2799,12 @@ public final class System {
             public boolean allowSecurityManager() {
                 return System.allowSecurityManager();
             }
+
+            @Override
+            public String shortVersionString() {
+                return VersionProps.shortVersionString();
+            }
+
         });
     }
 }

--- a/src/java.base/share/classes/java/lang/VersionProps.java.template
+++ b/src/java.base/share/classes/java/lang/VersionProps.java.template
@@ -232,4 +232,10 @@ class VersionProps {
 
     }
 
+    static String shortVersionString() {
+        return launcher_name + " " + java_version
+                   + " " + java_version_date
+                   + (isLTS ? " LTS" : "");
+    }
+
 }

--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -639,4 +639,9 @@ public interface JavaLangAccess {
      * (using -Djava.security.manager=allow)?
      */
     boolean allowSecurityManager();
+
+    /**
+     * Return a short version string for this runtime.
+     */
+    String shortVersionString();
 }

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -70,8 +70,8 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import jdk.internal.access.SharedSecrets;
 
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.MethodFinder;
 import jdk.internal.misc.PreviewFeatures;
 import jdk.internal.misc.VM;

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -586,6 +586,15 @@ public final class LauncherHelper {
         }
     }
 
+    /**
+     * Prints the short usage text to the desired output stream.
+     */
+    static void printConciseUsageMessage(boolean printToStderr) {
+        initOutput(printToStderr);
+        ostream.println(getLocalizedMessage("java.launcher.opt.concise.header",
+                File.pathSeparator));
+    }
+
     static void initOutput(boolean printToStderr) {
         ostream =  (printToStderr) ? System.err : System.out;
     }

--- a/src/java.base/share/classes/sun/launcher/LauncherHelper.java
+++ b/src/java.base/share/classes/sun/launcher/LauncherHelper.java
@@ -70,6 +70,7 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import jdk.internal.access.SharedSecrets;
 
 import jdk.internal.misc.MethodFinder;
 import jdk.internal.misc.PreviewFeatures;
@@ -591,6 +592,8 @@ public final class LauncherHelper {
      */
     static void printConciseUsageMessage(boolean printToStderr) {
         initOutput(printToStderr);
+        ostream.println(SharedSecrets.getJavaLangAccess().shortVersionString());
+        ostream.println();
         ostream.println(getLocalizedMessage("java.launcher.opt.concise.header",
                 File.pathSeparator));
     }

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -232,6 +232,20 @@ The following options are macOS specific:\n\
 \    -Xdock:icon=<path to icon file>\n\
 \                      override default icon displayed in dock\n\n
 
+# Translators please note do not translate the options themselves
+java.launcher.opt.concise.header  =   Usage: java [options] <mainclass> [args...]\n\
+\           (to execute a class)\n\
+\   or  java [options] -jar <jarfile> [args...]\n\
+\           (to execute a jar file)\n\
+\   or  java [options] -m <module>[/<mainclass>] [args...]\n\
+\           (to execute the main class in a module)\n\
+\   or  java [options] <sourcefile> [args]\n\
+\           (to execute a single source-file program)\n\n\
+\To get more detailed help on options and operations of this launcher, use:\n\
+\       java --help\n\n\
+\To get interactive Java environment, use:\n\
+\       jshell [options]\n\
+
 java.launcher.bad.option=\
 \n\
 Unrecognized showSettings option: {0}\n\

--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -233,18 +233,19 @@ The following options are macOS specific:\n\
 \                      override default icon displayed in dock\n\n
 
 # Translators please note do not translate the options themselves
-java.launcher.opt.concise.header  =   Usage: java [options] <mainclass> [args...]\n\
-\           (to execute a class)\n\
-\   or  java [options] -jar <jarfile> [args...]\n\
-\           (to execute a jar file)\n\
-\   or  java [options] -m <module>[/<mainclass>] [args...]\n\
-\           (to execute the main class in a module)\n\
-\   or  java [options] <sourcefile> [args]\n\
-\           (to execute a single source-file program)\n\n\
-\To get more detailed help on options and operations of this launcher, use:\n\
-\       java --help\n\n\
-\To get interactive Java environment, use:\n\
-\       jshell [options]\n\
+java.launcher.opt.concise.header  =   Usage: java [options...] <what to execute> [arguments to main method...]\n\n\
+\Where <what to execute> is one of:\n\
+\  <MainClass>                to execute the main method of a compiled class\n\
+\  -jar <jar-file.jar>        to execute the main class in a JAR archive\n\
+\  -m <module>[/<MainClass>]  to execute the main class of a module\n\
+\  <SourceFile.java>          to compile and execute a single-file program\n\n\
+\Where key options include:\n\
+\  --class-path <class path>\n\
+\      a {0} separated list of directories and JAR archives to search for class files\n\
+\  --module-path <module path>\n\
+\      a {0} separated list of directories and JAR archives to search for modules\n\n\
+\For more details about this launcher:   java --help\n\
+\For an interactive Java environment:    jshell
 
 java.launcher.bad.option=\
 \n\

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -538,7 +538,7 @@ JavaMain(void* _args)
 
     /* If the user specified neither a class name nor a JAR file */
     if (printXUsage || printUsage || what == 0 || mode == LM_UNKNOWN) {
-        PrintUsage(env, printXUsage, what == 0 || mode == LM_UNKNOWN);
+        PrintUsage(env, printXUsage, !printXUsage && !printUsage);
         CHECK_EXCEPTION_LEAVE(1);
         LEAVE();
     }

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -120,7 +120,7 @@ static void TranslateApplicationArgs(int jargc, const char **jargv, int *pargc, 
 static jboolean AddApplicationOptions(int cpathc, const char **cpathv);
 
 static void PrintJavaVersion(JNIEnv *env);
-static void PrintUsage(JNIEnv* env, jboolean doXUsage);
+static void PrintUsage(JNIEnv* env, jboolean doXUsage, jboolean conciseUsage);
 static void ShowSettings(JNIEnv* env, char *optString);
 static void ShowResolvedModules(JNIEnv* env);
 static void ListModules(JNIEnv* env);
@@ -538,7 +538,7 @@ JavaMain(void* _args)
 
     /* If the user specified neither a class name nor a JAR file */
     if (printXUsage || printUsage || what == 0 || mode == LM_UNKNOWN) {
-        PrintUsage(env, printXUsage);
+        PrintUsage(env, printXUsage, what == 0 || mode == LM_UNKNOWN);
         CHECK_EXCEPTION_LEAVE(1);
         LEAVE();
     }
@@ -1921,14 +1921,19 @@ DescribeModule(JNIEnv *env, char *optString)
  * Prints default usage or the Xusage message, see sun.launcher.LauncherHelper.java
  */
 static void
-PrintUsage(JNIEnv* env, jboolean doXUsage)
+PrintUsage(JNIEnv* env, jboolean doXUsage, jboolean conciseUsage)
 {
-  jmethodID initHelp, vmSelect, vmSynonym, printHelp, printXUsageMessage;
+  jmethodID initHelp, vmSelect, vmSynonym;
+  jmethodID printHelp, printConciseUsageMessage, printXUsageMessage;
   jstring jprogname, vm1, vm2;
   int i;
   jclass cls = GetLauncherHelperClass(env);
   NULL_CHECK(cls);
-  if (doXUsage) {
+  if (conciseUsage) {
+    NULL_CHECK(printConciseUsageMessage = (*env)->GetStaticMethodID(env, cls,
+                                        "printConciseUsageMessage", "(Z)V"));
+    (*env)->CallStaticVoidMethod(env, cls, printConciseUsageMessage, printTo);
+  } else if (doXUsage) {
     NULL_CHECK(printXUsageMessage = (*env)->GetStaticMethodID(env, cls,
                                         "printXUsageMessage", "(Z)V"));
     (*env)->CallStaticVoidMethod(env, cls, printXUsageMessage, printTo);


### PR DESCRIPTION
Currently, running `java` without any parameters will lead to an output that is a full `--help`, which is over 100 lines (on my computer at least), and it feels overwhelming. And many people might actually want to run JShell/REPL, not the `java` launcher, but it is difficult find out about JShell.

The proposal herein is to print a much shorter help, together with a pointer to JShell, when the launcher does not know what to do. I.e. there is nothing specified to start, and no option like `--help` is specified. In particular, on my machine, it prints:
```
$ java
openjdk 24-internal 2025-03-18

Usage: java [options...] <what to execute> [arguments to main method...]

Where <what to execute> is one of:
  <MainClass>                to execute the main method of a compiled class
  -jar <jar-file.jar>        to execute the main class in a JAR archive
  -m <module>[/<MainClass>]  to execute the main class of a module
  <SourceFile.java>          to compile and execute a single-file program

Where key options include:
  --class-path <class path>
      a : separated list of directories and JAR archives to search for class files
  --module-path <module path>
      a : separated list of directories and JAR archives to search for modules

For more details about this launcher:   java --help
For an interactive Java environment:    jshell
```

Hopefully, this may be easier both for people trying to run something, and for people that are really looking for JShell.

What do you think?

Thanks!
