### PR TITLE
8226938: [TEST_BUG]GTK L&F: There is no Details button in FileChooser Dialog

### DIFF
--- a/test/jdk/javax/swing/JFileChooser/bug4587721.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4587721.java
@@ -42,17 +42,13 @@ import javax.swing.plaf.metal.MetalLookAndFeel;
 public class bug4587721 {
 
     public static void main(String[] args) throws Exception {
-        try {
-            UIManager.setLookAndFeel(new MetalLookAndFeel());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        UIManager.setLookAndFeel(new MetalLookAndFeel());
 
         String instructions = """
-                                Click on the Details button in JFileChooser Window.
-                                If the filename text is chopped off by height,
-                                then Press FAIL else Press PASS.
-                                """;
+                Click on the Details button in JFileChooser Window.
+                If the filename text is chopped off by height,
+                then Press FAIL else Press PASS.
+                """;
 
         PassFailJFrame.builder()
                 .title("bug4587721")

--- a/test/jdk/javax/swing/JFileChooser/bug4587721.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4587721.java
@@ -49,9 +49,10 @@ public class bug4587721 {
         }
 
         String instructions = """
-                                Press the Details button.
-                                If the file name's text is chopped off by height,
-                                test failed, otherwise it succedeed.""";
+                                Click on the Details button in JFileChooser Window.
+                                If the filename text is chopped off by height,
+                                then Press FAIL else Press PASS.
+                                """;
 
         PassFailJFrame.builder()
                 .title("bug4587721")

--- a/test/jdk/javax/swing/JFileChooser/bug4587721.java
+++ b/test/jdk/javax/swing/JFileChooser/bug4587721.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 4587721
+ * @summary Tests if JFileChooser details view chops off text
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual bug4587721
+ */
+
+import java.awt.Font;
+import java.util.Enumeration;
+
+import javax.swing.JFileChooser;
+import javax.swing.UIDefaults;
+import javax.swing.UIManager;
+import javax.swing.plaf.FontUIResource;
+import javax.swing.plaf.metal.MetalLookAndFeel;
+
+public class bug4587721 {
+
+    public static void main(String[] args) throws Exception {
+        try {
+            UIManager.setLookAndFeel(new MetalLookAndFeel());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        String instructions = """
+                                Press the Details button.
+                                If the file name's text is chopped off by height,
+                                test failed, otherwise it succedeed.""";
+
+        PassFailJFrame.builder()
+                .title("bug4587721")
+                .instructions(instructions)
+                .columns(40)
+                .testUI(bug4587721::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static JFileChooser createUI() {
+        setFonts();
+        JFileChooser fc = new JFileChooser();
+        return fc;
+    }
+
+    public static void setFonts() {
+        UIDefaults defaults = UIManager.getDefaults();
+        Enumeration keys = defaults.keys();
+        while (keys.hasMoreElements()) {
+            Object key = keys.nextElement();
+            if (defaults.get(key) instanceof Font)
+                UIManager.put(key, new FontUIResource(new Font("Courier", Font.BOLD, 30)));
+        }
+    }
+}


### PR DESCRIPTION
Applet test converted to main based manual test and open sourced.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8226938](https://bugs.openjdk.org/browse/JDK-8226938): [TEST_BUG]GTK L&amp;F: There is no Details button in FileChooser Dialog (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21418/head:pull/21418` \
`$ git checkout pull/21418`

Update a local copy of the PR: \
`$ git checkout pull/21418` \
`$ git pull https://git.openjdk.org/jdk.git pull/21418/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21418`

View PR using the GUI difftool: \
`$ git pr show -t 21418`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21418.diff">https://git.openjdk.org/jdk/pull/21418.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21418#issuecomment-2401346340)