### PR TITLE
8342936: Enhance java.io.IO with parameter-less println() and readln()

### DIFF
--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -228,8 +228,7 @@ public sealed class Console implements Flushable permits ProxyingConsole {
     }
 
     /**
-     * Writes a prompt as if by calling {@code print}, then reads a single line
-     * of text from this console.
+     * Reads a single line of text from this console.
      *
      * @throws IOError
      *         If an I/O error occurs.

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -173,6 +173,19 @@ public sealed class Console implements Flushable permits ProxyingConsole {
     }
 
     /**
+     * Terminates the current line in this console's output stream using
+     * {@link System#lineSeparator()} and then flushes the console.
+     *
+     * @return  This console
+     *
+     * @since 24
+     */
+    @PreviewFeature(feature = PreviewFeature.Feature.IMPLICIT_CLASSES)
+    public Console println() {
+        return println("");
+    }
+
+    /**
      * Writes a string representation of the specified object to this console's
      * output stream and then flushes the console.
      *

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -228,6 +228,25 @@ public sealed class Console implements Flushable permits ProxyingConsole {
     }
 
     /**
+     * Writes a prompt as if by calling {@code print}, then reads a single line
+     * of text from this console.
+     *
+     * @throws IOError
+     *         If an I/O error occurs.
+     *
+     * @return  A string containing the line read from the console, not
+     *          including any line-termination characters, or {@code null}
+     *          if an end of stream has been reached without having read
+     *          any characters.
+     *
+     * @since 24
+     */
+    @PreviewFeature(feature = PreviewFeature.Feature.IMPLICIT_CLASSES)
+    public String readln() {
+        throw newUnsupportedOperationException();
+    }
+
+    /**
      * Writes a formatted string to this console's output stream using
      * the specified format string and arguments with the
      * {@link Locale##default_locale default format locale}.

--- a/src/java.base/share/classes/java/io/IO.java
+++ b/src/java.base/share/classes/java/io/IO.java
@@ -114,6 +114,24 @@ public final class IO {
         return con().readln(prompt);
     }
 
+    /**
+     * Reads a single line of text from the system console.
+     *
+     * <p> The effect is as if {@link Console#readln() readln()}
+     * had been called on {@code System.console()}.
+     *
+     * @return a string containing the line read from the system console, not
+     * including any line-termination characters. Returns {@code null} if an
+     * end of stream has been reached without having read any characters.
+     *
+     * @throws IOError if {@code System.console()} returns {@code null},
+     *                 or if an I/O error occurs
+     * @since 24
+     */
+    public static String readln() {
+        return con().readln();
+    }
+
     private static Console con() {
         var con = System.console();
         if (con != null) {

--- a/src/java.base/share/classes/java/io/IO.java
+++ b/src/java.base/share/classes/java/io/IO.java
@@ -64,6 +64,21 @@ public final class IO {
     }
 
     /**
+     * Terminates the current line on the system console and then flushes
+     * that console.
+     *
+     * <p> The effect is as if {@link Console#println() println()}
+     * had been called on {@code System.console()}.
+     *
+     * @throws IOError if {@code System.console()} returns {@code null},
+     *                 or if an I/O error occurs
+     * @since 24
+     */
+    public static void println() {
+        con().println();
+    }
+
+    /**
      * Writes a string representation of the specified object to the system
      * console and then flushes that console.
      *

--- a/src/java.base/share/classes/java/io/ProxyingConsole.java
+++ b/src/java.base/share/classes/java/io/ProxyingConsole.java
@@ -119,6 +119,18 @@ final class ProxyingConsole extends Console {
 
     /**
      * {@inheritDoc}
+     *
+     * @throws IOError {@inheritDoc}
+     */
+    @Override
+    public String readln() {
+        synchronized (readLock) {
+            return delegate.readln();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public Console format(String format, Object ... args) {

--- a/src/java.base/share/classes/jdk/internal/io/JdkConsole.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsole.java
@@ -41,6 +41,7 @@ public interface JdkConsole {
     JdkConsole println(Object obj);
     JdkConsole print(Object obj);
     String readln(String prompt);
+    String readln();
     JdkConsole format(Locale locale, String format, Object ... args);
     String readLine(Locale locale, String format, Object ... args);
     String readLine();

--- a/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
+++ b/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java
@@ -91,6 +91,21 @@ public final class JdkConsoleImpl implements JdkConsole {
     }
 
     @Override
+    public String readln() {
+        String line = null;
+        synchronized(readLock) {
+            try {
+                char[] ca = readline(false);
+                if (ca != null)
+                    line = new String(ca);
+            } catch (IOException x) {
+                throw new IOError(x);
+            }
+        }
+        return line;
+    }
+
+    @Override
     public JdkConsole format(Locale locale, String format, Object ... args) {
         formatter.format(locale, format, args).flush();
         return this;

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
@@ -99,6 +99,11 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
         }
 
         @Override
+        public String readln() {
+            return getDelegate(true).readln();
+        }
+
+        @Override
         public JdkConsole format(Locale locale, String format, Object... args) {
             JdkConsole delegate = getDelegate(false);
 
@@ -219,6 +224,16 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
             try {
                 initJLineIfNeeded();
                 return jline.readLine(prompt == null ? "null" : prompt.replace("%", "%%"));
+            } catch (EndOfFileException eofe) {
+                return null;
+            }
+        }
+
+        @Override
+        public String readln() {
+            try {
+                initJLineIfNeeded();
+                return jline.readLine();
             } catch (EndOfFileException eofe) {
                 return null;
             }

--- a/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
+++ b/src/jdk.internal.le/share/classes/jdk/internal/org/jline/JdkConsoleProviderImpl.java
@@ -231,12 +231,7 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
 
         @Override
         public String readln() {
-            try {
-                initJLineIfNeeded();
-                return jline.readLine();
-            } catch (EndOfFileException eofe) {
-                return null;
-            }
+            return readLine();
         }
 
         @Override
@@ -257,7 +252,12 @@ public class JdkConsoleProviderImpl implements JdkConsoleProvider {
 
         @Override
         public String readLine() {
-            return readLine(Locale.getDefault(Locale.Category.FORMAT), "");
+            try {
+                initJLineIfNeeded();
+                return jline.readLine();
+            } catch (EndOfFileException eofe) {
+                return null;
+            }
         }
 
         @Override

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/IOContext.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/IOContext.java
@@ -67,6 +67,10 @@ abstract class IOContext implements AutoCloseable {
         throw new UserInterruptException("");
     }
 
+    public String readUserLine() throws IOException {
+        throw new UserInterruptException("");
+    }
+
     public Writer userOutput() {
         throw new UnsupportedOperationException();
     }

--- a/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
+++ b/src/jdk.jshell/share/classes/jdk/internal/jshell/tool/JShellTool.java
@@ -4113,6 +4113,15 @@ public class JShellTool implements MessageHandler {
         }
 
         @Override
+        public String readLine() throws IOError {
+            try {
+                return input.readUserLine();
+            } catch (IOException ex) {
+                throw new IOError(ex);
+            }
+        }
+
+        @Override
         public char[] readPassword(String prompt) {
             try {
                 return input.readPassword(prompt);

--- a/src/jdk.jshell/share/classes/jdk/jshell/JShellConsole.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/JShellConsole.java
@@ -28,6 +28,7 @@ import java.io.IOError;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.nio.charset.Charset;
+import jdk.internal.javac.PreviewFeature;
 
 /**
  * An interface providing functionality for {@link java.io.Console} in the user's snippet.
@@ -74,6 +75,21 @@ public interface JShellConsole {
      * @see java.io.Console#readLine()
      */
     public String readLine(String prompt) throws IOError;
+
+    /**
+     * Reads a single line of text from the console.
+     *
+     * @throws IOError
+     *         If an I/O error occurs.
+     *
+     * @return  A string containing the line read from the console, not
+     *          including any line-termination characters, or {@code null}
+     *          if an end of stream has been reached.
+     * @see java.io.Console#readLine()
+     * @since 24
+     */
+    @PreviewFeature(feature=PreviewFeature.Feature.IMPLICIT_CLASSES)
+    public String readLine() throws IOError;
 
     /**
      * Provides a prompt, then reads a password or passphrase from

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
@@ -235,6 +235,24 @@ public class ConsoleImpl {
 
         /**
          * {@inheritDoc}
+         *
+         * @throws IOError {@inheritDoc}
+         */
+        @Override
+        public String readln() {
+            try {
+                return sendAndReceive(() -> {
+                    remoteInput.write(Task.READ_LINE_NO_PROMPT.ordinal());
+                    char[] line = readChars();
+                    return new String(line);
+                });
+            } catch (IOException ex) {
+                throw new IOError(ex);
+            }
+        }
+
+        /**
+         * {@inheritDoc}
          */
         @Override
         public JdkConsole format(Locale locale, String format, Object... args) {
@@ -404,6 +422,12 @@ public class ConsoleImpl {
                         bp = 0;
                     }
                 }
+                case READ_LINE_NO_PROMPT -> {
+                    String line = console.readLine();
+                    char[] chars = line.toCharArray();
+                    sendChars(sinkOutput, chars, 0, chars.length);
+                    bp = 0;
+                }
                 case READ_PASSWORD -> {
                     char[] data = readCharsOrNull(1);
                     if (data != null) {
@@ -478,6 +502,7 @@ public class ConsoleImpl {
         FLUSH_OUTPUT,
         READ_CHARS,
         READ_LINE,
+        READ_LINE_NO_PROMPT,
         READ_PASSWORD,
         FLUSH_CONSOLE,
         CHARSET,

--- a/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
+++ b/src/jdk.jshell/share/classes/jdk/jshell/execution/impl/ConsoleImpl.java
@@ -240,15 +240,7 @@ public class ConsoleImpl {
          */
         @Override
         public String readln() {
-            try {
-                return sendAndReceive(() -> {
-                    remoteInput.write(Task.READ_LINE_NO_PROMPT.ordinal());
-                    char[] line = readChars();
-                    return new String(line);
-                });
-            } catch (IOException ex) {
-                throw new IOError(ex);
-            }
+            return readLine();
         }
 
         /**
@@ -287,7 +279,15 @@ public class ConsoleImpl {
          */
         @Override
         public String readLine() {
-            return readLine(Locale.getDefault(Locale.Category.FORMAT), "");
+            try {
+                return sendAndReceive(() -> {
+                    remoteInput.write(Task.READ_LINE_NO_PROMPT.ordinal());
+                    char[] line = readChars();
+                    return new String(line);
+                });
+            } catch (IOException ex) {
+                throw new IOError(ex);
+            }
         }
 
         /**

--- a/test/jdk/java/io/IO/IO.java
+++ b/test/jdk/java/io/IO/IO.java
@@ -133,22 +133,26 @@ public class IO {
             var testSrc = System.getProperty("test.src", ".");
             var command = new ArrayList<String>();
             command.add(expect.toString());
-            command.add(Path.of(testSrc, "input.exp").toAbsolutePath().toString());
+            String expectInputName = PROMPT_NONE.equals(prompt) ? "input-no-prompt"
+                                                                : "input";
+            command.add(Path.of(testSrc, expectInputName + ".exp").toAbsolutePath().toString());
             command.add(System.getProperty("test.jdk") + "/bin/java");
             command.add("--enable-preview");
             if (console != null)
                 command.add("-Djdk.console=" + console);
             command.add(Path.of(testSrc, "Input.java").toAbsolutePath().toString());
-            command.add(prompt == null ? "0" : "1");
+            command.add(prompt == null ? "0" : PROMPT_NONE.equals(prompt) ? "2" : "1");
             command.add(String.valueOf(prompt));
             OutputAnalyzer output = ProcessTools.executeProcess(command.toArray(new String[]{}));
             output.reportDiagnosticSummary();
             assertEquals(0, output.getExitValue());
         }
 
+        private static final String PROMPT_NONE = "prompt-none";
+
         public static Stream<Arguments> args() {
             // cross product: consoles x prompts
-            return Stream.of(null, "gibberish").flatMap(console -> Stream.of(null, "?", "%s")
+            return Stream.of(null, "gibberish").flatMap(console -> Stream.of(null, "?", "%s", PROMPT_NONE)
                     .map(prompt -> new String[]{console, prompt}).map(Arguments::of));
         }
     }

--- a/test/jdk/java/io/IO/Input.java
+++ b/test/jdk/java/io/IO/Input.java
@@ -28,9 +28,11 @@ import static java.io.IO.readln;
 public class Input {
 
     public static void main(String[] args) throws IOException {
-        if (args[0].equals("0"))
-            System.out.print(readln(null));
-        else
-            System.out.print(readln(args[1]));
+        switch (args[0]) {
+            case "0" -> System.out.print(readln(null));
+            case "1" -> System.out.print(readln(args[1]));
+            case "2" -> System.out.print(readln());
+            default -> throw new AssertionError("Unknown command: " + args[0]);
+        }
     }
 }

--- a/test/jdk/java/io/IO/input-no-prompt.exp
+++ b/test/jdk/java/io/IO/input-no-prompt.exp
@@ -1,0 +1,30 @@
+#
+# Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
+
+set prompt [lindex $argv $argc-1]
+set stty_init "rows 24 cols 80"
+set timeout -1
+
+spawn {*}$argv
+send "hello\r"
+expect eof

--- a/test/langtools/jdk/jshell/ConsoleTest.java
+++ b/test/langtools/jdk/jshell/ConsoleTest.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8298425
  * @summary Verify behavior of System.console()
+ * @enablePreview
  * @build KullaTesting TestingInputStream
  * @run testng ConsoleTest
  */
@@ -67,6 +68,13 @@ public class ConsoleTest extends KullaTesting {
             }
         };
         assertEval("System.console().readLine(\"expected\")", "\"AB\"");
+        console = new ThrowingJShellConsole() {
+            @Override
+            public String readLine() throws IOError {
+                return "AB";
+            }
+        };
+        assertEval("System.console().readLine()", "\"AB\"");
         console = new ThrowingJShellConsole() {
             @Override
             public char[] readPassword(String prompt) throws IOError {
@@ -210,6 +218,10 @@ public class ConsoleTest extends KullaTesting {
                 return console.readLine(prompt);
             }
             @Override
+            public String readLine() throws IOError {
+                return console.readLine();
+            }
+            @Override
             public char[] readPassword(String prompt) throws IOError {
                 return console.readPassword(prompt);
             }
@@ -237,6 +249,10 @@ public class ConsoleTest extends KullaTesting {
         }
         @Override
         public String readLine(String prompt) throws IOError {
+            throw new IllegalStateException("Not expected!");
+        }
+        @Override
+        public String readLine() throws IOError {
             throw new IllegalStateException("Not expected!");
         }
         @Override


### PR DESCRIPTION
This PR is simply adding parameter-less `java.io.IO.{println(),readln()}`, with the (hopefully) obvious semantics, plus the corresponding wiring to make those work. This may become part of JEP 495:
https://openjdk.org/jeps/495

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8342937](https://bugs.openjdk.org/browse/JDK-8342937) to be approved
- [x] Change requires a JEP request to be targeted

### Issues
 * [JDK-8342936](https://bugs.openjdk.org/browse/JDK-8342936): Enhance java.io.IO with parameter-less println() and readln() (**Sub-task** - P4)
 * [JDK-8335984](https://bugs.openjdk.org/browse/JDK-8335984): JEP 495: Simple Source Files and Instance Main Methods (Fourth Preview) (**JEP**)
 * [JDK-8342937](https://bugs.openjdk.org/browse/JDK-8342937): Enhance java.io.IO with parameter-less println() and readln() (**CSR**)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**) Review applies to [78bf15bf](https://git.openjdk.org/jdk/pull/21693/files/78bf15bf1ad03a535b04727b1a982c7b440410e7)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21693/head:pull/21693` \
`$ git checkout pull/21693`

Update a local copy of the PR: \
`$ git checkout pull/21693` \
`$ git pull https://git.openjdk.org/jdk.git pull/21693/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21693`

View PR using the GUI difftool: \
`$ git pr show -t 21693`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21693.diff">https://git.openjdk.org/jdk/pull/21693.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21693#issuecomment-2436189851)
</details>
