### PR TITLE
8334010: VM crashes with ObjectAlignmentInBytes > GCCardSizeInBytes

### DIFF
--- a/src/hotspot/share/gc/shared/gcArguments.cpp
+++ b/src/hotspot/share/gc/shared/gcArguments.cpp
@@ -30,6 +30,7 @@
 #include "runtime/arguments.hpp"
 #include "runtime/globals.hpp"
 #include "runtime/globals_extension.hpp"
+#include "utilities/formatBuffer.hpp"
 #include "utilities/macros.hpp"
 
 size_t HeapAlignment = 0;
@@ -165,6 +166,13 @@ void GCArguments::initialize_heap_flags_and_sizes() {
   }
 
   FLAG_SET_ERGO(MinHeapDeltaBytes, align_up(MinHeapDeltaBytes, SpaceAlignment));
+
+  if (checked_cast<uint>(ObjectAlignmentInBytes) > GCCardSizeInBytes) {
+    err_msg message("ObjectAlignmentInBytes %u is larger than GCCardSizeInBytes %u",
+                    ObjectAlignmentInBytes, GCCardSizeInBytes);
+    vm_exit_during_initialization("Invalid combination of GCCardSizeInBytes and ObjectAlignmentInBytes",
+                                  message);
+  }
 
   DEBUG_ONLY(assert_flags();)
 }

--- a/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
+++ b/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package gc;
+
+/* @test TestObjectAlignmentCardSize.java
+ * @summary Test to check correct handling of ObjectAlignmentInBytes and GCCardSizeInBytes combinations
+ * @requires vm.gc != "Z"
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ * @run driver gc.TestObjectAlignmentCardSize
+ */
+
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class TestObjectAlignmentCardSize {
+  private static void runTest(int objectAlignment, int cardSize, boolean shouldSucceed) throws Exception {
+    OutputAnalyzer output = ProcessTools.executeTestJava(
+        "-XX:ObjectAlignmentInBytes=" + objectAlignment,
+        "-XX:GCCardSizeInBytes=" + cardSize,
+        "-Xmx32m",
+        "-Xms32m",
+        "-version");
+
+    System.out.println("Output:\n" + output.getOutput());
+
+    if (shouldSucceed) {
+      output.shouldHaveExitValue(0);
+    } else {
+      output.shouldContain("Error occurred during initialization of VM");
+      output.shouldNotHaveExitValue(0);
+    }
+  }
+
+  public static void main(String[] args) throws Exception {
+    runTest(8, 512, true);
+    runTest(128, 128, true);
+    runTest(256, 128, false);
+    runTest(256, 256, true);
+    runTest(256, 512, true);
+  }
+}

--- a/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
+++ b/test/hotspot/jtreg/gc/TestObjectAlignmentCardSize.java
@@ -48,7 +48,7 @@ public class TestObjectAlignmentCardSize {
     if (shouldSucceed) {
       output.shouldHaveExitValue(0);
     } else {
-      output.shouldContain("Error occurred during initialization of VM");
+      output.shouldContain("Invalid combination of GCCardSizeInBytes and ObjectAlignmentInBytes");
       output.shouldNotHaveExitValue(0);
     }
   }


### PR DESCRIPTION
Hi all,

  please review this change that makes VM initialization reject invalid combinations of `ObjectAlignmentInBytes` and `GCCardSizeInBytes`.

ObjectAlignmentInBytes larger than GCCardSizeInBytes causes issues with setting correct BOT offsets.

Testing: new test case, gha

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334010](https://bugs.openjdk.org/browse/JDK-8334010): VM crashes with ObjectAlignmentInBytes &gt; GCCardSizeInBytes (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21515/head:pull/21515` \
`$ git checkout pull/21515`

Update a local copy of the PR: \
`$ git checkout pull/21515` \
`$ git pull https://git.openjdk.org/jdk.git pull/21515/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21515`

View PR using the GUI difftool: \
`$ git pr show -t 21515`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21515.diff">https://git.openjdk.org/jdk/pull/21515.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21515#issuecomment-2413199511)