### PR TITLE
8341684: Typo in External Specifications link of java.util.Currency

### DIFF
--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -108,7 +108,7 @@ import sun.util.logging.PlatformLogger;
  * with {@code Currency} or monetary values as it provides better handling of floating
  * point numbers and their operations.
  *
- * @spec http://www.iso.org/iso/home/standards/currency_codes.htm ISO - ISO 4217 - Currency codes
+ * @spec http://www.iso.org/iso/home/standards/currency_codes.html ISO - ISO 4217 - Currency codes
  * @see java.math.BigDecimal
  * @since 1.4
  */

--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -108,7 +108,7 @@ import sun.util.logging.PlatformLogger;
  * with {@code Currency} or monetary values as it provides better handling of floating
  * point numbers and their operations.
  *
- * @spec http://www.iso.org/iso/home/standards/currency_codes.html ISO - ISO 4217 - Currency codes
+ * @spec https://www.iso.org/iso-4217-currency-codes.html ISO - ISO 4217 - Currency codes
  * @see java.math.BigDecimal
  * @since 1.4
  */


### PR DESCRIPTION
A trivial correction to the  _j.util.Currency_ external specification ISO currency codes link. Browsers will auto resolve and correct the link, but it should still be fixed regardless.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341684](https://bugs.openjdk.org/browse/JDK-8341684): Typo in External Specifications link of java.util.Currency (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Steven Loomis](https://openjdk.org/census#srl) (@srl295 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21416/head:pull/21416` \
`$ git checkout pull/21416`

Update a local copy of the PR: \
`$ git checkout pull/21416` \
`$ git pull https://git.openjdk.org/jdk.git pull/21416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21416`

View PR using the GUI difftool: \
`$ git pr show -t 21416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21416.diff">https://git.openjdk.org/jdk/pull/21416.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21416#issuecomment-2400986809)