### PR TITLE
8341820: Check return value of hcreate_r

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/symtab.c
@@ -389,9 +389,9 @@ static struct symtab* build_symtab_internal(int fd, const char *filename, bool t
         goto bad;
       }
 
-      // int rslt =
-      hcreate_r(htab_sz, symtab->hash_table);
-      // guarantee(rslt, "unexpected failure: hcreate_r");
+      if (hcreate_r(htab_sz, symtab->hash_table) == 0) {
+        goto bad;
+      }
 
       // shdr->sh_link points to the section that contains the actual strings
       // for symbol names. the st_name field in ELF_SYM is just the


### PR DESCRIPTION
In symtab.c there is some coding where hcreate_r is used. We should check the return value of the call (previously there was some guarantee checking the return value but uncommented).

This has been discussed in the PR of [JDK-8341722](https://bugs.openjdk.org/browse/JDK-8341722) .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341820](https://bugs.openjdk.org/browse/JDK-8341820): Check return value of hcreate_r (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21445/head:pull/21445` \
`$ git checkout pull/21445`

Update a local copy of the PR: \
`$ git checkout pull/21445` \
`$ git pull https://git.openjdk.org/jdk.git pull/21445/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21445`

View PR using the GUI difftool: \
`$ git pr show -t 21445`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21445.diff">https://git.openjdk.org/jdk/pull/21445.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21445#issuecomment-2404519445)