### PR TITLE
8342868: Errors related to unused code on Windows after 8339120 in core libs

### DIFF
--- a/src/java.base/share/native/libzip/zip_util.c
+++ b/src/java.base/share/native/libzip/zip_util.c
@@ -581,7 +581,9 @@ readCEN(jzfile *zip, jint knownTotal)
     jlong offset;
 #endif
     unsigned char endbuf[ENDHDR];
+#ifdef USE_MMAP
     jint endhdrlen = ENDHDR;
+#endif
     jzcell *entries;
     jint *table;
 
@@ -606,7 +608,9 @@ readCEN(jzfile *zip, jint knownTotal)
             cenoff = ZIP64_ENDOFF(end64buf);
             total = (jint)ZIP64_ENDTOT(end64buf);
             endpos = end64pos;
+#ifdef USE_MMAP
             endhdrlen = ZIP64_ENDHDR;
+#endif
         }
     }
 

--- a/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
+++ b/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
@@ -965,8 +965,9 @@ void getNumberPart(const jchar * langtag, const jint numberStyle, WCHAR * number
 void getFixPart(const jchar * langtag, const jint numberStyle, BOOL positive, BOOL prefix, WCHAR * ret) {
     DWORD pattern = 0;
     int style = numberStyle;
-    int got = 0;
+ // int got = 0;
 
+/*
     if (positive) {
         if (style == sun_util_locale_provider_HostLocaleProviderAdapterImpl_NF_CURRENCY) {
             got = getLocaleInfoWrapper(langtag,
@@ -992,6 +993,7 @@ void getFixPart(const jchar * langtag, const jint numberStyle, BOOL positive, BO
                 (LPWSTR)&pattern, sizeof(pattern));
         }
     }
+*/
 
     if (numberStyle == sun_util_locale_provider_HostLocaleProviderAdapterImpl_NF_INTEGER) {
         style = sun_util_locale_provider_HostLocaleProviderAdapterImpl_NF_NUMBER;

--- a/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
+++ b/src/java.base/windows/native/libjava/HostLocaleProviderAdapter_md.c
@@ -967,33 +967,36 @@ void getFixPart(const jchar * langtag, const jint numberStyle, BOOL positive, BO
     int style = numberStyle;
  // int got = 0;
 
-/*
     if (positive) {
         if (style == sun_util_locale_provider_HostLocaleProviderAdapterImpl_NF_CURRENCY) {
-            got = getLocaleInfoWrapper(langtag,
+         // got =
+                  getLocaleInfoWrapper(langtag,
                 LOCALE_ICURRENCY | LOCALE_RETURN_NUMBER,
                 (LPWSTR)&pattern, sizeof(pattern));
         } else if (style == sun_util_locale_provider_HostLocaleProviderAdapterImpl_NF_PERCENT) {
-            got = getLocaleInfoWrapper(langtag,
+         // got =
+                  getLocaleInfoWrapper(langtag,
                 LOCALE_IPOSITIVEPERCENT | LOCALE_RETURN_NUMBER,
                 (LPWSTR)&pattern, sizeof(pattern));
         }
     } else {
         if (style == sun_util_locale_provider_HostLocaleProviderAdapterImpl_NF_CURRENCY) {
-            got = getLocaleInfoWrapper(langtag,
+         // got =
+                  getLocaleInfoWrapper(langtag,
                 LOCALE_INEGCURR | LOCALE_RETURN_NUMBER,
                 (LPWSTR)&pattern, sizeof(pattern));
         } else if (style == sun_util_locale_provider_HostLocaleProviderAdapterImpl_NF_PERCENT) {
-            got = getLocaleInfoWrapper(langtag,
+         // got =
+                  getLocaleInfoWrapper(langtag,
                 LOCALE_INEGATIVEPERCENT | LOCALE_RETURN_NUMBER,
                 (LPWSTR)&pattern, sizeof(pattern));
         } else {
-            got = getLocaleInfoWrapper(langtag,
+         // got =
+                  getLocaleInfoWrapper(langtag,
                 LOCALE_INEGNUMBER | LOCALE_RETURN_NUMBER,
                 (LPWSTR)&pattern, sizeof(pattern));
         }
     }
-*/
 
     if (numberStyle == sun_util_locale_provider_HostLocaleProviderAdapterImpl_NF_INTEGER) {
         style = sun_util_locale_provider_HostLocaleProviderAdapterImpl_NF_NUMBER;

--- a/src/java.base/windows/native/libjava/TimeZone_md.c
+++ b/src/java.base/windows/native/libjava/TimeZone_md.c
@@ -232,7 +232,7 @@ static int getWinTimeZone(char *winZoneName, size_t winZoneNameBufSize)
         WCHAR stdNameInReg[MAX_ZONE_CHAR];
         TziValue tempTzi;
         WCHAR *stdNamePtr = tzi.StandardName;
-        int onlyMapID;
+     // int onlyMapID;
 
         timeType = GetTimeZoneInformation(&tzi);
         if (timeType == TIME_ZONE_ID_INVALID) {
@@ -304,7 +304,7 @@ static int getWinTimeZone(char *winZoneName, size_t winZoneNameBufSize)
          * Compare to the "Std" value of each subkey and find the entry that
          * matches the current control panel setting.
          */
-        onlyMapID = 0;
+     // onlyMapID = 0;
         for (i = 0; i < nSubKeys; ++i) {
             DWORD size = sizeof(subKeyName);
             ret = RegEnumKeyEx(hKey, i, subKeyName, &size, NULL, NULL, NULL, NULL);
@@ -325,7 +325,7 @@ static int getWinTimeZone(char *winZoneName, size_t winZoneNameBufSize)
                  * entry in the Time Zones registry.
                  */
                 RegCloseKey(hSubKey);
-                onlyMapID = 1;
+             // onlyMapID = 1;
                 ret = RegOpenKeyExW(hKey, stdNamePtr, 0, KEY_READ, (PHKEY)&hSubKey);
                 if (ret != ERROR_SUCCESS) {
                     goto err;

--- a/src/java.base/windows/native/libnet/NTLMAuthSequence.c
+++ b/src/java.base/windows/native/libnet/NTLMAuthSequence.c
@@ -47,7 +47,7 @@ static jfieldID ntlm_ctxHandleID;
 static jfieldID ntlm_crdHandleID;
 static jfieldID status_seqCompleteID;
 
-static HINSTANCE lib = NULL;
+// static HINSTANCE lib = NULL;
 
 JNIEXPORT void JNICALL Java_sun_net_www_protocol_http_ntlm_NTLMAuthSequence_initFirst
 (JNIEnv *env, jclass authseq_clazz, jclass status_clazz)


### PR DESCRIPTION
After 8339120, gcc began catching many different instances of unused code in the Windows specific codebase. Some of these seem to be bugs. I've taken the effort to mark out all the relevant globals and locals that trigger the unused warnings and addressed all of them by commenting out the code as appropriate. I am confident that in many cases this simplistic approach of commenting out code does not fix the underlying issue, and the warning actually found a bug that should be fixed. In these instances, I will be aiming to fix these bugs with help from reviewers, so I recommend anyone reviewing who knows more about the code than I do to see whether there is indeed a bug that needs fixing in a different way than what I did

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342868](https://bugs.openjdk.org/browse/JDK-8342868): Errors related to unused code on Windows after 8339120 in core libs (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21654/head:pull/21654` \
`$ git checkout pull/21654`

Update a local copy of the PR: \
`$ git checkout pull/21654` \
`$ git pull https://git.openjdk.org/jdk.git pull/21654/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21654`

View PR using the GUI difftool: \
`$ git pr show -t 21654`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21654.diff">https://git.openjdk.org/jdk/pull/21654.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21654#issuecomment-2430882273)
</details>
