### PR TITLE
8342839: Malformed copyright in StringNameTable since JDK-8342806

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/util/StringNameTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Trivially add a missing comma to satisfy Oracle-internal build check.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342839](https://bugs.openjdk.org/browse/JDK-8342839): Malformed copyright in StringNameTable since JDK-8342806 (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21640/head:pull/21640` \
`$ git checkout pull/21640`

Update a local copy of the PR: \
`$ git checkout pull/21640` \
`$ git pull https://git.openjdk.org/jdk.git pull/21640/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21640`

View PR using the GUI difftool: \
`$ git pr show -t 21640`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21640.diff">https://git.openjdk.org/jdk/pull/21640.diff</a>

</details>
