### PR TITLE
8343031: StopInterpreterAt not work on linux-x86_64

### DIFF
--- a/src/hotspot/os_cpu/linux_x86/assembler_linux_x86.cpp
+++ b/src/hotspot/os_cpu/linux_x86/assembler_linux_x86.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,5 +28,5 @@
 #include "runtime/os.hpp"
 
 void MacroAssembler::int3() {
-  call(RuntimeAddress(CAST_FROM_FN_PTR(address, os::breakpoint)));
+  emit_int8((unsigned char)0xCC);
 }


### PR DESCRIPTION
Hi all,
The VM option `-XX:StopInterpreterAt=1` doesn't work on linux-x86_64 before this PR. `MacroAssembler::int3` call `os::breakpoint()`, but the `os::breakpoint()` [implementation](https://github.com/openjdk/jdk/blob/master/src/hotspot/os/posix/os_posix.cpp#L284) is empty.
In this PR, I replace call `os::breakpoint()` as emit int3 assemble code directly.

Additional testing:

- [ ] linux x64 build with release/fastdebug/slowdebug configure
- [ ] linux x64 jtreg tests(include tier1/2/3 etc.) with release build
- [ ] linux x64 jtreg tests(include tier1/2/3 etc.) with fastdebug build