### PR TITLE
8324672: Update jdk/java/time/tck/java/time/TCKInstant.java now() to be more robust

### DIFF
--- a/test/jdk/java/time/tck/java/time/TCKInstant.java
+++ b/test/jdk/java/time/tck/java/time/TCKInstant.java
@@ -185,15 +185,23 @@ public class TCKInstant extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // now()
     //-----------------------------------------------------------------------
-    @Test(timeOut=60000)
+    @Test
     public void now() {
-        Instant expected, test;
-        long diff;
+        long beforeMillis, instantMillis, afterMillis, diff;
+        int retryRemaining = 5; // MAX_RETRY_COUNT
         do {
-            expected = Instant.now(Clock.systemUTC());
-            test = Instant.now();
-            diff = Math.abs(test.toEpochMilli() - expected.toEpochMilli());
-        } while( diff > 100 ); // retry if more than 0.1 sec
+            beforeMillis = Instant.now(Clock.systemUTC()).toEpochMilli();
+            instantMillis = Instant.now().toEpochMilli();
+            afterMillis = Instant.now(Clock.systemUTC()).toEpochMilli();
+            diff = instantMillis - beforeMillis;
+            if (instantMillis < beforeMillis || instantMillis > afterMillis) {
+                throw new RuntimeException(": Invalid instant: (~" + instantMillis + "ms)"
+                        + " when systemUTC in millis is in ["
+                        + beforeMillis + ", "
+                        + afterMillis + "]");
+            }
+        } while (diff > 100 && --retryRemaining > 0);  // retry if diff more than 0.1 sec
+        assertTrue(retryRemaining > 0);
     }
 
     //-----------------------------------------------------------------------

--- a/test/jdk/java/time/tck/java/time/TCKInstant.java
+++ b/test/jdk/java/time/tck/java/time/TCKInstant.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -190,7 +190,7 @@ public class TCKInstant extends AbstractDateTimeTest {
         Instant expected = Instant.now(Clock.systemUTC());
         Instant test = Instant.now();
         long diff = Math.abs(test.toEpochMilli() - expected.toEpochMilli());
-        assertTrue(diff < 100);  // less than 0.1 secs
+        assertTrue(diff < 10_000);  // less than 10 secs
     }
 
     //-----------------------------------------------------------------------

--- a/test/jdk/java/time/tck/java/time/TCKInstant.java
+++ b/test/jdk/java/time/tck/java/time/TCKInstant.java
@@ -185,12 +185,15 @@ public class TCKInstant extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // now()
     //-----------------------------------------------------------------------
-    @Test
+    @Test(timeOut=60000)
     public void now() {
-        Instant expected = Instant.now(Clock.systemUTC());
-        Instant test = Instant.now();
-        long diff = Math.abs(test.toEpochMilli() - expected.toEpochMilli());
-        assertTrue(diff < 10_000);  // less than 10 secs
+        Instant expected, test;
+        long diff;
+        do {
+            expected = Instant.now(Clock.systemUTC());
+            test = Instant.now();
+            diff = Math.abs(test.toEpochMilli() - expected.toEpochMilli());
+        } while( diff > 100 ); // retry if more than 0.1 sec
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
The time difference check might fail for scenarios such as batch compilation. It is safer to give a bigger allowance of 10 seconds instead of 0.1 sec.

Testing: The test was run for 100 times with -Xcomp option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8324672](https://bugs.openjdk.org/browse/JDK-8324672): Update jdk/java/time/tck/java/time/TCKInstant.java now() to be more robust (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21413/head:pull/21413` \
`$ git checkout pull/21413`

Update a local copy of the PR: \
`$ git checkout pull/21413` \
`$ git pull https://git.openjdk.org/jdk.git pull/21413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21413`

View PR using the GUI difftool: \
`$ git pr show -t 21413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21413.diff">https://git.openjdk.org/jdk/pull/21413.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21413#issuecomment-2400416740)