### PR TITLE
8342582: user.region for formatting number no longer works for 21.0.5

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -1126,28 +1126,11 @@ public final class Locale implements Cloneable, Serializable {
     }
 
     private static Locale initDefault() {
-        String language, region, script, country, variant;
-        language = StaticProperty.USER_LANGUAGE;
-        // for compatibility, check for old user.region property
-        region = StaticProperty.USER_REGION;
-        if (!region.isEmpty()) {
-            // region can be of form country, country_variant, or _variant
-            int i = region.indexOf('_');
-            if (i >= 0) {
-                country = region.substring(0, i);
-                variant = region.substring(i + 1);
-            } else {
-                country = region;
-                variant = "";
-            }
-            script = "";
-        } else {
-            script = StaticProperty.USER_SCRIPT;
-            country = StaticProperty.USER_COUNTRY;
-            variant = StaticProperty.USER_VARIANT;
-        }
-
-        return getInstance(language, script, country, variant,
+        return getInstance(
+                StaticProperty.USER_LANGUAGE,
+                StaticProperty.USER_SCRIPT,
+                StaticProperty.USER_COUNTRY,
+                StaticProperty.USER_VARIANT,
                 getDefaultExtensions(StaticProperty.USER_EXTENSIONS)
                     .orElse(null));
     }

--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,19 +98,33 @@ public final class StaticProperty {
         USER_LANGUAGE = getProperty(props, "user.language", "en");
         USER_LANGUAGE_DISPLAY = getProperty(props, "user.language.display", USER_LANGUAGE);
         USER_LANGUAGE_FORMAT = getProperty(props, "user.language.format", USER_LANGUAGE);
-        USER_SCRIPT = getProperty(props, "user.script", "");
+        // for compatibility, check for old user.region property
+        USER_REGION = getProperty(props, "user.region", "");
+        if (!USER_REGION.isEmpty()) {
+            // region can be of form country, country_variant, or _variant
+            int i = USER_REGION.indexOf('_');
+            if (i >= 0) {
+                USER_COUNTRY = USER_REGION.substring(0, i);
+                USER_VARIANT = USER_REGION.substring(i + 1);
+            } else {
+                USER_COUNTRY = USER_REGION;
+                USER_VARIANT = "";
+            }
+            USER_SCRIPT = "";
+        } else {
+            USER_SCRIPT = getProperty(props, "user.script", "");
+            USER_COUNTRY = getProperty(props, "user.country", "");
+            USER_VARIANT = getProperty(props, "user.variant", "");
+        }
         USER_SCRIPT_DISPLAY = getProperty(props, "user.script.display", USER_SCRIPT);
         USER_SCRIPT_FORMAT = getProperty(props, "user.script.format", USER_SCRIPT);
-        USER_COUNTRY = getProperty(props, "user.country", "");
         USER_COUNTRY_DISPLAY = getProperty(props, "user.country.display", USER_COUNTRY);
         USER_COUNTRY_FORMAT = getProperty(props, "user.country.format", USER_COUNTRY);
-        USER_VARIANT = getProperty(props, "user.variant", "");
         USER_VARIANT_DISPLAY = getProperty(props, "user.variant.display", USER_VARIANT);
         USER_VARIANT_FORMAT = getProperty(props, "user.variant.format", USER_VARIANT);
         USER_EXTENSIONS = getProperty(props, "user.extensions", "");
         USER_EXTENSIONS_DISPLAY = getProperty(props, "user.extensions.display", USER_EXTENSIONS);
         USER_EXTENSIONS_FORMAT = getProperty(props, "user.extensions.format", USER_EXTENSIONS);
-        USER_REGION = getProperty(props, "user.region", "");
     }
 
     private static String getProperty(Properties props, String key) {

--- a/test/jdk/java/util/Locale/UserRegionTest.java
+++ b/test/jdk/java/util/Locale/UserRegionTest.java
@@ -65,8 +65,7 @@ public class UserRegionTest {
 
     @Test
     public void testNumberFormat() {
-        var country = Locale.getDefault().getCountry();
-        if (country.equals("DE")) {
+        if (System.getProperty("user.region").startsWith("DE")) {
             assertEquals("0,50000", String.format("%.5f", 0.5f));
         } else {
             assertEquals("0.50000", String.format("%.5f", 0.5f));

--- a/test/jdk/java/util/Locale/UserRegionTest.java
+++ b/test/jdk/java/util/Locale/UserRegionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8342582
+ * @summary Test if "user.region" system property successfully overrides
+ *          other locale related system properties at startup
+ * @modules jdk.localedata
+ * @run junit/othervm
+ *      -Duser.region=DE_POSIX
+ *      -Duser.language=en
+ *      -Duser.script=Latn
+ *      -Duser.country=US
+ *      -Duser.variant=FOO UserRegionTest
+ */
+
+import java.util.Locale;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class UserRegionTest {
+    @Test
+    public void testDefaultLocale() {
+        var region = System.getProperty("user.region").split("_");
+        var expected = Locale.of(System.getProperty("user.language"), region[0], region[1]);
+        assertEquals(expected, Locale.getDefault());
+        assertEquals(expected, Locale.getDefault(Locale.Category.FORMAT));
+        assertEquals(expected, Locale.getDefault(Locale.Category.DISPLAY));
+    }
+
+    @Test
+    public void testNumberFormat() {
+        assertEquals("0,50000", String.format("%.5f", 0.5f));
+    }
+}

--- a/test/jdk/java/util/Locale/UserRegionTest.java
+++ b/test/jdk/java/util/Locale/UserRegionTest.java
@@ -28,7 +28,19 @@
  *          other locale related system properties at startup
  * @modules jdk.localedata
  * @run junit/othervm
+ *      -Duser.region=DE
+ *      -Duser.language=en
+ *      -Duser.script=Latn
+ *      -Duser.country=US
+ *      -Duser.variant=FOO UserRegionTest
+ * @run junit/othervm
  *      -Duser.region=DE_POSIX
+ *      -Duser.language=en
+ *      -Duser.script=Latn
+ *      -Duser.country=US
+ *      -Duser.variant=FOO UserRegionTest
+ * @run junit/othervm
+ *      -Duser.region=_POSIX
  *      -Duser.language=en
  *      -Duser.script=Latn
  *      -Duser.country=US
@@ -44,7 +56,8 @@ public class UserRegionTest {
     @Test
     public void testDefaultLocale() {
         var region = System.getProperty("user.region").split("_");
-        var expected = Locale.of(System.getProperty("user.language"), region[0], region[1]);
+        var expected = Locale.of(System.getProperty("user.language"),
+                region[0], region.length > 1 ? region[1] : "");
         assertEquals(expected, Locale.getDefault());
         assertEquals(expected, Locale.getDefault(Locale.Category.FORMAT));
         assertEquals(expected, Locale.getDefault(Locale.Category.DISPLAY));
@@ -52,6 +65,11 @@ public class UserRegionTest {
 
     @Test
     public void testNumberFormat() {
-        assertEquals("0,50000", String.format("%.5f", 0.5f));
+        var country = Locale.getDefault().getCountry();
+        if (country.equals("DE")) {
+            assertEquals("0,50000", String.format("%.5f", 0.5f));
+        } else {
+            assertEquals("0.50000", String.format("%.5f", 0.5f));
+        }
     }
 }


### PR DESCRIPTION
This is a regression caused by the fix to [JDK-8321206](https://bugs.openjdk.org/browse/JDK-8321206), where the default locale with `user.region` creation is inadvertently broken. Fix is to restore the user.region override within StaticProperty initialization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342582](https://bugs.openjdk.org/browse/JDK-8342582): user.region for formatting number no longer works for 21.0.5 (**Bug** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21645/head:pull/21645` \
`$ git checkout pull/21645`

Update a local copy of the PR: \
`$ git checkout pull/21645` \
`$ git pull https://git.openjdk.org/jdk.git pull/21645/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21645`

View PR using the GUI difftool: \
`$ git pr show -t 21645`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21645.diff">https://git.openjdk.org/jdk/pull/21645.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21645#issuecomment-2429942543)