### PR TITLE
8342644: Optimize InvokerBytecodeGenerator for using ClassFile API

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Alibaba Group Holding Limited. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -87,6 +88,9 @@ class InvokerBytecodeGenerator {
 
     private static final String CLASS_PREFIX = "java/lang/invoke/LambdaForm$";
     private static final String SOURCE_PREFIX = "LambdaForm$";
+    private static final ReferenceClassDescImpl CD_MH = ReferenceClassDescImpl.ofValidated("L" + CLASS_PREFIX + "MH;");
+    private static final ReferenceClassDescImpl CD_BMH = ReferenceClassDescImpl.ofValidated("L" + CLASS_PREFIX + "BMH;");
+    private static final ReferenceClassDescImpl CD_DMH = ReferenceClassDescImpl.ofValidated("L" + CLASS_PREFIX + "DMH;");
 
     /** Name of its super class*/
     static final ClassDesc INVOKER_SUPER_DESC = CD_Object;
@@ -131,9 +135,17 @@ class InvokerBytecodeGenerator {
             name = makeDumpableClassName(name);
         }
         this.name = name;
-        this.className = CLASS_PREFIX.concat(name);
-        validateInternalClassName(name);
-        this.classEntry = pool.classEntry(ReferenceClassDescImpl.ofValidated(concat("L", className, ";")));
+        var classDesc = switch (name) {
+            case "MH"  -> CD_MH;
+            case "DMH" -> CD_DMH;
+            case "BMH" -> CD_BMH;
+            default -> {
+                validateInternalClassName(name);
+                yield ReferenceClassDescImpl.ofValidated(concat("L" + CLASS_PREFIX, name, ";"));
+            }
+        };
+        this.className = classDesc.internalName();
+        this.classEntry = pool.classEntry(classDesc);
         this.lambdaForm = lambdaForm;
         this.invokerName = invokerName;
         this.invokerType = invokerType;

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -91,6 +91,8 @@ class InvokerBytecodeGenerator {
     private static final ReferenceClassDescImpl CD_MH = ReferenceClassDescImpl.ofValidated("L" + CLASS_PREFIX + "MH;");
     private static final ReferenceClassDescImpl CD_BMH = ReferenceClassDescImpl.ofValidated("L" + CLASS_PREFIX + "BMH;");
     private static final ReferenceClassDescImpl CD_DMH = ReferenceClassDescImpl.ofValidated("L" + CLASS_PREFIX + "DMH;");
+    private static final ReferenceClassDescImpl CD_LFI = ReferenceClassDescImpl.ofValidated("L" + CLASS_PREFIX + "LFI;");
+    private static final ReferenceClassDescImpl CD_NFI = ReferenceClassDescImpl.ofValidated("L" + CLASS_PREFIX + "NFI;");
 
     /** Name of its super class*/
     static final ClassDesc INVOKER_SUPER_DESC = CD_Object;
@@ -139,6 +141,8 @@ class InvokerBytecodeGenerator {
             case "MH"  -> CD_MH;
             case "DMH" -> CD_DMH;
             case "BMH" -> CD_BMH;
+            case "LFI" -> CD_LFI;
+            case "NFI" -> CD_NFI;
             default -> {
                 validateInternalClassName(name);
                 yield ReferenceClassDescImpl.ofValidated(concat("L" + CLASS_PREFIX, name, ";"));


### PR DESCRIPTION
Cache commonly used classDesc to avoid creating ReferenceClassDescImpl every time

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342644](https://bugs.openjdk.org/browse/JDK-8342644): Optimize InvokerBytecodeGenerator for using ClassFile API (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21580/head:pull/21580` \
`$ git checkout pull/21580`

Update a local copy of the PR: \
`$ git checkout pull/21580` \
`$ git pull https://git.openjdk.org/jdk.git pull/21580/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21580`

View PR using the GUI difftool: \
`$ git pr show -t 21580`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21580.diff">https://git.openjdk.org/jdk/pull/21580.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21580#issuecomment-2423482422)