### PR TITLE
8342825: Fix order of @param tags in module java.desktop

### DIFF
--- a/src/java.desktop/share/classes/java/awt/BorderLayout.java
+++ b/src/java.desktop/share/classes/java/awt/BorderLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/BorderLayout.java
+++ b/src/java.desktop/share/classes/java/awt/BorderLayout.java
@@ -554,12 +554,12 @@ public class BorderLayout implements LayoutManager2,
      * The {@code Container}'s component orientation is used to determine the location of components
      * added with {@code LINE_START} and {@code LINE_END}.
      *
-     * @param   constraints     the desired absolute position, one of {@code CENTER},
-     *                          {@code NORTH}, {@code SOUTH},
-     *                          {@code EAST}, {@code WEST}
      * @param   target     the {@code Container} used to obtain
      *                     the constraint location based on the target
      *                     {@code Container}'s component orientation.
+     * @param   constraints     the desired absolute position, one of {@code CENTER},
+     *                          {@code NORTH}, {@code SOUTH},
+     *                          {@code EAST}, {@code WEST}
      * @return  the component at the given location, or {@code null} if
      *          the location is empty
      * @throws   IllegalArgumentException  if the constraint object is

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/Graphics2D.java
+++ b/src/java.desktop/share/classes/java/awt/Graphics2D.java
@@ -564,9 +564,9 @@ public abstract class Graphics2D extends Graphics {
      * img1 = op.filter(img, null);
      * drawImage(img1, new AffineTransform(1f,0f,0f,1f,x,y), null);
      * </pre>
-     * @param op the filter to be applied to the image before rendering
      * @param img the specified {@code BufferedImage} to be rendered.
      *            This method does nothing if {@code img} is null.
+     * @param op the filter to be applied to the image before rendering
      * @param x the x coordinate of the location in user space where
      * the upper left corner of the image is rendered
      * @param y the y coordinate of the location in user space where

--- a/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
+++ b/src/java.desktop/share/classes/java/awt/dnd/DragSource.java
@@ -499,8 +499,8 @@ public class DragSource implements Serializable {
      *
      * @param <T> the type of {@code DragGestureRecognizer} to create
      * @param recognizerAbstractClass the requested abstract type
-     * @param actions                 the permitted source drag actions
      * @param c                       the {@code Component} target
+     * @param actions                 the permitted source drag actions
      * @param dgl        the {@code DragGestureListener} to notify
      *
      * @return the new {@code DragGestureRecognizer} or {@code null}

--- a/src/java.desktop/share/classes/java/awt/event/ActionEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/ActionEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/event/ActionEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/ActionEvent.java
@@ -206,13 +206,13 @@ public class ActionEvent extends AWTEvent {
      *                     the class description for {@link ActionEvent}
      * @param command A string that may specify a command (possibly one
      *                of several) associated with the event
+     * @param when   A long that gives the time the event occurred.
+     *               Passing negative or zero value
+     *               is not recommended
      * @param modifiers The modifier keys down during event
      *                  (shift, ctrl, alt, meta).
      *                  Passing negative parameter is not recommended.
      *                  Zero value means that no modifiers were passed
-     * @param when   A long that gives the time the event occurred.
-     *               Passing negative or zero value
-     *               is not recommended
      * @throws IllegalArgumentException if {@code source} is null
      * @see #getSource()
      * @see #getID()

--- a/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
+++ b/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
+++ b/src/java.desktop/share/classes/java/awt/geom/AffineTransform.java
@@ -2964,10 +2964,10 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * the original coordinates in that point are overwritten before
      * they can be converted.
      * @param ptSrc the array containing the source point objects
-     * @param ptDst the array into which the transform point objects are
-     * returned
      * @param srcOff the offset to the first point object to be
      * transformed in the source array
+     * @param ptDst the array into which the transform point objects are
+     * returned
      * @param dstOff the offset to the location of the first
      * transformed point object that is stored in the destination array
      * @param numPts the number of point objects to be transformed
@@ -3038,11 +3038,11 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * offset in the order {@code [x0, y0, x1, y1, ..., xn, yn]}.
      * @param srcPts the array containing the source point coordinates.
      * Each point is stored as a pair of x,&nbsp;y coordinates.
+     * @param srcOff the offset to the first point to be transformed
+     * in the source array
      * @param dstPts the array into which the transformed point coordinates
      * are returned.  Each point is stored as a pair of x,&nbsp;y
      * coordinates.
-     * @param srcOff the offset to the first point to be transformed
-     * in the source array
      * @param dstOff the offset to the location of the first
      * transformed point that is stored in the destination array
      * @param numPts the number of points to be transformed
@@ -3153,11 +3153,11 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * offset in the order {@code [x0, y0, x1, y1, ..., xn, yn]}.
      * @param srcPts the array containing the source point coordinates.
      * Each point is stored as a pair of x,&nbsp;y coordinates.
+     * @param srcOff the offset to the first point to be transformed
+     * in the source array
      * @param dstPts the array into which the transformed point
      * coordinates are returned.  Each point is stored as a pair of
      * x,&nbsp;y coordinates.
-     * @param srcOff the offset to the first point to be transformed
-     * in the source array
      * @param dstOff the offset to the location of the first
      * transformed point that is stored in the destination array
      * @param numPts the number of point objects to be transformed
@@ -3264,11 +3264,11 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * offset in the order {@code [x0, y0, x1, y1, ..., xn, yn]}.
      * @param srcPts the array containing the source point coordinates.
      * Each point is stored as a pair of x,&nbsp;y coordinates.
+     * @param srcOff the offset to the first point to be transformed
+     * in the source array
      * @param dstPts the array into which the transformed point coordinates
      * are returned.  Each point is stored as a pair of x,&nbsp;y
      * coordinates.
-     * @param srcOff the offset to the first point to be transformed
-     * in the source array
      * @param dstOff the offset to the location of the first
      * transformed point that is stored in the destination array
      * @param numPts the number of points to be transformed
@@ -3360,11 +3360,11 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * offset in the order {@code [x0, y0, x1, y1, ..., xn, yn]}.
      * @param srcPts the array containing the source point coordinates.
      * Each point is stored as a pair of x,&nbsp;y coordinates.
+     * @param srcOff the offset to the first point to be transformed
+     * in the source array
      * @param dstPts the array into which the transformed point
      * coordinates are returned.  Each point is stored as a pair of
      * x,&nbsp;y coordinates.
-     * @param srcOff the offset to the first point to be transformed
-     * in the source array
      * @param dstOff the offset to the location of the first
      * transformed point that is stored in the destination array
      * @param numPts the number of point objects to be transformed
@@ -3542,11 +3542,11 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * offset in the order {@code [x0, y0, x1, y1, ..., xn, yn]}.
      * @param srcPts the array containing the source point coordinates.
      * Each point is stored as a pair of x,&nbsp;y coordinates.
+     * @param srcOff the offset to the first point to be transformed
+     * in the source array
      * @param dstPts the array into which the transformed point
      * coordinates are returned.  Each point is stored as a pair of
      * x,&nbsp;y coordinates.
-     * @param srcOff the offset to the first point to be transformed
-     * in the source array
      * @param dstOff the offset to the location of the first
      * transformed point that is stored in the destination array
      * @param numPts the number of point objects to be transformed
@@ -3755,11 +3755,11 @@ public class AffineTransform implements Cloneable, java.io.Serializable {
      * offset in the order {@code [x0, y0, x1, y1, ..., xn, yn]}.
      * @param srcPts the array containing the source distance vectors.
      * Each vector is stored as a pair of relative x,&nbsp;y coordinates.
+     * @param srcOff the offset to the first vector to be transformed
+     * in the source array
      * @param dstPts the array into which the transformed distance vectors
      * are returned.  Each vector is stored as a pair of relative
      * x,&nbsp;y coordinates.
-     * @param srcOff the offset to the first vector to be transformed
-     * in the source array
      * @param dstOff the offset to the location of the first
      * transformed vector that is stored in the destination array
      * @param numPts the number of vector coordinate pairs to be

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormatImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormatImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormatImpl.java
+++ b/src/java.desktop/share/classes/javax/imageio/metadata/IIOMetadataFormatImpl.java
@@ -378,10 +378,10 @@ public abstract class IIOMetadataFormatImpl implements IIOMetadataFormat {
      * Adds an existing element to the list of legal children for a
      * given parent node type.
      *
-     * @param parentName the name of the element that will be the
-     * new parent of the element.
      * @param elementName the name of the element to be added as a
      * child.
+     * @param parentName the name of the element that will be the
+     * new parent of the element.
      *
      * @throws IllegalArgumentException if {@code elementName}
      * is {@code null}, or is not a legal element name for this

--- a/src/java.desktop/share/classes/javax/swing/GroupLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/GroupLayout.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/GroupLayout.java
+++ b/src/java.desktop/share/classes/javax/swing/GroupLayout.java
@@ -1777,9 +1777,9 @@ public class GroupLayout implements LayoutManager2 {
         /**
          * Adds a {@code Group} to this {@code Group}.
          *
-         * @param group the {@code Group} to add
          * @param useAsBaseline whether the specified {@code Group} should
          *        be used to calculate the baseline for this {@code Group}
+         * @param group the {@code Group} to add
          * @return this {@code Group}
          */
         public SequentialGroup addGroup(boolean useAsBaseline, Group group) {
@@ -2528,8 +2528,8 @@ public class GroupLayout implements LayoutManager2 {
          * Adds a {@code Component} to this {@code ParallelGroup} with
          * the specified alignment.
          *
-         * @param alignment the alignment
          * @param component the {@code Component} to add
+         * @param alignment the alignment
          * @return this {@code Group}
          * @throws IllegalArgumentException if {@code alignment} is
          *         {@code null}
@@ -2544,8 +2544,8 @@ public class GroupLayout implements LayoutManager2 {
          * Adds a {@code Component} to this {@code ParallelGroup} with the
          * specified alignment and size.
          *
-         * @param alignment the alignment
          * @param component the {@code Component} to add
+         * @param alignment the alignment
          * @param min the minimum size
          * @param pref the preferred size
          * @param max the maximum size

--- a/src/java.desktop/share/classes/javax/swing/LayoutStyle.java
+++ b/src/java.desktop/share/classes/javax/swing/LayoutStyle.java
@@ -165,13 +165,13 @@ public abstract class LayoutStyle {
      * @param component1 the <code>JComponent</code>
      *               <code>component2</code> is being placed relative to
      * @param component2 the <code>JComponent</code> being placed
+     * @param type how the two components are being placed
      * @param position the position <code>component2</code> is being placed
      *        relative to <code>component1</code>; one of
      *        <code>SwingConstants.NORTH</code>,
      *        <code>SwingConstants.SOUTH</code>,
      *        <code>SwingConstants.EAST</code> or
      *        <code>SwingConstants.WEST</code>
-     * @param type how the two components are being placed
      * @param parent the parent of <code>component2</code>; this may differ
      *        from the actual parent and it may be <code>null</code>
      * @return the amount of space to place between the two components

--- a/src/java.desktop/share/classes/javax/swing/LayoutStyle.java
+++ b/src/java.desktop/share/classes/javax/swing/LayoutStyle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/ProgressMonitorInputStream.java
+++ b/src/java.desktop/share/classes/javax/swing/ProgressMonitorInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/ProgressMonitorInputStream.java
+++ b/src/java.desktop/share/classes/javax/swing/ProgressMonitorInputStream.java
@@ -73,10 +73,10 @@ public class ProgressMonitorInputStream extends FilterInputStream
     /**
      * Constructs an object to monitor the progress of an input stream.
      *
-     * @param message Descriptive text to be placed in the dialog box
-     *                if one is popped up.
      * @param parentComponent The component triggering the operation
      *                        being monitored.
+     * @param message Descriptive text to be placed in the dialog box
+     *                if one is popped up.
      * @param in The input stream to be monitored.
      */
     public ProgressMonitorInputStream(Component parentComponent,

--- a/src/java.desktop/share/classes/javax/swing/text/PlainView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/PlainView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/PlainView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/PlainView.java
@@ -724,12 +724,12 @@ public class PlainView extends View implements TabExpander {
     /**
      * Repaint the given line range.
      *
-     * @param host the component hosting the view (used to call repaint)
-     * @param a  the region allocated for the view to render into
      * @param line0 the starting line number to repaint.  This must
      *   be a valid line number in the model.
      * @param line1 the ending line number to repaint.  This must
      *   be a valid line number in the model.
+     * @param a  the region allocated for the view to render into
+     * @param host the component hosting the view (used to call repaint)
      * @since 1.4
      */
     protected void damageLineRange(int line0, int line1, Shape a, Component host) {

--- a/src/java.desktop/share/classes/javax/swing/text/TableView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/TableView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/TableView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/TableView.java
@@ -292,13 +292,13 @@ public abstract class TableView extends BoxView {
      *
      * @param targetSpan the given span for total of all the table
      *  columns
+     * @param offsets the return value of the offset from the
+     *  origin for each column
+     * @param spans the return value of how much to allocated to
+     *  each column
      * @param reqs the requirements desired for each column.  This
      *  is the column maximum of the cells minimum, preferred, and
      *  maximum requested span
-     * @param spans the return value of how much to allocated to
-     *  each column
-     * @param offsets the return value of the offset from the
-     *  origin for each column
      */
     protected void layoutColumns(int targetSpan, int[] offsets, int[] spans,
                                  SizeRequirements[] reqs) {

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTMLEditorKit.java
@@ -328,9 +328,9 @@ public class HTMLEditorKit extends StyledEditorKit implements Accessible {
      *
      * @param doc the document to insert into
      * @param offset the offset to insert HTML at
+     * @param html the HTML string
      * @param popDepth the number of ElementSpec.EndTagTypes to generate
      *                  before inserting
-     * @param html the HTML string
      * @param pushDepth the number of ElementSpec.StartTagTypes with a direction
      *                  of ElementSpec.JoinNextDirection that should be generated
      *                  before inserting, but after the end tags have been generated


### PR DESCRIPTION
Please review a doc-only change to fix the order of javadoc @param tags in module java.desktop.

We are working on a javadoc feature to add an opt-in doclint warning for @param tags that don't match the order of parameters in the documented element. The warning will be enabled in OpenJDK builds and covers all uses of the @param tag, i.e. parameters of executable elements, type parameters, and record components.

I compared the generated API docs built with this branch with API docs built from master branch to make sure they are identical.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342825](https://bugs.openjdk.org/browse/JDK-8342825): Fix order of @<!---->param tags in module java.desktop (**Sub-task** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21636/head:pull/21636` \
`$ git checkout pull/21636`

Update a local copy of the PR: \
`$ git checkout pull/21636` \
`$ git pull https://git.openjdk.org/jdk.git pull/21636/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21636`

View PR using the GUI difftool: \
`$ git pr show -t 21636`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21636.diff">https://git.openjdk.org/jdk/pull/21636.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21636#issuecomment-2429267948)