### PR TITLE
8342967: Lambda deduplication fails with non-metafactory BSMs and mismatched local variables names

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/LambdaToMethod.java
@@ -217,7 +217,7 @@ public class LambdaToMethod extends TreeTranslator {
         public int hashCode() {
             int hashCode = this.hashCode;
             if (hashCode == 0) {
-                this.hashCode = hashCode = TreeHasher.hash(tree, symbol.params());
+                this.hashCode = hashCode = TreeHasher.hash(types, tree, symbol.params());
             }
             return hashCode;
         }
@@ -226,7 +226,7 @@ public class LambdaToMethod extends TreeTranslator {
         public boolean equals(Object o) {
             return (o instanceof DedupedLambda dedupedLambda)
                     && types.isSameType(symbol.asType(), dedupedLambda.symbol.asType())
-                    && new TreeDiffer(symbol.params(), dedupedLambda.symbol.params()).scan(tree, dedupedLambda.tree);
+                    && new TreeDiffer(types, symbol.params(), dedupedLambda.symbol.params()).scan(tree, dedupedLambda.tree);
         }
     }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -993,7 +993,7 @@ public class TransPatterns extends TreeTranslator {
                        !currentNullable &&
                        !previousCompletesNormally &&
                        !currentCompletesNormally &&
-                       new TreeDiffer(List.of(commonBinding), List.of(currentBinding))
+                       new TreeDiffer(types, List.of(commonBinding), List.of(currentBinding))
                                .scan(commonNestedExpression, currentNestedExpression)) {
                 accummulator.add(c.head);
             } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeDiffer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeDiffer.java
@@ -28,6 +28,9 @@ package com.sun.tools.javac.comp;
 
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
+import com.sun.tools.javac.code.TypeTag;
+import com.sun.tools.javac.code.Types;
+import com.sun.tools.javac.jvm.PoolConstant;
 import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.tree.JCTree.JCAnnotatedType;
 import com.sun.tools.javac.tree.JCTree.JCAnnotation;
@@ -107,10 +110,10 @@ import java.util.Objects;
 
 /** A visitor that compares two lambda bodies for structural equality. */
 public class TreeDiffer extends TreeScanner {
-
-    public TreeDiffer(
-            Collection<? extends Symbol> symbols, Collection<? extends Symbol> otherSymbols) {
+    public TreeDiffer(Types types,
+                      Collection<? extends Symbol> symbols, Collection<? extends Symbol> otherSymbols) {
         this.equiv = equiv(symbols, otherSymbols);
+        this.types = types;
     }
 
     private static Map<Symbol, Symbol> equiv(
@@ -127,6 +130,7 @@ public class TreeDiffer extends TreeScanner {
     private JCTree parameter;
     private boolean result;
     private Map<Symbol, Symbol> equiv = new HashMap<>();
+    final Types types;
 
     public boolean scan(JCTree tree, JCTree parameter) {
         if (tree == null || parameter == null) {
@@ -197,13 +201,27 @@ public class TreeDiffer extends TreeScanner {
                 return;
             }
         }
-        result = tree.sym == that.sym;
+        result = scan(symbol, otherSymbol);
+    }
+
+    private boolean scan(Symbol symbol, Symbol otherSymbol) {
+        if (symbol instanceof PoolConstant.Dynamic dms && otherSymbol instanceof PoolConstant.Dynamic other_dms) {
+            return dms.bsmKey(types).equals(other_dms.bsmKey(types));
+        }
+        else {
+            return symbol == otherSymbol;
+        }
     }
 
     @Override
     public void visitSelect(JCFieldAccess tree) {
         JCFieldAccess that = (JCFieldAccess) parameter;
-        result = scan(tree.selected, that.selected) && tree.sym == that.sym;
+        result = scan(tree.selected, that.selected);
+
+        Symbol symbol = tree.sym;
+        Symbol otherSymbol = that.sym;
+
+        result &= scan(symbol, otherSymbol);
     }
 
     @Override
@@ -667,10 +685,14 @@ public class TreeDiffer extends TreeScanner {
         JCVariableDecl that = (JCVariableDecl) parameter;
         result =
                 scan(tree.mods, that.mods)
-                        && tree.name == that.name
                         && scan(tree.nameexpr, that.nameexpr)
                         && scan(tree.vartype, that.vartype)
                         && scan(tree.init, that.init);
+
+        if (!tree.sym.owner.type.hasTag(TypeTag.METHOD)) {
+            result &= tree.name == that.name;
+        }
+
         if (!result) {
             return;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeDiffer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeDiffer.java
@@ -343,14 +343,7 @@ public class TreeDiffer extends TreeScanner {
 
     @Override
     public void visitClassDef(JCClassDecl tree) {
-        JCClassDecl that = (JCClassDecl) parameter;
-        result =
-                scan(tree.mods, that.mods)
-                        && tree.name == that.name
-                        && scan(tree.typarams, that.typarams)
-                        && scan(tree.extending, that.extending)
-                        && scan(tree.implementing, that.implementing)
-                        && scan(tree.defs, that.defs);
+        result = false;
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeDiffer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeDiffer.java
@@ -201,10 +201,10 @@ public class TreeDiffer extends TreeScanner {
                 return;
             }
         }
-        result = scan(symbol, otherSymbol);
+        result = scanSymbol(symbol, otherSymbol);
     }
 
-    private boolean scan(Symbol symbol, Symbol otherSymbol) {
+    private boolean scanSymbol(Symbol symbol, Symbol otherSymbol) {
         if (symbol instanceof PoolConstant.Dynamic dms && otherSymbol instanceof PoolConstant.Dynamic other_dms) {
             return dms.bsmKey(types).equals(other_dms.bsmKey(types));
         }
@@ -216,13 +216,9 @@ public class TreeDiffer extends TreeScanner {
     @Override
     public void visitSelect(JCFieldAccess tree) {
         JCFieldAccess that = (JCFieldAccess) parameter;
-        result = scan(tree.selected, that.selected);
 
-        Symbol symbol = tree.sym;
-        Symbol otherSymbol = that.sym;
-
-        if (result)
-            result = scan(symbol, otherSymbol);
+        result = scan(tree.selected, that.selected) &&
+                scanSymbol(tree.sym, that.sym);
     }
 
     @Override
@@ -690,14 +686,14 @@ public class TreeDiffer extends TreeScanner {
                         && scan(tree.vartype, that.vartype)
                         && scan(tree.init, that.init);
 
-        if (!tree.sym.owner.type.hasTag(TypeTag.METHOD) && result) {
+        if (tree.sym.owner.type.hasTag(TypeTag.CLASS)) {
+            // field names are important!
             result &= tree.name == that.name;
         }
 
-        if (!result) {
-            return;
+        if (result) {
+            equiv.put(tree.sym, that.sym);
         }
-        equiv.put(tree.sym, that.sym);
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeDiffer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeDiffer.java
@@ -221,7 +221,8 @@ public class TreeDiffer extends TreeScanner {
         Symbol symbol = tree.sym;
         Symbol otherSymbol = that.sym;
 
-        result &= scan(symbol, otherSymbol);
+        if (result)
+            result = scan(symbol, otherSymbol);
     }
 
     @Override
@@ -689,7 +690,7 @@ public class TreeDiffer extends TreeScanner {
                         && scan(tree.vartype, that.vartype)
                         && scan(tree.init, that.init);
 
-        if (!tree.sym.owner.type.hasTag(TypeTag.METHOD)) {
+        if (!tree.sym.owner.type.hasTag(TypeTag.METHOD) && result) {
             result &= tree.name == that.name;
         }
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeHasher.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeHasher.java
@@ -95,7 +95,6 @@ public class TreeHasher extends TreeScanner {
     @Override
     public void visitClassDef(JCClassDecl tree) {
         hash(tree.sym);
-        super.visitClassDef(tree);
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeHasher.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeHasher.java
@@ -30,6 +30,7 @@ import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Types;
 import com.sun.tools.javac.jvm.PoolConstant;
 import com.sun.tools.javac.tree.JCTree;
+import com.sun.tools.javac.tree.JCTree.JCClassDecl;
 import com.sun.tools.javac.tree.JCTree.JCFieldAccess;
 import com.sun.tools.javac.tree.JCTree.JCIdent;
 import com.sun.tools.javac.tree.JCTree.JCLiteral;
@@ -89,6 +90,12 @@ public class TreeHasher extends TreeScanner {
     public void visitLiteral(JCLiteral tree) {
         hash(tree.value);
         super.visitLiteral(tree);
+    }
+
+    @Override
+    public void visitClassDef(JCClassDecl tree) {
+        hash(tree.sym);
+        super.visitClassDef(tree);
     }
 
     @Override

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeHasher.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TreeHasher.java
@@ -101,22 +101,21 @@ public class TreeHasher extends TreeScanner {
                 return;
             }
         }
-        if (sym instanceof PoolConstant.Dynamic dynamic) {
-            hash(dynamic.bsmKey(types));
-        } else {
-            hash(sym);
-        }
+        hashSymbol(sym);
     }
 
     @Override
     public void visitSelect(JCFieldAccess tree) {
-        Symbol sym = tree.sym;
+        hashSymbol(tree.sym);
+        super.visitSelect(tree);
+    }
+
+    private void hashSymbol(Symbol sym) {
         if (sym instanceof PoolConstant.Dynamic dynamic) {
             hash(dynamic.bsmKey(types));
         } else {
             hash(sym);
         }
-        super.visitSelect(tree);
     }
 
     @Override

--- a/test/langtools/tools/javac/lambda/deduplication/Deduplication.java
+++ b/test/langtools/tools/javac/lambda/deduplication/Deduplication.java
@@ -29,52 +29,54 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 public class Deduplication {
+    void groupEquals(Object... xs) {}
+    void groupNotEquals(Object... xs) {}
     void group(Object... xs) {}
 
     void test() {
 
-        group(
+        groupEquals(
                 (Runnable) () -> { ( (Runnable) () -> {} ).run(); },
                 (Runnable) () -> { ( (Runnable) () -> {} ).run(); }
         );
 
-        group(
+        groupEquals(
                 (Runnable) () -> { Deduplication.class.toString(); },
                 (Runnable) () -> { Deduplication.class.toString(); }
         );
 
-        group(
+        groupEquals(
                 (Runnable) () -> { Integer[].class.toString(); },
                 (Runnable) () -> { Integer[].class.toString(); }
         );
 
-        group(
+        groupEquals(
                 (Runnable) () -> { char.class.toString(); },
                 (Runnable) () -> { char.class.toString(); }
         );
 
-        group(
+        groupEquals(
                 (Runnable) () -> { Void.class.toString(); },
                 (Runnable) () -> { Void.class.toString(); }
         );
 
-        group(
+        groupEquals(
                 (Runnable) () -> { void.class.toString(); },
                 (Runnable) () -> { void.class.toString(); }
         );
 
-        group((Function<String, Integer>) x -> x.hashCode());
-        group((Function<Object, Integer>) x -> x.hashCode());
+        groupEquals((Function<String, Integer>) x -> x.hashCode());
+        groupEquals((Function<Object, Integer>) x -> x.hashCode());
 
         {
             int x = 1;
-            group((Supplier<Integer>) () -> x + 1);
+            groupEquals((Supplier<Integer>) () -> x + 1);
         }
         {
             int x = 1;
-            group((Supplier<Integer>) () -> x + 1);
+            groupEquals((Supplier<Integer>) () -> x + 1);
         }
-        group(
+        groupEquals(
                 (BiFunction<Integer, Integer, ?>) (x, y) -> x + ((y)),
                 (BiFunction<Integer, Integer, ?>) (x, y) -> x + (y),
                 (BiFunction<Integer, Integer, ?>) (x, y) -> x + y,
@@ -85,29 +87,29 @@ public class Deduplication {
                 (BiFunction<Integer, Integer, ?>) (x, y) -> ((x)) + (y),
                 (BiFunction<Integer, Integer, ?>) (x, y) -> ((x)) + y);
 
-        group(
+        groupEquals(
                 (Function<Integer, Integer>) x -> x + (1 + 2 + 3),
                 (Function<Integer, Integer>) x -> x + 6);
 
-        group((Function<Integer, Integer>) x -> x + 1, (Function<Integer, Integer>) y -> y + 1);
+        groupEquals((Function<Integer, Integer>) x -> x + 1, (Function<Integer, Integer>) y -> y + 1);
 
-        group((Consumer<Integer>) x -> this.f(), (Consumer<Integer>) x -> this.f());
+        groupEquals((Consumer<Integer>) x -> this.f(), (Consumer<Integer>) x -> this.f());
 
-        group((Consumer<Integer>) y -> this.g());
+        groupEquals((Consumer<Integer>) y -> this.g());
 
-        group((Consumer<Integer>) x -> f(), (Consumer<Integer>) x -> f());
+        groupEquals((Consumer<Integer>) x -> f(), (Consumer<Integer>) x -> f());
 
-        group((Consumer<Integer>) y -> g());
+        groupEquals((Consumer<Integer>) y -> g());
 
-        group((Function<Integer, Integer>) x -> this.i, (Function<Integer, Integer>) x -> this.i);
+        groupEquals((Function<Integer, Integer>) x -> this.i, (Function<Integer, Integer>) x -> this.i);
 
-        group((Function<Integer, Integer>) y -> this.j);
+        groupEquals((Function<Integer, Integer>) y -> this.j);
 
-        group((Function<Integer, Integer>) x -> i, (Function<Integer, Integer>) x -> i);
+        groupEquals((Function<Integer, Integer>) x -> i, (Function<Integer, Integer>) x -> i);
 
-        group((Function<Integer, Integer>) y -> j);
+        groupEquals((Function<Integer, Integer>) y -> j);
 
-        group(
+        groupEquals(
                 (Function<Integer, Integer>)
                         y -> {
                             while (true) {
@@ -123,7 +125,7 @@ public class Deduplication {
                             return 42;
                         });
 
-        group(
+        groupEquals(
                 (Function<Integer, Integer>)
                         x -> {
                             int y = x;
@@ -135,13 +137,13 @@ public class Deduplication {
                             return y;
                         });
 
-        group(
+        groupEquals(
                 (Function<Integer, Integer>)
                         x -> {
                             int y = 0, z = x;
                             return y;
                         });
-        group(
+        groupEquals(
                 (Function<Integer, Integer>)
                         x -> {
                             int y = 0, z = x;
@@ -154,32 +156,32 @@ public class Deduplication {
             void f() {}
 
             {
-                group((Function<Integer, Integer>) x -> this.i);
-                group((Consumer<Integer>) x -> this.f());
-                group((Function<Integer, Integer>) x -> Deduplication.this.i);
-                group((Consumer<Integer>) x -> Deduplication.this.f());
+                groupEquals((Function<Integer, Integer>) x -> this.i);
+                groupEquals((Consumer<Integer>) x -> this.f());
+                groupEquals((Function<Integer, Integer>) x -> Deduplication.this.i);
+                groupEquals((Consumer<Integer>) x -> Deduplication.this.f());
             }
         }
 
-        group((Function<Integer, Integer>) x -> switch (x) { default: yield x; },
+        groupEquals((Function<Integer, Integer>) x -> switch (x) { default: yield x; },
               (Function<Integer, Integer>) x -> switch (x) { default: yield x; });
 
-        group((Function<Object, Integer>) x -> x instanceof Integer i ? i : -1,
+        groupEquals((Function<Object, Integer>) x -> x instanceof Integer i ? i : -1,
               (Function<Object, Integer>) x -> x instanceof Integer i ? i : -1);
 
-        group((Function<Object, Integer>) x -> x instanceof R(var i1, var i2) ? i1 : -1,
+        groupEquals((Function<Object, Integer>) x -> x instanceof R(var i1, var i2) ? i1 : -1,
               (Function<Object, Integer>) x -> x instanceof R(var i1, var i2) ? i1 : -1 );
 
-        group((Function<Object, Integer>) x -> x instanceof R(Integer i1, int i2) ? i2 : -1,
+        groupEquals((Function<Object, Integer>) x -> x instanceof R(Integer i1, int i2) ? i2 : -1,
               (Function<Object, Integer>) x -> x instanceof R(Integer i1, int i2) ? i2 : -1 );
 
-        group((Function<Object, Integer>) x -> x instanceof int i2 ? i2 : -1,
+        groupEquals((Function<Object, Integer>) x -> x instanceof int i2 ? i2 : -1,
               (Function<Object, Integer>) x -> x instanceof int i2 ? i2 : -1);
 
-        group((Function<Object, Integer>) x -> switch (x) { case String s -> s.length(); default -> -1; },
+        groupEquals((Function<Object, Integer>) x -> switch (x) { case String s -> s.length(); default -> -1; },
               (Function<Object, Integer>) x -> switch (x) { case String s -> s.length(); default -> -1; });
 
-        group((Function<Object, Integer>) x -> {
+        groupEquals((Function<Object, Integer>) x -> {
                     int y1 = -1;
                     return y1;
                 },
@@ -188,8 +190,7 @@ public class Deduplication {
                     return y2;
                });
 
-        group((Function<Object, Integer>) x -> {class C {} new C(); return 42; });
-        group((Function<Object, Integer>) x -> {class C {} new C(); return 42; });
+        groupNotEquals((Function<Object, Integer>) x -> {class C {} new C(); return 42; }, (Function<Object, Integer>) x -> {class C {} new C(); return 42; });
     }
 
     void f() {}

--- a/test/langtools/tools/javac/lambda/deduplication/Deduplication.java
+++ b/test/langtools/tools/javac/lambda/deduplication/Deduplication.java
@@ -172,6 +172,21 @@ public class Deduplication {
 
         group((Function<Object, Integer>) x -> x instanceof R(Integer i1, int i2) ? i2 : -1,
               (Function<Object, Integer>) x -> x instanceof R(Integer i1, int i2) ? i2 : -1 );
+
+        group((Function<Object, Integer>) x -> x instanceof int i2 ? i2 : -1,
+              (Function<Object, Integer>) x -> x instanceof int i2 ? i2 : -1);
+
+        group((Function<Object, Integer>) x -> switch (x) { case String s -> s.length(); default -> -1; },
+              (Function<Object, Integer>) x -> switch (x) { case String s -> s.length(); default -> -1; });
+
+        group((Function<Object, Integer>) x -> {
+                    int y1 = -1;
+                    return y1;
+                },
+              (Function<Object, Integer>) x -> {
+                    int y2 = -1;
+                    return y2;
+               });
     }
 
     void f() {}

--- a/test/langtools/tools/javac/lambda/deduplication/Deduplication.java
+++ b/test/langtools/tools/javac/lambda/deduplication/Deduplication.java
@@ -187,6 +187,9 @@ public class Deduplication {
                     int y2 = -1;
                     return y2;
                });
+
+        group((Function<Object, Integer>) x -> {class C {} new C(); return 42; });
+        group((Function<Object, Integer>) x -> {class C {} new C(); return 42; });
     }
 
     void f() {}

--- a/test/langtools/tools/javac/lambda/deduplication/DeduplicationTest.java
+++ b/test/langtools/tools/javac/lambda/deduplication/DeduplicationTest.java
@@ -149,7 +149,9 @@ public class DeduplicationTest {
             try (InputStream input = output.openInputStream()) {
                 cm = ClassFile.of().parse(input.readAllBytes());
             }
-            if (cm.thisClass().asInternalName().equals("com/sun/tools/javac/comp/Deduplication$R")) {
+            if (cm.thisClass().asInternalName().equals("com/sun/tools/javac/comp/Deduplication$R") ||
+                cm.thisClass().asInternalName().equals("com/sun/tools/javac/comp/Deduplication$1C") ||
+                cm.thisClass().asInternalName().equals("com/sun/tools/javac/comp/Deduplication$2C")) {
                 continue;
             }
             BootstrapMethodsAttribute bsm = cm.findAttribute(Attributes.bootstrapMethods()).orElseThrow();
@@ -305,18 +307,20 @@ public class DeduplicationTest {
                         dedupedLambdas.put(lhs, first);
                     }
                     for (JCLambda rhs : curr) {
-                        if (!new TreeDiffer(types, paramSymbols(lhs), paramSymbols(rhs))
-                                .scan(lhs.body, rhs.body)) {
-                            throw new AssertionError(
-                                    String.format(
-                                            "expected lambdas to be equal\n%s\n%s", lhs, rhs));
-                        }
-                        if (TreeHasher.hash(types, lhs, paramSymbols(lhs))
-                                != TreeHasher.hash(types, rhs, paramSymbols(rhs))) {
-                            throw new AssertionError(
-                                    String.format(
-                                            "expected lambdas to hash to the same value\n%s\n%s",
-                                            lhs, rhs));
+                        if (rhs != lhs) {
+                            if (!new TreeDiffer(types, paramSymbols(lhs), paramSymbols(rhs))
+                                    .scan(lhs.body, rhs.body)) {
+                                throw new AssertionError(
+                                        String.format(
+                                                "expected lambdas to be equal\n%s\n%s", lhs, rhs));
+                            }
+                            if (TreeHasher.hash(types, lhs, paramSymbols(lhs))
+                                    != TreeHasher.hash(types, rhs, paramSymbols(rhs))) {
+                                throw new AssertionError(
+                                        String.format(
+                                                "expected lambdas to hash to the same value\n%s\n%s",
+                                                lhs, rhs));
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
After experimentation and under certain conditions, a few equivalent lambdas (up to variable renaming) fail to deduplicate.

`TreeHasher` and `TreeDiffer` are now aware that other bootstraps may appear in lambda bodies (e.g. `SwitchBootstraps.typeSwitch`) and that variable names do not matter (when they appear in method/lambda definitions). In the first case equivalence is checked based on `bsmKey` and not the `Dynamic{Var, Method}Symbol` itself.

The test was also adjusted since it was assuming BSM with certain structure only (that `.get(1)` was unprotected).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342967](https://bugs.openjdk.org/browse/JDK-8342967): Lambda deduplication fails with non-metafactory BSMs and mismatched local variables names (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21687/head:pull/21687` \
`$ git checkout pull/21687`

Update a local copy of the PR: \
`$ git checkout pull/21687` \
`$ git pull https://git.openjdk.org/jdk.git pull/21687/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21687`

View PR using the GUI difftool: \
`$ git pr show -t 21687`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21687.diff">https://git.openjdk.org/jdk/pull/21687.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21687#issuecomment-2435617388)
</details>
