### PR TITLE
8341860: ProblemList applications/ctw/modules/java_base_2.java on linux-x64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -43,6 +43,8 @@
 
 # :hotspot_compiler
 
+applications/ctw/modules/java_base_2.java 8341831 linux-x64
+
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 


### PR DESCRIPTION
A trivial fix to ProblemList applications/ctw/modules/java_base_2.java on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341860](https://bugs.openjdk.org/browse/JDK-8341860): ProblemList applications/ctw/modules/java_base_2.java on linux-x64 (**Sub-task** - P3)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21430/head:pull/21430` \
`$ git checkout pull/21430`

Update a local copy of the PR: \
`$ git checkout pull/21430` \
`$ git pull https://git.openjdk.org/jdk.git pull/21430/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21430`

View PR using the GUI difftool: \
`$ git pr show -t 21430`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21430.diff">https://git.openjdk.org/jdk/pull/21430.diff</a>

</details>
