### PR TITLE
8342566: Improve javadoc of java.lang.annotation.ElementType

### DIFF
--- a/src/java.base/share/classes/java/lang/annotation/ElementType.java
+++ b/src/java.base/share/classes/java/lang/annotation/ElementType.java
@@ -39,22 +39,24 @@ package java.lang.annotation;
  * public @interface MyAnnotation {}
  * }
  *
- * <h2>Declaration annotations and type-use annotations</h2>
+ * <h2 id="kinds-of-annotations">Declaration annotations and type-use
+ * annotations</h2>
  *
  * <p>Most annotations in Java code are <b>declaration
  * annotations</b>, which act like modifiers of declarations (such as
- * a field declaration). The constants of this class cover all ten
- * kinds of annotatable declarations, plus a subcategory of {@link
- * #TYPE} called {@link #ANNOTATION_TYPE}. An annotation interface can
- * be used as a declaration annotation if it either omits {@code
- * @Target}, or uses it to list which specific kinds of declarations
- * it should apply to.
+ * a field or method declaration). The constants of this class cover
+ * all ten kinds of annotatable declarations, plus a subcategory of
+ * {@link #TYPE} called {@link #ANNOTATION_TYPE}. An annotation
+ * interface can be used as a declaration annotation if it either
+ * omits {@link java.lang.annotation.Target @Target}, or uses it to
+ * list which specific kinds of declarations it should apply to.
  *
  * <p>There are also <b>type-use annotations</b> (sometimes called
  * "type annotations"), which can appear anywhere a Java type is being
- * indicated (normally, immediately preceding that type). To enable
- * use as a type-use annotation, an annotation interface must
- * explicitly include {@link #TYPE_USE} in its list of targets. 
+ * indicated (normally, immediately preceding that type). To be used
+ * as a type-use annotation, an annotation interface must use {@link
+ * java.lang.annotation.Target @Target} and include {@link #TYPE_USE}
+ * explicitly.
  *
  * <h3 id="ambiguous">Ambiguous contexts</h3>
  *
@@ -94,7 +96,7 @@ package java.lang.annotation;
  */
 public enum ElementType {
 
-    /** 
+    /**
      * The declaration of a named class or interface. Classes without
      * names, such as an anonymous class or an enum constant with a
      * class body, cannot be annotated.
@@ -128,10 +130,9 @@ public enum ElementType {
      */
     METHOD,
 
-    /** 
-     * The declaration of a formal parameter (of a method, constructor,
-     * or lambda expression), exception parameter, or receiver
-     * parameter.
+    /**
+     * The declaration of a formal parameter of a method, constructor,
+     * or lambda expression, or of an exception parameter.
      *
      * <p>Any annotation valid for a parameter declaration may also
      * appear on the declaration of a record component. Unless the
@@ -161,7 +162,7 @@ public enum ElementType {
      */
     LOCAL_VARIABLE,
 
-    /** 
+    /**
      * The declaration of an annotation interface (a subcategory of
      * {@link #TYPE}). An annotation that itself appears on the
      * declaration of an annotation interface is sometimes informally
@@ -192,13 +193,13 @@ public enum ElementType {
      * annotation" (sometimes called just "type annotation", but be
      * careful not to confuse this with {@link #TYPE}, which is only
      * for <em>class</em> declarations).
-     * 
+     *
      * <p>This is a very broad category: {@jls 4.11} lists seventeen
      * kinds of type contexts, followed by five more locations where
      * type-use annotations can also legally appear. Six of these
      * locations are also annotatable <em>declarations</em>
      * themselves; see <a href="#ambiguous">ambiguous cases</a> above.
-     * 
+     *
      * <p>In addition, specifying this target automatically includes
      * the declaration targets {@link #TYPE} and {@link
      * #TYPE_PARAMETER}, though these are not type contexts.

--- a/src/java.base/share/classes/java/lang/annotation/ElementType.java
+++ b/src/java.base/share/classes/java/lang/annotation/ElementType.java
@@ -32,7 +32,7 @@ package java.lang.annotation;
  * java.lang.annotation.Target @Target} meta-annotation.
  *
  * <p>For example, an annotation of the following type may only appear
- * in a type parameter or local variable declaration:
+ * as part of a type parameter or local variable declaration:
  *
  * {@snippet id='example' :
  * @Target({ElementType.TYPE_PARAMETER, ElementType.LOCAL_VARIABLE})
@@ -58,31 +58,35 @@ package java.lang.annotation;
  *
  * <h3 id="ambiguous">Ambiguous contexts</h3>
  *
- * <p>In some declarations, immediately after the annotations and
- * modifers, some <em>type</em> is indicated; specifically, the
- * declaration of a field, parameter, local variable, record
- * component, or non-void method (indicating the method's <em>return
- * type</em>). In such declarations, type-use annotations can
- * <em>also</em> be freely intermingled with the declaration's
- * modifiers and declaration annotations, in any order, and these are
- * treated the same as if they had directly preceded the type.
+ * <p>For six kinds of declarations, type-use annotations can also
+ * appear freely intermingled with declaration annotations and
+ * modifiers:
+ *
+ * <ul>
+ * <li>a field, parameter, local variable, or record component
+ *     (treated as if it precedes that variable's type)
+ * <li>a non-void method (treated as if it precedes the method's
+ *     return type)
+ * <li>a constructor (treated as if it modifies the constructed type,
+ *     even though this is not technically a type context)
+ * </ul>
+ *
+ * <p>In general, a library method for reading declaration annotations
+ * (like {@link java.lang.reflect.Field#getAnnotations}) will not
+ * return type-use annotations found in the same location, and
+ * vice-versa.
  *
  * <p>An annotation interface may specify both {@link #TYPE_USE} and
  * declaration targets, and thereby be fully usable as either kind.
- * When an annotation of this type appears in one of the five
- * ambiguous contexts just listed, it functions as <em>both</em> a
- * declaration annotation and a type-use annotation at the same time.
- * The results may be counterintuitive in two cases: when the type in
- * question is an inner type (like {@code Map.Entry}), or an array
- * type. In these cases, the declaration annotation applies to the
- * "entire" declaration, yet the type-use annotation applies more
- * narrowly to the <em>outer type</em> or to the <em>component
- * type</em> of the array.
- *
- * <p>In general, a library method for reading declaration annotations
- * (like {@link java.lang.reflect.AnnotatedElement#getAnnotations})
- * will not return type-use annotations found in the same location,
- * and vice-versa.
+ * When an annotation of this type appears in one of the six ambiguous
+ * contexts just listed, it functions as <em>both</em> a declaration
+ * annotation and a type-use annotation at the same time. The results
+ * may be counterintuitive in two cases: when the variable type or
+ * method return type is an inner type or an array type. In these
+ * cases, the declaration annotation applies to the "entire"
+ * declaration, yet the type-use annotation applies more narrowly to
+ * the <em>outer type</em> or to the <em>component type</em> of the
+ * array.
  *
  * @author  Joshua Bloch
  * @since 1.5
@@ -190,19 +194,14 @@ public enum ElementType {
      * for <em>class</em> declarations).
      * 
      * <p>This is a very broad category: {@jls 4.11} lists seventeen
-     * kinds of type contexts, followed by more locations where
-     * type-use annotations can also legally appear. Eight of these
+     * kinds of type contexts, followed by five more locations where
+     * type-use annotations can also legally appear. Six of these
      * locations are also annotatable <em>declarations</em>
      * themselves; see <a href="#ambiguous">ambiguous cases</a> above.
      * 
-     * <p>Specifying this target automatically includes the declaration
-     * targets {@link #TYPE}, {@link #TYPE_PARAMETER}, and {@link
-     * #CONSTRUCTOR} as well, with no way to exclude them.
-     *
-     * <p>An annotation interface with no {@code @Target}
-     * meta-annotation can be used in <em>any</em> declaration, but not
-     * as a type-use annotation. That is, this is the only constant in
-     * this class that must always be specified explicitly.
+     * <p>In addition, specifying this target automatically includes
+     * the declaration targets {@link #TYPE} and {@link
+     * #TYPE_PARAMETER}, though these are not type contexts.
      *
      * @since 1.8
      */

--- a/src/java.base/share/classes/java/lang/annotation/ElementType.java
+++ b/src/java.base/share/classes/java/lang/annotation/ElementType.java
@@ -28,7 +28,7 @@ package java.lang.annotation;
 /**
  * A syntactic location where an annotation may appear in Java code.
  * An annotation interface may optionally restrict its usage to a
- * particular set of these locations using the {@link
+ * particular subset of these locations using the {@link
  * java.lang.annotation.Target @Target} meta-annotation.
  *
  * <p>For example, an annotation of the following type may only appear
@@ -36,45 +36,36 @@ package java.lang.annotation;
  *
  * {@snippet id='example' :
  * @Target({ElementType.TYPE_PARAMETER, ElementType.LOCAL_VARIABLE})
- * public @interface ActLocally {}
+ * public @interface MyAnnotation {}
  * }
  *
  * <h2>Declaration annotations and type-use annotations</h2>
  *
- * <p>Java annotations fall into two categories:
+ * <p>Most annotations in Java code are <b>declaration
+ * annotations</b>, which act like modifiers of declarations (such as
+ * a field declaration). The constants of this class cover all ten
+ * kinds of annotatable declarations, plus a subcategory of {@link
+ * #TYPE} called {@link #ANNOTATION_TYPE}. An annotation interface can
+ * be used as a declaration annotation if it either omits {@code
+ * @Target}, or uses it to list which specific kinds of declarations
+ * it should apply to.
  *
- * <ul>
- * <li><b>Declaration annotations</b>, which appear as modifiers of
- *     declarations (such as a class or field declaration)
- * <li><b>Type-use annotations</b> (sometimes called <em>type
- *     annotations</em>), which can appear anywhere a Java type is
- *     being indicated
- * </ul>
- *
- * <p>To enable use as a type-use annotation, an annotation interface
- * must include {@link #TYPE_USE} in its list of targets. To enable
- * use as a declaration annotation, it may either omit {@code
- * @Target}, or use it to list which specific kinds of declarations it
- * should apply to.
- *
- * <p>The constants of this class cover all ten kinds of annotatable
- * declarations, plus a subcategory of {@link #TYPE} called {@link
- * #ANNOTATION_TYPE} used for annotation types that apply only to
- * other annotation types.
+ * <p>There are also <b>type-use annotations</b> (sometimes called
+ * "type annotations"), which can appear anywhere a Java type is being
+ * indicated (normally, immediately preceding that type). To enable
+ * use as a type-use annotation, an annotation interface must
+ * explicitly include {@link #TYPE_USE} in its list of targets. 
  *
  * <h3 id="ambiguous">Ambiguous contexts</h3>
  *
- * <p>In some declarations, a type is specified immediately following
- * the modifiers and annotations: a field, parameter, local variable,
- * or record component declaration, or the declaration of a non-void
- * method (indicating the return type of the method). In these
- * declarations, type-use annotations can <em>also</em> be freely
- * intermingled with the declaration's modifiers and declaration
- * annotations, in any order, and these are treated the same as if
- * they had directly preceded the type. In general, a library method
- * for reading declaration annotations (like {@link
- * java.lang.reflect.AnnotatedElement#getAnnotations}) will not return
- * type-use annotations found in the same location, and vice-versa.
+ * <p>In some declarations, immediately after the annotations and
+ * modifers, some <em>type</em> is indicated; specifically, the
+ * declaration of a field, parameter, local variable, record
+ * component, or non-void method (indicating the method's <em>return
+ * type</em>). In such declarations, type-use annotations can
+ * <em>also</em> be freely intermingled with the declaration's
+ * modifiers and declaration annotations, in any order, and these are
+ * treated the same as if they had directly preceded the type.
  *
  * <p>An annotation interface may specify both {@link #TYPE_USE} and
  * declaration targets, and thereby be fully usable as either kind.
@@ -83,10 +74,15 @@ package java.lang.annotation;
  * declaration annotation and a type-use annotation at the same time.
  * The results may be counterintuitive in two cases: when the type in
  * question is an inner type (like {@code Map.Entry}), or an array
- * type. In these cases, the declaration annotation still applies to
- * the "entire" declaration (of course), yet the type-use annotation
- * applies more narrowly to the <em>outer type</em> or to the
- * <em>component type</em> of the array.
+ * type. In these cases, the declaration annotation applies to the
+ * "entire" declaration, yet the type-use annotation applies more
+ * narrowly to the <em>outer type</em> or to the <em>component
+ * type</em> of the array.
+ *
+ * <p>In general, a library method for reading declaration annotations
+ * (like {@link java.lang.reflect.AnnotatedElement#getAnnotations})
+ * will not return type-use annotations found in the same location,
+ * and vice-versa.
  *
  * @author  Joshua Bloch
  * @since 1.5

--- a/src/java.base/share/classes/java/lang/annotation/ElementType.java
+++ b/src/java.base/share/classes/java/lang/annotation/ElementType.java
@@ -26,13 +26,13 @@
 package java.lang.annotation;
 
 /**
- * A syntactic location where an annotation may appear in Java code.
- * An annotation interface may optionally restrict its usage to a
+ * A syntactic location where an annotation may appear in Java code. An
+ * annotation interface may optionally restrict its usage to a
  * particular subset of these locations using the {@link
  * java.lang.annotation.Target @Target} meta-annotation.
  *
  * <p>For example, an annotation of the following type may only appear
- * as part of a type parameter or local variable declaration:
+ * within a type parameter or local variable declaration:
  *
  * {@snippet id='example' :
  * @Target({ElementType.TYPE_PARAMETER, ElementType.LOCAL_VARIABLE})
@@ -42,25 +42,25 @@ package java.lang.annotation;
  * <h2 id="kinds-of-annotations">Declaration annotations and type-use
  * annotations</h2>
  *
- * <p>Most annotations in Java code are <b>declaration
- * annotations</b>, which act like modifiers of declarations (such as
- * a field or method declaration). The constants of this class cover
- * all ten kinds of annotatable declarations, plus a subcategory of
- * {@link #TYPE} called {@link #ANNOTATION_TYPE}. An annotation
- * interface can be used as a declaration annotation if it either
- * omits {@link java.lang.annotation.Target @Target}, or uses it to
- * list which specific kinds of declarations it should apply to.
+ * <p>Most annotations in Java code are <b>declaration annotations</b>,
+ * which act like modifiers of declarations (such as a field or method
+ * declaration). The constants of this class cover all the kinds of
+ * annotatable declarations, plus a subcategory of {@link #TYPE} called
+ * {@link #ANNOTATION_TYPE}. An annotation interface can be used as a
+ * declaration annotation if it either omits {@link
+ * java.lang.annotation.Target @Target}, or uses it to list which
+ * specific kinds of declarations it should apply to.
  *
- * <p>There are also <b>type-use annotations</b> (sometimes called
- * "type annotations"), which can appear anywhere a Java type is being
- * indicated (normally, immediately preceding that type). To be used
- * as a type-use annotation, an annotation interface must use {@link
+ * <p>There are also <b>type-use annotations</b> (sometimes called "type
+ * annotations"), which can appear anywhere a Java type is being
+ * indicated (normally, immediately preceding that type). To be used as
+ * a type-use annotation, an annotation interface must use {@link
  * java.lang.annotation.Target @Target} and include {@link #TYPE_USE}
  * explicitly.
  *
  * <h3 id="ambiguous">Ambiguous contexts</h3>
  *
- * <p>For six kinds of declarations, type-use annotations can also
+ * <p>For some kinds of declarations, type-use annotations can also
  * appear freely intermingled with declaration annotations and
  * modifiers:
  *
@@ -74,23 +74,22 @@ package java.lang.annotation;
  * </ul>
  *
  * <p>In general, a library method for reading declaration annotations
- * (like {@link java.lang.reflect.Field#getAnnotations}) will not
- * return type-use annotations found in the same location, and
- * vice-versa.
+ * (such as {@link java.lang.reflect.AccessibleObject#getAnnotations
+ * Field.getAnnotations()}) will not return type-use annotations found in
+ * the same location, and vice-versa.
  *
  * <p>An annotation interface may specify both {@link #TYPE_USE} and
  * declaration targets, and thereby be fully usable as either kind.
- * When an annotation of this type appears in one of the six ambiguous
+ * When an annotation of this type appears in one of the ambiguous
  * contexts just listed, it functions as <em>both</em> a declaration
  * annotation and a type-use annotation at the same time. The results
  * may be counterintuitive in two cases: when the variable type or
- * method return type is an inner type or an array type. In these
- * cases, the declaration annotation applies to the "entire"
- * declaration, yet the type-use annotation applies more narrowly to
- * the <em>outer type</em> or to the <em>component type</em> of the
- * array.
+ * method return type is an inner type or an array type. In these cases,
+ * the declaration annotation applies to the "entire" declaration, yet
+ * the type-use annotation applies more narrowly to the <em>outer
+ * type</em> or to the <em>component type</em> of the array.
  *
- * @author  Joshua Bloch
+ * @author Joshua Bloch
  * @since 1.5
  * @jls 9.7.4 Where Annotations May Appear
  */
@@ -98,14 +97,18 @@ public enum ElementType {
 
     /**
      * The declaration of a named class or interface. Classes without
-     * names, such as an anonymous class or an enum constant with a
-     * class body, cannot be annotated.
+     * names (such as an anonymous class) cannot be annotated.
      *
-     * <p><b>Terminology note:</b> despite this constant's name, an
-     * annotation applied to a class declaration is not a "type
-     * annotation". That phrase is only ever used as an abbreviation
-     * of "type-use annotation", which is supported by {@link
-     * #TYPE_USE}.
+     * <p><b>Terminology note:</b> an annotation on a class or interface
+     * declaration is not a case of a "type annotation", despite how this
+     * constant is named. That phrase is an abbreviation of "type-use
+     * annotation", which is supported by the {@link #TYPE_USE} target.
+     *
+     * @jls 8.1 Class Declarations
+     * @jls 8.9 Enum Classes
+     * @jls 8.10 Record Classes
+     * @jls 9.1 Interface Declarations
+     * @jls 9.6 Annotation Interfaces
      */
     TYPE,
 
@@ -116,6 +119,10 @@ public enum ElementType {
      * on the declaration of a record component, and is automatically
      * copied to the private field of the same name that is generated
      * during compilation.
+     *
+     * @jls 8.3 Field Declarations
+     * @jls 8.9.1 Enum Constants
+     * @jls 8.10.3 Record Members
      */
     FIELD,
 
@@ -127,6 +134,11 @@ public enum ElementType {
      * on the declaration of a record component, and is automatically
      * copied to the accessor method of the same name if one is
      * generated during compilation.
+     *
+     * @jls 8.4 Method Declarations (of classes)
+     * @jls 9.4 Method Declarations (of interfaces)
+     * @jls 9.6.1 Annotation Interface Elements
+     * @jls 8.10.3 Record Members
      */
     METHOD,
 
@@ -141,14 +153,20 @@ public enum ElementType {
      * corresponding parameter declaration of the constructor generated
      * during compilation.
      *
-     * <p>Lambda parameter declarations using the <em>concise
-     * syntax</em> cannot be annotated; either a type or the `var`
-     * keyword must be provided for each.
+     * <p>A lambda parameter declared using a <em>concise parameter
+     * specifier</em> cannot be annotated; either a type or the {@code var}
+     * keyword must be provided.
+     *
+     * @jls 8.4.1 Formal Parameters
+     * @jls 15.27.1 Lambda Parameters
+     * @jls 8.10.4 Record Constructor Declarations
      */
     PARAMETER,
 
     /**
      * The declaration of a constructor.
+     *
+     * @jls 8.8 Constructor Declarations
      */
     CONSTRUCTOR,
 
@@ -156,18 +174,20 @@ public enum ElementType {
      * The declaration of a local variable. This may be an ordinary
      * declaration statement, or declared within the header of a {@code
      * for} or {@code try} statement, or within a pattern as a pattern
-     * variable. However, the similar case of an exception variable
-     * declared in a {@code catch} clause is considered a {@link
-     * #PARAMETER} instead.
+     * variable. Note that an exception variable declared in a {@code
+     * catch} clause is considered a {@link #PARAMETER} instead.
+     *
+     * @jls 14.4 Local Variable Declarations
+     * @jls 14.20.3 Try-with-resources
+     * @jls 14.30.1 Kinds of Patterns
      */
     LOCAL_VARIABLE,
 
     /**
      * The declaration of an annotation interface (a subcategory of
-     * {@link #TYPE}). An annotation that itself appears on the
-     * declaration of an annotation interface is sometimes informally
-     * called a "meta-annotation"; {@link Target} itself is a primary
-     * example.
+     * {@link #TYPE}).
+     *
+     * @jls 9.6 Annotation Interfaces
      */
     ANNOTATION_TYPE,
 
@@ -175,15 +195,16 @@ public enum ElementType {
      * The declaration of a package in a {@code package-info.java} file.
      * Package declarations in other source files cannot be annotated.
      *
-     * @jls 7.4 Package Declarations
+     * @jls 7.4.1 Named Packages
      */
     PACKAGE,
 
     /**
-     * The declaration of a type parameter within a generic class,
+     * The declaration of a type parameter within a generic class, interface,
      * method, or constructor declaration.
      *
      * @since 1.8
+     * @jls 4.4 Type Variables
      */
     TYPE_PARAMETER,
 
@@ -194,17 +215,19 @@ public enum ElementType {
      * careful not to confuse this with {@link #TYPE}, which is only
      * for <em>class</em> declarations).
      *
-     * <p>This is a very broad category: {@jls 4.11} lists seventeen
-     * kinds of type contexts, followed by five more locations where
-     * type-use annotations can also legally appear. Six of these
-     * locations are also annotatable <em>declarations</em>
-     * themselves; see <a href="#ambiguous">ambiguous cases</a> above.
+     * <p>This is a very broad category: JLS {@jls 4.11} lists
+     * seventeen kinds of type contexts, followed by five more
+     * locations where type-use annotations can also legally appear.
+     * Several of these locations are also annotatable
+     * <em>declarations</em> themselves; see <a
+     * href="#ambiguous">ambiguous cases</a> above.
      *
-     * <p>In addition, specifying this target automatically includes
-     * the declaration targets {@link #TYPE} and {@link
-     * #TYPE_PARAMETER}, though these are not type contexts.
+     * <p>Specifying this target automatically includes the declaration
+     * targets {@link #TYPE} and {@link #TYPE_PARAMETER}, even though
+     * these are not type contexts.
      *
      * @since 1.8
+     * @jls 4.11 Where Types Are Used
      */
     TYPE_USE,
 

--- a/src/java.base/share/classes/java/lang/annotation/ElementType.java
+++ b/src/java.base/share/classes/java/lang/annotation/ElementType.java
@@ -29,7 +29,7 @@ package java.lang.annotation;
  * A syntactic location where an annotation may appear in Java code.
  * An annotation interface may optionally restrict its usage to a
  * particular subset of these locations using the {@link
- * java.lang.annotation.Target @Target} meta-annotation.
+ * Target @Target} meta-annotation.
  *
  * <p>For example, an annotation of the following type may only appear
  * within a type parameter or local variable declaration:
@@ -48,15 +48,14 @@ package java.lang.annotation;
  * all the kinds of annotatable declarations, plus a subcategory of
  * {@link #TYPE} called {@link #ANNOTATION_TYPE}. An annotation
  * interface can be used as a declaration annotation if it either
- * omits {@link java.lang.annotation.Target @Target}, or uses it to
- * list which specific kinds of declarations it should apply to.
+ * omits {@link Target @Target}, or uses it to list which specific
+ * kinds of declarations it should apply to.
  *
  * <p>There are also <b>type-use annotations</b> (sometimes called
  * "type annotations"), which can appear anywhere a Java type is being
  * indicated (normally, immediately preceding that type). To be used
  * as a type-use annotation, an annotation interface must explicitly
- * include {@link #TYPE_USE} in {@link
- * java.lang.annotation.Target @Target}.
+ * include {@link #TYPE_USE} in {@link Target @Target}.
  *
  * <h3 id="ambiguous">Ambiguous contexts</h3>
  *
@@ -117,7 +116,8 @@ public enum ElementType {
     TYPE,
 
     /**
-     * The declaration of a field (including that of an enum constant).
+     * The declaration of a field (including that of an enum
+     * constant).
      *
      * <p>Any annotation valid for a field declaration may also appear
      * on the declaration of a record component, and is automatically

--- a/src/java.base/share/classes/java/lang/annotation/ElementType.java
+++ b/src/java.base/share/classes/java/lang/annotation/ElementType.java
@@ -55,8 +55,8 @@ package java.lang.annotation;
  * "type annotations"), which can appear anywhere a Java type is being
  * indicated (normally, immediately preceding that type). To be used
  * as a type-use annotation, an annotation interface must explicitly
- * include {@link #TYPE_USE} in {@link java.lang.annotation.Target
- * @Target}.
+ * include {@link #TYPE_USE} in {@link
+ * java.lang.annotation.Target @Target}.
  *
  * <h3 id="ambiguous">Ambiguous contexts</h3>
  *
@@ -65,13 +65,13 @@ package java.lang.annotation;
  * modifiers:
  *
  * <ul>
- * <li>a field, parameter, record component, or local variable (if the
- *     type is being explicitly specified; treated as if it precedes
- *     that variable's type)
- * <li>a non-void method (treated as if it precedes the method's
- *     return type)
- * <li>a constructor (treated as if it modifies the constructed type,
- *     even though this is not technically a type context)
+ *   <li>a field, parameter, record component, or local variable (if
+ *       the type is being explicitly specified; treated as if it
+ *       precedes that variable's type)
+ *   <li>a non-void method (treated as if it precedes the method's
+ *       return type)
+ *   <li>a constructor (treated as if it modifies the constructed
+ *       type, even though this is not technically a type context)
  * </ul>
  *
  * <p>In general, a library method for reading declaration annotations
@@ -79,9 +79,9 @@ package java.lang.annotation;
  * Field.getAnnotations()}) will not return type-use annotations found
  * in the same location, and vice-versa.
  *
- * <p>An annotation interface may list both {@link #TYPE_USE} and
- * one or more declaration targets, and thereby be fully usable as
- * either kind. When an annotation of this type appears in one of the
+ * <p>An annotation interface may list both {@link #TYPE_USE} and one
+ * or more declaration targets, and thereby be fully usable as either
+ * kind. When an annotation of this type appears in one of the
  * ambiguous contexts just listed, it functions as <em>both</em> a
  * declaration annotation and a type-use annotation at the same time.
  * The results may be counterintuitive in two cases: when the variable
@@ -117,7 +117,7 @@ public enum ElementType {
     TYPE,
 
     /**
-     * The declaration of a field (including of an enum constant).
+     * The declaration of a field (including that of an enum constant).
      *
      * <p>Any annotation valid for a field declaration may also appear
      * on the declaration of a record component, and is automatically
@@ -132,8 +132,7 @@ public enum ElementType {
     FIELD,
 
     /**
-     * The declaration of a method (including of an element of an
-     * annotation interface).
+     * The declaration of a method.
      *
      * <p>Any annotation valid for a method declaration may also
      * appear on the declaration of a record component, and is
@@ -152,6 +151,10 @@ public enum ElementType {
      * The declaration of a formal parameter of a method, constructor,
      * or lambda expression, or of an exception parameter.
      *
+     * <p>A lambda parameter declared using a <em>concise parameter
+     * specifier</em> cannot be annotated; either a type or the {@code
+     * var} keyword must be provided.
+     *
      * <p>Any annotation valid for a parameter declaration may also
      * appear on the declaration of a record component. Unless the
      * canonical constructor's full signature was provided explicitly
@@ -161,14 +164,11 @@ public enum ElementType {
      * constructor was not provided explicitly or it used the compact
      * syntax without an explicit parameter list.
      *
-     * <p>A lambda parameter declared using a <em>concise parameter
-     * specifier</em> cannot be annotated; either a type or the {@code
-     * var} keyword must be provided.
-     *
      * @see java.lang.reflect.Parameter#getAnnotations()
-     *      Parameter.getAnnotations() (when applicable)
+     *     Parameter.getAnnotations() (when applicable)
      * @jls 8.4.1 Formal Parameters
      * @jls 15.27.1 Lambda Parameters
+     * @jls 14.20 The {@code try} Statement
      * @jls 8.10.4 Record Constructor Declarations
      */
     PARAMETER,
@@ -182,12 +182,11 @@ public enum ElementType {
     CONSTRUCTOR,
 
     /**
-     * The declaration of a local variable. This may be an ordinary
-     * declaration statement, or declared within the header of a
-     * {@code for} or {@code try} statement, or within a pattern as a
-     * pattern variable. Note that an exception variable declared in a
-     * {@code catch} clause is considered a {@link #PARAMETER}
-     * instead.
+     * The declaration of a local variable. The variable might be
+     * declared in an ordinary declaration statement, in the header of
+     * a {@code for} or {@code try} statement, or within a pattern (as
+     * a pattern variable). However, an exception variable declared
+     * after {@code catch} is considered a {@link #PARAMETER} instead.
      *
      * <p>These annotations are not available via reflection.
      *
@@ -228,42 +227,40 @@ public enum ElementType {
 
     /**
      * A syntactic location where a compile-time type is being
-     * explicitly indicated. An annotation in such a location is
-     * a <b>type-use annotation</b> (sometimes called just "type
-     * annotation", but be careful not to confuse this with {@link
-     * #TYPE}, which is for declaration annotations for classes
-     * and interfaces).
+     * explicitly indicated. An annotation in such a location is a
+     * <b>type-use annotation</b> (sometimes called a "type
+     * annotation", but not to be confused with {@link #TYPE}).
      *
      * <p>This is a very broad category: JLS {@jls 4.11} lists
      * seventeen kinds of type contexts, followed by five more
-     * locations where type-use annotations can also legally appear.
-     * Several of these locations are also annotatable
-     * <em>declarations</em> themselves; see
-     * <a href="#ambiguous">ambiguous cases</a> above. Type-use
-     * annotations may only appear where a type is being explicitly
-     * given (not, for example, if the {@code var} keyword is used).
+     * locations where type-use annotations can also appear. Several
+     * of these locations are also annotatable <em>declarations</em>
+     * themselves; see <a href="#ambiguous">ambiguous cases</a> above.
+     * Type-use annotations may only appear where a type is being
+     * explicitly given (not, for example, if the {@code var} keyword
+     * is used).
      *
-     * <p>For types that are available through the reflection API
-     * (for example, a field type, but not a local variable type),
-     * their associated runtime-retained type-use annotations are
-     * available as well, via the various methods (with "Annotated"
-     * in their names) that return {@link
+     * <p>Type-use annotations present on types exposed through the
+     * reflection API (for example, a field type, but not a local
+     * variable type) can be accessed via the various reflection
+     * methods, with "Annotated" in their names, that return {@link
      * java.lang.reflect.AnnotatedType}.
      *
-     * <p>Specifying this target automatically includes the
-     * declaration targets {@link #TYPE} and {@link #TYPE_PARAMETER}.
-     * Annotations appearing in such declarations are still treated as
-     * declaration annotations. As a special rule, type-use
-     * annotations can also appear in a constructor declaration, to be
-     * obtained by {@link
+     * <p>Specifying this target automatically implies the declaration
+     * targets {@link #TYPE} and {@link #TYPE_PARAMETER} as well.
+     * Annotations appearing in such declarations are declaration
+     * annotations. As a special rule, type-use annotations may also
+     * appear in a constructor declaration, to be obtained by {@link
      * java.lang.reflect.Constructor#getAnnotatedReturnType()
-     * Constructor.getAnnotatedReturnType()}.
+     * Constructor.getAnnotatedReturnType()}. These are <em>not</em>
+     * treated as declaration annotations unless {@link #CONSTRUCTOR}
+     * was also specified.
      *
      * <p>When the type of a record component is propagated to its
-     * generated field, accessor method, and/or constructor parameter,
-     * any present type-use annotations are propagated with it. This
-     * does not apply if the parameter or method was provided explicitly
-     * in the source code.
+     * generated field, accessor method, or constructor parameter, its
+     * embedded type-use annotations are propagated with it. No such
+     * propagation occurs if the parameter or method was declared
+     * explicitly in the source code.
      *
      * @since 1.8
      * @see java.lang.reflect.AnnotatedType#getAnnotations()
@@ -273,9 +270,10 @@ public enum ElementType {
 
     /**
      * The declaration of a module in a {@code module-info.java} file.
-     * Note that if a client uses the module on their <i>class
-     * path</i> rather than module path, the module declaration and
-     * all its annotations will be invisible.
+     *
+     * <p><b>Warning:</b> If a client uses the module on the <em>class
+     * path</em> rather than the module path, the module declaration
+     * and all its annotations will be invisible to that client.
      *
      * @since 9
      * @see java.lang.Module#getAnnotations()
@@ -284,25 +282,17 @@ public enum ElementType {
     MODULE,
 
     /**
-     * The declaration of a record component, in the header of a
-     * record class declaration.
+     * The declaration of a record component in a record class
+     * declaration.
      *
-     * <p>If an annotation interface should apply conceptually to the
-     * field, accessor method, or constructor parameter that is
-     * generated corresponding to a record component, it should
-     * specify the appropriate element types ({@link #FIELD}, {@link
-     * #METHOD}, or {@link #PARAMETER}), instead of {@code
-     * RECORD_COMPONENT} or in addition to it. This allows the
-     * annotation to be automatically copied to any generated elements
-     * it applies to.
-     *
-     * <p>Annotations are only available through {@link
+     * <p>The targets ({@link #FIELD}, {@link #METHOD}, and {@link
+     * #PARAMETER}) also enable usage on a record component
+     * declaration, as each explains. However, if the annotation
+     * interface uses {@link Target @Target} without explicitly
+     * including {@link #RECORD_COMPONENT}, annotations of that type
+     * will not be returned by {@link
      * java.lang.reflect.RecordComponent#getAnnotations()
-     * RecordComponent.getAnnotations()} API if they
-     * are explicitly record-component annotations (meaning they
-     * either name this element type explicitly in their {@link Target
-     * @Target} annotation, or they have no {@code @Target}
-     * annotation).
+     * RecordComponent.getAnnotations()}.
      *
      * @since 16
      * @jls 8.10.1 Record Components

--- a/src/java.base/share/classes/java/lang/annotation/ElementType.java
+++ b/src/java.base/share/classes/java/lang/annotation/ElementType.java
@@ -65,8 +65,8 @@ package java.lang.annotation;
  * modifiers:
  *
  * <ul>
- * <li>a field, parameter, record component, or local variable, if the
- *     type is being explicitly specified (treated as if it precedes
+ * <li>a field, parameter, record component, or local variable (if the
+ *     type is being explicitly specified; treated as if it precedes
  *     that variable's type)
  * <li>a non-void method (treated as if it precedes the method's
  *     return type)
@@ -75,20 +75,20 @@ package java.lang.annotation;
  * </ul>
  *
  * <p>In general, a library method for reading declaration annotations
- * (such as {@link java.lang.reflect.AccessibleObject#getAnnotations
+ * (such as {@link java.lang.reflect.Field#getAnnotations
  * Field.getAnnotations()}) will not return type-use annotations found
  * in the same location, and vice-versa.
  *
- * <p>An annotation interface may specify both {@link #TYPE_USE} and
- * declaration targets, and thereby be fully usable as either kind.
- * When an annotation of this type appears in one of the ambiguous
- * contexts just listed, it functions as <em>both</em> a declaration
- * annotation and a type-use annotation at the same time. The results
- * may be counterintuitive in two cases: when the variable type or
- * method return type is an inner type or an array type. In these
- * cases, the declaration annotation applies to the "entire"
+ * <p>An annotation interface may list both {@link #TYPE_USE} and
+ * one or more declaration targets, and thereby be fully usable as
+ * either kind. When an annotation of this type appears in one of the
+ * ambiguous contexts just listed, it functions as <em>both</em> a
+ * declaration annotation and a type-use annotation at the same time.
+ * The results may be counterintuitive in two cases: when the variable
+ * type or method return type is an inner type or an array type. In
+ * these cases, the declaration annotation applies to the "entire"
  * declaration, yet the type-use annotation applies more narrowly to
- * the <em>outer type</em> or to the <em>element type</em> of the
+ * the <em>outer type</em>, or to the <em>element type</em> of the
  * array.
  *
  * @author Joshua Bloch
@@ -107,6 +107,7 @@ public enum ElementType {
      * abbreviation of "type-use annotation", which is supported by
      * the {@link #TYPE_USE} target.
      *
+     * @see java.lang.Class#getAnnotations()
      * @jls 8.1 Class Declarations
      * @jls 8.9 Enum Classes
      * @jls 8.10 Record Classes
@@ -123,6 +124,7 @@ public enum ElementType {
      * copied to the private field of the same name that is generated
      * during compilation.
      *
+     * @see java.lang.reflect.Field#getAnnotations()
      * @jls 8.3 Field Declarations
      * @jls 8.9.1 Enum Constants
      * @jls 8.10.3 Record Members
@@ -138,6 +140,7 @@ public enum ElementType {
      * automatically copied to the accessor method of the same name if
      * one is generated during compilation.
      *
+     * @see java.lang.reflect.Method#getAnnotations()
      * @jls 8.4 Method Declarations (of classes)
      * @jls 9.4 Method Declarations (of interfaces)
      * @jls 9.6.1 Annotation Interface Elements
@@ -154,12 +157,16 @@ public enum ElementType {
      * canonical constructor's full signature was provided explicitly
      * in the source code, this annotation is automatically copied to
      * the corresponding parameter declaration of the constructor
-     * generated during compilation.
+     * generated during compilation. This happens either if the
+     * constructor was not provided explicitly or it used the compact
+     * syntax without an explicit parameter list.
      *
      * <p>A lambda parameter declared using a <em>concise parameter
      * specifier</em> cannot be annotated; either a type or the {@code
      * var} keyword must be provided.
      *
+     * @see java.lang.reflect.Parameter#getAnnotations()
+     *      Parameter.getAnnotations() (when applicable)
      * @jls 8.4.1 Formal Parameters
      * @jls 15.27.1 Lambda Parameters
      * @jls 8.10.4 Record Constructor Declarations
@@ -169,6 +176,7 @@ public enum ElementType {
     /**
      * The declaration of a constructor.
      *
+     * @see java.lang.reflect.Constructor#getAnnotations()
      * @jls 8.8 Constructor Declarations
      */
     CONSTRUCTOR,
@@ -181,6 +189,8 @@ public enum ElementType {
      * {@code catch} clause is considered a {@link #PARAMETER}
      * instead.
      *
+     * <p>These annotations are not available via reflection.
+     *
      * @jls 14.4 Local Variable Declarations
      * @jls 14.20.3 Try-with-resources
      * @jls 14.30.1 Kinds of Patterns
@@ -191,6 +201,7 @@ public enum ElementType {
      * The declaration of an annotation interface (a subcategory of
      * {@link #TYPE}).
      *
+     * @see java.lang.Class#getAnnotations()
      * @jls 9.6 Annotation Interfaces
      */
     ANNOTATION_TYPE,
@@ -200,6 +211,7 @@ public enum ElementType {
      * declaration may be annotated; by convention it should be in a
      * file named {@code package-info.java}.
      *
+     * @see java.lang.Package#getAnnotations()
      * @jls 7.4.1 Named Packages
      */
     PACKAGE,
@@ -209,31 +221,52 @@ public enum ElementType {
      * interface, method, or constructor declaration.
      *
      * @since 1.8
+     * @see java.lang.reflect.TypeVariable#getAnnotations()
      * @jls 4.4 Type Variables
      */
     TYPE_PARAMETER,
 
     /**
-     * A code location where a compile-time type is being indicated.
-     * An annotation in such a location is called a "type-use
-     * annotation" (sometimes called just "type annotation", but be
-     * careful not to confuse this with {@link #TYPE}, which is only
-     * for <em>class</em> declarations). Runtime-retained type-use
-     * annotations are accessed via reflection methods that return
-     * {@link java.lang.reflect.AnnotatedType}.
+     * A syntactic location where a compile-time type is being
+     * explicitly indicated. An annotation in such a location is
+     * a <b>type-use annotation</b> (sometimes called just "type
+     * annotation", but be careful not to confuse this with {@link
+     * #TYPE}, which is for declaration annotations for classes
+     * and interfaces).
      *
      * <p>This is a very broad category: JLS {@jls 4.11} lists
      * seventeen kinds of type contexts, followed by five more
      * locations where type-use annotations can also legally appear.
      * Several of these locations are also annotatable
      * <em>declarations</em> themselves; see
-     * <a href="#ambiguous">ambiguous cases</a> above.
+     * <a href="#ambiguous">ambiguous cases</a> above. Type-use
+     * annotations may only appear where a type is being explicitly
+     * given (not, for example, if the {@code var} keyword is used).
+     *
+     * <p>For types that are available through the reflection API
+     * (for example, a field type, but not a local variable type),
+     * their associated runtime-retained type-use annotations are
+     * available as well, via the various methods (with "Annotated"
+     * in their names) that return {@link
+     * java.lang.reflect.AnnotatedType}.
      *
      * <p>Specifying this target automatically includes the
-     * declaration targets {@link #TYPE} and {@link #TYPE_PARAMETER},
-     * even though these are not type contexts.
+     * declaration targets {@link #TYPE} and {@link #TYPE_PARAMETER}.
+     * Annotations appearing in such declarations are still treated as
+     * declaration annotations. As a special rule, type-use
+     * annotations can also appear in a constructor declaration, to be
+     * obtained by {@link
+     * java.lang.reflect.Constructor#getAnnotatedReturnType()
+     * Constructor.getAnnotatedReturnType()}.
+     *
+     * <p>When the type of a record component is propagated to its
+     * generated field, accessor method, and/or constructor parameter,
+     * any present type-use annotations are propagated with it. This
+     * does not apply if the parameter or method was provided explicitly
+     * in the source code.
      *
      * @since 1.8
+     * @see java.lang.reflect.AnnotatedType#getAnnotations()
      * @jls 4.11 Where Types Are Used
      */
     TYPE_USE,
@@ -245,6 +278,7 @@ public enum ElementType {
      * all its annotations will be invisible.
      *
      * @since 9
+     * @see java.lang.Module#getAnnotations()
      * @jls 7.7 Module Declarations
      */
     MODULE,
@@ -262,11 +296,13 @@ public enum ElementType {
      * annotation to be automatically copied to any generated elements
      * it applies to.
      *
-     * <p>Runtime-retained annotations are only available through the
-     * {@link java.lang.reflect.RecordComponent RecordComponent} API
-     * if they are explicitly record-component annotations (meaning
-     * they either name this element type explicitly in {@link Target
-     * @Target} or they have no {@code @Target} annotation).
+     * <p>Annotations are only available through {@link
+     * java.lang.reflect.RecordComponent#getAnnotations()
+     * RecordComponent.getAnnotations()} API if they
+     * are explicitly record-component annotations (meaning they
+     * either name this element type explicitly in their {@link Target
+     * @Target} annotation, or they have no {@code @Target}
+     * annotation).
      *
      * @since 16
      * @jls 8.10.1 Record Components

--- a/src/java.base/share/classes/java/lang/annotation/ElementType.java
+++ b/src/java.base/share/classes/java/lang/annotation/ElementType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2026, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,8 @@
 package java.lang.annotation;
 
 /**
- * A syntactic location where an annotation may appear in Java code. An
- * annotation interface may optionally restrict its usage to a
+ * A syntactic location where an annotation may appear in Java code.
+ * An annotation interface may optionally restrict its usage to a
  * particular subset of these locations using the {@link
  * java.lang.annotation.Target @Target} meta-annotation.
  *
@@ -42,21 +42,21 @@ package java.lang.annotation;
  * <h2 id="kinds-of-annotations">Declaration annotations and type-use
  * annotations</h2>
  *
- * <p>Most annotations in Java code are <b>declaration annotations</b>,
- * which act like modifiers of declarations (such as a field or method
- * declaration). The constants of this class cover all the kinds of
- * annotatable declarations, plus a subcategory of {@link #TYPE} called
- * {@link #ANNOTATION_TYPE}. An annotation interface can be used as a
- * declaration annotation if it either omits {@link
- * java.lang.annotation.Target @Target}, or uses it to list which
- * specific kinds of declarations it should apply to.
+ * <p>Most annotations in Java code are <b>declaration
+ * annotations</b>, which act like modifiers of declarations (such as
+ * a field or method declaration). The constants of this class cover
+ * all the kinds of annotatable declarations, plus a subcategory of
+ * {@link #TYPE} called {@link #ANNOTATION_TYPE}. An annotation
+ * interface can be used as a declaration annotation if it either
+ * omits {@link java.lang.annotation.Target @Target}, or uses it to
+ * list which specific kinds of declarations it should apply to.
  *
- * <p>There are also <b>type-use annotations</b> (sometimes called "type
- * annotations"), which can appear anywhere a Java type is being
- * indicated (normally, immediately preceding that type). To be used as
- * a type-use annotation, an annotation interface must use {@link
- * java.lang.annotation.Target @Target} and include {@link #TYPE_USE}
- * explicitly.
+ * <p>There are also <b>type-use annotations</b> (sometimes called
+ * "type annotations"), which can appear anywhere a Java type is being
+ * indicated (normally, immediately preceding that type). To be used
+ * as a type-use annotation, an annotation interface must explicitly
+ * include {@link #TYPE_USE} in {@link java.lang.annotation.Target
+ * @Target}.
  *
  * <h3 id="ambiguous">Ambiguous contexts</h3>
  *
@@ -65,8 +65,9 @@ package java.lang.annotation;
  * modifiers:
  *
  * <ul>
- * <li>a field, parameter, local variable, or record component
- *     (treated as if it precedes that variable's type)
+ * <li>a field, parameter, record component, or local variable, if the
+ *     type is being explicitly specified (treated as if it precedes
+ *     that variable's type)
  * <li>a non-void method (treated as if it precedes the method's
  *     return type)
  * <li>a constructor (treated as if it modifies the constructed type,
@@ -75,8 +76,8 @@ package java.lang.annotation;
  *
  * <p>In general, a library method for reading declaration annotations
  * (such as {@link java.lang.reflect.AccessibleObject#getAnnotations
- * Field.getAnnotations()}) will not return type-use annotations found in
- * the same location, and vice-versa.
+ * Field.getAnnotations()}) will not return type-use annotations found
+ * in the same location, and vice-versa.
  *
  * <p>An annotation interface may specify both {@link #TYPE_USE} and
  * declaration targets, and thereby be fully usable as either kind.
@@ -84,10 +85,11 @@ package java.lang.annotation;
  * contexts just listed, it functions as <em>both</em> a declaration
  * annotation and a type-use annotation at the same time. The results
  * may be counterintuitive in two cases: when the variable type or
- * method return type is an inner type or an array type. In these cases,
- * the declaration annotation applies to the "entire" declaration, yet
- * the type-use annotation applies more narrowly to the <em>outer
- * type</em> or to the <em>component type</em> of the array.
+ * method return type is an inner type or an array type. In these
+ * cases, the declaration annotation applies to the "entire"
+ * declaration, yet the type-use annotation applies more narrowly to
+ * the <em>outer type</em> or to the <em>element type</em> of the
+ * array.
  *
  * @author Joshua Bloch
  * @since 1.5
@@ -99,10 +101,11 @@ public enum ElementType {
      * The declaration of a named class or interface. Classes without
      * names (such as an anonymous class) cannot be annotated.
      *
-     * <p><b>Terminology note:</b> an annotation on a class or interface
-     * declaration is not a case of a "type annotation", despite how this
-     * constant is named. That phrase is an abbreviation of "type-use
-     * annotation", which is supported by the {@link #TYPE_USE} target.
+     * <p><b>Terminology note:</b> an annotation on a class or
+     * interface declaration is not a case of a "type annotation",
+     * despite how this constant is named. That phrase is an
+     * abbreviation of "type-use annotation", which is supported by
+     * the {@link #TYPE_USE} target.
      *
      * @jls 8.1 Class Declarations
      * @jls 8.9 Enum Classes
@@ -130,10 +133,10 @@ public enum ElementType {
      * The declaration of a method (including of an element of an
      * annotation interface).
      *
-     * <p>Any annotation valid for a method declaration may also appear
-     * on the declaration of a record component, and is automatically
-     * copied to the accessor method of the same name if one is
-     * generated during compilation.
+     * <p>Any annotation valid for a method declaration may also
+     * appear on the declaration of a record component, and is
+     * automatically copied to the accessor method of the same name if
+     * one is generated during compilation.
      *
      * @jls 8.4 Method Declarations (of classes)
      * @jls 9.4 Method Declarations (of interfaces)
@@ -148,14 +151,14 @@ public enum ElementType {
      *
      * <p>Any annotation valid for a parameter declaration may also
      * appear on the declaration of a record component. Unless the
-     * canonical constructor's full signature was provided explicitly in
-     * the source code, this annotation is automatically copied to the
-     * corresponding parameter declaration of the constructor generated
-     * during compilation.
+     * canonical constructor's full signature was provided explicitly
+     * in the source code, this annotation is automatically copied to
+     * the corresponding parameter declaration of the constructor
+     * generated during compilation.
      *
      * <p>A lambda parameter declared using a <em>concise parameter
-     * specifier</em> cannot be annotated; either a type or the {@code var}
-     * keyword must be provided.
+     * specifier</em> cannot be annotated; either a type or the {@code
+     * var} keyword must be provided.
      *
      * @jls 8.4.1 Formal Parameters
      * @jls 15.27.1 Lambda Parameters
@@ -172,10 +175,11 @@ public enum ElementType {
 
     /**
      * The declaration of a local variable. This may be an ordinary
-     * declaration statement, or declared within the header of a {@code
-     * for} or {@code try} statement, or within a pattern as a pattern
-     * variable. Note that an exception variable declared in a {@code
-     * catch} clause is considered a {@link #PARAMETER} instead.
+     * declaration statement, or declared within the header of a
+     * {@code for} or {@code try} statement, or within a pattern as a
+     * pattern variable. Note that an exception variable declared in a
+     * {@code catch} clause is considered a {@link #PARAMETER}
+     * instead.
      *
      * @jls 14.4 Local Variable Declarations
      * @jls 14.20.3 Try-with-resources
@@ -192,16 +196,17 @@ public enum ElementType {
     ANNOTATION_TYPE,
 
     /**
-     * The declaration of a package in a {@code package-info.java} file.
-     * Package declarations in other source files cannot be annotated.
+     * A package declaration. For each package, at most one package
+     * declaration may be annotated; by convention it should be in a
+     * file named {@code package-info.java}.
      *
      * @jls 7.4.1 Named Packages
      */
     PACKAGE,
 
     /**
-     * The declaration of a type parameter within a generic class, interface,
-     * method, or constructor declaration.
+     * The declaration of a type parameter within a generic class,
+     * interface, method, or constructor declaration.
      *
      * @since 1.8
      * @jls 4.4 Type Variables
@@ -213,18 +218,20 @@ public enum ElementType {
      * An annotation in such a location is called a "type-use
      * annotation" (sometimes called just "type annotation", but be
      * careful not to confuse this with {@link #TYPE}, which is only
-     * for <em>class</em> declarations).
+     * for <em>class</em> declarations). Runtime-retained type-use
+     * annotations are accessed via reflection methods that return
+     * {@link java.lang.reflect.AnnotatedType}.
      *
      * <p>This is a very broad category: JLS {@jls 4.11} lists
      * seventeen kinds of type contexts, followed by five more
      * locations where type-use annotations can also legally appear.
      * Several of these locations are also annotatable
-     * <em>declarations</em> themselves; see <a
-     * href="#ambiguous">ambiguous cases</a> above.
+     * <em>declarations</em> themselves; see
+     * <a href="#ambiguous">ambiguous cases</a> above.
      *
-     * <p>Specifying this target automatically includes the declaration
-     * targets {@link #TYPE} and {@link #TYPE_PARAMETER}, even though
-     * these are not type contexts.
+     * <p>Specifying this target automatically includes the
+     * declaration targets {@link #TYPE} and {@link #TYPE_PARAMETER},
+     * even though these are not type contexts.
      *
      * @since 1.8
      * @jls 4.11 Where Types Are Used
@@ -233,6 +240,9 @@ public enum ElementType {
 
     /**
      * The declaration of a module in a {@code module-info.java} file.
+     * Note that if a client uses the module on their <i>class
+     * path</i> rather than module path, the module declaration and
+     * all its annotations will be invisible.
      *
      * @since 9
      * @jls 7.7 Module Declarations
@@ -240,20 +250,23 @@ public enum ElementType {
     MODULE,
 
     /**
-     * The declaration of a record component, in the header of a record
-     * class declaration. If an annotation interface should apply
-     * conceptually to the field, accessor method, or constructor
-     * parameter that is generated corresponding to a record component,
-     * it should specify the appropriate element types ({@link #FIELD},
-     * {@link #METHOD}, or {@link #PARAMETER}), instead of {@code
+     * The declaration of a record component, in the header of a
+     * record class declaration.
+     *
+     * <p>If an annotation interface should apply conceptually to the
+     * field, accessor method, or constructor parameter that is
+     * generated corresponding to a record component, it should
+     * specify the appropriate element types ({@link #FIELD}, {@link
+     * #METHOD}, or {@link #PARAMETER}), instead of {@code
      * RECORD_COMPONENT} or in addition to it. This allows the
      * annotation to be automatically copied to any generated elements
      * it applies to.
      *
-     * <p>{@link #RECORD_COMPONENT} must be included explicitly in
-     * {@code @Target} in order for annotations of that type to be
-     * available via the {@link java.lang.reflect.RecordComponent
-     * RecordComponent} reflection API.
+     * <p>Runtime-retained annotations are only available through the
+     * {@link java.lang.reflect.RecordComponent RecordComponent} API
+     * if they are explicitly record-component annotations (meaning
+     * they either name this element type explicitly in {@link Target
+     * @Target} or they have no {@code @Target} annotation).
      *
      * @since 16
      * @jls 8.10.1 Record Components


### PR DESCRIPTION
- \[x\] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- \[ \] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- \[x\] Change must not contain extraneous whitespace
- \[x\] Commit message must refer to an issue

### Error
&nbsp;⚠️ Pull request body is missing required line: `- [x] I confirm that I make this contribution in accordance with the [OpenJDK Interim AI Policy](https://openjdk.org/legal/ai).`

### Issue
 * [JDK-8342566](https://bugs.openjdk.org/browse/JDK-8342566): Improve javadoc of java.lang.annotation.ElementType (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21506/head:pull/21506` \
`$ git checkout pull/21506`

Update a local copy of the PR: \
`$ git checkout pull/21506` \
`$ git pull https://git.openjdk.org/jdk.git pull/21506/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21506`

View PR using the GUI difftool: \
`$ git pr show -t 21506`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21506.diff">https://git.openjdk.org/jdk/pull/21506.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21506#issuecomment-2427290553)
</details>
