### PR TITLE
8341997: Tests create files in src tree instead of scratch dir

### DIFF
--- a/test/jdk/java/io/FileInputStream/ReadXBytes.java
+++ b/test/jdk/java/io/FileInputStream/ReadXBytes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ public class ReadXBytes {
     private static final Random RND = RandomFactory.getRandom();
 
     public static void main(String args[]) throws IOException {
-        File dir = new File(System.getProperty("test.src", "."));
+        File dir = new File(System.getProperty("test.dir", "."));
         dir.deleteOnExit();
 
         File empty = File.createTempFile("foo", "bar", dir);

--- a/test/jdk/java/io/FileInputStream/ReadXBytes.java
+++ b/test/jdk/java/io/FileInputStream/ReadXBytes.java
@@ -45,7 +45,7 @@ public class ReadXBytes {
     private static final Random RND = RandomFactory.getRandom();
 
     public static void main(String args[]) throws IOException {
-        File dir = new File(System.getProperty("test.dir", "."));
+        File dir = new File(".");
         dir.deleteOnExit();
 
         File empty = File.createTempFile("foo", "bar", dir);

--- a/test/jdk/java/nio/MappedByteBuffer/ForceException.java
+++ b/test/jdk/java/nio/MappedByteBuffer/ForceException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,7 +40,7 @@ public class ForceException {
         int numberOfBlocks = 200;
         int fileLength = numberOfBlocks * blockSize;
 
-        File file = new File(System.getProperty("test.src", "."), "test.dat");
+        File file = new File(System.getProperty("test.dir", "."), "test.dat");
         file.deleteOnExit();
         try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
             raf.setLength(fileLength);

--- a/test/jdk/java/nio/MappedByteBuffer/ForceException.java
+++ b/test/jdk/java/nio/MappedByteBuffer/ForceException.java
@@ -40,7 +40,7 @@ public class ForceException {
         int numberOfBlocks = 200;
         int fileLength = numberOfBlocks * blockSize;
 
-        File file = new File(System.getProperty("test.dir", "."), "test.dat");
+        File file = new File(".", "test.dat");
         file.deleteOnExit();
         try (RandomAccessFile raf = new RandomAccessFile(file, "rw")) {
             raf.setLength(fileLength);

--- a/test/jdk/java/nio/MappedByteBuffer/ForceViews.java
+++ b/test/jdk/java/nio/MappedByteBuffer/ForceViews.java
@@ -51,7 +51,7 @@ public class ForceViews {
 
     @BeforeTest(alwaysRun=true)
     public void openChannel() throws IOException {
-        Path file = Path.of(System.getProperty("test.dir", "."), "junk");
+        Path file = Path.of(".", "junk");
         fc = FileChannel.open(file, CREATE_NEW, READ, WRITE, DELETE_ON_CLOSE);
         ByteBuffer buf = ByteBuffer.wrap(new byte[1024]);
         fc.write(buf);

--- a/test/jdk/java/nio/MappedByteBuffer/ForceViews.java
+++ b/test/jdk/java/nio/MappedByteBuffer/ForceViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,7 +51,7 @@ public class ForceViews {
 
     @BeforeTest(alwaysRun=true)
     public void openChannel() throws IOException {
-        Path file = Path.of(System.getProperty("test.src", "."), "junk");
+        Path file = Path.of(System.getProperty("test.dir", "."), "junk");
         fc = FileChannel.open(file, CREATE_NEW, READ, WRITE, DELETE_ON_CLOSE);
         ByteBuffer buf = ByteBuffer.wrap(new byte[1024]);
         fc.write(buf);


### PR DESCRIPTION
Change property `test.src` to `test.dir`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341997](https://bugs.openjdk.org/browse/JDK-8341997): Tests create files in src tree instead of scratch dir (**Bug** - P2)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21503/head:pull/21503` \
`$ git checkout pull/21503`

Update a local copy of the PR: \
`$ git checkout pull/21503` \
`$ git pull https://git.openjdk.org/jdk.git pull/21503/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21503`

View PR using the GUI difftool: \
`$ git pr show -t 21503`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21503.diff">https://git.openjdk.org/jdk/pull/21503.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21503#issuecomment-2411876692)