### PR TITLE
8342508: Use latch in BasicMenuUI/bug4983388.java instead of delay

### DIFF
--- a/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
@@ -100,7 +100,7 @@ public class bug4983388 {
                 throw new RuntimeException("shortcuts on menus do not work");
             }
         } finally {
-            SwingUtilities.invokeAndWait(() -> frame.dispose());
+            SwingUtilities.invokeAndWait(frame::dispose);
         }
     }
 }

--- a/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
@@ -26,28 +26,41 @@
  * @key headful
  * @bug 4983388 8015600
  * @summary shortcuts on menus do not work on JDS
- * @author Oleg Mokhovikov
  * @library ../../../../regtesthelpers
  * @build Util
  * @run main bug4983388
  */
 
-import java.awt.*;
-import javax.swing.*;
-import javax.swing.event.MenuListener;
-import javax.swing.event.MenuEvent;
+import java.awt.Robot;
 import java.awt.event.KeyEvent;
+import java.util.concurrent.CountDownLatch;
+
+import javax.swing.JFrame;
+import javax.swing.JMenu;
+import javax.swing.JMenuBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
+import javax.swing.UnsupportedLookAndFeelException;
+import javax.swing.event.MenuEvent;
+import javax.swing.event.MenuListener;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 public class bug4983388 {
-    static volatile boolean bMenuSelected = false;
     static JFrame frame;
 
+    private static final CountDownLatch menuSelected = new CountDownLatch(1);
+
     private static class TestMenuListener implements MenuListener {
+        @Override
         public void menuCanceled(MenuEvent e) {}
+        @Override
         public void menuDeselected(MenuEvent e) {}
+
+        @Override
         public void menuSelected(MenuEvent e) {
             System.out.println("menuSelected");
-            bMenuSelected = true;
+            menuSelected.countDown();
         }
     }
 
@@ -56,21 +69,21 @@ public class bug4983388 {
         JMenu menu = new JMenu("File");
         menu.setMnemonic('F');
         menuBar.add(menu);
-        frame = new JFrame();
+        menu.addMenuListener(new TestMenuListener());
+
+        frame = new JFrame("bug4983388");
         frame.setJMenuBar(menuBar);
         frame.setLocationRelativeTo(null);
-        frame.pack();
+        frame.setSize(250, 100);
         frame.setVisible(true);
-        MenuListener listener = new TestMenuListener();
-        menu.addMenuListener(listener);
     }
 
     public static void main(String[] args) throws Exception {
-
         try {
             UIManager.setLookAndFeel("com.sun.java.swing.plaf.gtk.GTKLookAndFeel");
         } catch (UnsupportedLookAndFeelException | ClassNotFoundException ex) {
-            System.err.println("GTKLookAndFeel is not supported on this platform. Using defailt LaF for this platform.");
+            System.err.println("GTKLookAndFeel is not supported on this platform. "
+                               + "Using default LaF for this platform.");
         }
 
         SwingUtilities.invokeAndWait(new Runnable() {
@@ -85,13 +98,13 @@ public class bug4983388 {
         robot.delay(500);
 
         Util.hitMnemonics(robot, KeyEvent.VK_F);
-        robot.waitForIdle();
-        robot.delay(500);
 
-        SwingUtilities.invokeAndWait(() -> frame.dispose());
-
-        if (!bMenuSelected) {
-            throw new RuntimeException("shortcuts on menus do not work");
+        try {
+            if (!menuSelected.await(1, SECONDS)) {
+                throw new RuntimeException("shortcuts on menus do not work");
+            }
+        } finally {
+            SwingUtilities.invokeAndWait(() -> frame.dispose());
         }
     }
 }

--- a/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
+++ b/test/jdk/javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java
@@ -86,11 +86,7 @@ public class bug4983388 {
                                + "Using default LaF for this platform.");
         }
 
-        SwingUtilities.invokeAndWait(new Runnable() {
-            public void run() {
-                createAndShowGUI();
-            }
-        });
+        SwingUtilities.invokeAndWait(bug4983388::createAndShowGUI);
 
         Robot robot = new Robot();
         robot.setAutoDelay(50);


### PR DESCRIPTION
Use a `CountDownLatch` in `javax/swing/plaf/basic/BasicMenuUI/4983388/bug4983388.java` instead of delay.

The latch provides a direct way to synchronise EDT and main thread, the test will finish quicker.

I ran the updated test a few times with `JTREG=REPEAT_COUNT=20`, the test always passed in the CI.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342508](https://bugs.openjdk.org/browse/JDK-8342508): Use latch in BasicMenuUI/bug4983388.java instead of delay (**Bug** - P5)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [10b51b09](https://git.openjdk.org/jdk/pull/21585/files/10b51b09284a3bde942eb04c0f444bad17cacf02)
 * @abdelhak-zaaim (no known openjdk.org user name / role) Review applies to [10b51b09](https://git.openjdk.org/jdk/pull/21585/files/10b51b09284a3bde942eb04c0f444bad17cacf02)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21585/head:pull/21585` \
`$ git checkout pull/21585`

Update a local copy of the PR: \
`$ git checkout pull/21585` \
`$ git pull https://git.openjdk.org/jdk.git pull/21585/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21585`

View PR using the GUI difftool: \
`$ git pr show -t 21585`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21585.diff">https://git.openjdk.org/jdk/pull/21585.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21585#issuecomment-2422710065)