### PR TITLE
8341978: Improve JButton/bug4490179.java

### DIFF
--- a/test/jdk/javax/swing/JButton/bug4490179.java
+++ b/test/jdk/javax/swing/JButton/bug4490179.java
@@ -31,61 +31,107 @@
 
 import java.awt.Point;
 import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.util.concurrent.CountDownLatch;
+
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 
-public class bug4490179 {
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public final class bug4490179
+        extends MouseAdapter
+        implements ActionListener {
     static JFrame frame;
     static JButton button;
-    static volatile Point pt;
-    static volatile int buttonW;
-    static volatile int buttonH;
-    static volatile boolean passed = true;
+
+    private static volatile Point buttonCenter;
+
+    private static final CountDownLatch windowGainedFocus = new CountDownLatch(1);
+
+    private static final CountDownLatch mouseButton1Released = new CountDownLatch(1);
+    private static final CountDownLatch mouseButton3Released = new CountDownLatch(2);
+
+    private static final CountDownLatch actionPerformed = new CountDownLatch(1);
 
     public static void main(String[] args) throws Exception {
         Robot robot = new Robot();
         robot.setAutoDelay(100);
-        robot.setAutoWaitForIdle(true);
+
+        final bug4490179 eventHandler = new bug4490179();
         try {
             SwingUtilities.invokeAndWait(() -> {
-                frame = new JFrame("bug4490179");
                 button = new JButton("Button");
+                button.addActionListener(eventHandler);
+                button.addMouseListener(eventHandler);
+
+                frame = new JFrame("bug4490179");
                 frame.getContentPane().add(button);
-                button.addActionListener(e -> {
-                    if ((e.getModifiers() & InputEvent.BUTTON1_MASK)
-                            != InputEvent.BUTTON1_MASK) {
-                        System.out.println("Status: Failed");
-                        passed = false;
+
+                frame.addWindowFocusListener(new WindowAdapter() {
+                    @Override
+                    public void windowGainedFocus(WindowEvent e) {
+                        windowGainedFocus.countDown();
                     }
                 });
+
                 frame.pack();
                 frame.setLocationRelativeTo(null);
                 frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
                 frame.setVisible(true);
             });
+
+            if (!windowGainedFocus.await(1, SECONDS)) {
+                throw new RuntimeException("Window didn't gain focus");
+            }
             robot.waitForIdle();
-            robot.delay(1000);
+
             SwingUtilities.invokeAndWait(() -> {
-                pt = button.getLocationOnScreen();
-                buttonW = button.getSize().width;
-                buttonH = button.getSize().height;
+                Point location = button.getLocationOnScreen();
+                buttonCenter = new Point(location.x + button.getWidth() / 2,
+                                         location.y + button.getHeight() / 2);
             });
 
-            robot.mouseMove(pt.x + buttonW / 2, pt.y + buttonH / 2);
-            robot.waitForIdle();
+            robot.mouseMove(buttonCenter.x, buttonCenter.y);
+            System.out.println("Press / Release button 3");
             robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
 
+            System.out.println("Press button 1");
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            System.out.println("Press button 3");
             robot.mousePress(InputEvent.BUTTON3_DOWN_MASK);
+            System.out.println("Release button 3");
             robot.mouseRelease(InputEvent.BUTTON3_DOWN_MASK);
-            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-            robot.delay(500);
 
-            if (!passed) {
-                throw new RuntimeException("Test Failed");
+            try {
+                if (!mouseButton3Released.await(1, SECONDS)) {
+                    throw new RuntimeException("Mouse button 3 isn't released");
+                }
+
+                robot.waitForIdle();
+
+                if (actionPerformed.await(100, MILLISECONDS)) {
+                    throw new RuntimeException("Action event triggered by releasing button 3");
+                }
+            } finally {
+                System.out.println("Release button 1");
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            }
+
+            if (!mouseButton1Released.await(1, SECONDS)) {
+                throw new RuntimeException("Mouse button 1 isn't released");
+            }
+            if (!actionPerformed.await(100, MILLISECONDS)) {
+                throw new RuntimeException("Action event isn't triggered by releasing button 1");
             }
         } finally {
             SwingUtilities.invokeAndWait(() -> {
@@ -93,6 +139,23 @@ public class bug4490179 {
                     frame.dispose();
                 }
             });
+        }
+    }
+
+    @Override
+    public void actionPerformed(ActionEvent e) {
+        System.out.println("    actionPerformed");
+        actionPerformed.countDown();
+    }
+
+    @Override
+    public void mouseReleased(MouseEvent e) {
+        if (e.getButton() == MouseEvent.BUTTON1) {
+            System.out.println("    mouseReleased: button 1");
+            mouseButton1Released.countDown();
+        } else if (e.getButton() == MouseEvent.BUTTON3) {
+            System.out.println("    mouseReleased: button 3");
+            mouseButton3Released.countDown();
         }
     }
 }


### PR DESCRIPTION
At first, I noticed bug4490179.java didn't release mouse button 1, which could affect the following tests.

I started looking at the test and updated it to use `CountDownLatch` instead of delays.

@azvegint handled releasing mouse button 1 in https://github.com/openjdk/jdk/pull/19339#discussion_r1609201116.

The updated version first verifies `mouseButton3Released` event is received and ensures `actionPerformed` is not received at this time.

Then mouse button is released; this should trigger two events: `mouseButton1Released` and `actionPerformed`. It is verified that these events are received.

I kept debugging prints, they help understanding which actions lead to which events.

The updated test reproduces the original, it is easily verified using Java 8; the updated test is stable in CI.


The `javax/swing/JButton/bug4490179.java` test is also modified in https://github.com/openjdk/jdk/pull/20861, @mrserb, could you take a look? I was going to suggested factoring out the changes to this test from #20861, yet I modified it myself. I realised it when I started creating the PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341978](https://bugs.openjdk.org/browse/JDK-8341978): Improve JButton/bug4490179.java (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21474/head:pull/21474` \
`$ git checkout pull/21474`

Update a local copy of the PR: \
`$ git checkout pull/21474` \
`$ git pull https://git.openjdk.org/jdk.git pull/21474/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21474`

View PR using the GUI difftool: \
`$ git pr show -t 21474`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21474.diff">https://git.openjdk.org/jdk/pull/21474.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21474#issuecomment-2407805254)