### PR TITLE
8342809: C2 hits "assert(is_If()) failed: invalid node class: Con" during IGVN due to unhandled top

### DIFF
--- a/src/hotspot/share/opto/predicates.cpp
+++ b/src/hotspot/share/opto/predicates.cpp
@@ -115,8 +115,9 @@ bool RegularPredicateWithUCT::is_predicate(const Node* node, Deoptimization::Deo
 }
 
 // A Regular Predicate must have an If or a RangeCheck node, while the If should not be a zero trip guard check.
+// Note that this method can be called during IGVN, so we also need to check that the If is not top.
 bool RegularPredicate::may_be_predicate_if(const Node* node) {
-  if (node->is_IfProj()) {
+  if (node->is_IfProj() && node->in(0)->is_If()) {
     const IfNode* if_node = node->in(0)->as_If();
     const int opcode_if = if_node->Opcode();
     if ((opcode_if == Op_If && !if_node->is_zero_trip_guard())

--- a/test/hotspot/jtreg/compiler/predicates/TestTopIntoIfTrue.java
+++ b/test/hotspot/jtreg/compiler/predicates/TestTopIntoIfTrue.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @key stress randomness
+ * @bug 8342809
+ * @summary Test that a top input into an IfTrue of an Assertion Predicate is properly handled during IGVN.
+ * @requires vm.compiler2.enabled
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.predicates.TestTopIntoIfTrue::test -XX:-TieredCompilation
+ *                   -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN -XX:StressSeed=1073486978
+ *                   compiler.predicates.TestTopIntoIfTrue
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.predicates.TestTopIntoIfTrue::test -XX:-TieredCompilation
+ *                   -Xcomp -XX:+UnlockDiagnosticVMOptions -XX:+StressIGVN compiler.predicates.TestTopIntoIfTrue
+ */
+
+package compiler.predicates;
+
+public class TestTopIntoIfTrue {
+    static int iFld;
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 100; i++) {
+            test();
+        }
+    }
+
+    static void test() {
+        int x = 10;
+        for (int i = 1; i < 326; ++i) {
+            x += 12;
+            if (x != 0) {
+                Unloaded.trap(); // unloaded trap
+            }
+            iFld += 34;
+        }
+    }
+}
+
+class Unloaded {
+    static void trap() {}
+}


### PR DESCRIPTION
`RegularPredicate::may_be_predicate_if()` is now called from the `AssertionPredicateWithHalt` class which is invoked during IGVN. We therefore need to be able to handle top as a possible input for an Assertion Predicate success projection. This patch fixes this.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342809](https://bugs.openjdk.org/browse/JDK-8342809): C2 hits "assert(is_If()) failed: invalid node class: Con" during IGVN due to unhandled top (**Bug** - P3)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21634/head:pull/21634` \
`$ git checkout pull/21634`

Update a local copy of the PR: \
`$ git checkout pull/21634` \
`$ git pull https://git.openjdk.org/jdk.git pull/21634/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21634`

View PR using the GUI difftool: \
`$ git pr show -t 21634`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21634.diff">https://git.openjdk.org/jdk/pull/21634.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21634#issuecomment-2428972545)