### PR TITLE
8341794: Fix ExceptionOccurred in jdk.attach

### DIFF
--- a/src/jdk.attach/windows/native/libattach/VirtualMachineImpl.c
+++ b/src/jdk.attach/windows/native/libattach/VirtualMachineImpl.c
@@ -432,7 +432,7 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_enqueue
                     return;
                 }
             }
-            if ((*env)->ExceptionOccurred(env)) return;
+            if ((*env)->ExceptionCheck(env)) return;
         }
     }
     for (i = argsLen; i < MAX_ARGS; i++) {
@@ -463,7 +463,7 @@ JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_enqueue
     stubLen = (DWORD)(*env)->GetArrayLength(env, stub);
     stubCode = (*env)->GetByteArrayElements(env, stub, &isCopy);
 
-    if ((*env)->ExceptionOccurred(env)) return;
+    if ((*env)->ExceptionCheck(env)) return;
 
     pCode = (PDWORD) VirtualAllocEx( hProcess, 0, stubLen, MEM_COMMIT, PAGE_EXECUTE_READWRITE );
     if (pCode == NULL) {
@@ -636,7 +636,7 @@ static jboolean jstring_to_cstring(JNIEnv* env, jstring jstr, char* cstr, size_t
         cstr[0] = '\0';
     } else {
         str = JNU_GetStringPlatformChars(env, jstr, &isCopy);
-        if ((*env)->ExceptionOccurred(env)) {
+        if ((*env)->ExceptionCheck(env)) {
             return result;
         }
         if (strlen(str) >= cstr_buf_size) {


### PR DESCRIPTION
Please review this PR which is part of the bigger umbrella bug: https://bugs.openjdk.org/browse/JDK-8341542.

This fixes incorrect usage of `jthrowable ExceptionOccurred(JNIEnv *env)` within _jdk.attach_.
This corrects instances where the return value is being treated as a boolean. Such occurrences are replaced with `jboolean ExceptionCheck(JNIEnv *env)`.

JNI Docs - ExceptionCheck
> We introduce a convenience function to check for pending exceptions without creating a local reference to the exception object. ... Returns JNI_TRUE when there is a pending exception; otherwise, returns JNI_FALSE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341794](https://bugs.openjdk.org/browse/JDK-8341794): Fix ExceptionOccurred in jdk.attach (**Sub-task** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21459/head:pull/21459` \
`$ git checkout pull/21459`

Update a local copy of the PR: \
`$ git checkout pull/21459` \
`$ git pull https://git.openjdk.org/jdk.git pull/21459/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21459`

View PR using the GUI difftool: \
`$ git pr show -t 21459`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21459.diff">https://git.openjdk.org/jdk/pull/21459.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21459#issuecomment-2406115767)