### PR TITLE
8338751: ConfigureNotify behavior has changed in KWin 6.2

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -771,6 +771,7 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
             // TODO this should be the default for every case.
             switch (runningWM) {
                 case XWM.CDE_WM:
+                case XWM.KDE2_WM:
                 case XWM.MOTIF_WM:
                 case XWM.METACITY_WM:
                 case XWM.MUTTER_WM:


### PR DESCRIPTION
Prior to 6.2, kwin used to always send synthetic ConfigureNotify events regardless whether a real ConfigureNotify event is going to be sent. It used to do it because of some bugs in GTK2.

In 6.2, that workaround was dropped (it was needed to fix other issues during interactive resize) so kwin adheres to ICCCM 4.1.5 now.

Unfortunately, it seems like JDK relies on kwin always sending synthetic configure notify events, which is no longer the case.

This change makes AWT use the TranslateCoordinates request when a real ConfigureNotify event is received and running kwin as the window manager. It should work as expected even with kwin < 6.2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338751](https://bugs.openjdk.org/browse/JDK-8338751): ConfigureNotify behavior has changed in KWin 6.2 (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21449/head:pull/21449` \
`$ git checkout pull/21449`

Update a local copy of the PR: \
`$ git checkout pull/21449` \
`$ git pull https://git.openjdk.org/jdk.git pull/21449/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21449`

View PR using the GUI difftool: \
`$ git pr show -t 21449`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21449.diff">https://git.openjdk.org/jdk/pull/21449.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21449#issuecomment-2411938122)