### PR TITLE
8341399: Add since checker tests to the langtools modules

### DIFF
--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -670,4 +670,4 @@ jdk_core_no_security = \
 
 # Set of tests for `@since` checks in source code documentation
 jdk_since_checks = \
-   tools/sincechecker/modules/java_base/CheckSince_javaBase.java
+   tools/sincechecker/

--- a/test/jdk/tools/sincechecker/jdk_compiler/CheckSince_jdkCompiler.java
+++ b/test/jdk/tools/sincechecker/jdk_compiler/CheckSince_jdkCompiler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8341399
+ * @summary Test for `@since` for java.base module
+ * @library /test/lib
+ *          /test/jdk/tools/sincechecker
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          jdk.compiler/com.sun.tools.javac.code
+ * @run main SinceChecker jdk.compiler
+ */

--- a/test/jdk/tools/sincechecker/jdk_javadoc/CheckSince_jdkJavadoc.java
+++ b/test/jdk/tools/sincechecker/jdk_javadoc/CheckSince_jdkJavadoc.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8341399
+ * @summary Test for `@since` for java.base module
+ * @library /test/lib
+ *          /test/jdk/tools/sincechecker
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          jdk.compiler/com.sun.tools.javac.code
+ * @run main SinceChecker jdk.javadoc
+ */

--- a/test/jdk/tools/sincechecker/jdk_jdeps/CheckSince_jdkJdeps.java
+++ b/test/jdk/tools/sincechecker/jdk_jdeps/CheckSince_jdkJdeps.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8341399
+ * @summary Test for `@since` for java.base module
+ * @library /test/lib
+ *          /test/jdk/tools/sincechecker
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          jdk.compiler/com.sun.tools.javac.code
+ * @run main SinceChecker jdk.jdeps
+ */

--- a/test/jdk/tools/sincechecker/modules/java_compiler/CheckSince_javaCompiler.java
+++ b/test/jdk/tools/sincechecker/modules/java_compiler/CheckSince_javaCompiler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8341399
+ * @summary Test for `@since` for java.base module
+ * @library /test/lib
+ *          /test/jdk/tools/sincechecker
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.util
+ *          jdk.compiler/com.sun.tools.javac.code
+ * @run main SinceChecker java.compiler
+ */


### PR DESCRIPTION
Can I get a review for this patch that adds `@since` checker tests to the following modules: java.compiler, jdk.compiler, jdk.javadoc and jdk.jdeps. The initial test for `java.base` has been integrated in [JDK-8331051](https://bugs.openjdk.org/browse/JDK-8331051). 

The jtreg comments are almost the same as the ones for the `java.base` test, only the Bug ID and the module name being passed to the test are different.

I've made a small change to `test/jdk/TEST.groups` to include the new tests.

Here are the emails  [[1](https://mail.openjdk.org/pipermail/jdk-dev/2024-June/009160.html)] [[2](https://mail.openjdk.org/pipermail/jdk-dev/2024-October/009474.html)] in `jdk-dev` describing how the tests work and how to run them.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341399](https://bugs.openjdk.org/browse/JDK-8341399): Add since checker tests to the langtools modules (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21540/head:pull/21540` \
`$ git checkout pull/21540`

Update a local copy of the PR: \
`$ git checkout pull/21540` \
`$ git pull https://git.openjdk.org/jdk.git pull/21540/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21540`

View PR using the GUI difftool: \
`$ git pr show -t 21540`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21540.diff">https://git.openjdk.org/jdk/pull/21540.diff</a>

</details>
