### PR TITLE
8331467: ImageReaderFactory can cause a ClassNotFoundException if the default FileSystemProvider is not the system-default provider

### DIFF
--- a/src/java.base/aix/classes/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/src/java.base/aix/classes/sun/nio/fs/DefaultFileSystemProvider.java
@@ -50,4 +50,12 @@ public class DefaultFileSystemProvider {
     public static FileSystem theFileSystem() {
         return INSTANCE.theFileSystem();
     }
+
+    /**
+     * This method is from java8 API to be compatible against runtime.
+     * Returns the default FileSystemProvider.
+     */
+    public static FileSystemProvider create() {
+        return INSTANCE;
+    }
 }

--- a/src/java.base/linux/classes/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/src/java.base/linux/classes/sun/nio/fs/DefaultFileSystemProvider.java
@@ -50,4 +50,12 @@ public class DefaultFileSystemProvider {
     public static FileSystem theFileSystem() {
         return INSTANCE.theFileSystem();
     }
+
+    /**
+     * This method is from java8 API to be compatible against runtime.
+     * Returns the default FileSystemProvider.
+     */
+    public static FileSystemProvider create() {
+        return INSTANCE;
+    }
 }

--- a/src/java.base/macosx/classes/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/DefaultFileSystemProvider.java
@@ -50,4 +50,12 @@ public class DefaultFileSystemProvider {
     public static FileSystem theFileSystem() {
         return INSTANCE.theFileSystem();
     }
+
+    /**
+     * This method is from java8 API to be compatible against runtime.
+     * Returns the default FileSystemProvider.
+     */
+    public static FileSystemProvider create() {
+        return INSTANCE;
+    }
 }

--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReaderFactory.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReaderFactory.java
@@ -48,7 +48,7 @@ public class ImageReaderFactory {
 
     private static final String JAVA_HOME = System.getProperty("java.home");
     private static final Path BOOT_MODULES_JIMAGE =
-        Paths.get(JAVA_HOME, "lib", "modules");
+            sun.nio.fs.DefaultFileSystemProvider.create().getPath(JAVA_HOME, "lib", "modules");
 
     private static final Map<Path, ImageReader> readers = new ConcurrentHashMap<>();
 

--- a/src/java.base/windows/classes/sun/nio/fs/DefaultFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/DefaultFileSystemProvider.java
@@ -49,4 +49,12 @@ public class DefaultFileSystemProvider {
     public static FileSystem theFileSystem() {
         return INSTANCE.theFileSystem();
     }
+
+    /**
+     * This method is from java8 API to be compatible against runtime.
+     * Returns the default FileSystemProvider.
+     */
+    public static FileSystemProvider create() {
+        return INSTANCE;
+    }
 }


### PR DESCRIPTION
Use the built-in file system provider rather than the custom file system provider.
Add "public static FileSystemProvider create" method in DefaultFileSystemProvider which is from java8API to be compatible against runtime.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331467](https://bugs.openjdk.org/browse/JDK-8331467): ImageReaderFactory can cause a ClassNotFoundException if the default FileSystemProvider is not the system-default provider (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21556/head:pull/21556` \
`$ git checkout pull/21556`

Update a local copy of the PR: \
`$ git checkout pull/21556` \
`$ git pull https://git.openjdk.org/jdk.git pull/21556/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21556`

View PR using the GUI difftool: \
`$ git pr show -t 21556`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21556.diff">https://git.openjdk.org/jdk/pull/21556.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21556#issuecomment-2465987407)
</details>
