### PR TITLE
8342102: ZGC: Optimize copy constructors in ZPhysicalMemory

### DIFF
--- a/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
@@ -55,6 +55,11 @@ ZPhysicalMemory::ZPhysicalMemory(const ZPhysicalMemory& pmem)
 }
 
 const ZPhysicalMemory& ZPhysicalMemory::operator=(const ZPhysicalMemory& pmem) {
+  // Check for self-assignment
+  if (this == &pmem) {
+    return *this;
+  }
+
   // Free and copy segments
   _segments.clear_and_deallocate();
   _segments.reserve(pmem.nsegments());

--- a/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,20 +46,19 @@ ZPhysicalMemory::ZPhysicalMemory()
 
 ZPhysicalMemory::ZPhysicalMemory(const ZPhysicalMemorySegment& segment)
   : _segments() {
-  add_segment(segment);
+  _segments.append(segment);
 }
 
 ZPhysicalMemory::ZPhysicalMemory(const ZPhysicalMemory& pmem)
-  : _segments() {
-  add_segments(pmem);
+  : _segments(pmem.nsegments()) {
+  _segments.appendAll(&pmem._segments);
 }
 
 const ZPhysicalMemory& ZPhysicalMemory::operator=(const ZPhysicalMemory& pmem) {
-  // Free segments
+  // Free and copy segments
   _segments.clear_and_deallocate();
-
-  // Copy segments
-  add_segments(pmem);
+  _segments.reserve(pmem.nsegments());
+  _segments.appendAll(&pmem._segments);
 
   return *this;
 }


### PR DESCRIPTION
ZPhysicalMemory stores a sorted array of physical memory segments. Segments are added using either add_segments or add_segment, where the former calls add_segment on each individual segment. add_segment inserts segments in address order and also merges segments when possible.

When copying an instance of ZPhysicalMemory, segments are currently copied using either add_segments or add_segment, which works as described above. This requires more work than necessary and should be simplified to account for the fact that the array of segments is always sorted.

When copying, the copy constructors should instead use append or appendAll from the underlying GrowableArrayCHeap and also reserve enough memory so that the array's capacity is not increased more times than necessary during copying.

Tested with tiers 1-3.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342102](https://bugs.openjdk.org/browse/JDK-8342102): ZGC: Optimize copy constructors in ZPhysicalMemory (**Enhancement** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21523/head:pull/21523` \
`$ git checkout pull/21523`

Update a local copy of the PR: \
`$ git checkout pull/21523` \
`$ git pull https://git.openjdk.org/jdk.git pull/21523/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21523`

View PR using the GUI difftool: \
`$ git pr show -t 21523`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21523.diff">https://git.openjdk.org/jdk/pull/21523.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21523#issuecomment-2413706024)