### PR TITLE
8341782: Allow lambda capture of basic for() loop variables as with enhanced for()

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Flags.java
@@ -197,6 +197,13 @@ public class Flags {
      */
     public static final long BRIDGE          = 1L<<31;
 
+    /**
+     * Flag marking a basic for() loop iteration variable (i.e., a variable declared
+     * in the init section of the loop) that is allowed to be captured by a nested
+     * class or lambda even when the variable is neither final nor effectively final.
+     */
+    public static final long FOR_LOOP_BODY_MAY_CAPTURE = 1L<<32;
+
     /** Flag that marks formal parameters.
      */
     public static final long PARAMETER   = 1L<<33;
@@ -518,6 +525,7 @@ public class Flags {
         UNATTRIBUTED(Flags.UNATTRIBUTED),
         ANONCONSTR(Flags.ANONCONSTR),
         ACYCLIC(Flags.ACYCLIC),
+        FOR_LOOP_BODY_MAY_CAPTURE(Flags.FOR_LOOP_BODY_MAY_CAPTURE),
         PARAMETER(Flags.PARAMETER),
         VARARGS(Flags.VARARGS),
         ACYCLIC_ANN(Flags.ACYCLIC_ANN),

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -3468,7 +3468,9 @@ public class Flow {
             for (JCTree resource : tree.resources) {
                 if (!resource.hasTag(VARDEF)) {
                     Symbol var = TreeInfo.symbol(resource);
-                    if (var != null && (var.flags() & (FINAL | EFFECTIVELY_FINAL)) == 0) {
+                    if (var != null
+                            && (var.flags() & (FINAL | EFFECTIVELY_FINAL)) == 0
+                            && (!(var instanceof VarSymbol sym && capturable.isMember(sym.adr)))) {
                         log.error(resource.pos(), Errors.TryWithResourcesExprEffectivelyFinalVar(var));
                     }
                 }

--- a/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalInvalidTest.java
+++ b/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalInvalidTest.java
@@ -59,6 +59,27 @@ public class ForLoopVarsEffectivelyFinalInvalidTest {
         }
     }
 
+    // An extra level of nesting doesn't make it OK
+    {
+        for (int i = 0; true; ) {
+            for (int j = 0; j < 3; j++) {
+                i = 42;
+                Runnable r = () -> System.out.println(i);               // error: ...must be final or effectively final
+            }
+            break;
+        }
+    }
+
+    // An extra level of nesting doesn't make it OK
+    {
+        for (int i = 0; true; ) {
+            for (int j = 0; j < ++i; j++) {
+                Runnable r = () -> System.out.println(i);               // error: ...must be final or effectively final
+            }
+            break;
+        }
+    }
+
     int f(int i) {
         return i * i;
     }

--- a/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalInvalidTest.java
+++ b/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalInvalidTest.java
@@ -1,0 +1,65 @@
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8338711
+ * @summary Check for invalid cases relating to for() loop variables being effectively final in the body
+ * @compile/fail/ref=ForLoopVarsEffectivelyFinalInvalidTest.out -XDrawDiagnostics ForLoopVarsEffectivelyFinalInvalidTest.java
+ */
+
+import java.util.function.*;
+
+public class ForLoopVarsEffectivelyFinalInvalidTest {
+
+    // If the variable is mutated in the BODY, it loses its effectively final status in the BODY
+    {
+        for (int i = 0; i < 3; ) {
+            i++;
+            ((IntSupplier)() -> f(i)).getAsInt();                       // error: ...must be final or effectively final
+        }
+    }
+
+    // If the variable is mutated in the INIT, it loses its effectively final status in the INIT
+    {
+        for (int i = 0, j = i++ + ((IntSupplier)() -> f(i)).getAsInt(); // error: ...must be final or effectively final
+            i < 3; ) {
+            ((IntSupplier)() -> f(i)).getAsInt();                       // ok
+        }
+    }
+
+    // If the variable is mutated in the CONDITION, it loses its effectively final status in the CONDITION
+    {
+        for (int i = 0;
+          i++ + ((IntSupplier)() -> f(i)).getAsInt() < 3; ) {           // error: ...must be final or effectively final
+            ((IntSupplier)() -> f(i)).getAsInt();                       // ok
+        }
+    }
+
+    // If the variable is mutated in the STEP, it loses its effectively final status in the STEP
+    {
+        for (int i = 0;
+          i < 3;
+          i += ((IntSupplier)() -> f(i)).getAsInt()) {                  // error: ...must be final or effectively final
+            ((IntSupplier)() -> f(i)).getAsInt();                       // ok
+        }
+    }
+
+    // An extra level of nesting doesn't make it OK
+    {
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                ((IntSupplier)() -> f(i)).getAsInt();                   // error: ...must be final or effectively final
+            }
+            i++;
+        }
+    }
+
+    // If the variable is never initialized, it can't be captured
+    {
+        for (int i; "".hashCode() == 0; ) {
+            ((IntSupplier)() -> f(i)).getAsInt();                       // error: variable i might not have been initialized
+        }
+    }
+
+    int f(int i) {
+        return i * i;
+    }
+}

--- a/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalInvalidTest.out
+++ b/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalInvalidTest.out
@@ -1,0 +1,7 @@
+ForLoopVarsEffectivelyFinalInvalidTest.java:58:35: compiler.err.var.might.not.have.been.initialized: i
+ForLoopVarsEffectivelyFinalInvalidTest.java:16:35: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
+ForLoopVarsEffectivelyFinalInvalidTest.java:22:57: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
+ForLoopVarsEffectivelyFinalInvalidTest.java:31:39: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
+ForLoopVarsEffectivelyFinalInvalidTest.java:40:38: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
+ForLoopVarsEffectivelyFinalInvalidTest.java:49:39: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
+6 errors

--- a/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalInvalidTest.out
+++ b/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalInvalidTest.out
@@ -4,4 +4,6 @@ ForLoopVarsEffectivelyFinalInvalidTest.java:22:57: compiler.err.cant.ref.non.eff
 ForLoopVarsEffectivelyFinalInvalidTest.java:31:39: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
 ForLoopVarsEffectivelyFinalInvalidTest.java:40:38: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
 ForLoopVarsEffectivelyFinalInvalidTest.java:49:39: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
-6 errors
+ForLoopVarsEffectivelyFinalInvalidTest.java:67:55: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
+ForLoopVarsEffectivelyFinalInvalidTest.java:77:55: compiler.err.cant.ref.non.effectively.final.var: i, (compiler.misc.lambda)
+8 errors

--- a/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalValidTest.java
+++ b/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalValidTest.java
@@ -26,6 +26,7 @@
  * @summary Check for valid cases relating to for() loop variables being effectively final in the body
  */
 
+import java.io.*;
 import java.util.function.*;
 
 public class ForLoopVarsEffectivelyFinalValidTest {
@@ -101,13 +102,27 @@ public class ForLoopVarsEffectivelyFinalValidTest {
         return total;
     }
 
-    public static void main(String[] args) {
+    // Test: effectively final in the loop works with try-with-resources statements
+    public static void test7() throws IOException {
+        final InputStream input1 = new ByteArrayInputStream(new byte[0]);
+        final InputStream input2 = new ByteArrayInputStream(new byte[0]);
+        for (InputStream input = input1; true; input = input2) {
+            try (input) {
+                // nothing
+            }
+            if (input == input2)
+                break;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
         verify(test1(), 5);
         verify(test2(), 9);
         verify(test3(), 6);
         verify(test4(), 24);
         verify(test5(), 36);
         verify(test6(), 6);
+        test7();
     }
 
     public static void verify(int actual, int expected) {

--- a/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalValidTest.java
+++ b/test/langtools/tools/javac/forLoopVarsEffectivelyFinal/ForLoopVarsEffectivelyFinalValidTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/*
+ * @test
+ * @bug 8338711
+ * @summary Check for valid cases relating to for() loop variables being effectively final in the body
+ */
+
+import java.util.function.*;
+
+public class ForLoopVarsEffectivelyFinalValidTest {
+
+    // Test: a loop variable modified in INIT can be captured by a lambda in BODY
+    public static int test1() {
+        int total = 0;
+        for (int i = 1, j = ++i; i <= 3; i++) {
+            IntSupplier s = () -> i;
+            total += s.getAsInt();
+        }
+        return total;
+    }
+
+    // Test: a loop variable modified in CONDITION can be captured by a lambda BODY
+    public static int test2() {
+        int total = 0;
+        for (int i = 1; i++ <= 3; ) {
+            IntSupplier s = () -> i;
+            total += s.getAsInt();
+        }
+        return total;
+    }
+
+    // Test: a loop variable modified in STEP can be captured by a lambda BODY
+    public static int test3() {
+        int total = 0;
+        for (int i = 1; i <= 3; i++) {
+            IntSupplier s = () -> i;
+            total += s.getAsInt();
+        }
+        return total;
+    }
+
+    // Test: complicated nesting doesn't confuse the analysis logic
+    public static int test4() {
+        int total = 0;
+        for (int i = 1; i <= 3; i++) {
+            IntSupplier s = () -> {
+                int total2 = 0;
+                for (int i2 = i; i2 <= 3; i2++) {
+                    IntSupplier s2 = () -> i + i2;
+                    total2 += s2.getAsInt();
+                }
+                return total2;
+            };
+            total += s.getAsInt();
+        }
+        return total;
+    }
+
+    // Test: complicated nesting doesn't confuse the analysis logic
+    public static int test5() {
+        int total = 0;
+        for (int i = 1; i <= 3; i++) {
+            for (int j = 1; j <= 3; j++) {
+                IntSupplier s = () -> i + j;
+                total += s.getAsInt();
+            }
+        }
+        return total;
+    }
+
+    // Test: the variable's assigment may happen in the body
+    public static int test6() {
+        int total = 0;
+        int j = 0;
+        for (int i; j < 3; ) {
+            i = ++j;
+            IntSupplier s = () -> i;
+            total += s.getAsInt();
+        }
+        return total;
+    }
+
+    public static void main(String[] args) {
+        verify(test1(), 5);
+        verify(test2(), 9);
+        verify(test3(), 6);
+        verify(test4(), 24);
+        verify(test5(), 36);
+        verify(test6(), 6);
+    }
+
+    public static void verify(int actual, int expected) {
+        if (actual != expected)
+            throw new AssertionError(String.format("expected %d but got %d", expected, actual));
+    }
+}


### PR DESCRIPTION
This PR changes the compiler to allow basic `for()` loop iteration variables to be captured by lambdas in the loop body, even when their "effectively final" status is invalidated by modifications in the header of the loop.

This allows code like this to compile:
```java
for (int i = 1; i <= 3; i++) {
    Runnable r = () -> System.out.println(i);
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a JEP request to be targeted
- [ ] Change requires a CSR request matching fixVersion 25 to be approved (needs to be created)

### Issues
 * [JDK-8341782](https://bugs.openjdk.org/browse/JDK-8341782): Allow lambda capture of basic for() loop variables as with enhanced for() (**Sub-task** - P4)
 * [JDK-8341785](https://bugs.openjdk.org/browse/JDK-8341785): Treat Loop Variables as Effectively Final in the Bodies of All for() Loops (**JEP**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21415/head:pull/21415` \
`$ git checkout pull/21415`

Update a local copy of the PR: \
`$ git checkout pull/21415` \
`$ git pull https://git.openjdk.org/jdk.git pull/21415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21415`

View PR using the GUI difftool: \
`$ git pr show -t 21415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21415.diff">https://git.openjdk.org/jdk/pull/21415.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21415#issuecomment-2400714591)
</details>
