### PR TITLE
Apply jtreg 7.5 LIBRARY.properties for jdk repo.

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -1199,9 +1199,9 @@ var getJibProfilesDependencies = function (input, common) {
         jtreg: {
             server: "jpg",
             product: "jtreg",
-            version: "7.4",
-            build_number: "1",
-            file: "bundles/jtreg-7.4+1.zip",
+            version: "7.5",
+            build_number: "ci/31",
+            file: "bundles/jtreg-7.5+1.zip",
             environment_name: "JT_HOME",
             environment_path: input.get("jtreg", "home_path") + "/bin",
             configure_args: "--with-jtreg=" + input.get("jtreg", "home_path"),

--- a/test/jdk/java/lang/ClassLoader/securityManager/ClassLoaderTest.java
+++ b/test/jdk/java/lang/ClassLoader/securityManager/ClassLoaderTest.java
@@ -30,7 +30,6 @@
  * @modules java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.JarUtils
- *        jdk.test.lib.util.ModuleInfoWriter
  * @build TestClassLoader TestClient
  * @run main ClassLoaderTest -noPolicy
  * @run main ClassLoaderTest -validPolicy

--- a/test/jdk/java/lang/ModuleTests/AnnotationsTest.java
+++ b/test/jdk/java/lang/ModuleTests/AnnotationsTest.java
@@ -52,7 +52,6 @@ import static org.testng.Assert.*;
  * @enablePreview
  * @modules java.base/jdk.internal.module
  * @library /test/lib
- * @build jdk.test.lib.util.ModuleInfoWriter
  * @run testng AnnotationsTest
  * @summary Basic test of annotations on modules
  */

--- a/test/jdk/java/lang/instrument/RetransformApp.java
+++ b/test/jdk/java/lang/instrument/RetransformApp.java
@@ -36,6 +36,7 @@ import jdk.test.lib.helpers.ClassFileInstaller;
  *
  * @modules java.instrument
  * @library /test/lib
+ * @build jdk.test.lib.process.ProcessTools
  * @build RetransformAgent asmlib.Instrumentor
  * @enablePreview
  * @comment The test uses asmlib/Instrumentor.java which relies on ClassFile API PreviewFeature.

--- a/test/jdk/java/lang/invoke/common/LIBRARY.properties
+++ b/test/jdk/java/lang/invoke/common/LIBRARY.properties
@@ -1,0 +1,1 @@
+enablePreview = true

--- a/test/jdk/java/lang/module/ClassFileVersionsTest.java
+++ b/test/jdk/java/lang/module/ClassFileVersionsTest.java
@@ -26,7 +26,6 @@
  * @enablePreview
  * @modules java.base/jdk.internal.module
  * @library /test/lib
- * @build jdk.test.lib.util.ModuleInfoWriter
  * @run testng ClassFileVersionsTest
  * @summary Test parsing of module-info.class with different class file versions
  */

--- a/test/jdk/java/lang/module/ConfigurationTest.java
+++ b/test/jdk/java/lang/module/ConfigurationTest.java
@@ -28,7 +28,6 @@
  *          java.base/jdk.internal.module
  * @library /test/lib
  * @build ConfigurationTest
- *        jdk.test.lib.util.ModuleInfoWriter
  *        jdk.test.lib.util.ModuleUtils
  * @run testng ConfigurationTest
  * @summary Basic tests for java.lang.module.Configuration

--- a/test/jdk/java/lang/module/ModuleDescriptorTest.java
+++ b/test/jdk/java/lang/module/ModuleDescriptorTest.java
@@ -28,7 +28,6 @@
  * @modules java.base/jdk.internal.access
  *          java.base/jdk.internal.module
  * @library /test/lib
- * @build jdk.test.lib.util.ModuleInfoWriter
  * @run testng ModuleDescriptorTest
  * @summary Basic test for java.lang.module.ModuleDescriptor and its builder
  */

--- a/test/jdk/java/lang/module/ModuleFinderTest.java
+++ b/test/jdk/java/lang/module/ModuleFinderTest.java
@@ -26,7 +26,7 @@
  * @enablePreview
  * @modules java.base/jdk.internal.module
  * @library /test/lib
- * @build ModuleFinderTest jdk.test.lib.util.ModuleInfoWriter
+ * @build ModuleFinderTest
  * @run testng ModuleFinderTest
  * @summary Basic tests for java.lang.module.ModuleFinder
  */
@@ -827,4 +827,3 @@ public class ModuleFinderTest {
     }
 
 }
-

--- a/test/jdk/java/lang/module/ModuleNamesTest.java
+++ b/test/jdk/java/lang/module/ModuleNamesTest.java
@@ -27,7 +27,6 @@
  * @modules java.base/jdk.internal.access
  *          java.base/jdk.internal.module
  * @library /test/lib
- * @build jdk.test.lib.util.ModuleInfoWriter
  * @run testng ModuleNamesTest
  * @summary Basic test of reading a module-info.class with module names that
  *          are legal in class files but not legal in the Java Language

--- a/test/jdk/java/lang/module/MultiReleaseJarTest.java
+++ b/test/jdk/java/lang/module/MultiReleaseJarTest.java
@@ -28,7 +28,6 @@
  * @library /test/lib
  * @build MultiReleaseJarTest
  *        jdk.test.lib.util.JarUtils
- *        jdk.test.lib.util.ModuleInfoWriter
  * @run testng MultiReleaseJarTest
  * @run testng/othervm -Djdk.util.jar.enableMultiRelease=false MultiReleaseJarTest
  * @summary Basic test of modular JARs as multi-release JARs

--- a/test/jdk/java/security/Provider/SecurityProviderModularTest.java
+++ b/test/jdk/java/security/Provider/SecurityProviderModularTest.java
@@ -51,7 +51,6 @@ import jdk.test.lib.util.ModuleInfoWriter;
  * @modules java.base/jdk.internal.module
  * @library /test/lib
  * @build jdk.test.lib.util.JarUtils
- *        jdk.test.lib.util.ModuleInfoWriter
  *        TestProvider TestClient
  * @run main SecurityProviderModularTest CL true
  * @run main SecurityProviderModularTest CL false

--- a/test/jdk/javax/security/auth/login/modules/JaasModularClientTest.java
+++ b/test/jdk/javax/security/auth/login/modules/JaasModularClientTest.java
@@ -46,7 +46,7 @@ import jdk.test.lib.util.ModuleInfoWriter;
  * @enablePreview
  * @modules java.base/jdk.internal.module
  * @library /test/lib
- * @build jdk.test.lib.util.JarUtils jdk.test.lib.util.ModuleInfoWriter
+ * @build jdk.test.lib.util.JarUtils
  * @build TestLoginModule JaasClient
  * @run main JaasModularClientTest false
  * @run main JaasModularClientTest true

--- a/test/jdk/javax/security/auth/login/modules/JaasModularDefaultHandlerTest.java
+++ b/test/jdk/javax/security/auth/login/modules/JaasModularDefaultHandlerTest.java
@@ -45,7 +45,7 @@ import jdk.test.lib.util.ModuleInfoWriter;
  * @enablePreview
  * @modules java.base/jdk.internal.module
  * @library /test/lib
- * @build jdk.test.lib.util.JarUtils jdk.test.lib.util.ModuleInfoWriter
+ * @build jdk.test.lib.util.JarUtils
  * @build TestCallbackHandler TestLoginModule JaasClientWithDefaultHandler
  * @run main JaasModularDefaultHandlerTest
  */

--- a/test/jdk/jdk/modules/incubator/ServiceBinding.java
+++ b/test/jdk/jdk/modules/incubator/ServiceBinding.java
@@ -27,7 +27,7 @@
  * @enablePreview
  * @modules java.base/jdk.internal.module
  * @library /test/lib
- * @build ServiceBinding TestBootLayer jdk.test.lib.util.ModuleInfoWriter
+ * @build ServiceBinding TestBootLayer
  * @run testng ServiceBinding
  * @summary Test service binding with incubator modules
  */

--- a/test/jdk/sun/tools/jcmd/TestProcessHelper.java
+++ b/test/jdk/sun/tools/jcmd/TestProcessHelper.java
@@ -60,7 +60,6 @@ import jdk.test.lib.util.ModuleInfoWriter;
  * @library /test/lib
  * @build test.TestProcess
  *        jdk.test.lib.util.JarUtils
- *        jdk.test.lib.util.ModuleInfoWriter
  * @run main/othervm TestProcessHelper
  */
 public class TestProcessHelper {

--- a/test/jdk/tools/jlink/JLinkNegativeTest.java
+++ b/test/jdk/tools/jlink/JLinkNegativeTest.java
@@ -36,7 +36,7 @@
  *          jdk.jlink/jdk.tools.jimage
  *          jdk.compiler
  * @library /test/lib ../lib
- * @build tests.* jdk.test.lib.util.ModuleInfoWriter
+ * @build tests.*
  * @run testng JLinkNegativeTest
  */
 

--- a/test/jdk/tools/lib/LIBRARY.properties
+++ b/test/jdk/tools/lib/LIBRARY.properties
@@ -1,0 +1,1 @@
+enablePreview = true

--- a/test/langtools/lib/annotations/LIBRARY.properties
+++ b/test/langtools/lib/annotations/LIBRARY.properties
@@ -1,0 +1,1 @@
+enablePreview = true

--- a/test/langtools/tools/javac/classfiles/attributes/lib/LIBRARY.properties
+++ b/test/langtools/tools/javac/classfiles/attributes/lib/LIBRARY.properties
@@ -1,0 +1,1 @@
+enablePreview = true

--- a/test/lib/LIBRARY.properties
+++ b/test/lib/LIBRARY.properties
@@ -1,0 +1,1 @@
+enablePreview = false   # false so the common build is NOT --enable-preview


### PR DESCRIPTION
Apply jtreg 7.5 LIBRARY.properties for jdk repo.
Also update to use Jtreg 7.5 for testing.
The test library `test/lib` sets enablePreview = false to allow most tests to continue to run without --enable-preview. Tests needing preview must include their own @enablePreview. 
Tests using jdk.test.lib.ModuleInfoWriter are modified to compile that file for each test using enablePreview of the test (not the library).
A few other test libraries include LIBRARY.properties with enablePreview = true so that the @build directives for tests using the library will compile with --enable-preview and be shared.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21639/head:pull/21639` \
`$ git checkout pull/21639`

Update a local copy of the PR: \
`$ git checkout pull/21639` \
`$ git pull https://git.openjdk.org/jdk.git pull/21639/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21639`

View PR using the GUI difftool: \
`$ git pr show -t 21639`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21639.diff">https://git.openjdk.org/jdk/pull/21639.diff</a>

</details>
