### PR TITLE
8342042: PPC64: compiler_fast_unlock_object flags failure instead of success

### DIFF
--- a/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/macroAssembler_ppc.cpp
@@ -2741,7 +2741,7 @@ void MacroAssembler::compiler_fast_unlock_object(ConditionRegister flag, Registe
   cmpdi(flag, temp, 0);
   // Invert equal bit
   crnand(flag, Assembler::equal, flag, Assembler::equal);
-  beq(flag, success);  // There is a successor so we are done.
+  beq(flag, success);  // If there is a successor we are done.
 
   // Save the monitor pointer in the current thread, so we can try
   // to reacquire the lock in SharedRuntime::monitor_exit_helper().
@@ -3053,7 +3053,6 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
 
     bind(not_recursive);
 
-    Label set_eq_unlocked;
     const Register t2 = tmp2;
 
     // Set owner to null.
@@ -3075,17 +3074,14 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(ConditionRegister f
     // Check if there is a successor.
     ld(t, in_bytes(ObjectMonitor::succ_offset()), monitor);
     cmpdi(CCR0, t, 0);
-    bne(CCR0, set_eq_unlocked); // If so we are done.
+    // Invert equal bit
+    crnand(flag, Assembler::equal, flag, Assembler::equal);
+    beq(CCR0, unlocked); // If there is a successor we are done.
 
     // Save the monitor pointer in the current thread, so we can try
     // to reacquire the lock in SharedRuntime::monitor_exit_helper().
     std(monitor, in_bytes(JavaThread::unlocked_inflated_monitor_offset()), R16_thread);
-
-    crxor(CCR0, Assembler::equal, CCR0, Assembler::equal); // Set flag = NE => slow path
-    b(slow_path);
-
-    bind(set_eq_unlocked);
-    crorc(CCR0, Assembler::equal, CCR0, Assembler::equal); // Set flag = EQ => fast path
+    b(slow_path); // flag == NE
   }
 
   bind(unlocked);


### PR DESCRIPTION
This change inverts the `EQ` bit in `flag` with a condition register nand instruction in order to meet the post condition given at L2751-L2752:

```
  // flag == EQ indicates success, decrement held monitor count
  // flag == NE indicates failure
```

The fix passed our CI testing with LockingMode set to LM_LEGACY
Tier1-4 of hotspot and jdk. All of Langtools and jaxp. Renaissance Suite and SAP specific tests.
Testing was done on the main platforms and also on Linux/PPC64le and AIX.

The test runtime/logging/MonitorInflationTest.java failed on all platforms. Apparently it has issues with LM_LEGACY.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342042](https://bugs.openjdk.org/browse/JDK-8342042): PPC64: compiler_fast_unlock_object flags failure instead of success (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Fredrik Bredberg](https://openjdk.org/census#fbredberg) (@fbredber - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21496/head:pull/21496` \
`$ git checkout pull/21496`

Update a local copy of the PR: \
`$ git checkout pull/21496` \
`$ git pull https://git.openjdk.org/jdk.git pull/21496/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21496`

View PR using the GUI difftool: \
`$ git pr show -t 21496`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21496.diff">https://git.openjdk.org/jdk/pull/21496.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21496#issuecomment-2413047305)