### PR TITLE
8335977: Deoptimization fails with assert "object should be reallocated already"

### DIFF
--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1172,17 +1172,17 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
 
         for (int j = 0; j< merge->possible_objects()->length(); j++) {
           ObjectValue* ov = merge->possible_objects()->at(j)->as_ObjectValue();
-          // Already flagged as 'root' by something else. We shouldn't change it
-          // to non-root in a younger JVMS because it may need to be alive in
-          // the younger JVMS.
           if (ov->is_root()) {
-            continue;
+            // Already flagged as 'root' by something else. We shouldn't change it
+            // to non-root in a younger JVMS because it may need to be alive in
+            // a younger JVMS.
+          } else {
+            bool is_root = locarray->contains(ov) ||
+                          exparray->contains(ov) ||
+                          contains_as_owner(monarray, ov) ||
+                          contains_as_scalarized_obj(jvms, sfn, objs, ov);
+            ov->set_root(is_root);
           }
-          bool is_root = locarray->contains(ov) ||
-                         exparray->contains(ov) ||
-                         contains_as_owner(monarray, ov) ||
-                         contains_as_scalarized_obj(jvms, sfn, objs, ov);
-          ov->set_root(is_root);
         }
       }
     }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -1178,9 +1178,9 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
             // a younger JVMS.
           } else {
             bool is_root = locarray->contains(ov) ||
-                          exparray->contains(ov) ||
-                          contains_as_owner(monarray, ov) ||
-                          contains_as_scalarized_obj(jvms, sfn, objs, ov);
+                           exparray->contains(ov) ||
+                           contains_as_owner(monarray, ov) ||
+                           contains_as_scalarized_obj(jvms, sfn, objs, ov);
             ov->set_root(is_root);
           }
         }

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -792,7 +792,14 @@ void PhaseOutput::FillLocArray( int idx, MachSafePointNode* sfpt, Node *local,
 
       for (uint i = 1; i < smerge->req(); i++) {
         Node* obj_node = smerge->in(i);
-        (void)FillLocArray(mv->possible_objects()->length(), sfpt, obj_node, mv->possible_objects(), objs);
+        int idx = mv->possible_objects()->length();
+        (void)FillLocArray(idx, sfpt, obj_node, mv->possible_objects(), objs);
+
+        // By default ObjectValues that are in 'possible_objects' are not root objects.
+        // They will be marked as root later if they are directly referenced in a JVMS.
+        assert(mv->possible_objects()->length() > idx, "Didn't add entry to possible_objects?!");
+        assert(mv->possible_objects()->at(idx)->is_object(), "Entries in possible_objects should be ObjectValue.");
+        mv->possible_objects()->at(idx)->as_ObjectValue()->set_root(false);
       }
     }
     array->append(mv);
@@ -1127,7 +1134,14 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
 
           for (uint i = 1; i < smerge->req(); i++) {
             Node* obj_node = smerge->in(i);
-            FillLocArray(mv->possible_objects()->length(), sfn, obj_node, mv->possible_objects(), objs);
+            int idx = mv->possible_objects()->length();
+            (void)FillLocArray(idx, sfn, obj_node, mv->possible_objects(), objs);
+
+            // By default ObjectValues that are in 'possible_objects' are not root objects.
+            // They will be marked as root later if they are directly referenced in a JVMS.
+            assert(mv->possible_objects()->length() > idx, "Didn't add entry to possible_objects?!");
+            assert(mv->possible_objects()->at(idx)->is_object(), "Entries in possible_objects should be ObjectValue.");
+            mv->possible_objects()->at(idx)->as_ObjectValue()->set_root(false);
           }
         }
         scval = mv;
@@ -1158,6 +1172,12 @@ void PhaseOutput::Process_OopMap_Node(MachNode *mach, int current_offset) {
 
         for (int j = 0; j< merge->possible_objects()->length(); j++) {
           ObjectValue* ov = merge->possible_objects()->at(j)->as_ObjectValue();
+          // Already flagged as 'root' by something else. We shouldn't change it
+          // to non-root in a younger JVMS because it may need to be alive in
+          // the younger JVMS.
+          if (ov->is_root()) {
+            continue;
+          }
           bool is_root = locarray->contains(ov) ||
                          exparray->contains(ov) ||
                          contains_as_owner(monarray, ov) ||

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndJVMStates.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndJVMStates.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8335977
+ * @summary Check that Reduce Allocation Merges doesn't crash when there
+ *          is an uncommon_trap with a chain of JVMS and, the reduced phi
+ *          input(s) are local(s) in an old JVMS but not in a younger JVMS.
+ *          I.e., check that we don't lose track of "_is_root" when traversing
+ *          a JVMS chain.
+ * @run main/othervm -Xbatch
+ *                   -XX:CompileOnly=compiler.escapeAnalysis.TestReduceAllocationAndJVMStates::test*
+ *                   compiler.escapeAnalysis.TestReduceAllocationAndJVMStates
+ * @run main compiler.escapeAnalysis.TestReduceAllocationAndJVMStates
+ */
+package compiler.escapeAnalysis;
+
+public class TestReduceAllocationAndJVMStates {
+    static boolean bFld;
+    static int iFld;
+
+    public static void main(String[] args) {
+        bFld = false;
+
+        for (int i = 0; i < 10000; i++) {
+            test(i % 2 == 0);
+        }
+        bFld = true;
+
+        // This will trigger a deoptimization which
+        // will make the issue manifest to the user
+        //test1(true);
+        test(true);
+    }
+
+    static int test(boolean flag) {
+        Super a = new A();
+        Super b = new B();
+        Super s = (flag ? a : b);
+
+        // This needs to be inlined by C2
+        check();
+
+        return a.i + b.i + s.i;
+    }
+
+    // This shouldn't be manually inlined
+    static void check() {
+        if (bFld) {
+            iFld = 34;
+        }
+    }
+}
+
+class Super {
+    int i;
+}
+class A extends Super {}
+class B extends Super {}

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndJVMStates.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestReduceAllocationAndJVMStates.java
@@ -50,7 +50,6 @@ public class TestReduceAllocationAndJVMStates {
 
         // This will trigger a deoptimization which
         // will make the issue manifest to the user
-        //test1(true);
         test(true);
     }
 


### PR DESCRIPTION
Please, review this patch to fix an issue that may occur when serializing debug information related to reduce allocation merges. The problem happens when there are more than one JVMS in a `uncommon_trap` and a _younger_ JVMS doesn't have the RAM inputs as a local/expression/monitor but an older JVMS does. In that situation the loop at line 1173 of output.cpp will set the `is_root` property of the ObjectValue to `false` when processing the younger JVMS even though it may have been set to `true` when visiting the older JVMS.

Tested on: 
 - Win, Mac & Linux tier1-4 on x64 & Aarch64.
 - CTW with some thousands of jars.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335977](https://bugs.openjdk.org/browse/JDK-8335977): Deoptimization fails with assert "object should be reallocated already" (**Bug** - P2)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**) Review applies to [8e345b59](https://git.openjdk.org/jdk/pull/21624/files/8e345b593a3553cded11103c8912164fc2d7a090)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Contributors
 * Christian Hagedorn `<chagedorn@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21624/head:pull/21624` \
`$ git checkout pull/21624`

Update a local copy of the PR: \
`$ git checkout pull/21624` \
`$ git pull https://git.openjdk.org/jdk.git pull/21624/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21624`

View PR using the GUI difftool: \
`$ git pr show -t 21624`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21624.diff">https://git.openjdk.org/jdk/pull/21624.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21624#issuecomment-2427669633)
</details>
