### PR TITLE
8342376: More reliable OOM handling in ExceptionDuringDumpAtObjectsInitPhase test

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDumpTransformer.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDumpTransformer.java
@@ -34,7 +34,10 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
     static boolean TEST_WITH_CLEANER = Boolean.getBoolean("test.with.cleaner");
     static boolean TEST_WITH_EXCEPTION = Boolean.getBoolean("test.with.exception");
     static boolean TEST_WITH_OOM = Boolean.getBoolean("test.with.oom");
+
+    static final int WASTE_SIZE = 64 * 1024;
     static List<byte[]> waste = new ArrayList();
+    static Object sink;
 
     static Cleaner cleaner;
     static Thread thread;
@@ -59,10 +62,12 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
               return new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
             }
             if (TEST_WITH_OOM) {
-                // fill until OOM
+                // Fill until OOM with 1/4 waste size. This would guarantee
+                // that we will not be able to satisfy WASTE_SIZE allocation
+                // after we caught the OOM.
                 System.out.println("Fill objects until OOM");
-                for (;;) {
-                    waste.add(new byte[64*1024]);
+                while (true) {
+                    waste.add(new byte[WASTE_SIZE / 4]);
                 }
             }
         }
@@ -104,8 +109,8 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
     }
 
     public static void makeGarbage() {
-        for (int x=0; x<10; x++) {
-            Object[] a = new Object[10000];
+        for (int x = 0; x < 10; x++) {
+            sink = new byte[WASTE_SIZE];
         }
     }
 
@@ -115,7 +120,7 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
         public void run() {
             // Allocate something. This will cause G1 to allocate an EDEN region.
             // See JDK-8245925
-            Object o = new Object();
+            sink = new Object();
             System.out.println("cleaning " + i);
         }
     }

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDumpTransformer.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDumpTransformer.java
@@ -35,7 +35,7 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
     static boolean TEST_WITH_EXCEPTION = Boolean.getBoolean("test.with.exception");
     static boolean TEST_WITH_OOM = Boolean.getBoolean("test.with.oom");
 
-    static final int WASTE_SIZE = 32 * 1024;
+    static final int WASTE_SIZE = 1024;
     static List<byte[]> waste = new ArrayList();
     static Object sink;
 
@@ -62,12 +62,13 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
               return new byte[] {1, 2, 3, 4, 5, 6, 7, 8};
             }
             if (TEST_WITH_OOM) {
-                // Fill until OOM with 1/4 waste size. This would guarantee
-                // that we will not be able to satisfy WASTE_SIZE allocation
-                // after we caught the OOM.
+                // Fill until OOM and fail. This sets up heap for secondary OOM
+                // later on, which should be caught by CDS code. The size of waste
+                // array defines how much max free space would be left for later
+                // code to run with.
                 System.out.println("Fill objects until OOM");
                 while (true) {
-                    waste.add(new byte[WASTE_SIZE / 4]);
+                    waste.add(new byte[WASTE_SIZE]);
                 }
             }
         }

--- a/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDumpTransformer.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/javaldr/GCDuringDumpTransformer.java
@@ -35,7 +35,7 @@ public class GCDuringDumpTransformer implements ClassFileTransformer {
     static boolean TEST_WITH_EXCEPTION = Boolean.getBoolean("test.with.exception");
     static boolean TEST_WITH_OOM = Boolean.getBoolean("test.with.oom");
 
-    static final int WASTE_SIZE = 64 * 1024;
+    static final int WASTE_SIZE = 32 * 1024;
     static List<byte[]> waste = new ArrayList();
     static Object sink;
 


### PR DESCRIPTION
Found a test bug while testing [JDK-8341913](https://bugs.openjdk.org/browse/JDK-8341913) with Shenandoah. For OOM testing, the test fills out the heap with large arrays and then attempts to allocate a smaller array.

That allocation almost always succeeds with Shenandoah. Actually, it succeeds with other GCs as well, it just so happens that other GCs throw OOM with "GC overhead limit exceeded".

Plus, some allocations should be sinked to avoid dead-code elimination.

Additional testing:
 - [x] Linux x86_64 server fastdebug, test now passes reliably with JDK-8341913 and Shenandoah
 - [x] Linux x86_64 server fastdebug, test with {Serial, Parallel, G1, Shenandoah}, 50 times

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342376](https://bugs.openjdk.org/browse/JDK-8342376): More reliable OOM handling in ExceptionDuringDumpAtObjectsInitPhase test (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21536/head:pull/21536` \
`$ git checkout pull/21536`

Update a local copy of the PR: \
`$ git checkout pull/21536` \
`$ git pull https://git.openjdk.org/jdk.git pull/21536/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21536`

View PR using the GUI difftool: \
`$ git pr show -t 21536`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21536.diff">https://git.openjdk.org/jdk/pull/21536.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21536#issuecomment-2416754903)