### PR TITLE
8342704: GHA: Report truncation is broken after JDK-8341424

### DIFF
--- a/.github/scripts/gen-build-failure-report.sh
+++ b/.github/scripts/gen-build-failure-report.sh
@@ -25,7 +25,7 @@
 #
 
 # Import common utils
-. report-utils.sh
+. .github/scripts/report-utils.sh
 
 GITHUB_STEP_SUMMARY="$1"
 BUILD_DIR="$(ls -d build/*)"

--- a/.github/scripts/gen-test-results.sh
+++ b/.github/scripts/gen-test-results.sh
@@ -25,7 +25,7 @@
 #
 
 # Import common utils
-. report-utils.sh
+. .github/scripts/report-utils.sh
 
 GITHUB_STEP_SUMMARY="$1"
 

--- a/test/jdk/java/lang/Compare.java
+++ b/test/jdk/java/lang/Compare.java
@@ -135,10 +135,7 @@ public class Compare {
         if (x == null ? y == null : x.equals(y)) pass();
         else fail(x + " not equal to " + y);}
     public static void main(String[] args) throws Throwable {
-        new Compare().instanceMain(args);
-        // GHA TEST HOOK: FAIL A TEST AND SEE WHAT HAPPENS. REMOVE BEFORE INTEGRATION.
-        throw new IllegalStateException();
-        }
+        new Compare().instanceMain(args);}
     public void instanceMain(String[] args) throws Throwable {
         try {test(args);} catch (Throwable t) {unexpected(t);}
         System.out.printf("%nPassed = %d, failed = %d%n%n", passed, failed);

--- a/test/jdk/java/lang/Compare.java
+++ b/test/jdk/java/lang/Compare.java
@@ -135,7 +135,10 @@ public class Compare {
         if (x == null ? y == null : x.equals(y)) pass();
         else fail(x + " not equal to " + y);}
     public static void main(String[] args) throws Throwable {
-        new Compare().instanceMain(args);}
+        new Compare().instanceMain(args);
+        // GHA TEST HOOK: FAIL A TEST AND SEE WHAT HAPPENS. REMOVE BEFORE INTEGRATION.
+        throw new IllegalStateException();
+        }
     public void instanceMain(String[] args) throws Throwable {
         try {test(args);} catch (Throwable t) {unexpected(t);}
         System.out.printf("%nPassed = %d, failed = %d%n%n", passed, failed);


### PR DESCRIPTION
When GH output is too large, we do not actually truncate it after [JDK-8341424](https://bugs.openjdk.org/browse/JDK-8341424). The error log would be:

```
Run bash ./.github/scripts/gen-test-results.sh "$GITHUB_STEP_SUMMARY"
./.github/scripts/gen-test-results.sh: line 28: report-utils.sh: No such file or directory
./.github/scripts/gen-test-results.sh: line 97: truncate_summary: command not found

Error: Process completed with exit code 127.
Error: $GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of 1024k, got 1579k. For more information see: https://docs.github.com/actions/using-workflows/workflow-commands-for-github-actions#adding-a-markdown-summary
```

This is because we import report-utils.sh incorrectly: scripts try to find it in current directory, which is not the same directory where the importing scripts are located. And we never see it in normal cases, because scripts are just eating the errors without any other observable effects.

Additional testing: 
  - [x] GHA checks work with deliberately failing tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342704](https://bugs.openjdk.org/browse/JDK-8342704): GHA: Report truncation is broken after JDK-8341424 (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21617/head:pull/21617` \
`$ git checkout pull/21617`

Update a local copy of the PR: \
`$ git checkout pull/21617` \
`$ git pull https://git.openjdk.org/jdk.git pull/21617/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21617`

View PR using the GUI difftool: \
`$ git pr show -t 21617`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21617.diff">https://git.openjdk.org/jdk/pull/21617.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21617#issuecomment-2427149365)