### PR TITLE
8342540: InterfaceCalls micro-benchmark gives misleading results

### DIFF
--- a/test/micro/org/openjdk/bench/vm/compiler/InterfaceCalls.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/InterfaceCalls.java
@@ -48,7 +48,8 @@ public class InterfaceCalls {
 
     // Whether to step iteratively through the list of interfaces, or
     // to select one in an unpredictable way.
-    @Param({"false", "true"}) private boolean randomized;
+    @Param({"false", "true"})
+    private boolean randomized;
 
     interface FirstInterface {
         public int getIntFirst();

--- a/test/micro/org/openjdk/bench/vm/compiler/InterfaceCalls.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/InterfaceCalls.java
@@ -29,6 +29,7 @@ import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
@@ -44,6 +45,10 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @Fork(value = 3)
 public class InterfaceCalls {
+
+    // Whether to step iteratively through the list of interfaces, or
+    // to select one in an unpredictable way.
+    @Param({"false", "true"}) private boolean randomized;
 
     interface FirstInterface {
         public int getIntFirst();
@@ -241,44 +246,54 @@ public class InterfaceCalls {
      */
     @Benchmark
     public int test1stInt2Types() {
-        FirstInterface ai = as[l];
-        l = 1 - l;
+        FirstInterface ai = as[step(2)];
         return ai.getIntFirst();
     }
 
     @Benchmark
     public int test1stInt3Types() {
-        FirstInterface ai = as[l];
-        l = ++ l % 3;
+        FirstInterface ai = as[step(3)];
         return ai.getIntFirst();
     }
 
     @Benchmark
     public int test1stInt5Types() {
-        FirstInterface ai = as[l];
-        l = ++ l % asLength;
+        FirstInterface ai = as[step(asLength)];
         return ai.getIntFirst();
     }
 
     @Benchmark
     public int test2ndInt2Types() {
-        SecondInterface ai = (SecondInterface) as[l];
-        l = 1 - l;
+        SecondInterface ai = (SecondInterface) as[step(2)];
         return ai.getIntSecond();
     }
 
     @Benchmark
     public int test2ndInt3Types() {
-        SecondInterface ai = (SecondInterface) as[l];
-        l = ++ l % 3;
+        SecondInterface ai = (SecondInterface) as[step(3)];
         return ai.getIntSecond();
     }
 
     @Benchmark
     public int test2ndInt5Types() {
-        SecondInterface ai = (SecondInterface) as[l];
-        l = ++ l % asLength;
+        SecondInterface ai = (SecondInterface) as[step(asLength)];
         return ai.getIntSecond();
     }
 
+    int step(int range) {
+        if (randomized) {
+            l = scramble(l);
+        } else {
+            l++;
+        }
+        return (l & Integer.MAX_VALUE) % range;
+    }
+
+    static final int scramble(int n) {
+        int x = n;
+        x ^= x << 13;
+        x ^= x >>> 17;
+        x ^= x << 5;
+        return x == 0 ? 1 : x;
+    }
 }


### PR DESCRIPTION
`InterfaceCalls.java` makes highly predictable memory accesses, which leads to a gross time underestimate of the case where a megamorphic access is unpredictable.

Here's one example, with and without randomization. The unpredictable megamorphic call takes more than 4* as long as the benchmark.

```
Benchmark                            (randomized)  Mode  Cnt   Score   Error  Units
InterfaceCalls.test2ndInt3Types             false  avgt    4   5.013 ± 0.081  ns/op
InterfaceCalls.test2ndInt3Types              true  avgt    4  23.421 ± 0.102  ns/op
``` 

This patch adds the "randomized" parameter, which allows the measurement of predictable and unpredictable megamorphic calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342540](https://bugs.openjdk.org/browse/JDK-8342540): InterfaceCalls micro-benchmark gives misleading results (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21581/head:pull/21581` \
`$ git checkout pull/21581`

Update a local copy of the PR: \
`$ git checkout pull/21581` \
`$ git pull https://git.openjdk.org/jdk.git pull/21581/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21581`

View PR using the GUI difftool: \
`$ git pr show -t 21581`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21581.diff">https://git.openjdk.org/jdk/pull/21581.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21581#issuecomment-2422304581)