### PR TITLE
8341924: Improve error message with structurally malformed Code array

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -92,20 +92,22 @@ public class CodeWriter extends BasicWriter {
     public void writeInstrs(CodeAttribute attr) {
         List<InstructionDetailWriter> detailWriters = getDetailWriters(attr);
 
-        int pc = 0;
+        int[] pcState = {0};
         try {
-            for (var coe: attr) {
+            attr.forEach(coe -> {
                 if (coe instanceof Instruction instr) {
-                    for (InstructionDetailWriter w: detailWriters)
+                    int pc = pcState[0];
+                    for (InstructionDetailWriter w : detailWriters)
                         w.writeDetails(pc, instr);
                     writeInstr(pc, instr, attr);
-                    pc += instr.sizeInBytes();
+                    pcState[0] = pc + instr.sizeInBytes();
                 }
-            }
+            });
         } catch (IllegalArgumentException e) {
-            report("error at or after byte " + pc);
+            report("error at or after address " + pcState[0] + ": " + e.getMessage());
         }
 
+        int pc = pcState[0];
         for (InstructionDetailWriter w: detailWriters)
             w.flush(pc);
     }


### PR DESCRIPTION
Patch a tableswitch instruction's low value to be greater than a high value, previously, javap will not print any previous instruction and report problematic address/bci to be 0. This is because the iteration of bound models require first collecting all data into a buffer list. We call the eager `forEach` instead to avoid this problem.

Before:
```
$ javap -c BadSwitch.class
Compiled from "BadSwitch.java"
final class BadSwitch {
  static void work(int);
    Code:
Error: error at or after byte 0
}
```

Now:
```
$ $localjdk2/bin/javap -c BadSwitch.class
Compiled from "BadSwitch.java"
final class BadSwitch {
  static void work(int);
    Code:
       0: iload_0
Error: error at or after address 1: Invalid tableswitch values low: 9 high: 5
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341924](https://bugs.openjdk.org/browse/JDK-8341924): Improve error message with structurally malformed Code array (**Enhancement** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21463/head:pull/21463` \
`$ git checkout pull/21463`

Update a local copy of the PR: \
`$ git checkout pull/21463` \
`$ git pull https://git.openjdk.org/jdk.git pull/21463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21463`

View PR using the GUI difftool: \
`$ git pr show -t 21463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21463.diff">https://git.openjdk.org/jdk/pull/21463.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21463#issuecomment-2406594260)