### PR TITLE
added method containsIgnoreCase

### DIFF
--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3072,20 +3072,20 @@ public final class String
     public boolean contains(CharSequence s) {
         return indexOf(s.toString()) >= 0;
     }
-        
-   /**
-    * Returns true if and only if this string contains the specified
-    * sequence of char values, ignoring case considerations.
-    *
-    * @param s the sequence to search for
-    * @return true if this string contains the specified sequence of char values, ignoring case;
-    *         false otherwise
-    */
+
+    /**
+     * Returns true if and only if this string contains the specified
+     * sequence of char values, ignoring case considerations.
+     *
+     * @param s the sequence to search for
+     * @return true if this string contains the specified sequence of char values, ignoring case;
+     * false otherwise
+     */
     public boolean containsIgnoreCase(CharSequence s) {
-       String lowerThis = this.toLowerCase();
-       String lowerS = s.toString().toLowerCase();
-       return lowerThis.contains(lowerS);
-   }    
+        String lowerThis = this.toLowerCase();
+        String lowerS = s.toString().toLowerCase();
+        return lowerThis.contains(lowerS);
+    }
 
     /**
      * Replaces the first substring of this string that matches the given <a

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -3082,9 +3082,7 @@ public final class String
      * false otherwise
      */
     public boolean containsIgnoreCase(CharSequence s) {
-        String lowerThis = this.toLowerCase();
-        String lowerS = s.toString().toLowerCase();
-        return lowerThis.contains(lowerS);
+        return s == null ? false : this.toString().toLowerCase(Locale.ENGLISH).indexOf(s.toString().toLowerCase(Locale.ENGLISH)) >= 0;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/String.java
+++ b/src/java.base/share/classes/java/lang/String.java
@@ -133,6 +133,7 @@ import sun.nio.cs.UTF_8;
  * @author  Arthur van Hoff
  * @author  Martin Buchholz
  * @author  Ulf Zibis
+ * @author  Mote Amol
  * @see     java.lang.Object#toString()
  * @see     java.lang.StringBuffer
  * @see     java.lang.StringBuilder
@@ -3071,6 +3072,20 @@ public final class String
     public boolean contains(CharSequence s) {
         return indexOf(s.toString()) >= 0;
     }
+        
+   /**
+    * Returns true if and only if this string contains the specified
+    * sequence of char values, ignoring case considerations.
+    *
+    * @param s the sequence to search for
+    * @return true if this string contains the specified sequence of char values, ignoring case;
+    *         false otherwise
+    */
+    public boolean containsIgnoreCase(CharSequence s) {
+       String lowerThis = this.toLowerCase();
+       String lowerS = s.toString().toLowerCase();
+       return lowerThis.contains(lowerS);
+   }    
 
     /**
      * Replaces the first substring of this string that matches the given <a


### PR DESCRIPTION
This method is added to address the limitation of the default **contains** method, which is case-sensitive. In many cases, it is desirable to perform a substring search without considering case differences (e.g., when handling user input or comparing text in a case-insensitive manner). This method provides a convenient way to perform such comparisons by ignoring case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21590/head:pull/21590` \
`$ git checkout pull/21590`

Update a local copy of the PR: \
`$ git checkout pull/21590` \
`$ git pull https://git.openjdk.org/jdk.git pull/21590/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21590`

View PR using the GUI difftool: \
`$ git pr show -t 21590`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21590.diff">https://git.openjdk.org/jdk/pull/21590.diff</a>

</details>
