### PR TITLE
8339651: ShenandoahPacer::setup_for_mark, ShenandoahPacer::setup_for_updaterefs and ShenandoahPacer::setup_for_evac runtime error: division by zero

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -65,6 +65,7 @@ void ShenandoahPacer::setup_for_mark() {
 
   size_t non_taxable = free * ShenandoahPacingCycleSlack / 100;
   size_t taxable = free - non_taxable;
+  taxable = MAX2(1UL, taxable);
 
   double tax = 1.0 * live / taxable; // base tax for available free space
   tax *= 1;                          // mark can succeed with immediate garbage, claim all available space
@@ -88,6 +89,7 @@ void ShenandoahPacer::setup_for_evac() {
 
   size_t non_taxable = free * ShenandoahPacingCycleSlack / 100;
   size_t taxable = free - non_taxable;
+  taxable = MAX2(1UL, taxable);
 
   double tax = 1.0 * used / taxable; // base tax for available free space
   tax *= 2;                          // evac is followed by update-refs, claim 1/2 of remaining free
@@ -112,6 +114,7 @@ void ShenandoahPacer::setup_for_updaterefs() {
 
   size_t non_taxable = free * ShenandoahPacingCycleSlack / 100;
   size_t taxable = free - non_taxable;
+  taxable = MAX2(1UL, taxable);
 
   double tax = 1.0 * used / taxable; // base tax for available free space
   tax *= 1;                          // update-refs is the last phase, claim the remaining free

--- a/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPacer.cpp
@@ -65,7 +65,7 @@ void ShenandoahPacer::setup_for_mark() {
 
   size_t non_taxable = free * ShenandoahPacingCycleSlack / 100;
   size_t taxable = free - non_taxable;
-  taxable = MAX2(1UL, taxable);
+  taxable = MAX2<size_t>(1, taxable);
 
   double tax = 1.0 * live / taxable; // base tax for available free space
   tax *= 1;                          // mark can succeed with immediate garbage, claim all available space
@@ -89,7 +89,7 @@ void ShenandoahPacer::setup_for_evac() {
 
   size_t non_taxable = free * ShenandoahPacingCycleSlack / 100;
   size_t taxable = free - non_taxable;
-  taxable = MAX2(1UL, taxable);
+  taxable = MAX2<size_t>(1, taxable);
 
   double tax = 1.0 * used / taxable; // base tax for available free space
   tax *= 2;                          // evac is followed by update-refs, claim 1/2 of remaining free
@@ -114,7 +114,7 @@ void ShenandoahPacer::setup_for_updaterefs() {
 
   size_t non_taxable = free * ShenandoahPacingCycleSlack / 100;
   size_t taxable = free - non_taxable;
-  taxable = MAX2(1UL, taxable);
+  taxable = MAX2<size_t>(1, taxable);
 
   double tax = 1.0 * used / taxable; // base tax for available free space
   tax *= 1;                          // update-refs is the last phase, claim the remaining free


### PR DESCRIPTION
Avoid divide by zero error when there is no memory available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339651](https://bugs.openjdk.org/browse/JDK-8339651): ShenandoahPacer::setup_for_mark, ShenandoahPacer::setup_for_updaterefs and ShenandoahPacer::setup_for_evac runtime error: division by zero (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21432/head:pull/21432` \
`$ git checkout pull/21432`

Update a local copy of the PR: \
`$ git checkout pull/21432` \
`$ git pull https://git.openjdk.org/jdk.git pull/21432/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21432`

View PR using the GUI difftool: \
`$ git pr show -t 21432`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21432.diff">https://git.openjdk.org/jdk/pull/21432.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21432#issuecomment-2403426536)