### PR TITLE
8342145: File libCreationTimeHelper.c compile fails on Alpine

### DIFF
--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c
@@ -25,8 +25,8 @@
 #if defined(__linux__)
 #include <stdio.h>
 #include <string.h>
+#include <sys/types.h>
 #include <sys/stat.h>
-#include <bits/types.h>
 #include <dlfcn.h>
 #ifndef STATX_BASIC_STATS
 #define STATX_BASIC_STATS 0x000007ffU
@@ -44,13 +44,20 @@
 #define AT_FDCWD -100
 #endif
 
+#ifndef __GLIBC__
+// Alpine doesn't know these types, define them
+typedef unsigned int       __uint32_t;
+typedef unsigned short     __uint16_t;
+typedef unsigned long int  __uint64_t;
+#endif
+
 /*
  * Timestamp structure for the timestamps in struct statx.
  */
 struct my_statx_timestamp {
-        __int64_t   tv_sec;
+        int64_t   tv_sec;
         __uint32_t  tv_nsec;
-        __int32_t   __reserved;
+        int32_t   __reserved;
 };
 
 /*


### PR DESCRIPTION
Hi all,
The file `test/jdk/java/nio/file/attribute/BasicFileAttributeView/libCreationTimeHelper.c` compile fail on Alpine. Alpine use musl as runtime libary, and musl doesn't provide header file `<bits/types.h>`. This PR delete `#include <bits/types.h>`, and add some typedef to fix Alpine compile failure.

Additional testing:

- [x] compile `libCreationTimeHelper.c` on Alpine docker container
- [x] compile `libCreationTimeHelper.c` on centos6 docker container
- [x] build jdk with release/fastdebug configure on linux x86_64
- [x] build jdk with release/fastdebug configure on linux aarch64

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342145](https://bugs.openjdk.org/browse/JDK-8342145): File libCreationTimeHelper.c compile fails on Alpine (**Bug** - P2)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21522/head:pull/21522` \
`$ git checkout pull/21522`

Update a local copy of the PR: \
`$ git checkout pull/21522` \
`$ git pull https://git.openjdk.org/jdk.git pull/21522/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21522`

View PR using the GUI difftool: \
`$ git pr show -t 21522`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21522.diff">https://git.openjdk.org/jdk/pull/21522.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21522#issuecomment-2413673156)