### PR TITLE
8342681: TestLoadBypassesNullCheck.java fails improperly specified VM option

### DIFF
--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
@@ -28,11 +28,13 @@
  * @requires vm.flavor == "server"
  * @requires vm.gc.Shenandoah
  *
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
- *                   -XX:+StressGCM -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 -XX:StressSeed=270847015
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
+ *                   -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM -XX:StressSeed=270847015
  *                   TestLoadBypassesNullCheck
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
- *                   -XX:+StressGCM -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
+ *                   -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0
+ *                   -XX:+UnlockDiagnosticVMOptions -XX:+StressGCM -XX:+StressLCM
  *                   TestLoadBypassesNullCheck
  *
  */

--- a/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
+++ b/test/hotspot/jtreg/gc/shenandoah/compiler/TestLoadBypassesNullCheck.java
@@ -28,10 +28,12 @@
  * @requires vm.flavor == "server"
  * @requires vm.gc.Shenandoah
  *
- * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:+StressGCM
- *                   -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 -XX:StressSeed=270847015 TestLoadBypassesNullCheck
- * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:+StressGCM
- *                   -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 TestLoadBypassesNullCheck
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
+ *                   -XX:+StressGCM -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0 -XX:StressSeed=270847015
+ *                   TestLoadBypassesNullCheck
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation
+ *                   -XX:+StressGCM -XX:+StressLCM -XX:+UseShenandoahGC -XX:LoopMaxUnroll=0
+ *                   TestLoadBypassesNullCheck
  *
  */
 


### PR DESCRIPTION
Hi all,
Newly added test `gc/shenandoah/compiler/TestLoadBypassesNullCheck.java` fails `The unlock option must precede 'StressGCM'.` with release jdk build. This PR fix the test bug, only add `-XX:+UnlockDiagnosticVMOptions` to make test run passed by release jdk build.
The change has been verified locally with release/fastdebug/slowdebug on linux-x64. Test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342681](https://bugs.openjdk.org/browse/JDK-8342681): TestLoadBypassesNullCheck.java fails improperly specified VM option (**Bug** - P3)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21609/head:pull/21609` \
`$ git checkout pull/21609`

Update a local copy of the PR: \
`$ git checkout pull/21609` \
`$ git pull https://git.openjdk.org/jdk.git pull/21609/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21609`

View PR using the GUI difftool: \
`$ git pr show -t 21609`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21609.diff">https://git.openjdk.org/jdk/pull/21609.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21609#issuecomment-2426627326)