### PR TITLE
8342858: Make target mac-jdk-bundle fails on chmod command

### DIFF
--- a/make/common/FileUtils.gmk
+++ b/make/common/FileUtils.gmk
@@ -136,7 +136,7 @@ ifeq ($(call isTargetOs, macosx), true)
 	  $(CP) -fRP '$(call DecodeSpace, $<)' '$(call DecodeSpace, $@)'; \
 	fi
 	if [ -n "`$(XATTR) -ls '$(call DecodeSpace, $@)'`" ]; then \
-          $(CHMOD) u+w '$(call DecodeSpace, $@)'; \
+          $(CHMOD) -h u+w '$(call DecodeSpace, $@)'; \
 	  $(XATTR) -cs '$(call DecodeSpace, $@)'; \
 	fi
   endef


### PR DESCRIPTION
The target mac-jdk-bundle can fail randomly. MacBundles.gmk defines a large number of individual copy rules, which can execute in any order. The "install-file" (our copy) macro on macos includes a check for weird attributes using `xattr` so that we can remove them. We use the switch `-s` to make sure that xattr operates on symlinks instead of their targets. However, if we find something, we also run `chmod` to make sure we have the permissions to remove attributes in the first place, but the chmod command does not have the `-h` switch to operate on the symlink instead of the target. So if the symlink gets copied before its target, there is a chance that we try to run chmod before the target exists, which will result in a failure. My proposed fix is to add `-h` to the chmod command so that everything operates on the symlink instead of the target.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342858](https://bugs.openjdk.org/browse/JDK-8342858): Make target mac-jdk-bundle fails on chmod command (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21649/head:pull/21649` \
`$ git checkout pull/21649`

Update a local copy of the PR: \
`$ git checkout pull/21649` \
`$ git pull https://git.openjdk.org/jdk.git pull/21649/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21649`

View PR using the GUI difftool: \
`$ git pr show -t 21649`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21649.diff">https://git.openjdk.org/jdk/pull/21649.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21649#issuecomment-2430358746)