### PR TITLE
8341944: The zlib library no longer requires dummy byte for raw inflate

### DIFF
--- a/src/java.base/share/classes/java/util/zip/Deflater.java
+++ b/src/java.base/share/classes/java/util/zip/Deflater.java
@@ -165,11 +165,13 @@ public class Deflater {
 
     /**
      * Creates a new compressor using the specified compression level.
-     * If 'nowrap' is true then the ZLIB header and checksum fields will
-     * not be used in order to support the compression format used in
-     * both GZIP and PKZIP.
+     * If {@code nowrap} is true then the compressed output will be
+     * in the raw 'deflate' format, without any ZLIB header or checksum
+     * fields wrapping the compressed stream. This provides compatibility
+     * with compression formats used by both GZIP and ZIP.
+     *
      * @param level the compression level (0-9)
-     * @param nowrap if true then use GZIP compatible compression
+     * @param nowrap if true then produce a compressed output without ZLIB headers
      */
     @SuppressWarnings("this-escape")
     public Deflater(int level, boolean nowrap) {

--- a/src/java.base/share/classes/java/util/zip/Inflater.java
+++ b/src/java.base/share/classes/java/util/zip/Inflater.java
@@ -96,15 +96,13 @@ public class Inflater {
     }
 
     /**
-     * Creates a new decompressor. If the parameter 'nowrap' is true then
-     * the ZLIB header and checksum fields will not be used. This provides
-     * compatibility with the compression format used by both GZIP and PKZIP.
-     * <p>
-     * Note: When using the 'nowrap' option it is also necessary to provide
-     * an extra "dummy" byte as input. This is required by the ZLIB native
-     * library in order to support certain optimizations.
+     * Creates a new decompressor.
+     * If {@code nowrap} is true then the compressed input is expected to be
+     * in the raw 'deflate' format, without any ZLIB header or checksum
+     * fields wrapping the compressed stream. This provides compatibility
+     * with compression formats used by both GZIP and ZIP.
      *
-     * @param nowrap if true then support GZIP compatible compression
+     * @param nowrap if true then expect compressed input without ZLIB headers
      */
     @SuppressWarnings("this-escape")
     public Inflater(boolean nowrap) {

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -443,7 +443,6 @@ public class ZipFile implements ZipConstants, Closeable {
 
     private class ZipFileInflaterInputStream extends InflaterInputStream {
         private volatile boolean closeRequested;
-        private boolean eof = false;
         private final Cleanable cleanable;
 
         ZipFileInflaterInputStream(ZipFileInputStream zfin,
@@ -468,22 +467,6 @@ public class ZipFile implements ZipConstants, Closeable {
                 res.istreams.remove(this);
             }
             cleanable.clean();
-        }
-
-        // Override fill() method to provide an extra "dummy" byte
-        // at the end of the input stream. This is required when
-        // using the "nowrap" Inflater option.
-        protected void fill() throws IOException {
-            if (eof) {
-                throw new EOFException("Unexpected end of ZLIB input stream");
-            }
-            len = in.read(buf, 0, buf.length);
-            if (len == -1) {
-                buf[0] = 0;
-                len = 1;
-                eof = true;
-            }
-            inf.setInput(buf, 0, len);
         }
 
         public int available() throws IOException {

--- a/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
+++ b/src/jdk.zipfs/share/classes/jdk/nio/zipfs/ZipFileSystem.java
@@ -2462,24 +2462,6 @@ class ZipFileSystem extends FileSystem {
                         streams.remove(this);
                     }
                 }
-                // Override fill() method to provide an extra "dummy" byte
-                // at the end of the input stream. This is required when
-                // using the "nowrap" Inflater option. (it appears the new
-                // zlib in 7 does not need it, but keep it for now)
-                protected void fill() throws IOException {
-                    if (eof) {
-                        throw new EOFException(
-                            "Unexpected end of ZLIB input stream");
-                    }
-                    len = this.in.read(buf, 0, buf.length);
-                    if (len == -1) {
-                        buf[0] = 0;
-                        len = 1;
-                        eof = true;
-                    }
-                    inf.setInput(buf, 0, len);
-                }
-                private boolean eof;
 
                 public int available() {
                     if (isClosed)


### PR DESCRIPTION
Please review this cleanup PR which removes overrides of `InflaterInputStream.fill` in `ZipFileInflaterInputStream` and `ZipFileSystem::getInputStream`. Associated boolean fields used to track `eof` are also removed.

These overrides exist to provide zlib with an extra dummy byte at the end of raw compressed streams (no wrapping):

```java
// Override fill() method to provide an extra "dummy" byte
// at the end of the input stream. This is required when
// using the "nowrap" Inflater option.
protected void fill() throws IOException {
```
However, zlib has not required such an extra dummy byte since 2003. 

```
Changes in 1.2.0 (9 March 2003)
- New and improved inflate code
    - Raw inflate no longer needs an extra dummy byte at end
``` 

The code in these overrides is effectively dead and removing it cleans up our code and reclaims weirdness dollars for our budget.

Risk: I cannot imagine anyone is building OpenJDK with a 21 year old ZLIB.  Please advise if this is the case or if any zlib fork in use still has this limitation.

Testing: ZIP and ZIPFS tests run green locally. GHA also green. No tests are added or modified, this is a cleanup-only PR. Manually verified that the code is dead by injecting AssertionErrors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires a CSR request matching fixVersion 25 to be approved (needs to be created)

### Issue
 * [JDK-8341944](https://bugs.openjdk.org/browse/JDK-8341944): The zlib library no longer requires dummy byte for raw inflate (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21467/head:pull/21467` \
`$ git checkout pull/21467`

Update a local copy of the PR: \
`$ git checkout pull/21467` \
`$ git pull https://git.openjdk.org/jdk.git pull/21467/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21467`

View PR using the GUI difftool: \
`$ git pr show -t 21467`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21467.diff">https://git.openjdk.org/jdk/pull/21467.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21467#issuecomment-2406893500)
</details>
