### PR TITLE
8342578: GHA: RISC-V: Bootstrap using Debian snapshot is still failing

### DIFF
--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -152,6 +152,9 @@ jobs:
           rm -rf sysroot/usr/{sbin,bin,share}
           rm -rf sysroot/usr/lib/{apt,gcc,udev,systemd}
           rm -rf sysroot/usr/libexec/gcc
+          # /{bin,sbin,lib}/ are not symbolic links to /usr/{bin,sbin,lib}/ when debootstrap with --no-merged-usr
+          rm -rf sysroot/{sbin,bin}
+          rm -rf sysroot/lib/{udev,systemd}
         if: steps.create-sysroot.outcome == 'success' && steps.get-cached-sysroot.outputs.cache-hit != 'true'
 
       - name: 'Remove broken sysroot'

--- a/.github/workflows/build-cross-compile.yml
+++ b/.github/workflows/build-cross-compile.yml
@@ -84,7 +84,7 @@ jobs:
           - target-cpu: riscv64
             gnu-arch: riscv64
             debian-arch: riscv64
-            debian-repository: https://snapshot.debian.org/archive/debian/20240228T034848Z/
+            debian-repository: https://httpredir.debian.org/debian/
             debian-version: sid
             tolerate-sysroot-errors: true
 
@@ -131,6 +131,7 @@ jobs:
         id: create-sysroot
         run: >
           sudo debootstrap
+          --no-merged-usr
           --arch=${{ matrix.debian-arch }}
           --verbose
           --include=fakeroot,symlinks,build-essential,libx11-dev,libxext-dev,libxrender-dev,libxrandr-dev,libxtst-dev,libxt-dev,libcups2-dev,libfontconfig1-dev,libasound2-dev,libfreetype-dev,libpng-dev


### PR DESCRIPTION
In JDK-8339548, we switched to use Debian snapshot (https://snapshot.debian.org/archive/debian/20240228T034848Z/) for bootstrap. The reason is that we don't have a stable Debian release for RISC-V yet and Debian "sid" (https://httpredir.debian.org/debian) that we use for debootstrapping RISC-V breaks at that time. This works as expected for about one month. But bad news is that GHA linux-cross-build job for RISC-V starts to fail again this week. Sigh! I guess there might be some change on the distro running on GHA test machines as same debootstrap command still works on my x64 machine running Ubuntu 22.04.5.

Good news is that that Debian "sid" can now bootstrap for RISC-V. So this simply switches back to Debian "sid". As the version
of dpkg command on GHA machines is old (1.21.1), we need to add one extra option `--no-merged-usr` for bootstrap command to work (More discussion here: https://bugs.launchpad.net/ubuntu/+source/base-files/+bug/2054925). This option seems not necessary for newer dpkg versions like 1.22.6.

Testing:
- [x] GHA test

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342578](https://bugs.openjdk.org/browse/JDK-8342578): GHA: RISC-V: Bootstrap using Debian snapshot is still failing (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**) Review applies to [24cd3a93](https://git.openjdk.org/jdk/pull/21575/files/24cd3a936d3e41c8c22ea40d40bf7fada8b1a12c)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21575/head:pull/21575` \
`$ git checkout pull/21575`

Update a local copy of the PR: \
`$ git checkout pull/21575` \
`$ git pull https://git.openjdk.org/jdk.git pull/21575/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21575`

View PR using the GUI difftool: \
`$ git pr show -t 21575`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21575.diff">https://git.openjdk.org/jdk/pull/21575.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21575#issuecomment-2421053202)