### PR TITLE
8342958: Use jvmArgs consistently in microbenchmarks

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/CallerClassBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/CallerClassBench.java
@@ -36,7 +36,7 @@ import org.openjdk.jmh.annotations.Warmup;
 
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 3, jvmArgsAppend = {"-Xmx1g", "-Xms1g"})
+@Fork(value = 3, jvmArgs = {"-Xmx1g", "-Xms1g"})
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)

--- a/test/micro/org/openjdk/bench/java/lang/ObjectHashCode.java
+++ b/test/micro/org/openjdk/bench/java/lang/ObjectHashCode.java
@@ -50,37 +50,37 @@ public class ObjectHashCode {
     // Experimental hashCode generation schemes. See synchronizer.cpp get_next_hash
     /*
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=0"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=0"})
     public int mode_0() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=1"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=1"})
     public int mode_1() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=2"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=2"})
     public int mode_2() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=3"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=3"})
     public int mode_3() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=4"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=4"})
     public int mode_4() {
         return System.identityHashCode(new Object());
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=5"})
+    @Fork(jvmArgs = {"-XX:+UnlockExperimentalVMOptions", "-XX:hashCode=5"})
     public int mode_5() {
         return System.identityHashCode(new Object());
     }

--- a/test/micro/org/openjdk/bench/java/lang/ScopedValues.java
+++ b/test/micro/org/openjdk/bench/java/lang/ScopedValues.java
@@ -40,7 +40,7 @@ import static org.openjdk.bench.java.lang.ScopedValuesData.*;
 @Measurement(iterations=10, time=1)
 @Threads(1)
 @Fork(value = 1,
-      jvmArgsPrepend = {"-Djmh.executor.class=org.openjdk.bench.java.lang.ScopedValuesExecutorService",
+      jvmArgs = {"-Djmh.executor.class=org.openjdk.bench.java.lang.ScopedValuesExecutorService",
                         "-Djmh.executor=CUSTOM",
                         "-Djmh.blackhole.mode=COMPILER",
                         "--enable-preview"})

--- a/test/micro/org/openjdk/bench/java/lang/StringHashCode.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringHashCode.java
@@ -96,7 +96,7 @@ public class StringHashCode {
     @State(Scope.Thread)
     @Warmup(iterations = 5, time = 1)
     @Measurement(iterations = 5, time = 1)
-    @Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED"})
+    @Fork(value = 3, jvmArgs = {"--add-exports", "java.base/java.lang=ALL-UNNAMED", "--add-opens", "java.base/java.lang=ALL-UNNAMED"})
     public static class Algorithm {
 
         private final static String alphabet = "abcdefghijklmnopqrstuvwxyz";

--- a/test/micro/org/openjdk/bench/java/lang/classfile/TypeKindBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/classfile/TypeKindBench.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 3, time = 2)
 @Measurement(iterations = 6, time = 1)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @State(Scope.Thread)
 public class TypeKindBench {
 

--- a/test/micro/org/openjdk/bench/java/lang/classfile/Utf8EntryWriteTo.java
+++ b/test/micro/org/openjdk/bench/java/lang/classfile/Utf8EntryWriteTo.java
@@ -56,7 +56,7 @@ import jdk.internal.classfile.impl.*;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 1, time = 2)
 @Measurement(iterations = 3, time = 1)
-@Fork(jvmArgsAppend = "--enable-preview", value = 3)
+@Fork(jvmArgs = "--enable-preview", value = 3)
 @State(Scope.Thread)
 public class Utf8EntryWriteTo {
     static final ClassDesc STRING_BUILDER = ClassDesc.ofDescriptor("Ljava/lang/StringBuilder;");

--- a/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromSliceTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromSliceTest.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class AllocFromSliceTest extends CLayouts {
 
     @Param({"5", "20", "100", "500", "1000"})

--- a/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/AllocFromTest.java
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class AllocFromTest extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/AllocTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/AllocTest.java
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class AllocTest extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadConstant.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadConstant.java
@@ -41,7 +41,7 @@ import static org.openjdk.bench.java.lang.foreign.CallOverheadHelper.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class CallOverheadConstant {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadVirtual.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CallOverheadVirtual.java
@@ -41,7 +41,7 @@ import static org.openjdk.bench.java.lang.foreign.CallOverheadHelper.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class CallOverheadVirtual {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/CriticalCalls.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/CriticalCalls.java
@@ -51,7 +51,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class CriticalCalls {
 
     static final MethodHandle PINNED;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/InternalStrLen.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/InternalStrLen.java
@@ -50,7 +50,7 @@ import static jdk.internal.foreign.StringSupport.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports=java.base/jdk.internal.foreign=ALL-UNNAMED", "--enable-native-access=ALL-UNNAMED", "--enable-preview"})
+@Fork(value = 3, jvmArgs = {"--add-exports=java.base/jdk.internal.foreign=ALL-UNNAMED", "--enable-native-access=ALL-UNNAMED", "--enable-preview"})
 public class InternalStrLen {
 
     private MemorySegment singleByteSegment;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LinkUpcall.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LinkUpcall.java
@@ -47,7 +47,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class LinkUpcall extends CLayouts {
 
     static final Linker LINKER = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverNonConstantAsType.java
@@ -54,7 +54,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "-XX:-TieredCompilation" })
+@Fork(value = 3, jvmArgs = { "-XX:-TieredCompilation" })
 public class LoopOverNonConstantAsType extends JavaLayouts {
 
     static final Unsafe unsafe = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverOfAddress.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class LoopOverOfAddress extends JavaLayouts {
 
     static final int ITERATIONS = 1_000_000;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentCopyUnsafe.java
@@ -45,7 +45,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--enable-native-access=ALL-UNNAMED"})
 public class MemorySegmentCopyUnsafe {
 
     static final Unsafe UNSAFE = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGetUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentGetUnsafe.java
@@ -50,7 +50,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--enable-native-access=ALL-UNNAMED"})
 public class MemorySegmentGetUnsafe {
 
     static final Unsafe UNSAFE = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentZeroUnsafe.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/MemorySegmentZeroUnsafe.java
@@ -44,7 +44,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--enable-native-access=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--enable-native-access=ALL-UNNAMED"})
 public class MemorySegmentZeroUnsafe {
 
     static final Unsafe UNSAFE = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/PointerInvoke.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointerInvoke extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/QSort.java
@@ -46,7 +46,7 @@ import static java.lang.foreign.ValueLayout.JAVA_INT;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class QSort extends CLayouts {
 
     static final Linker abi = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkCopy.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkCopy.java
@@ -84,25 +84,25 @@ public class SegmentBulkCopy {
         dstBuffer.put(srcBuffer);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.copy=31"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.copy=31"})
     @Benchmark
     public void heapSegmentCopyJava() {
         MemorySegment.copy(heapSrcSegment, 0, heapDstSegment, 0, ELEM_SIZE);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.copy=0"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.copy=0"})
     @Benchmark
     public void heapSegmentCopyUnsafe() {
         MemorySegment.copy(heapSrcSegment, 0, heapDstSegment, 0, ELEM_SIZE);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.copy=31"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.copy=31"})
     @Benchmark
     public void nativeSegmentCopyJava() {
         MemorySegment.copy(nativeSrcSegment, 0, nativeDstSegment, 0, ELEM_SIZE);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.copy=0"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.copy=0"})
     @Benchmark
     public void nativeSegmentCopyUnsafe() {
         MemorySegment.copy(nativeSrcSegment, 0, nativeDstSegment, 0, ELEM_SIZE);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkFill.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkFill.java
@@ -74,37 +74,37 @@ public class SegmentBulkFill {
         Arrays.fill(array, (byte) 0);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.fill=31"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.fill=31"})
     @Benchmark
     public void heapSegmentFillJava() {
         heapSegment.fill((byte) 0);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.fill=0"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.fill=0"})
     @Benchmark
     public void heapSegmentFillUnsafe() {
         heapSegment.fill((byte) 0);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.fill=31"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.fill=31"})
     @Benchmark
     public void nativeSegmentFillJava() {
         nativeSegment.fill((byte) 0);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.fill=0"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.fill=0"})
     @Benchmark
     public void nativeSegmentFillUnsafe() {
         nativeSegment.fill((byte) 0);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.fill=31"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.fill=31"})
     @Benchmark
     public void unalignedSegmentFillJava() {
         unalignedSegment.fill((byte) 0);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.fill=0"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.fill=0"})
     @Benchmark
     public void unalignedSegmentFillUnsafe() {
         unalignedSegment.fill((byte) 0);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkMismatch.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkMismatch.java
@@ -79,25 +79,25 @@ public class SegmentBulkMismatch {
         dstHeap = MemorySegment.ofArray(dstArray);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.mismatch=31"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.mismatch=31"})
     @Benchmark
     public long nativeSegmentJava() {
         return srcNative.mismatch(dstNative);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.mismatch=31"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.mismatch=31"})
     @Benchmark
     public long heapSegmentJava() {
         return srcHeap.mismatch(dstHeap);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.mismatch=0"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.mismatch=0"})
     @Benchmark
     public long nativeSegmentUnsafe() {
         return srcNative.mismatch(dstNative);
     }
 
-    @Fork(value = 3, jvmArgsAppend = {"-Djava.lang.foreign.native.threshold.power.mismatch=0"})
+    @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.mismatch=0"})
     @Benchmark
     public long heapSegmentUnsafe() {
         return srcHeap.mismatch(dstHeap);

--- a/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/StrLenTest.java
@@ -48,7 +48,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class StrLenTest extends CLayouts {
 
     Arena arena = Arena.ofConfined();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToCStringTest.java
@@ -51,7 +51,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class ToCStringTest extends CLayouts {
 
     @Param({"5", "20", "100", "200"})

--- a/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/ToJavaStringTest.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "--enable-preview", "-Djava.library.path=micro/native" })
 public class ToJavaStringTest {
 
     private MemorySegment strSegment;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/UnrolledAccess.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/UnrolledAccess.java
@@ -40,7 +40,7 @@ import static java.lang.foreign.ValueLayout.*;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 public class UnrolledAccess extends JavaLayouts {
 
     static final Unsafe U = Utils.unsafe;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/Upcalls.java
@@ -45,7 +45,7 @@ import static java.lang.invoke.MethodHandles.lookup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class Upcalls extends CLayouts {
 
     static final Linker abi = Linker.nativeLinker();

--- a/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/pointers/PointerBench.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @Warmup(iterations = 3, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED" })
 @State(Scope.Benchmark)
 public class PointerBench {
 

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAccess.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAccess.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointsAccess {
 
     BBPoint BBPoint;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAlloc.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsAlloc.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointsAlloc {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsDistance.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsDistance.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointsDistance {
 
     BBPoint jniP1;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsFree.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/points/PointsFree.java
@@ -42,7 +42,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 public class PointsFree {
 
     JNIPoint jniPoint;

--- a/test/micro/org/openjdk/bench/java/lang/foreign/xor/XorTest.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/xor/XorTest.java
@@ -19,7 +19,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
+@Fork(value = 3, jvmArgs = { "--enable-native-access=ALL-UNNAMED", "-Djava.library.path=micro/native" })
 
 public class XorTest {
 

--- a/test/micro/org/openjdk/bench/java/lang/invoke/LazyStaticColdStart.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/LazyStaticColdStart.java
@@ -52,7 +52,7 @@ import static java.lang.classfile.ClassFile.ACC_STATIC;
 @BenchmarkMode(Mode.SingleShotTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)
-@Fork(value = 10, warmups = 5, jvmArgsAppend = {
+@Fork(value = 10, warmups = 5, jvmArgs = {
         "--enable-preview"
 })
 public class LazyStaticColdStart {

--- a/test/micro/org/openjdk/bench/java/lang/invoke/Wrappers.java
+++ b/test/micro/org/openjdk/bench/java/lang/invoke/Wrappers.java
@@ -45,7 +45,7 @@ import sun.invoke.util.Wrapper;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
-@Fork(value = 3, jvmArgsAppend = "--add-exports=java.base/sun.invoke.util=ALL-UNNAMED")
+@Fork(value = 3, jvmArgs = "--add-exports=java.base/sun.invoke.util=ALL-UNNAMED")
 public class Wrappers {
 
     public static Class<?>[] PRIM_CLASSES = {

--- a/test/micro/org/openjdk/bench/java/lang/reflect/proxy/ProxyGeneratorBench.java
+++ b/test/micro/org/openjdk/bench/java/lang/reflect/proxy/ProxyGeneratorBench.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
  */
 @Warmup(iterations = 5, time = 2)
 @Measurement(iterations = 5, time = 2)
-@Fork(value = 1, jvmArgsPrepend = "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED")
+@Fork(value = 1, jvmArgs = "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED")
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/java/net/NetworkInterfaceLookup.java
+++ b/test/micro/org/openjdk/bench/java/net/NetworkInterfaceLookup.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
-@Fork(value = 2, jvmArgsAppend = "--add-opens=java.base/java.net=ALL-UNNAMED")
+@Fork(value = 2, jvmArgs = "--add-opens=java.base/java.net=ALL-UNNAMED")
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 public class NetworkInterfaceLookup {

--- a/test/micro/org/openjdk/bench/java/net/SocketChannelConnectionSetup.java
+++ b/test/micro/org/openjdk/bench/java/net/SocketChannelConnectionSetup.java
@@ -125,7 +125,7 @@ public class SocketChannelConnectionSetup {
 
         opt = new OptionsBuilder()
                 .include(org.openjdk.bench.java.net.SocketChannelConnectionSetup.class.getSimpleName())
-                .jvmArgsPrepend("-Djdk.net.useFastTcpLoopback=true")
+                .jvmArgs("-Djdk.net.useFastTcpLoopback=true")
                 .warmupForks(1)
                 .forks(2)
                 .build();

--- a/test/micro/org/openjdk/bench/java/net/SocketEventOverhead.java
+++ b/test/micro/org/openjdk/bench/java/net/SocketEventOverhead.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 public class SocketEventOverhead {
 
-    @Fork(value = 1, jvmArgsAppend = {
+    @Fork(value = 1, jvmArgs = {
         "--add-exports",
         "java.base/jdk.internal.event=ALL-UNNAMED" })
     @Benchmark
@@ -53,7 +53,7 @@ public class SocketEventOverhead {
         return fixture.write();
     }
 
-    @Fork(value = 1, jvmArgsAppend = {
+    @Fork(value = 1, jvmArgs = {
         "--add-exports",
         "java.base/jdk.internal.event=ALL-UNNAMED",
         "-XX:StartFlightRecording:jdk.SocketWrite#enabled=false"})
@@ -62,7 +62,7 @@ public class SocketEventOverhead {
         return fixture.write();
     }
 
-    @Fork(value = 1, jvmArgsAppend = {
+    @Fork(value = 1, jvmArgs = {
         "--add-exports",
         "java.base/jdk.internal.event=ALL-UNNAMED",
         "-XX:StartFlightRecording:jdk.SocketWrite#enabled=true,jdk.SocketWrite#threshold=1s"})
@@ -71,7 +71,7 @@ public class SocketEventOverhead {
         return fixture.write();
     }
 
-    @Fork(value = 1, jvmArgsAppend = {
+    @Fork(value = 1, jvmArgs = {
         "--add-exports","java.base/jdk.internal.event=ALL-UNNAMED",
         "-XX:StartFlightRecording:jdk.SocketWrite#enabled=true,jdk.SocketWrite#threshold=0ms,disk=false,jdk.SocketWrite#stackTrace=false"})
     @Benchmark
@@ -79,7 +79,7 @@ public class SocketEventOverhead {
         return fixture.write();
     }
 
-    @Fork(value = 1, jvmArgsAppend = {
+    @Fork(value = 1, jvmArgs = {
         "--add-exports",
         "java.base/jdk.internal.event=ALL-UNNAMED" })
     @Benchmark
@@ -87,7 +87,7 @@ public class SocketEventOverhead {
         return fixture.read();
     }
 
-    @Fork(value = 1, jvmArgsAppend = {
+    @Fork(value = 1, jvmArgs = {
         "--add-exports",
         "java.base/jdk.internal.event=ALL-UNNAMED",
         "-XX:StartFlightRecording:jdk.SocketRead#enabled=false"})
@@ -96,7 +96,7 @@ public class SocketEventOverhead {
         return fixture.read();
     }
 
-    @Fork(value = 1, jvmArgsAppend = {
+    @Fork(value = 1, jvmArgs = {
         "--add-exports",
         "java.base/jdk.internal.event=ALL-UNNAMED",
         "-XX:StartFlightRecording:jdk.SocketRead#enabled=true,jdk.SocketRead#threshold=1s"})
@@ -105,7 +105,7 @@ public class SocketEventOverhead {
         return fixture.read();
     }
 
-    @Fork(value = 1, jvmArgsAppend = {
+    @Fork(value = 1, jvmArgs = {
         "--add-exports","java.base/jdk.internal.event=ALL-UNNAMED",
         "-XX:StartFlightRecording:jdk.SocketRead#enabled=true,jdk.SocketRead#threshold=0ms,disk=false,jdk.SocketRead#stackTrace=false"})
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/net/ThreadLocalParseUtil.java
+++ b/test/micro/org/openjdk/bench/java/net/ThreadLocalParseUtil.java
@@ -48,7 +48,7 @@ import static java.lang.invoke.MethodType.methodType;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsAppend = "--add-exports=java.base/sun.net.www=ALL-UNNAMED")
+@Fork(value = 1, jvmArgs = "--add-exports=java.base/sun.net.www=ALL-UNNAMED")
 public class ThreadLocalParseUtil {
 
     private static final MethodHandle MH_DECODE;

--- a/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
+++ b/test/micro/org/openjdk/bench/java/security/AlgorithmConstraintsPermits.java
@@ -45,7 +45,7 @@ import static sun.security.util.DisabledAlgorithmConstraints.PROPERTY_TLS_DISABL
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)

--- a/test/micro/org/openjdk/bench/java/security/CacheBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CacheBench.java
@@ -44,7 +44,7 @@ import sun.security.util.Cache;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 public class CacheBench {

--- a/test/micro/org/openjdk/bench/java/security/CipherSuiteBench.java
+++ b/test/micro/org/openjdk/bench/java/security/CipherSuiteBench.java
@@ -30,7 +30,7 @@ import java.lang.reflect.Method;
 import java.util.concurrent.TimeUnit;
 
 
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.ssl=ALL-UNNAMED", "--add-opens", "java.base/sun.security.ssl=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports", "java.base/sun.security.ssl=ALL-UNNAMED", "--add-opens", "java.base/sun.security.ssl=ALL-UNNAMED"})
 @State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @BenchmarkMode(Mode.Throughput)

--- a/test/micro/org/openjdk/bench/java/security/HSS.java
+++ b/test/micro/org/openjdk/bench/java/security/HSS.java
@@ -55,7 +55,7 @@ import sun.security.util.RawKeySpec;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports", "java.base/sun.security.util=ALL-UNNAMED"})
 
 // Tests 1-2 are from RFC 8554, Appendix F.
 

--- a/test/micro/org/openjdk/bench/java/security/MessageDigests.java
+++ b/test/micro/org/openjdk/bench/java/security/MessageDigests.java
@@ -47,7 +47,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
+@Fork(jvmArgs = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
 public class MessageDigests {
 
     @Param({"64", "16384"})

--- a/test/micro/org/openjdk/bench/java/security/PKCS12KeyStores.java
+++ b/test/micro/org/openjdk/bench/java/security/PKCS12KeyStores.java
@@ -41,7 +41,7 @@ import org.openjdk.jmh.annotations.*;
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
 @BenchmarkMode(Mode.AverageTime)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
+@Fork(jvmArgs = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
 public class PKCS12KeyStores {
 
     private static final char[] PASS = "changeit".toCharArray();

--- a/test/micro/org/openjdk/bench/java/security/ProtectionDomainBench.java
+++ b/test/micro/org/openjdk/bench/java/security/ProtectionDomainBench.java
@@ -123,7 +123,7 @@ public class ProtectionDomainBench {
     }
 
     @Benchmark
-    @Fork(value = 3, jvmArgsPrepend={"-Djava.security.manager=allow"})
+    @Fork(value = 3, jvmArgs={"-Djava.security.manager=allow"})
     public void withSecurityManager()  throws ClassNotFoundException {
         work();
     }

--- a/test/micro/org/openjdk/bench/java/security/Signatures.java
+++ b/test/micro/org/openjdk/bench/java/security/Signatures.java
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
+@Fork(jvmArgs = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 3)
 public class Signatures {
     private static Signature signer;
 

--- a/test/micro/org/openjdk/bench/java/util/ArraysSort.java
+++ b/test/micro/org/openjdk/bench/java/util/ArraysSort.java
@@ -47,7 +47,7 @@ import java.lang.reflect.Method;
 /**
  * Performance test of Arrays.sort() methods
  */
-@Fork(value=1, jvmArgsAppend={"-XX:CompileThreshold=1", "-XX:-TieredCompilation"})
+@Fork(value=1, jvmArgs={"-XX:CompileThreshold=1", "-XX:-TieredCompilation"})
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/java/util/ListArgs.java
+++ b/test/micro/org/openjdk/bench/java/util/ListArgs.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
  */
 @State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = { "-verbose:gc", "-XX:+UseParallelGC", "-Xms4g", "-Xmx4g", "-Xint" })
+@Fork(value = 3, jvmArgs = { "-verbose:gc", "-XX:+UseParallelGC", "-Xms4g", "-Xmx4g", "-Xint" })
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 2, timeUnit = TimeUnit.SECONDS)
 public class ListArgs {

--- a/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
+++ b/test/micro/org/openjdk/bench/java/util/StringJoinerBenchmark.java
@@ -45,7 +45,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
+@Fork(value = 3, jvmArgs = {"-Xms1g", "-Xmx1g"})
 public class StringJoinerBenchmark {
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRPar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRPar.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherFMRPar {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRSeq.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherFMRSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapInfinitySeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapInfinitySeq.java
@@ -48,7 +48,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherFlatMapInfinitySeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapSeq.java
@@ -48,7 +48,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherFlatMapSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapPar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapPar.java
@@ -48,7 +48,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherMapPar {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapSeq.java
@@ -48,7 +48,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherMapSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscPar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscPar.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherMiscPar {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscSeq.java
@@ -51,7 +51,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherMiscSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReducePar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReducePar.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherReducePar {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReduceSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReduceSeq.java
@@ -51,7 +51,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherReduceSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherWhileOrdered.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherWhileOrdered.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgsAppend = "--enable-preview", value = 1)
+@Fork(jvmArgs = "--enable-preview", value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherWhileOrdered {

--- a/test/micro/org/openjdk/bench/javax/crypto/AES.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/AES.java
@@ -59,19 +59,19 @@ public class AES {
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend = {"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseAES", "-XX:-UseAESIntrinsics"})
+    @Fork(jvmArgs = {"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseAES", "-XX:-UseAESIntrinsics"})
     public byte[] testBaseline() throws Exception {
         return cipher.doFinal(src);
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAES", "-XX:-UseAESIntrinsics"})
+    @Fork(jvmArgs = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAES", "-XX:-UseAESIntrinsics"})
     public byte[] testUseAes() throws Exception {
         return cipher.doFinal(src);
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAES", "-XX:+UseAESIntrinsics"})
+    @Fork(jvmArgs = {"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseAES", "-XX:+UseAESIntrinsics"})
     public byte[] testUseAesIntrinsics() throws Exception {
         return cipher.doFinal(src);
     }

--- a/test/micro/org/openjdk/bench/javax/crypto/AESReinit.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/AESReinit.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-Xms1g", "-Xmx1g"})
+@Fork(value = 3, jvmArgs = {"-Xms1g", "-Xmx1g"})
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/javax/crypto/Crypto.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/Crypto.java
@@ -51,7 +51,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @Warmup(iterations = 5)
 @Measurement(iterations = 10)
-@Fork(jvmArgsAppend = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 5)
+@Fork(jvmArgs = {"-Xms1024m", "-Xmx1024m", "-Xmn768m", "-XX:+UseParallelGC"}, value = 5)
 public class Crypto {
 
     @Param({"64", "1024", "16384"})

--- a/test/micro/org/openjdk/bench/javax/crypto/full/CryptoBase.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/CryptoBase.java
@@ -45,7 +45,7 @@ import java.util.Random;
 import java.util.concurrent.TimeUnit;
 
 
-@Fork(jvmArgsAppend = {"-XX:+AlwaysPreTouch"}, value = 5)
+@Fork(jvmArgs = {"-XX:+AlwaysPreTouch"}, value = 5)
 @Warmup(iterations = 3, time = 3)
 @Measurement(iterations = 8, time = 2)
 @OutputTimeUnit(TimeUnit.SECONDS)

--- a/test/micro/org/openjdk/bench/javax/crypto/full/Poly1305DigestBench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/Poly1305DigestBench.java
@@ -41,7 +41,7 @@ import java.nio.ByteBuffer;
 
 @Measurement(iterations = 3, time = 10)
 @Warmup(iterations = 3, time = 10)
-@Fork(value = 1, jvmArgsAppend = {"--add-opens", "java.base/com.sun.crypto.provider=ALL-UNNAMED"})
+@Fork(value = 1, jvmArgs = {"--add-opens", "java.base/com.sun.crypto.provider=ALL-UNNAMED"})
 public class Poly1305DigestBench extends CryptoBase {
     public static final int SET_SIZE = 128;
 

--- a/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
+++ b/test/micro/org/openjdk/bench/javax/crypto/full/PolynomialP256Bench.java
@@ -40,7 +40,7 @@ import sun.security.util.math.intpoly.IntegerPolynomialP256;
 import sun.security.util.math.MutableIntegerModuloP;
 import sun.security.util.math.ImmutableIntegerModuloP;
 
-@Fork(jvmArgsAppend = {"-XX:+AlwaysPreTouch",
+@Fork(jvmArgs = {"-XX:+AlwaysPreTouch",
     "--add-exports", "java.base/sun.security.util.math.intpoly=ALL-UNNAMED",
     "--add-exports", "java.base/sun.security.util.math=ALL-UNNAMED"}, value = 1)
 @Warmup(iterations = 3, time = 3)

--- a/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/AbstractCorpusBenchmark.java
@@ -43,7 +43,7 @@ import org.openjdk.jmh.annotations.Warmup;
  */
 @Warmup(iterations = 2)
 @Measurement(iterations = 4)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED",
         "--enable-preview",

--- a/test/micro/org/openjdk/bench/jdk/classfile/ClassfileBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/ClassfileBenchmark.java
@@ -50,7 +50,7 @@ import org.openjdk.jmh.infra.Blackhole;
  */
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--enable-preview"})
 
 @State(Scope.Benchmark)

--- a/test/micro/org/openjdk/bench/jdk/classfile/CodeAttributeTools.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/CodeAttributeTools.java
@@ -55,7 +55,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--enable-preview",
         "--add-exports", "java.base/jdk.internal.classfile.impl=ALL-UNNAMED"})
 @Warmup(iterations = 2)

--- a/test/micro/org/openjdk/bench/jdk/classfile/ConstantPoolBuildingClassEntry.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/ConstantPoolBuildingClassEntry.java
@@ -43,7 +43,7 @@ import static org.openjdk.bench.jdk.classfile.TestConstants.*;
 @Measurement(iterations = 5)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @BenchmarkMode(Mode.Throughput)
-@Fork(value = 1, jvmArgsAppend = {"--enable-preview"})
+@Fork(value = 1, jvmArgs = {"--enable-preview"})
 @State(Scope.Benchmark)
 public class ConstantPoolBuildingClassEntry {
     // JDK-8338546

--- a/test/micro/org/openjdk/bench/jdk/classfile/RebuildMethodBodies.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/RebuildMethodBodies.java
@@ -37,7 +37,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--enable-preview"})
 @Warmup(iterations = 2)
 @Measurement(iterations = 4)

--- a/test/micro/org/openjdk/bench/jdk/classfile/RepeatedModelTraversal.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/RepeatedModelTraversal.java
@@ -36,7 +36,7 @@ import org.openjdk.jmh.annotations.*;
 
 @BenchmarkMode(Mode.Throughput)
 @State(Scope.Benchmark)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--enable-preview"})
 @Warmup(iterations = 3)
 @Measurement(iterations = 4)

--- a/test/micro/org/openjdk/bench/jdk/classfile/Write.java
+++ b/test/micro/org/openjdk/bench/jdk/classfile/Write.java
@@ -56,7 +56,7 @@ import static org.openjdk.bench.jdk.classfile.TestConstants.*;
  */
 @Warmup(iterations = 3)
 @Measurement(iterations = 5)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED",
         "--enable-preview",

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/ArrayMismatchBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/ArrayMismatchBenchmark.java
@@ -47,7 +47,7 @@ import java.util.random.RandomGenerator;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class ArrayMismatchBenchmark {
 
     @Param({"9", "257", "100000"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/BlackScholes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/BlackScholes.java
@@ -39,7 +39,7 @@ import java.util.function.IntUnaryOperator;
 @State(Scope.Thread)
 @Warmup(iterations = 3, time = 5)
 @Measurement(iterations = 3, time = 5)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class BlackScholes {
 
     @Param("1024")

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/ColumnFilterBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/ColumnFilterBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector", "-XX:UseAVX=2"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector", "-XX:UseAVX=2"})
 public class ColumnFilterBenchmark {
     @Param({"1024", "2047", "4096"})
     int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/EqualsIgnoreCaseBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/EqualsIgnoreCaseBenchmark.java
@@ -46,7 +46,7 @@ import static jdk.incubator.vector.VectorOperators.*;
 @State(Scope.Benchmark)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 3, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 3, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class EqualsIgnoreCaseBenchmark {
     static final VectorSpecies<Byte> SPECIES = ByteVector.SPECIES_PREFERRED;
     private byte[] a;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/GatherOperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/GatherOperationsBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class GatherOperationsBenchmark {
     @Param({"64", "256", "1024", "4096"})
     int SIZE;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexInRangeBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class IndexInRangeBenchmark {
     @Param({"7", "256", "259", "512"})
     private int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexVectorBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/IndexVectorBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class IndexVectorBenchmark {
     @Param({"1024"})
     private int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/LoadMaskedIOOBEBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/LoadMaskedIOOBEBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class LoadMaskedIOOBEBenchmark {
     @Param({"1026"})
     private int inSize;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskCastOperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskCastOperationsBenchmark.java
@@ -30,7 +30,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class MaskCastOperationsBenchmark {
     VectorMask<Byte> bmask64;
     VectorMask<Byte> bmask128;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskFromLongBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskFromLongBenchmark.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class MaskFromLongBenchmark {
     private static final int ITERATION = 20000;
 

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskQueryOperationsBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskQueryOperationsBenchmark.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class MaskQueryOperationsBenchmark {
     @Param({"128","256","512"})
     int bits;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskedLogicOpts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MaskedLogicOpts.java
@@ -32,7 +32,7 @@ import java.util.Random;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class MaskedLogicOpts {
     @Param({"256","512","1024"})
     private int ARRAYLEN;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/MemorySegmentVectorAccess.java
@@ -48,7 +48,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
     "--add-modules=jdk.incubator.vector",
     "--enable-native-access", "ALL-UNNAMED"})
 public class MemorySegmentVectorAccess {

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/RearrangeBytesBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/RearrangeBytesBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class RearrangeBytesBenchmark {
     @Param({"256", "512", "1024"})
     int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/RotateBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/RotateBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class RotateBenchmark {
     @Param({"256","512"})
     int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/SelectFromBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/SelectFromBenchmark.java
@@ -33,7 +33,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class SelectFromBenchmark {
     @Param({"1024","2048"})
     int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskTrueCount.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskTrueCount.java
@@ -30,7 +30,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class StoreMaskTrueCount {
     private static final VectorSpecies<Short> S_SPECIES = ShortVector.SPECIES_PREFERRED;
     private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_PREFERRED;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedBenchmark.java
@@ -32,7 +32,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class StoreMaskedBenchmark {
     @Param({"1024"})
     private int size;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedIOOBEBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/StoreMaskedIOOBEBenchmark.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.*;
 @State(Scope.Thread)
 @Warmup(iterations = 3, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(value = 1, jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class StoreMaskedIOOBEBenchmark {
     @Param({"1024"})
     private int inSize;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadSegmentVarious.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadSegmentVarious.java
@@ -46,7 +46,7 @@ import java.util.concurrent.TimeUnit;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
         "--add-modules=jdk.incubator.vector",
         "--enable-native-access", "ALL-UNNAMED"})
 public class TestLoadSegmentVarious {

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreBytes.java
@@ -47,7 +47,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
     "--add-modules=jdk.incubator.vector",
     "--enable-native-access", "ALL-UNNAMED",
     "-Djdk.incubator.vector.VECTOR_ACCESS_OOB_CHECK=1"})

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/TestLoadStoreShorts.java
@@ -50,7 +50,7 @@ import org.openjdk.jmh.annotations.Warmup;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(org.openjdk.jmh.annotations.Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 1, jvmArgsAppend = {
+@Fork(value = 1, jvmArgs = {
     "--add-modules=jdk.incubator.vector",
     "--enable-native-access", "ALL-UNNAMED"})
 public class TestLoadStoreShorts {

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorExtractBenchmark.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorExtractBenchmark.java
@@ -28,7 +28,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class VectorExtractBenchmark {
     private int idx = 0;
     private boolean[] res = new boolean[8];

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorFPtoIntCastOperations.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorFPtoIntCastOperations.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class VectorFPtoIntCastOperations {
     @Param({"512", "1024"})
     static int SIZE;

--- a/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorZeroExtend.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/vector/VectorZeroExtend.java
@@ -32,7 +32,7 @@ import static jdk.incubator.vector.VectorOperators.*;
 
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
-@Fork(jvmArgsPrepend = {"--add-modules=jdk.incubator.vector"})
+@Fork(jvmArgs = {"--add-modules=jdk.incubator.vector"})
 public class VectorZeroExtend {
     private static final VectorSpecies<Byte> B_SPECIES = ByteVector.SPECIES_PREFERRED;
     private static final VectorSpecies<Short> S_SPECIES = ShortVector.SPECIES_PREFERRED;

--- a/test/micro/org/openjdk/bench/jdk/preview/patterns/Exactness.java
+++ b/test/micro/org/openjdk/bench/jdk/preview/patterns/Exactness.java
@@ -35,7 +35,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations=5, time=1)
 @Threads(2)
 @Fork(value = 1,
-      jvmArgsPrepend = {"-Djmh.blackhole.mode=COMPILER",
+      jvmArgs = {"-Djmh.blackhole.mode=COMPILER",
                         "--enable-preview"})
 @State(Scope.Thread)
 @SuppressWarnings("preview")

--- a/test/micro/org/openjdk/bench/vm/compiler/AllocationMerges.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/AllocationMerges.java
@@ -1194,7 +1194,7 @@ public abstract class AllocationMerges {
 
     // ------------------ Utility for Benchmarking ------------------- //
 
-    @Fork(value = 3, jvmArgsPrepend = {
+    @Fork(value = 3, jvmArgs = {
         "-XX:+UnlockDiagnosticVMOptions",
         "-XX:+UseTLAB",
         "-XX:-ReduceAllocationMerges",
@@ -1202,7 +1202,7 @@ public abstract class AllocationMerges {
     public static class NopRAM extends AllocationMerges {
     }
 
-    @Fork(value = 3, jvmArgsPrepend = {
+    @Fork(value = 3, jvmArgs = {
         "-XX:+UnlockDiagnosticVMOptions",
         "-XX:+ReduceAllocationMerges",
     })

--- a/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ClearMemory.java
@@ -38,7 +38,7 @@ import org.openjdk.jmh.infra.Blackhole;
 
 import java.util.concurrent.TimeUnit;
 
-@Fork(value = 3, jvmArgsPrepend = {"-XX:-EliminateAllocations", "-XX:-DoEscapeAnalysis"})
+@Fork(value = 3, jvmArgs = {"-XX:-EliminateAllocations", "-XX:-DoEscapeAnalysis"})
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/vm/compiler/ConstructorBarriers.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/ConstructorBarriers.java
@@ -41,7 +41,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-Xms512m", "-Xmx512m", "-XX:+AlwaysPreTouch", "-XX:+UseParallelGC"})
+@Fork(value = 3, jvmArgs = {"-Xms512m", "-Xmx512m", "-XX:+AlwaysPreTouch", "-XX:+UseParallelGC"})
 public class ConstructorBarriers {
 
     // Checks the barrier coalescing/optimization around field initializations.

--- a/test/micro/org/openjdk/bench/vm/compiler/InterfacePrivateCalls.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/InterfacePrivateCalls.java
@@ -64,7 +64,7 @@ public class InterfacePrivateCalls {
     @Benchmark
     @BenchmarkMode(Mode.AverageTime)
     @OutputTimeUnit(TimeUnit.NANOSECONDS)
-    @Fork(value=3, jvmArgsAppend={"-XX:TieredStopAtLevel=1"})
+    @Fork(value=3, jvmArgs={"-XX:TieredStopAtLevel=1"})
     public void invokePrivateInterfaceMethodC1() {
         for (int i = 0; i < objs.length; ++i) {
             objs[i].foo();

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStoreBench.java
@@ -43,7 +43,7 @@ import jdk.internal.misc.Unsafe;
 @State(Scope.Thread)
 @Warmup(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 5, time = 1000, timeUnit = TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = {"--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED"})
 public class MergeStoreBench {
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
 

--- a/test/micro/org/openjdk/bench/vm/compiler/MergeStores.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/MergeStores.java
@@ -43,7 +43,7 @@ import java.util.concurrent.TimeUnit;
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Warmup(iterations = 3, time = 3)
 @Measurement(iterations = 3, time = 3)
-@Fork(value = 3, jvmArgsAppend = {
+@Fork(value = 3, jvmArgs = {
         "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED",
         "--add-exports", "java.base/jdk.internal.util=ALL-UNNAMED"})
 @State(Scope.Benchmark)

--- a/test/micro/org/openjdk/bench/vm/compiler/SecondarySuperCacheHits.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/SecondarySuperCacheHits.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 5, time = 300, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 5, time = 300, timeUnit = TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1"})
+@Fork(value = 3, jvmArgs = {"-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1"})
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Threads(1)

--- a/test/micro/org/openjdk/bench/vm/compiler/SecondarySuperCacheInterContention.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/SecondarySuperCacheInterContention.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 5, time = 300, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 5, time = 300, timeUnit = TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1"})
+@Fork(value = 3, jvmArgs = {"-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1"})
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Threads(Threads.MAX)

--- a/test/micro/org/openjdk/bench/vm/compiler/SecondarySuperCacheIntraContention.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/SecondarySuperCacheIntraContention.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 5, time = 300, timeUnit = TimeUnit.MILLISECONDS)
 @Measurement(iterations = 5, time = 300, timeUnit = TimeUnit.MILLISECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1"})
+@Fork(value = 3, jvmArgs = {"-XX:+TieredCompilation", "-XX:TieredStopAtLevel=1"})
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @Threads(Threads.MAX)

--- a/test/micro/org/openjdk/bench/vm/compiler/SubIdealC0Minus_YPlusC1_.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/SubIdealC0Minus_YPlusC1_.java
@@ -47,7 +47,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3 , jvmArgsAppend = {"-XX:-TieredCompilation", "-Xbatch", "-Xcomp"})
+@Fork(value = 3 , jvmArgs = {"-XX:-TieredCompilation", "-Xbatch", "-Xcomp"})
 public class SubIdealC0Minus_YPlusC1_ {
 
     private static final int I_C0 = 1234567;

--- a/test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/TypeVectorOperations.java
@@ -382,7 +382,7 @@ public abstract class TypeVectorOperations {
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
+    @Fork(jvmArgs = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
     public void cmoveD() {
         for (int i = 0; i < COUNT; i++) {
             resD[i] = resD[i] < doubles[i] ? resD[i] : doubles[i];
@@ -390,21 +390,21 @@ public abstract class TypeVectorOperations {
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
+    @Fork(jvmArgs = {"-XX:+UseCMoveUnconditionally", "-XX:+UseVectorCmov"})
     public void cmoveF() {
         for (int i = 0; i < COUNT; i++) {
             resF[i] = resF[i] < floats[i] ? resF[i] : floats[i];
         }
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:+UseSuperWord"
     })
     public static class TypeVectorOperationsSuperWord extends TypeVectorOperations {
 
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:-UseSuperWord"
     })
     public static class TypeVectorOperationsNonSuperWord extends TypeVectorOperations {

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorAlignment.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorAlignment.java
@@ -293,22 +293,22 @@ public abstract class VectorAlignment {
         }
     }
 
-    @Fork(value = 1, jvmArgsPrepend = {
+    @Fork(value = 1, jvmArgs = {
         "-XX:+UseSuperWord", "-XX:CompileCommand=Option,*::*,Vectorize"
     })
     public static class VectorAlignmentSuperWordWithVectorize extends VectorAlignment {}
 
-    @Fork(value = 1, jvmArgsPrepend = {
+    @Fork(value = 1, jvmArgs = {
         "-XX:+UseSuperWord", "-XX:+AlignVector"
     })
     public static class VectorAlignmentSuperWordAlignVector extends VectorAlignment {}
 
-    @Fork(value = 1, jvmArgsPrepend = {
+    @Fork(value = 1, jvmArgs = {
         "-XX:+UseSuperWord"
     })
     public static class VectorAlignmentSuperWord extends VectorAlignment {}
 
-    @Fork(value = 1, jvmArgsPrepend = {
+    @Fork(value = 1, jvmArgs = {
         "-XX:-UseSuperWord"
     })
     public static class VectorAlignmentNoSuperWord extends VectorAlignment {}

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorBitCount.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorBitCount.java
@@ -72,14 +72,14 @@ public abstract class VectorBitCount {
     }
 
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:+UseSuperWord"
     })
     public static class WithSuperword extends VectorBitCount {
 
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:-UseSuperWord"
     })
     public static class NoSuperword extends VectorBitCount {

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorLoadToStoreForwarding.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorLoadToStoreForwarding.java
@@ -200,12 +200,12 @@ public abstract class VectorLoadToStoreForwarding {
         }
     }
 
-    @Fork(value = 1, jvmArgsPrepend = {
+    @Fork(value = 1, jvmArgs = {
         "-XX:+UseSuperWord"
     })
     public static class VectorLoadToStoreForwardingSuperWord extends VectorLoadToStoreForwarding {}
 
-    @Fork(value = 1, jvmArgsPrepend = {
+    @Fork(value = 1, jvmArgs = {
         "-XX:-UseSuperWord"
     })
     public static class VectorLoadToStoreForwardingNoSuperWord extends VectorLoadToStoreForwarding {}

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorReduction.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorReduction.java
@@ -176,14 +176,14 @@ public abstract class VectorReduction {
         }
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:+UseSuperWord"
     })
     public static class WithSuperword extends VectorReduction {
 
     }
 
-    @Fork(value = 2, jvmArgsPrepend = {
+    @Fork(value = 2, jvmArgs = {
         "-XX:-UseSuperWord"
     })
     public static class NoSuperword extends VectorReduction {

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorReduction2.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorReduction2.java
@@ -1445,10 +1445,10 @@ public abstract class VectorReduction2 {
         bh.consume(acc);
     }
 
-    @Fork(value = 1, jvmArgsPrepend = {"-XX:+UseSuperWord"})
+    @Fork(value = 1, jvmArgs = {"-XX:+UseSuperWord"})
     public static class WithSuperword extends VectorReduction2 {}
 
-    @Fork(value = 1, jvmArgsPrepend = {"-XX:-UseSuperWord"})
+    @Fork(value = 1, jvmArgs = {"-XX:-UseSuperWord"})
     public static class NoSuperword extends VectorReduction2 {}
 }
 

--- a/test/micro/org/openjdk/bench/vm/compiler/VectorReductionFloatingMinMax.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/VectorReductionFloatingMinMax.java
@@ -69,7 +69,7 @@ public class VectorReductionFloatingMinMax {
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:-SuperWordLoopUnrollAnalysis"})
+    @Fork(jvmArgs = {"-XX:-SuperWordLoopUnrollAnalysis"})
     public void maxRedF(Blackhole bh) {
         float max = 0.0f;
         for (int i = 0; i < COUNT_FLOAT; i++) {
@@ -79,7 +79,7 @@ public class VectorReductionFloatingMinMax {
     }
 
     @Benchmark
-    @Fork(jvmArgsPrepend = {"-XX:-SuperWordLoopUnrollAnalysis"})
+    @Fork(jvmArgs = {"-XX:-SuperWordLoopUnrollAnalysis"})
     public void minRedF(Blackhole bh) {
         float min = 0.0f;
         for (int i = 0; i < COUNT_FLOAT; i++) {

--- a/test/micro/org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.java
@@ -52,25 +52,25 @@ public class SimpleRepeatCompilation {
      = "-XX:CompileCommand=option,org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.mixHashCode,intx,RepeatCompilation,500";
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", MIXHASH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", MIXHASH_METHOD})
     public int mixHashCode_repeat() {
         return loop_hashCode();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:-TieredCompilation", MIXHASH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:-TieredCompilation", MIXHASH_METHOD})
     public int mixHashCode_repeat_c2() {
         return loop_hashCode();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:TieredStopAtLevel=1", MIXHASH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:TieredStopAtLevel=1", MIXHASH_METHOD})
     public int mixHashCode_repeat_c1() {
         return loop_hashCode();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch"})
+    @Fork(jvmArgs={"-Xbatch"})
     public int mixHashCode_baseline() {
         return loop_hashCode();
     }
@@ -95,25 +95,25 @@ public class SimpleRepeatCompilation {
      = "-XX:CompileCommand=option,org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.trivialMath,intx,RepeatCompilation,2000";
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch",TRIVIAL_MATH_METHOD})
+    @Fork(jvmArgs={"-Xbatch",TRIVIAL_MATH_METHOD})
     public int trivialMath_repeat() {
         return loop_trivialMath();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:-TieredCompilation", TRIVIAL_MATH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:-TieredCompilation", TRIVIAL_MATH_METHOD})
     public int trivialMath_repeat_c2() {
         return loop_trivialMath();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:TieredStopAtLevel=1", TRIVIAL_MATH_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:TieredStopAtLevel=1", TRIVIAL_MATH_METHOD})
     public int trivialMath_repeat_c1() {
         return loop_trivialMath();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch"})
+    @Fork(jvmArgs={"-Xbatch"})
     public int trivialMath_baseline() {
         return loop_trivialMath();
     }
@@ -135,25 +135,25 @@ public class SimpleRepeatCompilation {
      = "-XX:CompileCommand=option,org/openjdk/bench/vm/compiler/overhead/SimpleRepeatCompilation.largeMethod,intx,RepeatCompilation,100";
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch",LARGE_METHOD})
+    @Fork(jvmArgs={"-Xbatch",LARGE_METHOD})
     public int largeMethod_repeat() {
         return loop_largeMethod();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:-TieredCompilation", LARGE_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:-TieredCompilation", LARGE_METHOD})
     public int largeMethod_repeat_c2() {
         return loop_largeMethod();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch", "-XX:TieredStopAtLevel=1", LARGE_METHOD})
+    @Fork(jvmArgs={"-Xbatch", "-XX:TieredStopAtLevel=1", LARGE_METHOD})
     public int largeMethod_repeat_c1() {
         return loop_largeMethod();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-Xbatch"})
+    @Fork(jvmArgs={"-Xbatch"})
     public int largeMethod_baseline() {
         return loop_largeMethod();
     }

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/BasicRules.java
@@ -31,7 +31,7 @@ import java.util.Random;
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)
-@Fork(value = 3, jvmArgsAppend = "-XX:-UseSuperWord")
+@Fork(value = 3, jvmArgs = "-XX:-UseSuperWord")
 @Warmup(time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(time = 1, timeUnit = TimeUnit.SECONDS)
 public class BasicRules {

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/ConvertF2I.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/ConvertF2I.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
 @State(Scope.Thread)
 @Warmup(iterations = 5, time = 1)
 @Measurement(iterations = 5, time = 1)
-@Fork(value = 1, jvmArgsAppend = {"-XX:-UseSuperWord"})
+@Fork(value = 1, jvmArgs = {"-XX:-UseSuperWord"})
 public class ConvertF2I {
     static final int LENGTH = 1000;
     int[] intArray = new int[LENGTH];

--- a/test/micro/org/openjdk/bench/vm/compiler/x86/LeaInstruction.java
+++ b/test/micro/org/openjdk/bench/vm/compiler/x86/LeaInstruction.java
@@ -29,7 +29,7 @@ import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 2, jvmArgsAppend = {"-XX:LoopUnrollLimit=1"})
+@Fork(value = 2, jvmArgs = {"-XX:LoopUnrollLimit=1"})
 @Warmup(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 4, time = 2, timeUnit = TimeUnit.SECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/vm/fences/SafePublishing.java
+++ b/test/micro/org/openjdk/bench/vm/fences/SafePublishing.java
@@ -30,7 +30,7 @@ import java.util.concurrent.TimeUnit;
 
 @Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
-@Fork(value = 3, jvmArgsAppend = {"-XX:+UseParallelGC", "-Xmx128m"})
+@Fork(value = 3, jvmArgs = {"-XX:+UseParallelGC", "-Xmx128m"})
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
 @State(Scope.Thread)

--- a/test/micro/org/openjdk/bench/vm/gc/MicroLargePages.java
+++ b/test/micro/org/openjdk/bench/vm/gc/MicroLargePages.java
@@ -29,7 +29,7 @@ import org.openjdk.jmh.annotations.*;
 
 @OutputTimeUnit(TimeUnit.MINUTES)
 @State(Scope.Thread)
-@Fork(jvmArgsAppend = {"-Xmx256m", "-XX:+UseLargePages", "-XX:LargePageSizeInBytes=1g", "-Xlog:pagesize"}, value = 5)
+@Fork(jvmArgs = {"-Xmx256m", "-XX:+UseLargePages", "-XX:LargePageSizeInBytes=1g", "-Xlog:pagesize"}, value = 5)
 
 public class MicroLargePages {
 

--- a/test/micro/org/openjdk/bench/vm/gc/RawAllocationRate.java
+++ b/test/micro/org/openjdk/bench/vm/gc/RawAllocationRate.java
@@ -80,7 +80,7 @@ public class RawAllocationRate {
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:TieredStopAtLevel=1"})
+    @Fork(jvmArgs={"-XX:TieredStopAtLevel=1"})
     public Object[] arrayTest_C1() {
         return arrayTest();
     }
@@ -106,7 +106,7 @@ public class RawAllocationRate {
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:TieredStopAtLevel=1"})
+    @Fork(jvmArgs={"-XX:TieredStopAtLevel=1"})
     public Object[] instanceTest_C1() {
         return instanceTest();
     }

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/AllDead.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/AllDead.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class AllDead {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/AllLive.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class AllLive {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesArray.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesArray.java
@@ -35,7 +35,7 @@ import org.openjdk.jmh.annotations.State;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class DifferentObjectSizesArray {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesHashMap.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesHashMap.java
@@ -36,7 +36,7 @@ import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class DifferentObjectSizesHashMap {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesTreeMap.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/DifferentObjectSizesTreeMap.java
@@ -36,7 +36,7 @@ import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class DifferentObjectSizesTreeMap {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadFirstPart.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadFirstPart.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class HalfDeadFirstPart {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleaved.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleaved.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class HalfDeadInterleaved {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleavedChunks.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadInterleavedChunks.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class HalfDeadInterleavedChunks {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfDeadSecondPart.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class HalfDeadSecondPart {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfHashedHalfDead.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/HalfHashedHalfDead.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class HalfHashedHalfDead {

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/NoObjects.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/NoObjects.java
@@ -31,7 +31,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 public class NoObjects {
 

--- a/test/micro/org/openjdk/bench/vm/gc/systemgc/OneBigObject.java
+++ b/test/micro/org/openjdk/bench/vm/gc/systemgc/OneBigObject.java
@@ -35,7 +35,7 @@ import org.openjdk.jmh.annotations.State;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SingleShotTime)
-@Fork(value=25, jvmArgsAppend={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
+@Fork(value=25, jvmArgs={"-Xmx5g", "-Xms5g", "-Xmn3g", "-XX:+AlwaysPreTouch"})
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 public class OneBigObject {

--- a/test/micro/org/openjdk/bench/vm/lang/TypePollution.java
+++ b/test/micro/org/openjdk/bench/vm/lang/TypePollution.java
@@ -105,28 +105,28 @@ public class TypePollution {
     int probe = 99;
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
+    @Fork(jvmArgs={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public long parallelInstanceOfInterfaceSwitchLinearNoSCC() {
         return parallelInstanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
+    @Fork(jvmArgs={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public long parallelInstanceOfInterfaceSwitchLinearSCC() {
         return parallelInstanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
+    @Fork(jvmArgs={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public long parallelInstanceOfInterfaceSwitchTableNoSCC() {
         return parallelInstanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
+    @Fork(jvmArgs={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
     @OutputTimeUnit(TimeUnit.MILLISECONDS)
     public long parallelInstanceOfInterfaceSwitchTableSCC() {
         return parallelInstanceOfInterfaceSwitch();
@@ -149,25 +149,25 @@ public class TypePollution {
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
+    @Fork(jvmArgs={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
     public int instanceOfInterfaceSwitchLinearNoSCC() {
         return instanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
+    @Fork(jvmArgs={"-XX:+UnlockDiagnosticVMOptions", "-XX:-UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
     public int instanceOfInterfaceSwitchLinearSCC() {
         return instanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
+    @Fork(jvmArgs={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:-UseSecondarySupersCache"})
     public int instanceOfInterfaceSwitchTableNoSCC() {
         return instanceOfInterfaceSwitch();
     }
 
     @Benchmark
-    @Fork(jvmArgsAppend={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
+    @Fork(jvmArgs={"-XX:+UnlockDiagnosticVMOptions", "-XX:+UseSecondarySupersTable", "-XX:+UseSecondarySupersCache"})
     public int instanceOfInterfaceSwitchTableSCC() {
         return instanceOfInterfaceSwitch();
     }

--- a/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark.java
@@ -243,12 +243,12 @@ public abstract class NMTBenchmark {
   public static final String ADD_EXPORTS = "--add-exports";
   public static final String MISC_PACKAGE = "java.base/jdk.internal.misc=ALL-UNNAMED"; // used for Unsafe API
 
-  @Fork(value = 2, jvmArgsPrepend = { "-XX:NativeMemoryTracking=off", ADD_EXPORTS, MISC_PACKAGE})
+  @Fork(value = 2, jvmArgs = { "-XX:NativeMemoryTracking=off", ADD_EXPORTS, MISC_PACKAGE})
   public static class NMTOff extends NMTBenchmark { }
 
-  @Fork(value = 2, jvmArgsPrepend = { "-XX:NativeMemoryTracking=summary", ADD_EXPORTS, MISC_PACKAGE})
+  @Fork(value = 2, jvmArgs = { "-XX:NativeMemoryTracking=summary", ADD_EXPORTS, MISC_PACKAGE})
   public static class NMTSummary extends NMTBenchmark { }
 
-  @Fork(value = 2, jvmArgsPrepend = { "-XX:NativeMemoryTracking=detail", ADD_EXPORTS, MISC_PACKAGE})
+  @Fork(value = 2, jvmArgs = { "-XX:NativeMemoryTracking=detail", ADD_EXPORTS, MISC_PACKAGE})
   public static class NMTDetail extends NMTBenchmark { }
 }

--- a/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark_wb.java
+++ b/test/micro/org/openjdk/bench/vm/runtime/NMTBenchmark_wb.java
@@ -137,13 +137,13 @@ public abstract class NMTBenchmark_wb {
 
     public static final String WB_JAR_APPEND = "-Xbootclasspath/a:lib-test/wb.jar";
 
-    @Fork(value = 2, jvmArgsPrepend = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=off"})
+    @Fork(value = 2, jvmArgs = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=off"})
     public static class NMTOff extends NMTBenchmark_wb { }
 
-    @Fork(value = 2, jvmArgsPrepend = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=summary"})
+    @Fork(value = 2, jvmArgs = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=summary"})
     public static class NMTSummary extends NMTBenchmark_wb { }
 
-    // @Fork(value = 2, jvmArgsPrepend = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=detail"})
+    // @Fork(value = 2, jvmArgs = { WB_JAR_APPEND, WB_UNLOCK_OPTION, WB_API, ADD_EXPORTS, MISC_PACKAGE, "-XX:NativeMemoryTracking=detail"})
     // public static class NMTDetail extends NMTBenchmark_wb { }
 
 }


### PR DESCRIPTION
Many OpenJDK micros use `@Fork(jvmArgs/-Append/-Prepend)` to add JVM reasonable or necessary flags, but when deploying and running micros we often want to add or replace flags to tune to the machine, test different GCs, etc. The inconsistent use of the different `jvmArgs` options make it error prone, and we've had a few recent cases where we've not been testing with the expected set of flags. 

This PR suggests using `jvmArgs` consistently. I think this aligns with the intuition that when you use `jvmArgsAppend/-Prepend` intent is to add to a set of existing flags, while if you supply `jvmArgs` intent is "run with these and nothing else". Perhaps there are other opinions/preferences, and I don't feel strongly about which to consolidate to as long as we do so consistently. One argument could be made to consolidate on `jvmArgsAppend` since that one is (likely accidentally) the current most popular (143 compared to 59 `jvmArgsPrepend` and 18 `jvmArgs`).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342958](https://bugs.openjdk.org/browse/JDK-8342958): Use jvmArgs consistently in microbenchmarks (**Enhancement** - P4)


### Reviewers
 * [Eric Caspole](https://openjdk.org/census#ecaspole) (@ericcaspole - Committer)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21683/head:pull/21683` \
`$ git checkout pull/21683`

Update a local copy of the PR: \
`$ git checkout pull/21683` \
`$ git pull https://git.openjdk.org/jdk.git pull/21683/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21683`

View PR using the GUI difftool: \
`$ git pr show -t 21683`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21683.diff">https://git.openjdk.org/jdk/pull/21683.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21683#issuecomment-2435372202)