### PR TITLE
8317538: RSA have scalability issue for high vCPU numbers

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1279,12 +1279,7 @@ public abstract class Provider extends Properties {
      */
     public Service getService(String type, String algorithm) {
         checkInitialized();
-        // avoid allocating a new ServiceKey object if possible
-        ServiceKey key = previousKey;
-        if (!key.matches(type, algorithm)) {
-            key = new ServiceKey(type, algorithm, false);
-            previousKey = key;
-        }
+        ServiceKey key = new ServiceKey(type, algorithm, false);
 
         Service s = serviceMap.get(key);
         if (s == null) {
@@ -1304,15 +1299,6 @@ public abstract class Provider extends Properties {
 
         return s;
     }
-
-    // ServiceKey from previous getService() call
-    // by re-using it if possible we avoid allocating a new object
-    // and the toUpperCase() call.
-    // re-use will occur e.g. as the framework traverses the provider
-    // list and queries each provider with the same values until it finds
-    // a matching service
-    private static volatile ServiceKey previousKey =
-                                            new ServiceKey("", "", false);
 
     /**
      * Get an unmodifiable Set of all services supported by


### PR DESCRIPTION
The 'previous' key was removed while it is a bottleneck for the multithread environment. Without shared variable the performance for the specjvm2008::crypto.rsa on the 2 socket server with 8480+ CPUs changed as (average for 3 runs):
default, 1T: 646.84
patched, 1T: 642.13 (0.99 vs def)
default, 224T: 21668.13
patched, 224T: 44976.81 (2.08 vs def)

I.e. the one thread performance drop less than 1% but score for 224 threads improved in ~2x.

The micro benchmark test 'RSABench' reports no changes for 1 thread and ~2.4% improvement for the 224 threads run. It have other run pattern vs specjvm2008.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Issue
 * [JDK-8317538](https://bugs.openjdk.org/browse/JDK-8317538): RSA have scalability issue for high vCPU numbers (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21568/head:pull/21568` \
`$ git checkout pull/21568`

Update a local copy of the PR: \
`$ git checkout pull/21568` \
`$ git pull https://git.openjdk.org/jdk.git pull/21568/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21568`

View PR using the GUI difftool: \
`$ git pr show -t 21568`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21568.diff">https://git.openjdk.org/jdk/pull/21568.diff</a>

</details>
