### PR TITLE
JDK-8342635 : javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java creates tmp file in src dir

### DIFF
--- a/test/jdk/javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java
+++ b/test/jdk/javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java
+++ b/test/jdk/javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java
@@ -46,9 +46,6 @@ public class WBMPStreamTruncateTest
     static final int height = 100;
     public static void main(String[] args) throws IOException
     {
-        String sep = System.getProperty("file.separator");
-        String dir = System.getProperty("test.src", ".");
-        String filePath = dir+sep;
         BufferedImage srcImage = new
                 BufferedImage(width, height, BufferedImage.TYPE_BYTE_BINARY);
         Graphics2D g = (Graphics2D) srcImage.getGraphics();
@@ -57,7 +54,7 @@ public class WBMPStreamTruncateTest
         g.dispose();
         // create WBMP image
         File imageFile = File.
-                createTempFile("test", ".wbmp", new File(filePath));
+                createTempFile("test", ".wbmp", new File("./"));
         imageFile.deleteOnExit();
         ImageIO.write(srcImage, "wbmp", imageFile);
         BufferedImage testImg =

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java
+++ b/test/jdk/javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java
@@ -44,18 +44,16 @@ public class WindowsDefaultIconSizeTest {
     }
 
     public void test() {
-        String sep = System.getProperty("file.separator");
-        String dir = System.getProperty("test.src", ".");
         String filename = "test.not";
 
-        File testFile = new File(dir + sep + filename);
+        File testFile = new File(filename);
         try {
             if (!testFile.exists()) {
                 testFile.createNewFile();
                 testFile.deleteOnExit();
             }
             FileSystemView fsv = FileSystemView.getFileSystemView();
-            Icon icon = fsv.getSystemIcon(new File(dir + sep + filename));
+            Icon icon = fsv.getSystemIcon(new File(filename));
             if (icon instanceof ImageIcon) {
                 Image image = ((ImageIcon) icon).getImage();
                 if (image instanceof MultiResolutionImage) {


### PR DESCRIPTION
WindowsDefaultIconSizeTest.java and WBMPStreamTruncateTest.java updated to store the tmp file in test scratch dir (default location) instead of test src dir.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8342635](https://bugs.openjdk.org/browse/JDK-8342635): javax/swing/JFileChooser/FileSystemView/WindowsDefaultIconSizeTest.java creates tmp file in src dir (**Bug** - P3)
 * [JDK-8342634](https://bugs.openjdk.org/browse/JDK-8342634): javax/imageio/plugins/wbmp/WBMPStreamTruncateTest.java creates temp file in src dir (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**) Review applies to [32c58248](https://git.openjdk.org/jdk/pull/21619/files/32c582489e104cb14a96c66d0c6a14ffd91d5051)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21619/head:pull/21619` \
`$ git checkout pull/21619`

Update a local copy of the PR: \
`$ git checkout pull/21619` \
`$ git pull https://git.openjdk.org/jdk.git pull/21619/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21619`

View PR using the GUI difftool: \
`$ git pr show -t 21619`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21619.diff">https://git.openjdk.org/jdk/pull/21619.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21619#issuecomment-2427279967)
</details>
