### PR TITLE
Fix TestIllegalLink (JAVA_LONG.byteAlignment() == 8 is always true)

### DIFF
--- a/test/jdk/java/foreign/TestIllegalLink.java
+++ b/test/jdk/java/foreign/TestIllegalLink.java
@@ -217,11 +217,10 @@ public class TestIllegalLink extends NativeTestHelper {
                     "GroupLayout is too large"
             });
         }
-        if (ValueLayout.JAVA_LONG.byteAlignment() == 8) {
+        if (C_LONG_LONG.byteAlignment() == 8) {
             cases.add(new Object[]{
                     FunctionDescriptor.ofVoid(MemoryLayout.structLayout(
-                            ValueLayout.JAVA_LONG,
-                            ValueLayout.JAVA_INT)), // missing trailing padding
+                            C_LONG_LONG, ValueLayout.JAVA_INT)), // missing trailing padding
                     NO_OPTIONS,
                     "has unexpected size"
             });


### PR DESCRIPTION
Just a small typo

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21591/head:pull/21591` \
`$ git checkout pull/21591`

Update a local copy of the PR: \
`$ git checkout pull/21591` \
`$ git pull https://git.openjdk.org/jdk.git pull/21591/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21591`

View PR using the GUI difftool: \
`$ git pr show -t 21591`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21591.diff">https://git.openjdk.org/jdk/pull/21591.diff</a>

</details>
