### PR TITLE
8342857: SA: Heap iterator makes incorrect assumptions about TLAB layout

### DIFF
--- a/src/hotspot/share/gc/shared/vmStructs_gc.hpp
+++ b/src/hotspot/share/gc/shared/vmStructs_gc.hpp
@@ -91,6 +91,7 @@
   nonstatic_field(CardTableBarrierSet,         _defer_initial_card_mark,                      bool)                                  \
   nonstatic_field(CardTableBarrierSet,         _card_table,                                   CardTable*)                            \
                                                                                                                                      \
+     static_field(CollectedHeap,               _lab_alignment_reserve,                        size_t)                                \
   nonstatic_field(CollectedHeap,               _reserved,                                     MemRegion)                             \
   nonstatic_field(CollectedHeap,               _is_stw_gc_active,                             bool)                                  \
   nonstatic_field(CollectedHeap,               _total_collections,                            unsigned int)                          \

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ThreadLocalAllocBuffer.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ThreadLocalAllocBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ThreadLocalAllocBuffer.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/ThreadLocalAllocBuffer.java
@@ -75,11 +75,11 @@ public class ThreadLocalAllocBuffer extends VMObject {
   }
 
   private long endReserve() {
-    long minFillerArraySize = Array.baseOffsetInBytes(BasicType.T_INT);
+    long labAlignmentReserve = VM.getVM().getLabAlignmentReserve();
     long reserveForAllocationPrefetch = VM.getVM().getReserveForAllocationPrefetch();
     long heapWordSize = VM.getVM().getHeapWordSize();
 
-    return Math.max(minFillerArraySize, reserveForAllocationPrefetch * heapWordSize);
+    return Math.max(labAlignmentReserve, reserveForAllocationPrefetch) * heapWordSize;
   }
 
   /** Support for iteration over heap -- not sure how this will

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -139,12 +139,12 @@ public class VM {
   private Flag[] commandLineFlags;
   private Map<String, Flag> flagsMap;
 
-  private static Type intType;
-  private static Type uintType;
-  private static Type intxType;
-  private static Type uintxType;
-  private static Type sizetType;
-  private static Type uint64tType;
+  private static CIntegerType intType;
+  private static CIntegerType uintType;
+  private static CIntegerType intxType;
+  private static CIntegerType uintxType;
+  private static CIntegerType sizetType;
+  private static CIntegerType uint64tType;
   private static CIntegerType boolType;
   private Boolean sharingEnabled;
   private Boolean compressedOopsEnabled;
@@ -433,21 +433,28 @@ public class VM {
        vmRelease = CStringUtilities.getString(releaseAddr);
        Address vmInternalInfoAddr = vmVersion.getAddressField("_s_internal_vm_info_string").getValue();
        vmInternalInfo = CStringUtilities.getString(vmInternalInfoAddr);
-
-       Type threadLocalAllocBuffer = db.lookupType("ThreadLocalAllocBuffer");
-       CIntegerType intType = (CIntegerType) db.lookupType("int");
-       CIntegerField reserveForAllocationPrefetchField = threadLocalAllocBuffer.getCIntegerField("_reserve_for_allocation_prefetch");
-       reserveForAllocationPrefetch = (int)reserveForAllocationPrefetchField.getCInteger(intType);
-
-       Type collectedHeap = db.lookupType("CollectedHeap");
-       CIntegerType sizeType = (CIntegerType) db.lookupType("size_t");
-       CIntegerField labAlignmentReserveField = collectedHeap.getCIntegerField("_lab_alignment_reserve");
-       labAlignmentReserve = (int)labAlignmentReserveField.getCInteger(sizeType);
     } catch (Exception exp) {
        throw new RuntimeException("can't determine target's VM version : " + exp.getMessage());
     }
 
     checkVMVersion(vmRelease);
+
+    // Initialize common primitive types
+    intType = (CIntegerType) db.lookupType("int");
+    uintType = (CIntegerType) db.lookupType("uint");
+    intxType = (CIntegerType) db.lookupType("intx");
+    uintxType = (CIntegerType) db.lookupType("uintx");
+    sizetType = (CIntegerType) db.lookupType("size_t");
+    uint64tType = (CIntegerType) db.lookupType("uint64_t");
+    boolType = (CIntegerType) db.lookupType("bool");
+
+    Type threadLocalAllocBuffer = db.lookupType("ThreadLocalAllocBuffer");
+    CIntegerField reserveForAllocationPrefetchField = threadLocalAllocBuffer.getCIntegerField("_reserve_for_allocation_prefetch");
+    reserveForAllocationPrefetch = (int)reserveForAllocationPrefetchField.getCInteger(intType);
+
+    Type collectedHeap = db.lookupType("CollectedHeap");
+    CIntegerField labAlignmentReserveField = collectedHeap.getCIntegerField("_lab_alignment_reserve");
+    labAlignmentReserve = (int)labAlignmentReserveField.getCInteger(sizetType);
 
     invocationEntryBCI = db.lookupIntConstant("InvocationEntryBci").intValue();
 
@@ -498,14 +505,6 @@ public class VM {
     Flags_VALUE_ORIGIN_MASK = db.lookupIntConstant("JVMFlag::VALUE_ORIGIN_MASK").intValue();
     Flags_WAS_SET_ON_COMMAND_LINE = db.lookupIntConstant("JVMFlag::WAS_SET_ON_COMMAND_LINE").intValue();
     oopSize  = db.lookupIntConstant("oopSize").intValue();
-
-    intType = db.lookupType("int");
-    uintType = db.lookupType("uint");
-    intxType = db.lookupType("intx");
-    uintxType = db.lookupType("uintx");
-    sizetType = db.lookupType("size_t");
-    uint64tType = db.lookupType("uint64_t");
-    boolType = (CIntegerType) db.lookupType("bool");
 
     minObjAlignmentInBytes = getObjectAlignmentInBytes();
     if ((minObjAlignmentInBytes & (minObjAlignmentInBytes - 1)) != 0) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -440,7 +440,7 @@ public class VM {
        reserveForAllocationPrefetch = (int)reserveForAllocationPrefetchField.getCInteger(intType);
 
        Type collectedHeap = db.lookupType("CollectedHeap");
-       CIntegerType sizeType = (CIntegerType) db.lookupType("size_t");
+       CIntegerType sizeType = (CIntegerType) sizetType;
        CIntegerField labAlignmentReserveField = collectedHeap.getCIntegerField("_lab_alignment_reserve");
        labAlignmentReserve = (int)labAlignmentReserveField.getCInteger(sizeType);
     } catch (Exception exp) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -440,7 +440,7 @@ public class VM {
        reserveForAllocationPrefetch = (int)reserveForAllocationPrefetchField.getCInteger(intType);
 
        Type collectedHeap = db.lookupType("CollectedHeap");
-       CIntegerType sizeType = (CIntegerType) sizetType;
+       CIntegerType sizeType = (CIntegerType) db.lookupType("size_t");
        CIntegerField labAlignmentReserveField = collectedHeap.getCIntegerField("_lab_alignment_reserve");
        labAlignmentReserve = (int)labAlignmentReserveField.getCInteger(sizeType);
     } catch (Exception exp) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VM.java
@@ -127,6 +127,7 @@ public class VM {
   private ReversePtrs  revPtrs;
   private VMRegImpl    vmregImpl;
   private int          reserveForAllocationPrefetch;
+  private int          labAlignmentReserve;
 
   // System.getProperties from debuggee VM
   private Properties   sysProps;
@@ -437,6 +438,11 @@ public class VM {
        CIntegerType intType = (CIntegerType) db.lookupType("int");
        CIntegerField reserveForAllocationPrefetchField = threadLocalAllocBuffer.getCIntegerField("_reserve_for_allocation_prefetch");
        reserveForAllocationPrefetch = (int)reserveForAllocationPrefetchField.getCInteger(intType);
+
+       Type collectedHeap = db.lookupType("CollectedHeap");
+       CIntegerType sizeType = (CIntegerType) db.lookupType("size_t");
+       CIntegerField labAlignmentReserveField = collectedHeap.getCIntegerField("_lab_alignment_reserve");
+       labAlignmentReserve = (int)labAlignmentReserveField.getCInteger(sizeType);
     } catch (Exception exp) {
        throw new RuntimeException("can't determine target's VM version : " + exp.getMessage());
     }
@@ -927,6 +933,10 @@ public class VM {
 
   public int getReserveForAllocationPrefetch() {
     return reserveForAllocationPrefetch;
+  }
+
+  public int getLabAlignmentReserve() {
+    return labAlignmentReserve;
   }
 
   public boolean isSharingEnabled() {


### PR DESCRIPTION
When testing Lilliput we found a failure in `serviceability/sa/ClhsdbJstackWithConcurrentLock.java` test when running with C1-only.

The test uses the SA's thread printing feature to print the threads *and* the "concurrent locks" / AbstractOwnableSynchronizers. It then verifies that the expected lock is listed in the section for "Locked ownable synchronizers".

When we turned on Lilliput's -XX:+UseCompactObjectHeaders this stopped working, and we got nothing reported in that section:

```
"Thread-0" #31 prio=5 tid=0x00007a708c259ad0 nid=1480533 waiting on condition [0x00007a706fefe000]
   java.lang.Thread.State: TIMED_WAITING (sleeping)
   JavaThread state: _thread_blocked
 - java.lang.Thread.sleepNanos0(long) @bci=0 (Interpreted frame)
 - java.lang.Thread.sleepNanos(long) @bci=33, line=497 (Interpreted frame)
 - java.lang.Thread.sleep(long) @bci=25, line=528 (Interpreted frame)
 - LingeredAppWithConcurrentLock.lockMethod(java.util.concurrent.locks.Lock) @bci=13, line=38 (Interpreted frame)
	- locked <0x00000000ffd32d88> (a java.util.concurrent.locks.ReentrantLock)
 - LingeredAppWithConcurrentLock.lambda$main$0() @bci=3, line=46 (Interpreted frame)
 - LingeredAppWithConcurrentLock$$Lambda+0x00007a7023001000.run() @bci=0 (Interpreted frame)
 - java.lang.Thread.runWith(java.lang.Object, java.lang.Runnable) @bci=5, line=1589 (Interpreted frame)
 - java.lang.Thread.run() @bci=19, line=1576 (Interpreted frame)

Locked ownable synchronizers:
    - None
```

It should be saying:
```
Locked ownable synchronizers:
    - <0x00000000ffd32d88>, (a java/util/concurrent/locks/ReentrantLock$NonfairSync)
```

The problem lies within the code that searches for objects in the heap. It collects a bunch of regions and searches them for objects. However, the code that describes the TLAB regions are stale and doesn't match the C++ implementation in the JVM. When Lilliput shrinks the headers the SA code is broken enough to cause the TLAB regions to be reported as overlapping. This has ripple effects that the object iterators stop working.

I can get this test to pass, with and without compact object headers, by fixing the code in  `ThreadLocalAllocBuffer::hard_end()`.

This is a reproducer of the problem:
```
make -C ../build/fastdebug test TEST=serviceability/sa/ClhsdbJstackWithConcurrentLock.java JTREG="JAVA_OPTIONS=-XX:TieredStopAtLevel=2 -XX:+UnlockExperimentalVMOptions -XX:+UseCompactObjectHeaders"
```

I've tested this by running all 'serviceability' tests in our tier1-9 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342857](https://bugs.openjdk.org/browse/JDK-8342857): SA: Heap iterator makes incorrect assumptions about TLAB layout (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) Review applies to [3f50944e](https://git.openjdk.org/jdk/pull/21662/files/3f50944e8c94fa88a27fb5c8853b843417b3d7db)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) Review applies to [3f50944e](https://git.openjdk.org/jdk/pull/21662/files/3f50944e8c94fa88a27fb5c8853b843417b3d7db)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21662/head:pull/21662` \
`$ git checkout pull/21662`

Update a local copy of the PR: \
`$ git checkout pull/21662` \
`$ git pull https://git.openjdk.org/jdk.git pull/21662/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21662`

View PR using the GUI difftool: \
`$ git pr show -t 21662`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21662.diff">https://git.openjdk.org/jdk/pull/21662.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21662#issuecomment-2431850075)