### PR TITLE
8331958: Update PC/SC Lite for Suse Linux to 2.3.0

### DIFF
--- a/src/java.smartcardio/unix/legal/pcsclite.md
+++ b/src/java.smartcardio/unix/legal/pcsclite.md
@@ -1,4 +1,4 @@
-## PC/SC Lite v1.9.9
+## PC/SC Lite v2.3.0
 
 ### PC/SC Lite Notice
 ```
@@ -9,19 +9,19 @@ Only 3 header files are included in this distribution: winscard.h, wintypes.h, p
 Copyright for winscard.h:
  * Copyright (C) 1999-2003
  *  David Corcoran <corcoran@musclecard.com>
- * Copyright (C) 2002-2009
+ * Copyright (C) 2002-2018
  *  Ludovic Rousseau <ludovic.rousseau@free.fr>
 
 Copyright for wintypes.h:
  * Copyright (C) 1999
  *  David Corcoran <corcoran@musclecard.com>
- * Copyright (C) 2002-2011
+ * Copyright (C) 2002-2018
  *  Ludovic Rousseau <ludovic.rousseau@free.fr>
 
 Copyright for pcsclite.h:
  * Copyright (C) 1999-2004
  *  David Corcoran <corcoran@musclecard.com>
- * Copyright (C) 2002-2011
+ * Copyright (C) 2002-2024
  *  Ludovic Rousseau <ludovic.rousseau@free.fr>
  * Copyright (C) 2005
  *  Martin Paljak <martin@paljak.pri.ee>

--- a/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/pcsclite.h
+++ b/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/pcsclite.h
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 1999-2004
  *  David Corcoran <corcoran@musclecard.com>
- * Copyright (C) 2002-2011
+ * Copyright (C) 2002-2024
  *  Ludovic Rousseau <ludovic.rousseau@free.fr>
  * Copyright (C) 2005
  *  Martin Paljak <martin@paljak.pri.ee>
@@ -192,7 +192,8 @@ extern const SCARD_IO_REQUEST g_rgSCardT0Pci, g_rgSCardT1Pci, g_rgSCardRawPci;
 /** @ingroup ErrorCodes */
 #define SCARD_E_INVALID_CHV        ((LONG)0x8010002A) /**< The supplied PIN is incorrect. */
 /** @ingroup ErrorCodes */
-#define SCARD_E_UNKNOWN_RES_MNG        ((LONG)0x8010002B) /**< An unrecognized error code was returned from a layered component. */
+#define SCARD_E_UNKNOWN_RES_MSG        ((LONG)0x8010002B) /**< An unrecognized error code was returned from a layered component. */
+#define SCARD_E_UNKNOWN_RES_MNG        SCARD_E_UNKNOWN_RES_MSG
 /** @ingroup ErrorCodes */
 #define SCARD_E_NO_SUCH_CERTIFICATE    ((LONG)0x8010002C) /**< The requested certificate does not exist. */
 /** @ingroup ErrorCodes */
@@ -279,7 +280,7 @@ extern const SCARD_IO_REQUEST g_rgSCardT0Pci, g_rgSCardT1Pci, g_rgSCardRawPci;
 #define INFINITE            0xFFFFFFFF    /**< Infinite timeout */
 #endif
 
-#define PCSCLITE_VERSION_NUMBER        "1.9.9"    /**< Current version */
+#define PCSCLITE_VERSION_NUMBER        "2.3.0"    /**< Current version */
 /** Maximum readers context (a slot is count as a reader) */
 #define PCSCLITE_MAX_READERS_CONTEXTS            16
 

--- a/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/winscard.h
+++ b/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/winscard.h
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 1999-2003
  *  David Corcoran <corcoran@musclecard.com>
- * Copyright (C) 2002-2009
+ * Copyright (C) 2002-2018
  *  Ludovic Rousseau <ludovic.rousseau@free.fr>
  *
 Redistribution and use in source and binary forms, with or without

--- a/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/wintypes.h
+++ b/src/java.smartcardio/unix/native/libj2pcsc/MUSCLE/wintypes.h
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 1999
  *  David Corcoran <corcoran@musclecard.com>
- * Copyright (C) 2002-2011
+ * Copyright (C) 2002-2018
  *  Ludovic Rousseau <ludovic.rousseau@free.fr>
  *
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Could someone please help review this PR? It updates the PCSC Lite headers and the relevant files to v2.3.0.

Thanks!
Valerie

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331958](https://bugs.openjdk.org/browse/JDK-8331958): Update PC/SC Lite for Suse Linux to 2.3.0 (**Enhancement** - P4)


### Reviewers
 * [Weijun Wang](https://openjdk.org/census#weijun) (@wangweij - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21552/head:pull/21552` \
`$ git checkout pull/21552`

Update a local copy of the PR: \
`$ git checkout pull/21552` \
`$ git pull https://git.openjdk.org/jdk.git pull/21552/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21552`

View PR using the GUI difftool: \
`$ git pr show -t 21552`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21552.diff">https://git.openjdk.org/jdk/pull/21552.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21552#issuecomment-2418003611)