### PR TITLE
8341909: G1: Add region index to region printer output

### DIFF
--- a/src/hotspot/share/gc/g1/g1HeapRegionPrinter.hpp
+++ b/src/hotspot/share/gc/g1/g1HeapRegionPrinter.hpp
@@ -35,8 +35,8 @@ class G1HeapRegionPrinter : public AllStatic {
 
   // Print an action event.
   static void print(const char* action, G1HeapRegion* hr) {
-    log_trace(gc, region)("G1HR %s(%s) [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT "]",
-                          action, hr->get_type_str(), p2i(hr->bottom()), p2i(hr->top()), p2i(hr->end()));
+    log_trace(gc, region)("G1HR %4u %s(%s) [" PTR_FORMAT ", " PTR_FORMAT ", " PTR_FORMAT "]",
+                          hr->hrm_index(), action, hr->get_type_str(), p2i(hr->bottom()), p2i(hr->top()), p2i(hr->end()));
   }
 
 public:


### PR DESCRIPTION
Hi all,

  please review this small improvement to the G1HeapRegionPrinter output to add the region index - this makes cross-referencing with other log messages much easier.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341909](https://bugs.openjdk.org/browse/JDK-8341909): G1: Add region index to region printer output (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Leo Korinth](https://openjdk.org/census#lkorinth) (@lkorinth - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21454/head:pull/21454` \
`$ git checkout pull/21454`

Update a local copy of the PR: \
`$ git checkout pull/21454` \
`$ git pull https://git.openjdk.org/jdk.git pull/21454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21454`

View PR using the GUI difftool: \
`$ git pr show -t 21454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21454.diff">https://git.openjdk.org/jdk/pull/21454.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21454#issuecomment-2405415077)