### PR TITLE
8342693: Use byte[] as parameter in a FDBigInteger constructor and as field

### DIFF
--- a/src/java.base/share/classes/jdk/internal/math/FDBigInteger.java
+++ b/src/java.base/share/classes/jdk/internal/math/FDBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/math/FDBigInteger.java
+++ b/src/java.base/share/classes/jdk/internal/math/FDBigInteger.java
@@ -217,7 +217,7 @@ public /*@ spec_bigint_math @*/ class FDBigInteger {
      @ requires (\forall int i; 0 <= i && i < nDigits; '0' <= digits[i] && digits[i] <= '9');
      @ ensures this.value() == \old(lValue * pow10(nDigits - kDigits) + (\sum int i; kDigits <= i && i < nDigits; (digits[i] - '0') * pow10(nDigits - i - 1)));
      @*/
-    public FDBigInteger(long lValue, char[] digits, int kDigits, int nDigits) {
+    public FDBigInteger(long lValue, byte[] digits, int kDigits, int nDigits) {
         int n = Math.max((nDigits + 8) / 9, 2);        // estimate size needed.
         data = new int[n];      // allocate enough space
         data[0] = (int) lValue;    // starting value

--- a/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
+++ b/src/java.base/share/classes/jdk/internal/math/FloatingDecimal.java
@@ -1034,10 +1034,10 @@ public class FloatingDecimal{
     static class ASCIIToBinaryBuffer implements ASCIIToBinaryConverter {
         boolean     isNegative;
         int         decExponent;
-        char        digits[];
+        byte[]      digits;
         int         nDigits;
 
-        ASCIIToBinaryBuffer( boolean negSign, int decExponent, char[] digits, int n)
+        ASCIIToBinaryBuffer( boolean negSign, int decExponent, byte[] digits, int n)
         {
             this.isNegative = negSign;
             this.decExponent = decExponent;
@@ -1872,7 +1872,7 @@ public class FloatingDecimal{
                 }
             }  // look for and process decimal floating-point string
 
-            char[] digits = new char[ len ];
+            byte[] digits = new byte[ len ];
             boolean decSeen = false;
             int nDigits = 0;
             int decPt = 0;
@@ -1903,10 +1903,10 @@ public class FloatingDecimal{
             while (i < len) {
                 c = in.charAt(i);
                 if (c >= '1' && c <= '9') {
-                    digits[nDigits++] = c;
+                    digits[nDigits++] = (byte) c;
                     nTrailZero = 0;
                 } else if (c == '0') {
-                    digits[nDigits++] = c;
+                    digits[nDigits++] = (byte) c;
                     nTrailZero++;
                 } else if (c == '.') {
                     if (decSeen) {

--- a/test/jdk/jdk/internal/math/FloatingDecimal/TestFDBigInteger.java
+++ b/test/jdk/jdk/internal/math/FloatingDecimal/TestFDBigInteger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,13 +22,13 @@
  */
 
 import java.math.BigInteger;
-import java.util.Random;
+import java.nio.charset.StandardCharsets;
 import jdk.internal.math.FDBigInteger;
 
 /**
  * @test
- * @bug 7032154
- * @summary unit testys of FDBigInteger
+ * @bug 7032154 8342693
+ * @summary unit tests of FDBigInteger
  * @modules java.base/jdk.internal.math
  * @author Dmitry Nadezhin
  */
@@ -52,7 +52,7 @@ public class TestFDBigInteger {
     }
 
     private static FDBigInteger mutable(String hex, int offset) {
-        char[] chars = new BigInteger(hex, 16).toString().toCharArray();
+        byte[] chars = new BigInteger(hex, 16).toString().getBytes(StandardCharsets.US_ASCII);
         return new FDBigInteger(0, chars, 0, chars.length).multByPow52(0, offset * 32);
     }
 


### PR DESCRIPTION
This helps in reducing memory consumption, especially for long inputs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342693](https://bugs.openjdk.org/browse/JDK-8342693): Use byte[] as parameter in a FDBigInteger constructor and as field (**Enhancement** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21614/head:pull/21614` \
`$ git checkout pull/21614`

Update a local copy of the PR: \
`$ git checkout pull/21614` \
`$ git pull https://git.openjdk.org/jdk.git pull/21614/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21614`

View PR using the GUI difftool: \
`$ git pr show -t 21614`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21614.diff">https://git.openjdk.org/jdk/pull/21614.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21614#issuecomment-2426857026)
</details>
