### PR TITLE
8336684: Enhance JCmd by adding a new command to summarize target r/t metadata

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1343,16 +1343,8 @@ bool VMUsageMetadataDCmd::_writeJVMContainerInfo(const Formatter* formatter, out
 
   output->print("%s.%s%s\"%s\"%s", fieldName, "type", formatter->kvSeparator(), OSContainer::container_type(), formatter->fldSeparator());
 
-  char name[HOST_NAME_MAX + 1];
-
-  name[HOST_NAME_MAX] = '\0'; // in case gethostname overflows and does not null terminate ...
-
-  if (os::get_host_name(name, HOST_NAME_MAX)) {
-    output->print("%s.%s%s\"%s\"%s", fieldName, "name", formatter->kvSeparator(), name, formatter->fldSeparator());
-  }
-
   output->print("%s.%s%s%ld%s", fieldName, "memory.limit", formatter->kvSeparator(), (long)OSContainer::memory_limit_in_bytes(), formatter->fldSeparator());
-  output->print("%s.%s%s%d%s", fieldName, "active.cpus", formatter->kvSeparator(), OSContainer::active_processor_count(), formatter->fldSeparator());
+  output->print("%s.%s%s%d", fieldName, "active.cpus", formatter->kvSeparator(), OSContainer::active_processor_count());
 
   return true;
 }

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -1179,8 +1179,8 @@ void SystemDumpMapDCmd::execute(DCmdSource source, TRAPS) {
  */
 
 VMUsageMetadataDCmd::VMUsageMetadataDCmd(outputStream* output, bool heap) : DCmdWithParser(output, heap),
-  _omitIfNull("-omitIfNull", "omit null valued fields from output", "BOOLEAN", false, "false"),
-  _fields("fields", "a comma separated list of metadata fields to emit", "STRING", false),
+  _omitIfNull("-omitnulls", "omit null valued fields from output", "BOOLEAN", false, "false"),
+  _fields("fields", "a comma separated list of metadata fields to emit, prepend with '+' to append to defaults, otherwise replaces defaults", "STRING", false),
   _format("format", "Output format (\"plain\" or \"json\")", "STRING", false, _TEXT_PLAIN),
   _filename("filename", "The file path to the output file to append to", "FILE", false) {
   _dcmdparser.add_dcmd_option(&_omitIfNull);

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/UsageMetadataTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/UsageMetadataTest.java
@@ -73,8 +73,6 @@ public class UsageMetadataTest {
          // newEntry("jvm.ctr.info.name"),
          // newEntry("jvm.ctr.info.memory.limit"),
          // newEntry("jvm.ctr.info.active.cpus"),
-         newEntry("user.name"),
-         newEntry("user.dir"),
          newEntry("os.hostname"),
          newEntry("os.name"),
          newEntry("os.version"),

--- a/test/hotspot/jtreg/serviceability/dcmd/vm/UsageMetadataTest.java
+++ b/test/hotspot/jtreg/serviceability/dcmd/vm/UsageMetadataTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.BiFunction;
+import java.util.function.Predicate;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import org.testng.annotations.Test;
+
+import jdk.test.lib.dcmd.CommandExecutor;
+import jdk.test.lib.dcmd.JMXExecutor;
+
+/*
+ * @test
+ * @summary Test of diagnostic command VM.usage_metadata
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.compiler
+ *          java.management
+ *          jdk.internal.jvmstat/sun.jvmstat.monitor
+ * @run testng/othervm UsageMetadataTest
+ */
+public class UsageMetadataTest {
+
+    private static Map.Entry<String, Predicate<String>> newEntry(String field, Predicate<String> predicate) {
+        return Map.entry(field, predicate);
+    };
+
+    private static Map.Entry<String, Predicate<String>> newEntry(String field) {
+        return newEntry(field, (line) -> line.contains(field));
+    };
+
+    private static final Map<String, Predicate<String>> FIELDS = Map.ofEntries(
+         newEntry("timestamp"),
+         newEntry("jvm.starttime"),
+         newEntry("java.home"),
+         newEntry("java.version"),
+         newEntry("java.vm.version"),
+         newEntry("sun.java.launcher"),
+         newEntry("jvm.flags"),
+         newEntry("jvm.args"),
+         newEntry("sun.java.command"),
+         newEntry("java.class.path"),
+         // newEntry("jdk.module.path"),
+         // newEntry("jdk.main.module"),
+         // newEntry("jdk.main.module.class"),
+         // newEntry("jdk.upgrade.module.path"),
+         newEntry("jvm.pid"),
+         newEntry("jvm.uptime.ms"),
+         // newEntry("jvm.ctr.info.type"),
+         // newEntry("jvm.ctr.info.name"),
+         // newEntry("jvm.ctr.info.memory.limit"),
+         // newEntry("jvm.ctr.info.active.cpus"),
+         newEntry("user.name"),
+         newEntry("user.dir"),
+         newEntry("os.hostname"),
+         newEntry("os.name"),
+         newEntry("os.version"),
+         newEntry("os.arch")
+    );
+
+    public void run(CommandExecutor executor) {
+        OutputAnalyzer output = executor.execute("VM.usage_metadata");
+
+        output.stderrShouldBeEmpty();
+
+        /*
+         * the default o/p fields for VM.usage_metadata are:
+         *
+         * - timestamp
+         * - jvm.starttime
+         * - java.home
+         * - java.version
+         * - java.vm.version
+         * - sun.java.launcher
+         * - jvm.flags
+         * - jvm.args
+         * - sun.java.command
+         * - java.classpath
+         * - jdk.module.path (if present)
+         * - jdk.main.module (if present)
+         * - jdk.main.module.class (if present)
+         * - jdk.upgrade.module.path (if present)
+         * - jvm.pid
+         * - jvm.uptime
+         * - jvm.ctr.info.* (if present)
+         * - user.name
+         * - user.dir
+         * - os.hostname
+         * - os.name
+         * - os.version
+         * - os.arch
+         */
+
+        final var stdout =  output.getStdout();
+
+        for (var field : FIELDS.entrySet()) {
+            if (!field.getValue().test(stdout)) {
+                output.reportDiagnosticSummary();
+
+                throw new RuntimeException("'" + field.getKey() + "' misssing from stdout");
+            }
+        }
+    }
+
+    @Test
+    public void jmx() {
+        run(new JMXExecutor());
+    }
+}


### PR DESCRIPTION
Add a new command that the jcmd command line tool can use to print metadata about JVM usage.

The output is formatted (either in plain text or as JSON) as a list of key,value tuples.

The command effectively treats the individual metadata "fields" as System property names, and where none exist for particular metadata (such as JVM uptime) a "synthetic" property (name) is used in order to uniquely identify such metadata.

Here is example output (the output is JSON encoded to enable programmatic parsing, newlines are added here for clarity the implementation outputs the metadata on a single line suitable for appending to files etc).

```
135986:
{ 
 "timestamp" : "2024-09-10T12:06:02.953-0700", 
  "jvm.starttime" : "2024-09-10T19:05:41.976+0000", 
  "java.home" : "/home/auser/src/git/jdk/open/build/linux-x86_64-server-release/jdk", 
  "java.version" : "24-internal", 
  "java.vm.version" : "24-internal-adhoc.lpgc.open", 
  "sun.java.launcher" : "SUN_STANDARD", 
  "jvm.args" : [ "-Dapplication.home=/home/auser/src/git/jdk/open/build/linux-x86_64-server-release/jdk", "-Xms8m", "-Djdk.module.main=jdk.jshell" ], 
  "sun.java.command" : "jdk.jshell/jdk.internal.jshell.tool.JShellToolProvider",
  "java.class.path" : "", 
  "jvm.pid" : "135986", 
  "jvm.uptime.ms" : "21123", 
  "user.name" : "auser", 
  "user.dir" : "/home/auser/src/git/jdk/open", 
  "os.name" : "Linux", "os.version" : "4.18.0-553.16.1.el8_10.x86_64", 
  "os.arch" : "amd64" 
}
```
an example of plain text is:

```
135986:
"timestamp"="2024-09-10T12:26:17.478-0700", 
"jvm.starttime"="2024-09-10T19:05:41.976+0000",
"java.home"="/home/auser/src/git/jdk/open/build/linux-x86_64-server-release/jdk", 
"java.version"="24-internal", "java.vm.version"="24-internal-adhoc.auser.open", 
"sun.java.launcher"="SUN_STANDARD", 
"jvm.args"="'-Dapplication.home=/home/auser/src/git/jdk/open/build/linux-x86_64-server-release/jdk', '-Xms8m', '-Djdk.module.main=jdk.jshell'", 
"sun.java.command"="jdk.jshell/jdk.internal.jshell.tool.JShellToolProvider", "java.class.path"="", 
"jvm.pid"="135986", 
"jvm.uptime.ms"="1235648", 
"user.name"="auser", 
"user.dir"="/home/auser/src/git/jdk/open", 
"os.name"="Linux", 
"os.version"="4.18.0-553.16.1.el8_10.x86_64", "os.arch"="amd64"
```
The man page jcmd(1) describes this new jcmd as:
```

VM.usage_metadata [options]

Print VM usage metadata as a formatted list of key & (non null) value tuples.

Impact: Low

Note:

The following options must be specified using either key or key=value syntax.

options:

format: (Optional) Output format ("plain" or "json") (STRING, plain)

filepath: The file path to the output file into which, append usage metadata (STRING, no default value)

fields: a comma separated list of fields (System properties, real or synthetic) to print (when non-null) overriding the default (STRING, see below)

Fields are either System Property names(c.f: java.lang.System for definitions), or certain "synthetic" properties (where there is no pre-existing System Property):

jvm.args: any command line arguments specified for the JVM.

jvm.container.info: (linux only) if the JVM is executing within the context of a cgroup, emit:

type (cgroupv1 or cgroupv2)
container (host) name (usually by convention the container id)
memory.limit
# of active.cpus therein.
jvm.flags: the JVM flags.

jvm.pid: the process id of the JVM.

jvm.starttime: the time when the JVM completed its initialization just prior to commencing execution of user code.

jvm.uptime.ms: the uptime (in ms) of the JVM.

timestamp: the current time.

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8336684](https://bugs.openjdk.org/browse/JDK-8336684): Enhance JCmd by adding a new command to summarize target r/t metadata (**Enhancement** - P4) ⚠️ Issue is not open.
 * [JDK-8339877](https://bugs.openjdk.org/browse/JDK-8339877): Enhance JCmd by adding a new command to summarize target r/t metadata (**CSR**) (Withdrawn)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21694/head:pull/21694` \
`$ git checkout pull/21694`

Update a local copy of the PR: \
`$ git checkout pull/21694` \
`$ git pull https://git.openjdk.org/jdk.git pull/21694/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21694`

View PR using the GUI difftool: \
`$ git pr show -t 21694`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21694.diff">https://git.openjdk.org/jdk/pull/21694.diff</a>

</details>
