### PR TITLE
8342962: [s390x] TestOSRLotsOfLocals.java crashes

### DIFF
--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -136,13 +136,12 @@ void LIR_Assembler::osr_entry() {
 
     const int locals_space = BytesPerWord * method() -> max_locals();
     int monitor_offset = locals_space + (2 * BytesPerWord) * (number_of_locks - 1);
-    bool handled_manually = false;
+    bool large_offset = !Immediate::is_simm20(monitor_offset + BytesPerWord) && number_of_locks > 0;
 
-    if (!Immediate::is_simm20(monitor_offset + BytesPerWord) && number_of_locks > 0) {
+    if (large_offset) {
       // z_lg can only handle displacement upto 20bit signed binary integer
       __ z_algfi(OSR_buf, locals_space);
       monitor_offset -= locals_space;
-      handled_manually = true;
     }
 
     // SharedRuntime::OSR_migration_begin() packs BasicObjectLocks in
@@ -159,7 +158,7 @@ void LIR_Assembler::osr_entry() {
       __ z_stg(Z_R1_scratch, frame_map()->address_for_monitor_object(i));
     }
 
-    if (handled_manually) {
+    if (large_offset) {
       __ z_slgfi(OSR_buf, locals_space);
     }
   }

--- a/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_LIRAssembler_s390.cpp
@@ -140,8 +140,7 @@ void LIR_Assembler::osr_entry() {
 
     if (!Immediate::is_simm20(monitor_offset + BytesPerWord) && number_of_locks > 0) {
       // z_lg can only handle displacement upto 20bit signed binary integer
-      __ load_const(Z_R0_scratch, locals_space);
-      __ z_algr(OSR_buf, Z_R0_scratch);
+      __ z_algfi(OSR_buf, locals_space);
       monitor_offset -= locals_space;
       handled_manually = true;
     }
@@ -161,9 +160,7 @@ void LIR_Assembler::osr_entry() {
     }
 
     if (handled_manually) {
-      // Z_R0 is killed by asm_assert_mem8_isnot_zero
-      __ load_const(Z_R0_scratch, locals_space);
-      __ z_slgr(OSR_buf, Z_R0_scratch);
+      __ z_slgfi(OSR_buf, locals_space);
     }
   }
 }


### PR DESCRIPTION
We are on thin ice with the `TestOSRLotsOfLocals` test. Before it breaks, I'd like to provide the fix. :-)

Testing : Tier1 test with fastdebug vm.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342962](https://bugs.openjdk.org/browse/JDK-8342962): [s390x] TestOSRLotsOfLocals.java crashes (**Bug** - P3)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21703/head:pull/21703` \
`$ git checkout pull/21703`

Update a local copy of the PR: \
`$ git checkout pull/21703` \
`$ git pull https://git.openjdk.org/jdk.git pull/21703/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21703`

View PR using the GUI difftool: \
`$ git pr show -t 21703`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21703.diff">https://git.openjdk.org/jdk/pull/21703.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21703#issuecomment-2437077327)