### PR TITLE
8304674: AttachCurrentThread 's argument is JavaVMAttachArgs

### DIFF
--- a/src/java.base/share/native/include/jni.h
+++ b/src/java.base/share/native/include/jni.h
@@ -1939,13 +1939,13 @@ struct JNIInvokeInterface_ {
 
     jint (JNICALL *DestroyJavaVM)(JavaVM *vm);
 
-    jint (JNICALL *AttachCurrentThread)(JavaVM *vm, void **penv, void *args);
+    jint (JNICALL *AttachCurrentThread)(JavaVM *vm, void **penv, JavaVMAttachArgs *args);
 
     jint (JNICALL *DetachCurrentThread)(JavaVM *vm);
 
     jint (JNICALL *GetEnv)(JavaVM *vm, void **penv, jint version);
 
-    jint (JNICALL *AttachCurrentThreadAsDaemon)(JavaVM *vm, void **penv, void *args);
+    jint (JNICALL *AttachCurrentThreadAsDaemon)(JavaVM *vm, void **penv, JavaVMAttachArgs *args);
 };
 
 struct JavaVM_ {
@@ -1955,7 +1955,7 @@ struct JavaVM_ {
     jint DestroyJavaVM() {
         return functions->DestroyJavaVM(this);
     }
-    jint AttachCurrentThread(void **penv, void *args) {
+    jint AttachCurrentThread(void **penv, JavaVMAttachArgs *args) {
         return functions->AttachCurrentThread(this, penv, args);
     }
     jint DetachCurrentThread() {
@@ -1965,7 +1965,7 @@ struct JavaVM_ {
     jint GetEnv(void **penv, jint version) {
         return functions->GetEnv(this, penv, version);
     }
-    jint AttachCurrentThreadAsDaemon(void **penv, void *args) {
+    jint AttachCurrentThreadAsDaemon(void **penv, JavaVMAttachArgs *args) {
         return functions->AttachCurrentThreadAsDaemon(this, penv, args);
     }
 #endif


### PR DESCRIPTION
Try to add clear type annotations.

Please let me know how this patch can be properly reviewed >_<

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8304674](https://bugs.openjdk.org/browse/JDK-8304674)

### Issue
 * [JDK-8304674](https://bugs.openjdk.org/browse/JDK-8304674): File java.c compile error with -fsanitize=address -O0 (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21658/head:pull/21658` \
`$ git checkout pull/21658`

Update a local copy of the PR: \
`$ git checkout pull/21658` \
`$ git pull https://git.openjdk.org/jdk.git pull/21658/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21658`

View PR using the GUI difftool: \
`$ git pr show -t 21658`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21658.diff">https://git.openjdk.org/jdk/pull/21658.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21658#issuecomment-2764890935)
</details>
