### PR TITLE
8341831: PhaseCFG::insert_anti_dependences asserts with "no loads"

### DIFF
--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -770,7 +770,7 @@ Block* PhaseCFG::insert_anti_dependences(Block* LCA, Node* load, bool verify) {
     bool is_cache_wb = false;
     if (use_mem_state->is_Mach()) {
       int ideal_op = use_mem_state->as_Mach()->ideal_Opcode();
-      is_cache_wb = (ideal_op == Op_CacheWB || ideal_op == Op_CacheWBPostSync || ideal_op == Op_CacheWBPreSync);
+      is_cache_wb = (ideal_op == Op_CacheWB);
     }
     assert(!use_mem_state->needs_anti_dependence_check() || is_cache_wb, "no loads");
 #endif

--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -763,7 +763,15 @@ Block* PhaseCFG::insert_anti_dependences(Block* LCA, Node* load, bool verify) {
     worklist_def_use_mem_states.pop();
 
     uint op = use_mem_state->Opcode();
-    assert(!use_mem_state->needs_anti_dependence_check(), "no loads");
+
+#ifdef ASSERT
+    bool is_cache_wb = false;
+    if (use_mem_state->is_Mach()) {
+      int ideal_op = use_mem_state->as_Mach()->ideal_Opcode();
+      is_cache_wb = (ideal_op == Op_CacheWB || ideal_op == Op_CacheWBPostSync || ideal_op == Op_CacheWBPreSync);
+    }
+    assert(!use_mem_state->needs_anti_dependence_check() || is_cache_wb, "no loads");
+#endif
 
     // MergeMems do not directly have anti-deps.
     // Treat them as internal nodes in a forward tree of memory states,

--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -765,6 +765,8 @@ Block* PhaseCFG::insert_anti_dependences(Block* LCA, Node* load, bool verify) {
     uint op = use_mem_state->Opcode();
 
 #ifdef ASSERT
+    // CacheWB nodes are peculiar in a sense that they both are anti-dependent and produce memory.
+    // Allow them to be treated as a store.
     bool is_cache_wb = false;
     if (use_mem_state->is_Mach()) {
       int ideal_op = use_mem_state->as_Mach()->ideal_Opcode();

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -43,8 +43,6 @@
 
 # :hotspot_compiler
 
-applications/ctw/modules/java_base_2.java 8341831 linux-x64
-
 compiler/ciReplay/TestSAServer.java 8029528 generic-all
 compiler/compilercontrol/jcmd/ClearDirectivesFileStackTest.java 8225370 generic-all
 


### PR DESCRIPTION
`CacheWB` nodes are peculiar in a sense that they both are anti-dependent and produce memory. I think it's reasonable to relax the assert in `insert_anti_dependences()` to work around their properties.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341831](https://bugs.openjdk.org/browse/JDK-8341831): PhaseCFG::insert_anti_dependences asserts with "no loads" (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [ae69ee4b](https://git.openjdk.org/jdk/pull/21455/files/ae69ee4b10db4098e7be5280d5c29ae0847c1479)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21455/head:pull/21455` \
`$ git checkout pull/21455`

Update a local copy of the PR: \
`$ git checkout pull/21455` \
`$ git pull https://git.openjdk.org/jdk.git pull/21455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21455`

View PR using the GUI difftool: \
`$ git pr show -t 21455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21455.diff">https://git.openjdk.org/jdk/pull/21455.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21455#issuecomment-2405450750)