### PR TITLE
8337339: gc/arguments/Test*SizeFlags.java timing out with Xcomp

### DIFF
--- a/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestG1HeapSizeFlags.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @summary Tests argument processing for initial and maximum heap size for the G1 collector
  * @key flag-sensitive
  * @requires vm.gc.G1 & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestParallelHeapSizeFlags.java
@@ -30,6 +30,7 @@ package gc.arguments;
  * parallel collectors.
  * @key flag-sensitive
  * @requires vm.gc.Parallel & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc

--- a/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
+++ b/test/hotspot/jtreg/gc/arguments/TestSerialHeapSizeFlags.java
@@ -29,6 +29,7 @@ package gc.arguments;
  * @summary Tests argument processing for initial and maximum heap size for the Serial collector
  * @key flag-sensitive
  * @requires vm.gc.Serial & vm.opt.MinHeapSize == null & vm.opt.MaxHeapSize == null & vm.opt.InitialHeapSize == null
+ * @requires vm.compMode != "Xcomp"
  * @library /test/lib
  * @library /
  * @modules java.base/jdk.internal.misc


### PR DESCRIPTION
Hi all,

  please review this simple change to not run the Test*SizeFlags tests with -Xcomp to avoid timeouts. I do not expect any new insights running these tests with -Xcomp, so I agree that it is easiest to just not run them with that flag.

Testing: gha

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337339](https://bugs.openjdk.org/browse/JDK-8337339): gc/arguments/Test*SizeFlags.java timing out with Xcomp (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21516/head:pull/21516` \
`$ git checkout pull/21516`

Update a local copy of the PR: \
`$ git checkout pull/21516` \
`$ git pull https://git.openjdk.org/jdk.git pull/21516/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21516`

View PR using the GUI difftool: \
`$ git pr show -t 21516`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21516.diff">https://git.openjdk.org/jdk/pull/21516.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21516#issuecomment-2413223583)