### PR TITLE
8341984: Use PassFailJFrame for TimeChangeButtonClickTest.java

### DIFF
--- a/test/jdk/javax/swing/JButton/TimeChangeButtonClickTest.java
+++ b/test/jdk/javax/swing/JButton/TimeChangeButtonClickTest.java
@@ -26,6 +26,8 @@
  * @bug 7096375
  * @summary  Test that Swing does not ignore first click on a JButton after
  * decreasing system's time
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
  * @run main/manual TimeChangeButtonClickTest
  */
 

--- a/test/jdk/javax/swing/JButton/TimeChangeButtonClickTest.java
+++ b/test/jdk/javax/swing/JButton/TimeChangeButtonClickTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,193 +28,99 @@
  * decreasing system's time
  * @run main/manual TimeChangeButtonClickTest
  */
+
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.util.concurrent.CountDownLatch;
-import javax.swing.BorderFactory;
-import javax.swing.JPanel;
-import javax.swing.JTextArea;
-import javax.swing.SwingUtilities;
-import javax.swing.JButton;
-import javax.swing.JFrame;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.concurrent.TimeUnit;
+
+import javax.swing.BorderFactory;
 import javax.swing.Box;
+import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JLabel;
+import javax.swing.JPanel;
 
 public class TimeChangeButtonClickTest {
+    private static final String instructions = """
+            <html><body>
+            <ol>
+            <li>
+                <strong>Test 1:</strong>
+                <ol style="margin-top: 0px">
+                    <li>Click <b>Test Button</b> with left mouse button</li>
+                    <li>Observe: Button Press count change to 1</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Test 2:</strong>
+                <ol style="margin-top: 0px">
+                    <li>Change the system time to one hour less than current time</li>
+                    <li>Click <b>Test Button</b> with left mouse button</li>
+                    <li>Observe: Button Press count change to 2</li>
+                </ol>
+            </li>
+            <li>
+                <strong>Test 3:</strong>
+                <ol style="margin-top: 0px">
+                    <li>Change the system time by adding two hours</li>
+                    <li>Click <b>Test Button</b> with left mouse button</li>
+                    <li>Observe: Button Press count changes to 3</li>
+                </ol>
+            </li>
 
-    public static void main(String args[]) throws Exception {
-        final CountDownLatch latch = new CountDownLatch(1);
-        TestUI test = new TestUI(latch);
+            <li style="margin-top: 8px; padding-top: 8px; border-top: 1px solid">
+            Restore the system time.</li>
+            <li style="margin-top: 8px; padding-top: 8px; border-top: 1px solid">
+            Press <b>Pass</b> if Button Press count is 3,
+            and <b>Fail</b> otherwise.</li>
+            </ol>
+            </body></html>
+            """;
 
-        SwingUtilities.invokeLater(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    test.createUI();
-                } catch (Exception ex) {
-                    throw new RuntimeException("Exception while creating test UI");
-                }
-            }
-        });
-
-        boolean status = latch.await(5, TimeUnit.MINUTES);
-
-        if (!status) {
-            System.out.println("Test timed out.");
-        }
-
-        SwingUtilities.invokeAndWait(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    test.disposeUI();
-                } catch (Exception ex) {
-                    throw new RuntimeException("Exception while disposing test UI");
-                }
-            }
-        });
-
-        if (test.testResult == false) {
-            throw new RuntimeException("Test Failed.");
-        }
-    }
-}
-
-class TestUI {
-
-    private static JFrame mainFrame;
-    private static JPanel mainControlPanel;
-
-    private static JTextArea instructionTextArea;
-
-    private static JPanel resultButtonPanel;
-    private static JButton passButton;
-    private static JButton failButton;
-
-    private static JPanel testPanel;
-    private static JButton testButton;
-    private static JLabel buttonPressCountLabel;
-
-    private static GridBagLayout layout;
-    private final CountDownLatch latch;
-    public boolean testResult = false;
-    private int buttonPressCount = 0;
-
-    public TestUI(CountDownLatch latch) throws Exception {
-        this.latch = latch;
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                      .instructions(instructions)
+                      .rows(20)
+                      .columns(40)
+                      .splitUI(TimeChangeButtonClickTest::createTestPanel)
+                      .build()
+                      .awaitAndCheck();
     }
 
-    public final void createUI() throws Exception {
+    private static JComponent createTestPanel() {
+        final JLabel buttonPressCountLabel = new JLabel(
+                "Button Press Count: 0");
 
-        mainFrame = new JFrame("TimeChangeButtonClickTest");
-
-        layout = new GridBagLayout();
-        mainControlPanel = new JPanel(layout);
-        resultButtonPanel = new JPanel(layout);
-        testPanel = new JPanel(layout);
-
-        GridBagConstraints gbc = new GridBagConstraints();
-
-        // Create Test instructions
-        String instructions
-                = "Test 1 : --------------------\n"
-                + "1. Click 'Test Button' with left mouse button\n"
-                + "Observe : Button Press count change to 1\n"
-                + "Test 2 : --------------------\n"
-                + "1. Change the system time to one hour less than current time\n"
-                + "2. Click 'Test Button' with left mouse button\n"
-                + "Observe : Button Press count change to 2\n"
-                + "Test 3 : --------------------\n"
-                + "1. Change the system time by adding two hours\n"
-                + "2. Click 'Test Button' with left mouse button\n"
-                + "Observe : Button Press count change to 3\n"
-                + "--------------------\n"
-                + "Restore the system time.\n"
-                + "--------------------\n"
-                + "Press 'Pass' if Button Press count is 3, 'Fail' otherwise";
-
-        instructionTextArea = new JTextArea();
-        instructionTextArea.setText(instructions);
-        instructionTextArea.setEditable(false);
-        instructionTextArea.setBorder(BorderFactory.
-                createTitledBorder("Test Instructions"));
-
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-        gbc.fill = GridBagConstraints.HORIZONTAL;
-        mainControlPanel.add(instructionTextArea, gbc);
-
-        // Create Test Button and label
-        testButton = new JButton("Test Button");
+        JButton testButton = new JButton("Test Button");
         testButton.addActionListener(new ActionListener() {
+            private int buttonPressCount;
+
             @Override
             public void actionPerformed(ActionEvent e) {
                 buttonPressCount++;
                 buttonPressCountLabel.setText(
-                        "Button Press Count : " + buttonPressCount);
+                        "Button Press Count: " + buttonPressCount);
             }
         });
 
+        JPanel buttonPanel = new JPanel(new GridBagLayout());
+        GridBagConstraints gbc = new GridBagConstraints();
         gbc.gridx = 0;
         gbc.gridy = 0;
-        testPanel.add(testButton, gbc);
-
-        gbc.gridx = 0;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        buttonPanel.add(testButton, gbc);
         gbc.gridy = 1;
-        testPanel.add(Box.createVerticalStrut(50));
+        gbc.ipady = 16;
+        buttonPanel.add(buttonPressCountLabel, gbc);
 
-        gbc.gridx = 0;
-        gbc.gridy = 2;
-        buttonPressCountLabel = new JLabel(
-                "Button Press Count : " + buttonPressCount);
-        testPanel.add(buttonPressCountLabel, gbc);
+        Box testPanel = Box.createVerticalBox();
+        testPanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
 
-        mainControlPanel.add(testPanel);
+        testPanel.add(Box.createVerticalGlue());
+        testPanel.add(buttonPanel);
+        testPanel.add(Box.createVerticalGlue());
 
-        // Create resultButtonPanel with Pass, Fail buttons
-        passButton = new JButton("Pass");
-        passButton.setActionCommand("Pass");
-        passButton.addActionListener((ActionEvent e) -> {
-            System.out.println("Pass Button pressed!");
-            testResult = true;
-            latch.countDown();
-
-        });
-
-        failButton = new JButton("Fail");
-        failButton.setActionCommand("Fail");
-        failButton.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent e) {
-                System.out.println("Fail Button pressed!");
-                testResult = false;
-                latch.countDown();
-            }
-        });
-
-        gbc.gridx = 0;
-        gbc.gridy = 0;
-        resultButtonPanel.add(passButton, gbc);
-        gbc.gridx = 1;
-        gbc.gridy = 0;
-        resultButtonPanel.add(failButton, gbc);
-
-        gbc.gridx = 0;
-        gbc.gridy = 1;
-        mainControlPanel.add(resultButtonPanel, gbc);
-
-        mainFrame.add(mainControlPanel);
-
-        mainFrame.pack();
-        mainFrame.setVisible(true);
-    }
-
-    public void disposeUI() {
-        mainFrame.setVisible(false);
-        mainFrame.dispose();
+        return testPanel;
     }
 }
-

--- a/test/jdk/javax/swing/JButton/TimeChangeButtonClickTest.java
+++ b/test/jdk/javax/swing/JButton/TimeChangeButtonClickTest.java
@@ -44,7 +44,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 public class TimeChangeButtonClickTest {
-    private static final String instructions = """
+    private static final String INSTRUCTIONS = """
             <html><body>
             <ol>
             <li>
@@ -82,7 +82,7 @@ public class TimeChangeButtonClickTest {
 
     public static void main(String[] args) throws Exception {
         PassFailJFrame.builder()
-                      .instructions(instructions)
+                      .instructions(INSTRUCTIONS)
                       .rows(20)
                       .columns(40)
                       .splitUI(TimeChangeButtonClickTest::createTestPanel)


### PR DESCRIPTION
Refactor the test `javax/swing/JButton/TimeChangeButtonClickTest.java` to use the `PassFailJFrame` framework to handle the tester's decision on whether the test passes or fails.

I reformatted the instructions for performing the test into HTML.

I preserved the test UI panel which contains the button to press and the label with button press counter.

The updated test is shorter by nearly 100 lines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341984](https://bugs.openjdk.org/browse/JDK-8341984): Use PassFailJFrame for TimeChangeButtonClickTest.java (**Bug** - P4)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21476/head:pull/21476` \
`$ git checkout pull/21476`

Update a local copy of the PR: \
`$ git checkout pull/21476` \
`$ git pull https://git.openjdk.org/jdk.git pull/21476/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21476`

View PR using the GUI difftool: \
`$ git pr show -t 21476`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21476.diff">https://git.openjdk.org/jdk/pull/21476.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21476#issuecomment-2407961913)
</details>
