### PR TITLE
8342079: Shenandoah: Remove extra ShenandoahInitMarkRootsClosure

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahSTWMark.cpp
@@ -37,33 +37,6 @@
 #include "gc/shenandoah/shenandoahSTWMark.hpp"
 #include "gc/shenandoah/shenandoahVerifier.hpp"
 
-template<ShenandoahGenerationType GENERATION>
-class ShenandoahInitMarkRootsClosure : public OopClosure {
-private:
-  ShenandoahObjToScanQueue* const _queue;
-  ShenandoahMarkingContext* const _mark_context;
-
-  template <class T>
-  inline void do_oop_work(T* p);
-public:
-  ShenandoahInitMarkRootsClosure(ShenandoahObjToScanQueue* q);
-
-  void do_oop(narrowOop* p) { do_oop_work(p); }
-  void do_oop(oop* p)       { do_oop_work(p); }
-};
-
-template <ShenandoahGenerationType GENERATION>
-ShenandoahInitMarkRootsClosure<GENERATION>::ShenandoahInitMarkRootsClosure(ShenandoahObjToScanQueue* q) :
-  _queue(q),
-  _mark_context(ShenandoahHeap::heap()->marking_context()) {
-}
-
-template <ShenandoahGenerationType GENERATION>
-template <class T>
-void ShenandoahInitMarkRootsClosure<GENERATION>::do_oop_work(T* p) {
-  ShenandoahMark::mark_through_ref<T, GENERATION>(p, _queue, _mark_context, false);
-}
-
 class ShenandoahSTWMarkTask : public WorkerTask {
 private:
   ShenandoahSTWMark* const _mark;
@@ -137,8 +110,9 @@ void ShenandoahSTWMark::mark() {
 }
 
 void ShenandoahSTWMark::mark_roots(uint worker_id) {
-  ShenandoahInitMarkRootsClosure<NON_GEN>  init_mark(task_queues()->queue(worker_id));
-  _root_scanner.roots_do(&init_mark, worker_id);
+  ShenandoahReferenceProcessor* rp = ShenandoahHeap::heap()->ref_processor();
+  ShenandoahMarkRefsClosure<NON_GEN> cl(task_queues()->queue(worker_id), rp);
+  _root_scanner.roots_do(&cl, worker_id);
 }
 
 void ShenandoahSTWMark::finish_mark(uint worker_id) {


### PR DESCRIPTION
`ShenandoahInitMarkRootsClosure` in `ShenandoahSTWMark` is semantically similar to the shared `ShenandoahMarkRefsClosure`. It misses subclassing the metadata-visiting superclass, though, and `ShenandoahMarkRefsClosure` does it right. It is cleaner and safer to use the super-class directly, as concurrent mark does it. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342079](https://bugs.openjdk.org/browse/JDK-8342079): Shenandoah: Remove extra ShenandoahInitMarkRootsClosure (**Enhancement** - P4)


### Reviewers
 * [William Kemper](https://openjdk.org/census#wkemper) (@earthling-amzn - Committer)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21504/head:pull/21504` \
`$ git checkout pull/21504`

Update a local copy of the PR: \
`$ git checkout pull/21504` \
`$ git pull https://git.openjdk.org/jdk.git pull/21504/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21504`

View PR using the GUI difftool: \
`$ git pr show -t 21504`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21504.diff">https://git.openjdk.org/jdk/pull/21504.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21504#issuecomment-2412002510)