### PR TITLE
8341901: Using 'var' keyword switch pattern matching causes compiler error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4188,6 +4188,7 @@ public class Attr extends JCTree.Visitor {
         if (chk.checkUnique(tree.var.pos(), v, env.info.scope)) {
             chk.checkTransparentVar(tree.var.pos(), v, env.info.scope);
         }
+        chk.validate(tree.var.vartype, env, true);
         if (tree.var.isImplicitlyTyped()) {
             setSyntheticVariableType(tree.var, type == Type.noType ? syms.errType
                                                                    : type);
@@ -4197,7 +4198,6 @@ public class Attr extends JCTree.Visitor {
             annotate.queueScanTreeAndTypeAnnotate(tree.var.vartype, env, v, tree.var.pos());
         }
         annotate.flush();
-        chk.validate(tree.var.vartype, env, true);
         result = tree.type;
         if (v.isUnnamedVariable()) {
             matchBindings = MatchBindingsComputer.EMPTY;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -727,14 +727,15 @@ public class TreeMaker implements JCTree.Factory {
                                 ? sym.name
                                 : sym.flatName(), sym)
             .setPos(pos)
-            .setType(sym.type);
+            .setType(types.erasure(sym.type));
     }
 
     /** Create a selection node from a qualifier tree and a symbol.
      *  @param base   The qualifier tree.
      */
     public JCFieldAccess Select(JCExpression base, Symbol sym) {
-        return (JCFieldAccess)new JCFieldAccess(base, sym.name, sym).setPos(pos).setType(sym.type);
+        return (JCFieldAccess)new JCFieldAccess(base, sym.name, sym).setPos(pos)
+                                                                    .setType(types.erasure(sym.type));
     }
 
     /** Create a qualified identifier from a symbol, adding enough qualifications

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -738,7 +738,7 @@ public class TreeMaker implements JCTree.Factory {
     }
 
     /** Create a qualified identifier from a symbol, adding enough qualifications
-     *  to make the reference unique.
+     *  to make the reference unique. The types in the AST nodes will be erased.
      */
     public JCExpression QualIdent(Symbol sym) {
         JCExpression result = isUnqualifiable(sym)

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -727,28 +727,29 @@ public class TreeMaker implements JCTree.Factory {
                                 ? sym.name
                                 : sym.flatName(), sym)
             .setPos(pos)
-            .setType(types.erasure(sym.type));
+            .setType(sym.type);
     }
 
     /** Create a selection node from a qualifier tree and a symbol.
      *  @param base   The qualifier tree.
      */
     public JCFieldAccess Select(JCExpression base, Symbol sym) {
-        JCFieldAccess res =
-                (JCFieldAccess)new JCFieldAccess(base, sym.name, sym).setPos(pos);
-
-        res.setType(sym.kind == TYP ? types.erasure(sym.type) : sym.type);
-
-        return res;
+        return (JCFieldAccess)new JCFieldAccess(base, sym.name, sym).setPos(pos).setType(sym.type);
     }
 
     /** Create a qualified identifier from a symbol, adding enough qualifications
      *  to make the reference unique.
      */
     public JCExpression QualIdent(Symbol sym) {
-        return isUnqualifiable(sym)
+        JCExpression result = isUnqualifiable(sym)
             ? Ident(sym)
             : Select(QualIdent(sym.owner), sym);
+
+        if (sym.kind == TYP) {
+            result.setType(types.erasure(sym.type));
+        }
+
+        return result;
     }
 
     /** Create an identifier that refers to the variable declared in given variable

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/tree/TreeMaker.java
@@ -734,8 +734,12 @@ public class TreeMaker implements JCTree.Factory {
      *  @param base   The qualifier tree.
      */
     public JCFieldAccess Select(JCExpression base, Symbol sym) {
-        return (JCFieldAccess)new JCFieldAccess(base, sym.name, sym).setPos(pos)
-                                                                    .setType(types.erasure(sym.type));
+        JCFieldAccess res =
+                (JCFieldAccess)new JCFieldAccess(base, sym.name, sym).setPos(pos);
+
+        res.setType(sym.kind == TYP ? types.erasure(sym.type) : sym.type);
+
+        return res;
     }
 
     /** Create a qualified identifier from a symbol, adding enough qualifications

--- a/test/langtools/tools/javac/patterns/BindingPatternVarTypeModel.java
+++ b/test/langtools/tools/javac/patterns/BindingPatternVarTypeModel.java
@@ -23,18 +23,28 @@
 
 /*
  * @test
- * @bug 8332725
+ * @bug 8332725 8341901
  * @summary Verify the AST model works correctly for binding patterns with var
  */
 
 import com.sun.source.tree.BindingPatternTree;
 import com.sun.source.tree.CompilationUnitTree;
+import com.sun.source.tree.IdentifierTree;
+import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
 import com.sun.source.util.JavacTask;
+import com.sun.source.util.TreePathScanner;
 import com.sun.source.util.TreeScanner;
+import com.sun.source.util.Trees;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
+import javax.tools.DiagnosticListener;
 import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.SimpleJavaFileObject;
@@ -45,6 +55,7 @@ public class BindingPatternVarTypeModel {
 
     public static void main(String... args) throws Exception {
         new BindingPatternVarTypeModel().run();
+        new BindingPatternVarTypeModel().runVarParameterized();
     }
 
     private void run() throws Exception {
@@ -85,5 +96,86 @@ public class BindingPatternVarTypeModel {
         if (!foundBindingPattern.get()) {
             throw new AssertionError("Didn't find the binding pattern!");
         }
+    }
+
+    private void runVarParameterized() throws Exception {
+        JavaFileObject input =
+                SimpleJavaFileObject.forSource(URI.create("mem:///Test.java"),
+                                               """
+                                               package test;
+                                               public class Test {
+                                                   record R(N.I i) {}
+                                                   int test(Object o) {
+                                                       Test.N.I checkType0 = null;
+                                                       var checkType1 = checkType0;
+                                                       return switch (o) {
+                                                           case R(var checkType2) -> 0;
+                                                           default -> 0;
+                                                       };
+                                                   }
+                                                   static class N<T> {
+                                                       interface I {}
+                                                   }
+                                               }
+                                               """);
+        DiagnosticListener<JavaFileObject> noErrors = d -> {
+            if (d.getKind() == Diagnostic.Kind.ERROR) {
+                throw new IllegalStateException(d.toString());
+            }
+        };
+        JavacTask task =
+                (JavacTask) compiler.getTask(null, null, noErrors, null, null, List.of(input));
+        CompilationUnitTree cut = task.parse().iterator().next();
+        Trees trees = Trees.instance(task);
+
+        task.analyze();
+
+        new TreePathScanner<Void, Void>() {
+            private boolean checkAttributes;
+            @Override
+            public Void visitVariable(VariableTree node, Void p) {
+                boolean prevCheckAttributes = checkAttributes;
+                try {
+                    checkAttributes |= 
+                            node.getName().toString().startsWith("checkType");
+                    return super.visitVariable(node, p);
+                } finally {
+                    checkAttributes = prevCheckAttributes;
+                }
+            }
+
+            @Override
+            public Void visitIdentifier(IdentifierTree node, Void p) {
+                checkType();
+                return super.visitIdentifier(node, p);
+            }
+
+            @Override
+            public Void visitMemberSelect(MemberSelectTree node, Void p) {
+                checkType();
+                return super.visitMemberSelect(node, p);
+            }
+
+            private void checkType() {
+                if (!checkAttributes) {
+                    return ;
+                }
+
+                TypeMirror type = trees.getTypeMirror(getCurrentPath());
+
+                if (type.getKind() == TypeKind.PACKAGE) {
+                    return ; //OK
+                }
+                if (type.getKind() != TypeKind.DECLARED) {
+                    throw new AssertionError("Expected a declared type, but got: " +
+                                             type.getKind());
+                }
+
+                if (!((DeclaredType) type).getTypeArguments().isEmpty()) {
+                    throw new AssertionError("Unexpected type arguments: " +
+                                             ((DeclaredType) type).getTypeArguments());
+                }
+            }
+        }.scan(cut, null);
     }
 }

--- a/test/langtools/tools/javac/patterns/BindingPatternVarTypeModel.java
+++ b/test/langtools/tools/javac/patterns/BindingPatternVarTypeModel.java
@@ -136,7 +136,7 @@ public class BindingPatternVarTypeModel {
             public Void visitVariable(VariableTree node, Void p) {
                 boolean prevCheckAttributes = checkAttributes;
                 try {
-                    checkAttributes |= 
+                    checkAttributes |=
                             node.getName().toString().startsWith("checkType");
                     return super.visitVariable(node, p);
                 } finally {


### PR DESCRIPTION
Consider code like:
```
public class T {
   record R(N.I i) {}
   int test(Object o) {
       return switch (o) {
           case R(var nested) -> 0;
           default -> 0;
       };
   }
   static class N<T> {
       interface I {}
   }
}
```

This fails to compile since JDK 23, due to:
```
$ javac T.java 
error: cannot select a static class from a parameterized type
1 error
```

The reason for the error is this: the type of `nested` is inferred to `T.N.I`. This is correct. javac will then construct a synthetic AST for it, and the AST will be structurally correct as well: `T.N.I`. But a) the `Type` attached to `T.N` will be `T.N<T>` (which by itself is not correct), and b) after the synthetic AST is created, `Check.validate` is called on the type's AST, and fails, as the types is sees correspond to `T.N<T>.I`, which is illegal.

Note the synthetic AST is also set for local variable type inference, but the `validate` is called *before* the synthetic AST is created.

This PR proposes to do two things:
- move the `validate` call before the synthetic AST creation for `visitBindingPattern`, to mimic the behavior for `var`s.
- the `TreeMaker` is tweaked to inject erased types instead of parameterized types when generating qualified identifiers for classes or interfaces. This should correspond more closely to what happens when one types `T.N.I` in the source code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341901](https://bugs.openjdk.org/browse/JDK-8341901): Using 'var' keyword switch pattern matching causes compiler error (**Bug** - P3)


### Reviewers
 * [Aggelos Biboudis](https://openjdk.org/census#abimpoudis) (@biboudis - **Reviewer**) Review applies to [7bf21b9c](https://git.openjdk.org/jdk/pull/21495/files/7bf21b9cf95912c9c0ff7ab10461e5d49d16f7b4)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21495/head:pull/21495` \
`$ git checkout pull/21495`

Update a local copy of the PR: \
`$ git checkout pull/21495` \
`$ git pull https://git.openjdk.org/jdk.git pull/21495/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21495`

View PR using the GUI difftool: \
`$ git pr show -t 21495`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21495.diff">https://git.openjdk.org/jdk/pull/21495.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21495#issuecomment-2411369592)
</details>
