### PR TITLE
8341972: java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java timed out after JDK-8341257

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -201,6 +201,7 @@ java/awt/event/KeyEvent/ExtendedKeyCode/ExtendedKeyCodeTest.java 8169476 windows
 java/awt/event/KeyEvent/KeyChar/KeyCharTest.java 8169474,8224055 macosx-all,windows-all
 java/awt/event/KeyEvent/KeyTyped/CtrlASCII.java 8298910 linux-all
 
+java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java 8242805 macosx-all
 java/awt/dnd/DnDCursorCrashTest.java 8242805 macosx-all
 java/awt/dnd/DnDClipboardDeadlockTest.java 8079553 linux-all
 java/awt/dnd/URIListToFileListBetweenJVMsTest/URIListToFileListBetweenJVMsTest.java 8194947 generic-all

--- a/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
+++ b/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
@@ -64,7 +64,7 @@ public class DnDRemoveFocusOwnerCrashTest {
     public static Frame frame;
     public static Robot robot;
     public static DragSourceButton dragSourceButton;
-    public static Point p;
+    static volatile Point p;
 
     public static void main(String[] args) throws Exception {
         try {

--- a/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
+++ b/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
@@ -64,10 +64,13 @@ public class DnDRemoveFocusOwnerCrashTest {
     public static Frame frame;
     public static Robot robot;
     public static DragSourceButton dragSourceButton;
+    public static Point p;
 
     public static void main(String[] args) throws Exception {
         try {
             robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
             EventQueue.invokeAndWait(() -> {
                 frame = new Frame();
                 dragSourceButton = new DragSourceButton();
@@ -80,32 +83,20 @@ public class DnDRemoveFocusOwnerCrashTest {
                 frame.pack();
                 frame.setVisible(true);
 
-                try {
-                    robot.delay(FRAME_ACTIVATION_TIMEOUT);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    throw new RuntimeException("The test failed.");
-                }
-
-                Point p = dragSourceButton.getLocationOnScreen();
+                p = dragSourceButton.getLocationOnScreen();
                 p.translate(10, 10);
-
-                try {
-                    Robot robot = new Robot();
-                    robot.mouseMove(p.x, p.y);
-                    robot.keyPress(KeyEvent.VK_CONTROL);
-                    robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-                    for (int dy = 0; dy < 50; dy++) {
-                        robot.mouseMove(p.x, p.y + dy);
-                        robot.delay(10);
-                    }
-                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-                    robot.keyRelease(KeyEvent.VK_CONTROL);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    throw new RuntimeException("The test failed.");
-                }
             });
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
+            robot.mouseMove(p.x, p.y);
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
+            robot.keyPress(KeyEvent.VK_CONTROL);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (int dy = 0; dy < 50; dy++) {
+                robot.mouseMove(p.x, p.y + dy);
+                robot.delay(10);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.keyRelease(KeyEvent.VK_CONTROL);
         } finally {
             if (frame != null) {
                 EventQueue.invokeAndWait(() -> frame.dispose());

--- a/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
+++ b/test/jdk/java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java
@@ -82,10 +82,16 @@ public class DnDRemoveFocusOwnerCrashTest {
                 frame.add(dropTargetPanel);
                 frame.pack();
                 frame.setVisible(true);
+            });
 
+            robot.waitForIdle();
+            robot.delay(FRAME_ACTIVATION_TIMEOUT);
+
+            EventQueue.invokeAndWait(() -> {
                 p = dragSourceButton.getLocationOnScreen();
                 p.translate(10, 10);
             });
+
             robot.delay(FRAME_ACTIVATION_TIMEOUT);
             robot.mouseMove(p.x, p.y);
             robot.delay(FRAME_ACTIVATION_TIMEOUT);
@@ -98,9 +104,11 @@ public class DnDRemoveFocusOwnerCrashTest {
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.keyRelease(KeyEvent.VK_CONTROL);
         } finally {
-            if (frame != null) {
-                EventQueue.invokeAndWait(() -> frame.dispose());
-            }
+            EventQueue.invokeAndWait(() -> {
+                if (frame != null) {
+                    frame.dispose();
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Intermittent failure of awt test in windows only. When re-testing locally, the drag button wasn't actually drawn in the test. I made p static, added stability delays, and moved robot out of the EDT (as well as caught a duplicate robot instantiation). There's a merging issue that also missed adding this test to the problem list for MacOS, so it's been added here. Tested with 100 repeats on all platforms (but problem listed on MacOS) and the test now passes consistently.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341972](https://bugs.openjdk.org/browse/JDK-8341972): java/awt/dnd/DnDRemoveFocusOwnerCrashTest.java timed out after JDK-8341257 (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21477/head:pull/21477` \
`$ git checkout pull/21477`

Update a local copy of the PR: \
`$ git checkout pull/21477` \
`$ git pull https://git.openjdk.org/jdk.git pull/21477/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21477`

View PR using the GUI difftool: \
`$ git pr show -t 21477`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21477.diff">https://git.openjdk.org/jdk/pull/21477.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21477#issuecomment-2408023005)