### PR TITLE
8342409: [s390x] C1 unwind_handler fails to unlock synchronized methods with LM_MONITOR

### DIFF
--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -216,7 +216,11 @@ int LIR_Assembler::emit_unwind_handler() {
     LIR_Opr lock = FrameMap::as_opr(Z_R1_scratch);
     monitor_address(0, lock);
     stub = new MonitorExitStub(lock, true, 0);
-    __ unlock_object(Rtmp1, Rtmp2, lock->as_register(), *stub->entry());
+    if (LockingMode == LM_MONITOR) {
+      __ branch_optimized(Assembler::bcondAlways, *stub->entry());
+    } else {
+      __ unlock_object(Rtmp1, Rtmp2, lock->as_register(), *stub->entry());
+    }
     __ bind(*stub->continuation());
   }
 

--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -120,6 +120,8 @@ void C1_MacroAssembler::lock_object(Register Rmark, Register Roop, Register Rbox
     branch_optimized(Assembler::bcondNotZero, slow_case);
     // done
     bind(done);
+  } else {
+    assert(false, "Unhandled LockingMode:%d", LockingMode);
   }
 }
 
@@ -151,6 +153,8 @@ void C1_MacroAssembler::unlock_object(Register Rmark, Register Roop, Register Rb
     // If the object header was not pointing to the displaced header,
     // we do unlocking via runtime call.
     branch_optimized(Assembler::bcondNotEqual, slow_case);
+  } else {
+    assert(false, "Unhandled LockingMode:%d", LockingMode);
   }
   // done
   bind(done);


### PR DESCRIPTION
Make sure LIR_Assembler::emit_unwind_handler() jumps to the slow path directly for unlocking a synchronized method if LM_MONITOR is used.
On the fast paths assertions are added that the mode is actually handled.

Testing: Tier1 test for fastdebug vm showed no regression.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342409](https://bugs.openjdk.org/browse/JDK-8342409): [s390x] C1 unwind_handler fails to unlock synchronized methods with LM_MONITOR (**Bug** - P4)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21557/head:pull/21557` \
`$ git checkout pull/21557`

Update a local copy of the PR: \
`$ git checkout pull/21557` \
`$ git pull https://git.openjdk.org/jdk.git pull/21557/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21557`

View PR using the GUI difftool: \
`$ git pr show -t 21557`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21557.diff">https://git.openjdk.org/jdk/pull/21557.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21557#issuecomment-2418656874)