### PR TITLE
8342862: Gtest added by 8339507 appears to be causing 8GB build machines to hang

### DIFF
--- a/test/hotspot/gtest/x86/test_assemblerx86.cpp
+++ b/test/hotspot/gtest/x86/test_assemblerx86.cpp
@@ -74,7 +74,8 @@ TEST_VM(AssemblerX86, validate) {
   address entry = __ pc();
 
   // To build asmtest.out.h, ensure you have binutils version 2.34 or higher, then run:
-  // python3 x86-asmtest.py | expand > asmtest.out.h
+  // python3 x86-asmtest.py | expand > asmtest.out.h to generate tests with random inputs
+  // python3 x86-asmtest.py --full | expand > asmtest.out.h to generate tests with all possible inputs
 #include "asmtest.out.h"
 
   asm_check((const uint8_t *)entry, (const uint8_t *)insns, insns_lens, insns_strs, sizeof(insns_lens) / sizeof(insns_lens[0]));


### PR DESCRIPTION
We generate each test randomly. The `asmtest.out.h` is currently around 100 KB. We have added the `--full` argument to allow users to create a complete test set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342862](https://bugs.openjdk.org/browse/JDK-8342862): Gtest added by 8339507 appears to be causing 8GB build machines to hang (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21670/head:pull/21670` \
`$ git checkout pull/21670`

Update a local copy of the PR: \
`$ git checkout pull/21670` \
`$ git pull https://git.openjdk.org/jdk.git pull/21670/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21670`

View PR using the GUI difftool: \
`$ git pr show -t 21670`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21670.diff">https://git.openjdk.org/jdk/pull/21670.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21670#issuecomment-2433526374)