### PR TITLE
8342692: C2: MemorySegment API slow with short running loops

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -806,6 +806,10 @@
   product(bool, UseStoreStoreForCtor, true, DIAGNOSTIC,                     \
           "Use StoreStore barrier instead of Release barrier at the end "   \
           "of constructors")                                                \
+                                                                            \
+  product(uintx, ShortLoopIter, 1000,                                       \
+          "Number of iterations for a short running loop")                  \
+          range(0, max_juint)                                               \
 
 // end of C2_FLAGS
 

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -239,12 +239,13 @@ Node *CastIINode::Ideal(PhaseGVN *phase, bool can_reshape) {
   if (progress != nullptr) {
     return progress;
   }
-  if (can_reshape && !_range_check_dependency && !phase->C->post_loop_opts_phase()) {
-    // makes sure we run ::Value to potentially remove type assertion after loop opts
-    phase->C->record_for_post_loop_opts_igvn(this);
-  }
-  if (!_range_check_dependency) {
-    return optimize_integer_cast(phase, T_INT);
+  if (can_reshape && !_range_check_dependency) {
+    if (!phase->C->post_loop_opts_phase()) {
+      // makes sure we run ::Value to potentially remove type assertion after loop opts
+      phase->C->record_for_post_loop_opts_igvn(this);
+    } else {
+      return optimize_integer_cast(phase, T_INT);
+    }
   }
   return nullptr;
 }
@@ -329,7 +330,10 @@ Node* CastLLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
       }
     }
   }
-  return optimize_integer_cast(phase, T_LONG);
+  if (phase->C->post_loop_opts_phase()) {
+    return optimize_integer_cast(phase, T_LONG);
+  }
+  return nullptr;
 }
 
 //------------------------------Value------------------------------------------

--- a/src/hotspot/share/opto/castnode.cpp
+++ b/src/hotspot/share/opto/castnode.cpp
@@ -241,7 +241,7 @@ Node *CastIINode::Ideal(PhaseGVN *phase, bool can_reshape) {
   }
   if (can_reshape && !_range_check_dependency) {
     if (!phase->C->post_loop_opts_phase()) {
-      // makes sure we run ::Value to potentially remove type assertion after loop opts
+      // makes sure we run ::Value to potentially remove type assertion and optimize_integer_cast() after loop opts
       phase->C->record_for_post_loop_opts_igvn(this);
     } else {
       return optimize_integer_cast(phase, T_INT);
@@ -307,7 +307,7 @@ Node* CastLLNode::Ideal(PhaseGVN* phase, bool can_reshape) {
     return progress;
   }
   if (!phase->C->post_loop_opts_phase()) {
-    // makes sure we run ::Value to potentially remove type assertion after loop opts
+    // makes sure we run ::Value to potentially remove type assertion and optimize_integer_cast() after loop opts
     phase->C->record_for_post_loop_opts_igvn(this);
   }
   // transform (CastLL (ConvI2L ..)) into (ConvI2L (CastII ..)) if the type of the CastLL is narrower than the type of

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4084,6 +4084,8 @@ void GraphKit::add_parse_predicate(Deoptimization::DeoptReason reason, const int
 // Add Parse Predicates which serve as placeholders to create new Runtime Predicates above them. All
 // Runtime Predicates inside a Runtime Predicate block share the same uncommon trap as the Parse Predicate.
 void GraphKit::add_parse_predicates(int nargs) {
+  // Will narrow the limit down with a cast node. Predicates added later may depend on the cast so should be last when
+  // starting from the loop.
   add_parse_predicate(Deoptimization::Reason_short_running_loop, nargs);
   if (UseLoopPredicate) {
     add_parse_predicate(Deoptimization::Reason_predicate, nargs);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -4084,6 +4084,7 @@ void GraphKit::add_parse_predicate(Deoptimization::DeoptReason reason, const int
 // Add Parse Predicates which serve as placeholders to create new Runtime Predicates above them. All
 // Runtime Predicates inside a Runtime Predicate block share the same uncommon trap as the Parse Predicate.
 void GraphKit::add_parse_predicates(int nargs) {
+  add_parse_predicate(Deoptimization::Reason_short_running_loop, nargs);
   if (UseLoopPredicate) {
     add_parse_predicate(Deoptimization::Reason_predicate, nargs);
   }

--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -2173,6 +2173,7 @@ ParsePredicateNode::ParsePredicateNode(Node* control, Deoptimization::DeoptReaso
     case Deoptimization::Reason_predicate:
     case Deoptimization::Reason_profile_predicate:
     case Deoptimization::Reason_loop_limit_check:
+    case Deoptimization::Reason_short_running_loop:
       break;
     default:
       assert(false, "unsupported deoptimization reason for Parse Predicate");
@@ -2211,6 +2212,9 @@ void ParsePredicateNode::dump_spec(outputStream* st) const {
       break;
     case Deoptimization::DeoptReason::Reason_loop_limit_check:
       st->print("Loop_Limit_Check ");
+      break;
+    case Deoptimization::DeoptReason::Reason_short_running_loop:
+      st->print("Short_Running_Loop ");
       break;
     default:
       fatal("unknown kind");

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -302,39 +302,6 @@ void PhaseIdealLoop::clone_assertion_predicates_to_unswitched_loop(IdealLoopTree
 
   clone_assertion_predicates_to_slow_unswitched_loop(loop, old_new, reason, list, slow_loop_parse_predicate_proj);
   clone_assertion_predicates_to_fast_unswitched_loop(loop, reason, list, fast_loop_parse_predicate_proj);
-  // Node_List to_process;
-  // // Process in reverse order such that 'create_new_if_for_predicate' can be used in
-  // // 'clone_assertion_predicate_for_unswitched_loops' and the original order is maintained.
-  // for (int i = list.size() - 1; i >= 0; i--) {
-  //   Node* predicate = list.at(i);
-  //   assert(predicate->in(0)->is_If(), "must be If node");
-  //   IfNode* iff = predicate->in(0)->as_If();
-  //   assert(predicate->is_Proj() && predicate->as_Proj()->is_IfProj(), "predicate must be a projection of an if node");
-  //   IfProjNode* predicate_proj = predicate->as_IfProj();
-  //
-  //   IfProjNode* fast_proj = clone_assertion_predicate_for_unswitched_loops(iff, predicate_proj, reason, fast_loop_parse_predicate_proj);
-  //   assert(assertion_predicate_has_loop_opaque_node(fast_proj->in(0)->as_If()), "must find Assertion Predicate for fast loop");
-  //   IfProjNode* slow_proj = clone_assertion_predicate_for_unswitched_loops(iff, predicate_proj, reason, slow_loop_parse_predicate_proj);
-  //   assert(assertion_predicate_has_loop_opaque_node(slow_proj->in(0)->as_If()), "must find Assertion Predicate for slow loop");
-  //
-  //   // Update control dependent data nodes.
-  //   for (DUIterator j = predicate->outs(); predicate->has_out(j); j++) {
-  //     Node* fast_node = predicate->out(j);
-  //     if (loop->is_member(get_loop(ctrl_or_self(fast_node)))) {
-  //       assert(fast_node->in(0) == predicate, "only control edge");
-  //       Node* slow_node = old_new[fast_node->_idx];
-  //       assert(slow_node->in(0) == predicate, "only control edge");
-  //       _igvn.replace_input_of(fast_node, 0, fast_proj);
-  //       to_process.push(slow_node);
-  //       --j;
-  //     }
-  //   }
-  //   // Have to delay updates to the slow loop so uses of predicate are not modified while we iterate on them.
-  //   while (to_process.size() > 0) {
-  //     Node* slow_node = to_process.pop();
-  //     _igvn.replace_input_of(slow_node, 0, slow_proj);
-  //   }
-  // }
 }
 
 void PhaseIdealLoop::clone_assertion_predicates_to_fast_unswitched_loop(IdealLoopTree* loop,

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -466,7 +466,7 @@ void PhaseIdealLoop::clone_parse_and_assertion_predicates_to_unswitched_loop(Ide
 
   const Predicates predicates(entry);
   const PredicateBlock* short_running_loop_predicate_block = predicates.short_running_loop_predicate_block();
-  if (short_running_loop_predicate_block->has_parse_predicate() && !head->is_CountedLoop()) {
+  if (short_running_loop_predicate_block->has_parse_predicate()) {
     clone_parse_predicate_to_unswitched_loops(short_running_loop_predicate_block, Deoptimization::Reason_short_running_loop,
                                               iffast_pred, ifslow_pred);
   }

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -273,9 +273,9 @@ void PhaseIdealLoop::fix_cloned_data_node_controls(const ProjNode* old_uncommon_
   orig_to_clone.iterate_all(orig_clone_action);
 }
 
-IfProjNode* PhaseIdealLoop::clone_parse_predicate_to_unswitched_loop(ParsePredicateSuccessProj* parse_predicate_proj,
-                                                                     Node* new_entry, Deoptimization::DeoptReason reason,
-                                                                     const bool slow_loop) {
+IfProjNode* PhaseIdealLoop::clone_parse_predicate(ParsePredicateSuccessProj* parse_predicate_proj,
+                                                  Node* new_entry, Deoptimization::DeoptReason reason,
+                                                  const bool slow_loop) {
 
   IfProjNode* new_predicate_proj = create_new_if_for_predicate(parse_predicate_proj, new_entry, reason, Op_ParsePredicate,
                                                                slow_loop);
@@ -301,14 +301,14 @@ void PhaseIdealLoop::clone_assertion_predicates_to_unswitched_loop(IdealLoopTree
   get_assertion_predicates(old_predicate_proj, list);
 
   clone_assertion_predicates_to_slow_unswitched_loop(loop, old_new, reason, list, slow_loop_parse_predicate_proj);
-  clone_assertion_predicates_to_fast_unswitched_loop(loop, reason, list, fast_loop_parse_predicate_proj);
+  clone_assertion_predicates(loop, reason, list, fast_loop_parse_predicate_proj);
 }
 
-void PhaseIdealLoop::clone_assertion_predicates_to_fast_unswitched_loop(IdealLoopTree* loop,
-                                                                        Deoptimization::DeoptReason reason,
-                                                                        const Unique_Node_List& list,
-                                                                        ParsePredicateSuccessProj*
-                                                                        fast_loop_parse_predicate_proj) {
+void PhaseIdealLoop::clone_assertion_predicates(IdealLoopTree* loop,
+                                                Deoptimization::DeoptReason reason,
+                                                const Unique_Node_List &list,
+                                                ParsePredicateSuccessProj*
+                                                fast_loop_parse_predicate_proj) {
   assert(fast_loop_parse_predicate_proj->in(0)->is_ParsePredicate(), "sanity check");
   // Only need to clone range check predicates as those can be changed and duplicated by inserting pre/main/post loops
   // and doing loop unrolling. Push the original predicates on a list to later process them in reverse order to keep the
@@ -473,10 +473,10 @@ void PhaseIdealLoop::clone_parse_predicate_to_unswitched_loops(const PredicateBl
                                                                IfProjNode*& iffast_pred, IfProjNode*& ifslow_pred) {
   assert(predicate_block->has_parse_predicate(), "must have parse predicate");
   ParsePredicateSuccessProj* parse_predicate_proj = predicate_block->parse_predicate_success_proj();
-  iffast_pred = clone_parse_predicate_to_unswitched_loop(parse_predicate_proj, iffast_pred, reason, false);
+  iffast_pred = clone_parse_predicate(parse_predicate_proj, iffast_pred, reason, false);
   check_cloned_parse_predicate_for_unswitching(iffast_pred, true);
 
-  ifslow_pred = clone_parse_predicate_to_unswitched_loop(parse_predicate_proj, ifslow_pred, reason, true);
+  ifslow_pred = clone_parse_predicate(parse_predicate_proj, ifslow_pred, reason, true);
   check_cloned_parse_predicate_for_unswitching(ifslow_pred, false);
 }
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -129,6 +129,8 @@ void IdealLoopTree::compute_trip_count(PhaseIdealLoop* phase, BasicType loop_bt)
     julong uinit_con = init_con;
     jlong limit_con = (stride_con > 0) ? limit_type->hi_as_long() : limit_type->lo_as_long();
     julong ulimit_con = limit_con;
+    // The loop body is always executed at least once even if init >= limit (for stride_con > 0) or
+    // init <= limit (for stride_con < 0).
     julong udiff = 1;
     if (stride_con > 0 && limit_con > init_con) {
       udiff = ulimit_con - uinit_con;
@@ -149,7 +151,7 @@ void IdealLoopTree::compute_trip_count(PhaseIdealLoop* phase, BasicType loop_bt)
       // The loop body is always executed at least once even if init >= limit (for stride_con > 0) or
       // init <= limit (for stride_con < 0).
       trip_count = MAX2(trip_count, (jlong)1);
-      assert(checked_cast<juint>(trip_count) == checked_cast<juint>(utrip_count), "");
+      assert(checked_cast<juint>(trip_count) == checked_cast<juint>(utrip_count), "incorrect trip count computation");
     }
 #endif
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -97,11 +97,11 @@ void IdealLoopTree::record_for_igvn() {
 //------------------------------compute_exact_trip_count-----------------------
 // Compute loop trip count if possible. Do not recalculate trip count for
 // split loops (pre-main-post) which have their limits and inits behind Opaque node.
-void IdealLoopTree::compute_trip_count(PhaseIdealLoop* phase) {
-  if (!_head->as_Loop()->is_valid_counted_loop(T_INT)) {
+void IdealLoopTree::compute_trip_count(PhaseIdealLoop* phase, BasicType loop_bt) {
+  if (!_head->as_Loop()->is_valid_counted_loop(loop_bt)) {
     return;
   }
-  CountedLoopNode* cl = _head->as_CountedLoop();
+  BaseCountedLoopNode* cl = _head->as_BaseCountedLoop();
   // Trip count may become nonexact for iteration split loops since
   // RCE modifies limits. Note, _trip_count value is not reset since
   // it is used to limit unrolling of main loop.
@@ -121,23 +121,45 @@ void IdealLoopTree::compute_trip_count(PhaseIdealLoop* phase) {
   Node* limit_n = cl->limit();
   if (init_n != nullptr && limit_n != nullptr) {
     // Use longs to avoid integer overflow.
-    int stride_con = cl->stride_con();
-    const TypeInt* init_type = phase->_igvn.type(init_n)->is_int();
-    const TypeInt* limit_type = phase->_igvn.type(limit_n)->is_int();
-    jlong init_con = (stride_con > 0) ? init_type->_lo : init_type->_hi;
-    jlong limit_con = (stride_con > 0) ? limit_type->_hi : limit_type->_lo;
-    int stride_m = stride_con - (stride_con > 0 ? 1 : -1);
-    jlong trip_count = (limit_con - init_con + stride_m)/stride_con;
-    // The loop body is always executed at least once even if init >= limit (for stride_con > 0) or
-    // init <= limit (for stride_con < 0).
-    trip_count = MAX2(trip_count, (jlong)1);
-    if (trip_count < (jlong)max_juint) {
+    jlong stride_con = cl->stride_con();
+    const TypeInteger* init_type = phase->_igvn.type(init_n)->is_integer(loop_bt);
+    const TypeInteger* limit_type = phase->_igvn.type(limit_n)->is_integer(loop_bt);
+
+    jlong init_con = (stride_con > 0) ? init_type->lo_as_long() : init_type->hi_as_long();
+    julong uinit_con = init_con;
+    jlong limit_con = (stride_con > 0) ? limit_type->hi_as_long() : limit_type->lo_as_long();
+    julong ulimit_con = limit_con;
+    julong udiff = 1;
+    if (stride_con > 0 && limit_con > init_con) {
+      udiff = ulimit_con - uinit_con;
+    } else if (stride_con < 0 && limit_con < init_con) {
+      udiff = uinit_con - ulimit_con;
+    }
+    julong utrip_count = udiff / ABS(stride_con);
+    if (utrip_count * ABS(stride_con) != udiff) {
+      utrip_count++;
+    }
+
+#ifdef ASSERT
+    if (loop_bt == T_INT) {
+      jlong init_con = (stride_con > 0) ? init_type->is_int()->_lo : init_type->is_int()->_hi;
+      jlong limit_con = (stride_con > 0) ? limit_type->is_int()->_hi : limit_type->is_int()->_lo;
+      int stride_m = stride_con - (stride_con > 0 ? 1 : -1);
+      jlong trip_count = (limit_con - init_con + stride_m)/stride_con;
+      // The loop body is always executed at least once even if init >= limit (for stride_con > 0) or
+      // init <= limit (for stride_con < 0).
+      trip_count = MAX2(trip_count, (jlong)1);
+      assert(checked_cast<juint>(trip_count) == checked_cast<juint>(utrip_count), "");
+    }
+#endif
+
+    if (utrip_count < max_unsigned_integer(loop_bt)) {
       if (init_n->is_Con() && limit_n->is_Con()) {
         // Set exact trip count.
-        cl->set_exact_trip_count((uint)trip_count);
-      } else if (cl->unrolled_count() == 1) {
+        cl->set_exact_trip_count(utrip_count);
+      } else if (loop_bt == T_LONG || cl->as_CountedLoop()->unrolled_count() == 1) {
         // Set maximum trip count before unrolling.
-        cl->set_trip_count((uint)trip_count);
+        cl->set_trip_count(utrip_count);
       }
     }
   }
@@ -2043,7 +2065,7 @@ void PhaseIdealLoop::do_unroll(IdealLoopTree *loop, Node_List &old_new, bool adj
     loop->dump_head();
   } else if (TraceLoopOpts) {
     if (loop_head->trip_count() < (uint)LoopUnrollLimit) {
-      tty->print("Unroll %d(%2d) ", loop_head->unrolled_count()*2, loop_head->trip_count());
+      tty->print("Unroll %d(%2ld) ", loop_head->unrolled_count()*2, loop_head->trip_count());
     } else {
       tty->print("Unroll %d     ", loop_head->unrolled_count()*2);
     }
@@ -2296,7 +2318,7 @@ void PhaseIdealLoop::do_maximally_unroll(IdealLoopTree *loop, Node_List &old_new
   assert(cl->trip_count() > 0, "");
 #ifndef PRODUCT
   if (TraceLoopOpts) {
-    tty->print("MaxUnroll  %d ", cl->trip_count());
+    tty->print("MaxUnroll  %ld ", cl->trip_count());
     loop->dump_head();
   }
 #endif
@@ -3553,7 +3575,7 @@ bool IdealLoopTree::iteration_split_impl(PhaseIdealLoop *phase, Node_List &old_n
     return false;
   }
   // Compute loop trip count if possible.
-  compute_trip_count(phase);
+  compute_trip_count(phase, T_INT);
 
   // Convert one iteration loop into normal code.
   if (do_one_iteration_loop(phase)) {

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1168,25 +1168,25 @@ bool PhaseIdealLoop::short_running_loop(IdealLoopTree* loop, jint stride_con, co
     const PredicateBlock* predicate_block = predicates.loop_predicate_block();
     ParsePredicateSuccessProj* parse_predicate_proj = short_running_loop_predicate_block-> parse_predicate_success_proj();
     Node* ctrl = entry_control;
-    ctrl = clone_parse_predicate_to_unswitched_loop(parse_predicate_proj, ctrl,
+    ctrl = clone_parse_predicate(parse_predicate_proj, ctrl,
                                                     Deoptimization::Reason_short_running_loop, true);
     Node* short_running_loop_ctrl = ctrl;
     if (predicate_block->has_parse_predicate()) {
       parse_predicate_proj = predicate_block->parse_predicate_success_proj();
-      ctrl = clone_parse_predicate_to_unswitched_loop(parse_predicate_proj, ctrl, Deoptimization::Reason_predicate,
+      ctrl = clone_parse_predicate(parse_predicate_proj, ctrl, Deoptimization::Reason_predicate,
                                                       true);
       Unique_Node_List list;
       get_assertion_predicates(parse_predicate_proj, list);
-      clone_assertion_predicates_to_fast_unswitched_loop(loop, Deoptimization::Reason_predicate, list, ctrl->as_IfTrue());
+      clone_assertion_predicates(loop, Deoptimization::Reason_predicate, list, ctrl->as_IfTrue());
     }
     const PredicateBlock* profiled_predicate_block = predicates.profiled_loop_predicate_block();
     if (profiled_predicate_block->has_parse_predicate()) {
       parse_predicate_proj = profiled_predicate_block->parse_predicate_success_proj();
-      ctrl = clone_parse_predicate_to_unswitched_loop(parse_predicate_proj, ctrl,
+      ctrl = clone_parse_predicate(parse_predicate_proj, ctrl,
                                                       Deoptimization::Reason_profile_predicate, true);
       Unique_Node_List list;
       get_assertion_predicates(parse_predicate_proj, list);
-      clone_assertion_predicates_to_fast_unswitched_loop(loop, Deoptimization::Reason_profile_predicate, list, ctrl->as_IfTrue());
+      clone_assertion_predicates(loop, Deoptimization::Reason_profile_predicate, list, ctrl->as_IfTrue());
     }
     assert(ctrl != entry_control, "some parse predicates must have been inserted");
     _igvn.replace_input_of(head->skip_strip_mined(), LoopNode::EntryControl, ctrl);

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -1217,8 +1217,9 @@ bool PhaseIdealLoop::short_running_loop(IdealLoopTree* loop, jint stride_con, co
     entry_control = head->skip_strip_mined()->in(LoopNode::EntryControl);
   } else if (bt == T_LONG) {
     const Predicates predicates(entry_control);
+    const TypeLong* new_limit_t = new_limit->Value(&_igvn)->is_long();
     new_limit = ConstraintCastNode::make_cast_for_basic_type(predicates.entry(), new_limit,
-                                                             new_limit->Value(&_igvn),
+                                                             TypeLong::make(0, new_limit_t->_hi, new_limit_t->_widen),
                                                              ConstraintCastNode::UnconditionalDependency, bt);
     register_new_node(new_limit, predicates.entry());
   //   const TypeInteger* phi_t = _igvn.type(phi)->is_integer(bt);

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1682,18 +1682,19 @@ private:
                                                             IfProjNode*& ifslow_pred);
   void clone_parse_predicate_to_unswitched_loops(const PredicateBlock* predicate_block, Deoptimization::DeoptReason reason,
                                                  IfProjNode*& iffast_pred, IfProjNode*& ifslow_pred);
-  IfProjNode* clone_parse_predicate_to_unswitched_loop(ParsePredicateSuccessProj* parse_predicate_proj, Node* new_entry,
-                                                       Deoptimization::DeoptReason reason, bool slow_loop);
+
+  IfProjNode* clone_parse_predicate(ParsePredicateSuccessProj* parse_predicate_proj, Node* new_entry,
+                                    Deoptimization::DeoptReason reason, bool slow_loop);
   void clone_assertion_predicates_to_unswitched_loop(IdealLoopTree* loop, const Node_List& old_new,
                                                      Deoptimization::DeoptReason reason, IfProjNode* old_predicate_proj,
                                                      ParsePredicateSuccessProj* fast_loop_parse_predicate_proj,
                                                      ParsePredicateSuccessProj* slow_loop_parse_predicate_proj);
 
-  void clone_assertion_predicates_to_fast_unswitched_loop(IdealLoopTree* loop,
-                                                          Deoptimization::DeoptReason reason,
-                                                          const Unique_Node_List &list,
-                                                          ParsePredicateSuccessProj*
-                                                          fast_loop_parse_predicate_proj);
+  void clone_assertion_predicates(IdealLoopTree* loop,
+                                  Deoptimization::DeoptReason reason,
+                                  const Unique_Node_List &list,
+                                  ParsePredicateSuccessProj*
+                                  fast_loop_parse_predicate_proj);
 
   void clone_assertion_predicates_to_slow_unswitched_loop(IdealLoopTree* loop, const Node_List &old_new,
                                                           Deoptimization::DeoptReason reason,

--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -95,6 +95,7 @@ bool RegularPredicateWithUCT::has_valid_uncommon_trap(const Node* success_proj) 
   assert(RegularPredicate::may_be_predicate_if(success_proj), "must have been checked before");
   const Deoptimization::DeoptReason deopt_reason = uncommon_trap_reason(success_proj->as_IfProj());
   return (deopt_reason == Deoptimization::Reason_loop_limit_check ||
+          deopt_reason == Deoptimization::Reason_short_running_loop ||
           deopt_reason == Deoptimization::Reason_predicate ||
           deopt_reason == Deoptimization::Reason_profile_predicate);
 }
@@ -688,6 +689,8 @@ void Predicates::dump() const {
     _profiled_loop_predicate_block.dump("  ");
     tty->print_cr("- Loop Predicate Block:");
     _loop_predicate_block.dump("  ");
+    tty->print_cr("- Short Running Loop Predicate Block:");
+    _short_running_loop_predicate_block.dump("  ");
     tty->cr();
   } else {
     tty->print_cr("<no predicates>");

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -690,9 +690,9 @@ class PredicateIterator : public StackObj {
     PredicateBlockIterator profiled_loop_predicate_iterator(current, Deoptimization::Reason_profile_predicate);
     current = profiled_loop_predicate_iterator.for_each(predicate_visitor);
     PredicateBlockIterator loop_predicate_iterator(current, Deoptimization::Reason_predicate);
-    return loop_predicate_iterator.for_each(predicate_visitor);
+    current = loop_predicate_iterator.for_each(predicate_visitor);
     PredicateBlockIterator short_running_loop_predicate_iterator(current, Deoptimization::Reason_short_running_loop);
-    current = short_running_loop_predicate_iterator.for_each(predicate_visitor);
+    return short_running_loop_predicate_iterator.for_each(predicate_visitor);
   }
 };
 

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -691,6 +691,8 @@ class PredicateIterator : public StackObj {
     current = profiled_loop_predicate_iterator.for_each(predicate_visitor);
     PredicateBlockIterator loop_predicate_iterator(current, Deoptimization::Reason_predicate);
     return loop_predicate_iterator.for_each(predicate_visitor);
+    PredicateBlockIterator short_running_loop_predicate_iterator(current, Deoptimization::Reason_short_running_loop);
+    current = short_running_loop_predicate_iterator.for_each(predicate_visitor);
   }
 };
 
@@ -856,6 +858,7 @@ class Predicates : public StackObj {
   const PredicateBlock _loop_limit_check_predicate_block;
   const PredicateBlock _profiled_loop_predicate_block;
   const PredicateBlock _loop_predicate_block;
+  const PredicateBlock _short_running_loop_predicate_block;
   Node* const _entry;
 
  public:
@@ -866,7 +869,9 @@ class Predicates : public StackObj {
                                        Deoptimization::Reason_profile_predicate),
         _loop_predicate_block(_profiled_loop_predicate_block.entry(),
                               Deoptimization::Reason_predicate),
-        _entry(_loop_predicate_block.entry()) {}
+        _short_running_loop_predicate_block(_loop_predicate_block.entry(),
+                                            Deoptimization::Reason_short_running_loop),
+        _entry(_short_running_loop_predicate_block.entry()) {}
   NONCOPYABLE(Predicates);
 
   // Returns the control input the first predicate if there are any predicates. If there are no predicates, the same
@@ -885,6 +890,10 @@ class Predicates : public StackObj {
 
   const PredicateBlock* loop_limit_check_predicate_block() const {
     return &_loop_limit_check_predicate_block;
+  }
+
+  const PredicateBlock* short_running_loop_predicate_block() const {
+    return &_short_running_loop_predicate_block;
   }
 
   bool has_any() const {

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -2728,6 +2728,7 @@ const char* Deoptimization::_trap_reason_name[] = {
   "age",
   "predicate",
   "loop_limit_check",
+  "short_running_loop",
   "speculate_class_check",
   "speculate_null_check",
   "speculate_null_assert",

--- a/src/hotspot/share/runtime/deoptimization.hpp
+++ b/src/hotspot/share/runtime/deoptimization.hpp
@@ -110,6 +110,7 @@ class Deoptimization : AllStatic {
     Reason_age,                   // nmethod too old; tier threshold reached
     Reason_predicate,             // compiler generated predicate failed
     Reason_loop_limit_check,      // compiler generated loop limits check failed
+    Reason_short_running_loop,
     Reason_speculate_class_check, // saw unexpected object class from type speculation
     Reason_speculate_null_check,  // saw unexpected null from type speculation
     Reason_speculate_null_assert, // saw unexpected null from type speculation

--- a/src/hotspot/share/utilities/globalDefinitions.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions.hpp
@@ -803,6 +803,15 @@ inline jlong min_signed_integer(BasicType bt) {
   return min_jlong;
 }
 
+inline julong max_unsigned_integer(BasicType bt) {
+  if (bt == T_INT) {
+    return max_juint;
+  }
+  assert(bt == T_LONG, "unsupported");
+  return max_julong;
+}
+
+
 // Auxiliary math routines
 // least common multiple
 extern size_t lcm(size_t a, size_t b);

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -1349,6 +1349,11 @@ public class IRNode {
         trapNodes(RANGE_CHECK_TRAP, "range_check");
     }
 
+    public static final String SHORT_RUNNING_LOOP_TRAP = PREFIX + "SHORT_RUNNING_LOOP_TRAP" + POSTFIX;
+    static {
+        trapNodes(SHORT_RUNNING_LOOP_TRAP, "short_running_loop");
+    }
+
     public static final String REPLICATE_B = VECTOR_PREFIX + "REPLICATE_B" + POSTFIX;
     static {
         vectorNode(REPLICATE_B, "Replicate", TYPE_BYTE);

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningIntLoopWithLongChecksPredicates.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningIntLoopWithLongChecksPredicates.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:LoopUnrollLimit=100
+ *                   TestShortRunningIntLoopWithLongChecksPredicates
+ */
+
+import java.util.Objects;
+
+public class TestShortRunningIntLoopWithLongChecksPredicates {
+    private static volatile int volatileField;
+
+    public static void main(String[] args) {
+        int[] array = new int[100];
+        for (int i = 0; i < 20_000; i++) {
+            helper1(100, array, 100);
+            test1(1, 100);
+        }
+    }
+
+    private static void test1(int stop, long range) {
+        int[] array = new int[3];
+        helper1(stop, array, range);
+    }
+
+    private static void helper1(int stop, int[] array, long range) {
+        for (int i = 0; i < stop; i++) {
+            if (i % 2 == 0) {
+                array[i] = i;
+            } else {
+                volatileField = 42;
+            }
+            Objects.checkIndex(i, range);
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningIntLoopWithLongChecksPredicates.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningIntLoopWithLongChecksPredicates.java
@@ -32,6 +32,11 @@
 
 import java.util.Objects;
 
+// int RC is first eliminated by predication which causes assert
+// predicate to be added. Then the loop is transformed to make it
+// possible to optimize long RC. Finally unrolling happen which
+// require the assert predicate to have been properly copied when the
+// loop was transformed for the long range check.
 public class TestShortRunningIntLoopWithLongChecksPredicates {
     private static volatile int volatileField;
 

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningIntLoopWithLongChecksPredicates.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningIntLoopWithLongChecksPredicates.java
@@ -23,7 +23,8 @@
 
 /**
  * @test
- * @summary
+ * @bug 8342330
+ * @summary C2: MemorySegment API slow with short running loops
  * @requires vm.compiler2.enabled
  * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:LoopUnrollLimit=100
  *                   TestShortRunningIntLoopWithLongChecksPredicates

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoop.java
@@ -29,7 +29,8 @@ import jdk.test.whitebox.WhiteBox;
 import java.util.Objects;
 /*
  * @test
- * @summary
+ * @bug 8342330
+ * @summary C2: MemorySegment API slow with short running loops
  * @library /test/lib /
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoop.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoop.java
@@ -1,0 +1,507 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.longcountedloops;
+import compiler.lib.ir_framework.*;
+import compiler.whitebox.CompilerWhiteBoxTest;
+import jdk.test.whitebox.WhiteBox;
+
+import java.util.Objects;
+/*
+ * @test
+ * @summary
+ * @library /test/lib /
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI compiler.longcountedloops.TestShortRunningLongCountedLoop
+ */
+
+public class TestShortRunningLongCountedLoop {
+    private static volatile int volatileField;
+    private final static WhiteBox wb = WhiteBox.getWhiteBox();
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("-XX:LoopMaxUnroll=0", "-XX:ShortLoopIter=1000", "-XX:LoopStripMiningIter=1000", "-XX:+UseCountedLoopSafepoints");
+    }
+
+    // Check IR only has a counted loop when bounds are known and loop run for a short time
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static int testLongLoopConstantBoundsShortLoop1() {
+        int j = 0;
+        for (long i = 0; i < 100; i++) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Check(test = "testLongLoopConstantBoundsShortLoop1")
+    public static void checkTestLongLoopConstantBoundsShortLoop1(int res) {
+        if (res != 100) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Same with stride > 1
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static int testLongLoopConstantBoundsShortLoop2() {
+        int j = 0;
+        for (long i = 0; i < 2000; i += 20) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Check(test = "testLongLoopConstantBoundsShortLoop2")
+    public static void checkTestLongLoopConstantBoundsShortLoop2(int res) {
+        if (res != 100) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Same with loop going downward
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static int testLongLoopConstantBoundsShortLoop3() {
+        int j = 0;
+        for (long i = 99; i >= 0; i--) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Check(test = "testLongLoopConstantBoundsShortLoop3")
+    public static void checkTestLongLoopConstantBoundsShortLoop3(int res) {
+        if (res != 100) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Same with loop going downward and stride > 1
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static int testLongLoopConstantBoundsShortLoop4() {
+        int j = 0;
+        for (long i = 1999; i >= 0; i-=20) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Check(test = "testLongLoopConstantBoundsShortLoop4")
+    public static void checkTestLongLoopConstantBoundsShortLoop4(int res) {
+        if (res != 100) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Check IR only has a counted loop when bounds are known but not exact and loop run for a short time
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.OUTER_STRIP_MINED_LOOP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static int testLongLoopConstantBoundsShortLoop5(int start, int stop) {
+        start= Integer.max(start, 0);
+        stop= Integer.min(stop, 999);
+        int j = 0;
+        for (long i = start; i < stop; i++) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Run(test = "testLongLoopConstantBoundsShortLoop5")
+    public static void testLongLoopConstantBoundsShortLoop5_runner() {
+        int res = testLongLoopConstantBoundsShortLoop5(0, 100);
+        if (res != 100) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Check that loop nest is created when bounds are known and loop is not short run
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.LOOP, "1"})
+    @IR(failOn = { IRNode.SHORT_RUNNING_LOOP_TRAP, IRNode.OUTER_STRIP_MINED_LOOP })
+    public static int testLongLoopConstantBoundsLongLoop1() {
+        final long stride = Integer.MAX_VALUE / 1000;
+        int j = 0;
+        for (long i = 0; i < stride * 1001; i += stride) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Check(test = "testLongLoopConstantBoundsLongLoop1")
+    public static void checkTestLongLoopConstantBoundsLongLoop1(int res) {
+        if (res != 1001) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Same with negative stride
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.LOOP, "1"})
+    @IR(failOn = { IRNode.SHORT_RUNNING_LOOP_TRAP, IRNode.OUTER_STRIP_MINED_LOOP })
+    public static int testLongLoopConstantBoundsLongLoop2() {
+        final long stride = Integer.MAX_VALUE / 1000;
+        int j = 0;
+        for (long i = stride * 1000; i >= 0; i -= stride) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Check(test = "testLongLoopConstantBoundsLongLoop2")
+    public static void checkTestLongLoopConstantBoundsLongLoop2(int res) {
+        if (res != 1001) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Check IR only has a counted loop when bounds are unknown but profile reports a short running loop
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.SHORT_RUNNING_LOOP_TRAP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP })
+    public static int testLongLoopUnknownBoundsShortLoop(long start, long stop) {
+        int j = 0;
+        for (long i = start; i < stop; i++) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Run(test = "testLongLoopUnknownBoundsShortLoop")
+    @Warmup(10_000)
+    public static void testLongLoopUnknownBoundsShortLoop_runner() {
+        int res = testLongLoopUnknownBoundsShortLoop(0, 100);
+        if (res != 100) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // same with stride > 1
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.SHORT_RUNNING_LOOP_TRAP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP })
+    public static int testLongLoopUnknownBoundsShortLoop2(long start, long stop) {
+        int j = 0;
+        for (long i = start; i < stop; i+=20) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Run(test = "testLongLoopUnknownBoundsShortLoop2")
+    @Warmup(10_000)
+    public static void testLongLoopUnknownBoundsShortLoop2_runner() {
+        int res = testLongLoopUnknownBoundsShortLoop2(0, 2000);
+        if (res != 100) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // same with negative stride
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.SHORT_RUNNING_LOOP_TRAP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP })
+    public static int testLongLoopUnknownBoundsShortLoop3(long start, long stop) {
+        int j = 0;
+        for (long i = start; i >= stop; i--) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Run(test = "testLongLoopUnknownBoundsShortLoop3")
+    @Warmup(10_000)
+    public static void testLongLoopUnknownBoundsShortLoop3_runner() {
+        int res = testLongLoopUnknownBoundsShortLoop3(99, 0);
+        if (res != 100) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // same with negative stride > 1
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.SHORT_RUNNING_LOOP_TRAP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP })
+    public static int testLongLoopUnknownBoundsShortLoop4(long start, long stop) {
+        int j = 0;
+        for (long i = start; i >= stop; i -= 20) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Run(test = "testLongLoopUnknownBoundsShortLoop4")
+    @Warmup(10_000)
+    public static void testLongLoopUnknownBoundsShortLoop4_runner() {
+        int res = testLongLoopUnknownBoundsShortLoop4(1999, 0);
+        if (res != 100) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Check that loop nest is created when bounds are not known but profile reports loop is not short run
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.OUTER_STRIP_MINED_LOOP, "1", IRNode.LOOP,  "1"})
+    @IR(failOn = { IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static int testLongLoopUnknownBoundsLongLoop1(long start, long stop) {
+        int j = 0;
+        for (long i = start; i < stop; i++) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Run(test = "testLongLoopUnknownBoundsLongLoop1")
+    @Warmup(10_000)
+    public static void testLongLoopUnknownBoundsLongLoop1_runner() {
+        int res = testLongLoopUnknownBoundsLongLoop1(0, 2000);
+        if (res != 2000) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // same with negative stride
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.OUTER_STRIP_MINED_LOOP, "1", IRNode.LOOP,  "1"})
+    @IR(failOn = { IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static int testLongLoopUnknownBoundsLongLoop2(long start, long stop) {
+        int j = 0;
+        for (long i = start; i >= stop; i--) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Run(test = "testLongLoopUnknownBoundsLongLoop2")
+    @Warmup(10_000)
+    public static void testLongLoopUnknownBoundsLongLoop2_runner() {
+        int res = testLongLoopUnknownBoundsLongLoop2(1999, 0);
+        if (res != 2000) {
+            throw new RuntimeException("incorrect result: " + res);
+        }
+    }
+
+    // Check IR has a loop nest when bounds are unknown, profile reports a short running loop but trap is taken
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.LOOP, "1", IRNode.OUTER_STRIP_MINED_LOOP, "1" })
+    @IR(failOn = { IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static int testLongLoopUnknownBoundsShortLoopFailedSpeculation(long start, long stop) {
+        int j = 0;
+        for (long i = start; i < stop; i++) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Run(test = "testLongLoopUnknownBoundsShortLoopFailedSpeculation")
+    @Warmup(1)
+    public static void testLongLoopUnknownBoundsShortLoopFailedSpeculation_runner(RunInfo info) {
+        if (info.isWarmUp()) {
+            for (int i = 0; i < 10_0000; i++) {
+                int res = testLongLoopUnknownBoundsShortLoopFailedSpeculation(0, 100);
+                if (res != 100) {
+                    throw new RuntimeException("incorrect result: " + res);
+                }
+            }
+            wb.enqueueMethodForCompilation(info.getTest(), CompilerWhiteBoxTest.COMP_LEVEL_FULL_OPTIMIZATION);
+            if (!wb.isMethodCompiled(info.getTest())) {
+                throw new RuntimeException("Should be compiled now");
+            }
+            for (int i = 0; i < 10; i++) {
+                int res = testLongLoopUnknownBoundsShortLoopFailedSpeculation(0, 10_000);
+                if (res != 10_000) {
+                    throw new RuntimeException("incorrect result: " + res);
+                }
+            }
+        } else {
+            int res = testLongLoopUnknownBoundsShortLoopFailedSpeculation(0, 100);
+            if (res != 100) {
+                throw new RuntimeException("incorrect result: " + res);
+            }
+        }
+    }
+
+    // Check IR has a loop nest when bounds are known, is short running loop but trap was taken
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1"  })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static int testLongLoopKnownBoundsShortLoopFailedSpeculation() {
+        return testLongLoopKnownBoundsShortLoopFailedSpeculationHelper(0, 100);
+    }
+
+    @ForceInline
+    private static int testLongLoopKnownBoundsShortLoopFailedSpeculationHelper(long start, long stop) {
+        int j = 0;
+        for (long i = start; i < stop; i++) {
+            volatileField = 42;
+            j++;
+        }
+        return j;
+    }
+
+    @Run(test = "testLongLoopKnownBoundsShortLoopFailedSpeculation")
+    @Warmup(1)
+    public static void testLongLoopKnownBoundsShortLoopFailedSpeculation_runner(RunInfo info) {
+        if (info.isWarmUp()) {
+            for (int i = 0; i < 10_0000; i++) {
+                int res = testLongLoopKnownBoundsShortLoopFailedSpeculationHelper(0, 100);
+                if (res != 100) {
+                    throw new RuntimeException("incorrect result: " + res);
+                }
+            }
+            for (int i = 0; i < 10; i++) {
+                int res = testLongLoopKnownBoundsShortLoopFailedSpeculationHelper(0, 10_000);
+                if (res != 10_000) {
+                    throw new RuntimeException("incorrect result: " + res);
+                }
+            }
+            for (int i = 0; i < 10_0000; i++) {
+                int res = testLongLoopKnownBoundsShortLoopFailedSpeculation();
+                if (res != 100) {
+                    throw new RuntimeException("incorrect result: " + res);
+                }
+            }
+        } else {
+            int res = testLongLoopKnownBoundsShortLoopFailedSpeculation();
+            if (res != 100) {
+                throw new RuntimeException("incorrect result: " + res);
+            }
+        }
+    }
+
+    // Check range check can be eliminated by predication
+    @Test
+    @IR(counts = { IRNode.PREDICATE_TRAP, "1" })
+    @IR(failOn = { IRNode.COUNTED_LOOP, IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static void testLongLoopConstantBoundsPredication(long range) {
+        for (long i = 0; i < 100; i++) {
+            Objects.checkIndex(i, range);
+        }
+    }
+
+    @Run(test = "testLongLoopConstantBoundsPredication")
+    public static void testLongLoopConstantBoundsPredication_runner() {
+        testLongLoopConstantBoundsPredication(100);
+    }
+
+    @Test
+    @IR(counts = { IRNode.SHORT_RUNNING_LOOP_TRAP, "1", IRNode.PREDICATE_TRAP, "1" })
+    @IR(failOn = { IRNode.COUNTED_LOOP, IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP })
+    public static void testLongLoopUnknownBoundsShortLoopPredication(long start, long stop, long range) {
+        for (long i = start; i < stop; i++) {
+            Objects.checkIndex(i, range);
+        }
+    }
+
+    @Run(test = "testLongLoopUnknownBoundsShortLoopPredication")
+    @Warmup(10_000)
+    public static void testLongLoopUnknownBoundsShortLoopPredication_runner() {
+        testLongLoopUnknownBoundsShortLoopPredication(0, 100, 100);
+    }
+
+    // If scale too large, transformation can't happen
+    static final long veryLargeScale = Integer.MAX_VALUE / 99;
+    @Test
+    @IR(counts = { IRNode.LOOP, "1", IRNode.PREDICATE_TRAP, "2"})
+    @IR(failOn = { IRNode.COUNTED_LOOP, IRNode.OUTER_STRIP_MINED_LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static void testLongLoopConstantBoundsLargeScale(long range) {
+        for (long i = 0; i < 100; i++) {
+            Objects.checkIndex(veryLargeScale * i, range);
+        }
+    }
+
+    @Run(test = "testLongLoopConstantBoundsLargeScale")
+    public static void testLongLoopConstantBoundsLargeScale_runner() {
+        testLongLoopConstantBoundsLargeScale(veryLargeScale * 100);
+    }
+
+    @Test
+    @IR(counts = { IRNode.LOOP, "1", IRNode.PREDICATE_TRAP, "2"})
+    @IR(failOn = { IRNode.COUNTED_LOOP, IRNode.OUTER_STRIP_MINED_LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static void testLongLoopUnknownBoundsShortLoopLargeScale(long start, long stop, long range) {
+        for (long i = start; i < stop; i++) {
+            Objects.checkIndex(veryLargeScale * i, range);
+        }
+    }
+
+    @Run(test = "testLongLoopUnknownBoundsShortLoopLargeScale")
+    @Warmup(10_000)
+    public static void testLongLoopUnknownBoundsShortLoopLargeScale_runner() {
+        testLongLoopUnknownBoundsShortLoopLargeScale(0, 100, veryLargeScale * 100);
+    }
+
+    // Check IR only has a counted loop when bounds are known and loop run for a short time (int loop case)
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.PREDICATE_TRAP, "1" })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP, IRNode.SHORT_RUNNING_LOOP_TRAP })
+    public static void testIntLoopConstantBoundsShortLoop1(long range) {
+        for (int i = 0; i < 100; i++) {
+            Objects.checkIndex(i, range);
+            volatileField = 42;
+        }
+    }
+
+    @Run(test = "testIntLoopConstantBoundsShortLoop1")
+    public static void testIntLoopConstantBoundsShortLoop1_runner() {
+        testIntLoopConstantBoundsShortLoop1(100);
+    }
+
+    // Check IR only has a counted loop when bounds are unknown but profile reports a short running loop (int loop case)
+    @Test
+    @IR(counts = { IRNode.COUNTED_LOOP, "1", IRNode.SHORT_RUNNING_LOOP_TRAP, "1", IRNode.PREDICATE_TRAP, "1"  })
+    @IR(failOn = { IRNode.LOOP, IRNode.OUTER_STRIP_MINED_LOOP })
+    public static void testIntLoopUnknownBoundsShortLoop(int start, int stop, long range) {
+        for (int i = start; i < stop; i++) {
+            Objects.checkIndex(i, range);
+            volatileField = 42;
+        }
+    }
+
+    @Run(test = "testIntLoopUnknownBoundsShortLoop")
+    @Warmup(10_000)
+    public static void testIntLoopUnknownBoundsShortLoop_runner() {
+        testIntLoopUnknownBoundsShortLoop(0, 100, 100);
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopPredicatesClone.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopPredicatesClone.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:LoopMaxUnroll=0
+ *                   TestShortRunningLongCountedLoopPredicatesClone
+ */
+
+import java.util.Objects;
+
+public class TestShortRunningLongCountedLoopPredicatesClone {
+    public static void main(String[] args) {
+        A a = new A(100);
+        for (int i = 0; i < 20_000; i++) {
+            test1(a, 0);
+        }
+    }
+
+    private static void test1(A a, long start) {
+        long i = start;
+        do {
+            synchronized (new Object()) {}
+            Objects.checkIndex(i, a.range);
+            i++;
+        } while (i < a.range);
+    }
+
+    static class A {
+        A(long range) {
+            this.range = range;
+        }
+
+        long range;
+    }
+}

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopPredicatesClone.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopPredicatesClone.java
@@ -23,7 +23,8 @@
 
 /**
  * @test
- * @summary
+ * @bug 8342330
+ * @summary C2: MemorySegment API slow with short running loops
  * @requires vm.compiler2.enabled
  * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:LoopMaxUnroll=0
  *                   TestShortRunningLongCountedLoopPredicatesClone

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopPredicatesClone.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopPredicatesClone.java
@@ -32,6 +32,9 @@
 
 import java.util.Objects;
 
+// Predicate added after int counted loop is created depends on
+// narrowed limit which depends on predicate added before the int
+// counted loop was created: predicates need to be properly ordered.
 public class TestShortRunningLongCountedLoopPredicatesClone {
     public static void main(String[] args) {
         A a = new A(100);

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopScaleOverflow.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopScaleOverflow.java
@@ -32,6 +32,8 @@
 
 import java.util.Objects;
 
+// When scale is large, even if loop is short running having a single
+// counted loop is not possible.
 public class TestShortRunningLongCountedLoopScaleOverflow {
     public static void main(String[] args) {
         for (int i = 0; i < 20_000; i++) {

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopScaleOverflow.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopScaleOverflow.java
@@ -23,7 +23,8 @@
 
 /**
  * @test
- * @summary
+ * @bug 8342330
+ * @summary C2: MemorySegment API slow with short running loops
  * @requires vm.compiler2.enabled
  * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:LoopMaxUnroll=0
  *                   -XX:-UseLoopPredicate -XX:-RangeCheckElimination TestShortRunningLongCountedLoopScaleOverflow

--- a/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopScaleOverflow.java
+++ b/test/hotspot/jtreg/compiler/longcountedloops/TestShortRunningLongCountedLoopScaleOverflow.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @summary
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:-TieredCompilation -XX:-UseOnStackReplacement -XX:-BackgroundCompilation -XX:LoopMaxUnroll=0
+ *                   -XX:-UseLoopPredicate -XX:-RangeCheckElimination TestShortRunningLongCountedLoopScaleOverflow
+ */
+
+import java.util.Objects;
+
+public class TestShortRunningLongCountedLoopScaleOverflow {
+    public static void main(String[] args) {
+        for (int i = 0; i < 20_000; i++) {
+            test1(Integer.MAX_VALUE, 0);
+            test2(Integer.MAX_VALUE, 0, 100);
+        }
+        boolean exception = false;
+        try {
+            test1(Integer.MAX_VALUE, 10);
+        } catch (IndexOutOfBoundsException indexOutOfBoundsException) {
+            exception = true;
+        }
+        if (!exception) {
+            throw new RuntimeException("Expected exception not thrown");
+        }
+        exception = false;
+        try {
+            test2(Integer.MAX_VALUE, 10, 100);
+        } catch (IndexOutOfBoundsException indexOutOfBoundsException) {
+            exception = true;
+        }
+        if (!exception) {
+            throw new RuntimeException("Expected exception not thrown");
+        }
+    }
+
+    static final long veryLargeScale = 1 << 29;
+
+    private static void test1(long range, long j) {
+        Objects.checkIndex(0, range);
+        for (long i = 0; i < 100; i++) {
+            if (i == j) {
+                Objects.checkIndex(veryLargeScale * i, range);
+            }
+        }
+    }
+
+    private static void test2(long range, long j, long stop) {
+        Objects.checkIndex(0, range);
+        for (long i = 0; i < stop; i++) {
+            if (i == j) {
+                Objects.checkIndex(veryLargeScale * i, range);
+            }
+        }
+    }
+}


### PR DESCRIPTION
To optimize a long counted loop and long range checks in a long or int
counted loop, the loop is turned into a loop nest. When the loop has
few iterations, the overhead of having an outer loop whose backedge is
never taken, has a measurable cost. Furthermore, creating the loop
nest usually causes one iteration of the loop to be peeled so
predicates can be set up. If the loop is short running, then it's an
extra iteration that's run with range checks (compared to an int
counted loop with int range checks).

This change doesn't create a loop nest when:

1- it can be determined statically at loop nest creation time that the
   loop runs for a short enough number of iterations
  
2- profiling reports that the loop runs for no more than ShortLoopIter
   iterations (1000 by default).
  
For 2-, a guard is added which is implemented as yet another predicate.

While this change is in principle simple, I ran into a few
implementation issues:

- while c2 has a way to compute the number of iterations of an int
  counted loop, it doesn't have that for long counted loop. The
  existing logic for int counted loops promotes values to long to
  avoid overflows. I reworked it so it now works for both long and int
  counted loops.

- I added a new deoptimization reason (Reason_short_running_loop) for
  the new predicate. Given the number of iterations is narrowed down
  by the predicate, the limit of the loop after transformation is a
  cast node that's control dependent on the short running loop
  predicate. Because once the counted loop is transformed, it is
  likely that range check predicates will be inserted and they will
  depend on the limit, the short running loop predicate has to be the
  one that's further away from the loop entry. Now it is also possible
  that the limit before transformation depends on a predicate
  (TestShortRunningLongCountedLoopPredicatesClone is an example), we
  can have: new predicates inserted after the transformation that
  depend on the casted limit that itself depend on old predicates
  added before the transformation. To solve this cicular dependency,
  parse and assert predicates are cloned between the old predicates
  and the loop head. The cloned short running loop parse predicate is
  the one that's used to insert the short running loop predicate.

- In the case of a long counted loop, the loop is transformed into a
  regular loop with a new limit and transformed range checks that's
  later turned into an in counted loop. The int counted loop doesn't
  need loop limit checks because of the way it's constructed. There's
  an assert that catches that we don't attempt to add one. I ran into
  test failures where, by the time the int counted loop is created,
  the fact that the number of iterations of the loop is small enough
  to not need a loop limit check gets lost. I added a cast to make
  sure the narrowed limit's type is not lost (I had to do something
  similar for loop nests). But then, I ran into the same issue again
  because the cast was pushed through a sub or add and the narrowed
  type was lost. I propose that pushing casts through sub/add be only
  done after loop opts are over (same as what's done for range check
  `CastII`).

On Maurizio's benchmark that's mentioned in the bug, this gives a ~30%
performance increase.
/cc hotspot-compiler