### PR TITLE
8342332: [JVMCI] Export CompilerToVM::Data::dtanh

### DIFF
--- a/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
+++ b/src/hotspot/share/jvmci/vmStructs_jvmci.cpp
@@ -132,6 +132,7 @@
   static_field(CompilerToVM::Data,             dsin,                                   address)                                      \
   static_field(CompilerToVM::Data,             dcos,                                   address)                                      \
   static_field(CompilerToVM::Data,             dtan,                                   address)                                      \
+  static_field(CompilerToVM::Data,             dtanh,                                  address)                                      \
   static_field(CompilerToVM::Data,             dexp,                                   address)                                      \
   static_field(CompilerToVM::Data,             dlog,                                   address)                                      \
   static_field(CompilerToVM::Data,             dlog10,                                 address)                                      \


### PR DESCRIPTION
https://github.com/openjdk/jdk/pull/20657 adds x86_64 intrinsic for tanh. Exporting CompilerToVM::Data::dtanh allows JVMCI compiler to reuse the same HotSpot stub.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342332](https://bugs.openjdk.org/browse/JDK-8342332): [JVMCI] Export CompilerToVM::Data::dtanh (**Enhancement** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21535/head:pull/21535` \
`$ git checkout pull/21535`

Update a local copy of the PR: \
`$ git checkout pull/21535` \
`$ git pull https://git.openjdk.org/jdk.git pull/21535/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21535`

View PR using the GUI difftool: \
`$ git pr show -t 21535`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21535.diff">https://git.openjdk.org/jdk/pull/21535.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21535#issuecomment-2416589209)