### PR TITLE
8342044: Increase timeout of gc/shenandoah/oom/TestClassLoaderLeak.java

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/oom/TestClassLoaderLeak.java
+++ b/test/hotspot/jtreg/gc/shenandoah/oom/TestClassLoaderLeak.java
@@ -27,7 +27,7 @@
  * @summary Test OOME in due to classloader leak
  * @requires vm.gc.Shenandoah
  * @library /test/lib
- * @run driver TestClassLoaderLeak
+ * @run driver/timeout=600 TestClassLoaderLeak
  */
 
 import java.util.*;


### PR DESCRIPTION
Test gc/shenandoah/oom/TestClassLoaderLeak.java often times out on WIndows, we should increase the timeout values to avoid test errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342044](https://bugs.openjdk.org/browse/JDK-8342044): Increase timeout of gc/shenandoah/oom/TestClassLoaderLeak.java (**Sub-task** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21491/head:pull/21491` \
`$ git checkout pull/21491`

Update a local copy of the PR: \
`$ git checkout pull/21491` \
`$ git pull https://git.openjdk.org/jdk.git pull/21491/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21491`

View PR using the GUI difftool: \
`$ git pr show -t 21491`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21491.diff">https://git.openjdk.org/jdk/pull/21491.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21491#issuecomment-2410976434)