### PR TITLE
8340554: Improve MessageFormat readObject checks

### DIFF
--- a/src/java.base/share/classes/java/text/MessageFormat.java
+++ b/src/java.base/share/classes/java/text/MessageFormat.java
@@ -2037,7 +2037,7 @@ public class MessageFormat extends Format {
 
         // Check the correctness of arguments and offsets
         if (isValid) {
-            int lastOffset = patt.length() + 1;
+            int lastOffset = patt.length();
             for (int i = maxOff; i >= 0; --i) {
                 if (argNums[i] < 0 || argNums[i] >= MAX_ARGUMENT_INDEX
                         || offs[i] < 0 || offs[i] > lastOffset) {

--- a/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8331446
+ * @bug 8331446 8340554
  * @summary Check correctness of deserialization
  * @run junit SerializationTest
  */
@@ -70,7 +70,14 @@ public class SerializationTest {
                 // With null locale. (NPE not thrown, if no format defined)
                 new MessageFormat("{1} {0} foo", null),
                 // With formats
-                new MessageFormat("{0,number,short} {0} {1,date,long} foo")
+                new MessageFormat("{0,number,short} {0} {1,date,long} foo"),
+                // Offset equal to pattern length
+                new MessageFormat("{0}"),
+                // Offset equal to pattern length (variation)
+                new MessageFormat("{1}X"),
+                // Offset 1 under pattern length (variation)
+                new MessageFormat("{1}XX")
+
         );
     }
 

--- a/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
@@ -71,11 +71,11 @@ public class SerializationTest {
                 new MessageFormat("{1} {0} foo", null),
                 // With formats
                 new MessageFormat("{0,number,short} {0} {1,date,long} foo"),
-                // Offset equal to pattern length
+                // Offset equal to pattern length (0)
                 new MessageFormat("{0}"),
-                // Offset equal to pattern length (variation)
+                // Offset equal to pattern length (1)
                 new MessageFormat("X{0}"),
-                // Offset 1 under pattern length (variation)
+                // Offset 1 under pattern length
                 new MessageFormat("X{0}X")
         );
     }

--- a/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
+++ b/test/jdk/java/text/Format/MessageFormat/SerializationTest.java
@@ -74,10 +74,9 @@ public class SerializationTest {
                 // Offset equal to pattern length
                 new MessageFormat("{0}"),
                 // Offset equal to pattern length (variation)
-                new MessageFormat("{1}X"),
+                new MessageFormat("X{0}"),
                 // Offset 1 under pattern length (variation)
-                new MessageFormat("{1}XX")
-
+                new MessageFormat("X{0}X")
         );
     }
 


### PR DESCRIPTION
Please review this PR which improves the readObject logic for _j.text.MessageFormat_.

No offset should be larger than the pattern length. We already ensure the offsets when consumed backwards are equal/descending. The existing first/initial check was off by 1 since it was checking against the pattern length + 1; (see L2040 and L2043).

Please see the JBS issue for further info and other test details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340554](https://bugs.openjdk.org/browse/JDK-8340554): Improve MessageFormat readObject checks (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21570/head:pull/21570` \
`$ git checkout pull/21570`

Update a local copy of the PR: \
`$ git checkout pull/21570` \
`$ git pull https://git.openjdk.org/jdk.git pull/21570/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21570`

View PR using the GUI difftool: \
`$ git pr show -t 21570`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21570.diff">https://git.openjdk.org/jdk/pull/21570.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21570#issuecomment-2420478652)