### PR TITLE
8342647: [macosx] Clean up the NSInvocation based call to NSProcessInfo.operatingSystemVersion

### DIFF
--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -222,51 +222,32 @@ char *setupMacOSXLocale(int cat) {
     }
 }
 
-// 10.9 SDK does not include the NSOperatingSystemVersion struct.
-// For now, create our own
-typedef struct {
-        NSInteger majorVersion;
-        NSInteger minorVersion;
-        NSInteger patchVersion;
-} OSVerStruct;
-
 void setOSNameAndVersion(java_props_t *sprops) {
     // Hardcode os_name, and fill in os_version
     sprops->os_name = strdup("Mac OS X");
 
     NSString *nsVerStr = NULL;
     char* osVersionCStr = NULL;
-    // Mac OS 10.9 includes the [NSProcessInfo operatingSystemVersion] function,
-    // but it's not in the 10.9 SDK.  So, call it via NSInvocation.
-    if ([[NSProcessInfo processInfo] respondsToSelector:@selector(operatingSystemVersion)]) {
-        OSVerStruct osVer;
-        NSMethodSignature *sig = [[NSProcessInfo processInfo] methodSignatureForSelector:
-                @selector(operatingSystemVersion)];
-        NSInvocation *invoke = [NSInvocation invocationWithMethodSignature:sig];
-        invoke.selector = @selector(operatingSystemVersion);
-        [invoke invokeWithTarget:[NSProcessInfo processInfo]];
-        [invoke getReturnValue:&osVer];
-
-        // Copy out the char* if running on version other than 10.16 Mac OS (10.16 == 11.x)
-        // or explicitly requesting version compatibility
-        if (!((long)osVer.majorVersion == 10 && (long)osVer.minorVersion >= 16) ||
-                (getenv("SYSTEM_VERSION_COMPAT") != NULL)) {
-            if (osVer.patchVersion == 0) { // Omit trailing ".0"
-                nsVerStr = [NSString stringWithFormat:@"%ld.%ld",
-                        (long)osVer.majorVersion, (long)osVer.minorVersion];
-            } else {
-                nsVerStr = [NSString stringWithFormat:@"%ld.%ld.%ld",
-                        (long)osVer.majorVersion, (long)osVer.minorVersion, (long)osVer.patchVersion];
-            }
+    NSOperatingSystemVersion osVer = [[NSProcessInfo processInfo] operatingSystemVersion];
+    // Copy out the char* if running on version other than 10.16 Mac OS (10.16 == 11.x)
+    // or explicitly requesting version compatibility
+    if (!((long)osVer.majorVersion == 10 && (long)osVer.minorVersion >= 16) ||
+            (getenv("SYSTEM_VERSION_COMPAT") != NULL)) {
+        if (osVer.patchVersion == 0) { // Omit trailing ".0"
+            nsVerStr = [NSString stringWithFormat:@"%ld.%ld",
+                    (long)osVer.majorVersion, (long)osVer.minorVersion];
         } else {
-            // Version 10.16, without explicit env setting of SYSTEM_VERSION_COMPAT
-            // AKA 11+ Read the *real* ProductVersion from the hidden link to avoid SYSTEM_VERSION_COMPAT
-            // If not found, fallback below to the SystemVersion.plist
-            NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
-                             @"/System/Library/CoreServices/.SystemVersionPlatform.plist"];
-            if (version != NULL) {
-                nsVerStr = [version objectForKey : @"ProductVersion"];
-            }
+            nsVerStr = [NSString stringWithFormat:@"%ld.%ld.%ld",
+                    (long)osVer.majorVersion, (long)osVer.minorVersion, (long)osVer.patchVersion];
+        }
+    } else {
+        // Version 10.16, without explicit env setting of SYSTEM_VERSION_COMPAT
+        // AKA 11+ Read the *real* ProductVersion from the hidden link to avoid SYSTEM_VERSION_COMPAT
+        // If not found, fallback below to the SystemVersion.plist
+        NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
+                         @"/System/Library/CoreServices/.SystemVersionPlatform.plist"];
+        if (version != NULL) {
+            nsVerStr = [version objectForKey : @"ProductVersion"];
         }
     }
     // Fallback if running on pre-10.9 Mac OS

--- a/src/java.base/macosx/native/libjava/java_props_macosx.c
+++ b/src/java.base/macosx/native/libjava/java_props_macosx.c
@@ -250,7 +250,7 @@ void setOSNameAndVersion(java_props_t *sprops) {
             nsVerStr = [version objectForKey : @"ProductVersion"];
         }
     }
-    // Fallback if running on pre-10.9 Mac OS
+    // Fallback to reading the SystemVersion.plist
     if (nsVerStr == NULL) {
         NSDictionary *version = [NSDictionary dictionaryWithContentsOfFile :
                                  @"/System/Library/CoreServices/SystemVersion.plist"];


### PR DESCRIPTION
Can I please get a review of this change which does a tiny cleanup in the macosx specific code in `java_props_macosx.c`?

As noted in https://bugs.openjdk.org/browse/JDK-8342647 the `setOSNameAndVersion` function used to dynamically call `NSProcessInfo.operatingSystemVersion` because that property wasn't (statically) available until macosx 10.10 version. Since that version this property has been available even in the latest macosx versions https://developer.apple.com/documentation/foundation/nsprocessinfo/1410906-operatingsystemversion, so it's now possible to statically reference it in the code.

The change in this PR replaces the use of `NSInvocation` with the static reference to this property. No new tests have been added. Existing tier1, tier2 and tier3 tests with this change have all passed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342647](https://bugs.openjdk.org/browse/JDK-8342647): [macosx] Clean up the NSInvocation based call to NSProcessInfo.operatingSystemVersion (**Bug** - P4)


### Reviewers
 * [Brent Christian](https://openjdk.org/census#bchristi) (@bchristi-git - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21595/head:pull/21595` \
`$ git checkout pull/21595`

Update a local copy of the PR: \
`$ git checkout pull/21595` \
`$ git pull https://git.openjdk.org/jdk.git pull/21595/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21595`

View PR using the GUI difftool: \
`$ git pr show -t 21595`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21595.diff">https://git.openjdk.org/jdk/pull/21595.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21595#issuecomment-2424659684)
</details>
