### PR TITLE
8342673: Test serviceability/jvmti/events/NotifyFramePopStressTest/NotifyFramePopStressTest.java failed: waited too long for notify

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/events/NotifyFramePopStressTest/NotifyFramePopStressTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/NotifyFramePopStressTest/NotifyFramePopStressTest.java
@@ -78,6 +78,13 @@ public class NotifyFramePopStressTest {
         log("control has started");
         while (!done) {
             suspend(thread);
+            if (done) {
+                // Double check after suspending the thread. We don't want to do the notify
+                // if the main thread thinks it is done. An untimely notify during the
+                // join() call will result in a deadlock.
+                resume(thread);
+                break;
+            }
             if (notifyFramePop(thread)) {
                 notifyCount++;
                 log("control incremented notifyCount to " + notifyCount);


### PR DESCRIPTION
Fix deadlock with suspending the main thread while it is in Thread.join() to join the thread that is suspending it. The suspending thread then waits for a FRAME_POP event on the main thread, but that never happens because it is suspended.

Testing in progress. Running the test 100 times on all supported platforms, including separate run with `-Xcomp`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342673](https://bugs.openjdk.org/browse/JDK-8342673): Test serviceability/jvmti/events/NotifyFramePopStressTest/NotifyFramePopStressTest.java failed: waited too long for notify (**Bug** - P3)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21650/head:pull/21650` \
`$ git checkout pull/21650`

Update a local copy of the PR: \
`$ git checkout pull/21650` \
`$ git pull https://git.openjdk.org/jdk.git pull/21650/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21650`

View PR using the GUI difftool: \
`$ git pr show -t 21650`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21650.diff">https://git.openjdk.org/jdk/pull/21650.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21650#issuecomment-2430385920)