### PR TITLE
8340494: Open some dialog awt tests 4

### DIFF
--- a/test/jdk/java/awt/Container/ActivateOnFocusTest.java
+++ b/test/jdk/java/awt/Container/ActivateOnFocusTest.java
@@ -60,6 +60,8 @@ public class ActivateOnFocusTest {
 
             Robot robot = new Robot();
             robot.waitForIdle();
+            robot.delay(1000);
+
             EventQueue.invokeAndWait(() -> {
                 p = mf1.mb.getLocationOnScreen();
             });
@@ -69,8 +71,9 @@ public class ActivateOnFocusTest {
             robot.mouseMove(p.x + 5, p.y + 5);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-            robot.delay(250);
             robot.waitForIdle();
+            robot.delay(250);
+
         } finally {
             if (mf1 != null) {
                 EventQueue.invokeAndWait(mf1::dispose);

--- a/test/jdk/java/awt/Container/ActivateOnFocusTest.java
+++ b/test/jdk/java/awt/Container/ActivateOnFocusTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FlowLayout;
+import java.awt.Frame;
+import java.awt.Graphics;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
+
+/*
+ * @test
+ * @bug 4111098
+ * @key headful
+ * @summary Test for no window activation on control requestFocus()
+ * @run main/timeout=30 ActivateOnFocusTest
+ */
+
+public class ActivateOnFocusTest {
+    static MyFrame mf1;
+    static Point p;
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            mf1 = new MyFrame();
+            mf1.setBounds(100, 100, 300, 300);
+            mf1.mc1.requestFocusInWindow();
+        });
+
+        Robot robot = new Robot();
+        robot.waitForIdle();
+        EventQueue.invokeAndWait(() -> {
+            p = mf1.mb.getLocationOnScreen();
+        });
+
+        robot.waitForIdle();
+
+        robot.mouseMove(p.x + 5, p.y + 5);
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(250);
+        robot.waitForIdle();
+    }
+}
+
+class MyFrame extends Frame implements ActionListener, WindowListener {
+    public Button mb;
+    public MyComponent mc1;
+    public MyComponent mc2;
+
+    public MyFrame() {
+        super();
+        setTitle("ActivateOnFocusTest");
+        setLayout(new FlowLayout());
+        mb = new Button("Pull");
+        mb.addActionListener(this);
+        add(mb);
+        mc1 = new MyComponent(Color.red);
+        add(mc1);
+        mc2 = new MyComponent(Color.blue);
+        add(mc2);
+        addWindowListener(this);
+        setVisible(true);
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        MyFrame mf2 = new MyFrame();
+        mf2.setBounds(200, 200, 300, 300);
+        mf2.setVisible(true);
+        mf2.mc1.requestFocusInWindow();
+    }
+
+    public void windowOpened(WindowEvent e) {
+    }
+
+    public void windowClosing(WindowEvent e) {
+    }
+
+    public void windowClosed(WindowEvent e) {
+    }
+
+    public void windowIconified(WindowEvent e) {
+    }
+
+    public void windowDeiconified(WindowEvent e) {
+    }
+
+    public void windowActivated(WindowEvent e) {
+        mc1.requestFocusInWindow();
+    }
+
+    public void windowDeactivated(WindowEvent e) {
+        mc2.requestFocusInWindow();
+    }
+}
+
+class MyComponent extends Component {
+    public MyComponent(Color c) {
+        super();
+        setBackground(c);
+    }
+
+    public void paint(Graphics g) {
+        Dimension d = getSize();
+        g.setColor(getBackground());
+        g.fillRect(0, 0, d.width, d.height);
+    }
+
+    public boolean isFocusTraversable() {
+        return true;
+    }
+
+    public Dimension getPreferredSize() {
+        return new Dimension(50, 50);
+    }
+}

--- a/test/jdk/java/awt/Container/ActivateOnFocusTest.java
+++ b/test/jdk/java/awt/Container/ActivateOnFocusTest.java
@@ -50,25 +50,31 @@ public class ActivateOnFocusTest {
     static Point p;
 
     public static void main(String[] args) throws Exception {
-        EventQueue.invokeAndWait(() -> {
-            mf1 = new MyFrame();
-            mf1.setBounds(100, 100, 300, 300);
-            mf1.mc1.requestFocusInWindow();
-        });
+        try {
+            EventQueue.invokeAndWait(() -> {
+                mf1 = new MyFrame();
+                mf1.setBounds(100, 100, 300, 300);
+                mf1.mc1.requestFocusInWindow();
+            });
 
-        Robot robot = new Robot();
-        robot.waitForIdle();
-        EventQueue.invokeAndWait(() -> {
-            p = mf1.mb.getLocationOnScreen();
-        });
+            Robot robot = new Robot();
+            robot.waitForIdle();
+            EventQueue.invokeAndWait(() -> {
+                p = mf1.mb.getLocationOnScreen();
+            });
 
-        robot.waitForIdle();
+            robot.waitForIdle();
 
-        robot.mouseMove(p.x + 5, p.y + 5);
-        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        robot.delay(250);
-        robot.waitForIdle();
+            robot.mouseMove(p.x + 5, p.y + 5);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(250);
+            robot.waitForIdle();
+        } finally {
+            if (mf1 != null) {
+                EventQueue.invokeAndWait(mf1::dispose);
+            }
+        }
     }
 }
 

--- a/test/jdk/java/awt/Container/ActivateOnFocusTest.java
+++ b/test/jdk/java/awt/Container/ActivateOnFocusTest.java
@@ -34,6 +34,7 @@ import java.awt.Robot;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.InputEvent;
+import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.event.WindowListener;
 
@@ -78,7 +79,7 @@ public class ActivateOnFocusTest {
     }
 }
 
-class MyFrame extends Frame implements ActionListener, WindowListener {
+class MyFrame extends Frame implements ActionListener {
     public Button mb;
     public MyComponent mc1;
     public MyComponent mc2;
@@ -94,7 +95,16 @@ class MyFrame extends Frame implements ActionListener, WindowListener {
         add(mc1);
         mc2 = new MyComponent(Color.blue);
         add(mc2);
-        addWindowListener(this);
+        addWindowListener(new WindowAdapter() {
+            @Override
+            public void windowActivated(WindowEvent e) {
+                mc1.requestFocusInWindow();
+            }
+            @Override
+            public void windowDeactivated(WindowEvent e) {
+                mc2.requestFocusInWindow();
+            }
+        });
         setVisible(true);
     }
 
@@ -103,29 +113,6 @@ class MyFrame extends Frame implements ActionListener, WindowListener {
         mf2.setBounds(200, 200, 300, 300);
         mf2.setVisible(true);
         mf2.mc1.requestFocusInWindow();
-    }
-
-    public void windowOpened(WindowEvent e) {
-    }
-
-    public void windowClosing(WindowEvent e) {
-    }
-
-    public void windowClosed(WindowEvent e) {
-    }
-
-    public void windowIconified(WindowEvent e) {
-    }
-
-    public void windowDeiconified(WindowEvent e) {
-    }
-
-    public void windowActivated(WindowEvent e) {
-        mc1.requestFocusInWindow();
-    }
-
-    public void windowDeactivated(WindowEvent e) {
-        mc2.requestFocusInWindow();
     }
 }
 

--- a/test/jdk/java/awt/Container/MouseEnteredTest.java
+++ b/test/jdk/java/awt/Container/MouseEnteredTest.java
@@ -85,33 +85,39 @@ public class MouseEnteredTest extends JFrame implements ActionListener {
     }
 
     public static void main(String[] args) throws Exception {
-        EventQueue.invokeAndWait(() -> {
-            test = new MouseEnteredTest();
-        });
+        try {
+            EventQueue.invokeAndWait(() -> {
+                test = new MouseEnteredTest();
+            });
 
-        Robot robot = new Robot();
-        robot.setAutoWaitForIdle(true);
-        robot.waitForIdle();
-        robot.delay(250);
+            Robot robot = new Robot();
+            robot.setAutoWaitForIdle(true);
+            robot.waitForIdle();
+            robot.delay(250);
 
-        EventQueue.invokeAndWait(() -> {
-            p = m.getLocationOnScreen();
-            p2 = menu.getLocationOnScreen();
-        });
-        robot.waitForIdle();
-        robot.delay(250);
-        robot.mouseMove(p.x + 5, p.y + 10);
-        robot.waitForIdle();
+            EventQueue.invokeAndWait(() -> {
+                p = m.getLocationOnScreen();
+                p2 = menu.getLocationOnScreen();
+            });
+            robot.waitForIdle();
+            robot.delay(250);
+            robot.mouseMove(p.x + 5, p.y + 10);
+            robot.waitForIdle();
 
-        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
-        for (int i = p.x; i < p2.x + 10; i = i + 2) {
-            robot.mouseMove(i, p2.y + 10);
-        }
-        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
-        robot.delay(2000);
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+            for (int i = p.x; i < p2.x + 10; i = i + 2) {
+                robot.mouseMove(i, p2.y + 10);
+            }
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+            robot.delay(2000);
 
-        if (m.isPopupMenuVisible()) {
-            throw new RuntimeException("First menu is showing. Test Failed.");
+            if (m.isPopupMenuVisible()) {
+                throw new RuntimeException("First menu is showing. Test Failed.");
+            }
+        } finally {
+            if (test != null) {
+                EventQueue.invokeAndWait(test::dispose);
+            }
         }
     }
 

--- a/test/jdk/java/awt/Container/MouseEnteredTest.java
+++ b/test/jdk/java/awt/Container/MouseEnteredTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Component;
+import java.awt.EventQueue;
+import java.awt.Point;
+import java.awt.Robot;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
+import javax.swing.ButtonGroup;
+import javax.swing.JCheckBoxMenuItem;
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.JMenuItem;
+import javax.swing.JPopupMenu;
+import javax.swing.JRadioButtonMenuItem;
+import javax.swing.JTextArea;
+import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+
+/*
+ * @test
+ * @bug 4159745
+ * @key headful
+ * @summary Mediumweight popup dragging broken
+ * @run main MouseEnteredTest
+ */
+
+public class MouseEnteredTest extends JFrame implements ActionListener {
+    static volatile MouseEnteredTest test;
+    static volatile Point p;
+    static volatile Point p2;
+
+    static String strMotif = "Motif";
+    static String motifClassName = "com.sun.java.swing.plaf.motif.MotifLookAndFeel";
+    static char cMotif = 'o';
+
+    static String strWindows = "Windows";
+    static String windowsClassName = "com.sun.java.swing.plaf.windows.WindowsLookAndFeel";
+    static char cWindows = 'W';
+
+    static String strMetal = "Metal";
+    static String metalClassName = "javax.swing.plaf.metal.MetalLookAndFeel";
+    static char cMetal = 'M';
+
+    static JMenu m;
+    static JMenu menu;
+
+    static MouseListener ml = new MouseEnteredTest.MouseEventListener();
+
+    public MouseEnteredTest() {
+        JPopupMenu.setDefaultLightWeightPopupEnabled(false);
+        setJMenuBar(getMyMenuBar());
+        getContentPane().add("Center", new JTextArea());
+        setSize(400, 500);
+        setLocationRelativeTo(null);
+        setVisible(true);
+    }
+
+    public static void main(String[] args) throws Exception {
+        EventQueue.invokeAndWait(() -> {
+            test = new MouseEnteredTest();
+        });
+
+        Robot robot = new Robot();
+        robot.setAutoWaitForIdle(true);
+        robot.waitForIdle();
+        robot.delay(250);
+
+        EventQueue.invokeAndWait(() -> {
+            p = m.getLocationOnScreen();
+            p2 = menu.getLocationOnScreen();
+        });
+        robot.waitForIdle();
+        robot.delay(250);
+        robot.mouseMove(p.x + 5, p.y + 10);
+        robot.waitForIdle();
+
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
+        for (int i = p.x; i < p2.x + 10; i = i + 2) {
+            robot.mouseMove(i, p2.y + 10);
+        }
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
+        robot.delay(2000);
+
+        if (m.isPopupMenuVisible()) {
+            throw new RuntimeException("First menu is showing. Test Failed.");
+        }
+    }
+
+    public JMenuBar getMyMenuBar() {
+        JMenuBar menubar;
+        JMenuItem menuItem;
+
+        menubar = GetLNFMenuBar();
+
+        menu = menubar.add(new JMenu("Test"));
+        menu.setName("Test");
+        menu.addMouseListener(ml);
+        menu.setMnemonic('T');
+        menuItem = menu.add(new JMenuItem("Menu Item"));
+        menuItem.addActionListener(this);
+        menuItem.setMnemonic('M');
+        menuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_M, ActionEvent.ALT_MASK));
+
+        JRadioButtonMenuItem mi = new JRadioButtonMenuItem("Radio Button");
+        mi.addActionListener(this);
+        mi.setMnemonic('R');
+        mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_R, ActionEvent.ALT_MASK));
+        menu.add(mi);
+
+        JCheckBoxMenuItem mi1 = new JCheckBoxMenuItem("Check Box");
+        mi1.addActionListener(this);
+        mi1.setMnemonic('C');
+        mi1.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_C, ActionEvent.ALT_MASK));
+        menu.add(mi1);
+        return menubar;
+    }
+
+    public void actionPerformed(ActionEvent e) {
+        String str = e.getActionCommand();
+        if (str.equals(metalClassName) || str.equals(windowsClassName) || str.equals(motifClassName)) {
+            changeLNF(str);
+        } else {
+            System.out.println("ActionEvent: " + str);
+        }
+    }
+
+    public void changeLNF(String str) {
+        System.out.println("Changing LNF to " + str);
+        try {
+            UIManager.setLookAndFeel(str);
+            SwingUtilities.updateComponentTreeUI(this);
+            pack();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public JMenuBar GetLNFMenuBar() {
+        JMenuBar mbar = new JMenuBar();
+        m = new JMenu("Look and Feel");
+        m.setName("Look and Feel");
+        m.addMouseListener(ml);
+        m.setMnemonic('L');
+        ButtonGroup bg = new ButtonGroup();
+
+        JRadioButtonMenuItem mi;
+
+        mi = new JRadioButtonMenuItem(strMetal);
+        mi.addActionListener(this);
+        mi.setActionCommand(metalClassName);
+        mi.setMnemonic(cMetal);
+        mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_1, ActionEvent.ALT_MASK));
+        mi.setSelected(true);
+        bg.add(mi);
+        m.add(mi);
+
+        mi = new JRadioButtonMenuItem(strWindows);
+        mi.addActionListener(this);
+        mi.setActionCommand(windowsClassName);
+        mi.setMnemonic(cWindows);
+        mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_2, ActionEvent.ALT_MASK));
+        bg.add(mi);
+        m.add(mi);
+
+        mi = new JRadioButtonMenuItem(strMotif);
+        mi.addActionListener(this);
+        mi.setActionCommand(motifClassName);
+        mi.setMnemonic(cMotif);
+        mi.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_3, ActionEvent.ALT_MASK));
+        bg.add(mi);
+        m.add(mi);
+
+        mbar.add(m);
+        return mbar;
+    }
+
+    static class MouseEventListener implements MouseListener, MouseMotionListener {
+        public void mouseClicked(MouseEvent e) {
+            System.out.println("In mouseClicked for " + e.getComponent().getName());
+        }
+
+        public void mousePressed(MouseEvent e) {
+            Component c = e.getComponent();
+            System.out.println("In mousePressed for " + c.getName());
+        }
+
+        public void mouseReleased(MouseEvent e) {
+            System.out.println("In mouseReleased for " + e.getComponent().getName());
+        }
+
+        public void mouseEntered(MouseEvent e) {
+            System.out.println("In mouseEntered for " + e.getComponent().getName());
+            System.out.println("MouseEvent:" + e.getComponent());
+        }
+
+        public void mouseExited(MouseEvent e) {
+            System.out.println("In mouseExited for " + e.getComponent().getName());
+        }
+
+        public void mouseDragged(MouseEvent e) {
+            System.out.println("In mouseDragged for " + e.getComponent().getName());
+        }
+
+        public void mouseMoved(MouseEvent e) {
+            System.out.println("In mouseMoved for " + e.getComponent().getName());
+        }
+    }
+}

--- a/test/jdk/java/awt/Container/MouseEnteredTest.java
+++ b/test/jdk/java/awt/Container/MouseEnteredTest.java
@@ -76,6 +76,7 @@ public class MouseEnteredTest extends JFrame implements ActionListener {
     static MouseListener ml = new MouseEnteredTest.MouseEventListener();
 
     public MouseEnteredTest() {
+        setTitle("MouseEnteredTest");
         JPopupMenu.setDefaultLightWeightPopupEnabled(false);
         setJMenuBar(getMyMenuBar());
         getContentPane().add("Center", new JTextArea());
@@ -93,7 +94,7 @@ public class MouseEnteredTest extends JFrame implements ActionListener {
             Robot robot = new Robot();
             robot.setAutoWaitForIdle(true);
             robot.waitForIdle();
-            robot.delay(250);
+            robot.delay(1000);
 
             EventQueue.invokeAndWait(() -> {
                 p = m.getLocationOnScreen();

--- a/test/jdk/java/awt/Dialog/ModalExcludedTest.java
+++ b/test/jdk/java/awt/Dialog/ModalExcludedTest.java
@@ -1,0 +1,333 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.GridLayout;
+import java.awt.JobAttributes;
+import java.awt.PageAttributes;
+import java.awt.Panel;
+import java.awt.PrintJob;
+import java.awt.TextArea;
+import java.awt.Toolkit;
+import java.awt.Window;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.KeyAdapter;
+import java.awt.event.KeyEvent;
+import java.awt.event.KeyListener;
+import java.awt.event.MouseAdapter;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
+import java.awt.event.WindowAdapter;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowListener;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+
+import sun.awt.SunToolkit;
+
+/*
+ * @test
+ * @bug 4813288 4866704
+ * @summary Test for "modal exclusion" functionality
+ * @library /open/test/jdk/java/awt/regtesthelpers /open/test/lib
+ * @build PassFailJFrame
+ * @modules java.desktop/sun.awt
+ * @run main/manual ModalExcludedTest
+ */
+
+public class ModalExcludedTest {
+    private static final String INSTRUCTIONS = """
+            1. Press 'Modal dialog w/o modal excluded' button below
+                A window, a modeless dialog and a modal dialog will appear
+                Make sure the frame and the modeless dialog are inaccessible,
+                i.e. receive no mouse and keyboard events. MousePressed and
+                KeyPressed events are logged in the text area below - use it
+                to watch events
+            Close all 3 windows
+
+            2. Press 'Modal dialog w/ modal excluded' button below
+                Again, 3 windows will appear (frame, dialog, modal dialog),
+                but the frame and the dialog would be modal excluded, i.e.
+                behave the same way as there is no modal dialog shown. Verify
+                this by pressing mouse buttons and typing any keys. The
+                RootFrame would be modal blocked - verify this too
+            Close all 3 windows
+
+            3. Repeat step 2 for file and print dialogs using appropriate
+                buttons below
+
+            Notes: if there is no printer installed in the system you may not
+                get any print dialogs
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ModalExcludedTest")
+                .instructions(INSTRUCTIONS)
+                .rows(10)
+                .columns(35)
+                .testUI(ModalExcludedTest::createGUIs)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUIs() {
+        final Frame f = new Frame("RootFrame");
+        f.setBounds(0, 0, 480, 500);
+        f.setLayout(new BorderLayout());
+
+        final TextArea messages = new TextArea();
+
+        final WindowListener wl = new WindowAdapter() {
+            public void windowClosing(WindowEvent ev) {
+                if (ev.getSource() instanceof Window) {
+                    ((Window) ev.getSource()).dispose();
+                }
+            }
+        };
+        final MouseListener ml = new MouseAdapter() {
+            public void mousePressed(MouseEvent ev) {
+                messages.append(ev + "\n");
+            }
+        };
+        final KeyListener kl = new KeyAdapter() {
+            public void keyPressed(KeyEvent ev) {
+                messages.append(ev + "\n");
+            }
+        };
+
+        if (!SunToolkit.isModalExcludedSupported()) {
+            throw new jtreg.SkippedException("Modal exclude is not supported on this platform.");
+        }
+
+        messages.addMouseListener(ml);
+        messages.addKeyListener(kl);
+        f.add(messages, BorderLayout.CENTER);
+
+        Panel buttons = new Panel();
+        buttons.setLayout(new GridLayout(6, 1));
+
+        Button b = new Button("Modal dialog w/o modal excluded");
+        b.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                Frame ff = new Frame("Non-modal-excluded frame");
+                ff.setBounds(400, 0, 200, 100);
+                ff.addWindowListener(wl);
+                ff.addMouseListener(ml);
+                ff.addKeyListener(kl);
+                ff.setVisible(true);
+
+                Dialog dd = new Dialog(ff, "Non-modal-excluded dialog", false);
+                dd.setBounds(500, 100, 200, 100);
+                dd.addWindowListener(wl);
+                dd.addMouseListener(ml);
+                dd.addKeyListener(kl);
+                dd.setVisible(true);
+
+                Dialog d = new Dialog(f, "Modal dialog", true);
+                d.setBounds(600, 200, 200, 100);
+                d.addWindowListener(wl);
+                d.addMouseListener(ml);
+                d.addKeyListener(kl);
+                d.setVisible(true);
+            }
+        });
+        buttons.add(b);
+
+        Button c = new Button("Modal dialog w/ modal excluded");
+        c.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                JFrame ff = new JFrame("Modal-excluded frame");
+                ff.setBounds(400, 0, 200, 100);
+                ff.addWindowListener(wl);
+                ff.addMouseListener(ml);
+                ff.addKeyListener(kl);
+                JMenuBar mb = new JMenuBar();
+                JMenu m = new JMenu("Test menu");
+                m.add("Test menu item");
+                m.add("Test menu item");
+                m.add("Test menu item");
+                m.add("Test menu item");
+                m.add("Test menu item");
+                m.add("Test menu item");
+                m.add("Test menu item");
+                m.add("Test menu item");
+                m.add("Test menu item");
+                mb.add(m);
+                ff.setJMenuBar(mb);
+                // 1: set visible
+                ff.setVisible(true);
+
+                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+                dd.setBounds(500, 100, 200, 100);
+                dd.addWindowListener(wl);
+                dd.addMouseListener(ml);
+                dd.addKeyListener(kl);
+                dd.setVisible(true);
+                // dialog should be modal excluded as being a child of the modal excluded frame
+                //          SunToolkit.setModalExcluded(dd);
+
+                // 2: set modal excluded
+                SunToolkit.setModalExcluded(ff);
+
+                Dialog d = new Dialog(f, "Modal dialog", true);
+                d.setBounds(600, 200, 200, 100);
+                d.addWindowListener(wl);
+                d.addMouseListener(ml);
+                d.addKeyListener(kl);
+                d.setVisible(true);
+            }
+        });
+        buttons.add(c);
+
+        Button c1 = new Button("Modal dialog before modal excluded");
+        c1.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                // 1: create dialog
+                Dialog d = new Dialog(f, "Modal dialog", true);
+                d.setBounds(600, 200, 200, 100);
+                d.addWindowListener(wl);
+                d.addMouseListener(ml);
+                d.addKeyListener(kl);
+
+                // 2: create frame
+                Frame ff = new Frame("Modal-excluded frame");
+                // 3: set modal excluded
+                SunToolkit.setModalExcluded(ff);
+                ff.setBounds(400, 0, 200, 100);
+                ff.addWindowListener(wl);
+                ff.addMouseListener(ml);
+                ff.addKeyListener(kl);
+                // 4: show frame
+                ff.setVisible(true);
+
+                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+                dd.setBounds(500, 100, 200, 100);
+                dd.addWindowListener(wl);
+                dd.addMouseListener(ml);
+                dd.addKeyListener(kl);
+                dd.setVisible(true);
+
+                // 5: show dialog
+                d.setVisible(true);
+            }
+        });
+        buttons.add(c1);
+
+        Button d = new Button("File dialog w/ modal excluded");
+        d.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                Frame ff = new Frame("Modal-excluded frame");
+                ff.setBounds(400, 0, 200, 100);
+                ff.addWindowListener(wl);
+                ff.addMouseListener(ml);
+                ff.addKeyListener(kl);
+                // 1: set modal excluded (peer is not created yet)
+                SunToolkit.setModalExcluded(ff);
+                // 2: set visible
+                ff.setVisible(true);
+
+                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+                dd.setBounds(500, 100, 200, 100);
+                dd.addWindowListener(wl);
+                dd.addMouseListener(ml);
+                dd.addKeyListener(kl);
+                dd.setVisible(true);
+                SunToolkit.setModalExcluded(dd);
+
+                Dialog d = new FileDialog(f, "File dialog");
+                d.setVisible(true);
+            }
+        });
+        buttons.add(d);
+
+        Button e = new Button("Native print dialog w/ modal excluded");
+        e.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                Frame ff = new Frame("Modal-excluded frame");
+                ff.setBounds(400, 0, 200, 100);
+                ff.addWindowListener(wl);
+                ff.addMouseListener(ml);
+                ff.addKeyListener(kl);
+                ff.setVisible(true);
+                SunToolkit.setModalExcluded(ff);
+
+                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+                dd.setBounds(500, 100, 200, 100);
+                dd.addWindowListener(wl);
+                dd.addMouseListener(ml);
+                dd.addKeyListener(kl);
+                dd.setVisible(true);
+                // dialog should be modal excluded as being child of modal excluded frame
+                //          SunToolkit.setModalExcluded(dd);
+
+                JobAttributes jobAttributes = new JobAttributes();
+                jobAttributes.setDialog(JobAttributes.DialogType.NATIVE);
+                PageAttributes pageAttributes = new PageAttributes();
+                PrintJob job = Toolkit.getDefaultToolkit().getPrintJob(f, "Test", jobAttributes, pageAttributes);
+            }
+        });
+        buttons.add(e);
+
+        Button g = new Button("Common print dialog w/ modal excluded");
+        g.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent ev) {
+                Frame ff = new Frame("Modal-excluded frame");
+                ff.setBounds(400, 0, 200, 100);
+                ff.addWindowListener(wl);
+                ff.addMouseListener(ml);
+                ff.addKeyListener(kl);
+                ff.setVisible(true);
+                SunToolkit.setModalExcluded(ff);
+                ff.dispose();
+                // modal excluded must still be alive
+                ff.setVisible(true);
+
+                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+                dd.setBounds(500, 100, 200, 100);
+                dd.addWindowListener(wl);
+                dd.addMouseListener(ml);
+                dd.addKeyListener(kl);
+                dd.setVisible(true);
+                // dialog should be modal excluded as being child of modal excluded frame
+                //          SunToolkit.setModalExcluded(dd);
+
+                JobAttributes jobAttributes = new JobAttributes();
+                jobAttributes.setDialog(JobAttributes.DialogType.COMMON);
+                PageAttributes pageAttributes = new PageAttributes();
+                PrintJob job = Toolkit.getDefaultToolkit().getPrintJob(f, "Test", jobAttributes, pageAttributes);
+            }
+        });
+        buttons.add(g);
+
+        f.add(buttons, BorderLayout.SOUTH);
+        return f;
+    }
+}

--- a/test/jdk/java/awt/Dialog/ModalExcludedTest.java
+++ b/test/jdk/java/awt/Dialog/ModalExcludedTest.java
@@ -68,7 +68,7 @@ public class ModalExcludedTest {
                 A window, a modeless dialog and a modal dialog will appear
                 Make sure the frame and the modeless dialog are inaccessible,
                 i.e. receive no mouse and keyboard events. MousePressed and
-                KeyPressed events are logged in the text area below - use it
+                KeyPressed events are logged in the text area - use it
                 to watch events
             Close all 3 windows
 

--- a/test/jdk/java/awt/Dialog/ModalExcludedTest.java
+++ b/test/jdk/java/awt/Dialog/ModalExcludedTest.java
@@ -56,7 +56,7 @@ import sun.awt.SunToolkit;
  * @test
  * @bug 4813288 4866704
  * @summary Test for "modal exclusion" functionality
- * @library /open/test/jdk/java/awt/regtesthelpers /open/test/lib
+ * @library /java/awt/regtesthelpers /open/test/lib
  * @build PassFailJFrame
  * @modules java.desktop/sun.awt
  * @run main/manual ModalExcludedTest

--- a/test/jdk/java/awt/Dialog/ModalExcludedTest.java
+++ b/test/jdk/java/awt/Dialog/ModalExcludedTest.java
@@ -56,7 +56,7 @@ import sun.awt.SunToolkit;
  * @test
  * @bug 4813288 4866704
  * @summary Test for "modal exclusion" functionality
- * @library /java/awt/regtesthelpers /open/test/lib
+ * @library /java/awt/regtesthelpers /test/lib
  * @build PassFailJFrame
  * @modules java.desktop/sun.awt
  * @run main/manual ModalExcludedTest

--- a/test/jdk/java/awt/Dialog/ModalExcludedTest.java
+++ b/test/jdk/java/awt/Dialog/ModalExcludedTest.java
@@ -135,195 +135,177 @@ public class ModalExcludedTest {
         buttons.setLayout(new GridLayout(6, 1));
 
         Button b = new Button("Modal dialog w/o modal excluded");
-        b.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                Frame ff = new Frame("Non-modal-excluded frame");
-                ff.setBounds(400, 0, 200, 100);
-                ff.addWindowListener(wl);
-                ff.addMouseListener(ml);
-                ff.addKeyListener(kl);
-                ff.setVisible(true);
+        b.addActionListener(ev -> {
+            Frame ff = new Frame("Non-modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            ff.setVisible(true);
 
-                Dialog dd = new Dialog(ff, "Non-modal-excluded dialog", false);
-                dd.setBounds(500, 100, 200, 100);
-                dd.addWindowListener(wl);
-                dd.addMouseListener(ml);
-                dd.addKeyListener(kl);
-                dd.setVisible(true);
+            Dialog dd = new Dialog(ff, "Non-modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
 
-                Dialog d = new Dialog(f, "Modal dialog", true);
-                d.setBounds(600, 200, 200, 100);
-                d.addWindowListener(wl);
-                d.addMouseListener(ml);
-                d.addKeyListener(kl);
-                d.setVisible(true);
-            }
+            Dialog d = new Dialog(f, "Modal dialog", true);
+            d.setBounds(600, 200, 200, 100);
+            d.addWindowListener(wl);
+            d.addMouseListener(ml);
+            d.addKeyListener(kl);
+            d.setVisible(true);
         });
         buttons.add(b);
 
         Button c = new Button("Modal dialog w/ modal excluded");
-        c.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                JFrame ff = new JFrame("Modal-excluded frame");
-                ff.setBounds(400, 0, 200, 100);
-                ff.addWindowListener(wl);
-                ff.addMouseListener(ml);
-                ff.addKeyListener(kl);
-                JMenuBar mb = new JMenuBar();
-                JMenu m = new JMenu("Test menu");
-                m.add("Test menu item");
-                m.add("Test menu item");
-                m.add("Test menu item");
-                m.add("Test menu item");
-                m.add("Test menu item");
-                m.add("Test menu item");
-                m.add("Test menu item");
-                m.add("Test menu item");
-                m.add("Test menu item");
-                mb.add(m);
-                ff.setJMenuBar(mb);
-                // 1: set visible
-                ff.setVisible(true);
+        c.addActionListener(ev -> {
+            JFrame ff = new JFrame("Modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            JMenuBar mb = new JMenuBar();
+            JMenu m = new JMenu("Test menu");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            m.add("Test menu item");
+            mb.add(m);
+            ff.setJMenuBar(mb);
+            // 1: set visible
+            ff.setVisible(true);
 
-                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
-                dd.setBounds(500, 100, 200, 100);
-                dd.addWindowListener(wl);
-                dd.addMouseListener(ml);
-                dd.addKeyListener(kl);
-                dd.setVisible(true);
-                // dialog should be modal excluded as being a child of the modal excluded frame
-                //          SunToolkit.setModalExcluded(dd);
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
 
-                // 2: set modal excluded
-                SunToolkit.setModalExcluded(ff);
+            // 2: set modal excluded
+            SunToolkit.setModalExcluded(ff);
 
-                Dialog d = new Dialog(f, "Modal dialog", true);
-                d.setBounds(600, 200, 200, 100);
-                d.addWindowListener(wl);
-                d.addMouseListener(ml);
-                d.addKeyListener(kl);
-                d.setVisible(true);
-            }
+            Dialog d = new Dialog(f, "Modal dialog", true);
+            d.setBounds(600, 200, 200, 100);
+            d.addWindowListener(wl);
+            d.addMouseListener(ml);
+            d.addKeyListener(kl);
+            d.setVisible(true);
         });
         buttons.add(c);
 
         Button c1 = new Button("Modal dialog before modal excluded");
-        c1.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                // 1: create dialog
-                Dialog d = new Dialog(f, "Modal dialog", true);
-                d.setBounds(600, 200, 200, 100);
-                d.addWindowListener(wl);
-                d.addMouseListener(ml);
-                d.addKeyListener(kl);
+        c1.addActionListener(ev -> {
+            // 1: create dialog
+            Dialog d = new Dialog(f, "Modal dialog", true);
+            d.setBounds(600, 200, 200, 100);
+            d.addWindowListener(wl);
+            d.addMouseListener(ml);
+            d.addKeyListener(kl);
 
-                // 2: create frame
-                Frame ff = new Frame("Modal-excluded frame");
-                // 3: set modal excluded
-                SunToolkit.setModalExcluded(ff);
-                ff.setBounds(400, 0, 200, 100);
-                ff.addWindowListener(wl);
-                ff.addMouseListener(ml);
-                ff.addKeyListener(kl);
-                // 4: show frame
-                ff.setVisible(true);
+            // 2: create frame
+            Frame ff = new Frame("Modal-excluded frame");
+            // 3: set modal excluded
+            SunToolkit.setModalExcluded(ff);
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            // 4: show frame
+            ff.setVisible(true);
 
-                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
-                dd.setBounds(500, 100, 200, 100);
-                dd.addWindowListener(wl);
-                dd.addMouseListener(ml);
-                dd.addKeyListener(kl);
-                dd.setVisible(true);
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
 
-                // 5: show dialog
-                d.setVisible(true);
-            }
+            // 5: show dialog
+            d.setVisible(true);
         });
         buttons.add(c1);
 
         Button d = new Button("File dialog w/ modal excluded");
-        d.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                Frame ff = new Frame("Modal-excluded frame");
-                ff.setBounds(400, 0, 200, 100);
-                ff.addWindowListener(wl);
-                ff.addMouseListener(ml);
-                ff.addKeyListener(kl);
-                // 1: set modal excluded (peer is not created yet)
-                SunToolkit.setModalExcluded(ff);
-                // 2: set visible
-                ff.setVisible(true);
+        d.addActionListener(ev -> {
+            Frame ff = new Frame("Modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            // 1: set modal excluded (peer is not created yet)
+            SunToolkit.setModalExcluded(ff);
+            // 2: set visible
+            ff.setVisible(true);
 
-                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
-                dd.setBounds(500, 100, 200, 100);
-                dd.addWindowListener(wl);
-                dd.addMouseListener(ml);
-                dd.addKeyListener(kl);
-                dd.setVisible(true);
-                SunToolkit.setModalExcluded(dd);
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
+            SunToolkit.setModalExcluded(dd);
 
-                Dialog d = new FileDialog(f, "File dialog");
-                d.setVisible(true);
-            }
+            Dialog d1 = new FileDialog(f, "File dialog");
+            d1.setVisible(true);
         });
         buttons.add(d);
 
         Button e = new Button("Native print dialog w/ modal excluded");
-        e.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                Frame ff = new Frame("Modal-excluded frame");
-                ff.setBounds(400, 0, 200, 100);
-                ff.addWindowListener(wl);
-                ff.addMouseListener(ml);
-                ff.addKeyListener(kl);
-                ff.setVisible(true);
-                SunToolkit.setModalExcluded(ff);
+        e.addActionListener(ev -> {
+            Frame ff = new Frame("Modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            ff.setVisible(true);
+            SunToolkit.setModalExcluded(ff);
 
-                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
-                dd.setBounds(500, 100, 200, 100);
-                dd.addWindowListener(wl);
-                dd.addMouseListener(ml);
-                dd.addKeyListener(kl);
-                dd.setVisible(true);
-                // dialog should be modal excluded as being child of modal excluded frame
-                //          SunToolkit.setModalExcluded(dd);
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
 
-                JobAttributes jobAttributes = new JobAttributes();
-                jobAttributes.setDialog(JobAttributes.DialogType.NATIVE);
-                PageAttributes pageAttributes = new PageAttributes();
-                PrintJob job = Toolkit.getDefaultToolkit().getPrintJob(f, "Test", jobAttributes, pageAttributes);
-            }
+            JobAttributes jobAttributes = new JobAttributes();
+            jobAttributes.setDialog(JobAttributes.DialogType.NATIVE);
+            PageAttributes pageAttributes = new PageAttributes();
+            PrintJob job = Toolkit.getDefaultToolkit().getPrintJob(f, "Test", jobAttributes, pageAttributes);
         });
         buttons.add(e);
 
         Button g = new Button("Common print dialog w/ modal excluded");
-        g.addActionListener(new ActionListener() {
-            public void actionPerformed(ActionEvent ev) {
-                Frame ff = new Frame("Modal-excluded frame");
-                ff.setBounds(400, 0, 200, 100);
-                ff.addWindowListener(wl);
-                ff.addMouseListener(ml);
-                ff.addKeyListener(kl);
-                ff.setVisible(true);
-                SunToolkit.setModalExcluded(ff);
-                ff.dispose();
-                // modal excluded must still be alive
-                ff.setVisible(true);
+        g.addActionListener(ev -> {
+            Frame ff = new Frame("Modal-excluded frame");
+            ff.setBounds(400, 0, 200, 100);
+            ff.addWindowListener(wl);
+            ff.addMouseListener(ml);
+            ff.addKeyListener(kl);
+            ff.setVisible(true);
+            SunToolkit.setModalExcluded(ff);
+            ff.dispose();
+            // modal excluded must still be alive
+            ff.setVisible(true);
 
-                Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
-                dd.setBounds(500, 100, 200, 100);
-                dd.addWindowListener(wl);
-                dd.addMouseListener(ml);
-                dd.addKeyListener(kl);
-                dd.setVisible(true);
-                // dialog should be modal excluded as being child of modal excluded frame
-                //          SunToolkit.setModalExcluded(dd);
+            Dialog dd = new Dialog(ff, "Modal-excluded dialog", false);
+            dd.setBounds(500, 100, 200, 100);
+            dd.addWindowListener(wl);
+            dd.addMouseListener(ml);
+            dd.addKeyListener(kl);
+            dd.setVisible(true);
 
-                JobAttributes jobAttributes = new JobAttributes();
-                jobAttributes.setDialog(JobAttributes.DialogType.COMMON);
-                PageAttributes pageAttributes = new PageAttributes();
-                PrintJob job = Toolkit.getDefaultToolkit().getPrintJob(f, "Test", jobAttributes, pageAttributes);
-            }
+            JobAttributes jobAttributes = new JobAttributes();
+            jobAttributes.setDialog(JobAttributes.DialogType.COMMON);
+            PageAttributes pageAttributes = new PageAttributes();
+            PrintJob job = Toolkit.getDefaultToolkit().getPrintJob(f, "Test", jobAttributes, pageAttributes);
         });
         buttons.add(g);
 


### PR DESCRIPTION
Fifth set of swing test to open for fall 2024 test sprint

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340494](https://bugs.openjdk.org/browse/JDK-8340494): Open some dialog awt tests 4 (**Bug** - P4)


### Reviewers
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21479/head:pull/21479` \
`$ git checkout pull/21479`

Update a local copy of the PR: \
`$ git checkout pull/21479` \
`$ git pull https://git.openjdk.org/jdk.git pull/21479/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21479`

View PR using the GUI difftool: \
`$ git pr show -t 21479`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21479.diff">https://git.openjdk.org/jdk/pull/21479.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21479#issuecomment-2408185740)