### PR TITLE
8341832: Incorrect continuation address of synthetic SIGSEGV for APX in product builds

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.cpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.cpp
@@ -437,6 +437,7 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ cmpl(rax, 0x80000);
     __ jcc(Assembler::notEqual, vector_save_restore);
 
+#ifndef PRODUCT
     bool save_apx = UseAPX;
     VM_Version::set_apx_cpuFeatures();
     UseAPX = true;
@@ -453,6 +454,7 @@ class VM_Version_StubGenerator: public StubCodeGenerator {
     __ movq(Address(rsi, 8), r31);
 
     UseAPX = save_apx;
+#endif
 #endif
     __ bind(vector_save_restore);
     //


### PR DESCRIPTION
- Enable APX EGPRs state save restoration check which triggers synthetic SIGSEGV and verifies modified EGPRs state across OS signal handling for non-product builds to match with [corresponding logic in signal handlers.](https://github.com/openjdk/jdk/blob/master/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp#L251)

- Currently we haven't enabled APX support in product builds and intend to do so once entire planned support ([JDK-8329030](https://bugs.openjdk.org/browse/JDK-8329030)) is validated and checked into JDK-mainline, we are following incremental development approach for APX and hence don't want partial APX support to be enabled in intermediate releases.

Kindly review.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341832](https://bugs.openjdk.org/browse/JDK-8341832): Incorrect continuation address of synthetic SIGSEGV for APX in product builds (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21419/head:pull/21419` \
`$ git checkout pull/21419`

Update a local copy of the PR: \
`$ git checkout pull/21419` \
`$ git pull https://git.openjdk.org/jdk.git pull/21419/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21419`

View PR using the GUI difftool: \
`$ git pr show -t 21419`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21419.diff">https://git.openjdk.org/jdk/pull/21419.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21419#issuecomment-2401657099)