### PR TITLE
8342679: Clean up PreviewFeature.Feature

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -64,6 +64,10 @@ public @interface PreviewFeature {
      * Values should be annotated with the feature's {@code JEP}.
      */
     public enum Feature {
+        // while building the interim javac, the ClassReader will produce a warning when loading a class
+        // keeping the constant of a feature that has been integrated or dropped, serves the purpose of muting such warnings.
+
+        ////
         @JEP(number=477, title="Implicitly Declared Classes and Instance Main Methods", status="Third Preview")
         IMPLICIT_CLASSES,
         @JEP(number=481, title="Scoped Values", status="Third Preview")

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -67,7 +67,7 @@ public @interface PreviewFeature {
         // while building the interim javac, the ClassReader will produce a warning when loading a class
         // keeping the constant of a feature that has been integrated or dropped, serves the purpose of muting such warnings.
 
-        ////
+        //---
         @JEP(number=477, title="Implicitly Declared Classes and Instance Main Methods", status="Third Preview")
         IMPLICIT_CLASSES,
         @JEP(number=481, title="Scoped Values", status="Third Preview")

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -64,11 +64,6 @@ public @interface PreviewFeature {
      * Values should be annotated with the feature's {@code JEP}.
      */
     public enum Feature {
-        // not used, but required for interim javac to not warn.
-        VIRTUAL_THREADS,
-        FOREIGN,
-        @JEP(number=459, title="String Templates", status="Second Preview")
-        STRING_TEMPLATES,
         @JEP(number=477, title="Implicitly Declared Classes and Instance Main Methods", status="Third Preview")
         IMPLICIT_CLASSES,
         @JEP(number=481, title="Scoped Values", status="Third Preview")


### PR DESCRIPTION
After doing a build + bootcycle build confirms that these constants can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342679](https://bugs.openjdk.org/browse/JDK-8342679): Clean up PreviewFeature.Feature (**Bug** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21605/head:pull/21605` \
`$ git checkout pull/21605`

Update a local copy of the PR: \
`$ git checkout pull/21605` \
`$ git pull https://git.openjdk.org/jdk.git pull/21605/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21605`

View PR using the GUI difftool: \
`$ git pr show -t 21605`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21605.diff">https://git.openjdk.org/jdk/pull/21605.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21605#issuecomment-2426408657)