### PR TITLE
8342612: Increase memory usage of compiler/c2/TestScalarReplacementMaxLiveNodes.java

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestScalarReplacementMaxLiveNodes.java
+++ b/test/hotspot/jtreg/compiler/c2/TestScalarReplacementMaxLiveNodes.java
@@ -36,6 +36,7 @@
  *                   -XX:CompileCommand=inline,*String*::*
  *                   -XX:CompileCommand=dontinline,*StringBuilder*::ensureCapacityInternal
  *                   -XX:CompileCommand=dontinline,*String*::substring
+ *                   -XX:CompileCommand=MemLimit,*.*,0
  *                   -XX:NodeCountInliningCutoff=220000
  *                   -XX:DesiredMethodLimit=100000
  *                   compiler.c2.TestScalarReplacementMaxLiveNodes


### PR DESCRIPTION
Hi all,
The test `test/hotspot/jtreg/compiler/c2/TestScalarReplacementMaxLiveNodes.java` fails on linux-x64/macos-x64/macos-aarch64/windows-x64. To make less CI noisy, we can simply increase the max memory usage before the failure root cause been fixed.
The change has been verified locally. Test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342612](https://bugs.openjdk.org/browse/JDK-8342612): Increase memory usage of compiler/c2/TestScalarReplacementMaxLiveNodes.java (**Sub-task** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21586/head:pull/21586` \
`$ git checkout pull/21586`

Update a local copy of the PR: \
`$ git checkout pull/21586` \
`$ git pull https://git.openjdk.org/jdk.git pull/21586/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21586`

View PR using the GUI difftool: \
`$ git pr show -t 21586`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21586.diff">https://git.openjdk.org/jdk/pull/21586.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21586#issuecomment-2422790895)