### PR TITLE
8342730: Get rid of SummaryDiff in VMATree

### DIFF
--- a/src/hotspot/share/nmt/memoryFileTracker.cpp
+++ b/src/hotspot/share/nmt/memoryFileTracker.cpp
@@ -45,21 +45,11 @@ void MemoryFileTracker::allocate_memory(MemoryFile* file, size_t offset,
                                         MemTag mem_tag) {
   NativeCallStackStorage::StackIndex sidx = _stack_storage.push(stack);
   VMATree::RegionData regiondata(sidx, mem_tag);
-  VMATree::SummaryDiff diff = file->_tree.commit_mapping(offset, size, regiondata);
-  for (int i = 0; i < mt_number_of_tags; i++) {
-    VirtualMemory* summary = file->_summary.by_type(NMTUtil::index_to_tag(i));
-    summary->reserve_memory(diff.tag[i].commit);
-    summary->commit_memory(diff.tag[i].commit);
-  }
+  file->_tree.commit_mapping(offset, size, regiondata, file->_summary);
 }
 
 void MemoryFileTracker::free_memory(MemoryFile* file, size_t offset, size_t size) {
-  VMATree::SummaryDiff diff = file->_tree.release_mapping(offset, size);
-  for (int i = 0; i < mt_number_of_tags; i++) {
-    VirtualMemory* summary = file->_summary.by_type(NMTUtil::index_to_tag(i));
-    summary->reserve_memory(diff.tag[i].commit);
-    summary->commit_memory(diff.tag[i].commit);
-  }
+  file->_tree.release_mapping(offset, size, file->_summary);
 }
 
 void MemoryFileTracker::print_report_on(const MemoryFile* file, outputStream* stream, size_t scale) {

--- a/src/hotspot/share/nmt/vmatree.hpp
+++ b/src/hotspot/share/nmt/vmatree.hpp
@@ -157,38 +157,27 @@ private:
 public:
   VMATree() : _tree() {}
 
-  struct SingleDiff {
-    using delta = int64_t;
-    delta reserve;
-    delta commit;
-  };
-  struct SummaryDiff {
-    SingleDiff tag[mt_number_of_tags];
-    SummaryDiff() {
-      for (int i = 0; i < mt_number_of_tags; i++) {
-        tag[i] = SingleDiff{0, 0};
-      }
-    }
-  };
-
  private:
-  SummaryDiff register_mapping(position A, position B, StateType state, const RegionData& metadata, bool use_tag_inplace = false);
+  void register_mapping(position A, position B, StateType state, const RegionData& metadata,
+                        VirtualMemorySnapshot& diff, bool use_tag_inplace = false);
 
  public:
-  SummaryDiff reserve_mapping(position from, position sz, const RegionData& metadata) {
-    return register_mapping(from, from + sz, StateType::Reserved, metadata, false);
+  void reserve_mapping(position from, position sz,
+                       const RegionData& metadata, VirtualMemorySnapshot& diff) {
+    register_mapping(from, from + sz, StateType::Reserved, metadata, diff, false);
   }
 
-  SummaryDiff commit_mapping(position from, position sz, const RegionData& metadata, bool use_tag_inplace = false) {
-    return register_mapping(from, from + sz, StateType::Committed, metadata, use_tag_inplace);
+  void commit_mapping(position from, position sz, const RegionData& metadata,
+                      VirtualMemorySnapshot& diff, bool use_tag_inplace = false) {
+    register_mapping(from, from + sz, StateType::Committed, metadata, diff, use_tag_inplace);
   }
 
-  SummaryDiff uncommit_mapping(position from, position sz, const RegionData& metadata) {
-    return register_mapping(from, from + sz, StateType::Reserved, metadata, true);
+  void uncommit_mapping(position from, position sz, const RegionData& metadata, VirtualMemorySnapshot& diff) {
+    register_mapping(from, from + sz, StateType::Reserved, metadata, diff, true);
   }
 
-  SummaryDiff release_mapping(position from, position sz) {
-    return register_mapping(from, from + sz, StateType::Released, VMATree::empty_regiondata);
+  void release_mapping(position from, position sz, VirtualMemorySnapshot& diff) {
+    register_mapping(from, from + sz, StateType::Released, VMATree::empty_regiondata, diff);
   }
 
 public:


### PR DESCRIPTION
Hi,

`SummaryDiff` turned out to be a bad idea which is also costly performance-wise. Removing it and just passing in a reference to `VirtualMemorySnapshot` increased performance significantly (I think about 100% faster than without it).

Tests are currently failing because of a previously unnoticed bug, I'll move this out of draft when the bug is fixed and the GHA tests are passing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Issue
 * [JDK-8342730](https://bugs.openjdk.org/browse/JDK-8342730): Get rid of SummaryDiff in VMATree (**Enhancement** - P4)(⚠️ The fixVersion in this issue is [25] but the fixVersion in .jcheck/conf is 24, a new backport will be created when this pr is integrated.)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21638/head:pull/21638` \
`$ git checkout pull/21638`

Update a local copy of the PR: \
`$ git checkout pull/21638` \
`$ git pull https://git.openjdk.org/jdk.git pull/21638/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21638`

View PR using the GUI difftool: \
`$ git pr show -t 21638`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21638.diff">https://git.openjdk.org/jdk/pull/21638.diff</a>

</details>
