### PR TITLE
8342576: [macos] AppContentTest still fails after JDK-8341443 for same reason on older macOS versions

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -715,6 +715,12 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
         return this;
     }
 
+    public JPackageCommand setExecuteWithoutExitCodeCheck(boolean v) {
+        verifyMutable();
+        executeWithoutExitCodeCheck = v;
+        return this;
+    }
+
     public boolean isWithToolProvider() {
         return Optional.ofNullable(withToolProvider).orElse(
                 defaultWithToolProvider);
@@ -786,10 +792,18 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
             }
         }
 
-        Executor.Result result = new JPackageCommand(this)
-                .adjustArgumentsBeforeExecution()
-                .createExecutor()
-                .execute(expectedExitCode);
+        Executor.Result result;
+        if (executeWithoutExitCodeCheck) {
+            result = new JPackageCommand(this)
+                    .adjustArgumentsBeforeExecution()
+                    .createExecutor()
+                    .executeWithoutExitCodeCheck();
+        } else {
+            result = new JPackageCommand(this)
+                    .adjustArgumentsBeforeExecution()
+                    .createExecutor()
+                    .execute(expectedExitCode);
+        }
 
         if (result.exitCode == 0) {
             executeVerifyActions();
@@ -1108,6 +1122,7 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
     private boolean suppressOutput;
     private boolean ignoreDefaultRuntime;
     private boolean ignoreDefaultVerbose;
+    private boolean executeWithoutExitCodeCheck;
     private boolean immutable;
     private final Actions prerequisiteActions;
     private final Actions verifyActions;


### PR DESCRIPTION
- It is not clear on which macOS versions codesign fails if application bundle contains additional content.
- As a result test was modified to generate only application image, since PKG or DMG cannot be generated if signing fails. Exit code of jpackage is ignored, but generated application image will be checked for additional content.
- This change is for macOS only.
- Previous implementation of test (forcing expected exist code to 1) was not doing anything useful, since we never checked if additional content was copied or not.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342576](https://bugs.openjdk.org/browse/JDK-8342576): [macos] AppContentTest still fails after JDK-8341443 for same reason on older macOS versions (**Bug** - P3)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21698/head:pull/21698` \
`$ git checkout pull/21698`

Update a local copy of the PR: \
`$ git checkout pull/21698` \
`$ git pull https://git.openjdk.org/jdk.git pull/21698/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21698`

View PR using the GUI difftool: \
`$ git pr show -t 21698`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21698.diff">https://git.openjdk.org/jdk/pull/21698.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21698#issuecomment-2436649596)