### PR TITLE
8342653: Fix minor doc issues in AnnotatedElement

### DIFF
--- a/src/java.base/share/classes/java/lang/reflect/AnnotatedElement.java
+++ b/src/java.base/share/classes/java/lang/reflect/AnnotatedElement.java
@@ -257,7 +257,7 @@ import sun.reflect.annotation.AnnotationType;
  * {@link java.lang.annotation.AnnotationFormatError} is thrown.
  *
  * <p>Finally, attempting to read a member whose definition has evolved
- * incompatibly will result in a {@link
+ * incompatibly will result in an {@link
  * java.lang.annotation.AnnotationTypeMismatchException} or an
  * {@link java.lang.annotation.IncompleteAnnotationException}.
  *
@@ -286,7 +286,6 @@ public interface AnnotatedElement {
      * @return true if an annotation for the specified annotation
      *     type is present on this element, else false
      * @throws NullPointerException if the given annotation class is null
-     * @since 1.5
      */
     default boolean isAnnotationPresent(Class<? extends Annotation> annotationClass) {
         return getAnnotation(annotationClass) != null;
@@ -302,7 +301,6 @@ public interface AnnotatedElement {
      * @return this element's annotation for the specified annotation type if
      *     present on this element, else null
      * @throws NullPointerException if the given annotation class is null
-     * @since 1.5
      */
     <T extends Annotation> T getAnnotation(Class<T> annotationClass);
 
@@ -316,7 +314,6 @@ public interface AnnotatedElement {
      * have no effect on the arrays returned to other callers.
      *
      * @return annotations present on this element
-     * @since 1.5
      */
     Annotation[] getAnnotations();
 
@@ -478,7 +475,6 @@ public interface AnnotatedElement {
      * have no effect on the arrays returned to other callers.
      *
      * @return annotations directly present on this element
-     * @since 1.5
      */
     Annotation[] getDeclaredAnnotations();
 }


### PR DESCRIPTION
Fix typo and remove redundant `@since` tags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342653](https://bugs.openjdk.org/browse/JDK-8342653): Fix minor doc issues in AnnotatedElement (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21597/head:pull/21597` \
`$ git checkout pull/21597`

Update a local copy of the PR: \
`$ git checkout pull/21597` \
`$ git pull https://git.openjdk.org/jdk.git pull/21597/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21597`

View PR using the GUI difftool: \
`$ git pr show -t 21597`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21597.diff">https://git.openjdk.org/jdk/pull/21597.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21597#issuecomment-2425257124)