### PR TITLE
8336726: C2: assert(!do_asserts || projs->fallthrough_ioproj != nullptr) failed: must be found

### DIFF
--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -964,7 +964,7 @@ void CallNode::extract_projections(CallProjections* projs, bool separate_io_proj
   do_asserts = do_asserts && !Compile::current()->inlining_incrementally();
   assert(!do_asserts || projs->fallthrough_catchproj != nullptr, "must be found");
   assert(!do_asserts || projs->fallthrough_memproj   != nullptr, "must be found");
-  //assert(!do_asserts || projs->fallthrough_ioproj    != nullptr, "must be found");
+  assert(!do_asserts || projs->fallthrough_ioproj    != nullptr, "must be found");
   assert(!do_asserts || projs->catchall_catchproj    != nullptr, "must be found");
   if (separate_io_proj) {
     assert(!do_asserts || projs->catchall_memproj    != nullptr, "must be found");

--- a/src/hotspot/share/opto/callnode.cpp
+++ b/src/hotspot/share/opto/callnode.cpp
@@ -964,7 +964,7 @@ void CallNode::extract_projections(CallProjections* projs, bool separate_io_proj
   do_asserts = do_asserts && !Compile::current()->inlining_incrementally();
   assert(!do_asserts || projs->fallthrough_catchproj != nullptr, "must be found");
   assert(!do_asserts || projs->fallthrough_memproj   != nullptr, "must be found");
-  assert(!do_asserts || projs->fallthrough_ioproj    != nullptr, "must be found");
+  //assert(!do_asserts || projs->fallthrough_ioproj    != nullptr, "must be found");
   assert(!do_asserts || projs->catchall_catchproj    != nullptr, "must be found");
   if (separate_io_proj) {
     assert(!do_asserts || projs->catchall_memproj    != nullptr, "must be found");

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -1930,7 +1930,7 @@ static void add_mergemem_users_to_worklist(Unique_Node_List& wl, Node* mem) {
 }
 
 // Replace the call with the current state of the kit.
-void GraphKit::replace_call(CallNode* call, Node* result, bool do_replaced_nodes) {
+void GraphKit::replace_call(CallNode* call, Node* result, bool do_replaced_nodes, bool do_asserts) {
   JVMState* ejvms = nullptr;
   if (has_exceptions()) {
     ejvms = transfer_exceptions_into_jvms();
@@ -1944,7 +1944,7 @@ void GraphKit::replace_call(CallNode* call, Node* result, bool do_replaced_nodes
 
   // Find all the needed outputs of this call
   CallProjections callprojs;
-  call->extract_projections(&callprojs, true);
+  call->extract_projections(&callprojs, true, do_asserts);
 
   Unique_Node_List wl;
   Node* init_mem = call->in(TypeFunc::Memory);

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -731,7 +731,7 @@ class GraphKit : public Phase {
   // Replace the call with the current state of the kit.  Requires
   // that the call was generated with separate io_projs so that
   // exceptional control flow can be handled properly.
-  void replace_call(CallNode* call, Node* result, bool do_replaced_nodes = false);
+  void replace_call(CallNode* call, Node* result, bool do_replaced_nodes = false, bool do_asserts = true);
 
   // helper functions for statistics
   void increment_counter(address counter_addr);   // increment a debug counter

--- a/test/hotspot/jtreg/compiler/c2/TestCallDevirtualizationWithInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCallDevirtualizationWithInfiniteLoop.java
@@ -50,7 +50,9 @@ public class TestCallDevirtualizationWithInfiniteLoop {
 
     public static void test(boolean flag) {
         // Avoid executing endless loop
-        if (flag) return;
+        if (flag) {
+            return;
+        }
 
         // We only know after loop opts that the receiver type is B.
         I recv = a;

--- a/test/hotspot/jtreg/compiler/c2/TestCallDevirtualizationWithInfiniteLoop.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCallDevirtualizationWithInfiniteLoop.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8336726
+ * @summary Test that post-parse call devirtualization works when call does not have an IO projection.
+ * @run main/othervm -XX:-TieredCompilation -Xcomp -XX:CompileCommand=compileonly,TestCallDevirtualizationWithInfiniteLoop::test
+ *                   TestCallDevirtualizationWithInfiniteLoop
+ */
+
+public class TestCallDevirtualizationWithInfiniteLoop {
+
+    static interface I {
+        public void method();
+    }
+
+    static final class A implements I {
+        @Override
+        public void method() { };
+    }
+
+    static final class B implements I {
+        @Override
+        public void method() { };
+    }
+
+    static final A a = new A();
+    static final B b = new B();
+
+    public static void test(boolean flag) {
+        // Avoid executing endless loop
+        if (flag) return;
+
+        // We only know after loop opts that the receiver type is B.
+        I recv = a;
+        for (int i = 0; i < 3; ++i) {
+            if (i > 1) {
+                recv = b;
+            }
+        }
+        // Post-parse call devirtualization will then convert below
+        // virtual call to a static call.
+        recv.method();
+
+        // Endless loop which does not use IO. As a result the IO
+        // projection of the call is removed unexpectedly.
+        while (true) { }
+    }
+
+    public static void main(String[] args) {
+        test(true);
+    }
+}


### PR DESCRIPTION
Post-parse call devirtualization asserts when calling `CallNode::extract_projections` on a virtual call that does not have the `fallthrough_ioproj` anymore. The projection was removed because the call is followed by an endless loop that does not have any IO uses.

Similar to incremental inlining, we should not assert that all call projections are still there for post-parse call devirtualization because parts of the graph might have been removed already:
https://github.com/openjdk/jdk/blob/580eb62dc097efeb51c76b095c1404106859b673/src/hotspot/share/opto/callnode.cpp#L963-L965

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336726](https://bugs.openjdk.org/browse/JDK-8336726): C2: assert(!do_asserts || projs-&gt;fallthrough_ioproj != nullptr) failed: must be found (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21450/head:pull/21450` \
`$ git checkout pull/21450`

Update a local copy of the PR: \
`$ git checkout pull/21450` \
`$ git pull https://git.openjdk.org/jdk.git pull/21450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21450`

View PR using the GUI difftool: \
`$ git pr show -t 21450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21450.diff">https://git.openjdk.org/jdk/pull/21450.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21450#issuecomment-2406778573)