### PR TITLE
8342975: C2: Micro-optimize PhaseIdealLoop::Dominators()

### DIFF
--- a/src/hotspot/share/opto/domgraph.cpp
+++ b/src/hotspot/share/opto/domgraph.cpp
@@ -410,8 +410,8 @@ void PhaseIdealLoop::Dominators() {
   // Setup mappings from my Graph to Tarjan's stuff and back
   // Note: Tarjan uses 1-based arrays
   NTarjan *ntarjan = NEW_RESOURCE_ARRAY(NTarjan,C->unique()+1);
-  // Initialize all fields for safety.
-  // This initializes _control field for fast reference.
+  // Initialize all fields at once for safety and extra performance.
+  // Among other things, this initializes _control field for fast reference.
   memset(ntarjan, 0, (C->unique() + 1)*sizeof(NTarjan));
 
   // Store the DFS order for the main loop

--- a/src/hotspot/share/opto/domgraph.cpp
+++ b/src/hotspot/share/opto/domgraph.cpp
@@ -410,10 +410,9 @@ void PhaseIdealLoop::Dominators() {
   // Setup mappings from my Graph to Tarjan's stuff and back
   // Note: Tarjan uses 1-based arrays
   NTarjan *ntarjan = NEW_RESOURCE_ARRAY(NTarjan,C->unique()+1);
-  // Initialize _control field for fast reference
-  int i;
-  for( i= C->unique()-1; i>=0; i-- )
-    ntarjan[i]._control = nullptr;
+  // Initialize all fields for safety.
+  // This initializes _control field for fast reference.
+  memset(ntarjan, 0, (C->unique() + 1)*sizeof(NTarjan));
 
   // Store the DFS order for the main loop
   const uint fill_value = max_juint;
@@ -429,6 +428,7 @@ void PhaseIdealLoop::Dominators() {
   ntarjan[0]._size = ntarjan[0]._semi = 0;
   ntarjan[0]._label = &ntarjan[0];
 
+  int i;
   for( i = dfsnum-1; i>1; i-- ) {        // For all nodes in reverse DFS order
     NTarjan *w = &ntarjan[i];            // Get Node from DFS
     assert(w->_control != nullptr,"bad DFS walk");


### PR DESCRIPTION
Noticed this while looking at Leyden profiles. C2 seems to spend considerable time doing in this loop. The disassembly shows this loop is fairly hot. Replacing the initialization with memset, while touching more memory, is apparently faster. memset is also what we normally do around C2 for arena-allocated data. We seem to touch a lot of these structs later on, so pulling them to cache with memset is likely "free". 

It also looks like current initialization misses initializing the last element (at `C->unique()`).

I'll put performance data in separate comment.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342975](https://bugs.openjdk.org/browse/JDK-8342975): C2: Micro-optimize PhaseIdealLoop::Dominators() (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [9a5953d4](https://git.openjdk.org/jdk/pull/21690/files/9a5953d463149f30cb9f39c38453de0e80073cee)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21690/head:pull/21690` \
`$ git checkout pull/21690`

Update a local copy of the PR: \
`$ git checkout pull/21690` \
`$ git pull https://git.openjdk.org/jdk.git pull/21690/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21690`

View PR using the GUI difftool: \
`$ git pr show -t 21690`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21690.diff">https://git.openjdk.org/jdk/pull/21690.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21690#issuecomment-2436045426)