### PR TITLE
8341893: AArch64: Micro-optimize compressed ptr decoding 

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -5011,8 +5011,10 @@ void  MacroAssembler::decode_heap_oop(Register d, Register s) {
   verify_heapbase("MacroAssembler::decode_heap_oop: heap base corrupted?");
 #endif
   if (CompressedOops::base() == nullptr) {
-    if (CompressedOops::shift() != 0 || d != s) {
+    if (CompressedOops::shift() != 0) {
       lsl(d, s, CompressedOops::shift());
+    } else if (d != s) {
+      mov(d, s);
     }
   } else {
     Label done;


### PR DESCRIPTION
See the bug for full description. I think there is an accidental inefficiency in decoding: we don't have to shift when shift is zero, but we are tripped by `d != s` check. Other architectures seem to do this right. This fix surgically fixes the decoding. I have a variant of a more comprehensive MacroAssembler fix that could cover this shift-to-mov translation wholesale, but that fix is riskier.

Additional testing:
 - [x] Linux AArch64 server fastdebug, `tier{1,2,3}`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341893](https://bugs.openjdk.org/browse/JDK-8341893): AArch64: Micro-optimize compressed ptr decoding (**Enhancement** - P4)


### Reviewers
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21443/head:pull/21443` \
`$ git checkout pull/21443`

Update a local copy of the PR: \
`$ git checkout pull/21443` \
`$ git pull https://git.openjdk.org/jdk.git pull/21443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21443`

View PR using the GUI difftool: \
`$ git pr show -t 21443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21443.diff">https://git.openjdk.org/jdk/pull/21443.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21443#issuecomment-2404591078)