### PR TITLE
8340389: vmTestbase/gc/gctests/PhantomReference/phantom001/TestDescription.java Test exit code: 97 with -Xcomp UseAVX=3

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
@@ -179,8 +179,9 @@ public class phantom001 extends ThreadedGCTest {
                 progress("Waiting for finalization: " + type);
                 WhiteBox.getWhiteBox().fullGC();
                 for (int checks = 0; !finalized && !shouldTerminate(); ++checks) {
-                    // There are scenarios where one WB.fillGC() isn't enough,
-                    // but 10 iterations really ought to be sufficient.
+                    // Wait for up to 10 iterations that the finalizer has been run,
+                    // this ought to be sufficient. Full GCs of other threads might
+                    // starve out the finalizer thread, requiring more waiting.
                     if (checks > 10) {
                         fail("Waiting for finalization: " + type);
                         return;

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
@@ -180,7 +180,7 @@ public class phantom001 extends ThreadedGCTest {
                 WhiteBox.getWhiteBox().fullGC();
                 for (int checks = 0; !finalized && !shouldTerminate(); ++checks) {
                     // Wait for up to 10 iterations that the finalizer has been run,
-                    // this ought to be sufficient. Full GCs of other threads might
+                    // this ought to be sufficient. Full GCs and other threads might
                     // starve out the finalizer thread, requiring more waiting.
                     if (checks > 10) {
                         fail("Waiting for finalization: " + type);

--- a/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
+++ b/test/hotspot/jtreg/vmTestbase/gc/gctests/PhantomReference/phantom001/phantom001.java
@@ -177,6 +177,7 @@ public class phantom001 extends ThreadedGCTest {
             // If referent is finalizable, provoke GCs and wait for finalization.
             if (type.equals("class")) {
                 progress("Waiting for finalization: " + type);
+                WhiteBox.getWhiteBox().fullGC();
                 for (int checks = 0; !finalized && !shouldTerminate(); ++checks) {
                     // There are scenarios where one WB.fillGC() isn't enough,
                     // but 10 iterations really ought to be sufficient.
@@ -184,7 +185,6 @@ public class phantom001 extends ThreadedGCTest {
                         fail("Waiting for finalization: " + type);
                         return;
                     }
-                    WhiteBox.getWhiteBox().fullGC();
                     // Give some time for finalizer to run.
                     try {
                         Thread.sleep(checks * 100);


### PR DESCRIPTION
Hi all,

  please review this fix to the phantom001 test to do much less garbage collections that inhibit passing the test.

Testing: gha, running the test with and without the change for 500 times with the problematic options - fails 379 times without the change, passes all runs with the change.

Thanks,
   Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340389](https://bugs.openjdk.org/browse/JDK-8340389): vmTestbase/gc/gctests/PhantomReference/phantom001/TestDescription.java Test exit code: 97 with -Xcomp UseAVX=3 (**Bug** - P2)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21538/head:pull/21538` \
`$ git checkout pull/21538`

Update a local copy of the PR: \
`$ git checkout pull/21538` \
`$ git pull https://git.openjdk.org/jdk.git pull/21538/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21538`

View PR using the GUI difftool: \
`$ git pr show -t 21538`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21538.diff">https://git.openjdk.org/jdk/pull/21538.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21538#issuecomment-2417042780)