### PR TITLE
8342785: XWindowPeer::getNewLocation() adheres to ICCCM 4.1.5 only with some WMs

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XWindowPeer.java
@@ -767,28 +767,12 @@ class XWindowPeer extends XPanelPeer implements WindowPeer,
             // a window is resized but the client can not tell if the window was
             // moved or not. The client should consider the position as unknown
             // and use TranslateCoordinates to find the actual position.
-            //
-            // TODO this should be the default for every case.
-            switch (runningWM) {
-                case XWM.CDE_WM:
-                case XWM.KDE2_WM:
-                case XWM.MOTIF_WM:
-                case XWM.METACITY_WM:
-                case XWM.MUTTER_WM:
-                case XWM.SAWFISH_WM:
-                case XWM.UNITY_COMPIZ_WM:
-                {
-                    Point xlocation = queryXLocation();
-                    if (log.isLoggable(PlatformLogger.Level.FINE)) {
-                        log.fine("New X location: {0}", xlocation);
-                    }
-                    if (xlocation != null) {
-                        newLocation = xlocation;
-                    }
-                    break;
-                }
-                default:
-                    break;
+            Point xlocation = queryXLocation();
+            if (log.isLoggable(PlatformLogger.Level.FINE)) {
+                log.fine("New X location: {0}", xlocation);
+            }
+            if (xlocation != null) {
+                newLocation = xlocation;
             }
         }
         return newLocation;


### PR DESCRIPTION
It is not guaranteed that the WM will always send a synthetic ConfigureNotify event after changing the geometry. As ICCCM 4.1.5 suggests, the WM may not send a synthetic configure notify event if the window is resized for real. In that case, the client needs to use the TranslateCoordinates() request in order to determine the position of its window in the global coordinate space.

However, it does so only with certain WMs. Some digging in the JDK history shows that AWT used to assume that synthetic configure notify events are always sent, however it was not the case with WMs such as Metacity so the switch statement was added. I don't know exactly why the new code path had been enabled only with handful of WMs, perhaps it was done to play safe or as an optimization. But, in general, as the TODO comment and the ICCCM spec say, this code needs to be enabled regardless of the WM.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342785](https://bugs.openjdk.org/browse/JDK-8342785): XWindowPeer::getNewLocation() adheres to ICCCM 4.1.5 only with some WMs (**Enhancement** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21632/head:pull/21632` \
`$ git checkout pull/21632`

Update a local copy of the PR: \
`$ git checkout pull/21632` \
`$ git pull https://git.openjdk.org/jdk.git pull/21632/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21632`

View PR using the GUI difftool: \
`$ git pr show -t 21632`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21632.diff">https://git.openjdk.org/jdk/pull/21632.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21632#issuecomment-2428851626)
</details>
