### PR TITLE
8341803: ProblemList containers/docker/TestJcmdWithSideCar.java on linux-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -39,9 +39,11 @@ serviceability/jvmti/vthread/SuspendWithInterruptLock/SuspendWithInterruptLock.j
 
 serviceability/sa/ClhsdbInspect.java 8283578 windows-x64
 
-vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 windows-x64
-vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_a/TestDescription.java 8308367 windows-x64
-vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInTarget/TestDescription.java 8308367 windows-x64
+vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manyDiff_a/TestDescription.java 8308367 generic-all
+vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2manySame_a/TestDescription.java 8308367 generic-all
+vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_indy2none_b/TestDescription.java 8308367 generic-all
+vmTestbase/vm/mlvm/indy/func/jvmti/mergeCP_none2indy_b/TestDescription.java 8308367 generic-all
+vmTestbase/vm/mlvm/indy/func/jvmti/redefineClassInTarget/TestDescription.java 8308367 generic-all
 
 vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt001/TestDescription.java 8043571 generic-all
 vmTestbase/nsk/jdi/StepRequest/addClassFilter_rt/filter_rt003/TestDescription.java 8043571 generic-all

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -121,6 +121,7 @@ applications/jcstress/copy.java 8229852 linux-all
 containers/docker/TestJcmd.java 8278102 linux-all
 containers/docker/TestMemoryAwareness.java 8303470 linux-all
 containers/docker/TestJFREvents.java 8327723 linux-x64
+containers/docker/TestJcmdWithSideCar.java 8341518 linux-x64
 
 #############################################################################
 


### PR DESCRIPTION
A couple of trivial fixes to ProblemList some noisy tests:
[JDK-8341803](https://bugs.openjdk.org/browse/JDK-8341803) ProblemList containers/docker/TestJcmdWithSideCar.java on linux-x64
[JDK-8341805](https://bugs.openjdk.org/browse/JDK-8341805) ProblemList five mlvm/indy/func/jvmti tests in Xcomp mode

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8341803](https://bugs.openjdk.org/browse/JDK-8341803): ProblemList containers/docker/TestJcmdWithSideCar.java on linux-x64 (**Sub-task** - P4)
 * [JDK-8341805](https://bugs.openjdk.org/browse/JDK-8341805): ProblemList five mlvm/indy/func/jvmti tests in Xcomp mode (**Sub-task** - P4)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21417/head:pull/21417` \
`$ git checkout pull/21417`

Update a local copy of the PR: \
`$ git checkout pull/21417` \
`$ git pull https://git.openjdk.org/jdk.git pull/21417/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21417`

View PR using the GUI difftool: \
`$ git pr show -t 21417`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21417.diff">https://git.openjdk.org/jdk/pull/21417.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21417#issuecomment-2401002846)