### PR TITLE
8341880: RISC-V: riscv_vector.h native build fails with gcc13 after JDK-8320500

### DIFF
--- a/make/modules/jdk.incubator.vector/Lib.gmk
+++ b/make/modules/jdk.incubator.vector/Lib.gmk
@@ -50,6 +50,7 @@ ifeq ($(call isTargetOs, linux)+$(call isTargetCpu, riscv64)+$(INCLUDE_COMPILER2
       EXTRA_SRC := libsleef/generated, \
       DISABLED_WARNINGS_gcc := unused-function sign-compare tautological-compare ignored-qualifiers, \
       DISABLED_WARNINGS_clang := unused-function sign-compare tautological-compare ignored-qualifiers, \
+      CFLAGS := -march=rv64gcv, \
   ))
 
   TARGETS += $(BUILD_LIBSLEEF)

--- a/make/modules/jdk.incubator.vector/Lib.gmk
+++ b/make/modules/jdk.incubator.vector/Lib.gmk
@@ -50,7 +50,6 @@ ifeq ($(call isTargetOs, linux)+$(call isTargetCpu, riscv64)+$(INCLUDE_COMPILER2
       EXTRA_SRC := libsleef/generated, \
       DISABLED_WARNINGS_gcc := unused-function sign-compare tautological-compare ignored-qualifiers, \
       DISABLED_WARNINGS_clang := unused-function sign-compare tautological-compare ignored-qualifiers, \
-      CFLAGS := -march=rv64gcv, \
   ))
 
   TARGETS += $(BUILD_LIBSLEEF)

--- a/src/jdk.incubator.vector/linux/native/libsleef/lib/vector_math_rvv.c
+++ b/src/jdk.incubator.vector/linux/native/libsleef/lib/vector_math_rvv.c
@@ -119,6 +119,6 @@ DEFINE_VECTOR_MATH_BINARY_RVV(hypotdx_u05, vdouble_rvvm1_sleef)
 
 #undef DEFINE_VECTOR_MATH_BINARY_RVV
 
-#endif /* __riscv_v_intrinsic */
+#endif  /* __riscv_v_intrinsic */
 
-#endif
+#endif  /* check gcc and clang version */

--- a/src/jdk.incubator.vector/linux/native/libsleef/lib/vector_math_rvv.c
+++ b/src/jdk.incubator.vector/linux/native/libsleef/lib/vector_math_rvv.c
@@ -31,6 +31,8 @@
 // At run-time, if the library is found and the bridge functions are available in the
 // library, then the java vector API will call into the bridge functions and sleef.
 
+#if __GNUC__ >= 14 || (defined(__clang_major__) && __clang_major__ >= 17)
+
 #ifdef __riscv_v_intrinsic
 
 #include <stdint.h>
@@ -118,3 +120,5 @@ DEFINE_VECTOR_MATH_BINARY_RVV(hypotdx_u05, vdouble_rvvm1_sleef)
 #undef DEFINE_VECTOR_MATH_BINARY_RVV
 
 #endif /* __riscv_v_intrinsic */
+
+#endif


### PR DESCRIPTION
Hi all,
The file `src/jdk.incubator.vector/linux/native/libsleef/lib/vector_math_rvv.c` introduced by [JDK-8341880](https://bugs.openjdk.org/browse/JDK-8341880) native build fails by fedora OS shipped gcc13.
Gcc13 doesn't have `__riscv_v_intrinsic` macro by default, and do have `__riscv_v_intrinsic` macro with option: `-march=rv64gcv`. libsleef only supported from llvm version 17 and gcc version 14 onwards, so we need to check the compiler version before use the `__riscv_v_intrinsic`.

![image](https://github.com/user-attachments/assets/3bf8557d-d156-48a1-a762-44c1fa50a31c)


gcc version infomation:
```
/usr/bin/gcc -v
Using built-in specs.
COLLECT_GCC=/usr/bin/gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/riscv64-redhat-linux/13/lto-wrapper
Target: riscv64-redhat-linux
Configured with: ../configure --enable-bootstrap --enable-languages=c,c++,fortran,objc,obj-c++,ada,go,d,m2,lto --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-shared --enable-threads=posix --enable-checking=release --enable-multilib --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --enable-gnu-unique-object --enable-linker-build-id --with-gcc-major-version-only --enable-libstdcxx-backtrace --with-libstdcxx-zoneinfo=/usr/share/zoneinfo --with-linker-hash-style=gnu --enable-plugin --enable-initfini-array --with-isl=/builddir/build/BUILD/gcc-13.2.1-20230728/obj-riscv64-redhat-linux/isl-install --enable-gnu-indirect-function --with-arch=rv64gc --with-abi=lp64d --with-multilib-list=lp64d --build=riscv64-redhat-linux --with-build-config=bootstrap-lto --enable-link-serialization=1
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 13.2.1 20230728 (Red Hat 13.2.1-1) (GCC)
```

Additonal testing:

- [x] riscv64 native release debug-level build with gcc13
- [x] riscv64 native fastdebug debug-level build with gcc13
- [x] riscv64 native release debug-level build with gcc14
- [ ] riscv64 native fastdebug debug-level build with gcc14

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341880](https://bugs.openjdk.org/browse/JDK-8341880): RISC-V: riscv_vector.h native build fails with gcc13 after JDK-8320500 (**Bug** - P2)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) Review applies to [b9484edd](https://git.openjdk.org/jdk/pull/21442/files/b9484eddea9ed538440411fd712987b2be331015)

### Contributors
 * Fei Yang `<fyang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21442/head:pull/21442` \
`$ git checkout pull/21442`

Update a local copy of the PR: \
`$ git checkout pull/21442` \
`$ git pull https://git.openjdk.org/jdk.git pull/21442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21442`

View PR using the GUI difftool: \
`$ git pr show -t 21442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21442.diff">https://git.openjdk.org/jdk/pull/21442.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21442#issuecomment-2404322811)