### PR TITLE
JDK-8342938: Problem list java/io/IO/IO.java test on Linux ppc64le

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -531,6 +531,7 @@ java/lang/instrument/RetransformBigClass.sh                     8065756 generic-
 # jdk_io
 
 java/io/pathNames/GeneralWin32.java                             8180264 windows-all
+java/io/IO/IO.java                                              8337935 linux-ppc64le
 
 ############################################################################
 


### PR DESCRIPTION
Test java/io/IO/IO.java fails on Linux ppc64le because of issues with 'expect' .