### PR TITLE
8340145: Problem with generic pattern matching results in internal compiler error

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Flow.java
@@ -910,7 +910,7 @@ public class Flow {
                     Set<PatternDescription> toAdd = new HashSet<>();
 
                     for (Type sup : types.directSupertypes(bpOne.type)) {
-                        ClassSymbol clazz = (ClassSymbol) sup.tsym;
+                        ClassSymbol clazz = (ClassSymbol) types.erasure(sup).tsym;
 
                         clazz.complete();
 

--- a/test/langtools/tools/javac/patterns/T8340145.java
+++ b/test/langtools/tools/javac/patterns/T8340145.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8340145
+ * @summary Problem with generic pattern matching results in internal compiler error
+ * @compile T8340145.java
+ * @run main T8340145
+ */
+public class T8340145 {
+    public static void main(String[] args) {
+        Option<Integer> optionInteger = new Option.Some<>(21);
+        Number number = Option.unwrapOrElse(optionInteger, 5.2);
+        System.out.println(number);
+    }
+
+    sealed interface Option<T> permits Option.Some, Option.None {
+        record Some<T>(T value) implements Option<T> {}
+        record None<T>() implements Option<T> {}
+
+        static <T, T2 extends T> T unwrapOrElse(Option<T2> option, T defaultValue) {
+            return switch (option) {
+                case Option.Some(T2 value) -> value;
+                case Option.None<T2> _ -> defaultValue;
+            };
+        }
+    }
+}

--- a/test/langtools/tools/javac/patterns/T8340145.java
+++ b/test/langtools/tools/javac/patterns/T8340145.java
@@ -32,7 +32,9 @@ public class T8340145 {
     public static void main(String[] args) {
         Option<Integer> optionInteger = new Option.Some<>(21);
         Number number = Option.unwrapOrElse(optionInteger, 5.2);
-        System.out.println(number);
+
+        Option2<Impl> optionBound = new Option2.Some<>(new Impl (){});
+        Bound number2 = Option2.unwrapOrElse(optionBound, new Impl(){});
     }
 
     sealed interface Option<T> permits Option.Some, Option.None {
@@ -43,6 +45,21 @@ public class T8340145 {
             return switch (option) {
                 case Option.Some(T2 value) -> value;
                 case Option.None<T2> _ -> defaultValue;
+            };
+        }
+    }
+
+    interface Bound {}
+    interface Bound2 {}
+    static class Impl implements Bound, Bound2 {}
+    sealed interface Option2<T> permits Option2.Some, Option2.None {
+        record Some<T>(T value) implements Option2<T> {}
+        record None<T>() implements Option2<T> {}
+
+        static <T extends Bound & Bound2> T unwrapOrElse(Option2<T> option, T defaultValue) {
+            return switch (option) {
+                case Option2.Some(T value) -> value;
+                case Option2.None<T> _ -> defaultValue;
             };
         }
     }


### PR DESCRIPTION
In the following code, when calculating recursively the covered binding patterns, the nested case assumed that the direct supertype of `T2` will always be represented by a `ClassSymbol`. This PR intervenes the erasure calculation.

```java
static <T, T2 extends T> T unwrapOrElse(Option<T2> option, T defaultValue) {
  return switch (option) {
     case Option.Some(T2 value) -> value;
     case Option.None<T2> _ -> defaultValue;
  };
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340145](https://bugs.openjdk.org/browse/JDK-8340145): Problem with generic pattern matching results in internal compiler error (**Bug** - P3)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21606/head:pull/21606` \
`$ git checkout pull/21606`

Update a local copy of the PR: \
`$ git checkout pull/21606` \
`$ git pull https://git.openjdk.org/jdk.git pull/21606/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21606`

View PR using the GUI difftool: \
`$ git pr show -t 21606`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21606.diff">https://git.openjdk.org/jdk/pull/21606.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21606#issuecomment-2426487186)
</details>
