### PR TITLE
8342823: Ubsan: ciEnv.cpp:1614:65: runtime error: member call on null pointer of type 'struct CompileTask'

### DIFF
--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1611,7 +1611,9 @@ void ciEnv::dump_replay_data_helper(outputStream* out) {
 
   // The very first entry is the InstanceKlass of the root method of the current compilation in order to get the right
   // protection domain to load subsequent classes during replay compilation.
-  ciInstanceKlass::dump_replay_instanceKlass(out, task()->method()->method_holder());
+  if (this->task() != nullptr) {
+    ciInstanceKlass::dump_replay_instanceKlass(out, task()->method()->method_holder());
+  }
 
   for (int i = 0; i < objects->length(); i++) {
     objects->at(i)->dump_replay_data(out);

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1597,6 +1597,10 @@ void ciEnv::dump_replay_data_helper(outputStream* out) {
   NoSafepointVerifier no_safepoint;
   ResourceMark rm;
 
+  if (this->task() == nullptr) {
+    return;
+  }
+
   dump_replay_data_version(out);
 #if INCLUDE_JVMTI
   out->print_cr("JvmtiExport can_access_local_variables %d",     _jvmti_can_access_local_variables);
@@ -1611,17 +1615,13 @@ void ciEnv::dump_replay_data_helper(outputStream* out) {
 
   // The very first entry is the InstanceKlass of the root method of the current compilation in order to get the right
   // protection domain to load subsequent classes during replay compilation.
-  if (this->task() != nullptr) {
-    ciInstanceKlass::dump_replay_instanceKlass(out, task()->method()->method_holder());
-  }
+  ciInstanceKlass::dump_replay_instanceKlass(out, task()->method()->method_holder());
 
   for (int i = 0; i < objects->length(); i++) {
     objects->at(i)->dump_replay_data(out);
   }
 
-  if (this->task() != nullptr) {
-    dump_compile_data(out);
-  }
+  dump_compile_data(out);
   out->flush();
 }
 

--- a/src/hotspot/share/ci/ciEnv.cpp
+++ b/src/hotspot/share/ci/ciEnv.cpp
@@ -1597,9 +1597,7 @@ void ciEnv::dump_replay_data_helper(outputStream* out) {
   NoSafepointVerifier no_safepoint;
   ResourceMark rm;
 
-  if (this->task() == nullptr) {
-    return;
-  }
+  assert(this->task() != nullptr, "task must not be null");
 
   dump_replay_data_version(out);
 #if INCLUDE_JVMTI

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1862,7 +1862,7 @@ void VMError::report_and_die(int id, const char* message, const char* detail_fmt
   if (DumpReplayDataOnError && _thread && _thread->is_Compiler_thread() && !skip_replay) {
     skip_replay = true;
     ciEnv* env = ciEnv::current();
-    if (env != nullptr) {
+    if (env != nullptr && env->task() != nullptr) {
       const bool overwrite = false; // We do not overwrite an existing replay file.
       int fd = prepare_log_file(ReplayDataFile, "replay_pid%p.log", overwrite, buffer, sizeof(buffer));
       if (fd != -1) {


### PR DESCRIPTION
When running with ubsanized binaries on Linux x86_64,
hs jtreg test compiler/startup/StartupOutput.java
showed this issue

jdk/src/hotspot/share/ci/ciEnv.cpp:1614:65: runtime error: member call on null pointer of type 'struct CompileTask'
    #0 0x7fcea0810117 in ciEnv::dump_replay_data_helper(outputStream*) src/hotspot/share/ci/ciEnv.cpp:1614
    #1 0x7fcea3123577 in VMError::report_and_die(int, char const*, char const*, __va_list_tag*, Thread*, unsigned char*, void*, void*, char const*, int, unsigned long) src/hotspot/share/utilities/vmError.cpp:1872
    #2 0x7fcea0c01499 in report_fatal(VMErrorType, char const*, int, char const*, ...) src/hotspot/share/utilities/debug.cpp:214
    #3 0x7fcea09e9d85 in RuntimeStub::new_runtime_stub(char const*, CodeBuffer*, short, int, OopMapSet*, bool, bool) src/hotspot/share/code/codeBlob.cpp:413
    #4 0x7fcea066da1d in Runtime1::generate_blob(BufferBlob*, C1StubId, char const*, bool, StubAssemblerCodeGenClosure*) src/hotspot/share/c1/c1_Runtime1.cpp:233
    #5 0x7fcea066dfb0 in Runtime1::generate_blob_for(BufferBlob*, C1StubId) src/hotspot/share/c1/c1_Runtime1.cpp:262
    #6 0x7fcea066dfb0 in Runtime1::initialize(BufferBlob*) src/hotspot/share/c1/c1_Runtime1.cpp:272
    #7 0x7fcea03d2be1 in Compiler::init_c1_runtime() src/hotspot/share/c1/c1_Compiler.cpp:53
    #8 0x7fcea03d2be1 in Compiler::initialize() src/hotspot/share/c1/c1_Compiler.cpp:74
    #9 0x7fcea0acc0c2 in CompileBroker::init_compiler_runtime() src/hotspot/share/compiler/compileBroker.cpp:1771
    #10 0x7fcea0ad9a3f in CompileBroker::compiler_thread_loop() src/hotspot/share/compiler/compileBroker.cpp:1913
    #11 0x7fcea161264a in JavaThread::thread_main_inner() src/hotspot/share/runtime/javaThread.cpp:759
    #12 0x7fcea2ec739a in Thread::call_run() src/hotspot/share/runtime/thread.cpp:234
    #13 0x7fcea251e1d2 in thread_native_entry src/hotspot/os/linux/os_linux.cpp:858
    #14 0x7fcea7c6c6e9 in start_thread (/lib64/libpthread.so.0+0xa6e9) (BuildId: 1b515766201d47a183932ba0c8c8bd0d9ee8755b)
    #15 0x7fcea730f58e in clone (/lib64/libc.so.6+0x11858e) (BuildId: 448a3ddd22596e1adb8fb3dec8921ed5b9d54dc2)

So a nullptr check should be better added .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342823](https://bugs.openjdk.org/browse/JDK-8342823): Ubsan: ciEnv.cpp:1614:65: runtime error: member call on null pointer of type 'struct CompileTask' (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21684/head:pull/21684` \
`$ git checkout pull/21684`

Update a local copy of the PR: \
`$ git checkout pull/21684` \
`$ git pull https://git.openjdk.org/jdk.git pull/21684/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21684`

View PR using the GUI difftool: \
`$ git pr show -t 21684`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21684.diff">https://git.openjdk.org/jdk/pull/21684.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21684#issuecomment-2435398133)