### PR TITLE
8342285: Mark jdk/jfr/api/event/TestIsEnabledMultiple.java as intermittent

### DIFF
--- a/test/jdk/jdk/jfr/api/event/TestIsEnabledMultiple.java
+++ b/test/jdk/jdk/jfr/api/event/TestIsEnabledMultiple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,7 @@ import jdk.test.lib.Asserts;
 /**
  * @test
  * @summary Test Event.isEnabled() with multiple recordings
- * @key jfr
+ * @key jfr intermittent
  * @requires vm.hasJFR
  * @library /test/lib
  * @run main/othervm jdk.jfr.api.event.TestIsEnabledMultiple


### PR DESCRIPTION
Hi all,
The test `jdk/jfr/api/event/TestIsEnabledMultiple.java` has been observed intermittent failure several times. I think we should mark this test as intermittent failure. Trivial fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342285](https://bugs.openjdk.org/browse/JDK-8342285): Mark jdk/jfr/api/event/TestIsEnabledMultiple.java as intermittent (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21666/head:pull/21666` \
`$ git checkout pull/21666`

Update a local copy of the PR: \
`$ git checkout pull/21666` \
`$ git pull https://git.openjdk.org/jdk.git pull/21666/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21666`

View PR using the GUI difftool: \
`$ git pr show -t 21666`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21666.diff">https://git.openjdk.org/jdk/pull/21666.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21666#issuecomment-2432695914)