### PR TITLE
8342633: javax/management/security/HashedPasswordFileTest.java creates tmp file in src dir

### DIFF
--- a/test/jdk/javax/management/security/HashedPasswordFileTest.java
+++ b/test/jdk/javax/management/security/HashedPasswordFileTest.java
@@ -110,9 +110,7 @@ public class HashedPasswordFileTest {
     }
 
     private String getPasswordFilePath() {
-        String testDir = System.getProperty("test.src");
-        String testFileName = "jmxremote.password";
-        return testDir + File.separator + testFileName;
+        return "jmxremote.password";
     }
 
     private File createNewPasswordFile() throws IOException {


### PR DESCRIPTION
Test update: HashedPasswordFileTest.java was using System.getProperty("test.src") as a place to _create_ a file.

jtreg gives us the current working directory for the test invocation as a scratch directory.  Create files there, without reading any property to find another location.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342633](https://bugs.openjdk.org/browse/JDK-8342633): javax/management/security/HashedPasswordFileTest.java creates tmp file in src dir (**Bug** - P3)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21602/head:pull/21602` \
`$ git checkout pull/21602`

Update a local copy of the PR: \
`$ git checkout pull/21602` \
`$ git pull https://git.openjdk.org/jdk.git pull/21602/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21602`

View PR using the GUI difftool: \
`$ git pr show -t 21602`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21602.diff">https://git.openjdk.org/jdk/pull/21602.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21602#issuecomment-2426118896)