### PR TITLE
8342787: Move misplaced TestTemplateAssertionPredicateWithTwoUCTs.java from src to test directory

### DIFF
--- a/test/hotspot/jtreg/compiler/predicates/TestTemplateAssertionPredicateWithTwoUCTs.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestTemplateAssertionPredicateWithTwoUCTs.java
@@ -25,7 +25,7 @@
 /*
  * @test
  * @bug 8342287
- * @summary Test that a fail path projection of a Template Assertion Predicate is not treated as success path projection
+ * @summary Test that a fail path projection of a Template Assertion Predicate is not treated as success path projection.
  * @run main/othervm -XX:-TieredCompilation -Xbatch
  *                   -XX:CompileCommand=compileonly,compiler.predicates.TestTemplateAssertionPredicateWithTwoUCTs::test
  *                   compiler.predicates.TestTemplateAssertionPredicateWithTwoUCTs
@@ -43,7 +43,7 @@ public class TestTemplateAssertionPredicateWithTwoUCTs {
     }
 
     static void test() {
-        int lArr[][] = new int[100][1];
+        int[][] lArr = new int[100][1];
         for (int i14 = 5; i14 < 273; ++i14) {
             int i16 = 1;
             while (++i16 < 94) {
@@ -58,4 +58,3 @@ public class TestTemplateAssertionPredicateWithTwoUCTs {
         }
     }
 }
-


### PR DESCRIPTION
For some unknown reason, `TestTemplateAssertionPredicateWithTwoUCTs.java` ended up in the src directory instead of the test directory with [JDK-8342287](https://bugs.openjdk.org/browse/JDK-8342787). Maybe a patch application have gone wrong when moving the test to another checked out JDK repository. Anyway, this patch moves it to the correct place.

Thanks to @TheShermanTanker for spotting this!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342787](https://bugs.openjdk.org/browse/JDK-8342787): Move misplaced TestTemplateAssertionPredicateWithTwoUCTs.java from src to test directory (**Bug** - P5)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21629/head:pull/21629` \
`$ git checkout pull/21629`

Update a local copy of the PR: \
`$ git checkout pull/21629` \
`$ git pull https://git.openjdk.org/jdk.git pull/21629/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21629`

View PR using the GUI difftool: \
`$ git pr show -t 21629`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21629.diff">https://git.openjdk.org/jdk/pull/21629.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21629#issuecomment-2428460216)