### PR TITLE
8342287: C2 fails with "assert(is_IfTrue()) failed: invalid node class: IfFalse" due to Template Assertion Predicate with two UCTs

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2826,6 +2826,10 @@ SafePointNode* CountedLoopNode::outer_safepoint() const {
 
 Node* CountedLoopNode::skip_assertion_predicates_with_halt() {
   Node* ctrl = in(LoopNode::EntryControl);
+  if (ctrl == nullptr) {
+    // Dying loop.
+    return nullptr;
+  }
   if (is_main_loop()) {
     ctrl = skip_strip_mined()->in(LoopNode::EntryControl);
   }

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -34,6 +34,7 @@
 // Walk over all Initialized Assertion Predicates and return the entry into the first Initialized Assertion Predicate
 // (i.e. not belonging to an Initialized Assertion Predicate anymore)
 Node* AssertionPredicatesWithHalt::find_entry(Node* start_proj) {
+  assert(start_proj != nullptr, "should not be null");
   Node* entry = start_proj;
   while (AssertionPredicateWithHalt::is_predicate(entry)) {
     entry = entry->in(0)->in(0);
@@ -42,7 +43,7 @@ Node* AssertionPredicatesWithHalt::find_entry(Node* start_proj) {
 }
 
 bool AssertionPredicateWithHalt::is_predicate(const Node* maybe_success_proj) {
-  if (maybe_success_proj == nullptr || !maybe_success_proj->is_IfProj() || !maybe_success_proj->in(0)->is_If()) {
+  if (!AssertionPredicate::may_be_predicate_if(maybe_success_proj)) {
     return false;
   }
   return has_assertion_predicate_opaque(maybe_success_proj) && has_halt(maybe_success_proj);
@@ -130,10 +131,15 @@ bool RuntimePredicate::is_predicate(Node* node, Deoptimization::DeoptReason deop
   return RegularPredicateWithUCT::is_predicate(node, deopt_reason);
 }
 
+// An Assertion Predicate has always a true projection on the success path.
+bool AssertionPredicate::may_be_predicate_if(const Node* node) {
+  return node->is_IfTrue() && RegularPredicate::may_be_predicate_if(node->as_IfProj());
+}
+
 // A Template Assertion Predicate has an If/RangeCheckNode and either an UCT or a halt node depending on where it
 // was created.
 bool TemplateAssertionPredicate::is_predicate(Node* node) {
-  if (!RegularPredicate::may_be_predicate_if(node)) {
+  if (!AssertionPredicate::may_be_predicate_if(node)) {
     return false;
   }
   IfNode* if_node = node->in(0)->as_If();

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -369,12 +369,6 @@ class RuntimePredicate : public Predicate {
   static bool is_predicate(Node* node, Deoptimization::DeoptReason deopt_reason);
 };
 
-// Utility class to represent an Assertion Predicate.
-class AssertionPredicate : public StackObj {
- public:
-  static bool may_be_predicate_if(const Node* node);
-};
-
 // Class to represent a Template Assertion Predicate.
 class TemplateAssertionPredicate : public Predicate {
   IfTrueNode* _success_proj;

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -369,6 +369,12 @@ class RuntimePredicate : public Predicate {
   static bool is_predicate(Node* node, Deoptimization::DeoptReason deopt_reason);
 };
 
+// Utility class to represent an Assertion Predicate.
+class AssertionPredicate : public StackObj {
+ public:
+  static bool may_be_predicate_if(const Node* node);
+};
+
 // Class to represent a Template Assertion Predicate.
 class TemplateAssertionPredicate : public Predicate {
   IfTrueNode* _success_proj;
@@ -687,10 +693,15 @@ class PredicateIterator : public StackObj {
     Node* current = _start_node;
     PredicateBlockIterator loop_limit_check_predicate_iterator(current, Deoptimization::Reason_loop_limit_check);
     current = loop_limit_check_predicate_iterator.for_each(predicate_visitor);
-    PredicateBlockIterator profiled_loop_predicate_iterator(current, Deoptimization::Reason_profile_predicate);
-    current = profiled_loop_predicate_iterator.for_each(predicate_visitor);
-    PredicateBlockIterator loop_predicate_iterator(current, Deoptimization::Reason_predicate);
-    return loop_predicate_iterator.for_each(predicate_visitor);
+    if (UseLoopPredicate) {
+      if (UseProfiledLoopPredicate) {
+        PredicateBlockIterator profiled_loop_predicate_iterator(current, Deoptimization::Reason_profile_predicate);
+        current = profiled_loop_predicate_iterator.for_each(predicate_visitor);
+      }
+      PredicateBlockIterator loop_predicate_iterator(current, Deoptimization::Reason_predicate);
+      current = loop_predicate_iterator.for_each(predicate_visitor);
+    }
+    return current;
   }
 };
 

--- a/src/hotspot/test/hotspot/jtreg/compiler/predicates/TestTemplateAssertionPredicateWithTwoUCTs.java
+++ b/src/hotspot/test/hotspot/jtreg/compiler/predicates/TestTemplateAssertionPredicateWithTwoUCTs.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8342287
+ * @summary Test that a fail path projection of a Template Assertion Predicate is not treated as success path projection
+ * @run main/othervm -XX:-TieredCompilation -Xbatch
+ *                   -XX:CompileCommand=compileonly,compiler.predicates.TestTemplateAssertionPredicateWithTwoUCTs::test
+ *                   compiler.predicates.TestTemplateAssertionPredicateWithTwoUCTs
+ */
+
+package compiler.predicates;
+
+public class TestTemplateAssertionPredicateWithTwoUCTs {
+    static int iFld;
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 1000; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        int lArr[][] = new int[100][1];
+        for (int i14 = 5; i14 < 273; ++i14) {
+            int i16 = 1;
+            while (++i16 < 94) {
+                lArr[i16][0] += 1;
+                switch (i14) {
+                    case 11:
+                    case 2:
+                    case 13:
+                        iFld = 34;
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
### Assertion Predicates Have the True Projection on the Success Path
By design, Template and Initialized Assertion Predicates have the true projection on the success path and false projection on the failing path. 

### Is a Node a Template Assertion Predicate?
Template Assertion Predicates can have an uncommon trap on or a `Halt` node following the failing/false projection. When trying to find out if a node is a Template Assertion Predicate, we call `TemplateAssertionPredicate::is_predicate()` which checks if the provided node is the success projection of a Template Assertion Predicate. This involves checking if the other projection has a `Halt` node or an UCT (L141):
https://github.com/openjdk/jdk/blob/7a64fbbb9292f4d65a6970206dec1a7d7645046b/src/hotspot/share/opto/predicates.cpp#L135-L144

### New `PredicateIterator` Class

[JDK-8340786](https://bugs.openjdk.org/browse/JDK-8340786) introduced a new `PredicateIterator` class to simplify iteration over predicates and replaced code that was doing some custom iteration. 

#### Usual Usage
Normally, we always start from a loop entry and follow the predicates (i.e. reaching a predicate over its success path).

#### Special Usage
However, I also replaced the predicate skipping in `PhaseIdealLoop::build_loop_late_post_work()` with the new `PredicateIterator` class which could start at any node, including a failing path false projection.

### Problem: Two Uncommon Traps for a Template Assertion Predicate
The fuzzer now found a case where a Template Assertion Predicate has a predicate UCT on the failing **and** the success path due to folding away some dead nodes:

![image](https://github.com/user-attachments/assets/c2a9395e-9eaf-46a0-b978-8847d8e21945)

In the Special Usage mentioned above, we could be using the `PredicateIterator` with `505 IfFalse` as starting node. In the core method `RegularPredicateBlockIterator::for_each()` for the traversal, we call the following with `current` = `505 IfFalse`:
https://github.com/openjdk/jdk/blob/1ea1f33f66326804ca2892fe0659a9acb7ee72ae/src/hotspot/share/opto/predicates.hpp#L628-L629
`TemplateAssertionPredicate::is_predicate()` succeeds because we have a valid Template Assertion Predicate If node and the other projection `504 IfTrue` has a predicate UCT. We then fail when trying to convert the `IfFalse` to an `IfTrue` with `current->as_IfTrue()` on L629.

### Solution
The fix is straight forward: `TemplateAssertionPredicate::is_predicate()` (and `InitiliazedAssertionPredicate::is_predicate()`) should additionally check, if the provided node as an `IfTrue` projection which by definition is the success projection. This avoids to wrongly match a failing path projection as success projection.

### Additional Tweaks - Probably Not Worth to Do Separatly
- While working on this, I noticed that predicate iteration can be limited if `UseLoopPredicate/UseProfiledLoopPredicate` is disabled.
- Made `AssertionPredicatesWithHalt` work with only non-null nodes and moved the null check to the only usage from `CountedLoopNode::skip_assertion_predicates_with_halt()`. There it could be possible, that we have a dying `CountedLoopNode` where the entry control was already replaced with null. 

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342287](https://bugs.openjdk.org/browse/JDK-8342287): C2 fails with "assert(is_IfTrue()) failed: invalid node class: IfFalse" due to Template Assertion Predicate with two UCTs (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21561/head:pull/21561` \
`$ git checkout pull/21561`

Update a local copy of the PR: \
`$ git checkout pull/21561` \
`$ git pull https://git.openjdk.org/jdk.git pull/21561/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21561`

View PR using the GUI difftool: \
`$ git pr show -t 21561`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21561.diff">https://git.openjdk.org/jdk/pull/21561.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21561#issuecomment-2419330845)