### PR TITLE
8342439: Build failure after 8338023

### DIFF
--- a/src/hotspot/share/opto/vectorIntrinsics.cpp
+++ b/src/hotspot/share/opto/vectorIntrinsics.cpp
@@ -2873,7 +2873,7 @@ static Node* LowerSelectFromTwoVectorOperation(PhaseGVN& phase, Node* index_vec,
   // Wrap indexes into two vector index range [0, VLEN * 2)
   Node* two_vect_lane_cnt_m1 = phase.makecon(TypeInt::make(2 * num_elem - 1));
   Node* bcast_two_vect_lane_cnt_m1_vec = phase.transform(VectorNode::scalar2vector(two_vect_lane_cnt_m1, num_elem,
-                                                                                   Type::get_const_basic_type(T_BYTE), false));
+                                                                                   T_BYTE, false));
   index_byte_vec = phase.transform(VectorNode::make(Op_AndV, index_byte_vec, bcast_two_vect_lane_cnt_m1_vec,
                                                     index_byte_vec->bottom_type()->is_vect()));
 
@@ -2884,7 +2884,7 @@ static Node* LowerSelectFromTwoVectorOperation(PhaseGVN& phase, Node* index_vec,
   const TypeVect* vmask_type = TypeVect::makemask(T_BYTE, num_elem);
   Node* lane_cnt_m1 = phase.makecon(TypeInt::make(num_elem - 1));
   Node* bcast_lane_cnt_m1_vec = phase.transform(VectorNode::scalar2vector(lane_cnt_m1, num_elem,
-                                                                          Type::get_const_basic_type(T_BYTE), false));
+                                                                          T_BYTE, false));
   Node* mask = phase.transform(new VectorMaskCmpNode(pred, index_byte_vec, bcast_lane_cnt_m1_vec, pred_node, vmask_type));
 
   // Rearrange expects the indexes to lie within single vector index range [0, VLEN).
@@ -3012,7 +3012,7 @@ bool LibraryCallKit::inline_vector_select_from_two_vectors() {
     }
     int indexRangeMask = 2 * num_elem - 1;
     Node* wrap_mask = gvn().makecon(TypeInteger::make(indexRangeMask, indexRangeMask, Type::WidenMin, index_elem_bt != T_LONG ? T_INT : index_elem_bt));
-    Node* wrap_mask_vec = gvn().transform(VectorNode::scalar2vector(wrap_mask, num_elem, Type::get_const_basic_type(index_elem_bt), false));
+    Node* wrap_mask_vec = gvn().transform(VectorNode::scalar2vector(wrap_mask, num_elem, index_elem_bt, false));
     opd1 = gvn().transform(VectorNode::make(Op_AndV, opd1, wrap_mask_vec, opd1->bottom_type()->is_vect()));
     operation = gvn().transform(VectorNode::make(Op_SelectFromTwoVector, opd1, opd2, opd3, vt));
   }


### PR DESCRIPTION
Fix failing build. 

Due to notification problem with integration system.

Thanks,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342439](https://bugs.openjdk.org/browse/JDK-8342439): Build failure after 8338023 (**Bug** - P1)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21547/head:pull/21547` \
`$ git checkout pull/21547`

Update a local copy of the PR: \
`$ git checkout pull/21547` \
`$ git pull https://git.openjdk.org/jdk.git pull/21547/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21547`

View PR using the GUI difftool: \
`$ git pr show -t 21547`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21547.diff">https://git.openjdk.org/jdk/pull/21547.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21547#issuecomment-2417590503)