### PR TITLE
8342610: ZGC: Cleanup pre-touching code

### DIFF
--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -30,6 +30,7 @@
 #include "gc/z/zGeneration.inline.hpp"
 #include "gc/z/zGenerationId.hpp"
 #include "gc/z/zGlobals.hpp"
+#include "gc/z/zLargePages.inline.hpp"
 #include "gc/z/zLock.inline.hpp"
 #include "gc/z/zPage.inline.hpp"
 #include "gc/z/zPageAge.hpp"
@@ -232,29 +233,38 @@ bool ZPageAllocator::is_initialized() const {
 
 class ZPreTouchTask : public ZTask {
 private:
-  const ZPhysicalMemoryManager* const _physical;
-  volatile zoffset                    _start;
-  const zoffset_end                   _end;
+  volatile uintptr_t _current;
+  const uintptr_t    _end;
+
+  static void pretouch(zaddress zaddr, size_t size) {
+    const uintptr_t addr = untype(zaddr);
+    const size_t page_size = ZLargePages::is_explicit() ? ZGranuleSize : os::vm_page_size();
+    os::pretouch_memory((void*)addr, (void*)(addr + size), page_size);
+  }
 
 public:
-  ZPreTouchTask(const ZPhysicalMemoryManager* physical, zoffset start, zoffset_end end)
+  ZPreTouchTask(zoffset start, zoffset_end end)
     : ZTask("ZPreTouchTask"),
-      _physical(physical),
-      _start(start),
-      _end(end) {}
+      _current(untype(start)),
+      _end(untype(end)) {}
 
   virtual void work() {
+    const size_t size = ZGranuleSize;
+
     for (;;) {
-      // Get granule offset
-      const size_t size = ZGranuleSize;
-      const zoffset offset = to_zoffset(Atomic::fetch_then_add((uintptr_t*)&_start, size));
-      if (offset >= _end) {
+      // Claim an offset for this thread
+      const uintptr_t claimed = Atomic::fetch_then_add(&_current, size);
+      if (claimed >= _end) {
         // Done
         break;
       }
 
-      // Pre-touch granule
-      _physical->pretouch(offset, size);
+      // At this point we know that we have a valid zoffset / zaddress.
+      const zoffset offset = to_zoffset(claimed);
+      const zaddress addr = ZOffset::address(offset);
+
+      // Pre-touch the granule
+      pretouch(addr, size);
     }
   }
 };
@@ -271,7 +281,7 @@ bool ZPageAllocator::prime_cache(ZWorkers* workers, size_t size) {
 
   if (AlwaysPreTouch) {
     // Pre-touch page
-    ZPreTouchTask task(&_physical, page->start(), page->end());
+    ZPreTouchTask task(page->start(), page->end());
     workers->run_all(&task);
   }
 

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -47,6 +47,7 @@
 #include "runtime/globals.hpp"
 #include "runtime/init.hpp"
 #include "runtime/java.hpp"
+#include "runtime/os.hpp"
 #include "utilities/debug.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/gc/z/zPhysicalMemory.cpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.cpp
@@ -353,12 +353,6 @@ bool ZPhysicalMemoryManager::uncommit(ZPhysicalMemory& pmem) {
   return true;
 }
 
-void ZPhysicalMemoryManager::pretouch(zoffset offset, size_t size) const {
-  const uintptr_t addr = untype(ZOffset::address(offset));
-  const size_t page_size = ZLargePages::is_explicit() ? ZGranuleSize : os::vm_page_size();
-  os::pretouch_memory((void*)addr, (void*)(addr + size), page_size);
-}
-
 // Map virtual memory to physcial memory
 void ZPhysicalMemoryManager::map(zoffset offset, const ZPhysicalMemory& pmem) const {
   const zaddress_unsafe addr = ZOffset::address_unsafe(offset);

--- a/src/hotspot/share/gc/z/zPhysicalMemory.hpp
+++ b/src/hotspot/share/gc/z/zPhysicalMemory.hpp
@@ -84,10 +84,6 @@ private:
   ZPhysicalMemoryBacking _backing;
   ZMemoryManager         _manager;
 
-  void pretouch_view(zaddress addr, size_t size) const;
-  void map_view(zaddress_unsafe addr, const ZPhysicalMemory& pmem) const;
-  void unmap_view(zaddress_unsafe addr, size_t size) const;
-
 public:
   ZPhysicalMemoryManager(size_t max_capacity);
 
@@ -101,8 +97,6 @@ public:
 
   bool commit(ZPhysicalMemory& pmem);
   bool uncommit(ZPhysicalMemory& pmem);
-
-  void pretouch(zoffset offset, size_t size) const;
 
   void map(zoffset offset, const ZPhysicalMemory& pmem) const;
   void unmap(zoffset offset, size_t size) const;


### PR DESCRIPTION
There's a few things that we'd like to cleanup around the pre-touching code.
* Remove the dependency to ZPhysicalMemoryManager - cleans up the call site
* Remove unimplemented function pretouch_view (and its friends)
* Change type from zoffset for the iteration variable - multiple threads update it and it is not guaranteed to stay below the required ZAddressOffsetMax. I can trigger an assert here if I change the code to prime_cache in the higher address range instead of the lower and setting a max heap size that matches ZAddressOffsetMax.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342610](https://bugs.openjdk.org/browse/JDK-8342610): ZGC: Cleanup pre-touching code (**Enhancement** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer) Review applies to [fdb58e36](https://git.openjdk.org/jdk/pull/21600/files/fdb58e3666fc8915d1a57e51b11db79e7a487943)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) Review applies to [fdb58e36](https://git.openjdk.org/jdk/pull/21600/files/fdb58e3666fc8915d1a57e51b11db79e7a487943)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21600/head:pull/21600` \
`$ git checkout pull/21600`

Update a local copy of the PR: \
`$ git checkout pull/21600` \
`$ git pull https://git.openjdk.org/jdk.git pull/21600/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21600`

View PR using the GUI difftool: \
`$ git pr show -t 21600`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21600.diff">https://git.openjdk.org/jdk/pull/21600.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21600#issuecomment-2425955232)