### PR TITLE
8341453: java/awt/a11y/AccessibleJTableTest.java fails in some cases where the test tables are not visible

### DIFF
--- a/test/jdk/java/awt/a11y/AccessibleJTableTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJTableTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2021, JetBrains s.r.o.. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -26,17 +26,10 @@
  * @test
  * @bug 8267388
  * @summary Test implementation of NSAccessibilityTable protocol peer
- * @author Artem.Semenov@jetbrains.com
  * @run main/manual AccessibleJTableTest
  * @requires (os.family == "windows" | os.family == "mac")
  */
 
-import javax.swing.JButton;
-import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.JTable;
-import javax.swing.SwingUtilities;
-import javax.swing.table.AbstractTableModel;
 
 import java.awt.FlowLayout;
 import java.awt.GridLayout;
@@ -44,6 +37,12 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.table.AbstractTableModel;
 
 public class AccessibleJTableTest extends AccessibleComponentTest {
     private static final String[] columnNames = {"One", "Two", "Three"};

--- a/test/jdk/java/awt/a11y/AccessibleJTableTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJTableTest.java
@@ -31,13 +31,15 @@
  * @requires (os.family == "windows" | os.family == "mac")
  */
 
-import javax.swing.*;
-import javax.swing.event.TableModelEvent;
-import javax.swing.event.TableModelListener;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
-import javax.swing.table.TableModel;
 
-import java.awt.*;
+import java.awt.FlowLayout;
+import java.awt.GridLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.concurrent.CountDownLatch;
@@ -105,7 +107,9 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
                 + "If you can hear second table name: \"second table\" - ctrl+tab further and press PASS, otherwise press FAIL.\n";
 
         JTable table = new JTable(data, columnNames);
+        table.setPreferredScrollableViewportSize(table.getPreferredSize());
         JTable secondTable = new JTable(data, columnNames);
+        secondTable.setPreferredScrollableViewportSize(secondTable.getPreferredSize());
         secondTable.getAccessibleContext().setAccessibleName("Second table");
         JPanel panel = new JPanel();
         panel.setLayout(new FlowLayout());

--- a/test/jdk/java/awt/a11y/AccessibleJTableTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJTableTest.java
@@ -69,6 +69,7 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
                 + "If you can hear table cells ctrl+tab further and press PASS, otherwise press FAIL.\n";
 
         JTable table = new JTable(data, columnNames);
+        table.setPreferredScrollableViewportSize(table.getPreferredSize());
         JPanel panel = new JPanel();
         panel.setLayout(new FlowLayout());
         JScrollPane scrollPane = new JScrollPane(table);
@@ -84,12 +85,13 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
                 + "Turn screen reader on, and Tab to the table.\n"
                 + "Using arrow keys navigate to the last cell in the first row in the table."
                 + "Screen reader should announce it as \"Column 3 row 1\"\n\n"
-                + "Using mouse drag the header of the last culumn so the last column becomes the first one."
+                + "Using mouse drag the header of the last column so the last column becomes the first one."
                 + "Wait for the screen reader to finish announcing new position in table.\n\n"
                 + "If new position in table corresponds to the new table layout ctrl+tab further "
                 + "and press PASS, otherwise press FAIL.\n";
 
         JTable table = new JTable(data, columnNames);
+        table.setPreferredScrollableViewportSize(table.getPreferredSize());
         JPanel panel = new JPanel();
         panel.setLayout(new FlowLayout());
         JScrollPane scrollPane = new JScrollPane(table);
@@ -130,8 +132,8 @@ public class AccessibleJTableTest extends AccessibleComponentTest {
                 + "If you hear changes in the table - ctrl+tab further and press PASS, otherwise press FAIL.\n";
 
         JTable table = new JTable(new TestTableModel(3, 3));
-
-                JPanel panel = new JPanel();
+        table.setPreferredScrollableViewportSize(table.getPreferredSize());
+        JPanel panel = new JPanel();
         panel.setLayout(new FlowLayout());
         JScrollPane scrollPane = new JScrollPane(table);
         panel.add(scrollPane);

--- a/test/jdk/java/awt/a11y/AccessibleJTableTest.java
+++ b/test/jdk/java/awt/a11y/AccessibleJTableTest.java
@@ -30,7 +30,6 @@
  * @requires (os.family == "windows" | os.family == "mac")
  */
 
-
 import java.awt.FlowLayout;
 import java.awt.GridLayout;
 import java.awt.event.ActionEvent;


### PR DESCRIPTION
This issue can be fixed by setting the preferred scrollable viewport size of the two tables using
        JTable table = new JTable(data, columnNames);
    +  table.setPreferredScrollableViewportSize(table.getPreferredSize());
        JTable secondTable = new JTable(data, columnNames);
    +  secondTable.setPreferredScrollableViewportSize(secondTable.getPreferredSize());
    
    The other changes in imports section are just re-arrangements and expansion of imports.

Testing: This is a manual test and it is tested and verified manually in my local system
Screenshots of before and after the fix are attached in the bug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341453](https://bugs.openjdk.org/browse/JDK-8341453): java/awt/a11y/AccessibleJTableTest.java fails in some cases where the test tables are not visible (**Bug** - P4)


### Reviewers
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer) Review applies to [d4d83388](https://git.openjdk.org/jdk/pull/21549/files/d4d8338895abe248b665d61a31f00d39b64bc663)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21549/head:pull/21549` \
`$ git checkout pull/21549`

Update a local copy of the PR: \
`$ git checkout pull/21549` \
`$ git pull https://git.openjdk.org/jdk.git pull/21549/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21549`

View PR using the GUI difftool: \
`$ git pr show -t 21549`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21549.diff">https://git.openjdk.org/jdk/pull/21549.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21549#issuecomment-2417628930)