### PR TITLE
8342953: RISC-V: Fix definition of RISCV_HWPROBE_EXT_ZVFHMIN

### DIFF
--- a/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/riscv_hwprobe.cpp
@@ -74,7 +74,7 @@
 #define   RISCV_HWPROBE_EXT_ZFHMIN              (1 << 28)
 #define   RISCV_HWPROBE_EXT_ZIHINTNTL           (1 << 29)
 #define   RISCV_HWPROBE_EXT_ZVFH                (1 << 30)
-#define   RISCV_HWPROBE_EXT_ZVFHMIN             (1 << 31)
+#define   RISCV_HWPROBE_EXT_ZVFHMIN             (1ULL << 31)
 #define   RISCV_HWPROBE_EXT_ZFA                 (1ULL << 32)
 #define   RISCV_HWPROBE_EXT_ZTSO                (1ULL << 33)
 #define   RISCV_HWPROBE_EXT_ZACAS               (1ULL << 34)


### PR DESCRIPTION
Hi,

Please review this trivial change correcting definition of macro `RISCV_HWPROBE_EXT_ZVFHMIN`.

This macro is supposed to be used when making a `hwprobe` linux syscall for detecting the Zvfhmin extension. Current definition yields a negative 32bits value, messing up hwprobe result when Zvfhmin extension presents. Replace it by using a 1ULL bit shift value as done in kernel upstream [1]. Although it is not used by the JVM for now, it's better to fix it for consistency with the kernel upstream.

[1] https://github.com/torvalds/linux/commit/5ea6764d9095e234b024054f75ebbccc4f0eb146

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342953](https://bugs.openjdk.org/browse/JDK-8342953): RISC-V: Fix definition of RISCV_HWPROBE_EXT_ZVFHMIN (**Enhancement** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * @abdelhak-zaaim (no known openjdk.org user name / role)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21680/head:pull/21680` \
`$ git checkout pull/21680`

Update a local copy of the PR: \
`$ git checkout pull/21680` \
`$ git pull https://git.openjdk.org/jdk.git pull/21680/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21680`

View PR using the GUI difftool: \
`$ git pr show -t 21680`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21680.diff">https://git.openjdk.org/jdk/pull/21680.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21680#issuecomment-2434991257)