### PR TITLE
8342939: Building ZGC without compiler2 fails

### DIFF
--- a/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/gc/z/zBarrierSetAssembler_x86.cpp
@@ -363,8 +363,12 @@ static void emit_store_fast_path_check_c2(MacroAssembler* masm, Address ref_addr
 }
 
 static bool is_c2_compilation() {
+#ifdef COMPILER2
   CompileTask* task = ciEnv::current()->task();
   return task != nullptr && is_c2_compile(task->comp_level());
+#else
+  return false;
+#endif
 }
 
 void ZBarrierSetAssembler::store_barrier_fast(MacroAssembler* masm,


### PR DESCRIPTION
Hi all,

  please review this change that makes ZGC compile without the C2 compiler.

The solution is to ifdef the offending C2 code, and returning `false` for the predicate that checks whether this is a C2 compilation (which can't be because there is no C2 compiled in).

Testing: manual compilation without C2, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342939](https://bugs.openjdk.org/browse/JDK-8342939): Building ZGC without compiler2 fails (**Bug** - P4)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21677/head:pull/21677` \
`$ git checkout pull/21677`

Update a local copy of the PR: \
`$ git checkout pull/21677` \
`$ git pull https://git.openjdk.org/jdk.git pull/21677/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21677`

View PR using the GUI difftool: \
`$ git pr show -t 21677`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21677.diff">https://git.openjdk.org/jdk/pull/21677.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21677#issuecomment-2434592494)