### PR TITLE
8338126 : C2 SuperWord: VectorCastF2HF / vcvtps2ph produces wrong results for vector length 2

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -3676,6 +3676,7 @@ instruct vconvF2HF(vec dst, vec src) %{
 %}
 
 instruct vconvF2HF_mem_reg(memory mem, vec src) %{
+  predicate(Matcher::vector_length_in_bytes(n->in(3)->in(1)) >= 16);
   match(Set mem (StoreVector mem (VectorCastF2HF src)));
   format %{ "vcvtps2ph $mem,$src" %}
   ins_encode %{

--- a/test/hotspot/jtreg/compiler/vectorization/TestFloatConversionsVector.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestFloatConversionsVector.java
@@ -67,7 +67,16 @@ public class TestFloatConversionsVector {
         }
     }
 
-    @Run(test = {"test_float_float16", "test_float_float16_strided"}, mode = RunMode.STANDALONE)
+    @Test
+    public void test_float_float16_short_vector(short[] sout, float[] finp) {
+        for (int i = 0; i < finp.length - 1; i++) {
+            sout[i+0] = Float.floatToFloat16(finp[i+0]);
+            sout[i+1] = Float.floatToFloat16(finp[i+1]);
+        }
+    }
+
+    @Run(test = {"test_float_float16", "test_float_float16_strided",
+                 "test_float_float16_short_vector"}, mode = RunMode.STANDALONE)
     public void kernel_test_float_float16() {
         finp = new float[ARRLEN];
         sout = new short[ARRLEN];
@@ -92,6 +101,15 @@ public class TestFloatConversionsVector {
         // Verifying the result
         for (int i = 0; i < ARRLEN/2; i++) {
             Asserts.assertEquals(Float.floatToFloat16(finp[i*2]), sout[i*2]);
+        }
+
+        for (int i = 0; i < ITERS; i++) {
+            test_float_float16_short_vector(sout, finp);
+        }
+
+        // Verifying the result
+        for (int i = 0; i < ARRLEN; i++) {
+            Asserts.assertEquals(Float.floatToFloat16(finp[i]), sout[i]);
         }
     }
 


### PR DESCRIPTION
When Float.floatToFloat16 is vectorized using a 2-element vector width due to dependencies, we incorrectly generate a 4-element vcvtps2ph with memory as destination storing 8 bytes instead of desired 4 bytes.  This issue is fixed in this PR by limiting the memory version of match rule to 4-element and above.
Also a regression test case is added accordingly.

Best Regards,
Sandhya

 

