### PR TITLE
8342330: C2: "node pinned on loop exit test?" assert failure

### DIFF
--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1946,7 +1946,6 @@ bool PhaseIdealLoop::ctrl_of_use_out_of_loop(const Node* n, Node* n_ctrl, IdealL
   // to a check that's eliminated by range check elimination, it becomes input to an expression that feeds into the exit
   // test of the pre loop above the point in the graph where it's pinned.
   if (n_loop->_head->is_CountedLoop() && n_loop->_head->as_CountedLoop()->is_pre_loop()) {
-    bool res = false;
     CountedLoopNode* pre_loop = n_loop->_head->as_CountedLoop();
     if (is_dominator(pre_loop->loopexit(), ctrl)) {
       return false;

--- a/src/hotspot/share/opto/loopopts.cpp
+++ b/src/hotspot/share/opto/loopopts.cpp
@@ -1945,10 +1945,12 @@ bool PhaseIdealLoop::ctrl_of_use_out_of_loop(const Node* n, Node* n_ctrl, IdealL
   // Sinking a node from a pre loop to its main loop pins the node between the pre and main loops. If that node is input
   // to a check that's eliminated by range check elimination, it becomes input to an expression that feeds into the exit
   // test of the pre loop above the point in the graph where it's pinned.
-  if (n_loop->_head->is_CountedLoop() && n_loop->_head->as_CountedLoop()->is_pre_loop() &&
-      u_loop->_head->is_CountedLoop() && u_loop->_head->as_CountedLoop()->is_main_loop() &&
-      n_loop->_next == get_loop(u_loop->_head->as_CountedLoop()->skip_strip_mined())) {
-    return false;
+  if (n_loop->_head->is_CountedLoop() && n_loop->_head->as_CountedLoop()->is_pre_loop()) {
+    bool res = false;
+    CountedLoopNode* pre_loop = n_loop->_head->as_CountedLoop();
+    if (is_dominator(pre_loop->loopexit(), ctrl)) {
+      return false;
+    }
   }
   return true;
 }

--- a/test/hotspot/jtreg/compiler/rangechecks/TestSunkRangeFromPreLoopRCE.java
+++ b/test/hotspot/jtreg/compiler/rangechecks/TestSunkRangeFromPreLoopRCE.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8342330
+ * @summary C2: "node pinned on loop exit test?" assert failure
+ * @requires vm.flavor == "server"
+  *
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-TieredCompilation
+ *                   -XX:-UseLoopPredicate -XX:LoopMaxUnroll=0 TestSunkRangeFromPreLoopRCE
+ *
+ */
+
+
+import java.util.Arrays;
+
+public class TestSunkRangeFromPreLoopRCE {
+    private static int[] array = new int[1000];
+    private static A objectField = new A(42);
+
+    public static void main(String[] args) {
+        boolean[] allTrue = new boolean[1000];
+        Arrays.fill(allTrue, true);
+        boolean[] allFalse = new boolean[1000];
+        for (int i = 0; i < 20_000; i++) {
+            test1(array.length/4, allTrue, 1, 0);
+            test1(array.length/4, allFalse, 1, 0);
+        }
+    }
+
+    private static int test1(int stop, boolean[] flags, int otherScale, int x) {
+        int scale;
+        for (scale = 0; scale < 4; scale++) {
+            for (int i = 0; i < 10; i++) {
+
+            }
+        }
+        if (array == null) {
+        }
+        int v = 0;
+        for (int i = 0; i < stop; i++) {
+            v += array[i];
+            v += array[scale * i];
+            if (i * scale + (objectField.intField + 1) == x) {
+            }
+            v += (scale - 4) * (x-objectField.intField);
+            if (flags[i]) {
+                return (x-objectField.intField);
+            }
+        }
+        return v;
+    }
+
+    private static class A {
+        A(int field) {
+            intField = field;
+        }
+        public int intField;
+    }
+}


### PR DESCRIPTION
The assert fires because range check elimination processes a test of
the shape:

```
if (i * 4 != (x - objectField.intField) - 1)) {
  ...
}
```

and `(x - objectField.intField) - 1)` has control on the exit
projection of the pre loop.

This happens because:

- `objectField.intField` depends on the null check of `objectField`
  which is performed in the pre loop.
  
- `i * scale + (objectField.intField + 1) == x` is transformed into:
  `i * scale == x - (objectField.intField + 1)`

- `(x - objectField.intField) - 1)` only has uses out of the pre loop
  and is sunk out of the loop. It ends up pinned on the the exit
  projection of the pre loop.
  

There is already logic in `PhaseIdealLoop::ctrl_of_use_out_of_loop()`
to handle similar cases but, here, the difference is that the use
(`SubI` of 1) for what's being sunk doesn't have control in the main
loop but between the pre and main loop so that logic doesn't catch
this case.

There is also a possible bug in that logic:

```
n_loop->_next == get_loop(u_loop->_head->as_CountedLoop()->skip_strip_mined())
```

assumes the loop that follows the pre loop in the loop tree is the
main loop which is not guaranteed.

In this particular case, the assert is harmless: RCE can't eliminate
the condition but it's hard to rule out a similar scenario with a
condition that RCE could remove. I propose revisiting the condition in
`PhaseIdealLoop::ctrl_of_use_out_of_loop()` so it skips all uses that
are dominated by the loop exit of the pre loop.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342330](https://bugs.openjdk.org/browse/JDK-8342330): C2: "node pinned on loop exit test?" assert failure (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) Review applies to [2fd46262](https://git.openjdk.org/jdk/pull/21601/files/2fd46262db2c43a4c75ece7d4b01bfd921f22220)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21601/head:pull/21601` \
`$ git checkout pull/21601`

Update a local copy of the PR: \
`$ git checkout pull/21601` \
`$ git pull https://git.openjdk.org/jdk.git pull/21601/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21601`

View PR using the GUI difftool: \
`$ git pr show -t 21601`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21601.diff">https://git.openjdk.org/jdk/pull/21601.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21601#issuecomment-2426013756)