### PR TITLE
8341584: Test java/foreign/TestUpcallStress.java intermittent timeout with -Xcomp

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -28,5 +28,4 @@
 #############################################################################
 
 java/lang/invoke/MethodHandles/CatchExceptionTest.java          8146623 generic-all
-java/foreign/TestUpcallStress.java                              8341584 generic-all
 com/sun/jdi/InterruptHangTest.java                              8043571 generic-all

--- a/test/jdk/java/foreign/TestUpcallStress.java
+++ b/test/jdk/java/foreign/TestUpcallStress.java
@@ -26,6 +26,7 @@
  * @requires jdk.foreign.linker != "FALLBACK"
  * @requires (os.arch == "aarch64" | os.arch=="riscv64") & os.name == "Linux"
  * @requires os.maxMemory > 4G
+ * @requires vm.compMode != "Xcomp"
  * @modules java.base/jdk.internal.foreign
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  * @bug 8337753


### PR DESCRIPTION
Hi all,
Test `java/foreign/TestUpcallStress.java` intermittent timeout with -Xcomp, and this test use a very precise race, thus `-Xcomp` probably will never trigger the problematic use-case. So this test not suitable for -Xcomp mode.I add `@requires vm.compMode != "Xcomp"` to exclude from Xcomp testing and remove this test from `ProblemList-Xcomp.txt`.
Trivial fix, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341584](https://bugs.openjdk.org/browse/JDK-8341584): Test java/foreign/TestUpcallStress.java intermittent timeout with -Xcomp (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21512/head:pull/21512` \
`$ git checkout pull/21512`

Update a local copy of the PR: \
`$ git checkout pull/21512` \
`$ git pull https://git.openjdk.org/jdk.git pull/21512/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21512`

View PR using the GUI difftool: \
`$ git pr show -t 21512`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21512.diff">https://git.openjdk.org/jdk/pull/21512.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21512#issuecomment-2412635344)