### PR TITLE
8342482: Use the same native thread initialization procedure on all platforms

### DIFF
--- a/src/hotspot/os/aix/osThread_aix.cpp
+++ b/src/hotspot/os/aix/osThread_aix.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -39,11 +39,9 @@ OSThread::OSThread()
     _siginfo(nullptr),
     _ucontext(nullptr),
     _expanding_stack(0),
-    _alt_sig_stack(nullptr),
-    _startThread_lock(new Monitor(Mutex::event, "startThread_lock")) {
+    _alt_sig_stack(nullptr) {
   sigemptyset(&_caller_sigmask);
 }
 
 OSThread::~OSThread() {
-  delete _startThread_lock;
 }

--- a/src/hotspot/os/aix/osThread_aix.hpp
+++ b/src/hotspot/os/aix/osThread_aix.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2013 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -121,15 +121,6 @@ class OSThread : public OSThreadBase {
 
   void set_alt_sig_stack(address val)     { _alt_sig_stack = val; }
   address alt_sig_stack(void)             { return _alt_sig_stack; }
-
- private:
-  Monitor* _startThread_lock;     // sync parent and child in thread creation
-
- public:
-
-  Monitor* startThread_lock() const {
-    return _startThread_lock;
-  }
 
   // Printing
   uintx thread_id_for_printing() const override {

--- a/src/hotspot/os/bsd/osThread_bsd.cpp
+++ b/src/hotspot/os/bsd/osThread_bsd.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,8 +45,7 @@ OSThread::OSThread()
     _siginfo(nullptr),
     _ucontext(nullptr),
     _expanding_stack(0),
-    _alt_sig_stack(nullptr),
-    _startThread_lock(new Monitor(Mutex::event, "startThread_lock")) {
+    _alt_sig_stack(nullptr) {
   sigemptyset(&_caller_sigmask);
 }
 
@@ -67,5 +66,4 @@ void OSThread::set_unique_thread_id() {
 }
 
 OSThread::~OSThread() {
-  delete _startThread_lock;
 }

--- a/src/hotspot/os/bsd/osThread_bsd.hpp
+++ b/src/hotspot/os/bsd/osThread_bsd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -122,15 +122,6 @@ public:
 
   void set_alt_sig_stack(address val)     { _alt_sig_stack = val; }
   address alt_sig_stack(void)             { return _alt_sig_stack; }
-
-private:
-  Monitor* _startThread_lock;     // sync parent and child in thread creation
-
-public:
-
-  Monitor* startThread_lock() const {
-    return _startThread_lock;
-  }
 
   uintx thread_id_for_printing() const override {
     return (uintx)_thread_id;

--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -571,7 +571,6 @@ static void *thread_native_entry(Thread *thread) {
   thread->initialize_thread_current();
 
   OSThread* osthread = thread->osthread();
-  Monitor* sync = osthread->startThread_lock();
 
   osthread->set_thread_id(os::Bsd::gettid());
 
@@ -594,18 +593,7 @@ static void *thread_native_entry(Thread *thread) {
 #endif
 
   // handshaking with parent thread
-  {
-    MutexLocker ml(sync, Mutex::_no_safepoint_check_flag);
-
-    // notify parent thread
-    osthread->set_state(INITIALIZED);
-    sync->notify_all();
-
-    // wait until os::start_thread()
-    while (osthread->get_state() == INITIALIZED) {
-      sync->wait_without_safepoint_check();
-    }
-  }
+  osthread->wait_for_start();
 
   log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", pthread id: " UINTX_FORMAT ").",
     os::current_thread_id(), (uintx) pthread_self());
@@ -635,9 +623,6 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
 
   // set the correct thread state
   osthread->set_thread_type(thr_type);
-
-  // Initial state is ALLOCATED but not INITIALIZED
-  osthread->set_state(ALLOCATED);
 
   thread->set_osthread(osthread);
 
@@ -689,20 +674,10 @@ bool os::create_thread(Thread* thread, ThreadType thr_type,
     // Store pthread info into the OSThread
     osthread->set_pthread_id(tid);
 
-    // Wait until child thread is either initialized or aborted
-    {
-      Monitor* sync_with_child = osthread->startThread_lock();
-      MutexLocker ml(sync_with_child, Mutex::_no_safepoint_check_flag);
-      while ((state = osthread->get_state()) == ALLOCATED) {
-        sync_with_child->wait_without_safepoint_check();
-      }
-    }
-
+    // The new thread won't proceed past initialization until
+    // os::start_thread() is called later.
+    osthread->wait_for_init();
   }
-
-  // The thread is returned suspended (in state INITIALIZED),
-  // and is started higher up in the call chain
-  assert(state == INITIALIZED, "race condition");
   return true;
 }
 
@@ -754,14 +729,6 @@ bool os::create_attached_thread(JavaThread* thread) {
                        os::current_thread_id(), (uintx) pthread_self(),
                        p2i(thread->stack_base()), p2i(thread->stack_end()), thread->stack_size() / K);
   return true;
-}
-
-void os::pd_start_thread(Thread* thread) {
-  OSThread * osthread = thread->osthread();
-  assert(osthread->get_state() != INITIALIZED, "just checking");
-  Monitor* sync_with_child = osthread->startThread_lock();
-  MutexLocker ml(sync_with_child, Mutex::_no_safepoint_check_flag);
-  sync_with_child->notify();
 }
 
 // Free Bsd resources related to the OSThread

--- a/src/hotspot/os/linux/osThread_linux.cpp
+++ b/src/hotspot/os/linux/osThread_linux.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,11 +38,9 @@ OSThread::OSThread()
     _siginfo(nullptr),
     _ucontext(nullptr),
     _expanding_stack(0),
-    _alt_sig_stack(nullptr),
-    _startThread_lock(new Monitor(Mutex::event, "startThread_lock")) {
+    _alt_sig_stack(nullptr) {
   sigemptyset(&_caller_sigmask);
 }
 
 OSThread::~OSThread() {
-  delete _startThread_lock;
 }

--- a/src/hotspot/os/linux/osThread_linux.hpp
+++ b/src/hotspot/os/linux/osThread_linux.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,15 +111,6 @@ public:
 
   void set_alt_sig_stack(address val)     { _alt_sig_stack = val; }
   address alt_sig_stack(void)             { return _alt_sig_stack; }
-
-private:
-  Monitor* _startThread_lock;     // sync parent and child in thread creation
-
-public:
-
-  Monitor* startThread_lock() const {
-    return _startThread_lock;
-  }
 
   // Printing
   uintx thread_id_for_printing() const override {

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -839,11 +839,7 @@ int os::random() {
   }
 }
 
-// The INITIALIZED state is distinguished from the SUSPENDED state because the
-// conditions in which a thread is first started are different from those in which
-// a suspension is resumed.  These differences make it hard for us to apply the
-// tougher checks when starting threads that we want to do when resuming them.
-// However, when start_thread is called as a result of Thread.start, on a Java
+// When start_thread is called as a result of Thread.start, on a Java
 // thread, the operation is synchronized on the Java Thread object.  So there
 // cannot be a race to start the thread and hence for the thread to exit while
 // we are working on it.  Non-Java threads that start Java threads either have
@@ -851,9 +847,7 @@ int os::random() {
 // locking.
 
 void os::start_thread(Thread* thread) {
-  OSThread* osthread = thread->osthread();
-  osthread->set_state(RUNNABLE);
-  pd_start_thread(thread);
+  thread->osthread()->start_thread();
 }
 
 void os::abort(bool dump_core) {

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -586,7 +586,6 @@ class os: AllStatic {
 #endif
 
   static bool create_attached_thread(JavaThread* thread);
-  static void pd_start_thread(Thread* thread);
   static void start_thread(Thread* thread);
 
   // Returns true if successful.

--- a/src/hotspot/share/runtime/osThreadBase.hpp
+++ b/src/hotspot/share/runtime/osThreadBase.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,18 +56,22 @@ typedef int (*OSThreadStartFunc)(void*);
 class OSThreadBase: public CHeapObj<mtThread> {
   friend class VMStructs;
   friend class JVMCIVMStructs;
+  friend class os;
  private:
   volatile ThreadState _state;    // Thread state *hint*
+  Monitor* _startThread_lock;     // Sync parent and child in thread creation
+  void wait_for_init();           // Wait until the new thread has initialized
+  void start_thread();            // Allow the new thread to proceed after init
 
-  // Methods
  public:
-  OSThreadBase() {}
-  virtual ~OSThreadBase() {}
+  OSThreadBase();
+  ~OSThreadBase();
   NONCOPYABLE(OSThreadBase);
 
-  void set_state(ThreadState state)                { _state = state; }
-  ThreadState get_state()                          { return _state; }
+  void set_state(ThreadState state) { _state = state; }
+  ThreadState get_state()           { return _state; }
 
+  void wait_for_start();         // Make the new thread wait for os::start_thread
 
   virtual uintx thread_id_for_printing() const = 0;
 


### PR DESCRIPTION
This fixes an issue reported in https://bugs.openjdk.org/browse/JDK-8340401 caused by a difference in the thread initialization protocol for new Java threads, by using the same Monitor-based "handshake" protocol on all platforms. This allows all the related code, including the `_threadStart_lock` to be put into the shared `OSThreadBase` class.

For AIX and Windows this means threads are no longer started in a suspended state.

Testing
 - GHA
 - Tiers 1-4

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Issue
 * [JDK-8342482](https://bugs.openjdk.org/browse/JDK-8342482): Use the same native thread initialization procedure on all platforms (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21558/head:pull/21558` \
`$ git checkout pull/21558`

Update a local copy of the PR: \
`$ git checkout pull/21558` \
`$ git pull https://git.openjdk.org/jdk.git pull/21558/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21558`

View PR using the GUI difftool: \
`$ git pr show -t 21558`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21558.diff">https://git.openjdk.org/jdk/pull/21558.diff</a>

</details>
