### PR TITLE
8341138: Rename jtreg property docker.support as container.support

### DIFF
--- a/test/hotspot/jtreg/TEST.ROOT
+++ b/test/hotspot/jtreg/TEST.ROOT
@@ -86,7 +86,7 @@ requires.properties= \
     vm.compiler2.enabled \
     vm.musl \
     vm.flagless \
-    docker.support \
+    container.support \
     systemd.support \
     jdk.containerized
 

--- a/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
+++ b/test/hotspot/jtreg/containers/docker/DockerBasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Basic (sanity) test for JDK-under-test inside a docker image.
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/ShareTmpDir.java
+++ b/test/hotspot/jtreg/containers/docker/ShareTmpDir.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @bug 8286030
  * @key cgroups
  * @summary Test for hsperfdata file name conflict when two containers share the same /tmp directory
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @build WaitForFlagFile
  * @run driver ShareTmpDir

--- a/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @test
  * @key cgroups
  * @summary Test JVM's CPU resource awareness when running inside docker container
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.platform

--- a/test/hotspot/jtreg/containers/docker/TestCPUSets.java
+++ b/test/hotspot/jtreg/containers/docker/TestCPUSets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @test
  * @key cgroups
  * @summary Test JVM's awareness of cpu sets (cpus and mems)
- * @requires docker.support
+ * @requires container.support
  * @requires (os.arch != "s390x")
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
+++ b/test/hotspot/jtreg/containers/docker/TestContainerInfo.java
@@ -27,7 +27,7 @@
  * @test
  * @summary Test container info for cgroup v2
  * @key cgroups
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestJFREvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFREvents.java
@@ -29,7 +29,7 @@
  *          when run inside Docker container, such as available CPU and memory.
  *          Also make sure that PIDs are based on value provided by container,
  *          not by the host system.
- * @requires (docker.support & os.maxMemory >= 2g)
+ * @requires (container.support & os.maxMemory >= 2g)
  * @modules java.base/jdk.internal.platform
  * @library /test/lib
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFRNetworkEvents.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @summary Test JFR network related events inside a container; make sure
  *          the reported host ip and host name are correctly reported within
  *          the container.
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestJFRWithJMX.java
+++ b/test/hotspot/jtreg/containers/docker/TestJFRWithJMX.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test JFR recording controlled via JMX across container boundary.
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestJcmd.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
  * @test
  * @summary Test JCMD across container boundary. The JCMD runs on a host system,
  *          while sending commands to a JVM that runs inside a container.
- * @requires docker.support
+ * @requires container.support
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
+++ b/test/hotspot/jtreg/containers/docker/TestJcmdWithSideCar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@
  *          and other uses. In side car pattern the main application/service container
  *          is paired with a sidecar container by sharing certain aspects of container
  *          namespace such as PID namespace, specific sub-directories, IPC and more.
- * @requires docker.support
+ * @requires container.support
  * @requires vm.flagless
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
+++ b/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
@@ -28,7 +28,7 @@
  * @bug 8308090
  * @key cgroups
  * @summary Test container limits updating as they get updated at runtime without restart
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox LimitUpdateChecker
  * @run driver jdk.test.lib.helpers.ClassFileInstaller -jar whitebox.jar jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
+++ b/test/hotspot/jtreg/containers/docker/TestLimitsUpdating.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
+++ b/test/hotspot/jtreg/containers/docker/TestMemoryAwareness.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @bug 8146115 8292083
  * @key cgroups
  * @summary Test JVM's memory resource awareness when running inside docker container
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.base/jdk.internal.platform

--- a/test/hotspot/jtreg/containers/docker/TestMisc.java
+++ b/test/hotspot/jtreg/containers/docker/TestMisc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
 /*
  * @test
  * @summary Test miscellanous functionality related to JVM running in docker container
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/hotspot/jtreg/containers/docker/TestPids.java
+++ b/test/hotspot/jtreg/containers/docker/TestPids.java
@@ -27,7 +27,7 @@
  * @test
  * @key cgroups
  * @summary Test JVM's awareness of pids controller
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          java.management

--- a/test/jdk/TEST.ROOT
+++ b/test/jdk/TEST.ROOT
@@ -100,7 +100,7 @@ requires.properties= \
     vm.jvmci.enabled \
     vm.jvmti \
     vm.cpu.features \
-    docker.support \
+    container.support \
     systemd.support \
     release.implementor \
     jdk.containerized \

--- a/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
@@ -26,7 +26,7 @@
  * @bug 8293540
  * @summary Verify that -XshowSettings:system works
  * @key cgroups
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @run main/timeout=360 TestDockerBasic
  */

--- a/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerBasic.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Red Hat, Inc.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerCpuMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,7 @@ import jdk.test.lib.containers.docker.DockerTestUtils;
  * @test
  * @key cgroups
  * @summary Test JDK Metrics class when running inside docker container
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build MetricsCpuTester

--- a/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestDockerMemoryMetrics.java
@@ -32,7 +32,7 @@ import jdk.test.lib.process.OutputAnalyzer;
  * @test
  * @key cgroups
  * @summary Test JDK Metrics class when running inside docker container
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build MetricsMemoryTester

--- a/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -25,7 +25,7 @@
  * @test
  * @key cgroups
  * @bug 8242480
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @build GetFreeSwapSpaceSize
  * @run driver TestGetFreeSwapSpaceSize

--- a/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
+++ b/test/jdk/jdk/internal/platform/docker/TestGetFreeSwapSpaceSize.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2020, 2022 THL A29 Limited, a Tencent company. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
+++ b/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
@@ -28,7 +28,7 @@
  * @bug 8308090
  * @key cgroups
  * @summary Test container limits updating as they get updated at runtime without restart
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build LimitUpdateChecker

--- a/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
+++ b/test/jdk/jdk/internal/platform/docker/TestLimitsUpdating.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2023, Red Hat, Inc.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  *
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *

--- a/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
+++ b/test/jdk/jdk/internal/platform/docker/TestPidsLimit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -27,7 +27,7 @@
  * @key cgroups
  * @summary Test JDK Metrics class when running inside a docker container with limited pids
  * @bug 8266490
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @build TestPidsLimit
  * @run driver TestPidsLimit

--- a/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
+++ b/test/jdk/jdk/internal/platform/docker/TestSystemMetrics.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,7 @@
  * @test
  * @key cgroups
  * @summary Test JDK Metrics class when running inside docker container
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @run main TestSystemMetrics

--- a/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Red Hat, Inc.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
+++ b/test/jdk/jdk/internal/platform/docker/TestUseContainerSupport.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary UseContainerSupport flag should reflect Metrics being available
- * @requires docker.support
+ * @requires container.support
  * @library /test/lib
  * @modules java.base/jdk.internal.platform
  * @build CheckUseContainerSupport

--- a/test/jtreg-ext/requires/VMProps.java
+++ b/test/jtreg-ext/requires/VMProps.java
@@ -131,7 +131,7 @@ public class VMProps implements Callable<Map<String, String>> {
         map.put("vm.libgraal.jit", this::isLibgraalJIT);
         map.put("vm.compiler1.enabled", this::isCompiler1Enabled);
         map.put("vm.compiler2.enabled", this::isCompiler2Enabled);
-        map.put("docker.support", this::dockerSupport);
+        map.put("container.support", this::containerSupport);
         map.put("systemd.support", this::systemdSupport);
         map.put("vm.musl", this::isMusl);
         map.put("release.implementor", this::implementor);
@@ -585,16 +585,16 @@ public class VMProps implements Callable<Map<String, String>> {
     }
 
     /**
-     * A simple check for docker support
+     * A simple check for container support
      *
-     * @return true if docker is supported in a given environment
+     * @return true if container is supported in a given environment
      */
-    protected String dockerSupport() {
-        log("Entering dockerSupport()");
+    protected String containerSupport() {
+        log("Entering containerSupport()");
 
         boolean isSupported = false;
         if (Platform.isLinux()) {
-           // currently docker testing is only supported for Linux,
+           // currently container testing is only supported for Linux,
            // on certain platforms
 
            String arch = System.getProperty("os.arch");
@@ -610,17 +610,17 @@ public class VMProps implements Callable<Map<String, String>> {
            }
         }
 
-        log("dockerSupport(): platform check: isSupported = " + isSupported);
+        log("containerSupport(): platform check: isSupported = " + isSupported);
 
         if (isSupported) {
            try {
-              isSupported = checkProgramSupport("checkDockerSupport()", Container.ENGINE_COMMAND);
+              isSupported = checkProgramSupport("checkContainerSupport()", Container.ENGINE_COMMAND);
            } catch (Exception e) {
               isSupported = false;
            }
          }
 
-        log("dockerSupport(): returning isSupported = " + isSupported);
+        log("containerSupport(): returning isSupported = " + isSupported);
         return "" + isSupported;
     }
 

--- a/test/lib/jdk/test/lib/Container.java
+++ b/test/lib/jdk/test/lib/Container.java
@@ -24,7 +24,7 @@
 package jdk.test.lib;
 
 public class Container {
-    // Use this property to specify container location on your system.
+    // Use this property to specify container runtime location (e.g. docker) on your system.
     // E.g.: "/usr/local/bin/docker". We define this constant here so
     // that it can be used in VMProps as well which checks container support
     // via this command

--- a/test/lib/jdk/test/lib/Container.java
+++ b/test/lib/jdk/test/lib/Container.java
@@ -23,9 +23,9 @@
 package jdk.test.lib;
 
 public class Container {
-    // Use this property to specify docker location on your system.
+    // Use this property to specify container location on your system.
     // E.g.: "/usr/local/bin/docker". We define this constant here so
-    // that it can be used in VMProps as well which checks docker support
+    // that it can be used in VMProps as well which checks container support
     // via this command
     public static final String ENGINE_COMMAND =
         System.getProperty("jdk.test.container.command", "docker");

--- a/test/lib/jdk/test/lib/Container.java
+++ b/test/lib/jdk/test/lib/Container.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, Red Hat Inc.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The System property "docker.support" defined in VMProps gives a wrong impression that it is tied to docker alone. The property is common for any container runtime. Hence, it needs to be renamed as "container.support".

Positive Testing:
tier1,tier2,tier3 - to check stability
tier5 - to run container tests

Negative Testing:
Ran the following groups in hosts where container is not present.
open/test/hotspot/jtreg/containers/
open/test/jdk/jdk/internal/platform/docker/
open/test/jdk/jdk/internal/platform/cgroup/

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341138](https://bugs.openjdk.org/browse/JDK-8341138): Rename jtreg property docker.support as container.support (**Enhancement** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)
 * [Mikhailo Seledtsov](https://openjdk.org/census#mseledtsov) (@mseledts - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21423/head:pull/21423` \
`$ git checkout pull/21423`

Update a local copy of the PR: \
`$ git checkout pull/21423` \
`$ git pull https://git.openjdk.org/jdk.git pull/21423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21423`

View PR using the GUI difftool: \
`$ git pr show -t 21423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21423.diff">https://git.openjdk.org/jdk/pull/21423.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21423#issuecomment-2402589048)