### PR TITLE
8341957: Add test for URLClassLoader loading invalid class with mismatching CRC32

### DIFF
--- a/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCClassData.java
+++ b/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCClassData.java
@@ -26,6 +26,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.lang.classfile.ClassFile;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.ConstantDescs;
 import java.lang.module.Configuration;
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleFinder;
@@ -54,22 +57,23 @@ import static org.junit.jupiter.api.Assertions.*;
  *          defineClass fails with ClassFormatError
  * @run junit InvalidCRCData
  */
-public class InvalidCRCData {
+public class InvalidCRCClassData {
 
     String className = "foo.bar.Library";
 
     /**
      * Verify that URLClassLoader adds a suppressed exception when
-     * a class file is rejected with ClassFormatError and the class data
-     * file CRC32 checksum does not match the CRC32 stated in the JAR CEN header.
+     * a class file is rejected with ClassFormatError and the CRC32 checksum
+     * of the class data file does not match the CRC32 stated in the JAR CEN header.
      *
      * @throws IOException if an unexpected IO exception occurs
      * @throws ClassNotFoundException if a class is unexpectedly not found
      */
     @Test
-    public void verifyURLClassLoader() throws IOException, ClassNotFoundException {
+    public void invalidClassInvalidCRC_URLClassLoader() throws IOException, ClassNotFoundException {
 
-        Path jarFile = createJarFile();
+        // Create a JAR file with invalid class data, invalid CRC
+        Path jarFile = createJarFile(false, false);
 
         try (var cl = new CustomURLClassLoader(jarFile)) {
             // Expect ClassFormatError
@@ -83,18 +87,66 @@ public class InvalidCRCData {
     }
 
     /**
+     * A CRC mismatch itself does not cause exceptions for a valid class
+     *
+     * @throws IOException if an unexpected IO exception occurs
+     * @throws ClassNotFoundException if a class is unexpectedly not found
+     */
+    @Test
+    public void validClassInvalidCRC_URLClassLoader() throws IOException, ClassNotFoundException {
+
+        // Create a JAR file with valid class data, invalid CRC
+        Path jarFile = createJarFile(true, false);
+
+        try (var cl = new CustomURLClassLoader(jarFile)) {
+            assertEquals(className, cl.findClass(className).getName());
+        }
+    }
+
+    /**
      * Document that a JAR file with invalid class file data and a mismatching
-     * CRC32 checksums does not cause ClassFormatError to have suppressed
+     * CRC32 checksum does not cause ClassFormatError to have suppressed
      * exceptions when loaded using the module class loader.
      *
      * @throws IOException if an unexpected IO exception occurs
      * @throws ClassNotFoundException if a class is unexpectedly not found
      */
     @Test
-    public void verifyModule() throws IOException, ClassNotFoundException {
+    public void invalidClassCRCMismatchModule() throws IOException, ClassNotFoundException {
 
+        // Load a module with invalid class data and invalid CRC
+        Module m1 = loadModule(false, false);
+
+        // Expect ClassFormatError when loading class
+        ClassFormatError exception = assertThrows(ClassFormatError.class, () -> {
+            m1.getClassLoader().loadClass(className);
+        });
+
+        // Verify that jdk.internal.Loader does not check CRC32 on ClassFormatError
+        assertFalse(isCRC32Suppressed(exception));
+    }
+
+    /**
+     * Document that a JAR file with valid class file data and a mismatching
+     * CRC32 checksums does not cause exceptions
+     *
+     * @throws IOException if an unexpected IO exception occurs
+     * @throws ClassNotFoundException if a class is unexpectedly not found
+     */
+    @Test
+    public void validClassCRCMismatchModule() throws IOException, ClassNotFoundException {
+
+        // Load a module with valid class data, but invalid CRC
+        Module m1 = loadModule(true, false);
+
+        // Expect class to load, even with CRC mismatch
+        assertEquals(className, m1.getClassLoader().loadClass(className).getName());
+    }
+
+    // Load a module from a constructed JAR file
+    private Module loadModule(boolean validClass, boolean validCrc) throws IOException {
         // Create a module JAR file
-        Path jarFile = createJarFile();
+        Path jarFile = createJarFile(validClass, validCrc);
 
         // Load the module
         ModuleFinder moduleFinder = ModuleFinder.of(jarFile);
@@ -106,15 +158,7 @@ public class InvalidCRCData {
                 Collections.singletonList(ModuleLayer.boot()),
                 getClass().getClassLoader());
 
-        Module m1 = controller.layer().findModule("m1").orElseThrow();
-
-        // Expect ClassFormatError when loading class
-        ClassFormatError exception = assertThrows(ClassFormatError.class, () -> {
-            m1.getClassLoader().loadClass(className);
-        });
-
-        // Verify that jdk.internal.Loader does not check CRC32 on ClassFormatError
-        assertFalse(isCRC32Suppressed(exception));
+        return controller.layer().findModule("m1").orElseThrow();
     }
 
     // Return true iff CFE has a suppressed CRC32 mismatch error
@@ -128,8 +172,9 @@ public class InvalidCRCData {
         return false;
     }
 
-    // Create a JAR / module file for use in this test
-    private Path createJarFile() throws IOException {
+    // Create a JAR / module file for use in this test,
+    // optionally with invalid class file data or invalid CRC checksum
+    private Path createJarFile(boolean validClass, boolean validCrc) throws IOException {
         // Create a ZIP file with an invalid class file
         Path zipFile = Path.of("invalid-class-data.jar");
         ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -137,8 +182,11 @@ public class InvalidCRCData {
             // Write library class
             String entryName = className.replace('.', '/') +".class";
             zo.putNextEntry(new ZipEntry(entryName));
-            // Invalid class file data
-            zo.write("efac".getBytes(StandardCharsets.UTF_8));
+            if (!validClass) {
+                // Invalid class file data
+                zo.write("efac".getBytes(StandardCharsets.UTF_8));
+            }
+            zo.write(libraryClass());
 
             // Write module descriptor
             zo.putNextEntry(new ZipEntry("module-info.class"));
@@ -150,14 +198,22 @@ public class InvalidCRCData {
 
         byte[] bytes = out.toByteArray();
 
-        // Put an invalid CRC value in the CEN header for the class file entry
-        ByteBuffer buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
-        int cenOff = buf.getInt(bytes.length - ZipEntry.ENDHDR + ZipEntry.ENDOFF);
-        buf.putInt(cenOff + ZipEntry.CENCRC, 0x0);
+        if (!validCrc) {
+            // Put an invalid CRC value in the CEN header for the class file entry
+            ByteBuffer buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+            int cenOff = buf.getInt(bytes.length - ZipEntry.ENDHDR + ZipEntry.ENDOFF);
+            buf.putInt(cenOff + ZipEntry.CENCRC, 0x0);
+        }
 
         // Write the file to disk
         Files.write(zipFile, bytes);
         return zipFile;
+    }
+
+    private byte[] libraryClass() {
+        return ClassFile.of().build(ClassDesc.of(className), cb -> {
+            cb.withSuperclass(ConstantDescs.CD_Object);
+        });
     }
 
     // URLClassLoader with access bridge to findClass

--- a/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCData.java
+++ b/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCData.java
@@ -117,7 +117,7 @@ public class InvalidCRCData {
         assertFalse(isCRC32Suppressed(exception));
     }
 
-    // Return true iff CFE has a suppressed CRC32 missmatch error
+    // Return true iff CFE has a suppressed CRC32 mismatch error
     private static boolean isCRC32Suppressed(ClassFormatError exception) {
         for (Throwable t : exception.getSuppressed()) {
             if (t instanceof IOException ioe &&

--- a/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCData.java
+++ b/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCData.java
@@ -58,6 +58,14 @@ public class InvalidCRCData {
 
     String className = "foo.bar.Library";
 
+    /**
+     * Verify that URLClassLoader adds a suppressed exception when
+     * a class file is rejected with ClassFormatError and the class data
+     * file CRC32 checksum does not match the CRC32 stated in the JAR CEN header.
+     *
+     * @throws IOException if an unexpected IO exception occurs
+     * @throws ClassNotFoundException if a class is unexpectedly not found
+     */
     @Test
     public void verifyURLClassLoader() throws IOException, ClassNotFoundException {
 
@@ -74,6 +82,14 @@ public class InvalidCRCData {
         }
     }
 
+    /**
+     * Document that a JAR file with invalid class file data and a mismatching
+     * CRC32 checksums does not cause ClassFormatError to have suppressed
+     * exceptions when loaded using the module class loader.
+     *
+     * @throws IOException if an unexpected IO exception occurs
+     * @throws ClassNotFoundException if a class is unexpectedly not found
+     */
     @Test
     public void verifyModule() throws IOException, ClassNotFoundException {
 

--- a/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCData.java
+++ b/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCData.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.util.ModuleInfoWriter;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.lang.module.Configuration;
+import java.lang.module.ModuleDescriptor;
+import java.lang.module.ModuleFinder;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @test
+ * @bug 8341957
+ * @enablePreview
+ * @modules java.base/jdk.internal.module
+ * @library /test/lib
+ * @summary Verify that URLClassLoader checks CRC32 of class file data when
+ *          defineClass fails with ClassFormatError
+ * @run junit InvalidCRCData
+ */
+public class InvalidCRCData {
+
+    String className = "foo.bar.Library";
+
+    @Test
+    public void verifyURLClassLoader() throws IOException, ClassNotFoundException {
+
+        Path zipFile = createJarFile();
+
+        try (var cl = new CustomURLClassLoader(zipFile)) {
+            // Expect ClassFormatError
+            ClassFormatError exception = assertThrows(ClassFormatError.class, () -> {
+                cl.findClass(className);
+            });
+
+            // CRC32 exception should be added as suppressed
+            assertTrue(isCRC32Suppressed(exception));
+        }
+    }
+
+    @Test
+    public void verifyModule() throws IOException, ClassNotFoundException {
+
+        // Create a module JAR file
+        Path zipFile = createJarFile();
+
+        // Load the module
+        ModuleFinder moduleFinder = ModuleFinder.of(zipFile);
+        Configuration parent = ModuleLayer.boot().configuration();
+
+        Configuration configuration = parent.resolve(moduleFinder, ModuleFinder.of(), Set.of("m1"));
+
+        ModuleLayer.Controller controller = ModuleLayer.defineModulesWithOneLoader(configuration,
+                Collections.singletonList(ModuleLayer.boot()),
+                getClass().getClassLoader());
+
+        Module m1 = controller.layer().findModule("m1").orElseThrow();
+
+        // Expect ClassFormatError when loading class
+        ClassFormatError exception = assertThrows(ClassFormatError.class, () -> {
+            m1.getClassLoader().loadClass(className);
+        });
+
+        // Verify that jdk.internal.Loader does not check CRC32 on ClassFormatError
+        assertFalse(isCRC32Suppressed(exception));
+    }
+
+    // Return true iff CFE has a suppressed CRC32 missmatch error
+    private static boolean isCRC32Suppressed(ClassFormatError exception) {
+        for (Throwable t : exception.getSuppressed()) {
+            if (t instanceof IOException ioe &&
+                    "CRC error while extracting entry from JAR file".equals(ioe.getMessage())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Create a JAR / module file for use in this test
+    private Path createJarFile() throws IOException {
+        // Create a ZIP file with an invalid class file
+        Path zipFile = Path.of("invalid-class-data.jar");
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (var zo = new ZipOutputStream(out)) {
+            // Write library class
+            String entryName = className.replace('.', '/') +".class";
+            zo.putNextEntry(new ZipEntry(entryName));
+            // Invalid class file data
+            zo.write("efac".getBytes(StandardCharsets.UTF_8));
+
+            // Write module descriptor
+            zo.putNextEntry(new ZipEntry("module-info.class"));
+            ModuleDescriptor descriptor = ModuleDescriptor.newModule("m1")
+                    .requires("java.base")
+                    .build();
+            ModuleInfoWriter.write(descriptor, zo);
+        }
+
+        byte[] bytes = out.toByteArray();
+
+        // Put an invalid CRC value in the CEN header for the class file entry
+        ByteBuffer buf = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN);
+        int cenOff = buf.getInt(bytes.length - ZipEntry.ENDHDR + ZipEntry.ENDOFF);
+        buf.putInt(cenOff + ZipEntry.CENCRC, 0x0);
+
+        // Write the file to disk
+        Files.write(zipFile, bytes);
+        return zipFile;
+    }
+
+    // URLClassLoader with access bridge to findClass
+    class CustomURLClassLoader extends URLClassLoader {
+        public CustomURLClassLoader(Path jarFile) throws MalformedURLException {
+            super(new URL[] {jarFile.toUri().toURL()});
+        }
+        @Override
+        protected Class<?> findClass(String name) throws ClassNotFoundException {
+            return super.findClass(name);
+        }
+    }
+}

--- a/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCData.java
+++ b/test/jdk/jdk/internal/loader/URLClassPath/InvalidCRCData.java
@@ -69,9 +69,9 @@ public class InvalidCRCData {
     @Test
     public void verifyURLClassLoader() throws IOException, ClassNotFoundException {
 
-        Path zipFile = createJarFile();
+        Path jarFile = createJarFile();
 
-        try (var cl = new CustomURLClassLoader(zipFile)) {
+        try (var cl = new CustomURLClassLoader(jarFile)) {
             // Expect ClassFormatError
             ClassFormatError exception = assertThrows(ClassFormatError.class, () -> {
                 cl.findClass(className);
@@ -94,10 +94,10 @@ public class InvalidCRCData {
     public void verifyModule() throws IOException, ClassNotFoundException {
 
         // Create a module JAR file
-        Path zipFile = createJarFile();
+        Path jarFile = createJarFile();
 
         // Load the module
-        ModuleFinder moduleFinder = ModuleFinder.of(zipFile);
+        ModuleFinder moduleFinder = ModuleFinder.of(jarFile);
         Configuration parent = ModuleLayer.boot().configuration();
 
         Configuration configuration = parent.resolve(moduleFinder, ModuleFinder.of(), Set.of("m1"));


### PR DESCRIPTION
Please review this PR which adds test coverage for the case where `URLClassLoader.defineClass` fails with a `ClassFormatError` _and_ the CRC32 checksum of the class file byte array did not match the CRC32 value stated in the JAR file's CEN header.

In such cases, an `IOException` with the message _"CRC error while extracting entry from JAR file"_ is added as a suppressed exception to the `ClassFormatError`.

Adding a test documents this unspecified, but long-standing behavior.

For good measure, the test also covers the existing behavior of the module system class loader. Since the module system does not add similar suppressed exception on a CRC32 mismatch, this test mostly serves the purpose of documentation. 

The test is parameterized, as such it covers all eight combinations of {URLClassLoader/module class loader, valid/invalid class data, valid/invalid CRC checksum}.

Should any of the class loaders change behavior in the future (with or without intent), this test will notice and may need to be updated to document the new behavior. Otherwise, it will catch unintended regressions.

Testing: This is a test-only enhancement PR, no existing tests are updated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341957](https://bugs.openjdk.org/browse/JDK-8341957): Add test for URLClassLoader loading invalid class with mismatching CRC32 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21469/head:pull/21469` \
`$ git checkout pull/21469`

Update a local copy of the PR: \
`$ git checkout pull/21469` \
`$ git pull https://git.openjdk.org/jdk.git pull/21469/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21469`

View PR using the GUI difftool: \
`$ git pr show -t 21469`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21469.diff">https://git.openjdk.org/jdk/pull/21469.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21469#issuecomment-2407664449)