### PR TITLE
8342850: Change ProblemList to have LimitDirectMemory refer to JDK-8342849

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -585,7 +585,7 @@ java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc6
 
 # jdk_nio
 
-java/nio/Buffer/LimitDirectMemory.java                          8340728 generic-all
+java/nio/Buffer/LimitDirectMemory.java                          8342849 generic-all
 
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 


### PR DESCRIPTION
Separate LimitDirectMemory failure from JDK-8340728.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342850](https://bugs.openjdk.org/browse/JDK-8342850): Change ProblemList to have LimitDirectMemory refer to JDK-8342849 (**Sub-task** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21643/head:pull/21643` \
`$ git checkout pull/21643`

Update a local copy of the PR: \
`$ git checkout pull/21643` \
`$ git pull https://git.openjdk.org/jdk.git pull/21643/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21643`

View PR using the GUI difftool: \
`$ git pr show -t 21643`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21643.diff">https://git.openjdk.org/jdk/pull/21643.diff</a>

</details>
