### PR TITLE
8342211: Insufficient buffer remaining for AEAD cipher fragment

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -2125,7 +2125,6 @@ enum SSLCipher {
                         "fragment (" + bb.remaining() + "). Needs to be " +
                         "more than tag size (" + tagSize + ") for " +
                         ContentType.nameOf(contentType) + " content");
-
                 }
 
                 byte[] sn = sequence;
@@ -2385,7 +2384,6 @@ enum SSLCipher {
                         "fragment (" + bb.remaining() + "). Needs to be " +
                         "more than tag size (" + tagSize + ") for " +
                         ContentType.nameOf(contentType) + " content");
-
                 }
 
                 byte[] sn = sequence;

--- a/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLCipher.java
@@ -1606,7 +1606,8 @@ enum SSLCipher {
                         "Insufficient buffer remaining for AEAD cipher " +
                         "fragment (" + bb.remaining() + "). Needs to be " +
                         "more than or equal to IV size (" + recordIvSize +
-                         ") + tag size (" + tagSize + ")");
+                         ") + tag size (" + tagSize + ") for " +
+                        ContentType.nameOf(contentType) + " content");
                 }
 
                 // initialize the AEAD cipher for the unique IV
@@ -1862,7 +1863,8 @@ enum SSLCipher {
                     throw new BadPaddingException(
                         "Insufficient buffer remaining for AEAD cipher " +
                         "fragment (" + bb.remaining() + "). Needs to be " +
-                        "more than tag size (" + tagSize + ")");
+                        "more than tag size (" + tagSize + ") for " +
+                        ContentType.nameOf(contentType) + " content");
                 }
 
                 byte[] sn = sequence;
@@ -2121,7 +2123,9 @@ enum SSLCipher {
                     throw new BadPaddingException(
                         "Insufficient buffer remaining for AEAD cipher " +
                         "fragment (" + bb.remaining() + "). Needs to be " +
-                        "more than tag size (" + tagSize + ")");
+                        "more than tag size (" + tagSize + ") for " +
+                        ContentType.nameOf(contentType) + " content");
+
                 }
 
                 byte[] sn = sequence;
@@ -2379,7 +2383,9 @@ enum SSLCipher {
                     throw new BadPaddingException(
                         "Insufficient buffer remaining for AEAD cipher " +
                         "fragment (" + bb.remaining() + "). Needs to be " +
-                        "more than tag size (" + tagSize + ")");
+                        "more than tag size (" + tagSize + ") for " +
+                        ContentType.nameOf(contentType) + " content");
+
                 }
 
                 byte[] sn = sequence;


### PR DESCRIPTION
Hi,

Please review this simple update, which is trying to expose more information about the failed decryption.

Here is the JBS: https://bugs.openjdk.org/browse/JDK-8342211

Best,
Xuelei

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Issue
 * [JDK-8342211](https://bugs.openjdk.org/browse/JDK-8342211): Insufficient buffer remaining for AEAD cipher fragment (**Enhancement** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21529/head:pull/21529` \
`$ git checkout pull/21529`

Update a local copy of the PR: \
`$ git checkout pull/21529` \
`$ git pull https://git.openjdk.org/jdk.git pull/21529/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21529`

View PR using the GUI difftool: \
`$ git pr show -t 21529`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21529.diff">https://git.openjdk.org/jdk/pull/21529.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21529#issuecomment-2415764383)
</details>
