### PR TITLE
8342882: RISC-V: Unify handling of jumps to runtime

### DIFF
--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
@@ -758,15 +758,14 @@ void ZBarrierSetAssembler::generate_c2_store_barrier_stub(MacroAssembler* masm, 
     __ la(c_rarg0, stub->ref_addr());
 
     if (stub->is_native()) {
-      __ la(t1, RuntimeAddress(ZBarrierSetRuntime::store_barrier_on_native_oop_field_without_healing_addr()));
+      __ rt_call(ZBarrierSetRuntime::store_barrier_on_native_oop_field_without_healing_addr());
     } else if (stub->is_atomic()) {
-      __ la(t1, RuntimeAddress(ZBarrierSetRuntime::store_barrier_on_oop_field_with_healing_addr()));
+      __ rt_call(ZBarrierSetRuntime::store_barrier_on_oop_field_with_healing_addr());
     } else if (stub->is_nokeepalive()) {
-      __ la(t1, RuntimeAddress(ZBarrierSetRuntime::no_keepalive_store_barrier_on_oop_field_without_healing_addr()));
+      __ rt_call(ZBarrierSetRuntime::no_keepalive_store_barrier_on_oop_field_without_healing_addr());
     } else {
-      __ la(t1, RuntimeAddress(ZBarrierSetRuntime::store_barrier_on_oop_field_without_healing_addr()));
+      __ rt_call(ZBarrierSetRuntime::store_barrier_on_oop_field_without_healing_addr());
     }
-    __ jalr(t1);
   }
 
   // Stub exit

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -663,7 +663,7 @@ class MacroAssembler: public Assembler {
   // For long reach uses temp register for:
   // la + jr
   void j(const address dest, Register temp = t1);
-  void j(const Address &adr, Register temp = t1);
+  void j(const Address &dest, Register temp = t1);
   void j(Label &l, Register temp = noreg);
 
   // jump register: jalr x0, offset(rs)

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1139,8 +1139,7 @@ static void gen_continuation_yield(MacroAssembler* masm,
   Label ok;
   __ beqz(t0, ok);
   __ leave();
-  __ la(t1, RuntimeAddress(StubRoutines::forward_exception_entry()));
-  __ jr(t1);
+  __ j(RuntimeAddress(StubRoutines::forward_exception_entry()));
   __ bind(ok);
 
   __ leave();

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -508,7 +508,7 @@ class StubGenerator: public StubCodeGenerator {
     // complete return to VM
     assert(StubRoutines::_call_stub_return_address != nullptr,
            "_call_stub_return_address must have been generated before");
-    __ j(StubRoutines::_call_stub_return_address);
+    __ j(RuntimeAddress(StubRoutines::_call_stub_return_address));
 
     return start;
   }
@@ -3782,8 +3782,7 @@ class StubGenerator: public StubCodeGenerator {
     Label thaw_success;
     // t1 contains the size of the frames to thaw, 0 if overflow or no more frames
     __ bnez(t1, thaw_success);
-    __ la(t1, RuntimeAddress(SharedRuntime::throw_StackOverflowError_entry()));
-    __ jr(t1);
+    __ j(RuntimeAddress(SharedRuntime::throw_StackOverflowError_entry()));
     __ bind(thaw_success);
 
     // make room for the thawed frames

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -421,7 +421,7 @@ address TemplateInterpreterGenerator::generate_exception_handler_common(
                c_rarg1, c_rarg2);
   }
   // throw exception
-  __ j(address(Interpreter::throw_exception_entry()));
+  __ j(RuntimeAddress(Interpreter::throw_exception_entry()));
   return entry;
 }
 

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -1085,7 +1085,7 @@ void TemplateTable::aastore() {
 
   // Come here on failure
   // object is at TOS
-  __ j(Interpreter::_throw_ArrayStoreException_entry);
+  __ j(RuntimeAddress(Interpreter::_throw_ArrayStoreException_entry));
 
   // Come here on success
   __ bind(ok_is_subtype);
@@ -3672,7 +3672,7 @@ void TemplateTable::checkcast() {
   // Come here on failure
   __ push_reg(x13);
   // object is at TOS
-  __ j(Interpreter::_throw_ClassCastException_entry);
+  __ j(RuntimeAddress(Interpreter::_throw_ClassCastException_entry));
 
   // Come here on success
   __ bind(ok_is_subtype);
@@ -3779,7 +3779,7 @@ void TemplateTable::_breakpoint() {
 void TemplateTable::athrow() {
   transition(atos, vtos);
   __ null_check(x10);
-  __ j(Interpreter::throw_exception_entry());
+  __ j(RuntimeAddress(Interpreter::throw_exception_entry()));
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
This fixes and unifies handling of jumps to runtime. Was previously discussed here [1]. ( Tagging @robehn )
Seems not reasonable for `MacroAssembler::j(const Address &dest, Register temp)` to directly delegate work to `MacroAssembler::j(const address dest, Register temp)` for literal Address. This could generate a plain `JAL`, which means when we relocate the code, but the `JAL` immediate could be too large. This change relaxes this constaint.

[1] https://github.com/openjdk/jdk/pull/21406#issuecomment-2415965656

Simply did a native fastdebug build and tried specjbb2005 workload.
More testing on linux-riscv64 in progress.
- [x] tier1 - tier3 (release)
- [x] hotspot:tier1 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342882](https://bugs.openjdk.org/browse/JDK-8342882): RISC-V: Unify handling of jumps to runtime (**Enhancement** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21661/head:pull/21661` \
`$ git checkout pull/21661`

Update a local copy of the PR: \
`$ git checkout pull/21661` \
`$ git pull https://git.openjdk.org/jdk.git pull/21661/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21661`

View PR using the GUI difftool: \
`$ git pr show -t 21661`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21661.diff">https://git.openjdk.org/jdk/pull/21661.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21661#issuecomment-2431670580)