### PR TITLE
8342854: [JVMCI] Block secondary thread reporting a JVMCI fatal error

### DIFF
--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -117,8 +117,8 @@ class JVMCI : public AllStatic {
   // The path of the file underlying _fatal_log_fd if it is a normal file.
   static const char* _fatal_log_filename;
 
-  // Native thread id of thread that will initialize _fatal_log_fd.
-  static volatile intx _fatal_log_init_thread;
+  // Thread id of the first thread reporting a libjvmci error.
+  static volatile intx _first_error_tid;
 
   // JVMCI event log (shows up in hs_err crash logs).
   static StringEventLog* _events;


### PR DESCRIPTION
A fatal crash on a second thread causes the thread to [sleep infinitely](https://github.com/openjdk/jdk/blob/d6eddcdaf92f2352266ba519608879141997cd63/src/hotspot/share/utilities/vmError.cpp#L1709-L1718) while error reporting continues on the first crashing thread. The same should be done for reporting fatal crashes in libjvmci to avoid interleaving reports. This PR implements this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342854](https://bugs.openjdk.org/browse/JDK-8342854): [JVMCI] Block secondary thread reporting a JVMCI fatal error (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21646/head:pull/21646` \
`$ git checkout pull/21646`

Update a local copy of the PR: \
`$ git checkout pull/21646` \
`$ git pull https://git.openjdk.org/jdk.git pull/21646/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21646`

View PR using the GUI difftool: \
`$ git pr show -t 21646`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21646.diff">https://git.openjdk.org/jdk/pull/21646.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21646#issuecomment-2430085386)