### PR TITLE
8339871: serviceability/sa/TestDebugInfoDecode.java should be driver

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestDebugInfoDecode.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestDebugInfoDecode.java
@@ -107,7 +107,7 @@ public class TestDebugInfoDecode {
         if (args == null || args.length == 0) {
             try {
                 theApp = new LingeredApp();
-                LingeredApp.startApp(theApp);
+                LingeredApp.startApp(theApp, "-Xmx1g", "-Xcomp");
                 createAnotherToAttach(theApp.getPid());
             } finally {
                 LingeredApp.stopApp(theApp);


### PR DESCRIPTION
Passing "-Xmx1g -Xcomp" to the LingeredApp.
Testing: tier1 