### PR TITLE
8341859: Optimize ClassFile Benchmark Write

### DIFF
--- a/test/micro/org/openjdk/bench/jdk/classfile/Write.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/Write.java
@@ -62,6 +62,15 @@ import static org.openjdk.bench.jdk.classfile.TestConstants.*;
         "--enable-preview",
         "--add-exports", "java.base/jdk.internal.classfile.impl=ALL-UNNAMED"})
 public class Write {
+    static final int REPEATS = 40;
+    static final String[] METHOD_NAMES;
+    static {
+        var names = new String[REPEATS];
+        for (int xi = 0; xi < REPEATS; ++xi) {
+            names[xi] = "main" + ((xi == 0) ? "" : "" + xi);
+        }
+        METHOD_NAMES = names;
+    }
     static String checkFileAsm = "/tmp/asw/MyClass.class";
     static String checkFileBc = "/tmp/byw/MyClass.class";
     static boolean writeClassAsm = Files.exists(Paths.get(checkFileAsm).getParent());
@@ -90,8 +99,8 @@ public class Write {
             mv.visitEnd();
         }
 
-        for (int xi = 0; xi < 40; ++xi) {
-            MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC+Opcodes.ACC_STATIC, "main"+ ((xi==0)? "" : ""+xi), "([Ljava/lang/String;)V", null, null);
+        for (int xi = 0; xi < REPEATS; ++xi) {
+            MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC+Opcodes.ACC_STATIC, METHOD_NAMES[xi], "([Ljava/lang/String;)V", null, null);
             mv.visitCode();
             Label loopTop = new Label();
             Label loopEnd = new Label();
@@ -146,8 +155,8 @@ public class Write {
                                               .return_()
                       )
               );
-            for (int xi = 0; xi < 40; ++xi) {
-                cb.withMethod("main" + ((xi == 0) ? "" : "" + xi), MTD_void_StringArray,
+            for (int xi = 0; xi < REPEATS; ++xi) {
+                cb.withMethod(METHOD_NAMES[xi], MTD_void_StringArray,
                               ACC_PUBLIC | ACC_STATIC,
                               mb -> mb.withCode(c0 -> {
                                   java.lang.classfile.Label loopTop = c0.newLabel();


### PR DESCRIPTION
Cache method names to reduce the overhead of using StringBuilder to construct method names, which will make the performance test results more stable.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341859](https://bugs.openjdk.org/browse/JDK-8341859): Optimize ClassFile Benchmark Write (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21425/head:pull/21425` \
`$ git checkout pull/21425`

Update a local copy of the PR: \
`$ git checkout pull/21425` \
`$ git pull https://git.openjdk.org/jdk.git pull/21425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21425`

View PR using the GUI difftool: \
`$ git pr show -t 21425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21425.diff">https://git.openjdk.org/jdk/pull/21425.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21425#issuecomment-2402919039)