### PR TITLE
8342156: C2: Compilation failure with fewer arguments after JDK-8329032

### DIFF
--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -171,10 +171,13 @@ int RegisterForm::RegMask_Size() {
   // on the stack (stack registers) up to some interesting limit.  Methods
   // that need more parameters will NOT be compiled.  On Intel, the limit
   // is something like 90+ parameters.
-  // Add a few (3 words == 96 bits) for incoming & outgoing arguments to calls.
-  // Add one more word to avoid problematic rounding. Specifically, APX added
-  // 16 more registers but did not result in a mask size increase.
-  // Round up to the next doubleword size.
+  // - Add a few (3 words == 96 bits) for incoming & outgoing arguments to
+  //   calls.
+  // - Round up to the next doubleword size.
+  // - Add one more word to accommodate a reasonable number of stack locations
+  //   in the register mask regardless of how much slack is created by rounding
+  //   up. Problematic rounding occurred when we added 16 new registers for
+  //   APX.
   return (words_for_regs + 3 + 1 + 1) & ~1;
 }
 

--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -172,8 +172,10 @@ int RegisterForm::RegMask_Size() {
   // that need more parameters will NOT be compiled.  On Intel, the limit
   // is something like 90+ parameters.
   // Add a few (3 words == 96 bits) for incoming & outgoing arguments to calls.
+  // Add one more word to avoid problematic rounding. Specifically, APX added
+  // 16 more registers but did not result in a mask size increase.
   // Round up to the next doubleword size.
-  return (words_for_regs + 3 + 1) & ~1;
+  return (words_for_regs + 3 + 1 + 1) & ~1;
 }
 
 void RegisterForm::dump() {                  // Debug printer

--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -175,7 +175,7 @@ int RegisterForm::RegMask_Size() {
   //   calls.
   // - Round up to the next doubleword size.
   // - Add one more word to accommodate a reasonable number of stack locations
-  //   in the register mask regardless of how much slack is created by rounding
+  //   in the register mask regardless of how much slack is created by rounding.
   //   This was found necessary after adding 16 new registers for APX.
   return (words_for_regs + 3 + 1 + 1) & ~1;
 }

--- a/src/hotspot/share/adlc/formsopt.cpp
+++ b/src/hotspot/share/adlc/formsopt.cpp
@@ -176,8 +176,7 @@ int RegisterForm::RegMask_Size() {
   // - Round up to the next doubleword size.
   // - Add one more word to accommodate a reasonable number of stack locations
   //   in the register mask regardless of how much slack is created by rounding
-  //   up. Problematic rounding occurred when we added 16 new registers for
-  //   APX.
+  //   This was found necessary after adding 16 new registers for APX.
   return (words_for_regs + 3 + 1 + 1) & ~1;
 }
 

--- a/test/hotspot/jtreg/compiler/arguments/TestManyParameters.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestManyParameters.java
@@ -23,9 +23,9 @@
 
 /**
  * @test
- * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @requires os.simpleArch == "x64"
  * @bug 8342156
- * @summary Check that C2 restriction on number of method arguments is not too
+ * @summary Check that C2's restriction on number of method arguments is not too
  *          restrictive on x64.
  *
  * @run main/othervm -Xcomp

--- a/test/hotspot/jtreg/compiler/arguments/TestManyParameters.java
+++ b/test/hotspot/jtreg/compiler/arguments/TestManyParameters.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @requires os.arch=="amd64" | os.arch=="x86_64"
+ * @bug 8342156
+ * @summary Check that C2 restriction on number of method arguments is not too
+ *          restrictive on x64.
+ *
+ * @run main/othervm -Xcomp
+ *                   -XX:CompileCommand=compileonly,compiler.arguments.TestManyParameters::test
+ *                   -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+AbortVMOnCompilationFailure
+ *                   compiler.arguments.TestManyParameters
+ */
+
+package compiler.arguments;
+
+public class TestManyParameters {
+
+    public static void main(String[] args) {
+        test(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54);
+    }
+
+    static void test(int i1, int i2, int i3, int i4, int i5, int i6, int i7, int i8, int i9, int i10, int i11, int i12, int i13, int i14, int i15, int i16, int i17, int i18, int i19, int i20, int i21, int i22, int i23, int i24, int i25, int i26, int i27, int i28, int i29, int i30, int i31, int i32, int i33, int i34, int i35, int i36, int i37, int i38, int i39, int i40, int i41, int i42, int i43, int i44, int i45, int i46, int i47, int i48, int i49, int i50, int i51, int i52, int i53, int i54) {}
+}


### PR DESCRIPTION
### Issue Summary

Adding C2 register allocation support for APX EGPRs ([JDK-8329032](https://bugs.openjdk.org/browse/JDK-8329032)) reduced, due to unfortunate rounding in the register mask size computation, the available space for incoming/outgoing method arguments in register masks.

### Changeset

- Bump the number of 32-bit words dedicated to incoming/outgoing arguments in register masks from 3 to 4.
- Add a regression test.

### Testing

- [GitHub Actions](https://github.com/dlunde/jdk/actions/runs/11436050131)
- `tier1` to `tier4` (and additional Oracle-internal testing) on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64.
- C2 compilation time benchmarking for DaCapo on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64. There is no observable difference in C2 compilation time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342156](https://bugs.openjdk.org/browse/JDK-8342156): C2: Compilation failure with fewer arguments after JDK-8329032 (**Bug** - P3)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [873a8ffe](https://git.openjdk.org/jdk/pull/21612/files/873a8ffea0f1f99230c563ae55aada8c9b5b5860)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Contributors
 * Christian Hagedorn `<chagedorn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21612/head:pull/21612` \
`$ git checkout pull/21612`

Update a local copy of the PR: \
`$ git checkout pull/21612` \
`$ git pull https://git.openjdk.org/jdk.git pull/21612/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21612`

View PR using the GUI difftool: \
`$ git pr show -t 21612`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21612.diff">https://git.openjdk.org/jdk/pull/21612.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21612#issuecomment-2426808286)