### PR TITLE
8335271: Specify the MessageFormat ArgumentIndex Implementation Limit

### DIFF
--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -124,7 +124,7 @@ import java.util.Objects;
  * are case-insensitive when passed to {@link #applyPattern(String)}. Combinations
  * not shown in the table are illegal. A <i>SubformatPattern</i> must
  * be a valid pattern string for the {@code Format} subclass used.
- * @implSpec For this implementation, the limit of <b>ArgumentIndex</b> is 10,000
+ * @implNote For this implementation, the limit of <b>ArgumentIndex</b> is 10,000
  *
  * <table class="plain">
  * <caption style="display:none">Shows how FormatType and FormatStyle values map to Format instances</caption>

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -110,21 +110,21 @@ import java.util.Objects;
  * </pre></blockquote>
  *
  * <p>
- * The <b>ArgumentIndex</b> value is a non-negative integer written
+ * The {@code ArgumentIndex} value is a non-negative integer written
  * using the digits {@code '0'} through {@code '9'}, and represents an index into the
  * {@code arguments} array passed to the {@code format} methods
  * or the result array returned by the {@code parse} methods.
  * <p>
  * Any constructor or method that takes a String pattern parameter will throw an {@code IllegalArgumentException} if the
- * pattern contains an <b>ArgumentIndex</b> value that is equal to or exceeds an implementation limit.
+ * pattern contains an {@code ArgumentIndex} value that is equal to or exceeds an implementation limit.
  * <p>
- * The <b>FormatType</b> and <b>FormatStyle</b> values are used to create
+ * The {@code FormatType} and {@code FormatStyle} values are used to create
  * a {@code Format} instance for the format element. The following
  * table shows how the values map to {@code Format} instances. These values
  * are case-insensitive when passed to {@link #applyPattern(String)}. Combinations
  * not shown in the table are illegal. A <i>SubformatPattern</i> must
  * be a valid pattern string for the {@code Format} subclass used.
- * @implNote For this implementation, the limit of <b>ArgumentIndex</b> is 10,000
+ * @implNote For this implementation, the limit of {@code ArgumentIndex} is 10,000.
  *
  * <table class="plain">
  * <caption style="display:none">Shows how FormatType and FormatStyle values map to Format instances</caption>

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -124,7 +124,7 @@ import java.util.Objects;
  * are case-insensitive when passed to {@link #applyPattern(String)}. Combinations
  * not shown in the table are illegal. A <i>SubformatPattern</i> must
  * be a valid pattern string for the {@code Format} subclass used.
- * @implNote For this implementation, the limit of {@code ArgumentIndex} is 10,000.
+ * @implNote In the reference implementation, the limit of {@code ArgumentIndex} is 10,000.
  *
  * <table class="plain">
  * <caption style="display:none">Shows how FormatType and FormatStyle values map to Format instances</caption>

--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -110,17 +110,21 @@ import java.util.Objects;
  * </pre></blockquote>
  *
  * <p>
- * The <i>ArgumentIndex</i> value is a non-negative integer written
+ * The <b>ArgumentIndex</b> value is a non-negative integer written
  * using the digits {@code '0'} through {@code '9'}, and represents an index into the
  * {@code arguments} array passed to the {@code format} methods
  * or the result array returned by the {@code parse} methods.
  * <p>
- * The <i>FormatType</i> and <i>FormatStyle</i> values are used to create
+ * Any constructor or method that takes a String pattern parameter will throw an {@code IllegalArgumentException} if the
+ * pattern contains an <b>ArgumentIndex</b> value that is equal to or exceeds an implementation limit.
+ * <p>
+ * The <b>FormatType</b> and <b>FormatStyle</b> values are used to create
  * a {@code Format} instance for the format element. The following
  * table shows how the values map to {@code Format} instances. These values
  * are case-insensitive when passed to {@link #applyPattern(String)}. Combinations
  * not shown in the table are illegal. A <i>SubformatPattern</i> must
  * be a valid pattern string for the {@code Format} subclass used.
+ * @implSpec For this implementation, the limit of <b>ArgumentIndex</b> is 10,000
  *
  * <table class="plain">
  * <caption style="display:none">Shows how FormatType and FormatStyle values map to Format instances</caption>


### PR DESCRIPTION
Please review this PR which specifies the _j.text.MessageFormat_ ArgumentIndex limit. A corresponding CSR is drafted.

Both the existence of the limit (and behavior if violated), as well as this implementation's limit are added to the class description. See the JBS issue comments for further history.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8342436](https://bugs.openjdk.org/browse/JDK-8342436) to be approved

### Issues
 * [JDK-8335271](https://bugs.openjdk.org/browse/JDK-8335271): Specify the MessageFormat ArgumentIndex Implementation Limit (**Bug** - P4)
 * [JDK-8342436](https://bugs.openjdk.org/browse/JDK-8342436): Specify the MessageFormat ArgumentIndex Implementation Limit (**CSR**)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) Review applies to [448c2453](https://git.openjdk.org/jdk/pull/21554/files/448c2453a06234e484bd4d2606e7e3c3e37ec275)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**) Review applies to [448c2453](https://git.openjdk.org/jdk/pull/21554/files/448c2453a06234e484bd4d2606e7e3c3e37ec275)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21554/head:pull/21554` \
`$ git checkout pull/21554`

Update a local copy of the PR: \
`$ git checkout pull/21554` \
`$ git pull https://git.openjdk.org/jdk.git pull/21554/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21554`

View PR using the GUI difftool: \
`$ git pr show -t 21554`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21554.diff">https://git.openjdk.org/jdk/pull/21554.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21554#issuecomment-2418102595)