### PR TITLE
8342682: Errors related to unused code on Windows after 8339120

### DIFF
--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -581,7 +581,9 @@ readCEN(jzfile *zip, jint knownTotal)
     jlong offset;
 #endif
     unsigned char endbuf[ENDHDR];
+#ifdef USE_MMAP
     jint endhdrlen = ENDHDR;
+#endif
     jzcell *entries;
     jint *table;
 


### PR DESCRIPTION
After 8339120, gcc began catching many different instances of unused code in the Windows specific codebase. Some of these seem to be bugs, so this Pull Request attempts to fix all of these in areas outside of HotSpot (Which likely needs more careful consideration)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342682](https://bugs.openjdk.org/browse/JDK-8342682): Errors related to unused code on Windows after 8339120 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21607/head:pull/21607` \
`$ git checkout pull/21607`

Update a local copy of the PR: \
`$ git checkout pull/21607` \
`$ git pull https://git.openjdk.org/jdk.git pull/21607/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21607`

View PR using the GUI difftool: \
`$ git pr show -t 21607`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21607.diff">https://git.openjdk.org/jdk/pull/21607.diff</a>

</details>
