### PR TITLE
8342974: Inconsistent building of static JDK libraries

### DIFF
--- a/make/common/native/Link.gmk
+++ b/make/common/native/Link.gmk
@@ -68,12 +68,8 @@ endef
 
 ################################################################################
 define CreateStaticLibrary
-  # Include partial linking when building the static library with clang on linux
-  ifeq ($(call isTargetOs, linux), true)
-    ifneq ($(findstring $(TOOLCHAIN_TYPE), clang), )
-      $1_ENABLE_PARTIAL_LINKING := true
-    endif
-  endif
+  # Disable partial linking due to JDK-8342974
+  $1_ENABLE_PARTIAL_LINKING := false
 
   $1_VARDEPS := $$($1_AR) $$(ARFLAGS) $$($1_LIBS) \
       $$($1_EXTRA_LIBS)


### PR DESCRIPTION
This PR addresses an inconsistency in the building of static JDK libraries on Linux when using Clang.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342974](https://bugs.openjdk.org/browse/JDK-8342974): Inconsistent building of static JDK libraries (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21689/head:pull/21689` \
`$ git checkout pull/21689`

Update a local copy of the PR: \
`$ git checkout pull/21689` \
`$ git pull https://git.openjdk.org/jdk.git pull/21689/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21689`

View PR using the GUI difftool: \
`$ git pr show -t 21689`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21689.diff">https://git.openjdk.org/jdk/pull/21689.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21689#issuecomment-2435784978)
</details>
