### PR TITLE
8338570: sun/font/HBShaper - mismatch in return type of FFM upcall function description and native invocation

### DIFF
--- a/src/java.desktop/share/classes/sun/font/HBShaper.java
+++ b/src/java.desktop/share/classes/sun/font/HBShaper.java
@@ -187,7 +187,6 @@ public class HBShaper {
         dispose_face_handle = tmp3;
 
         FunctionDescriptor shapeDesc = FunctionDescriptor.ofVoid(
-            //JAVA_INT,    // return type
             JAVA_FLOAT,  // ptSize
             ADDRESS,     // matrix
             ADDRESS,     // face
@@ -470,7 +469,7 @@ public class HBShaper {
                 MemorySegment matrix = arena.allocateFrom(JAVA_FLOAT, mat);
                 MemorySegment chars = arena.allocateFrom(JAVA_CHAR, text);
 
-                /*int ret =*/ jdk_hb_shape_handle.invokeExact(
+                jdk_hb_shape_handle.invokeExact(
                      ptSize, matrix, hbface, chars, text.length,
                      script, offset, limit,
                      baseIndex, startX, startY, flags, slot,

--- a/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c
+++ b/src/java.desktop/share/native/libfontmanager/HBShaper_Panama.c
@@ -63,7 +63,7 @@ static float euclidianDistance(float a, float b)
 #define TYPO_LIGA 0x00000002
 #define TYPO_RTL  0x80000000
 
-JDKEXPORT int jdk_hb_shape(
+JDKEXPORT void jdk_hb_shape(
      float ptSize,
      float *matrix,
      void* pFace,
@@ -92,7 +92,6 @@ JDKEXPORT int jdk_hb_shape(
      int featureCount = 0;
      char* kern = (flags & TYPO_KERN) ? "kern" : "-kern";
      char* liga = (flags & TYPO_LIGA) ? "liga" : "-liga";
-     int ret;
      unsigned int buflen;
 
      float devScale = 1.0f;
@@ -132,7 +131,7 @@ JDKEXPORT int jdk_hb_shape(
      glyphInfo = hb_buffer_get_glyph_infos(buffer, 0);
      glyphPos = hb_buffer_get_glyph_positions(buffer, &buflen);
 
-     ret = (*store_layout_results_fn)
+     (*store_layout_results_fn)
                (slot, baseIndex, offset, startX, startY, devScale,
                 charCount, glyphCount, glyphInfo, glyphPos);
 
@@ -141,5 +140,5 @@ JDKEXPORT int jdk_hb_shape(
      if (features != NULL) {
          free(features);
      }
-     return ret;
+     return;
 }

--- a/src/java.desktop/share/native/libfontmanager/hb-jdk-p.h
+++ b/src/java.desktop/share/native/libfontmanager/hb-jdk-p.h
@@ -56,13 +56,13 @@ hb_font_t* jdk_font_create_hbp(
                hb_font_funcs_t* font_funcs);
 
 
-typedef int (*store_layoutdata_func_t)
+typedef void (*store_layoutdata_func_t)
    (int slot, int baseIndex, int offset,
     float startX, float startY, float devScale,
     int charCount, int glyphCount,
     hb_glyph_info_t *glyphInfo, hb_glyph_position_t *glyphPos);
 
-JDKEXPORT int jdk_hb_shape(
+JDKEXPORT void jdk_hb_shape(
 
      float ptSize,
      float *matrix,


### PR DESCRIPTION
Fix a couple of function signature mismatches.
No regression test viable that I can see.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338570](https://bugs.openjdk.org/browse/JDK-8338570): sun/font/HBShaper - mismatch in return type of FFM upcall function description and native invocation (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21588/head:pull/21588` \
`$ git checkout pull/21588`

Update a local copy of the PR: \
`$ git checkout pull/21588` \
`$ git pull https://git.openjdk.org/jdk.git pull/21588/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21588`

View PR using the GUI difftool: \
`$ git pr show -t 21588`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21588.diff">https://git.openjdk.org/jdk/pull/21588.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21588#issuecomment-2422880622)