### PR TITLE
8342724

### DIFF
--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -138,6 +138,8 @@ public:
   using TreapNode = VMATreap::TreapNode;
 
 private:
+  // Keep a re-usable worklist to minimize constantly allocating/deallocating
+  GrowableArrayCHeap<TreapNode*, mtNMT> _worklist;
   VMATreap _tree;
 
   // AddressState saves the necessary information for performing online summary accounting.
@@ -155,7 +157,7 @@ private:
   };
 
 public:
-  VMATree() : _tree() {}
+  VMATree() : _wworklist(), _tree() {}
 
   struct SingleDiff {
     using delta = int64_t;


### PR DESCRIPTION
Today, VMATree::register_mapping depends on two worklist arrays which are used for keeping track of the iteration order of the tree. These arrays are re-allocated for each call to register_mapping, which has a measurable performance impact on the tree.

This PR intends to remedy the situation in two ways:

1. By removing one of the arrays entirely, and instead using merge/split operations for what this array used to be employed for.
2. By saving the remaining array as part of the VMATree instance, reusing it. As the size of this tree grows on an order of log n where n is the number of nodes in the tree, and its elements are small, this is not a large cost.

When measuring performance, I have observed a ~2x improvement through the use of a profiler. My colleague, @gerard-ziemski, has observed a ~3x improvement when running Java2Demo with NMT summary mode in terms of CPU time over a set of NMT operations.

Cheers.