### PR TITLE
8342838: ECDHE algorithm can't be disabled for TLSv1.3 cipher suites

### DIFF
--- a/src/java.base/share/classes/sun/security/ssl/SSLAlgorithmDecomposer.java
+++ b/src/java.base/share/classes/sun/security/ssl/SSLAlgorithmDecomposer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,6 +51,11 @@ class SSLAlgorithmDecomposer extends AlgorithmDecomposer {
     private Set<String> decomposes(CipherSuite.KeyExchange keyExchange) {
         Set<String> components = new HashSet<>();
         switch (keyExchange) {
+            case null:
+                // keyExchange is null for TLSv1.3 cipher suites,
+                // it means ECDHE for both key exchange and authentication.
+                components.add("ECDHE");
+                break;
             case K_NULL:
                 if (!onlyX509) {
                     components.add("K_NULL");
@@ -229,9 +234,7 @@ class SSLAlgorithmDecomposer extends AlgorithmDecomposer {
             HashAlg hashAlg) {
         Set<String> components = new HashSet<>();
 
-        if (keyExchange != null) {
-            components.addAll(decomposes(keyExchange));
-        }
+        components.addAll(decomposes(keyExchange));
 
         if (onlyX509) {
             // Certification path algorithm constraints do not apply

--- a/test/jdk/sun/security/ssl/CipherSuite/DisableKeyExchangeAlgorithmOfCipherSuiteTLSv13.java
+++ b/test/jdk/sun/security/ssl/CipherSuite/DisableKeyExchangeAlgorithmOfCipherSuiteTLSv13.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8342838
+ * @summary ECDHE algorithm can't be disabled for TLSv1.3 cipher suites
+ * @run testng/othervm DisableKeyExchangeAlgorithmOfCipherSuiteTLSv13
+ */
+
+import static org.testng.AssertJUnit.assertTrue;
+
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.security.Security;
+import java.util.List;
+
+public class DisableKeyExchangeAlgorithmOfCipherSuiteTLSv13 extends NoDesRC4DesEdeCiphSuite {
+
+    private static final String SECURITY_PROPERTY = "jdk.tls.disabledAlgorithms";
+    private static final String TEST_ALGORITHMS = "ECDHE";
+    private static final String[] CIPHER_SUITES = new String[] {
+        "TLS_AES_256_GCM_SHA384",
+        "TLS_AES_128_GCM_SHA256",
+        "TLS_CHACHA20_POLY1305_SHA256"
+    };
+    static final List<Integer> CIPHER_SUITES_IDS = List.of(
+        0x1302,
+        0x1301,
+        0x1303
+    );
+
+    @Override
+    protected String getProtocol() {
+        return "TLSv1.3";
+    }
+
+    @BeforeTest
+    void setUp() throws Exception {
+        Security.setProperty(SECURITY_PROPERTY, TEST_ALGORITHMS);
+    }
+
+    @Test
+    public void testDefault() throws Exception {
+        assertTrue(testDefaultCase(CIPHER_SUITES_IDS));
+    }
+
+    @Test
+    public void testAddDisabled() throws Exception {
+        assertTrue(testEngAddDisabled(CIPHER_SUITES, CIPHER_SUITES_IDS));
+    }
+
+    @Test
+    public void testOnlyDisabled() throws Exception {
+        assertTrue(testEngOnlyDisabled(CIPHER_SUITES));
+    }
+}

--- a/test/jdk/sun/security/ssl/CipherSuite/NoDesRC4DesEdeCiphSuite.java
+++ b/test/jdk/sun/security/ssl/CipherSuite/NoDesRC4DesEdeCiphSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 public class NoDesRC4DesEdeCiphSuite {
-
-    private static final boolean DEBUG = false;
 
     private static final byte RECTYPE_HS = 0x16;
     private static final byte HSMSG_CLIHELLO = 0x01;
@@ -100,21 +98,22 @@ public class NoDesRC4DesEdeCiphSuite {
         boolean allGood = true;
         String disAlg = Security.getProperty("jdk.tls.disabledAlgorithms");
         System.err.println("Disabled Algs: " + disAlg);
+        NoDesRC4DesEdeCiphSuite test = new NoDesRC4DesEdeCiphSuite();
 
         // Disabled DES tests
-        allGood &= testDefaultCase(DES_CS_LIST);
-        allGood &= testEngAddDisabled(DES_CS_LIST_NAMES, DES_CS_LIST);
-        allGood &= testEngOnlyDisabled(DES_CS_LIST_NAMES);
+        allGood &= test.testDefaultCase(DES_CS_LIST);
+        allGood &= test.testEngAddDisabled(DES_CS_LIST_NAMES, DES_CS_LIST);
+        allGood &= test.testEngOnlyDisabled(DES_CS_LIST_NAMES);
 
         // Disabled RC4 tests
-        allGood &= testDefaultCase(RC4_CS_LIST);
-        allGood &= testEngAddDisabled(RC4_CS_LIST_NAMES, RC4_CS_LIST);
-        allGood &= testEngOnlyDisabled(RC4_CS_LIST_NAMES);
+        allGood &= test.testDefaultCase(RC4_CS_LIST);
+        allGood &= test.testEngAddDisabled(RC4_CS_LIST_NAMES, RC4_CS_LIST);
+        allGood &= test.testEngOnlyDisabled(RC4_CS_LIST_NAMES);
 
         // Disabled 3DES tests
-        allGood &= testDefaultCase(DESEDE_CS_LIST);
-        allGood &= testEngAddDisabled(DESEDE_CS_LIST_NAMES, DESEDE_CS_LIST);
-        allGood &= testEngOnlyDisabled(DESEDE_CS_LIST_NAMES);
+        allGood &= test.testDefaultCase(DESEDE_CS_LIST);
+        allGood &= test.testEngAddDisabled(DESEDE_CS_LIST_NAMES, DESEDE_CS_LIST);
+        allGood &= test.testEngOnlyDisabled(DESEDE_CS_LIST_NAMES);
 
         if (allGood) {
             System.err.println("All tests passed");
@@ -132,17 +131,17 @@ public class NoDesRC4DesEdeCiphSuite {
      *
      * @return true if the test passed (No disabled suites), false otherwise
      */
-    private static boolean testDefaultCase(List<Integer> disabledSuiteIds)
+    protected boolean testDefaultCase(List<Integer> disabledSuiteIds)
             throws Exception {
         System.err.println("\nTest: Default SSLEngine suite set");
         SSLEngine ssle = makeEngine();
-        if (DEBUG) {
+        if (getDebug()) {
             listCiphers("Suite set upon creation", ssle);
         }
         SSLEngineResult clientResult;
         ByteBuffer cTOs = makeClientBuf(ssle);
         clientResult = ssle.wrap(CLIOUTBUF, cTOs);
-        if (DEBUG) {
+        if (getDebug()) {
             dumpResult("ClientHello: ", clientResult);
         }
         cTOs.flip();
@@ -167,20 +166,20 @@ public class NoDesRC4DesEdeCiphSuite {
      * @return true if the engine throws SSLHandshakeException during client
      *      hello creation, false otherwise.
      */
-    private static boolean testEngOnlyDisabled(String[] disabledSuiteNames)
+    protected boolean testEngOnlyDisabled(String[] disabledSuiteNames)
             throws Exception {
         System.err.println(
                 "\nTest: SSLEngine configured with only disabled suites");
         try {
             SSLEngine ssle = makeEngine();
             ssle.setEnabledCipherSuites(disabledSuiteNames);
-            if (DEBUG) {
+            if (getDebug()) {
                 listCiphers("Suite set upon creation", ssle);
             }
             SSLEngineResult clientResult;
             ByteBuffer cTOs = makeClientBuf(ssle);
             clientResult = ssle.wrap(CLIOUTBUF, cTOs);
-            if (DEBUG) {
+            if (getDebug()) {
                 dumpResult("ClientHello: ", clientResult);
             }
             cTOs.flip();
@@ -197,14 +196,14 @@ public class NoDesRC4DesEdeCiphSuite {
      * set of cipher suites.  Make sure none of the disabled suites show up
      * in the client hello even though they were explicitly added.
      *
-     * @param disabledSuiteNames an array of cipher suite names that
+     * @param disabledNames an array of cipher suite names that
      *      should be disabled cipher suites.
      * @param disabledIds the {@code List} of disabled cipher suite IDs
      *      to be checked for.
      *
      * @return true if the test passed (No disabled suites), false otherwise
      */
-    private static boolean testEngAddDisabled(String[] disabledNames,
+    protected boolean testEngAddDisabled(String[] disabledNames,
             List<Integer> disabledIds) throws Exception {
         System.err.println("\nTest: SSLEngine with disabled suites added");
         SSLEngine ssle = makeEngine();
@@ -217,13 +216,13 @@ public class NoDesRC4DesEdeCiphSuite {
                 initialSuites.length, disabledNames.length);
         ssle.setEnabledCipherSuites(plusDisSuites);
 
-        if (DEBUG) {
+        if (getDebug()) {
             listCiphers("Suite set upon creation", ssle);
         }
         SSLEngineResult clientResult;
         ByteBuffer cTOs = makeClientBuf(ssle);
         clientResult = ssle.wrap(CLIOUTBUF, cTOs);
-        if (DEBUG) {
+        if (getDebug()) {
             dumpResult("ClientHello: ", clientResult);
         }
         cTOs.flip();
@@ -237,8 +236,12 @@ public class NoDesRC4DesEdeCiphSuite {
         }
     }
 
-    private static SSLEngine makeEngine() throws GeneralSecurityException {
-        SSLContext ctx = SSLContext.getInstance("TLSv1.2");
+    protected String getProtocol() {
+        return "TLSv1.2";
+    }
+
+    private SSLEngine makeEngine() throws GeneralSecurityException {
+        SSLContext ctx = SSLContext.getInstance(getProtocol());
         ctx.init(null, null, null);
         return ctx.createSSLEngine();
     }
@@ -276,7 +279,7 @@ public class NoDesRC4DesEdeCiphSuite {
      * @throws IOException if the data in the {@code clientHello}
      *      buffer is not a TLS handshake message or is not a client hello.
      */
-    private static boolean areSuitesPresentCH(ByteBuffer clientHello,
+    private boolean areSuitesPresentCH(ByteBuffer clientHello,
             List<Integer> suiteIdList) throws IOException {
         byte val;
 
@@ -355,9 +358,13 @@ public class NoDesRC4DesEdeCiphSuite {
         }
     }
 
-    private static void log(String str) {
-        if (DEBUG) {
+    private void log(String str) {
+        if (getDebug()) {
             System.err.println(str);
         }
+    }
+
+    protected boolean getDebug() {
+        return false;
     }
 }


### PR DESCRIPTION
`SSLAlgorithmDecomposer.decomposes(CipherSuite.KeyExchange keyExchange)` method is missing the `null` case: TLSv1.3 cipher suites with ECDHE being used for both key exchange and authentication have `null` for KeyExchange object.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342838](https://bugs.openjdk.org/browse/JDK-8342838): ECDHE algorithm can't be disabled for TLSv1.3 cipher suites (**Bug** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21648/head:pull/21648` \
`$ git checkout pull/21648`

Update a local copy of the PR: \
`$ git checkout pull/21648` \
`$ git pull https://git.openjdk.org/jdk.git pull/21648/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21648`

View PR using the GUI difftool: \
`$ git pr show -t 21648`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21648.diff">https://git.openjdk.org/jdk/pull/21648.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21648#issuecomment-2430251826)