### PR TITLE
8341854: Incorrect clearing of ZF in fast_unlock_lightweight on x86

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -822,7 +822,7 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register reg_rax, 
     }
     movptr(Address(thread, JavaThread::unlocked_inflated_monitor_offset()), monitor);
 
-    testl(monitor, monitor);            // Fast Unlock ZF = 0
+    orl(t, 1); // Fast Unlock ZF = 0
     jmpb(slow_path);
 
     // Recursive unlock.


### PR DESCRIPTION
This bug was created in [JDK-8320318](https://bugs.openjdk.org/browse/JDK-8320318).

`C2_MacroAssembler::fast_unlock_lightweight()` on x86 issues a `testl(monitor, monitor);` instruction for the sole purpose of clearing the zero-flag, which should force us to go into the slow path.

However, this instruction incorrectly only checks the lower 32-bits, which results in setting the zero-flag if the ObjectMonitor has all-zeros in the lower 32-bits. For some reason this seems to be quite common on macosx-x64, where we tend to get an ObjectMonitor address that is 0x0000600000000000.

The reason we wanted to go into the slow path was that we've observed that there is a thread queued on either the EntryList or cxq, and there is no successor. However since we failed to clear the zero-flag, we will go into the fast path and no one will wake up the stranded thread. Thus the system will hang and any test system will timeout.

Tested ok in tier1-3 on all x64 related platforms. Also ran the vm.lang.LockUnlock.testContendedLock test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341854](https://bugs.openjdk.org/browse/JDK-8341854): Incorrect clearing of ZF in fast_unlock_lightweight on x86 (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21422/head:pull/21422` \
`$ git checkout pull/21422`

Update a local copy of the PR: \
`$ git checkout pull/21422` \
`$ git pull https://git.openjdk.org/jdk.git pull/21422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21422`

View PR using the GUI difftool: \
`$ git pr show -t 21422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21422.diff">https://git.openjdk.org/jdk/pull/21422.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21422#issuecomment-2402387778)