### PR TITLE
8342768: GTest AssemblerX86.validate_vm failed: assert(VM_Version::supports_bmi1()) failed: tzcnt instruction not supported

### DIFF
--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -643,6 +643,7 @@ public:
   static void set_avx_cpuFeatures() { _features = (CPU_SSE | CPU_SSE2 | CPU_AVX | CPU_VZEROUPPER ); }
   static void set_evex_cpuFeatures() { _features = (CPU_AVX512F | CPU_SSE | CPU_SSE2 | CPU_VZEROUPPER ); }
   static void set_apx_cpuFeatures() { _features |= CPU_APX_F; }
+  static void set_bmi1_cpuFeatures() { _features |= CPU_BMI1; }
 
   // Initialization
   static void initialize();

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -640,8 +640,8 @@ public:
   LP64_ONLY(static void clear_apx_test_state());
 
   static void clean_cpuFeatures()   { _features = 0; }
-  static void set_avx_cpuFeatures() { _features = (CPU_SSE | CPU_SSE2 | CPU_AVX | CPU_VZEROUPPER ); }
-  static void set_evex_cpuFeatures() { _features = (CPU_AVX512F | CPU_SSE | CPU_SSE2 | CPU_VZEROUPPER ); }
+  static void set_avx_cpuFeatures() { _features |= (CPU_SSE | CPU_SSE2 | CPU_AVX | CPU_VZEROUPPER ); }
+  static void set_evex_cpuFeatures() { _features |= (CPU_AVX512F | CPU_SSE | CPU_SSE2 | CPU_VZEROUPPER ); }
   static void set_apx_cpuFeatures() { _features |= CPU_APX_F; }
   static void set_bmi1_cpuFeatures() { _features |= CPU_BMI1; }
 

--- a/src/hotspot/cpu/x86/vm_version_x86.hpp
+++ b/src/hotspot/cpu/x86/vm_version_x86.hpp
@@ -643,7 +643,7 @@ public:
   static void set_avx_cpuFeatures() { _features |= (CPU_SSE | CPU_SSE2 | CPU_AVX | CPU_VZEROUPPER ); }
   static void set_evex_cpuFeatures() { _features |= (CPU_AVX512F | CPU_SSE | CPU_SSE2 | CPU_VZEROUPPER ); }
   static void set_apx_cpuFeatures() { _features |= CPU_APX_F; }
-  static void set_bmi1_cpuFeatures() { _features |= CPU_BMI1; }
+  static void set_bmi_cpuFeatures() { _features |= (CPU_BMI1 | CPU_BMI2 | CPU_LZCNT); }
 
   // Initialization
   static void initialize();

--- a/test/hotspot/gtest/x86/test_assemblerx86.cpp
+++ b/test/hotspot/gtest/x86/test_assemblerx86.cpp
@@ -67,6 +67,7 @@ static void asm_check(const uint8_t *insns, const uint8_t *insns1, const unsigne
 
 TEST_VM(AssemblerX86, validate) {
   FlagSetting flag_change_apx(UseAPX, true);
+  VM_Version::set_bmi1_cpuFeatures();
   VM_Version::set_apx_cpuFeatures();
   BufferBlob* b = BufferBlob::create("x64Test", 500000);
   CodeBuffer code(b);

--- a/test/hotspot/gtest/x86/test_assemblerx86.cpp
+++ b/test/hotspot/gtest/x86/test_assemblerx86.cpp
@@ -67,7 +67,7 @@ static void asm_check(const uint8_t *insns, const uint8_t *insns1, const unsigne
 
 TEST_VM(AssemblerX86, validate) {
   FlagSetting flag_change_apx(UseAPX, true);
-  VM_Version::set_bmi1_cpuFeatures();
+  VM_Version::set_bmi_cpuFeatures();
   VM_Version::set_evex_cpuFeatures();
   VM_Version::set_avx_cpuFeatures();
   VM_Version::set_apx_cpuFeatures();

--- a/test/hotspot/gtest/x86/test_assemblerx86.cpp
+++ b/test/hotspot/gtest/x86/test_assemblerx86.cpp
@@ -68,6 +68,8 @@ static void asm_check(const uint8_t *insns, const uint8_t *insns1, const unsigne
 TEST_VM(AssemblerX86, validate) {
   FlagSetting flag_change_apx(UseAPX, true);
   VM_Version::set_bmi1_cpuFeatures();
+  VM_Version::set_evex_cpuFeatures();
+  VM_Version::set_avx_cpuFeatures();
   VM_Version::set_apx_cpuFeatures();
   BufferBlob* b = BufferBlob::create("x64Test", 500000);
   CodeBuffer code(b);


### PR DESCRIPTION
The `tzcnt` instruction requires the VM to support `bmi1` feature, which we set directly when running the test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342768](https://bugs.openjdk.org/browse/JDK-8342768): GTest AssemblerX86.validate_vm failed: assert(VM_Version::supports_bmi1()) failed: tzcnt instruction not supported (**Bug** - P3)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21644/head:pull/21644` \
`$ git checkout pull/21644`

Update a local copy of the PR: \
`$ git checkout pull/21644` \
`$ git pull https://git.openjdk.org/jdk.git pull/21644/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21644`

View PR using the GUI difftool: \
`$ git pr show -t 21644`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21644.diff">https://git.openjdk.org/jdk/pull/21644.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21644#issuecomment-2429893649)