### PR TITLE
8337269: G1ConfidencePercent interpreted inconsistently

### DIFF
--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -53,7 +53,7 @@
 #include "gc/shared/gcTraceTime.inline.hpp"
 
 G1Policy::G1Policy(STWGCTimer* gc_timer) :
-  _predictor(G1ConfidencePercent / 100.0),
+  _predictor((100 - G1ConfidencePercent) / 100.0),
   _analytics(new G1Analytics(&_predictor)),
   _remset_tracker(),
   _mmu_tracker(new G1MMUTracker(GCPauseIntervalMillis / 1000.0, MaxGCPauseMillis / 1000.0)),

--- a/src/hotspot/share/gc/g1/g1Predictions.hpp
+++ b/src/hotspot/share/gc/g1/g1Predictions.hpp
@@ -49,8 +49,8 @@ private:
   }
 
 public:
-  G1Predictions(double sigma_scale) : _stddev_scale(sigma_scale) {
-    assert(sigma_scale >= 0.0, "must be larger than or equal to zero");
+  G1Predictions(double stddev_scale) : _stddev_scale(stddev_scale) {
+    assert(stddev_scale >= 0.0, "must be");
   }
 
   double predict(TruncatedSeq const* seq) const {

--- a/src/hotspot/share/gc/g1/g1Predictions.hpp
+++ b/src/hotspot/share/gc/g1/g1Predictions.hpp
@@ -29,8 +29,9 @@
 
 // Utility class containing various helper methods for prediction.
 class G1Predictions {
- private:
-  double _sigma;
+private:
+  // Scale factor indicating to which degree stddev should be taking into account in predictions.
+  double _stddev_scale; 
 
   // This function is used to estimate the stddev of sample sets. There is some
   // special consideration of small sample sets: the actual stddev for them is
@@ -46,16 +47,14 @@ class G1Predictions {
     }
     return estimate;
   }
- public:
-  G1Predictions(double sigma) : _sigma(sigma) {
-    assert(sigma >= 0.0, "Confidence must be larger than or equal to zero");
+
+public:
+  G1Predictions(double sigma_scale) : _stddev_scale(sigma_scale) {
+    assert(sigma_scale >= 0.0, "must be larger than or equal to zero");
   }
 
-  // Confidence factor.
-  double sigma() const { return _sigma; }
-
   double predict(TruncatedSeq const* seq) const {
-    return seq->davg() + _sigma * stddev_estimate(seq);
+    return seq->davg() + _stddev_scale * stddev_estimate(seq);
   }
 
   double predict_in_unit_interval(TruncatedSeq const* seq) const {

--- a/src/hotspot/share/gc/g1/g1Predictions.hpp
+++ b/src/hotspot/share/gc/g1/g1Predictions.hpp
@@ -31,7 +31,7 @@
 class G1Predictions {
 private:
   // Scale factor indicating to which degree stddev should be taking into account in predictions.
-  double _stddev_scale; 
+  double _stddev_scale;
 
   // This function is used to estimate the stddev of sample sets. There is some
   // special consideration of small sample sets: the actual stddev for them is

--- a/src/hotspot/share/gc/g1/g1_globals.hpp
+++ b/src/hotspot/share/gc/g1/g1_globals.hpp
@@ -111,7 +111,8 @@
           range(1, max_intx)                                                \
                                                                             \
   product(uint, G1ConfidencePercent, 50,                                    \
-          "Confidence level for MMU/pause predictions")                     \
+          "Confidence level for MMU/pause predictions. A higher value "     \
+          "means that G1 will use less safety margin for its predictions.") \
           range(1, 100)                                                     \
                                                                             \
   product(uintx, G1SummarizeRSetStatsPeriod, 0, DIAGNOSTIC,                 \


### PR DESCRIPTION
Hi all,

  please review this change that removes the inconsistency in interpretation of G1ConfidencePercent; higher confidence means that G1 should use less safety margin (i.e. part of the variance).

Other than that it does not change the uses for it.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337269](https://bugs.openjdk.org/browse/JDK-8337269): G1ConfidencePercent interpreted inconsistently (**Bug** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**) Review applies to [9ffbbdc9](https://git.openjdk.org/jdk/pull/21448/files/9ffbbdc9401b75f13c282988fb27ff3ba69ed844)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21448/head:pull/21448` \
`$ git checkout pull/21448`

Update a local copy of the PR: \
`$ git checkout pull/21448` \
`$ git pull https://git.openjdk.org/jdk.git pull/21448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21448`

View PR using the GUI difftool: \
`$ git pr show -t 21448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21448.diff">https://git.openjdk.org/jdk/pull/21448.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21448#issuecomment-2404648025)