### PR TITLE
8342806: Desugar capturing lambda in StringNameTable

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
@@ -62,11 +62,12 @@ public class StringNameTable extends Name.Table {
 
     @Override
     public Name fromString(String string) {
-        if (intern) {
-            return this.nameMap.computeIfAbsent(string, s -> new NameImpl(this, s.intern()));
-        } else {
-            return this.nameMap.computeIfAbsent(string, s -> new NameImpl(this, s));
+        Name name = this.nameMap.get(string);
+        if (name == null) {
+            name = new NameImpl(this, intern ? string.intern() : string);
+            this.nameMap.put(string, name);
         }
+        return name;
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
@@ -62,7 +62,11 @@ public class StringNameTable extends Name.Table {
 
     @Override
     public Name fromString(String string) {
-        return this.nameMap.computeIfAbsent(string, s -> new NameImpl(this, intern ? s.intern() : s));
+        if (intern) {
+            return this.nameMap.computeIfAbsent(string, s -> new NameImpl(this, s.intern()));
+        } else {
+            return this.nameMap.computeIfAbsent(string, s -> new NameImpl(this, s));
+        }
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
@@ -64,7 +64,10 @@ public class StringNameTable extends Name.Table {
     public Name fromString(String string) {
         Name name = nameMap.get(string);
         if (name == null) {
-            name = new NameImpl(this, intern ? string.intern() : string);
+            if (intern) {
+                string = string.intern();
+            }
+            name = new NameImpl(this, string);
             nameMap.put(string, name);
         }
         return name;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
@@ -62,10 +62,10 @@ public class StringNameTable extends Name.Table {
 
     @Override
     public Name fromString(String string) {
-        Name name = this.nameMap.get(string);
+        Name name = nameMap.get(string);
         if (name == null) {
             name = new NameImpl(this, intern ? string.intern() : string);
-            this.nameMap.put(string, name);
+            nameMap.put(string, name);
         }
         return name;
     }

--- a/test/micro/org/openjdk/bench/javax/tools/JavacNameTable.java
+++ b/test/micro/org/openjdk/bench/javax/tools/JavacNameTable.java
@@ -53,7 +53,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(2)
+@Fork(value = 2, jvmArgs = "-Xmx1g")
 public class JavacNameTable {
 
     private List<JavaSourceFromString> compilationUnits;
@@ -112,6 +112,11 @@ public class JavacNameTable {
     @Benchmark
     public Boolean testStringTable() throws Exception {
         return testCompile("-XDuseStringTable=true");
+    }
+
+    @Benchmark
+    public Boolean testInternStringTable() throws Exception {
+        return testCompile("-XDinternStringTable=true");
     }
 
     public Boolean testCompile(String flag) throws Exception {

--- a/test/micro/org/openjdk/bench/javax/tools/JavacNameTable.java
+++ b/test/micro/org/openjdk/bench/javax/tools/JavacNameTable.java
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
-@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 5, timeUnit = TimeUnit.SECONDS)
 @Fork(2)
 public class JavacNameTable {
 

--- a/test/micro/org/openjdk/bench/javax/tools/JavacNameTable.java
+++ b/test/micro/org/openjdk/bench/javax/tools/JavacNameTable.java
@@ -51,9 +51,9 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(1)
+@Fork(2)
 public class JavacNameTable {
 
     private List<JavaSourceFromString> compilationUnits;

--- a/test/micro/org/openjdk/bench/javax/tools/JavacNameTable.java
+++ b/test/micro/org/openjdk/bench/javax/tools/JavacNameTable.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.javax.tools;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+import javax.tools.JavaCompiler;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class JavacNameTable {
+
+    private List<JavaSourceFromString> compilationUnits;
+    private JavaCompiler compiler;
+    private StandardJavaFileManager fileManager;
+    private File classDir;
+
+    @Setup
+    public void prepare() throws IOException {
+
+        // Create a source file with lots of names
+        StringBuilder buf = new StringBuilder();
+        buf.append("class BigSource {\n");
+        for (int i = 0; i < 20000; i++) {
+            buf.append(String.format(
+                //"final String name%05d = \"some text #%5d\";\n", i, i));
+                "String name%05d;\n", i, i));
+        }
+        buf.append("}\n");
+        String bigSource = buf.toString();
+
+        compiler = ToolProvider.getSystemJavaCompiler();
+
+        fileManager = compiler.getStandardFileManager(null, null, null);
+        classDir = Files.createTempDirectory(
+          JavacNameTable.class.getName()).toFile();
+        fileManager.setLocation(StandardLocation.CLASS_OUTPUT,
+          Collections.singleton(classDir));
+
+        compilationUnits = new ArrayList<>();
+        compilationUnits.add(new JavaSourceFromString("BigSource", bigSource));
+    }
+
+    @TearDown
+    public void tearDown() {
+        for (File f : classDir.listFiles()) {
+            if (f.isFile()) {
+                f.delete();
+            } else {
+                throw new IllegalStateException("Unexpected non-file: " + f);
+            }
+        }
+        classDir.delete();
+    }
+
+    @Benchmark
+    public Boolean testSharedTable() throws Exception {
+        return testCompile(null);
+    }
+
+    @Benchmark
+    public Boolean testUnsharedTable() throws Exception {
+        return testCompile("-XDuseUnsharedTable=true");
+    }
+
+    @Benchmark
+    public Boolean testStringTable() throws Exception {
+        return testCompile("-XDuseStringTable=true");
+    }
+
+    public Boolean testCompile(String flag) throws Exception {
+        final List<String> options = flag != null ?
+          Collections.singletonList(flag) : null;
+        JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager,
+          null, options, null, compilationUnits);
+        return task.call();
+    }
+
+    private static class JavaSourceFromString extends SimpleJavaFileObject {
+
+        private final String code;
+
+        JavaSourceFromString(String name, String code) {
+            super(URI.create("string:///"
+              + name.replace('.', '/') + Kind.SOURCE.extension), Kind.SOURCE);
+            this.code = code;
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) {
+            return code;
+        }
+    }
+}


### PR DESCRIPTION
- Desugar `computeIfAbsent` to `get` & `put` to avoid a capturing lambda. Since the map is a non-synchronized `HashMap` this is just as non-thread-safe as before.
- Salvage the microbenchmark added as a JBS comment to https://bugs.openjdk.org/browse/JDK-8268622 
- Microbenchmark show a modest reduction in allocations for tests stressing `StringNameTable` (Macbook M1):

```
Name                  Cnt         Base         Error          Test         Error   Unit  Change
testInternStringTable  10       55,731 ±       3,701        51,083 ±       2,062  ms/op   1,09x (p = 0,000*)
  :gc.alloc.rate.norm     54705366,956 ±  375197,844  53936224,624 ± 1421298,600   B/op   0,99x (p = 0,031 )
testSharedTable        10       47,997 ±       5,802        48,022 ±       4,968  ms/op   1,00x (p = 0,988 )
  :gc.alloc.rate.norm     56562680,368 ± 1535117,433  53403645,438 ±  218526,779   B/op   0,94x (p = 0,000*)
testStringTable        10       45,933 ±       2,542        44,094 ±       1,360  ms/op   1,04x (p = 0,009*)
  :gc.alloc.rate.norm     56244541,359 ± 1019940,919  53226602,956 ±  510018,314   B/op   0,95x (p = 0,000*)
testUnsharedTable      10       60,474 ±       1,912        59,068 ±       1,038  ms/op   1,02x (p = 0,008*)
  :gc.alloc.rate.norm     66970079,820 ± 1402704,512  67285851,746 ±  883540,307   B/op   1,00x (p = 0,377 )
  * = significant
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342806](https://bugs.openjdk.org/browse/JDK-8342806): Desugar capturing lambda in StringNameTable (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21631/head:pull/21631` \
`$ git checkout pull/21631`

Update a local copy of the PR: \
`$ git checkout pull/21631` \
`$ git pull https://git.openjdk.org/jdk.git pull/21631/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21631`

View PR using the GUI difftool: \
`$ git pr show -t 21631`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21631.diff">https://git.openjdk.org/jdk/pull/21631.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21631#issuecomment-2428814164)