### PR TITLE
8295269: G1: Improve slow startup due to predictor initialization

### DIFF
--- a/src/hotspot/share/gc/g1/g1AnalyticsSequences.hpp
+++ b/src/hotspot/share/gc/g1/g1AnalyticsSequences.hpp
@@ -35,6 +35,7 @@ class G1Predictions;
 // Container for TruncatedSeqs that need separate predictors by GC phase.
 class G1PhaseDependentSeq {
   TruncatedSeq _young_only_seq;
+  double _initial_value;
   TruncatedSeq _mixed_seq;
 
   NONCOPYABLE(G1PhaseDependentSeq);

--- a/src/hotspot/share/gc/g1/g1AnalyticsSequences.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1AnalyticsSequences.inline.hpp
@@ -34,6 +34,7 @@ bool G1PhaseDependentSeq::enough_samples_to_use_mixed_seq() const {
 
 G1PhaseDependentSeq::G1PhaseDependentSeq(int length) :
   _young_only_seq(length),
+  _initial_value(0.0),
   _mixed_seq(length)
 { }
 
@@ -42,7 +43,7 @@ TruncatedSeq* G1PhaseDependentSeq::seq_raw(bool use_young_only_phase_seq) {
 }
 
 void G1PhaseDependentSeq::set_initial(double value) {
-  _young_only_seq.add(value);
+  _initial_value = value;
 }
 
 void G1PhaseDependentSeq::add(double value, bool for_young_only_phase) {
@@ -51,8 +52,12 @@ void G1PhaseDependentSeq::add(double value, bool for_young_only_phase) {
 
 double G1PhaseDependentSeq::predict(const G1Predictions* predictor, bool use_young_only_phase_seq) const {
   if (use_young_only_phase_seq || !enough_samples_to_use_mixed_seq()) {
+    if (_young_only_seq.num() == 0) {
+      return _initial_value;
+    }
     return predictor->predict(&_young_only_seq);
   } else {
+    assert(_mixed_seq.num() > 0, "must not ask this with no samples");
     return predictor->predict(&_mixed_seq);
   }
 }

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1327,6 +1327,7 @@ void G1Policy::record_concurrent_mark_cleanup_end(bool has_rebuilt_remembered_se
   if (!mixed_gc_pending) {
     abort_time_to_mixed_tracking();
     log_debug(gc, ergo)("request young-only gcs (candidate old regions not available)");
+    if (!UseNewCode) _g1h->expand(G1HeapRegion::GrainBytes);
   }
   collector_state()->set_in_young_gc_before_mixed(mixed_gc_pending);
   collector_state()->set_mark_or_rebuild_in_progress(false);

--- a/src/hotspot/share/gc/g1/g1Policy.cpp
+++ b/src/hotspot/share/gc/g1/g1Policy.cpp
@@ -1327,7 +1327,6 @@ void G1Policy::record_concurrent_mark_cleanup_end(bool has_rebuilt_remembered_se
   if (!mixed_gc_pending) {
     abort_time_to_mixed_tracking();
     log_debug(gc, ergo)("request young-only gcs (candidate old regions not available)");
-    if (!UseNewCode) _g1h->expand(G1HeapRegion::GrainBytes);
   }
   collector_state()->set_in_young_gc_before_mixed(mixed_gc_pending);
   collector_state()->set_mark_or_rebuild_in_progress(false);


### PR DESCRIPTION
Hi all,

  please review this change that decreases the time it takes to adapt the predictors to actual values during startup.

Currently predictors are initialized using compiled-in values. These values are extremely conservative as they have been based on some SPARC test runs on specjbb2000(?) or so, which means that it takes a while until the weights from these values are "gone" from the predictor sequences. (This can take 20-30 GCs).

The change modifies prediction so that only the first prediction will use these pre-baked values, after that use live values.

This makes G1 adapt much more quickly to the current application/environment.

The drawback is that there may be differences (including regressions) in out-of-box performance because the initial garbage collections heavily impact heap expansion, potentially expanding the heap much less, resulting in less throughput. I.e. in the old policy we may do many more GCs during startup, causing higher cpu time ratio at that time, expanding more (than necessary).

GC cpu usage with the new policy is still well within allowed range wrt to cpu time ratio.

This also does not impact reasonable test setups.

Testing: gha, internal performance benchmarks mostly show no change or improvements. There are some regressions that are "fixed" by setting min/max heap size indicating this is a heap sizing difference caused by differences due to faster startup.

Hth,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8295269](https://bugs.openjdk.org/browse/JDK-8295269): G1: Improve slow startup due to predictor initialization (**Enhancement** - P4)


### Reviewers
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21518/head:pull/21518` \
`$ git checkout pull/21518`

Update a local copy of the PR: \
`$ git checkout pull/21518` \
`$ git pull https://git.openjdk.org/jdk.git pull/21518/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21518`

View PR using the GUI difftool: \
`$ git pr show -t 21518`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21518.diff">https://git.openjdk.org/jdk/pull/21518.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21518#issuecomment-2421771618)