### PR TITLE
8342496: C2/Shenandoah: SEGV in compiled code when running jcstress

### DIFF
--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -1041,7 +1041,7 @@ void ShenandoahBarrierC2Support::fix_ctrl(Node* barrier, Node* region, const Mem
     Node* u = ctrl->fast_out(i);
     if (u->_idx < last &&
         u != barrier &&
-        !u->depends_only_on_test() && // floating nodes must not loose their dependency
+        !u->depends_only_on_test() && // preserve dependency on test
         !uses_to_ignore.member(u) &&
         (u->in(0) != ctrl || (!u->is_Region() && !u->is_Phi())) &&
         (ctrl->Opcode() != Op_CatchProj || u->Opcode() != Op_CreateEx)) {

--- a/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
+++ b/src/hotspot/share/gc/shenandoah/c2/shenandoahSupport.cpp
@@ -1041,6 +1041,7 @@ void ShenandoahBarrierC2Support::fix_ctrl(Node* barrier, Node* region, const Mem
     Node* u = ctrl->fast_out(i);
     if (u->_idx < last &&
         u != barrier &&
+        !u->depends_only_on_test() && // floating nodes must not loose their dependency
         !uses_to_ignore.member(u) &&
         (u->in(0) != ctrl || (!u->is_Region() && !u->is_Phi())) &&
         (ctrl->Opcode() != Op_CatchProj || u->Opcode() != Op_CreateEx)) {

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8342496
+ * @summary C2/Shenandoah: SEGV in compiled code when running jcstress
+ * @requires vm.flavor == "server"
+ * @requires vm.gc.Shenandoah
+ *
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:+StressGCM
+ *                   -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 -XX:StressSeed=270847015 TestLoadBypassesNullCheck
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:+StressGCM
+ *                   -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 TestLoadBypassesNullCheck
+ *
+ */
+
+public class TestLoadBypassesNullCheck {
+    private static A fieldA = new A();
+    private static Object fieldO = new Object();
+    private static volatile int volatileField;
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test1();
+        }
+        fieldA = null;
+        try {
+            test1();
+        } catch (NullPointerException npe) {
+        }
+    }
+
+    private static boolean test1() {
+        for (int i = 0; i < 1000; i++) {
+            volatileField = 42;
+            A a = fieldA;
+            Object o = a.fieldO;
+            if (o == fieldO) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static class A {
+        public Object fieldO;
+    }
+}


### PR DESCRIPTION
The reason for the crash is that compiled code reads from an object
that's null. All field loads from an object are guarded by a null
check. Where is the null check in that case? After the field load:

```
0x00007ffaac91261f:  44 8B 69 0C                      mov    r13d, dword ptr [rcx + 0xc] <- field load
0x00007ffaac912623:  85 C9                            test   ecx, ecx                    <- null check (oops!)
0x00007ffaac912625:  74 5C                            je     0x7ffaac912683
```

When the IR graph is constructed for the test case, the field load is
correctly made dependent on the null check (through a `CastPP` node)
but then something happens that's shenandoah specific and that causes
the field load to become dependent on another check so it can execute
before the null check.

There are several load barriers involved in the process. One of them
is expanded at the null check projection. In the process, control for
the nodes that are control dependent on the null check is updated to
be the region at the end of the just expanded barrier. The `CastPP`
node for the null check gets the `Region` as new control.

Another barrier is expanded right after that one. The 2 are back to
back. They are merged. The `Region` that the `CastPP` depends on goes
away, the `CastPP` is cloned in both branches at the `Region` and one
of them becomes control dependent on the heap stable test of the first
expanded barrier. At this point, one of the `CastPP` is control
dependent on a heap stable test that's after the null check. But then,
the heap stable test is moved out of loop and 2 copies of the loop are
made so one can run without any overhead from barriers. When that
happens, the `CastPP` becomes dependent on a test that dominates the
null check and so the field load that depends on the `CastPP` can be
scheduled before the null check.

The fix I propose is not update the control when the barrier is
expanded for nodes that can float when the test they depend on
moves. This way the `CastPP` remains dependent on the null check.


/cc hotspot-compiler

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342496](https://bugs.openjdk.org/browse/JDK-8342496): C2/Shenandoah: SEGV in compiled code when running jcstress (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21562/head:pull/21562` \
`$ git checkout pull/21562`

Update a local copy of the PR: \
`$ git checkout pull/21562` \
`$ git pull https://git.openjdk.org/jdk.git pull/21562/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21562`

View PR using the GUI difftool: \
`$ git pr show -t 21562`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21562.diff">https://git.openjdk.org/jdk/pull/21562.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21562#issuecomment-2419525426)