### PR TITLE
8341895: AArch64: Optimize MacroAssembler for identity bit manipulations

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -237,6 +237,54 @@ class MacroAssembler: public Assembler {
   inline void tstw(Register Rd, uint64_t imm) { andsw(zr, Rd, imm); }
   inline void tst(Register Rd, uint64_t imm) { ands(zr, Rd, imm); }
 
+  inline void ubfm(Register Rd, Register Rn, unsigned immr, unsigned imms) {
+    if (immr == 0 && imms == 63) {
+      mov(Rd, Rn);
+    } else {
+      Assembler::ubfm(Rd, Rn, immr, imms);
+    }
+  }
+
+  inline void ubfmw(Register Rd, Register Rn, unsigned immr, unsigned imms) {
+    if (immr == 0 && imms == 31) {
+      movw(Rd, Rn);
+    } else {
+      Assembler::ubfmw(Rd, Rn, immr, imms);
+    }
+  }
+
+  inline void bfm(Register Rd, Register Rn, unsigned immr, unsigned imms) {
+    if (immr == 0 && imms == 63) {
+      mov(Rd, Rn);
+    } else {
+      Assembler::bfm(Rd, Rn, immr, imms);
+    }
+  }
+
+  inline void bfmw(Register Rd, Register Rn, unsigned immr, unsigned imms) {
+    if (immr == 0 && imms == 31) {
+      movw(Rd, Rn);
+    } else {
+      Assembler::bfmw(Rd, Rn, immr, imms);
+    }
+  }
+
+  inline void sbfm(Register Rd, Register Rn, unsigned immr, unsigned imms) {
+    if (immr == 0 && imms == 63) {
+      mov(Rd, Rn);
+    } else {
+      Assembler::sbfm(Rd, Rn, immr, imms);
+    }
+  }
+
+  inline void sbfmw(Register Rd, Register Rn, unsigned immr, unsigned imms) {
+    if (immr == 0 && imms == 31) {
+      movw(Rd, Rn);
+    } else {
+      Assembler::sbfmw(Rd, Rn, immr, imms);
+    }
+  }
+
   inline void bfiw(Register Rd, Register Rn, unsigned lsb, unsigned width) {
     bfmw(Rd, Rn, ((32 - lsb) & 31), (width - 1));
   }


### PR DESCRIPTION
WIP.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341895](https://bugs.openjdk.org/browse/JDK-8341895): AArch64: Optimize MacroAssembler for identity bit manipulations (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21444/head:pull/21444` \
`$ git checkout pull/21444`

Update a local copy of the PR: \
`$ git checkout pull/21444` \
`$ git pull https://git.openjdk.org/jdk.git pull/21444/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21444`

View PR using the GUI difftool: \
`$ git pr show -t 21444`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21444.diff">https://git.openjdk.org/jdk/pull/21444.diff</a>

</details>
