### PR TITLE
8321500: javadoc rejects '@' in multi-line attribute value

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/DocCommentParser.java
@@ -1147,7 +1147,6 @@ public class DocCommentParser {
         ListBuffer<DCTree> attrs = new ListBuffer<>();
         skipWhitespace();
 
-        loop:
         while (bp < buflen && isIdentifierStart(ch)) {
             int namePos = bp;
             Name name = readAttributeName();
@@ -1165,14 +1164,6 @@ public class DocCommentParser {
                     nextChar();
                     textStart = bp;
                     while (bp < buflen && ch != quote) {
-                        if (newline && ch == '@') {
-                            attrs.add(erroneous("dc.unterminated.string", namePos));
-                            // No point trying to read more.
-                            // In fact, all attrs get discarded by the caller
-                            // and superseded by a malformed.html node because
-                            // the html tag itself is not terminated correctly.
-                            break loop;
-                        }
                         attrValueChar(v);
                     }
                     addPendingText(v, bp - 1, DocTree.Kind.TEXT);

--- a/test/langtools/tools/javac/doctree/AttrTest.java
+++ b/test/langtools/tools/javac/doctree/AttrTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614 8076026 8273244
+ * @bug 7021614 8076026 8273244 8321500
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.file
@@ -345,4 +345,70 @@ DocComment[DOC_COMMENT, pos:1
   block tags: empty
 ]
 */
+
+    /**
+     * <a name1="{@literal value}" name2='@foo' name3="abc
+     *@notag &lt;Noref&gt; {@literal xyz}">
+     */
+    void tags_in_attr() { }
+/*
+DocComment[DOC_COMMENT, pos:1
+  firstSentence: 1
+    StartElement[START_ELEMENT, pos:1
+      name:a
+      attributes: 3
+        Attribute[ATTRIBUTE, pos:4
+          name: name1
+          vkind: DOUBLE
+          value: 1
+            Literal[LITERAL, pos:11, value]
+        ]
+        Attribute[ATTRIBUTE, pos:29
+          name: name2
+          vkind: SINGLE
+          value: 1
+            Text[TEXT, pos:36, @foo]
+        ]
+        Attribute[ATTRIBUTE, pos:42
+          name: name3
+          vkind: DOUBLE
+          value: 6
+            Text[TEXT, pos:49, abc|@notag_]
+            Entity[ENTITY, pos:60, lt]
+            Text[TEXT, pos:64, Noref]
+            Entity[ENTITY, pos:69, gt]
+            Text[TEXT, pos:73, _]
+            Literal[LITERAL, pos:74, xyz]
+        ]
+    ]
+  body: empty
+  block tags: empty
+]
+*/
+
+    /**
+     * <a name1="{@literal value}" name2='@foo' name3="abc
+     * @see Ref {@literal xyz}
+     */
+    void unclosed_attr() { }
+/*
+DocComment[DOC_COMMENT, pos:1
+  firstSentence: 4
+    Erroneous[ERRONEOUS, pos:1
+      code: compiler.err.dc.malformed.html
+      body: <
+    ]
+    Text[TEXT, pos:2, a_name1="]
+    Literal[LITERAL, pos:11, value]
+    Text[TEXT, pos:27, "_name2='@foo'_name3="abc]
+  body: empty
+  block tags: 1
+    See[SEE, pos:54
+      reference: 2
+        Reference[REFERENCE, pos:59, Ref]
+        Literal[LITERAL, pos:63, xyz]
+    ]
+]
+*/
+
 }


### PR DESCRIPTION
Please review the removal of code in `DocCommentParser` that created an error when encountering a spurious "@" character in an HTML attribute value after a line break. 

The removed code (which was added in its current form in 2012) seemed to assume that such a "@" character was part of a block tag and therefore an indication of an unclosed attribute value. However, both line breaks and "@" are valid characters in HTML attributes. Note that valid content for HTML attributes in `DocCommentParser` is [text and entities as per HTML5][html5-attributes] as well as JavaDoc inline tags, but not block tags.

[html5-attributes]: https://html.spec.whatwg.org/multipage/syntax.html#syntax-attribute-value

The change adds two doctree tests, one to make sure HTML attributes with mixed values (text, line breaks, entities, inline tags, "@") are parsed correctly, and a second one to make sure actual unclosed attribute values are still recognized as errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8321500: javadoc rejects '@' in multi-line attribute value`

### Issue
 * [JDK-8321500](https://bugs.openjdk.org/browse/JDK-8321500): javadoc rejects '@<!---->' in multi-line attribute value (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21520/head:pull/21520` \
`$ git checkout pull/21520`

Update a local copy of the PR: \
`$ git checkout pull/21520` \
`$ git pull https://git.openjdk.org/jdk.git pull/21520/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21520`

View PR using the GUI difftool: \
`$ git pr show -t 21520`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21520.diff">https://git.openjdk.org/jdk/pull/21520.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21520#issuecomment-2413542721)
</details>
