### PR TITLE
JDK-8342449: reimplement: JDK-8327114 Attach in Linux may have wrong behavior when pid == ns_pid

### DIFF
--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -250,23 +250,23 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         // 3. Caller and target processes share PID namespace but NOT root filesystem (container to container).
         // 4. Caller and target processes share neither PID namespace nor root filesystem (host to container).
 
-	final var procPidRoot = PROC.resolve(Long.toString(pid)).resolve(ROOT_TMP);
+        final var procPidRoot = PROC.resolve(Long.toString(pid)).resolve(ROOT_TMP);
 
-	/*
-	 * if target is elevated, we cant use /proc/<pid>/... so we have to fallback to /tmp, but that may not be shared 
-	 * with the target/attachee process, we can try, except in the case where the ns_pid also exists in this pid ns
-	 * which is ambiguous, if we share /tmp with the intended target, the attach will succeed, if we do not, 
-	 * then we will potentially attempt to attach to some arbitrary process with the same pid (in this pid ns)
-	 * as that of the intended target (in its * pid ns).
-	 *
-	 * so in that case we should prehaps throw - or risk sending SIGQUIT to some arbitrary process... which could kill it
-	 *
-	 * however we can also check the target pid's signal masks to see if it catches SIGQUIT and only do so if in
-	 * fact it does ... this reduces the risk of killing an innocent process in the current ns as opposed to 
-	 * attaching to the actual target JVM ... c.f: checkCatchesAndSendQuitTo() below.
-	 *
-	 * note that if pid == ns_pid we are in a shared pid ns with the target and may (potentially) share /tmp
-	 */
+        /*
+         * if target is elevated, we cant use /proc/<pid>/... so we have to fallback to /tmp, but that may not be shared 
+         * with the target/attachee process, we can try, except in the case where the ns_pid also exists in this pid ns
+         * which is ambiguous, if we share /tmp with the intended target, the attach will succeed, if we do not, 
+         * then we will potentially attempt to attach to some arbitrary process with the same pid (in this pid ns)
+         * as that of the intended target (in its * pid ns).
+         *
+         * so in that case we should prehaps throw - or risk sending SIGQUIT to some arbitrary process... which could kill it
+         *
+         * however we can also check the target pid's signal masks to see if it catches SIGQUIT and only do so if in
+         * fact it does ... this reduces the risk of killing an innocent process in the current ns as opposed to 
+         * attaching to the actual target JVM ... c.f: checkCatchesAndSendQuitTo() below.
+         *
+         * note that if pid == ns_pid we are in a shared pid ns with the target and may (potentially) share /tmp
+         */
 
         return (Files.isWritable(procPidRoot) ? procPidRoot : TMPDIR).toString();
     }
@@ -348,7 +348,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
 
             if (!m.matches()) continue;
 
-	    var       signals = m.group(MASK);
+            var       signals = m.group(MASK);
             final var slen    = signals.length();
 
             signals = signals.substring(slen / 2 , slen); // only really interested in the non r/t signals ...
@@ -366,7 +366,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
 
         final boolean  okToSendQuit = (!quitIgn && quitCgt); // ignore blocked as it may be temporary ...
 
-	if (okToSendQuit) {
+        if (okToSendQuit) {
             sendQuitTo(pid);
         } else if (throwIfNotReady) {
             final var cmdline = Files.lines(procPid.resolve("cmdline")).findFirst();
@@ -377,11 +377,11 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
                 cmd = cmdline.get();
                 cmd = cmd.substring(0, cmd.length() - 1); // remove trailing \0
             }
-		
-	    throw new AttachNotSupportedException("pid: " + pid + " cmd: '" + cmd + "' state is not ready to participate in attach handshake!");
+                
+            throw new AttachNotSupportedException("pid: " + pid + " cmd: '" + cmd + "' state is not ready to participate in attach handshake!");
         }
 
-	return okToSendQuit;
+        return okToSendQuit;
     }
 
     //-- native methods

--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -34,7 +34,8 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Optional;
+
+import java.util.regex.Pattern;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -51,25 +52,8 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
     private static final Path TMPDIR = Path.of("/tmp");
 
     private static final Path PROC     = Path.of("/proc");
-    private static final Path NS_MNT   = Path.of("ns/mnt");
-    private static final Path NS_PID   = Path.of("ns/pid");
-    private static final Path SELF     = PROC.resolve("self");
     private static final Path STATUS   = Path.of("status");
     private static final Path ROOT_TMP = Path.of("root/tmp");
-
-    private static final Optional<Path> SELF_MNT_NS;
-
-    static {
-        Path nsPath = null;
-
-        try {
-            nsPath = Files.readSymbolicLink(SELF.resolve(NS_MNT));
-        } catch (IOException _) {
-            // do nothing
-        } finally {
-            SELF_MNT_NS = Optional.ofNullable(nsPath);
-        }
-    }
 
     String socket_path;
 
@@ -98,7 +82,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
             // Keep canonical version of File, to delete, in case target process ends and /proc link has gone:
             File f = createAttachFile(pid, ns_pid).getCanonicalFile();
             try {
-                sendQuitTo(pid);
+                checkCatchesAndSendQuitTo(pid);
 
                 // give the target VM time to start the attach mechanism
                 final int delay_step = 100;
@@ -265,71 +249,25 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         // 3. Caller and target processes share PID namespace but NOT root filesystem (container to container).
         // 4. Caller and target processes share neither PID namespace nor root filesystem (host to container).
 
-        Optional<ProcessHandle> target = ProcessHandle.of(pid);
-        Optional<ProcessHandle> ph = target;
-        long nsPid = ns_pid;
-        Optional<Path> prevPidNS = Optional.empty();
+	final var procPidRoot = PROC.resolve(Long.toString(pid)).resolve(ROOT_TMP);
 
-        while (ph.isPresent()) {
-            final var curPid = ph.get().pid();
-            final var procPidPath = PROC.resolve(Long.toString(curPid));
-            Optional<Path> targetMountNS = Optional.empty();
+	/*
+	 * if target is elevated, we cant use /proc/<pid>/... so we have to fallback to /tmp, but that may not be shared 
+	 * with the target/attachee process, we can try, except in the case where the ns_pid also exists in this pid ns
+	 * which is ambiguous, if we share /tmp with the intended target, the attach will succeed, if we do not, 
+	 * then we will potentially attempt to attach to some arbitrary process with the same pid (in this pid ns)
+	 * as that of the intended target (in its * pid ns).
+	 *
+	 * so in that case we should prehaps throw - or risk sending SIGQUIT to some arbitrary process... which could kill it
+	 *
+	 * however we can also check the target pid's signal masks to see if it catches SIGQUIT and only do so if in
+	 * fact it does ... this reduces the risk of killing an innocent process in the current ns as opposed to 
+	 * attaching to the actual target JVM ... c.f: checkCatchesAndSendQuitTo() below.
+	 *
+	 * note that if pid == ns_pid we are in a shared pid ns with the target and may (potentially) share /tmp
+	 */
 
-            try {
-                // attempt to read the target's mnt ns id
-                targetMountNS = Optional.ofNullable(Files.readSymbolicLink(procPidPath.resolve(NS_MNT)));
-            } catch (IOException _) {
-                // if we fail to read the target's mnt ns id then we either don't have access or it no longer exists!
-                if (!Files.exists(procPidPath)) {
-                    throw new IOException(String.format("unable to attach, %s non-existent! process: %d terminated", procPidPath, pid));
-                }
-                // the process still exists, but we don't have privileges to read its procfs
-            }
-
-            final var sameMountNS = SELF_MNT_NS.isPresent() && SELF_MNT_NS.equals(targetMountNS);
-
-            if (sameMountNS) {
-                return TMPDIR.toString(); // we share TMPDIR in common!
-            } else {
-                // we could not read the target's mnt ns
-                final var procPidRootTmp = procPidPath.resolve(ROOT_TMP);
-                if (Files.isReadable(procPidRootTmp)) {
-                    return procPidRootTmp.toString(); // not in the same mnt ns but tmp is accessible via /proc
-                }
-            }
-
-            // let's attempt to obtain the pid ns, best efforts to avoid crossing pid ns boundaries (as with a container)
-            Optional<Path> curPidNS = Optional.empty();
-
-            try {
-                // attempt to read the target's pid ns id
-                curPidNS = Optional.ofNullable(Files.readSymbolicLink(procPidPath.resolve(NS_PID)));
-            } catch (IOException _) {
-                // if we fail to read the target's pid ns id then we either don't have access or it no longer exists!
-                if (!Files.exists(procPidPath)) {
-                    throw new IOException(String.format("unable to attach, %s non-existent! process: %d terminated", procPidPath, pid));
-                }
-                // the process still exists, but we don't have privileges to read its procfs
-            }
-
-            // recurse "up" the process hierarchy if appropriate. PID 1 cannot have a parent in the same namespace
-            final var havePidNSes = prevPidNS.isPresent() && curPidNS.isPresent();
-            final var ppid = ph.get().parent();
-
-            if (ppid.isPresent() && (havePidNSes && curPidNS.equals(prevPidNS)) || (!havePidNSes && nsPid > 1)) {
-                ph = ppid;
-                nsPid = getNamespacePid(ph.get().pid()); // get the ns pid of the parent
-                prevPidNS = curPidNS;
-            } else {
-                ph = Optional.empty();
-            }
-        }
-
-        if (target.orElseThrow(AttachNotSupportedException::new).isAlive()) {
-            return TMPDIR.toString(); // fallback...
-        } else {
-            throw new IOException(String.format("unable to attach, process: %d terminated", pid));
-        }
+        return (Files.isWritable(procPidRoot) ? procPidRoot : TMPDIR).toString();
     }
 
     /*
@@ -378,6 +316,69 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
         }
     }
 
+    private static final String FIELD = "field";
+    private static final String MASK  = "mask";
+
+    private static final String SIGNAL_MASK_PATTERN = "(?<" + FIELD + ">Sig\\p{Alpha}{3}):\\s+(?<" + MASK + ">\\p{XDigit}{16}).*";
+
+    private static final long SIGQUIT = 1L << 2;
+
+    private static void checkCatchesAndSendQuitTo(int pid) throws AttachNotSupportedException, IOException {
+        var quitIgn = false;
+        var quitBlk = false;
+        var quitCgt = false;
+
+        final var procPid = PROC.resolve(Integer.toString(pid));
+
+        final var p = Pattern.compile(SIGNAL_MASK_PATTERN);
+
+        var readBlk = false;
+        var readIgn = false;
+        var readCgt = false;
+
+
+        if (!Files.exists(procPid)) throw new IOException("non existent pid: " + pid);
+
+        for (var line : Files.readAllLines(procPid.resolve("status"))) {
+
+            if (!line.startsWith("Sig")) continue; // to speed things up ... avoids the matcher/RE invocation...
+
+            final var m = p.matcher(line);
+
+            if (!m.matches()) continue;
+
+	    var       signals = m.group(MASK);
+            final var slen    = signals.length();
+
+            signals = signals.substring(slen / 2 , slen); // only really interested in the non r/t signals ...
+
+            final var sigquit = (Long.valueOf(signals, 16) & SIGQUIT) != 0L;
+
+            switch (m.group(FIELD)) {
+                case "SigBlk": { quitBlk = sigquit; readBlk = true; break; }
+                case "SigIgn": { quitIgn = sigquit; readCgt = true; break; }
+                case "SigCgt": { quitCgt = sigquit; readIgn = true; break; }
+            }
+
+            if (readBlk && readIgn && readCgt) break;
+        }
+
+
+        if (!quitBlk && !quitIgn && quitCgt) {
+            sendQuitTo(pid);
+        } else {
+            final var cmdline = Files.lines(procPid.resolve("cmdline")).findFirst();
+
+            var cmd = "null"; // default
+
+            if (cmdline.isPresent()) {
+                cmd = cmdline.get();
+                cmd = cmd.substring(0, cmd.length() - 1); // remove trailing \0
+            }
+		
+	    throw new AttachNotSupportedException("pid: " + pid + " cmd: '" + cmd + "' state is not ready to participate in attach handshake!");
+        }
+    }
 
     //-- native methods
 

--- a/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
+++ b/src/jdk.attach/linux/classes/sun/tools/attach/VirtualMachineImpl.java
@@ -364,7 +364,7 @@ public class VirtualMachineImpl extends HotSpotVirtualMachine {
             if (readBlk && readIgn && readCgt) break;
         }
 
-        final boolean  okToSendQuit = !quitBlk && !quitIgn && quitCgt;
+        final boolean  okToSendQuit = (!quitIgn && quitCgt); // ignore blocked as it may be temporary ...
 
 	if (okToSendQuit) {
             sendQuitTo(pid);


### PR DESCRIPTION
the implementation I originally provided does not in fact solve the issue!

the attach protocol initiation "handshake" requires that the "attacher" (the caller of this code) and the "attachee"(the target JVM to be "attached" to) *must* share a "/tmp" (or access to the attachee's `cwd`)  in common in order to rendezvous on the "attach" socket (created in the /tmp or attachee `cwd` filesystem).

"attacher" and "attachee" JVM processes are guaranteed to share a common directory/filesystem when thy occupy the same "mount namespace", this is the environment in which "peers" exist, and the attach
handshake (initiated by the attacher) can use "/tmp" to establish the socket connection with the attachee.

with the advent of "containers" (implemented in Linux via various namespaces, e.g.: pid & mount) another "attacher" and "attachee" relationship exists, that of "attacher" (namespace ancestor) and "attachee" (namespace descendant).

in this environment it is possible (and highly probable) that the "attacher" and the "attachee" do not share a directory in common.

In this scenario the "attacher" must resort to handshaking with the attachee via the /proc filesystem in order to access the "attachee's" directory from the "attacher".

In order to achieve this rendezvous, the "attachee" must occupy a descendant, or same, (pid) namespace of, or as, the "attacher".

since (pid) namespaces are hierarchical, a descendant process (in its own descendent pid namespace) will also occupy all its ancestor (pid) namespaces (between it and the 'root' or 'host' pid namespace) with a unique pid in each of those "interstitial" (pid) namespace(s).

thus the "attachee" directory is accessible, via an "ancestor's" (or peer's) /proc filesystem using the pid of the "attachee" that is associated with it in that (pid) namespace.

thus an "ancestor" "attacher" can handshake with a descendant "attachee" in this fashion.

therefore an "attacher" has two choices when attempting to attach:

- use the /proc/<pid>/root/tmp path to the "attachee's" /tmp (or its cwd)
  - this works with both peers and descendants

- use /tmp
  - this only works if the "attacher" and "attachee" share a /tmp in common

the obvious choice is to default to /proc/<pid>/root/tmp (or cwd) however there is an issue with this; should the attachee have elevated privileges, the attacher may not have r/w permission on the attachee's /proc/<pid>/root (or cwd) path.

In these circumstances, the "attacher" can only resort to /tmp which may or may not be in common with the "attachee".

the logic required for an "attacher" to determine if an "attachee" /tmp *is* in common unfortunately requires read access (from the attacher) to the"attachee's" /proc filesystem (namely to read namespace identities and to also 'stat(2)' the /proc/<pid>/root/tmp directory to obtain device and inode values for comparison in order to determine if "/tmp" is in common.

when the "attachee" has elevated privileges, this access is not available to the "attacher".

therefore in such circumstances, the "attacher" has no choice but to attempt
to use /tmp and simply timeout the handshake if in fact the "attachee" does not share a /tmp in common

In this elevated case, there is a remote possibility that another process (in the attacher's pid ns) shares the same pid as the attachee (in its descendant pid ns) in this case, if they do not share a filesystem in common the attacher may attempt
to attach to an unsuspecting process in its pid ns, this could result in that process being killed.

In order to reduce the possibility of this mis-attach resulting in process death, the attacher now tests the attachee to determine if it can participate in the attach handshake, by inspecting its signal masks and not delivering the signal to
the attachee if it is not catching the signal.