### PR TITLE
8342930: New tests from JDK-8335912 are failing

### DIFF
--- a/src/jdk.jartool/share/man/jar.1
+++ b/src/jdk.jartool/share/man/jar.1
@@ -118,6 +118,9 @@ Updates an existing JAR file.
 .TP
 \f[V]-x\f[R] or \f[V]--extract\f[R]
 Extracts the named (or all) files from the archive.
+If a file with the same name appears more than once in the archive, each
+copy will be extracted, with later copies overwriting (replacing)
+earlier copies unless -k is specified.
 .TP
 \f[V]-d\f[R] or \f[V]--describe-module\f[R]
 Prints the module descriptor or automatic module name.
@@ -212,6 +215,14 @@ time-zone format, to use for the timestamp of the entries, e.g.
 .TP
 \f[V]--dir\f[R] \f[I]DIR\f[R]
 Directory into which the JAR file will be extracted.
+.TP
+\f[V]-k\f[R] or \f[V]--keep-old-files\f[R]
+Do not overwrite existing files.
+If a Jar file entry with the same name exists in the target directory,
+the existing file will not be overwritten.
+As a result, if a file appears more than once in an archive, later
+copies will not overwrite earlier copies.
+Also note that some file system can be case insensitive.
 .SH OTHER OPTIONS
 .PP
 The following options are recognized by the \f[V]jar\f[R] command and

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -723,9 +723,6 @@ javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.ja
 
 # core_tools
 
-tools/jar/ExtractFilesTest.java 8342930 generic-all
-tools/jar/MultipleManifestTest.java 8342930 generic-all
-
 
 ############################################################################
 

--- a/test/jdk/tools/jar/ExtractFilesTest.java
+++ b/test/jdk/tools/jar/ExtractFilesTest.java
@@ -88,7 +88,7 @@ import jdk.test.lib.util.FileUtils;
                 " inflated: testfile1" + nl +
                 " inflated: testfile2" + nl;
         rm("META-INF testfile1 testfile2");
-        Assertions.assertArrayEquals(baos.toByteArray(), output.getBytes());
+        assertOutputContains(output);
     }
 
     /**
@@ -105,7 +105,7 @@ import jdk.test.lib.util.FileUtils;
                 " inflated: testfile2" + nl;
         Assertions.assertEquals("testfile1", cat("testfile1"));
         rm("META-INF testfile1 testfile2");
-        Assertions.assertArrayEquals(baos.toByteArray(), output.getBytes());
+        assertOutputContains(output);
     }
 
     /**
@@ -123,7 +123,7 @@ import jdk.test.lib.util.FileUtils;
         Assertions.assertEquals("", cat("testfile1"));
         Assertions.assertEquals("testfile2", cat("testfile2"));
         rm("META-INF testfile1 testfile2");
-        Assertions.assertArrayEquals(baos.toByteArray(), output.getBytes());
+        assertOutputContains(output);
     }
 
     /**
@@ -141,7 +141,7 @@ import jdk.test.lib.util.FileUtils;
         Assertions.assertEquals("", cat("testfile1"));
         Assertions.assertEquals("", cat("testfile2"));
         rm("META-INF testfile1 testfile2");
-        Assertions.assertArrayEquals(baos.toByteArray(), output.getBytes());
+        assertOutputContains(output);
     }
 
     /**
@@ -159,7 +159,7 @@ import jdk.test.lib.util.FileUtils;
         Assertions.assertEquals("testfile1", cat("testfile1"));
         Assertions.assertEquals("", cat("testfile2"));
         rm("META-INF testfile1 testfile2");
-        Assertions.assertArrayEquals(baos.toByteArray(), output.getBytes());
+        assertOutputContains(output);
     }
 
     /**
@@ -175,8 +175,12 @@ import jdk.test.lib.util.FileUtils;
                 "testfile1" + nl +
                 "testfile2" + nl;
 
-        Assertions.assertArrayEquals(baos.toByteArray(), output.getBytes());
+        assertOutputContains(output);
         Assertions.assertEquals("Warning: The --keep-old-files/-k/k option is not valid with current usage, will be ignored." + nl, err);
+    }
+
+    private void assertOutputContains(String expected) {
+        Assertions.assertTrue(baos.toString().contains(expected));
     }
 
     private Stream<Path> mkpath(String... args) {

--- a/test/jdk/tools/jar/MultipleManifestTest.java
+++ b/test/jdk/tools/jar/MultipleManifestTest.java
@@ -154,7 +154,7 @@ class MultipleManifestTest {
                 " inflated: entry1.txt" + nl +
                 " inflated: META-INF/MANIFEST.MF" + nl +
                 " inflated: entry2.txt" + nl;
-        Assertions.assertArrayEquals(baos.toByteArray(), output.getBytes());
+        assertOutputContains(output);
     }
 
     /**
@@ -170,7 +170,7 @@ class MultipleManifestTest {
                 " inflated: entry1.txt" + nl +
                 "  skipped: META-INF/MANIFEST.MF exists" + nl +
                 " inflated: entry2.txt" + nl;
-        Assertions.assertArrayEquals(baos.toByteArray(), output.getBytes());
+        assertOutputContains(output);
     }
 
     private String getManifestVersion() throws IOException {
@@ -197,6 +197,10 @@ class MultipleManifestTest {
         } finally {
             System.setErr(saveErr);
         }
+    }
+
+    private void assertOutputContains(String expected) {
+        Assertions.assertTrue(baos.toString().contains(expected));
     }
 
     private void println() throws IOException {


### PR DESCRIPTION
Check output for including values rather than exact match.
Also include the manpage change  and revert the problem list.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342930](https://bugs.openjdk.org/browse/JDK-8342930): New tests from JDK-8335912 are failing (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21697/head:pull/21697` \
`$ git checkout pull/21697`

Update a local copy of the PR: \
`$ git checkout pull/21697` \
`$ git pull https://git.openjdk.org/jdk.git pull/21697/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21697`

View PR using the GUI difftool: \
`$ git pr show -t 21697`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21697.diff">https://git.openjdk.org/jdk/pull/21697.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21697#issuecomment-2436639230)