### PR TITLE
8341931: os_linux gtest uses lambdas with explicit capture lists

### DIFF
--- a/test/hotspot/gtest/runtime/test_os_linux.cpp
+++ b/test/hotspot/gtest/runtime/test_os_linux.cpp
@@ -360,10 +360,10 @@ TEST_VM(os_linux, pretouch_thp_and_use_concurrent) {
   EXPECT_TRUE(os::commit_memory(heap, size, false));
 
   {
-    auto pretouch = [heap](Thread*, int) {
+    auto pretouch = [&](Thread*, int) {
       os::pretouch_memory(heap, heap + size, os::vm_page_size());
     };
-    auto useMemory = [heap](Thread*, int) {
+    auto useMemory = [&](Thread*, int) {
       int* iptr = reinterpret_cast<int*>(heap);
       for (int i = 0; i < 1000; i++) *iptr++ = i;
     };


### PR DESCRIPTION
Please review this simple change to two lambdas in a gtest, to use the
preferred implicit reference capture rather than explicit capture.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341931](https://bugs.openjdk.org/browse/JDK-8341931): os_linux gtest uses lambdas with explicit capture lists (**Enhancement** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21513/head:pull/21513` \
`$ git checkout pull/21513`

Update a local copy of the PR: \
`$ git checkout pull/21513` \
`$ git pull https://git.openjdk.org/jdk.git pull/21513/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21513`

View PR using the GUI difftool: \
`$ git pr show -t 21513`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21513.diff">https://git.openjdk.org/jdk/pull/21513.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21513#issuecomment-2412645062)