### PR TITLE
8341792: Fix ExceptionOccurred in java.security.jgss

### DIFF
--- a/src/java.security.jgss/macosx/native/libosxkrb5/SCDynamicStoreConfig.m
+++ b/src/java.security.jgss/macosx/native/libosxkrb5/SCDynamicStoreConfig.m
@@ -51,7 +51,7 @@ void _SCDynamicStoreCallBack(SCDynamicStoreRef store, CFArrayRef changedKeys, vo
         jmethodID jm_Config_refresh = (*env)->GetStaticMethodID(env, jc_Config, "refresh", "()V");
         CHECK_NULL(jm_Config_refresh);
         (*env)->CallStaticVoidMethod(env, jc_Config, jm_Config_refresh);
-        if ((*env)->ExceptionOccurred(env) != NULL) {
+        if ((*env)->ExceptionCheck(env)) {
             (*env)->ExceptionClear(env);
         }
         if (createdFromAttach) {

--- a/src/java.security.jgss/windows/native/libw2k_lsa_auth/NativeCreds.c
+++ b/src/java.security.jgss/windows/native/libw2k_lsa_auth/NativeCreds.c
@@ -877,13 +877,13 @@ jobject BuildTicket(JNIEnv *env, PUCHAR encodedTicket, ULONG encodedTicketSize) 
 
     (*env)->SetByteArrayRegion(env, ary, (jsize) 0, encodedTicketSize,
                                     (jbyte *)encodedTicket);
-    if ((*env)->ExceptionOccurred(env)) {
+    if ((*env)->ExceptionCheck(env)) {
         (*env)->DeleteLocalRef(env, ary);
         return (jobject) NULL;
     }
 
     ticket = (*env)->NewObject(env, ticketClass, ticketConstructor, ary);
-    if ((*env)->ExceptionOccurred(env)) {
+    if ((*env)->ExceptionCheck(env)) {
         (*env)->DeleteLocalRef(env, ary);
         return (jobject) NULL;
     }
@@ -993,7 +993,7 @@ jobject BuildEncryptionKey(JNIEnv *env, PKERB_CRYPTO_KEY cryptoKey) {
     }
     (*env)->SetByteArrayRegion(env, ary, (jsize) 0, cryptoKey->Length,
                                     (jbyte *)cryptoKey->Value);
-    if ((*env)->ExceptionOccurred(env)) {
+    if ((*env)->ExceptionCheck(env)) {
         (*env)->DeleteLocalRef(env, ary);
     } else {
         encryptionKey = (*env)->NewObject(env, encryptionKeyClass,
@@ -1018,7 +1018,7 @@ jobject BuildTicketFlags(JNIEnv *env, PULONG flags) {
     }
     (*env)->SetByteArrayRegion(env, ary, (jsize) 0, sizeof(*flags),
                                     (jbyte *)&nlflags);
-    if ((*env)->ExceptionOccurred(env)) {
+    if ((*env)->ExceptionCheck(env)) {
         (*env)->DeleteLocalRef(env, ary);
     } else {
         ticketFlags = (*env)->NewObject(env, ticketFlagsClass,


### PR DESCRIPTION
Switch to `ExceptionCheck`.

This is a part of an umbrella bug [JDK-8341542 JNI uses of ExceptionOccurred() treated as if function returns a bool](https://bugs.openjdk.org/browse/JDK-8341542).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341792](https://bugs.openjdk.org/browse/JDK-8341792): Fix ExceptionOccurred in java.security.jgss (**Sub-task** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21424/head:pull/21424` \
`$ git checkout pull/21424`

Update a local copy of the PR: \
`$ git checkout pull/21424` \
`$ git pull https://git.openjdk.org/jdk.git pull/21424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21424`

View PR using the GUI difftool: \
`$ git pr show -t 21424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21424.diff">https://git.openjdk.org/jdk/pull/21424.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21424#issuecomment-2402801179)