### PR TITLE
8341913: Support CDS heap dumping for Shenandoah and Epsilon

### DIFF
--- a/src/hotspot/share/cds/heapShared.hpp
+++ b/src/hotspot/share/cds/heapShared.hpp
@@ -143,13 +143,18 @@ class HeapShared: AllStatic {
   friend class VerifySharedOopClosure;
 
 public:
-  // Can this VM write a heap region into the CDS archive? Currently only {G1|Parallel|Serial}+compressed_cp
+  // Can this VM write a heap region into the CDS archive?
   static bool can_write() {
     CDS_JAVA_HEAP_ONLY(
       if (_disable_writing) {
         return false;
       }
-      return (UseG1GC || UseParallelGC || UseSerialGC) && UseCompressedClassPointers;
+      // Need compressed class pointers for heap region dump.
+      if (!UseCompressedClassPointers) {
+        return false;
+      }
+      // Almost all GCs support heap region dump, except ZGC (so far).
+      return !UseZGC;
     )
     NOT_CDS_JAVA_HEAP(return false;)
   }

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
@@ -108,9 +108,10 @@ public class IncompatibleOptions {
             testDump(1, "-XX:+UseZGC", "-XX:-UseCompressedOops", null, false);
         }
 
-        // Dump heap objects with ParallelGC and SerialGC
+        // Dump heap objects with Parallel, Serial, Shenandoah GC
         testDump(2, "-XX:+UseParallelGC", "", "", false);
         testDump(3, "-XX:+UseSerialGC", "", "", false);
+        testDump(4, "-XX:+UseShenandoahGC", "", "", false);
 
         // Explicitly archive with compressed oops, run without.
         testDump(5, "-XX:+UseG1GC", "-XX:+UseCompressedOops", null, false);

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/IncompatibleOptions.java
@@ -111,7 +111,9 @@ public class IncompatibleOptions {
         // Dump heap objects with Parallel, Serial, Shenandoah GC
         testDump(2, "-XX:+UseParallelGC", "", "", false);
         testDump(3, "-XX:+UseSerialGC", "", "", false);
-        testDump(4, "-XX:+UseShenandoahGC", "", "", false);
+        if (GC.Shenandoah.isSupported()) {
+            testDump(4, "-XX:+UseShenandoahGC", "", "", false);
+        }
 
         // Explicitly archive with compressed oops, run without.
         testDump(5, "-XX:+UseG1GC", "-XX:+UseCompressedOops", null, false);


### PR DESCRIPTION
This follows [JDK-8298614](https://bugs.openjdk.org/browse/JDK-8298614) and completes support for CDS dumping for Shenandoah and Epsilon. We have already enabled these in Leyden repo. I took a chance to clean up the code a bit. Shenandoah support is tested by the existing test. Epsilon support was tested manually, since it is quite likely flaky (= depends on pre-dump conditions not to run into OOM) to include in tests.

Additional testing:
 - [x] Linux x86_64 fastdebug server, `runtime/cds`
 - [x] Linux x86_64 fastdebug server, `runtime/cds`, `-XX:+UseShenandoahGC`
 - [x] Linux x86_64 fastdebug server, manual dumps with `-XX:+UseEpsilonGC`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341913](https://bugs.openjdk.org/browse/JDK-8341913): Support CDS heap dumping for Shenandoah and Epsilon (**Enhancement** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21457/head:pull/21457` \
`$ git checkout pull/21457`

Update a local copy of the PR: \
`$ git checkout pull/21457` \
`$ git pull https://git.openjdk.org/jdk.git pull/21457/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21457`

View PR using the GUI difftool: \
`$ git pr show -t 21457`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21457.diff">https://git.openjdk.org/jdk/pull/21457.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21457#issuecomment-2427456364)