### PR TITLE
8331467: ImageReaderFactory can cause a ClassNotFoundException if the default FileSystemProvider is not the system-default provider

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReaderFactory.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReaderFactory.java
@@ -48,7 +48,7 @@ public class ImageReaderFactory {
 
     private static final String JAVA_HOME = System.getProperty("java.home");
     private static final Path BOOT_MODULES_JIMAGE =
-        Paths.get(JAVA_HOME, "lib", "modules");
+            sun.nio.fs.DefaultFileSystemProvider.create().getPath(JAVA_HOME, "lib", "modules");
 
     private static final Map<Path, ImageReader> readers = new ConcurrentHashMap<>();
 


### PR DESCRIPTION
use built-in FileSystemProvider

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8331467](https://bugs.openjdk.org/browse/JDK-8331467): ImageReaderFactory can cause a ClassNotFoundException if the default FileSystemProvider is not the system-default provider (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21465/head:pull/21465` \
`$ git checkout pull/21465`

Update a local copy of the PR: \
`$ git checkout pull/21465` \
`$ git pull https://git.openjdk.org/jdk.git pull/21465/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21465`

View PR using the GUI difftool: \
`$ git pr show -t 21465`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21465.diff">https://git.openjdk.org/jdk/pull/21465.diff</a>

</details>
