### PR TITLE
8342683: Use non-short forward jump when passing stop()

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -837,8 +837,9 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register reg_rax, 
 #ifdef ASSERT
   // Check that unlocked label is reached with ZF set.
   Label zf_correct;
+  Label zf_bad_zero;
   jcc(Assembler::zero, zf_correct);
-  stop("Fast Unlock ZF != 1");
+  jmp(zf_bad_zero);
 #endif
 
   bind(slow_path);
@@ -847,8 +848,10 @@ void C2_MacroAssembler::fast_unlock_lightweight(Register obj, Register reg_rax, 
   }
 #ifdef ASSERT
   // Check that stub->continuation() label is reached with ZF not set.
-  jccb(Assembler::notZero, zf_correct);
+  jcc(Assembler::notZero, zf_correct);
   stop("Fast Unlock ZF != 0");
+  bind(zf_bad_zero);
+  stop("Fast Unlock ZF != 1");
   bind(zf_correct);
 #endif
   // C2 uses the value of ZF to determine the continuation.


### PR DESCRIPTION
Fixed a "short forward jump exceeds 8-bit offset at" error in `fast_unlock_lightweight()` that appears on x86 based platforms when using `-XX:+ShowMessageBoxOnError`.

Tested ok in tier1-3 on all x86 based platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342683](https://bugs.openjdk.org/browse/JDK-8342683): Use non-short forward jump when passing stop() (**Bug** - P4)


### Reviewers
 * [Axel Boldt-Christmas](https://openjdk.org/census#aboldtch) (@xmas92 - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21635/head:pull/21635` \
`$ git checkout pull/21635`

Update a local copy of the PR: \
`$ git checkout pull/21635` \
`$ git pull https://git.openjdk.org/jdk.git pull/21635/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21635`

View PR using the GUI difftool: \
`$ git pr show -t 21635`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21635.diff">https://git.openjdk.org/jdk/pull/21635.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21635#issuecomment-2429480656)