### PR TITLE
8341806: Gcc version detection failure on Alinux3

### DIFF
--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -358,6 +358,11 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
     #     Copyright (C) 2013 Free Software Foundation, Inc.
     #     This is free software; see the source for copying conditions.  There is NO
     #     warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    # or look like
+    #     gcc (GCC) 10.2.1 20200825 (Alibaba 10.2.1-3.8 2.32)
+    #     Copyright (C) 2020 Free Software Foundation, Inc.
+    #     This is free software; see the source for copying conditions.  There is NO
+    #     warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
     COMPILER_VERSION_OUTPUT=`$COMPILER --version 2>&1`
     # Check that this is likely to be GCC.
     $ECHO "$COMPILER_VERSION_OUTPUT" | $GREP "Free Software Foundation" > /dev/null
@@ -371,7 +376,8 @@ AC_DEFUN([TOOLCHAIN_EXTRACT_COMPILER_VERSION],
     COMPILER_VERSION_STRING=`$ECHO $COMPILER_VERSION_OUTPUT | \
         $SED -e 's/ *Copyright .*//'`
     COMPILER_VERSION_NUMBER=`$ECHO $COMPILER_VERSION_OUTPUT | \
-        $SED -e 's/^.* \(@<:@1-9@:>@<:@0-9@:>@*\.@<:@0-9.@:>@*\)@<:@^0-9.@:>@.*$/\1/'`
+        $AWK -F ')' '{print [$]2}' | \
+        $AWK '{print [$]1}'`
   elif test  "x$TOOLCHAIN_TYPE" = xclang; then
     # clang --version output typically looks like
     #    Apple clang version 15.0.0 (clang-1500.3.9.4)


### PR DESCRIPTION
Hi all,
There is a gcc version detection bug in `make/autoconf/toolchain.m4`.
Before this PR, the gcc version detection shell command is:
```shell
gcc --version 2>&1 | tr "\n" " " | sed -e 's/ *Copyright .*//' | sed -e 's/^.* \([1-9][0-9]*\.[0-9.]*\)[^0-9.].*$/\1/'
```
And this gcc version detection command can't work on some linux distribution such as alinux3(Alibaba Cloud Linux 3.2104).
The `gcc --version` first line output is `gcc (GCC) 10.2.1 20200825 (Alibaba 10.2.1-3.8 2.32)`, because the `sed -e` get the `.*` strings as greedy mode, so  the original command get gcc  version as `2.32`, but the actual version is `10.2.1`

I observed some `gcc --version` output like:

1. alinux3 gcc: `gcc (GCC) 10.2.1 20200825 (Alibaba 10.2.1-3.8 2.32)`
2. centos7/8 gcc: `gcc (GCC) 10.2.1 20210130 (Red Hat 10.2.1-11)`
3. ubuntu22 gcc: `gcc (Ubuntu 9.4.0-1ubuntu1~20.04.2) 9.4.0`
4. gcc build from source: `gcc (GCC) 10.3.0`
5. riscv cross gcc compiler which build from source: `riscv64-unknown-linux-gnu-gcc (g85f323c2dc3) 13.3.1 20240901`

The command `gcc version` string pattern is, after the first `) ` split string, and before an empty space or at the end of line.
So I change the gcc version detection shell command to:
```shell
gcc --version 2>&1 | tr "\n" " " | sed -e 's/ *Copyright .*//' | awk -F ')' '{print $2}' | awk '{print $1}'
```

Addiontial testing:

- [x] configure on alinux3
- [x] configure on ubuntu22
- [x] configure on centos7
- [x] configure with gcc10 which build from source

By the way, the original makefile command miss an `@` character.
```makefile
$SED -e 's/^.* \(@<:@1-9@:>@<:@0-9@:>@*\.@<:@0-9.@:>@*\)@<:@^0-9.@:>@.*$/\1/'`
```
The correct makefile command should be:
```makefile
$SED -e 's/^.* \(@<:@1-9@:>@@<:@0-9@:>@*\.@<:@0-9.@:>@*\)@<:@^0-9.@:>@.*$/\1/'`
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341806](https://bugs.openjdk.org/browse/JDK-8341806): Gcc version detection failure on Alinux3 (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21421/head:pull/21421` \
`$ git checkout pull/21421`

Update a local copy of the PR: \
`$ git checkout pull/21421` \
`$ git pull https://git.openjdk.org/jdk.git pull/21421/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21421`

View PR using the GUI difftool: \
`$ git pr show -t 21421`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21421.diff">https://git.openjdk.org/jdk/pull/21421.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21421#issuecomment-2402126390)