### PR TITLE
8342002: sun/security/tools/keytool/GenKeyPairSigner.java failed due to missing certificate output

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -644,8 +644,6 @@ sun/security/provider/PolicyParser/PrincipalExpansionError.java 8039280 generic-
 
 sun/security/pkcs11/sslecc/ClientJSSEServerJSSE.java            8316183 linux-ppc64le
 
-sun/security/tools/keytool/GenKeyPairSigner.java                8342002 generic-all
-
 ############################################################################
 
 # jdk_sound

--- a/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
+++ b/test/jdk/sun/security/tools/keytool/GenKeyPairSigner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -84,7 +84,7 @@ public class GenKeyPairSigner {
         System.out.println("Generating an XDH cert with -signer option");
         SecurityTools.keytool("-keystore ks -storepass changeit " +
                 "-genkeypair -keyalg XDH -alias e1 -dname CN=E1 -signer ca")
-                .shouldContain("Generating 255 bit XDH key pair and a certificate (Ed25519) issued by <ca> with a validity of 90 days")
+                .shouldContain("Generating 255 bit X25519 key pair and a certificate (Ed25519) issued by <ca> with a validity of 90 days")
                 .shouldContain("for: CN=E1")
                 .shouldHaveExitValue(0);
 
@@ -118,7 +118,7 @@ public class GenKeyPairSigner {
                 .shouldContain("Alias name: e1")
                 .shouldContain("Certificate chain length: 2")
                 .shouldContain("Signature algorithm name: Ed25519")
-                .shouldContain("Subject Public Key Algorithm: 255-bit XDH key")
+                .shouldContain("Subject Public Key Algorithm: 255-bit X25519 key")
                 .shouldHaveExitValue(0);
 
         // check to make sure that cert's AKID is created from the SKID of the signing cert
@@ -150,7 +150,7 @@ public class GenKeyPairSigner {
         System.out.println("Generating an X448 cert with -signer option");
         SecurityTools.keytool("-keystore ks -storepass changeit " +
                 "-genkeypair -keyalg X448 -alias e2 -dname CN=E2 -sigalg SHA384withRSA -signer ca2")
-                .shouldContain("Generating 448 bit XDH key pair and a certificate (SHA384withRSA) issued by <ca2> with a validity of 90 days")
+                .shouldContain("Generating 448 bit X448 key pair and a certificate (SHA384withRSA) issued by <ca2> with a validity of 90 days")
                 .shouldContain("for: CN=E2")
                 .shouldHaveExitValue(0);
 
@@ -177,7 +177,7 @@ public class GenKeyPairSigner {
                 "-list -v")
                 .shouldContain("Alias name: e2")
                 .shouldContain("Signature algorithm name: SHA384withRSA")
-                .shouldContain("Subject Public Key Algorithm: 448-bit XDH key")
+                .shouldContain("Subject Public Key Algorithm: 448-bit X448 key")
                 .shouldHaveExitValue(0);
 
         kt("-genkeypair -keyalg DSA -alias ca3 -dname CN=CA3 -ext bc:c ",
@@ -249,7 +249,7 @@ public class GenKeyPairSigner {
         SecurityTools.keytool("-keystore ksjks -storepass changeit -storetype jks " +
                 "-genkeypair -keyalg XDH -alias e1 -dname CN=E1 " +
                 "-keypass e1keypass -signer ca1 -signerkeypass ca1keypass")
-                .shouldContain("Generating 255 bit XDH key pair and a certificate (SHA256withDSA) issued by <ca1> with a validity of 90 days")
+                .shouldContain("Generating 255 bit X25519 key pair and a certificate (SHA256withDSA) issued by <ca1> with a validity of 90 days")
                 .shouldContain("for: CN=E1")
                 .shouldContain("The generated certificate #2 of 3 uses a 1024-bit DSA key which is considered a security risk")
                 .shouldContain("The generated certificate #3 of 3 uses a 1024-bit RSA key which is considered a security risk")
@@ -285,7 +285,7 @@ public class GenKeyPairSigner {
                 .shouldContain("Alias name: e1")
                 .shouldContain("Certificate chain length: 3")
                 .shouldContain("Signature algorithm name: SHA256withDSA")
-                .shouldContain("Subject Public Key Algorithm: 255-bit XDH key")
+                .shouldContain("Subject Public Key Algorithm: 255-bit X25519 key")
                 .shouldHaveExitValue(0);
     }
 


### PR DESCRIPTION
Previous code change for [JDK-8340327](https://bugs.openjdk.org/browse/JDK-8340327) changed the display names for all keys with a `NamedParameterSpec` to be the parameter set name. This test is not updated.

I understand the current "255 bit X25519 key" looks redundant. I've filed an enhancement at [JDK-8342062](https://bugs.openjdk.org/browse/JDK-8342062) at a boarder scale on the keytool and jarsigner output messages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342002](https://bugs.openjdk.org/browse/JDK-8342002): sun/security/tools/keytool/GenKeyPairSigner.java failed due to missing certificate output (**Bug** - P2)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21499/head:pull/21499` \
`$ git checkout pull/21499`

Update a local copy of the PR: \
`$ git checkout pull/21499` \
`$ git pull https://git.openjdk.org/jdk.git pull/21499/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21499`

View PR using the GUI difftool: \
`$ git pr show -t 21499`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21499.diff">https://git.openjdk.org/jdk/pull/21499.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21499#issuecomment-2411354570)