### PR TITLE
8340140: Open some dialog awt tests 3

### DIFF
--- a/test/jdk/java/awt/Dialog/ClosingParentTest.java
+++ b/test/jdk/java/awt/Dialog/ClosingParentTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+import java.awt.event.WindowEvent;
+import java.awt.event.WindowAdapter;
+
+/*
+ * @test
+ * @bug 4336913
+ * @summary On Win32, disable parent window controls while modal dialog is being created.
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual ClosingParentTest
+ */
+
+public class ClosingParentTest {
+
+    static String instructions = """
+            When the test starts, you will see a Frame with a Button
+            titled 'Show modal dialog with delay'. Press this button
+            and before the modal Dialog is shown, try to close the
+            Frame using X button or system menu for windowing systems
+            which don't provide X button in Window decorations. The
+            delay before Dialog showing is 5 seconds.
+            If in test output you see message about WINDOW_CLOSING
+            being dispatched, then test fails. If no such message
+            is printed, the test passes.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("ClosingParentTest")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(35)
+                .testUI(ClosingParentTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static Frame createGUI() {
+        Frame frame = new Frame("Main Frame");
+        Dialog dialog = new Dialog(frame, true);
+
+        Button button = new Button("Show modal dialog with delay");
+        button.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                try {
+                    Thread.currentThread().sleep(5000);
+                } catch (InterruptedException x) {
+                    x.printStackTrace();
+                }
+
+                dialog.setVisible(true);
+            }
+        });
+        frame.add(button);
+        frame.pack();
+        frame.addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                System.out.println("WINDOW_CLOSING dispatched on the frame");
+            }
+        });
+
+        dialog.setSize(100, 100);
+        dialog.addWindowListener(new WindowAdapter() {
+            public void windowClosing(WindowEvent e) {
+                dialog.dispose();
+            }
+        });
+
+        return frame;
+    }
+}

--- a/test/jdk/java/awt/Dialog/ClosingParentTest.java
+++ b/test/jdk/java/awt/Dialog/ClosingParentTest.java
@@ -32,8 +32,8 @@ import java.awt.event.WindowAdapter;
 /*
  * @test
  * @bug 4336913
- * @summary On Win32, disable parent window controls while modal dialog is being created.
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @summary On Windows, disable parent window controls while modal dialog is being created.
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual ClosingParentTest
  */

--- a/test/jdk/java/awt/Dialog/FileDialogEmptyTitleTest.java
+++ b/test/jdk/java/awt/Dialog/FileDialogEmptyTitleTest.java
@@ -28,7 +28,7 @@ import java.awt.Frame;
  * @test
  * @bug 4177831
  * @summary solaris: default FileDialog title is not empty
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual FileDialogEmptyTitleTest
  */

--- a/test/jdk/java/awt/Dialog/FileDialogEmptyTitleTest.java
+++ b/test/jdk/java/awt/Dialog/FileDialogEmptyTitleTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.FileDialog;
+import java.awt.Frame;
+
+/*
+ * @test
+ * @bug 4177831
+ * @summary solaris: default FileDialog title is not empty
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual FileDialogEmptyTitleTest
+ */
+
+public class FileDialogEmptyTitleTest {
+    static String instructions = """
+            Test passes if title of file dialog is empty,
+            otherwise test failed.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("FileDialogEmptyTitleTest")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(35)
+                .testUI(FileDialogEmptyTitleTest::createGUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public static FileDialog createGUI() {
+        Frame frame = new Frame("invisible dialog owner");
+        FileDialog fileDialog = new FileDialog(frame);
+        return fileDialog;
+    }
+}

--- a/test/jdk/java/awt/Dialog/FileDialogUIUpdate.java
+++ b/test/jdk/java/awt/Dialog/FileDialogUIUpdate.java
@@ -34,7 +34,7 @@ import java.awt.event.ActionListener;
  * @requires (os.family == "windows")
  * @summary Verify that FileDialog matches the look
     of the native windows FileDialog
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual FileDialogUIUpdate
  */

--- a/test/jdk/java/awt/Dialog/FileDialogUIUpdate.java
+++ b/test/jdk/java/awt/Dialog/FileDialogUIUpdate.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.BorderLayout;
+import java.awt.Button;
+import java.awt.FileDialog;
+import java.awt.Frame;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4859390
+ * @requires (os.family == "windows")
+ * @summary Verify that FileDialog matches the look
+    of the native windows FileDialog
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual FileDialogUIUpdate
+ */
+
+public class FileDialogUIUpdate extends Frame {
+    static String instructions = """
+            Click the button to show the FileDialog. Then open the Paint
+            application (usually found in Program Files->Accessories).
+            Select File->Open from Paint to display a native Open dialog.
+            Compare the native dialog to the AWT FileDialog.
+            Specifically, confirm that the Places Bar icons are along the left side (or
+            not, if the native dialog doesn't have them), and that the
+            dialogs are both resizable (or not).
+            If the file dialogs both look the same press Pass.  If not,
+            press Fail.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame.builder()
+                .title("FileDialogUIUpdate")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows(12)
+                .columns(35)
+                .testUI(FileDialogUIUpdate::new)
+                .build()
+                .awaitAndCheck();
+    }
+
+    public FileDialogUIUpdate() {
+        final FileDialog fd = new FileDialog(new Frame("FileDialogUIUpdate frame"),
+                "Open FileDialog");
+        Button showButton = new Button("Show FileDialog");
+        setLayout(new BorderLayout());
+
+        fd.setDirectory("c:/");
+        showButton.addActionListener(new ActionListener() {
+            public void actionPerformed(ActionEvent e) {
+                fd.setVisible(true);
+            }
+        });
+
+        add(showButton);
+        setSize(200, 200);
+    }
+}

--- a/test/jdk/java/awt/Dialog/MenuAndModalDialogTest.java
+++ b/test/jdk/java/awt/Dialog/MenuAndModalDialogTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.awt.Button;
+import java.awt.Dialog;
+import java.awt.Frame;
+import java.awt.Menu;
+import java.awt.MenuBar;
+import java.awt.MenuItem;
+import java.awt.event.ActionEvent;
+import java.awt.event.ActionListener;
+
+/*
+ * @test
+ * @bug 4070085
+ * @summary Java program locks up X server
+ * @library /open/test/jdk/java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual MenuAndModalDialogTest
+ */
+
+public class MenuAndModalDialogTest {
+    static Frame frame;
+    static String instructions = """
+            1. Bring up the File Menu and leave it up.
+            2. In a few seconds, the modal dialog will appear.
+            3. Verify that your system does not lock up when you push the "OK" button.
+            """;
+
+    public static void main(String[] args) throws Exception {
+        PassFailJFrame pf = PassFailJFrame.builder()
+                .title("MenuAndModalDialogTest")
+                .instructions(instructions)
+                .testTimeOut(5)
+                .rows(10)
+                .columns(35)
+                .testUI(MenuAndModalDialogTest::createFrame)
+                .build();
+
+        // Allow time to pop up the menu
+        try {
+            Thread.currentThread().sleep(5000);
+        } catch (InterruptedException exception) {
+        }
+
+        createDialog();
+        pf.awaitAndCheck();
+    }
+
+    public static Frame createFrame() {
+        frame = new Frame("MenuAndModalDialogTest frame");
+
+        MenuBar menuBar = new MenuBar();
+        frame.setMenuBar(menuBar);
+
+        Menu file = new Menu("File");
+        menuBar.add(file);
+
+        MenuItem menuItem = new MenuItem("A Menu Entry");
+        file.add(menuItem);
+
+        frame.setSize(200, 200);
+        frame.setLocationRelativeTo(null);
+        return frame;
+    }
+
+    public static void createDialog() {
+        Dialog dialog = new Dialog(frame);
+
+        Button button = new Button("OK");
+        dialog.add(button);
+        button.addActionListener(
+                new ActionListener() {
+                    public void actionPerformed(ActionEvent e) {
+                        dialog.dispose();
+                    }
+                }
+        );
+
+        dialog.setSize(200, 200);
+        dialog.setModal(true);
+        dialog.setVisible(true);
+    }
+}

--- a/test/jdk/java/awt/Dialog/MenuAndModalDialogTest.java
+++ b/test/jdk/java/awt/Dialog/MenuAndModalDialogTest.java
@@ -34,7 +34,7 @@ import java.awt.event.ActionListener;
  * @test
  * @bug 4070085
  * @summary Java program locks up X server
- * @library /open/test/jdk/java/awt/regtesthelpers
+ * @library /java/awt/regtesthelpers
  * @build PassFailJFrame
  * @run main/manual MenuAndModalDialogTest
  */


### PR DESCRIPTION
Third set of dialog swing tests to open during fall 2024 test sprint

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340140](https://bugs.openjdk.org/browse/JDK-8340140): Open some dialog awt tests 3 (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21511/head:pull/21511` \
`$ git checkout pull/21511`

Update a local copy of the PR: \
`$ git checkout pull/21511` \
`$ git pull https://git.openjdk.org/jdk.git pull/21511/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21511`

View PR using the GUI difftool: \
`$ git pr show -t 21511`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21511.diff">https://git.openjdk.org/jdk/pull/21511.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21511#issuecomment-2412576764)