### PR TITLE
8342905: Thread.setContextClassloader from thread in FJP commonPool task no longer works after JDK-8327501 redux

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
+++ b/src/java.base/share/classes/java/util/concurrent/ForkJoinPool.java
@@ -51,6 +51,8 @@ import java.util.Objects;
 import java.util.function.Predicate;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.locks.LockSupport;
+
+import jdk.internal.access.JavaLangAccess;
 import jdk.internal.access.JavaUtilConcurrentFJPAccess;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.Unsafe;
@@ -1133,9 +1135,7 @@ public class ForkJoinPool extends AbstractExecutorService {
         implements ForkJoinWorkerThreadFactory {
         public final ForkJoinWorkerThread newThread(ForkJoinPool pool) {
             boolean isCommon = (pool.workerNamePrefix == null);
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null && isCommon)
+            if (isCommon && JLA.allowSecurityManager())
                 return newCommonWithACC(pool);
             else
                 return newRegularWithACC(pool);
@@ -1151,6 +1151,8 @@ public class ForkJoinPool extends AbstractExecutorService {
          */
         @SuppressWarnings("removal")
         static volatile AccessControlContext regularACC, commonACC;
+
+        private static final JavaLangAccess JLA = SharedSecrets.getJavaLangAccess();
 
         @SuppressWarnings("removal")
         static ForkJoinWorkerThread newRegularWithACC(ForkJoinPool pool) {


### PR DESCRIPTION
Having opted in to allow setting an SM is a clearer signal.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342905](https://bugs.openjdk.org/browse/JDK-8342905): Thread.setContextClassloader from thread in FJP commonPool task no longer works after JDK-8327501 redux (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21668/head:pull/21668` \
`$ git checkout pull/21668`

Update a local copy of the PR: \
`$ git checkout pull/21668` \
`$ git pull https://git.openjdk.org/jdk.git pull/21668/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21668`

View PR using the GUI difftool: \
`$ git pr show -t 21668`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21668.diff">https://git.openjdk.org/jdk/pull/21668.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21668#issuecomment-2433154855)