### PR TITLE
8342698: Fix order of @param tags in module java.base

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
+++ b/src/java.base/share/classes/java/lang/invoke/MethodHandles.java
@@ -463,8 +463,8 @@ public class MethodHandles {
      * If there is a security manager, its {@code checkPermission} method
      * is called with a {@code ReflectPermission("suppressAccessChecks")} permission.
      * @param <T> the desired type of the result, either {@link Member} or a subtype
-     * @param target a direct method handle to crack into symbolic reference components
      * @param expected a class object representing the desired result type {@code T}
+     * @param target a direct method handle to crack into symbolic reference components
      * @return a reference to the method, constructor, or field object
      * @throws    SecurityException if the caller is not privileged to call {@code setAccessible}
      * @throws    NullPointerException if either argument is {@code null}

--- a/src/java.base/share/classes/java/lang/invoke/VarHandle.java
+++ b/src/java.base/share/classes/java/lang/invoke/VarHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2371,9 +2371,9 @@ public abstract sealed class VarHandle implements Constable
          * Returns a {@linkplain VarHandleDesc} corresponding to a {@link VarHandle}
          * for an instance field.
          *
-         * @param name the unqualified name of the field
          * @param declaringClass a {@link ClassDesc} describing the declaring class,
          *                       for field var handles
+         * @param name the unqualified name of the field
          * @param fieldType a {@link ClassDesc} describing the type of the field
          * @return the {@linkplain VarHandleDesc}
          * @throws NullPointerException if any of the arguments are null
@@ -2390,9 +2390,9 @@ public abstract sealed class VarHandle implements Constable
          * Returns a {@linkplain VarHandleDesc} corresponding to a {@link VarHandle}
          * for a static field.
          *
-         * @param name the unqualified name of the field
          * @param declaringClass a {@link ClassDesc} describing the declaring class,
          *                       for field var handles
+         * @param name the unqualified name of the field
          * @param fieldType a {@link ClassDesc} describing the type of the field
          * @return the {@linkplain VarHandleDesc}
          * @throws NullPointerException if any of the arguments are null

--- a/src/java.base/share/classes/java/security/cert/CertificateRevokedException.java
+++ b/src/java.base/share/classes/java/security/cert/CertificateRevokedException.java
@@ -86,12 +86,12 @@ public class CertificateRevokedException extends CertificateException {
      * @param revocationDate the date on which the certificate was revoked. The
      *    date is copied to protect against subsequent modification.
      * @param reason the revocation reason
-     * @param extensions a map of X.509 Extensions. Each key is an OID String
-     *    that maps to the corresponding Extension. The map is copied to
-     *    prevent subsequent modification.
      * @param authority the {@code X500Principal} that represents the name
      *    of the authority that signed the certificate's revocation status
      *    information
+     * @param extensions a map of X.509 Extensions. Each key is an OID String
+     *    that maps to the corresponding Extension. The map is copied to
+     *    prevent subsequent modification.
      * @throws NullPointerException if {@code revocationDate},
      *    {@code reason}, {@code authority}, or
      *    {@code extensions} is {@code null}

--- a/src/java.base/share/classes/java/security/interfaces/DSAKeyPairGenerator.java
+++ b/src/java.base/share/classes/java/security/interfaces/DSAKeyPairGenerator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -105,11 +105,11 @@ public interface DSAKeyPairGenerator {
      * @param modlen the modulus length in bits. Valid values are any
      * multiple of 64 between 512 and 1024, inclusive, 2048, and 3072.
      *
-     * @param random the random bit source to use to generate key bits;
-     * can be null.
-     *
      * @param genParams whether to generate new parameters for
      * the modulus length requested.
+     *
+     * @param random the random bit source to use to generate key bits;
+     * can be null.
      *
      * @throws    InvalidParameterException if {@code modlen} is
      * invalid, or unsupported, or if {@code genParams} is false and there

--- a/src/java.base/share/classes/java/util/Arrays.java
+++ b/src/java.base/share/classes/java/util/Arrays.java
@@ -3491,8 +3491,8 @@ public final class Arrays {
      * is greater than that of the original array.
      * The resulting array is of the class {@code newType}.
      *
-     * @param <U> the class of the objects in the original array
      * @param <T> the class of the objects in the returned array
+     * @param <U> the class of the objects in the original array
      * @param original the array to be copied
      * @param newLength the length of the copy to be returned
      * @param newType the class of the copy to be returned
@@ -3782,8 +3782,8 @@ public final class Arrays {
      * of the returned array will be {@code to - from}.
      * The resulting array is of the class {@code newType}.
      *
-     * @param <U> the class of the objects in the original array
      * @param <T> the class of the objects in the returned array
+     * @param <U> the class of the objects in the original array
      * @param original the array from which a range is to be copied
      * @param from the initial index of the range to be copied, inclusive
      * @param to the final index of the range to be copied, exclusive.

--- a/src/java.base/share/classes/java/util/stream/Collectors.java
+++ b/src/java.base/share/classes/java/util/stream/Collectors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1088,13 +1088,13 @@ public final class Collectors {
      *
      * @param <T> the type of the input elements
      * @param <K> the type of the keys
-     * @param <A> the intermediate accumulation type of the downstream collector
      * @param <D> the result type of the downstream reduction
+     * @param <A> the intermediate accumulation type of the downstream collector
      * @param <M> the type of the resulting {@code Map}
      * @param classifier a classifier function mapping input elements to keys
-     * @param downstream a {@code Collector} implementing the downstream reduction
      * @param mapFactory a supplier providing a new empty {@code Map}
      *                   into which the results will be inserted
+     * @param downstream a {@code Collector} implementing the downstream reduction
      * @return a {@code Collector} implementing the cascaded group-by operation
      *
      * @see #groupingBy(Function, Collector)
@@ -1250,9 +1250,9 @@ public final class Collectors {
      * @param <D> the result type of the downstream reduction
      * @param <M> the type of the resulting {@code ConcurrentMap}
      * @param classifier a classifier function mapping input elements to keys
-     * @param downstream a {@code Collector} implementing the downstream reduction
      * @param mapFactory a supplier providing a new empty {@code ConcurrentMap}
      *                   into which the results will be inserted
+     * @param downstream a {@code Collector} implementing the downstream reduction
      * @return a concurrent, unordered {@code Collector} implementing the cascaded group-by operation
      *
      * @see #groupingByConcurrent(Function)
@@ -1347,8 +1347,8 @@ public final class Collectors {
      * applying the finisher function.
      *
      * @param <T> the type of the input elements
-     * @param <A> the intermediate accumulation type of the downstream collector
      * @param <D> the result type of the downstream reduction
+     * @param <A> the intermediate accumulation type of the downstream collector
      * @param predicate a predicate used for classifying input elements
      * @param downstream a {@code Collector} implementing the downstream
      *                   reduction


### PR DESCRIPTION
Please review a doc-only change to fix the order of javadoc `@param` tags in module java.base.

We are working on a javadoc feature to add an opt-in doclint warning for `@param` tags that don't match the order of parameters in the documented element. The warning will be enabled in OpenJDK builds and covers all uses of the `@param` tag, i.e. parameters of executable elements, type parameters, and record components.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342698](https://bugs.openjdk.org/browse/JDK-8342698): Fix order of @<!---->param tags in module java.base (**Sub-task** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21611/head:pull/21611` \
`$ git checkout pull/21611`

Update a local copy of the PR: \
`$ git checkout pull/21611` \
`$ git pull https://git.openjdk.org/jdk.git pull/21611/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21611`

View PR using the GUI difftool: \
`$ git pr show -t 21611`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21611.diff">https://git.openjdk.org/jdk/pull/21611.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21611#issuecomment-2426745664)