### PR TITLE
8342700: Set the default value of DirectCodeBuilder::handlers to Null

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/DirectCodeBuilder.java
@@ -802,7 +802,7 @@ public final class DirectCodeBuilder
 
     public List<AbstractPseudoInstruction.ExceptionCatchImpl> getHandlers() {
         if (handlers == null) {
-            return Collections.emptyList();
+            return List.of();
         }
         return handlers;
     }

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackCounter.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackCounter.java
@@ -58,7 +58,7 @@ public final class StackCounter {
                 (dcb.methodInfo.methodFlags() & ACC_STATIC) != 0,
                 dcb.bytecodesBufWriter.bytecodeView(),
                 dcb.constantPool,
-                dcb.handlers);
+                dcb.getHandlers());
     }
 
     private int stack, maxStack, maxLocals, rets;

--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -157,7 +157,7 @@ public final class StackMapGenerator {
                 dcb.bytecodesBufWriter.bytecodeView(),
                 dcb.constantPool,
                 dcb.context,
-                dcb.handlers);
+                dcb.getHandlers());
     }
 
     private static final String OBJECT_INITIALIZER_NAME = "<init>";


### PR DESCRIPTION
Set the default value of DirectCodeBuilder::handlers to Null to reduce overhead in scenarios where there is no handler.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342700](https://bugs.openjdk.org/browse/JDK-8342700): Set the default value of DirectCodeBuilder::handlers to Null (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21598/head:pull/21598` \
`$ git checkout pull/21598`

Update a local copy of the PR: \
`$ git checkout pull/21598` \
`$ git pull https://git.openjdk.org/jdk.git pull/21598/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21598`

View PR using the GUI difftool: \
`$ git pr show -t 21598`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21598.diff">https://git.openjdk.org/jdk/pull/21598.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21598#issuecomment-2426761451)
</details>
