### PR TITLE
8342707: Prepare Gatherers for graduation from Preview

### DIFF
--- a/src/java.base/share/classes/java/util/stream/Gatherer.java
+++ b/src/java.base/share/classes/java/util/stream/Gatherer.java
@@ -24,7 +24,6 @@
  */
 package java.util.stream;
 
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.vm.annotation.ForceInline;
 
 import java.util.*;
@@ -197,7 +196,6 @@ import java.util.function.Supplier;
  * @param <R> the type of output elements from the gatherer operation
  * @since 24
  */
-@PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
 public interface Gatherer<T, A, R> {
     /**
      * A function that produces an instance of the intermediate state used for
@@ -484,7 +482,6 @@ public interface Gatherer<T, A, R> {
      * @since 24
      */
     @FunctionalInterface
-    @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
     interface Downstream<T> {
 
         /**
@@ -527,7 +524,6 @@ public interface Gatherer<T, A, R> {
      * @since 24
      */
     @FunctionalInterface
-    @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
     interface Integrator<A, T, R> {
         /**
          * Performs an action given: the current state, the next element, and
@@ -587,7 +583,6 @@ public interface Gatherer<T, A, R> {
          * @since 24
          */
         @FunctionalInterface
-        @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
         interface Greedy<A, T, R> extends Integrator<A, T, R> { }
     }
 }

--- a/src/java.base/share/classes/java/util/stream/Gatherer.java
+++ b/src/java.base/share/classes/java/util/stream/Gatherer.java
@@ -195,7 +195,7 @@ import java.util.function.Supplier;
  * @param <A> the potentially mutable state type of the gatherer operation
  *            (often hidden as an implementation detail)
  * @param <R> the type of output elements from the gatherer operation
- * @since 22
+ * @since 24
  */
 @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
 public interface Gatherer<T, A, R> {
@@ -481,7 +481,7 @@ public interface Gatherer<T, A, R> {
      * A Downstream object is the next stage in a pipeline of operations,
      * to which elements can be sent.
      * @param <T> the type of elements this downstream accepts
-     * @since 22
+     * @since 24
      */
     @FunctionalInterface
     @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
@@ -524,7 +524,7 @@ public interface Gatherer<T, A, R> {
      * @param <A> the type of state used by this integrator
      * @param <T> the type of elements this integrator consumes
      * @param <R> the type of results this integrator can produce
-     * @since 22
+     * @since 24
      */
     @FunctionalInterface
     @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
@@ -584,7 +584,7 @@ public interface Gatherer<T, A, R> {
          * @param <A> the type of state used by this integrator
          * @param <T> the type of elements this greedy integrator receives
          * @param <R> the type of results this greedy integrator can produce
-         * @since 22
+         * @since 24
          */
         @FunctionalInterface
         @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)

--- a/src/java.base/share/classes/java/util/stream/GathererOp.java
+++ b/src/java.base/share/classes/java/util/stream/GathererOp.java
@@ -45,7 +45,7 @@ import java.util.stream.Gatherer.Integrator;
  * The performance-critical code below contains some more complicated encodings:
  * therefore, make sure to run benchmarks to verify changes to prevent regressions.
  *
- * @since 22
+ * @since 24
  */
 final class GathererOp<T, A, R> extends ReferencePipeline<T, R> {
     @SuppressWarnings("unchecked")

--- a/src/java.base/share/classes/java/util/stream/Gatherers.java
+++ b/src/java.base/share/classes/java/util/stream/Gatherers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/java/util/stream/Gatherers.java
+++ b/src/java.base/share/classes/java/util/stream/Gatherers.java
@@ -25,7 +25,6 @@
 package java.util.stream;
 
 import jdk.internal.access.SharedSecrets;
-import jdk.internal.javac.PreviewFeature;
 import jdk.internal.vm.annotation.ForceInline;
 
 import java.util.ArrayDeque;
@@ -50,7 +49,6 @@ import java.util.stream.Gatherer.Downstream;
  *
  * @since 24
 */
-@PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
 public final class Gatherers {
     private Gatherers() { } // This class is not intended to be instantiated
 

--- a/src/java.base/share/classes/java/util/stream/Gatherers.java
+++ b/src/java.base/share/classes/java/util/stream/Gatherers.java
@@ -48,7 +48,7 @@ import java.util.stream.Gatherer.Downstream;
  * operations, such as windowing functions, folding functions,
  * transforming elements concurrently, etc.
  *
- * @since 22
+ * @since 24
 */
 @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
 public final class Gatherers {

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,8 +23,6 @@
  * questions.
  */
 package java.util.stream;
-
-import jdk.internal.javac.PreviewFeature;
 
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1096,7 +1096,7 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      * @param <R> The element type of the new stream
      * @param gatherer a gatherer
      * @return the new stream
-     * @since 22
+     * @since 24
      */
     @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
     default <R> Stream<R> gather(Gatherer<? super T, ?, R> gatherer) {

--- a/src/java.base/share/classes/java/util/stream/Stream.java
+++ b/src/java.base/share/classes/java/util/stream/Stream.java
@@ -1098,7 +1098,6 @@ public interface Stream<T> extends BaseStream<T, Stream<T>> {
      * @return the new stream
      * @since 24
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.STREAM_GATHERERS)
     default <R> Stream<R> gather(Gatherer<? super T, ?, R> gatherer) {
         return StreamSupport.stream(spliterator(), isParallel())
                             .gather(gatherer)

--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -76,7 +76,6 @@ public @interface PreviewFeature {
         STRUCTURED_CONCURRENCY,
         @JEP(number=466, title="ClassFile API", status="Second Preview")
         CLASSFILE_API,
-        @JEP(number=473, title="Stream Gatherers", status="Second Preview")
         STREAM_GATHERERS,
         @JEP(number=476, title="Module Import Declarations", status="Preview")
         MODULE_IMPORTS,

--- a/test/jdk/java/util/stream/GathererAPITest.java
+++ b/test/jdk/java/util/stream/GathererAPITest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assumptions.*;
 /**
  * @test
  * @summary Testing public API of Gatherer
- * @enablePreview
  * @run junit GathererAPITest
  */
 

--- a/test/jdk/java/util/stream/GathererShortCircuitTest.java
+++ b/test/jdk/java/util/stream/GathererShortCircuitTest.java
@@ -32,7 +32,6 @@ import static org.junit.jupiter.api.Assumptions.*;
  * @test
  * @bug 8328316
  * @summary Testing Gatherer behavior under short circuiting
- * @enablePreview
  * @run junit GathererShortCircuitTest
  */
 

--- a/test/jdk/java/util/stream/GathererTest.java
+++ b/test/jdk/java/util/stream/GathererTest.java
@@ -37,7 +37,6 @@ import static org.junit.jupiter.api.Assumptions.*;
 /**
  * @test
  * @summary Testing the Gatherer contract
- * @enablePreview
  * @library /lib/testlibrary/bootlib
  * @build java.base/java.util.stream.DefaultMethodStreams
  * @run junit GathererTest

--- a/test/jdk/java/util/stream/GatherersFoldTest.java
+++ b/test/jdk/java/util/stream/GatherersFoldTest.java
@@ -34,7 +34,6 @@ import static org.junit.jupiter.api.Assumptions.*;
 /**
  * @test
  * @summary Tests the API and contract of Gatherers.fold
- * @enablePreview
  * @run junit GatherersFoldTest
  */
 

--- a/test/jdk/java/util/stream/GatherersMapConcurrentTest.java
+++ b/test/jdk/java/util/stream/GatherersMapConcurrentTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assumptions.*;
 /**
  * @test
  * @summary Tests the API and contract of Gatherers.mapConcurrent
- * @enablePreview
  * @run junit GatherersMapConcurrentTest
  */
 

--- a/test/jdk/java/util/stream/GatherersScanTest.java
+++ b/test/jdk/java/util/stream/GatherersScanTest.java
@@ -35,7 +35,6 @@ import static org.junit.jupiter.api.Assumptions.*;
 /**
  * @test
  * @summary Tests the API and contract of Gatherers.scan
- * @enablePreview
  * @run junit GatherersScanTest
  */
 

--- a/test/jdk/java/util/stream/GatherersWindowFixedTest.java
+++ b/test/jdk/java/util/stream/GatherersWindowFixedTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assumptions.*;
 /**
  * @test
  * @summary Tests the API and contract of Gatherers.windowFixed
- * @enablePreview
  * @run junit GatherersWindowFixedTest
  */
 

--- a/test/jdk/java/util/stream/GatherersWindowSlidingTest.java
+++ b/test/jdk/java/util/stream/GatherersWindowSlidingTest.java
@@ -36,7 +36,6 @@ import static org.junit.jupiter.api.Assumptions.*;
 /**
  * @test
  * @summary Tests the API and contract of Gatherers.windowSliding
- * @enablePreview
  * @run junit GatherersWindowSlidingTest
  */
 

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRPar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRPar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRPar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRPar.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherFMRPar {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFMRSeq.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherFMRSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapInfinitySeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapInfinitySeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapInfinitySeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapInfinitySeq.java
@@ -48,7 +48,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherFlatMapInfinitySeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherFlatMapSeq.java
@@ -48,7 +48,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherFlatMapSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapPar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapPar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapPar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapPar.java
@@ -48,7 +48,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherMapPar {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMapSeq.java
@@ -48,7 +48,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherMapSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscPar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscPar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscPar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscPar.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherMiscPar {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherMiscSeq.java
@@ -51,7 +51,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherMiscSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReducePar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReducePar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReducePar.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReducePar.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherReducePar {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReduceSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReduceSeq.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReduceSeq.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherReduceSeq.java
@@ -51,7 +51,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherReduceSeq {

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherWhileOrdered.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherWhileOrdered.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherWhileOrdered.java
+++ b/test/micro/org/openjdk/bench/java/util/stream/ops/ref/GatherWhileOrdered.java
@@ -49,7 +49,7 @@ import static org.openjdk.bench.java.util.stream.ops.ref.BenchmarkGathererImpls.
 @BenchmarkMode(Mode.Throughput)
 @Warmup(iterations = 4, time = 5, timeUnit = TimeUnit.SECONDS)
 @Measurement(iterations = 7, time = 5, timeUnit = TimeUnit.SECONDS)
-@Fork(jvmArgs = "--enable-preview", value = 1)
+@Fork(value = 1)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Thread)
 public class GatherWhileOrdered {


### PR DESCRIPTION
Make final adjustments to drop PreviewFeature and updating the @ since markers.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8343323](https://bugs.openjdk.org/browse/JDK-8343323) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8342707](https://bugs.openjdk.org/browse/JDK-8342707): Prepare Gatherers for graduation from Preview (**Enhancement** - P4)
 * [JDK-8343323](https://bugs.openjdk.org/browse/JDK-8343323): Prepare Gatherers for graduation from Preview (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21686/head:pull/21686` \
`$ git checkout pull/21686`

Update a local copy of the PR: \
`$ git checkout pull/21686` \
`$ git pull https://git.openjdk.org/jdk.git pull/21686/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21686`

View PR using the GUI difftool: \
`$ git pr show -t 21686`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21686.diff">https://git.openjdk.org/jdk/pull/21686.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21686#issuecomment-2435575169)
</details>
