### PR TITLE
8341697: C2: Register allocation inefficiency in tight loop

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -781,6 +781,10 @@
           "Run DuplicateBackedge whenever possible ignoring benefit"        \
           "analysis")                                                       \
                                                                             \
+  product(bool, LoopAwaredSpilling, true, DIAGNOSTIC,                       \
+          "Eagerly spill or reload live ranges at loop entry if it seems"   \
+          "beneficial")                                                     \
+                                                                            \
   product(bool, VerifyReceiverTypes, trueInDebug, DIAGNOSTIC,               \
           "Verify receiver types at runtime")                               \
                                                                             \

--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -781,7 +781,7 @@
           "Run DuplicateBackedge whenever possible ignoring benefit"        \
           "analysis")                                                       \
                                                                             \
-  product(bool, LoopAwaredSpilling, true, DIAGNOSTIC,                       \
+  product(bool, LoopAwareSpilling, true, DIAGNOSTIC,                        \
           "Eagerly spill or reload live ranges at loop entry if it seems"   \
           "beneficial")                                                     \
                                                                             \

--- a/src/hotspot/share/opto/chaitin.hpp
+++ b/src/hotspot/share/opto/chaitin.hpp
@@ -472,8 +472,6 @@ class PhaseChaitin : public PhaseRegAlloc {
   // instead.  Update high-pressure indices.  Create a new live range.
   void insert_proj( Block *b, uint i, Node *spill, uint maxlrg );
 
-  bool is_high_pressure( Block *b, LRG *lrg, uint insidx );
-
   uint _oldphi;                 // Node index which separates pre-allocation nodes
 
   Block **_blks;                // Array of blocks sorted by frequency for coalescing

--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -2300,9 +2300,6 @@ bool CFGLoop::in_loop_nest(Block* b) {
   int depth = _depth;
   CFGLoop* b_loop = b->_loop;
   int b_depth = b_loop->_depth;
-  if (depth == b_depth) {
-    return true;
-  }
   while (b_depth > depth) {
     b_loop = b_loop->_parent;
     b_depth = b_loop->_depth;

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -729,8 +729,9 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
         if (!needs_split && !u3) {
           UPblock[slidx] = false;
         }
-        // If we enter a loop and will spill there, try to spill in the loop entry
-        if (b->head()->is_Loop() && is_spilt_in_loop_nest(_cfg, b->_loop, lrgs(lidx))) {
+        // If we enter a loop and will spill there, try to spill in the loop entry, except if we
+        // are reassigned in the loop anyway
+        if (!has_phi && b->head()->is_Loop() && is_spilt_in_loop_nest(_cfg, b->_loop, lrgs(lidx))) {
           UPblock[slidx] = false;
         }
       }  // end if phi is needed

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -495,14 +495,14 @@ enum class SpillAction {
 // Uncommon means that the action is neither common nor untaken
 // The action we will perform on the live range at loop entry depends on the common-ness of the spilling and reloading actions:
 //
-//    Reload     Common      Uncommon      Untaken
-// Spill
-//
-//  Common       Spill        Spill         Spill
-//
-// Uncommon      Reload       Spill         Spill
-//
-// Untaken       Reload       Reload        None
+//     Reload |  Common   |  Uncommon  |   Untaken
+// Spill      |           |            |
+//------------|-----------|------------|------------
+//   Common   |  Spill    |   Spill    |    Spill
+//------------|-----------|------------|------------
+//  Uncommon  |  Reload   |   Spill    |    Spill
+//------------|-----------|------------|------------
+//  Untaken   |  Reload   |   Reload   |    None
 //
 // In general, if a live range is spilt more than it is used, we try to eagerly spill it, and vice versa,
 // if a live range is used more than it is spilt, we try to eagerly reload it as the spills will not happen
@@ -805,7 +805,7 @@ uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
         assert(phi != nullptr,"Must have a Phi Node here");
         phis.push(phi);
 
-        if (LoopAwaredSpilling && !has_phi && b->head()->is_Loop()) {
+        if (LoopAwareSpilling && !has_phi && b->head()->is_Loop()) {
           // Loop will always have needs_phi because the LoopBack block has not been processed yet
           assert(needs_phi, "must be");
           SpillAction action = should_spill_before_loop(_cfg, *this, b->_loop, lidx, lrgs(lidx));

--- a/test/micro/org/openjdk/bench/vm/compiler/LoopCounterBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/LoopCounterBench.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.vm.compiler;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.*;
+
+@State(Scope.Thread)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class LoopCounterBench {
+    int increment;
+    long[] src, dest;
+
+    @Setup
+    public void setup() {
+        final int SIZE = 1000;
+        src = new long[SIZE];
+        dest = new long[SIZE];
+        increment = 1;
+    }
+
+    @Benchmark
+    public long[] field_ret() {
+        for (int i = 0; i < src.length; i = i + increment) {
+            dest[i] = src[i];
+        }
+        return dest;
+    }
+
+    @Benchmark
+    public long[] localVar_ret() {
+        final int inc = increment;
+        for (int i = 0; i < src.length; i = i + inc) {
+            dest[i] = src[i];
+        }
+        return dest;
+    }
+}


### PR DESCRIPTION
Hi,

This patch improves the spill placement in the presence of loops. Currently, when trying to spill a live range, we will create a `Phi` at the loop head, this `Phi` will then be spilt inside the loop body, and as the `Phi` is `UP` (lives in register) at the loop head, we need to emit an additional reload at the loop back-edge block. This introduces loop-carried dependencies, greatly reduces loop throughput.

My proposal is to be aware of loop heads and try to eagerly spill or reload live ranges at the loop entries. In general, if a live range is spilt in the loop common path, then we should spill it in the loop entries and reload it at its use sites, this may increase the number of loads but will eliminate loop-carried dependencies, making the load latency-free. On the otherhand, if a live range is only spilt in the uncommon path but is used in the common path, then we should reload it eagerly. I think it is appropriate to bias towards spilling, i.e. if a live range is both spilt and reloaded in the common path, we spill it. This eliminates loop-carried dependencies.

A downfall of this algorithm is that we may overspill, which means that after spilling some live ranges, the others do not need to be spilt anymore but are unnecessarily spilt.

- A possible approach is to split the live ranges one-by-one and try to colour them afterwards. This seems prohibitively expensive.
- Another approach is to be aware of the number of registers that need spilling, sorting the live ones accordingly.
- Finally, we can eagerly split a live range at uncommon branches and do conservative coalescing afterwards. I think this is the most elegant and efficient solution for that.

Please take a look and leave your reviews, thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341697](https://bugs.openjdk.org/browse/JDK-8341697): C2: Register allocation inefficiency in tight loop (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21472/head:pull/21472` \
`$ git checkout pull/21472`

Update a local copy of the PR: \
`$ git checkout pull/21472` \
`$ git pull https://git.openjdk.org/jdk.git pull/21472/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21472`

View PR using the GUI difftool: \
`$ git pr show -t 21472`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21472.diff">https://git.openjdk.org/jdk/pull/21472.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21472#issuecomment-2407696685)
</details>
