### PR TITLE
8341819: LightweightSynchronizer::enter_for races with deflation

### DIFF
--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -637,6 +637,11 @@ void LightweightSynchronizer::enter_for(Handle obj, BasicLock* lock, JavaThread*
   } else {
     // It is assumed that enter_for must enter on an object without contention.
     monitor = inflate_and_enter(obj(), ObjectSynchronizer::inflate_cause_monitor_enter, locking_thread, current);
+    if (monitor == nullptr) {
+      // But there may still be a race with deflation.
+      // But with no contention there is no safepoint poll. So deflation only happens once.
+      monitor = inflate_and_enter(obj(), ObjectSynchronizer::inflate_cause_monitor_enter, locking_thread, current);
+    }
   }
 
   assert(monitor != nullptr, "LightweightSynchronizer::enter_for must succeed");

--- a/src/hotspot/share/runtime/lightweightSynchronizer.cpp
+++ b/src/hotspot/share/runtime/lightweightSynchronizer.cpp
@@ -635,13 +635,11 @@ void LightweightSynchronizer::enter_for(Handle obj, BasicLock* lock, JavaThread*
     bool entered = monitor->enter_for(locking_thread);
     assert(entered, "recursive ObjectMonitor::enter_for must succeed");
   } else {
-    // It is assumed that enter_for must enter on an object without contention.
-    monitor = inflate_and_enter(obj(), ObjectSynchronizer::inflate_cause_monitor_enter, locking_thread, current);
-    if (monitor == nullptr) {
-      // But there may still be a race with deflation.
-      // But with no contention there is no safepoint poll. So deflation only happens once.
+    do {
+      // It is assumed that enter_for must enter on an object without contention.
       monitor = inflate_and_enter(obj(), ObjectSynchronizer::inflate_cause_monitor_enter, locking_thread, current);
-    }
+      // But there may still be a race with deflation.
+    } while (monitor == nullptr);
   }
 
   assert(monitor != nullptr, "LightweightSynchronizer::enter_for must succeed");

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -160,7 +160,6 @@
  *                 -XX:GuaranteedAsyncDeflationInterval=1000
  *
  * @bug 8341819
- * @test id=8341819
  * @comment Regression test for re-locking racing with deflation with LM_LIGHTWEIGHT.
  * @run driver EATests
  *                 -XX:+UnlockDiagnosticVMOptions

--- a/test/jdk/com/sun/jdi/EATests.java
+++ b/test/jdk/com/sun/jdi/EATests.java
@@ -158,6 +158,20 @@
  *                 -XX:+DoEscapeAnalysis -XX:+EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks
  *                 -XX:LockingMode=0
  *                 -XX:GuaranteedAsyncDeflationInterval=1000
+ *
+ * @bug 8341819
+ * @test id=8341819
+ * @comment Regression test for re-locking racing with deflation with LM_LIGHTWEIGHT.
+ * @run driver EATests
+ *                 -XX:+UnlockDiagnosticVMOptions
+ *                 -Xms256m -Xmx256m
+ *                 -Xbootclasspath/a:.
+ *                 -XX:CompileCommand=dontinline,*::dontinline_*
+ *                 -XX:+WhiteBoxAPI
+ *                 -Xbatch
+ *                 -XX:+DoEscapeAnalysis -XX:+EliminateAllocations -XX:+EliminateLocks -XX:+EliminateNestedLocks
+ *                 -XX:LockingMode=2
+ *                 -XX:GuaranteedAsyncDeflationInterval=1
  */
 
 /**


### PR DESCRIPTION
This is a regression from [JDK-8315884](https://bugs.openjdk.org/browse/JDK-8315884).

When using `+UseObjectMonitorTable` monitors are inflated in a locked state effectively blocking out deflation. `LightweightSynchronizer::enter_for` assumed this to be true. But when the `-UseObjectMonitorTable` path was added `// Do the old inflate and enter.` this is no longer true as it first inflates a monitor in an unlocked state and then tries to lock. We need to introduce a retry loop similar to what was used before [JDK-8315884](https://bugs.openjdk.org/browse/JDK-8315884).

I propose we add this retry loop for both cases, to decouple the `LightweightSynchronizer::enter_for` from how lock elimination is done. With a retry loop, the only requirements for using `LightweightSynchronizer::enter_for` is that the Object locked on cannot have been locked on by another thread, i.e. there is no contention, but makes no assumptions on the interaction with the deflation thread.

For `-UseObjectMonitorTable` 7bdbe114eb57fe7310f9664a434c4d9203e656fc should be enough, as it will assist the deflating thread with deflation, so the second call must succeed. 

However `+UseObjectMonitorTable` cannot do this so it must wait for the deflating thread to make progress. But as mentioned above, this would only happen if partial lock elimination is performed. E.g.
```java
Object o = new Object();
synchronized(o) {
  o.wait(1);
}
synchronized(o) {
  deoptimize();
}
```
got transformed to 
```java
Object o = new Object();
synchronized(o) {
  o.wait(1);
}
// synchronized(o) { Eliminated lock
  deoptimize();
// }
```

As far as I can tell, this does not happen. But I do not want to couple lock elimination decision with `LightweightSynchronizer::enter_for`. So I propose a retry loop instead of just the two calls.
After this change the only prerequisite for using `LightweightSynchronizer::enter_for` is that the object being synchronized can not have been reached by another JavaThread (except the deflating thread).  So there may never be contention, but there may be deflation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341819](https://bugs.openjdk.org/browse/JDK-8341819): LightweightSynchronizer::enter_for races with deflation (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) Review applies to [e16bfde1](https://git.openjdk.org/jdk/pull/21420/files/e16bfde139fdca4fe772acad267c5afb90bea4fd)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21420/head:pull/21420` \
`$ git checkout pull/21420`

Update a local copy of the PR: \
`$ git checkout pull/21420` \
`$ git pull https://git.openjdk.org/jdk.git pull/21420/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21420`

View PR using the GUI difftool: \
`$ git pr show -t 21420`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21420.diff">https://git.openjdk.org/jdk/pull/21420.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21420#issuecomment-2402044082)