### PR TITLE
Optimize DirectCodeBuilder writeBody

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -374,24 +374,19 @@ public final class DirectCodeBuilder
                             dcb.methodInfo.methodTypeSymbol().displayDescriptor()));
                 }
 
+                boolean codeMatch = dcb.original != null && codeAndExceptionsMatch(codeLength);
                 var context = dcb.context;
-                if (dcb.original != null && codeAndExceptionsMatch(codeLength)) {
-                    if (context.stackMapsWhenRequired()) {
+                if (context.stackMapsWhenRequired()) {
+                    if (codeMatch) {
                         dcb.attributes.withAttribute(dcb.original.findAttribute(Attributes.stackMapTable()).orElse(null));
                         writeCounters(true, buf);
-                    } else if (context.generateStackMaps()) {
-                        generateStackMaps(buf);
-                    } else if (context.dropStackMaps()) {
-                        writeCounters(true, buf);
-                    }
-                } else {
-                    if (context.stackMapsWhenRequired()) {
+                    } else {
                         tryGenerateStackMaps(false, buf);
-                    } else if (context.generateStackMaps()) {
-                        generateStackMaps(buf);
-                    } else if (context.dropStackMaps()) {
-                        writeCounters(false, buf);
                     }
+                } else if (context.generateStackMaps()) {
+                    generateStackMaps(buf);
+                } else if (context.dropStackMaps()) {
+                    writeCounters(codeMatch, buf);
                 }
 
                 buf.writeInt(codeLength);


### PR DESCRIPTION
A simple optimization to reduce duplicate code. Reduce the codeSize of writeBody from 268 to 240