### PR TITLE
8341975: Unable to set encoding for IO.println, IO.print and IO.readln

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -580,7 +580,8 @@ public sealed class Console implements Flushable permits ProxyingConsole {
      * the {@code Console}.
      * <p>
      * The returned charset corresponds to the input and output source
-     * (e.g., keyboard and/or display) specified by the host environment or user.
+     * (e.g., keyboard and/or display) specified by the host environment or user,
+     * which defaults to the one based on {@link System##stdout.encoding stdtout.encoding}.
      * It may not necessarily be the same as the default charset returned from
      * {@link java.nio.charset.Charset#defaultCharset() Charset.defaultCharset()}.
      *

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -34,7 +34,7 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.io.JdkConsoleImpl;
 import jdk.internal.io.JdkConsoleProvider;
 import jdk.internal.javac.PreviewFeature;
-import jdk.internal.util.StaticProperty;
+import sun.nio.cs.UTF_8;
 import sun.security.action.GetPropertyAction;
 
 /**
@@ -614,27 +614,10 @@ public sealed class Console implements Flushable permits ProxyingConsole {
                 "Console class itself does not provide implementation");
     }
 
-    private static native String encoding();
     private static final boolean istty = istty();
     static final Charset CHARSET;
     static {
-        Charset cs = null;
-
-        if (istty) {
-            String csname = encoding();
-            if (csname == null) {
-                csname = GetPropertyAction.privilegedGetProperty("stdout.encoding");
-            }
-            if (csname != null) {
-                cs = Charset.forName(csname, null);
-            }
-        }
-        if (cs == null) {
-            cs = Charset.forName(StaticProperty.nativeEncoding(),
-                    Charset.defaultCharset());
-        }
-
-        CHARSET = cs;
+        CHARSET = Charset.forName(GetPropertyAction.privilegedGetProperty("stdout.encoding"), UTF_8.INSTANCE);
 
         cons = instantiateConsole();
 

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -581,7 +581,7 @@ public sealed class Console implements Flushable permits ProxyingConsole {
      * <p>
      * The returned charset corresponds to the input and output source
      * (e.g., keyboard and/or display) specified by the host environment or user,
-     * which defaults to the one based on {@link System##stdout.encoding stdtout.encoding}.
+     * which defaults to the one based on {@link System##stdout.encoding stdout.encoding}.
      * It may not necessarily be the same as the default charset returned from
      * {@link java.nio.charset.Charset#defaultCharset() Charset.defaultCharset()}.
      *

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -615,12 +615,10 @@ public sealed class Console implements Flushable permits ProxyingConsole {
     }
 
     private static final boolean istty = istty();
-    static final Charset CHARSET;
+    static final Charset CHARSET =
+        Charset.forName(GetPropertyAction.privilegedGetProperty("stdout.encoding"), UTF_8.INSTANCE);
+    private static final Console cons = instantiateConsole();
     static {
-        CHARSET = Charset.forName(GetPropertyAction.privilegedGetProperty("stdout.encoding"), UTF_8.INSTANCE);
-
-        cons = instantiateConsole();
-
         // Set up JavaIOAccess in SharedSecrets
         SharedSecrets.setJavaIOAccess(new JavaIOAccess() {
             public Console console() {
@@ -672,6 +670,5 @@ public sealed class Console implements Flushable permits ProxyingConsole {
         return c;
     }
 
-    private static final Console cons;
     private static native boolean istty();
 }

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -147,7 +147,7 @@ public final class System {
      * corresponds to display output or another output destination
      * specified by the host environment or user. The encoding used
      * in the conversion from characters to bytes is equivalent to
-     * <a href="#stdout.encoding">stdout.encoding</a>.
+     * {@link ##stdout.encoding stdout.encoding}.
      * <p>
      * For simple stand-alone Java applications, a typical way to write
      * a line of output data is:
@@ -167,7 +167,7 @@ public final class System {
      * @see     java.io.PrintStream#println(long)
      * @see     java.io.PrintStream#println(java.lang.Object)
      * @see     java.io.PrintStream#println(java.lang.String)
-     * @see     <a href="#stdout.encoding">stdout.encoding</a>
+     * @see     ##stdout.encoding stdout.encoding
      */
     public static final PrintStream out = null;
 
@@ -183,11 +183,9 @@ public final class System {
      * variable {@code out}, has been redirected to a file or other
      * destination that is typically not continuously monitored.
      * The encoding used in the conversion from characters to bytes is
-     * equivalent to {@link Console#charset()} if the {@code Console}
-     * exists, <a href="#stderr.encoding">stderr.encoding</a> otherwise.
+     * equivalent to {@link ##stderr.encoding stderr.encoding}.
      *
-     * @see     Console#charset()
-     * @see     <a href="#stderr.encoding">stderr.encoding</a>
+     * @see     ##stderr.encoding stderr.encoding
      */
     public static final PrintStream err = null;
 

--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -147,8 +147,7 @@ public final class System {
      * corresponds to display output or another output destination
      * specified by the host environment or user. The encoding used
      * in the conversion from characters to bytes is equivalent to
-     * {@link Console#charset()} if the {@code Console} exists,
-     * <a href="#stdout.encoding">stdout.encoding</a> otherwise.
+     * <a href="#stdout.encoding">stdout.encoding</a>.
      * <p>
      * For simple stand-alone Java applications, a typical way to write
      * a line of output data is:
@@ -168,7 +167,6 @@ public final class System {
      * @see     java.io.PrintStream#println(long)
      * @see     java.io.PrintStream#println(java.lang.Object)
      * @see     java.io.PrintStream#println(java.lang.String)
-     * @see     Console#charset()
      * @see     <a href="#stdout.encoding">stdout.encoding</a>
      */
     public static final PrintStream out = null;
@@ -788,7 +786,8 @@ public final class System {
      *     <td>Character encoding name derived from the host environment and/or
      *     the user's settings. Setting this system property has no effect.</td></tr>
      * <tr><th scope="row">{@systemProperty stdout.encoding}</th>
-     *     <td>Character encoding name for {@link System#out System.out}.
+     *     <td>Character encoding name for {@link System#out System.out} and
+     *     {@link System#console() System.console()}.
      *     The Java runtime can be started with the system property set to {@code UTF-8},
      *     starting it with the property set to another value leads to undefined behavior.
      * <tr><th scope="row">{@systemProperty stderr.encoding}</th>

--- a/src/java.base/unix/native/libjava/Console_md.c
+++ b/src/java.base/unix/native/libjava/Console_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,10 +35,4 @@ JNIEXPORT jboolean JNICALL
 Java_java_io_Console_istty(JNIEnv *env, jclass cls)
 {
     return isatty(fileno(stdin)) && isatty(fileno(stdout));
-}
-
-JNIEXPORT jstring JNICALL
-Java_java_io_Console_encoding(JNIEnv *env, jclass cls)
-{
-    return NULL;
 }

--- a/src/java.base/windows/native/libjava/Console_md.c
+++ b/src/java.base/windows/native/libjava/Console_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,18 +48,4 @@ Java_java_io_Console_istty(JNIEnv *env, jclass cls)
     }
 
     return JNI_TRUE;
-}
-
-JNIEXPORT jstring JNICALL
-Java_java_io_Console_encoding(JNIEnv *env, jclass cls)
-{
-    char buf[64];
-    int cp = GetConsoleCP();
-    if (cp >= 874 && cp <= 950)
-        snprintf(buf, sizeof(buf), "ms%d", cp);
-    else if (cp == 65001)
-        snprintf(buf, sizeof(buf), "UTF-8");
-    else
-        snprintf(buf, sizeof(buf), "cp%d", cp);
-    return JNU_NewStringPlatform(env, buf);
 }

--- a/test/jdk/java/io/Console/DefaultCharsetTest.java
+++ b/test/jdk/java/io/Console/DefaultCharsetTest.java
@@ -29,6 +29,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @bug 8341975
  * @summary Tests the default charset. It should honor `stdout.encoding`
  *          which should be the same as System.out.charset()
+ * @modules jdk.internal.le
  * @run junit/othervm -Dstdout.encoding=UTF-8 DefaultCharsetTest
  * @run junit/othervm -Dstdout.encoding=ISO-8859-1 DefaultCharsetTest
  * @run junit/othervm -Dstdout.encoding=US-ASCII DefaultCharsetTest

--- a/test/jdk/java/io/Console/DefaultCharsetTest.java
+++ b/test/jdk/java/io/Console/DefaultCharsetTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * @test
+ * @bug 8341975
+ * @summary Tests the default charset. It should honor `stdout.encoding`
+ *          which should be the same as System.out.charset()
+ * @run junit/othervm -Dstdout.encoding=UTF-8 DefaultCharsetTest
+ * @run junit/othervm -Dstdout.encoding=ISO-8859-1 DefaultCharsetTest
+ * @run junit/othervm -Dstdout.encoding=US-ASCII DefaultCharsetTest
+ * @run junit/othervm -Dstdout.encoding=foo DefaultCharsetTest
+ * @run junit/othervm DefaultCharsetTest
+ */
+public class DefaultCharsetTest {
+    @Test
+    public void testDefaultCharset() {
+        var stdoutEncoding = System.getProperty("stdout.encoding");
+        var sysoutCharset = System.out.charset();
+        var consoleCharset = System.console().charset();
+        System.out.println("""
+                    stdout.encoding = %s
+                    System.out.charset() = %s
+                    System.console().charset() = %s
+                """.formatted(stdoutEncoding, sysoutCharset.name(), consoleCharset.name()));
+        assertEquals(consoleCharset, sysoutCharset,
+            "Charsets for System.out and Console differ for stdout.encoding: %s".formatted(stdoutEncoding));
+    }
+}


### PR DESCRIPTION
Changing the charset initialization of `java.io.Console` class, which is the basis of `java.io.IO`, so that it would behave the same way as `System.out` wrt encoding. This change will also have the capability to override the default charset used in `IO` methods with `stdout.encoding` system property. A corresponding CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8342208](https://bugs.openjdk.org/browse/JDK-8342208) to be approved

### Issues
 * [JDK-8341975](https://bugs.openjdk.org/browse/JDK-8341975): Unable to set encoding for IO.println, IO.print and IO.readln (**Enhancement** - P4)
 * [JDK-8342208](https://bugs.openjdk.org/browse/JDK-8342208): Unable to set encoding for IO.println, IO.print and IO.readln (**CSR**)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**) Review applies to [805365c6](https://git.openjdk.org/jdk/pull/21569/files/805365c6e32270b049cc1c34da8497096b89ed9b)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [805365c6](https://git.openjdk.org/jdk/pull/21569/files/805365c6e32270b049cc1c34da8497096b89ed9b)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21569/head:pull/21569` \
`$ git checkout pull/21569`

Update a local copy of the PR: \
`$ git checkout pull/21569` \
`$ git pull https://git.openjdk.org/jdk.git pull/21569/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21569`

View PR using the GUI difftool: \
`$ git pr show -t 21569`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21569.diff">https://git.openjdk.org/jdk/pull/21569.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21569#issuecomment-2420449027)