### PR TITLE
Update GTS demo site URLs

### DIFF
--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -638,8 +638,8 @@ public class CAInterop {
                     new CATestURLs("https://good.gsr4.demo.pki.goog",
                     "https://revoked.gsr4.demo.pki.goog");
             case "gtsrootcar1" ->
-                    new CATestURLs("https://good.gtsr1.demosite.pki.goog/",
-                    "https://revoked.gtsr1.demosite.pki.goog/");
+                    new CATestURLs("https://good.gtsr1.demosite.pki.goog",
+                    "https://revoked.gtsr1.demosite.pki.goog");
             case "gtsrootcar2" ->
                     new CATestURLs("https://good.gtsr2.demosite.pki.goog",
                     "https://revoked.gtsr2.demosite.pki.goog");

--- a/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
+++ b/test/jdk/security/infra/java/security/cert/CertPathValidator/certification/CAInterop.java
@@ -638,17 +638,17 @@ public class CAInterop {
                     new CATestURLs("https://good.gsr4.demo.pki.goog",
                     "https://revoked.gsr4.demo.pki.goog");
             case "gtsrootcar1" ->
-                    new CATestURLs("https://good.gtsr1.demo.pki.goog",
-                    "https://revoked.gtsr1.demo.pki.goog");
+                    new CATestURLs("https://good.gtsr1.demosite.pki.goog/",
+                    "https://revoked.gtsr1.demosite.pki.goog/");
             case "gtsrootcar2" ->
-                    new CATestURLs("https://good.gtsr2.demo.pki.goog",
-                    "https://revoked.gtsr2.demo.pki.goog");
+                    new CATestURLs("https://good.gtsr2.demosite.pki.goog",
+                    "https://revoked.gtsr2.demosite.pki.goog");
             case "gtsrootecccar3" ->
-                    new CATestURLs("https://good.gtsr3.demo.pki.goog",
-                    "https://revoked.gtsr3.demo.pki.goog");
+                    new CATestURLs("https://good.gtsr3.demosite.pki.goog",
+                    "https://revoked.gtsr3.demosite.pki.goog");
             case "gtsrootecccar4" ->
-                    new CATestURLs("https://good.gtsr4.demo.pki.goog",
-                    "https://revoked.gtsr4.demo.pki.goog");
+                    new CATestURLs("https://good.gtsr4.demosite.pki.goog",
+                    "https://revoked.gtsr4.demosite.pki.goog");
 
             case "microsoftecc2017" ->
                     new CATestURLs("https://acteccroot2017.pki.microsoft.com",


### PR DESCRIPTION
GTS changed the URLs for its demo certificates. See: https://pki.goog/repository/ (Roots > Action > Good / Expired / Revoked)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21671/head:pull/21671` \
`$ git checkout pull/21671`

Update a local copy of the PR: \
`$ git checkout pull/21671` \
`$ git pull https://git.openjdk.org/jdk.git pull/21671/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21671`

View PR using the GUI difftool: \
`$ git pr show -t 21671`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21671.diff">https://git.openjdk.org/jdk/pull/21671.diff</a>

</details>
