### PR TITLE
8342607: Enhance register printing on x86_64 platforms

### DIFF
--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -544,7 +544,6 @@ void os::print_context(outputStream *st, const void *context) {
   st->print(", ERR=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_ERR]);
   st->cr();
   st->print("  TRAPNO=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_TRAPNO]);
-#ifndef MUSL_LIBC
   // Add XMM registers + MXCSR. Note that C2 uses XMM to spill GPR values including pointers.
   st->cr();
   st->cr();
@@ -559,7 +558,6 @@ void os::print_context(outputStream *st, const void *context) {
     }
     st->print("  MXCSR=" UINT32_FORMAT_X_0, uc->uc_mcontext.fpregs->mxcsr);
   }
-#endif
 #else
   st->print(  "EAX=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EAX]);
   st->print(", EBX=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EBX]);

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -547,9 +547,9 @@ void os::print_context(outputStream *st, const void *context) {
   // Add XMM registers + MXCSR. Note that C2 uses XMM to spill GPR values including pointers.
   st->cr();
   st->cr();
-  size_t fpregs_offset = ((address)uc->uc_mcontext.fpregs >= (address)uc) ?
-                         pointer_delta(uc->uc_mcontext.fpregs, uc, 1) : 0;
-  if (fpregs_offset >= sizeof(ucontext_t) || fpregs_offset == 0) {
+  // Sanity check: fpregs should point into the context.
+  if ((address)uc->uc_mcontext.fpregs < (address)uc ||
+      pointer_delta(uc->uc_mcontext.fpregs, uc, 1) >= sizeof(ucontext_t)) {
     st->print_cr("bad uc->uc_mcontext.fpregs: " INTPTR_FORMAT " (uc: " INTPTR_FORMAT ")",
                  p2i(uc->uc_mcontext.fpregs), p2i(uc));
   } else {

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -549,7 +549,7 @@ void os::print_context(outputStream *st, const void *context) {
   st->cr();
   st->cr();
   size_t fpregs_offset = pointer_delta(uc->uc_mcontext.fpregs, uc, 1);
-  if (fpregs_offset > sizeof(ucontext_t)) {
+  if (fpregs_offset >= sizeof(ucontext_t)) {
     st->print_cr("bad uc->uc_mcontext.fpregs: " INTPTR_FORMAT " (uc: " INTPTR_FORMAT ")",
                  p2i(uc->uc_mcontext.fpregs), p2i(uc));
   } else {

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -544,6 +544,17 @@ void os::print_context(outputStream *st, const void *context) {
   st->print(", ERR=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_ERR]);
   st->cr();
   st->print("  TRAPNO=" INTPTR_FORMAT, (intptr_t)uc->uc_mcontext.gregs[REG_TRAPNO]);
+#ifndef MUSL_LIBC
+  // Add XMM registers + MXCSR. Note that C2 uses XMM to spill GPR values including pointers.
+  st->cr();
+  st->cr();
+  for (int i = 0; i < 16; ++i) {
+    const __uint32_t *xmm = &(uc->__fpregs_mem._xmm[i].element[0]);
+    st->print_cr("XMM[%d]=" INTPTR_FORMAT " " INTPTR_FORMAT,
+                 i, (uint64_t)xmm[3] << 32 | (uint64_t)xmm[2], (uint64_t)xmm[1] << 32 | (uint64_t)xmm[0]);
+  }
+  st->print("  MXCSR=" UINT32_FORMAT_X_0, uc->__fpregs_mem.mxcsr);
+#endif
 #else
   st->print(  "EAX=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EAX]);
   st->print(", EBX=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EBX]);

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -549,11 +549,10 @@ void os::print_context(outputStream *st, const void *context) {
   st->cr();
   st->cr();
   for (int i = 0; i < 16; ++i) {
-    const __uint32_t *xmm = &(uc->__fpregs_mem._xmm[i].element[0]);
-    st->print_cr("XMM[%d]=" INTPTR_FORMAT " " INTPTR_FORMAT,
-                 i, (uint64_t)xmm[3] << 32 | (uint64_t)xmm[2], (uint64_t)xmm[1] << 32 | (uint64_t)xmm[0]);
+    const int64_t* xmm_val_addr = (int64_t*)&(uc->uc_mcontext.fpregs->_xmm[i]);
+    st->print_cr("XMM[%d]=" INTPTR_FORMAT " " INTPTR_FORMAT, i, xmm_val_addr[1], xmm_val_addr[0]);
   }
-  st->print("  MXCSR=" UINT32_FORMAT_X_0, uc->__fpregs_mem.mxcsr);
+  st->print("  MXCSR=" UINT32_FORMAT_X_0, uc->uc_mcontext.fpregs->mxcsr);
 #endif
 #else
   st->print(  "EAX=" INTPTR_FORMAT, uc->uc_mcontext.gregs[REG_EAX]);

--- a/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/os_linux_x86.cpp
@@ -547,8 +547,9 @@ void os::print_context(outputStream *st, const void *context) {
   // Add XMM registers + MXCSR. Note that C2 uses XMM to spill GPR values including pointers.
   st->cr();
   st->cr();
-  size_t fpregs_offset = pointer_delta(uc->uc_mcontext.fpregs, uc, 1);
-  if (fpregs_offset >= sizeof(ucontext_t)) {
+  size_t fpregs_offset = ((address)uc->uc_mcontext.fpregs >= (address)uc) ?
+                         pointer_delta(uc->uc_mcontext.fpregs, uc, 1) : 0;
+  if (fpregs_offset >= sizeof(ucontext_t) || fpregs_offset == 0) {
     st->print_cr("bad uc->uc_mcontext.fpregs: " INTPTR_FORMAT " (uc: " INTPTR_FORMAT ")",
                  p2i(uc->uc_mcontext.fpregs), p2i(uc));
   } else {

--- a/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
+++ b/src/hotspot/os_cpu/windows_x86/os_windows_x86.cpp
@@ -437,6 +437,15 @@ void os::print_context(outputStream *st, const void *context) {
   st->cr();
   st->print(  "RIP=" INTPTR_FORMAT, uc->Rip);
   st->print(", EFLAGS=" INTPTR_FORMAT, uc->EFlags);
+  // Add XMM registers + MXCSR. Note that C2 uses XMM to spill GPR values including pointers.
+  st->cr();
+  st->cr();
+  for (int i = 0; i < 16; ++i) {
+    const uint64_t *xmm = ((const uint64_t*)&(uc->Xmm0)) + 2 * i;
+    st->print_cr("XMM[%d]=" INTPTR_FORMAT " " INTPTR_FORMAT,
+                 i, xmm[1], xmm[0]);
+  }
+  st->print("  MXCSR=" UINT32_FORMAT_X_0, uc->MxCsr);
 #else
   st->print(  "EAX=" INTPTR_FORMAT, uc->Eax);
   st->print(", EBX=" INTPTR_FORMAT, uc->Ebx);

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -731,7 +731,9 @@ static void store_context(const void* context) {
 #if defined(PPC64)
   *((void**) &g_stored_assertion_context.uc_mcontext.regs) = &(g_stored_assertion_context.uc_mcontext.gp_regs);
 #elif defined(AMD64)
-  *((void**) &g_stored_assertion_context.uc_mcontext.fpregs) = &(g_stored_assertion_context.uc_mcontext.fpregs);
+  // In the copied version, fpregs should point to the copied contents. Preserve the offset.
+  intptr_t fpregs_offset = (address)(void*)(((const ucontext_t*)context)->uc_mcontext.fpregs) - (address)context;
+  *((void**) &g_stored_assertion_context.uc_mcontext.fpregs) = (void*)((address)(void*)&g_stored_assertion_context + fpregs_offset);
 #endif
 #endif
 }

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -725,10 +725,14 @@ void disarm_assert_poison() {
 
 static void store_context(const void* context) {
   memcpy(&g_stored_assertion_context, context, sizeof(ucontext_t));
-#if defined(LINUX) && defined(PPC64)
+#if defined(LINUX)
   // on Linux ppc64, ucontext_t contains pointers into itself which have to be patched up
   //  after copying the context (see comment in sys/ucontext.h):
+#if defined(PPC64)
   *((void**) &g_stored_assertion_context.uc_mcontext.regs) = &(g_stored_assertion_context.uc_mcontext.gp_regs);
+#elif defined(AMD64)
+  *((void**) &g_stored_assertion_context.uc_mcontext.fpregs) = &(g_stored_assertion_context.uc_mcontext.fpregs);
+#endif
 #endif
 }
 

--- a/src/hotspot/share/utilities/debug.cpp
+++ b/src/hotspot/share/utilities/debug.cpp
@@ -732,7 +732,7 @@ static void store_context(const void* context) {
   *((void**) &g_stored_assertion_context.uc_mcontext.regs) = &(g_stored_assertion_context.uc_mcontext.gp_regs);
 #elif defined(AMD64)
   // In the copied version, fpregs should point to the copied contents. Preserve the offset.
-  intptr_t fpregs_offset = (address)(void*)(((const ucontext_t*)context)->uc_mcontext.fpregs) - (address)context;
+  size_t fpregs_offset = pointer_delta(((const ucontext_t*)context)->uc_mcontext.fpregs, context, 1);
   *((void**) &g_stored_assertion_context.uc_mcontext.fpregs) = (void*)((address)(void*)&g_stored_assertion_context + fpregs_offset);
 #endif
 #endif


### PR DESCRIPTION
There are some situations in which the XMM registers are relevant to understand errors. E.g. C2 compiler uses them to spill GPR values (see https://github.com/openjdk/jdk/blob/d6eddcdaf92f2352266ba519608879141997cd63/src/hotspot/cpu/x86/x86_64.ad#L1312), so they may contain Oops etc. We may consider searching and printing the content for Oops in a future RFE.
I've implemented [JDK-8342607](https://bugs.openjdk.org/browse/JDK-8342607) such that linux and Windows show the same output format. (Skipped Intel-Mac because Apple has stopped shipping that platform. I don't have it and I'm not familiar with it.)

Example output (linux):
```
Registers:
RAX=0x00007fea8bdb3000, RBX=0x00007fea8b48d5d4, RCX=0x00007fea8b4d2255, RDX=0x0000000000000340
RSP=0x00007fea897d0b60, RBP=0x00007fea897d0b90, RSI=0x00007fea8b5f1448, RDI=0x00000000e0000000
R8 =0x00007fea8b48d5d4, R9 =0x0000000000000006, R10=0x00007fea8bb4b500, R11=0x00007fea7cc2f120
R12=0x0000000000000000, R13=0x00007fea897d0bc0, R14=0x00007fea897d0c50, R15=0x00007fea8402c9c0
RIP=0x00007fea8ac008e5, EFLAGS=0x0000000000010246, CSGSFS=0x002b000000000033, ERR=0x0000000000000006
  TRAPNO=0x000000000000000e

XMM[0]=0x0000000000000000 0x0000000000000000
XMM[1]=0x00007fea3c034200 0x0000000000000000
XMM[2]=0x00000000fffffffe 0x00007fea8402c9c0
XMM[3]=0x00007fea7c3d6608 0x0000000000000000
XMM[4]=0x00007f0000000000 0x0000000000000000
XMM[5]=0x00007fea897d0fe8 0x00007feaffffffff
XMM[6]=0x0000000000000000 0x00007fea897d0f98
XMM[7]=0x0202020202020202 0x0000000000000000
XMM[8]=0x0000000000000000 0x0202020202020202
XMM[9]=0x666e69206e6f6974 0x0000000000000000
XMM[10]=0x0000000000000000 0x6e6f6974616d726f
XMM[11]=0x0000000000000001 0x0000000000000000
XMM[12]=0x00007fea8b684400 0x0000000000000001
XMM[13]=0x0000000000000000 0x0000000000000000
XMM[14]=0x0000000000000000 0x0000000000000000
XMM[15]=0x0000000000000000 0x0000000000000000
  MXCSR=0x0000037f
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342607](https://bugs.openjdk.org/browse/JDK-8342607): Enhance register printing on x86_64 platforms (**Enhancement** - P4)


### Reviewers
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**) Review applies to [b3ec6143](https://git.openjdk.org/jdk/pull/21615/files/b3ec6143878d5d4c9a005264e3b4b8baabfbe040)
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**)

### Contributors
 * Richard Reingruber `<rrich@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21615/head:pull/21615` \
`$ git checkout pull/21615`

Update a local copy of the PR: \
`$ git checkout pull/21615` \
`$ git pull https://git.openjdk.org/jdk.git pull/21615/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21615`

View PR using the GUI difftool: \
`$ git pr show -t 21615`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21615.diff">https://git.openjdk.org/jdk/pull/21615.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21615#issuecomment-2426876074)