### PR TITLE
8342081: Shenandoah: Remove extra ShenandoahMarkUpdateRefsSuperClosure

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.hpp
@@ -61,33 +61,23 @@ public:
   }
 };
 
-class ShenandoahMarkUpdateRefsSuperClosure : public ShenandoahMarkRefsSuperClosure {
-protected:
+template <ShenandoahGenerationType GENERATION>
+class ShenandoahMarkUpdateRefsClosure : public ShenandoahMarkRefsSuperClosure {
+private:
   ShenandoahHeap* const _heap;
 
-  template <class T, ShenandoahGenerationType GENERATION>
+  template <class T>
   inline void work(T* p);
 
 public:
-  ShenandoahMarkUpdateRefsSuperClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
+  ShenandoahMarkUpdateRefsClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
     ShenandoahMarkRefsSuperClosure(q, rp),
     _heap(ShenandoahHeap::heap()) {
     assert(_heap->is_stw_gc_in_progress(), "Can only be used for STW GC");
-  };
-};
+  }
 
-template <ShenandoahGenerationType GENERATION>
-class ShenandoahMarkUpdateRefsClosure : public ShenandoahMarkUpdateRefsSuperClosure {
-private:
-  template <class T>
-  inline void do_oop_work(T* p)     { work<T, GENERATION>(p); }
-
-public:
-  ShenandoahMarkUpdateRefsClosure(ShenandoahObjToScanQueue* q, ShenandoahReferenceProcessor* rp) :
-    ShenandoahMarkUpdateRefsSuperClosure(q, rp) {}
-
-  virtual void do_oop(narrowOop* p) { do_oop_work(p); }
-  virtual void do_oop(oop* p)       { do_oop_work(p); }
+  virtual void do_oop(narrowOop* p) { work(p); }
+  virtual void do_oop(oop* p)       { work(p); }
 };
 
 template <ShenandoahGenerationType GENERATION>

--- a/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.inline.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahOopClosures.inline.hpp
@@ -35,8 +35,9 @@ inline void ShenandoahMarkRefsSuperClosure::work(T* p) {
   ShenandoahMark::mark_through_ref<T, GENERATION>(p, _queue, _mark_context, _weak);
 }
 
-template<class T, ShenandoahGenerationType GENERATION>
-inline void ShenandoahMarkUpdateRefsSuperClosure::work(T* p) {
+template<ShenandoahGenerationType GENERATION>
+template<class T>
+inline void ShenandoahMarkUpdateRefsClosure<GENERATION>::work(T* p) {
   // Update the location
   _heap->update_with_forwarded(p);
 


### PR DESCRIPTION
`ShenandoahMarkUpdateRefsSuperClosure` has only one real subclass, which is used in STW mark. We can collapse the class hierarchy a bit here. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `hotspot_gc_shenandoah`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342081](https://bugs.openjdk.org/browse/JDK-8342081): Shenandoah: Remove extra ShenandoahMarkUpdateRefsSuperClosure (**Enhancement** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21505/head:pull/21505` \
`$ git checkout pull/21505`

Update a local copy of the PR: \
`$ git checkout pull/21505` \
`$ git pull https://git.openjdk.org/jdk.git pull/21505/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21505`

View PR using the GUI difftool: \
`$ git pr show -t 21505`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21505.diff">https://git.openjdk.org/jdk/pull/21505.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21505#issuecomment-2412048031)