### PR TITLE
8342334: CDS: Scratch mirrors should not point to dead klasses

### DIFF
--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -386,10 +386,9 @@ void HeapShared::set_scratch_java_mirror(Klass* k, oop mirror) {
 }
 
 void HeapShared::remove_scratch_objects(Klass* k) {
-  // Before we remove the Java mirror from the table, we need to break the link
-  // from mirror to the Klass. Java mirror can still be alive, and it should
-  // not point to dead klass. See how InstanceKlass::deallocate_contents does it
-  // for normal mirrors.
+  // Klass is being deallocated. Java mirror can still be alive, and it should not
+  // point to dead klass. We need to break the link from mirror to the Klass.
+  // See how InstanceKlass::deallocate_contents does it for normal mirrors.
   oop mirror = _scratch_java_mirror_table->get_oop(k);
   if (mirror != nullptr) {
     java_lang_Class::set_klass(mirror, nullptr);

--- a/src/hotspot/share/cds/heapShared.cpp
+++ b/src/hotspot/share/cds/heapShared.cpp
@@ -386,6 +386,14 @@ void HeapShared::set_scratch_java_mirror(Klass* k, oop mirror) {
 }
 
 void HeapShared::remove_scratch_objects(Klass* k) {
+  // Before we remove the Java mirror from the table, we need to break the link
+  // from mirror to the Klass. Java mirror can still be alive, and it should
+  // not point to dead klass. See how InstanceKlass::deallocate_contents does it
+  // for normal mirrors.
+  oop mirror = _scratch_java_mirror_table->get_oop(k);
+  if (mirror != nullptr) {
+    java_lang_Class::set_klass(mirror, nullptr);
+  }
   _scratch_java_mirror_table->remove_oop(k);
   if (k->is_instance_klass()) {
     _scratch_references_table->remove(InstanceKlass::cast(k)->constants());


### PR DESCRIPTION
See the symptoms and discussions in the bug. The fix does the same thing we do for normal CM->IK link during the deallocation:
https://github.com/openjdk/jdk/blob/ebc17c7c8d6febd5a887309d1b7a466bcd2cc0a9/src/hotspot/share/oops/instanceKlass.cpp#L592-L594

...but for scratch mirrors allocated by CDS dumping code.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `runtime/cds`
 - [x]  Linux x86_64 server fastdebug, `runtime/cds` with [JDK-8341913](https://bugs.openjdk.org/browse/JDK-8341913) and Shenandoah enabled -- used to reliably crash, now it does not

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342334](https://bugs.openjdk.org/browse/JDK-8342334): CDS: Scratch mirrors should not point to dead klasses (**Bug** - P4)


### Reviewers
 * [Andrew Dinn](https://openjdk.org/census#adinn) (@adinn - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21531/head:pull/21531` \
`$ git checkout pull/21531`

Update a local copy of the PR: \
`$ git checkout pull/21531` \
`$ git pull https://git.openjdk.org/jdk.git pull/21531/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21531`

View PR using the GUI difftool: \
`$ git pr show -t 21531`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21531.diff">https://git.openjdk.org/jdk/pull/21531.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21531#issuecomment-2416345887)