### PR TITLE
8342646: JTREG_TEST_THREAD_FACTORY in testing.md should be TEST_THREAD_FACTORY

### DIFF
--- a/doc/testing.html
+++ b/doc/testing.html
@@ -434,7 +434,7 @@ GB/2</em>.</p>
 <p>Sets the argument <code>-timeoutHandlerTimeout</code> for JTReg. The
 default value is 0. This is only valid if the failure handler is
 built.</p>
-<h4 id="jtreg_test_thread_factory">JTREG_TEST_THREAD_FACTORY</h4>
+<h4 id="test_thread_factory">TEST_THREAD_FACTORY</h4>
 <p>Sets the <code>-testThreadFactory</code> for JTReg. It should be the
 fully qualified classname of a class which implements
 <code>java.util.concurrent.ThreadFactory</code>. One such implementation

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -380,7 +380,7 @@ Defaults to 4.
 Sets the argument `-timeoutHandlerTimeout` for JTReg. The default value is 0.
 This is only valid if the failure handler is built.
 
-#### JTREG_TEST_THREAD_FACTORY
+#### TEST_THREAD_FACTORY
 
 Sets the `-testThreadFactory` for JTReg. It should be the fully qualified
 classname of a class which implements `java.util.concurrent.ThreadFactory`. One

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage001.java
@@ -63,7 +63,7 @@ public class objmonusage001 {
         }
         // Virtual threads are not supported by GetObjectMonitorUsage.
         // Correct the expected values if the test is executed with
-        // JTREG="JTREG_TEST_THREAD_FACTORY=Virtual".
+        // JTREG="TEST_THREAD_FACTORY=Virtual".
         Thread expOwner = mainThread.isVirtual() ? null : mainThread;
         int expEntryCount = mainThread.isVirtual() ? 0 : 1;
 
@@ -157,7 +157,7 @@ class objmonusage001a extends Thread {
     public void run() {
         // Virtual threads are not supported by GetObjectMonitorUsage.
         // Correct the expected values if the test is executed with
-        // JTREG="JTREG_TEST_THREAD_FACTORY=Virtual".
+        // JTREG="TEST_THREAD_FACTORY=Virtual".
         Thread expOwner = this.isVirtual() ? null : this;
         Thread expNotifyWaiter = mainThread.isVirtual() ? null : mainThread;
         int expEntryCount = this.isVirtual() ? 0 : 1;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage001.java
@@ -63,7 +63,7 @@ public class objmonusage001 {
         }
         // Virtual threads are not supported by GetObjectMonitorUsage.
         // Correct the expected values if the test is executed with
-        // TEST_THREAD_FACTORY=Virtual.
+        // JTREG="JTREG_TEST_THREAD_FACTORY=Virtual".
         Thread expOwner = mainThread.isVirtual() ? null : mainThread;
         int expEntryCount = mainThread.isVirtual() ? 0 : 1;
 
@@ -157,7 +157,7 @@ class objmonusage001a extends Thread {
     public void run() {
         // Virtual threads are not supported by GetObjectMonitorUsage.
         // Correct the expected values if the test is executed with
-        // TEST_THREAD_FACTORY=Virtual.
+        // JTREG="JTREG_TEST_THREAD_FACTORY=Virtual".
         Thread expOwner = this.isVirtual() ? null : this;
         Thread expNotifyWaiter = mainThread.isVirtual() ? null : mainThread;
         int expEntryCount = this.isVirtual() ? 0 : 1;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage001.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage001.java
@@ -63,7 +63,7 @@ public class objmonusage001 {
         }
         // Virtual threads are not supported by GetObjectMonitorUsage.
         // Correct the expected values if the test is executed with
-        // JTREG_TEST_THREAD_FACTORY=Virtual.
+        // TEST_THREAD_FACTORY=Virtual.
         Thread expOwner = mainThread.isVirtual() ? null : mainThread;
         int expEntryCount = mainThread.isVirtual() ? 0 : 1;
 
@@ -157,7 +157,7 @@ class objmonusage001a extends Thread {
     public void run() {
         // Virtual threads are not supported by GetObjectMonitorUsage.
         // Correct the expected values if the test is executed with
-        // JTREG_TEST_THREAD_FACTORY=Virtual.
+        // TEST_THREAD_FACTORY=Virtual.
         Thread expOwner = this.isVirtual() ? null : this;
         Thread expNotifyWaiter = mainThread.isVirtual() ? null : mainThread;
         int expEntryCount = this.isVirtual() ? 0 : 1;

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage004.java
@@ -62,7 +62,7 @@ public class objmonusage004 {
         synchronized (lockCheck) {
             // Virtual threads are not supported by GetObjectMonitorUsage.
             // Correct the expected values if the test is executed with
-            // TEST_THREAD_FACTORY=Virtual.
+            // JTREG="JTREG_TEST_THREAD_FACTORY=Virtual".
             Thread expOwner = currThread.isVirtual() ? null : currThread;
             int expEntryCount = currThread.isVirtual() ? 0 : 2;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage004.java
@@ -62,7 +62,7 @@ public class objmonusage004 {
         synchronized (lockCheck) {
             // Virtual threads are not supported by GetObjectMonitorUsage.
             // Correct the expected values if the test is executed with
-            // JTREG_TEST_THREAD_FACTORY=Virtual.
+            // TEST_THREAD_FACTORY=Virtual.
             Thread expOwner = currThread.isVirtual() ? null : currThread;
             int expEntryCount = currThread.isVirtual() ? 0 : 2;
 

--- a/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage004.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jvmti/GetObjectMonitorUsage/objmonusage004.java
@@ -62,7 +62,7 @@ public class objmonusage004 {
         synchronized (lockCheck) {
             // Virtual threads are not supported by GetObjectMonitorUsage.
             // Correct the expected values if the test is executed with
-            // JTREG="JTREG_TEST_THREAD_FACTORY=Virtual".
+            // JTREG="TEST_THREAD_FACTORY=Virtual".
             Thread expOwner = currThread.isVirtual() ? null : currThread;
             int expEntryCount = currThread.isVirtual() ? 0 : 2;
 


### PR DESCRIPTION
Hi all,
In [make/RunTests.gmk](https://github.com/openjdk/jdk/blob/master/make/RunTests.gmk#L208), the keyword is 'TEST_THREAD_FACTORY'.

So the below test command will print error:
```shell
make test TEST=test/jdk/java/math/BigInteger/TestValueExact.java CONF=linux-x86_64-server-release JTREG="JTREG_TEST_THREAD_FACTORY=Virtual"
```
```
Building target 'test' in configuration 'linux-x86_64-server-release'
JTREG_TEST_THREAD_FACTORY=Virtual is not a valid keyword for JTREG.
Valid keywords: JOBS TIMEOUT_FACTOR FAILURE_HANDLER_TIMEOUT TEST_MODE ASSERT VERBOSE RETAIN TEST_THREAD_FACTORY MAX_MEM RUN_PROBLEM_LISTS RETRY_COUNT REPEAT_COUNT MAX_OUTPUT REPORT OPTIONS JAVA_OPTIONS VM_OPTIONS KEYWORDS EXTRA_PROBLEM_LISTS LAUNCHER_OPTIONS.
RunTests.gmk:206: *** Cannot continue. Stop.
```

So I think we should fix the document bug in `doc/testing.md` to avoid take the same mistake. Trivial fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342646](https://bugs.openjdk.org/browse/JDK-8342646): JTREG_TEST_THREAD_FACTORY in testing.md should be TEST_THREAD_FACTORY (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21594/head:pull/21594` \
`$ git checkout pull/21594`

Update a local copy of the PR: \
`$ git checkout pull/21594` \
`$ git pull https://git.openjdk.org/jdk.git pull/21594/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21594`

View PR using the GUI difftool: \
`$ git pr show -t 21594`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21594.diff">https://git.openjdk.org/jdk/pull/21594.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21594#issuecomment-2424426470)