### PR TITLE
8342295: compiler/jvmci/TestJVMCISavedProperties.java fails due to garbage in output

### DIFF
--- a/test/hotspot/jtreg/compiler/jvmci/TestJVMCISavedProperties.java
+++ b/test/hotspot/jtreg/compiler/jvmci/TestJVMCISavedProperties.java
@@ -48,15 +48,13 @@ public class TestJVMCISavedProperties {
         ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
             "-XX:+UnlockExperimentalVMOptions",
             "-XX:+EagerJVMCI",
-            "-XX:+UseJVMCICompiler",
-            "-Djvmci.Compiler=null",
+            "-XX:+EnableJVMCI",
             "-Ddebug.jvmci.PrintSavedProperties=true",
             "-Dapp1.propX=true",
             "-Dapp2.propY=SomeStringValue",
             "TestJVMCISavedProperties", "true");
         OutputAnalyzer output = new OutputAnalyzer(pb.start());
         output.stdoutShouldContain("debug.jvmci.PrintSavedProperties=true");
-        output.stdoutShouldContain("jvmci.Compiler=null");
         output.stdoutShouldContain("app1.propX=true");
         output.stdoutShouldContain("app2.propY=SomeStringValue");
         output.stdoutShouldContain("java.specification.version=" + Runtime.version().feature());


### PR DESCRIPTION
The `compiler/jvmci/TestJVMCISavedProperties` test fails due to overlapping output from the saved system properties. The initialization of `savedProperties` in `jdk.vm.ci.services.Services` is correctly synchronized, the issue suggests that two separate libjvmci compiler isolates are each printing their own set of saved properties.

In a successful test run, the `CompileBroker` thread aborts the VM before it completes initialization, displaying the error message `Cannot use JVMCI compiler: Value of jvmci.Compiler is “null”` (due to the `-Djvmci.Compiler=null` setting), and the message `DONE IN MAIN` is never printed. However, in the failed test output, the `DONE IN MAIN` message appears, indicating that the VM initialization completed and created the `JVMCIRuntime` instance. The `CompileBroker` thread might have concurrently initialized `JVMCIRuntime` in another isolate. Since each `JVMCIRuntime` initialization outputs system properties, this is likely the cause of the overlapping output.

The proposed solution is to use the `-XX:+EnableJVMCI` flag instead of `-XX:+UseJVMCICompiler`, to avoid this issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342295](https://bugs.openjdk.org/browse/JDK-8342295): compiler/jvmci/TestJVMCISavedProperties.java fails due to garbage in output (**Bug** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21583/head:pull/21583` \
`$ git checkout pull/21583`

Update a local copy of the PR: \
`$ git checkout pull/21583` \
`$ git pull https://git.openjdk.org/jdk.git pull/21583/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21583`

View PR using the GUI difftool: \
`$ git pr show -t 21583`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21583.diff">https://git.openjdk.org/jdk/pull/21583.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21583#issuecomment-2422545517)