### PR TITLE
8341791: Fix ExceptionOccurred in java.prefs

### DIFF
--- a/src/java.prefs/macosx/native/libprefs/MacOSXPreferencesFile.m
+++ b/src/java.prefs/macosx/native/libprefs/MacOSXPreferencesFile.m
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -83,7 +83,7 @@ static void throwOutOfMemoryError(JNIEnv *env, const char *msg)
         c = exceptionClass;
     } else {
         c = (*env)->FindClass(env, "java/lang/OutOfMemoryError");
-        if ((*env)->ExceptionOccurred(env)) return;
+        if ((*env)->ExceptionCheck(env)) return;
         exceptionClass = (*env)->NewGlobalRef(env, c);
     }
 
@@ -211,7 +211,7 @@ static jarray createJavaStringArray(JNIEnv *env, CFIndex count)
         c = stringClass;
     } else {
         c = (*env)->FindClass(env, "java/lang/String");
-        if ((*env)->ExceptionOccurred(env)) return NULL;
+        if ((*env)->ExceptionCheck(env)) return NULL;
         stringClass = (*env)->NewGlobalRef(env, c);
     }
 
@@ -892,7 +892,7 @@ Java_java_util_prefs_MacOSXPreferencesFile_getKeyFromNode
             result = NULL;
         } else {
             CFStringRef cfString = copyToCFString(env, value);
-            if ((*env)->ExceptionOccurred(env)) {
+            if ((*env)->ExceptionCheck(env)) {
                 // memory error in copyToCFString
                 result = NULL;
             } else if (cfString == NULL) {
@@ -940,10 +940,10 @@ static void BuildJavaArrayFn(const void *key, const void *value, void *context)
     CFStringRef cfString = NULL;
     JNIEnv *env = args->env;
 
-    if ((*env)->ExceptionOccurred(env)) return; // already failed
+    if ((*env)->ExceptionCheck(env)) return; // already failed
 
     cfString = copyToCFString(env, propkey);
-    if ((*env)->ExceptionOccurred(env)) {
+    if ((*env)->ExceptionCheck(env)) {
         // memory error in copyToCFString
     } else if (!cfString) {
         // bogus value type in prefs file - no Java errors available
@@ -960,9 +960,9 @@ static void BuildJavaArrayFn(const void *key, const void *value, void *context)
         }
         if (CFStringGetLength(cfString) <= 0) goto bad; // ignore empty
         javaString = toJavaString(env, cfString);
-        if ((*env)->ExceptionOccurred(env)) goto bad;
+        if ((*env)->ExceptionCheck(env)) goto bad;
         (*env)->SetObjectArrayElement(env, args->result,args->used,javaString);
-        if ((*env)->ExceptionOccurred(env)) goto bad;
+        if ((*env)->ExceptionCheck(env)) goto bad;
         args->used++;
     }
 
@@ -1003,7 +1003,7 @@ static jarray getStringsForNode(JNIEnv *env, jobject klass, jobject jpath,
             args.used = 0;
             args.allowSlash = allowSlash;
             CFDictionaryApplyFunction(node, BuildJavaArrayFn, &args);
-            if (!(*env)->ExceptionOccurred(env)) {
+            if (!(*env)->ExceptionCheck(env)) {
                 // array construction succeeded
                 if (args.used < count) {
                     // finished array is smaller than expected.


### PR DESCRIPTION
Please review this PR which fixes incorrect usage of `jthrowable ExceptionOccurred(JNIEnv *env)` within _java.prefs_.

This corrects instances where the return value is being treated as a boolean. Such occurrences are replaced with `jboolean ExceptionCheck(JNIEnv *env)`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341791](https://bugs.openjdk.org/browse/JDK-8341791): Fix ExceptionOccurred in java.prefs (**Sub-task** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21427/head:pull/21427` \
`$ git checkout pull/21427`

Update a local copy of the PR: \
`$ git checkout pull/21427` \
`$ git pull https://git.openjdk.org/jdk.git pull/21427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21427`

View PR using the GUI difftool: \
`$ git pr show -t 21427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21427.diff">https://git.openjdk.org/jdk/pull/21427.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21427#issuecomment-2402908745)