### PR TITLE
8343020: (fs) Add support for SecureDirectoryStream on macOS

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -569,7 +569,7 @@ class UnixNativeDispatcher {
     }
 
     /**
-     * Supports futimes or futimesat
+     * Supports futimes
      */
     static boolean futimesSupported() {
         return (capabilities & SUPPORTS_FUTIMES) != 0;

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -363,8 +363,8 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
     /* system calls that might not be available at run time */
 
 #if defined(_ALLBSD_SOURCE)
-    my_openat_func = (openat_func*)dlsym(RTLD_DEFAULT, "openat");
-    my_fstatat_func = (fstatat_func*)dlsym(RTLD_DEFAULT, "fstatat");
+    my_openat_func = (openat_func*) openat;
+    my_fstatat_func = (fstatat_func*) fstatat;
 #else
     // Make sure we link to the 64-bit version of the functions
     my_openat_func = (openat_func*) dlsym(RTLD_DEFAULT, "openat64");
@@ -387,6 +387,8 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
 #if defined(_AIX)
     // Make sure we link to the 64-bit version of the function
     my_fdopendir_func = (fdopendir_func*) dlsym(RTLD_DEFAULT, "fdopendir64");
+#elif defined(_ALLBSD_SOURCE)
+    my_fdopendir_func = (fdopendir_func*) fdopendir;
 #else
     my_fdopendir_func = (fdopendir_func*) dlsym(RTLD_DEFAULT, "fdopendir");
 #endif

--- a/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
+++ b/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
@@ -22,7 +22,7 @@
  */
 
 /* @test
- * @bug 4313887 6838333
+ * @bug 4313887 6838333 8343020
  * @summary Unit test for java.nio.file.SecureDirectoryStream
  * @requires (os.family == "linux" | os.family == "mac")
  * @library ..

--- a/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
+++ b/test/jdk/java/nio/file/DirectoryStream/SecureDS.java
@@ -24,6 +24,7 @@
 /* @test
  * @bug 4313887 6838333
  * @summary Unit test for java.nio.file.SecureDirectoryStream
+ * @requires (os.family == "linux" | os.family == "mac")
  * @library ..
  */
 
@@ -45,11 +46,7 @@ public class SecureDS {
             DirectoryStream<Path> stream = newDirectoryStream(dir);
             stream.close();
             if (!(stream instanceof SecureDirectoryStream)) {
-                if (System.getProperty("os.name").equals("Linux"))
-                    throw new AssertionError(
-                            "SecureDirectoryStream not supported.");
-                System.out.println("SecureDirectoryStream not supported.");
-                return;
+                throw new AssertionError("SecureDirectoryStream not supported.");
             }
 
             supportsSymbolicLinks = TestUtil.supportsSymbolicLinks(dir);


### PR DESCRIPTION
OpenJDK will not produce SecureDirectoryStreams on MacOS. Support for SecureDirectoryStream on UNIX-like OSes is predicated on the `SUPPORTS_OPENAT` flag in UnixNativeDispatcher. That flag in turn is set when the runtime environment supports `openat`, `fstatat`, `unlinkat`, `renameat`, `futimesat`, and `fdopendir`.

This fails on MacOS because `futimesat` does not exist on that platform, apparently having been a proposed-but-not-accepted part of POSIX some time ago. While there is an indirect replacement that is supported on MacOS - `utimensat` - this is not actually needed, because the unique functionality provided by `futimesat` (that is, performing the action of `futimes` relative to an open directory file descriptor) is not utilized, since the only place this function is used passes `NULL` as the relative filename argument.

Replacing this with simply calling `futimes` instead allows `SecureDirectoryStream` to function on MacOS.

Additionally, we must ensure that `openat`, `fstatat`, and `fdopendir` are properly detected on MacOS x64, because there are 32- and 64-bit variations on that platform which misbehave subtly when done improperly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8343020](https://bugs.openjdk.org/browse/JDK-8343020): (fs) Add support for SecureDirectoryStream on macOS (**New Feature** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21696/head:pull/21696` \
`$ git checkout pull/21696`

Update a local copy of the PR: \
`$ git checkout pull/21696` \
`$ git pull https://git.openjdk.org/jdk.git pull/21696/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21696`

View PR using the GUI difftool: \
`$ git pr show -t 21696`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21696.diff">https://git.openjdk.org/jdk/pull/21696.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21696#issuecomment-2436499867)