### PR TITLE
8343040: Clean up references to JRE in the launcher code

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -149,7 +149,7 @@ GetExecName() {
 /*
  * Exports the JNI interface from libjli
  *
- * This allows client code to link against the .jre/.jdk bundles,
+ * This allows client code to link against the JDK bundles,
  * and not worry about trying to pick a HotSpot to link against.
  *
  * Switching architectures is unsupported, since client code has
@@ -162,10 +162,10 @@ static char *sPreferredJVMType = NULL;
 static InvocationFunctions *GetExportedJNIFunctions() {
     if (sExportedJNIFunctions != NULL) return sExportedJNIFunctions;
 
-    char jrePath[PATH_MAX];
-    jboolean gotJREPath = GetJREPath(jrePath, sizeof(jrePath), JNI_FALSE);
-    if (!gotJREPath) {
-        JLI_ReportErrorMessage("Failed to GetJREPath()");
+    char jdkRoot[PATH_MAX];
+    jboolean got = GetJDKInstallRoot(jdkRoot, sizeof(jdkRoot), JNI_FALSE);
+    if (!got) {
+        JLI_ReportErrorMessage("Failed to determine JDK installation root");
         return NULL;
     }
 
@@ -183,7 +183,7 @@ static InvocationFunctions *GetExportedJNIFunctions() {
     }
 
     char jvmPath[PATH_MAX];
-    jboolean gotJVMPath = GetJVMPath(jrePath, preferredJVM, jvmPath, sizeof(jvmPath));
+    jboolean gotJVMPath = GetJVMPath(jdkRoot, preferredJVM, jvmPath, sizeof(jvmPath));
     if (!gotJVMPath) {
         JLI_ReportErrorMessage("Failed to GetJVMPath()");
         return NULL;
@@ -326,9 +326,9 @@ static void MacOSXStartup(int argc, char *argv[]) {
 
 void
 CreateExecutionEnvironment(int *pargc, char ***pargv,
-                           char jrepath[], jint so_jrepath,
+                           char jdkroot[], jint so_jdkroot,
                            char jvmpath[], jint so_jvmpath,
-                           char jvmcfg[],  jint so_jvmcfg) {
+                           char jvmcfg[], jint so_jvmcfg) {
     /* Compute/set the name of the executable */
     SetExecname(*pargv);
 
@@ -336,13 +336,13 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     int  argc         = *pargc;
     char **argv       = *pargv;
 
-    /* Find out where the JRE is that we will be using. */
-    if (!GetJREPath(jrepath, so_jrepath, JNI_FALSE) ) {
-        JLI_ReportErrorMessage(JRE_ERROR1);
+    /* Find out where the JDK is that we will be using. */
+    if (!GetJDKInstallRoot(jdkroot, so_jdkroot, JNI_FALSE) ) {
+        JLI_ReportErrorMessage(LAUNCHER_ERROR1);
         exit(2);
     }
     JLI_Snprintf(jvmcfg, so_jvmcfg, "%s%slib%sjvm.cfg",
-                 jrepath, FILESEP, FILESEP);
+                 jdkroot, FILESEP, FILESEP);
     /* Find the specified JVM type */
     if (ReadKnownVMs(jvmcfg, JNI_FALSE) < 1) {
         JLI_ReportErrorMessage(CFG_ERROR7);
@@ -356,7 +356,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
         exit(4);
     }
 
-    if (!GetJVMPath(jrepath, jvmtype, jvmpath, so_jvmpath)) {
+    if (!GetJVMPath(jdkroot, jvmtype, jvmpath, so_jvmpath)) {
         JLI_ReportErrorMessage(CFG_ERROR8, jvmtype, jvmpath);
         exit(4);
     }
@@ -378,7 +378,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
  * VM choosing is done by the launcher (java.c).
  */
 static jboolean
-GetJVMPath(const char *jrepath, const char *jvmtype,
+GetJVMPath(const char *jdkroot, const char *jvmtype,
            char *jvmpath, jint jvmpathsize)
 {
     struct stat s;
@@ -390,7 +390,7 @@ GetJVMPath(const char *jrepath, const char *jvmtype,
          * macosx client library is built thin, i386 only.
          * 64 bit client requests must load server library
          */
-        JLI_Snprintf(jvmpath, jvmpathsize, "%s/lib/%s/" JVM_DLL, jrepath, jvmtype);
+        JLI_Snprintf(jvmpath, jvmpathsize, "%s/lib/%s/" JVM_DLL, jdkroot, jvmtype);
     }
 
     JLI_TraceLauncher("Does `%s' exist ... ", jvmpath);
@@ -408,15 +408,15 @@ GetJVMPath(const char *jrepath, const char *jvmtype,
 }
 
 /*
- * Find path to JRE based on .exe's location or registry settings.
+ * Find path to the JDK installation root
  */
 static jboolean
-GetJREPath(char *path, jint pathsize, jboolean speculative)
+GetJDKInstallRoot(char *path, jint pathsize, jboolean speculative)
 {
     char libjava[MAXPATHLEN];
 
     if (GetApplicationHome(path, pathsize)) {
-        /* Is JRE co-located with the application? */
+        /* Is the JDK co-located with the application? */
         if (JLI_IsStaticallyLinked()) {
             char jvm_cfg[MAXPATHLEN];
             JLI_Snprintf(jvm_cfg, sizeof(jvm_cfg), "%s/lib/jvm.cfg", path);
@@ -445,7 +445,7 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
 
     /* try to find ourselves instead */
     Dl_info selfInfo;
-    dladdr(&GetJREPath, &selfInfo);
+    dladdr(&GetJDKInstallRoot, &selfInfo);
 
     if (JLI_IsStaticallyLinked()) {
         char jvm_cfg[MAXPATHLEN];
@@ -488,8 +488,8 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
         return JNI_TRUE;
     }
 
-    // If libjli.dylib is loaded from a macos bundle MacOS dir, find the JRE dir
-    // in ../Home.
+    // If libjli.dylib is loaded from a macos bundle MacOS dir, find the JDK
+    // install root at ../Home.
     const char altLastPathComponent[] = "/MacOS/libjli.dylib";
     size_t sizeOfAltLastPathComponent = sizeof(altLastPathComponent) - 1;
     if (pathLen < sizeOfLastPathComponent) {
@@ -505,7 +505,7 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
     }
 
     if (!speculative)
-      JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);
+      JLI_ReportErrorMessage(LAUNCHER_ERROR2 JAVA_DLL);
     return JNI_FALSE;
 }
 
@@ -642,27 +642,27 @@ static void* hSplashLib = NULL;
 
 void* SplashProcAddress(const char* name) {
     if (!hSplashLib) {
-        char jrePath[PATH_MAX];
-        if (!GetJREPath(jrePath, sizeof(jrePath), JNI_FALSE)) {
-            JLI_ReportErrorMessage(JRE_ERROR1);
+        char jdkRoot[PATH_MAX];
+        if (!GetJDKInstallRoot(jdkRoot, sizeof(jdkRoot), JNI_FALSE)) {
+            JLI_ReportErrorMessage(LAUNCHER_ERROR1);
             return NULL;
         }
 
         char splashPath[PATH_MAX];
         const int ret = JLI_Snprintf(splashPath, sizeof(splashPath),
-                "%s/lib/%s", jrePath, SPLASHSCREEN_SO);
+                                     "%s/lib/%s", jdkRoot, SPLASHSCREEN_SO);
         if (ret >= (int)sizeof(splashPath)) {
-            JLI_ReportErrorMessage(JRE_ERROR11);
+            JLI_ReportErrorMessage(LAUNCHER_ERROR3);
             return NULL;
         }
         if (ret < 0) {
-            JLI_ReportErrorMessage(JRE_ERROR13);
+            JLI_ReportErrorMessage(LAUNCHER_ERROR5);
             return NULL;
         }
 
         hSplashLib = dlopen(splashPath, RTLD_LAZY | RTLD_GLOBAL);
         // It's OK if dlopen() fails. The splash screen library binary file
-        // might have been stripped out from the JRE image to reduce its size
+        // might have been stripped out from the JDK image to reduce its size
         // (e.g. on embedded platforms).
 
         if (hSplashLib) {

--- a/src/java.base/share/native/libjli/emessages.h
+++ b/src/java.base/share/native/libjli/emessages.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -62,60 +62,33 @@
 #define JVM_ERROR1      "Error: Could not create the Java Virtual Machine.\n" GEN_ERROR
 #define JVM_ERROR2      "Error: Could not detach main thread.\n" JNI_ERROR
 
-#define JAR_ERROR1      "Error: Failed to load Main-Class manifest attribute from\n%s\n%s"
 #define JAR_ERROR2      "Error: Unable to access jarfile %s"
 #define JAR_ERROR3      "Error: Invalid or corrupt jarfile %s"
-
-#define CLS_ERROR1      "Error: Could not find the main class %s.\n" JNI_ERROR
-#define CLS_ERROR2      "Error: Failed to load Main Class: %s\n%s"
-#define CLS_ERROR3      "Error: No main method found in specified class.\n" GEN_ERROR
-#define CLS_ERROR4      "Error: Main method not public\n" GEN_ERROR
-#define CLS_ERROR5      "Error: main-class: attribute exceeds system limits of %d bytes\n" GEN_ERROR
 
 #define CFG_WARN1       "Warning: %s VM not supported; %s VM will be used"
 #define CFG_WARN2       "Warning: No leading - on line %d of `%s'"
 #define CFG_WARN3       "Warning: Missing VM type on line %d of `%s'"
-#define CFG_WARN4       "Warning: Missing server class VM on line %d of `%s'"
 #define CFG_WARN5       "Warning: Unknown VM type on line %d of `%s'"
 
 #define CFG_ERROR1      "Error: Corrupt jvm.cfg file; cycle in alias list."
 #define CFG_ERROR2      "Error: Unable to resolve VM alias %s"
 #define CFG_ERROR3      "Error: %s VM not supported"
-#define CFG_ERROR4      "Error: Unable to locate JRE meeting specification \"%s\""
 #define CFG_ERROR5      "Error: Could not determine application home."
 #define CFG_ERROR6      "Error: could not open `%s'"
 #define CFG_ERROR7      "Error: no known VMs. (check for corrupt jvm.cfg file)"
-#define CFG_ERROR8      "Error: missing `%s' JVM at `%s'.\nPlease install or use the JRE or JDK that contains these missing components."
+#define CFG_ERROR8      "Error: missing `%s' JVM at `%s'.\nPlease install a JDK that contains these missing components."
 #define CFG_ERROR9      "Error: could not determine JVM type."
 #define CFG_ERROR10     "Error: Argument file size should not be larger than %lu."
 
-#define JRE_ERROR1      "Error: Could not find Java SE Runtime Environment."
-#define JRE_ERROR2      "Error: This Java instance does not support a %d-bit JVM.\nPlease install the desired version."
-#define JRE_ERROR3      "Error: Improper value at line %d."
-#define JRE_ERROR4      "Error: trying to exec %s.\nCheck if file exists and permissions are set correctly."
-#define JRE_ERROR5      "Error: Failed to start a %d-bit JVM process from a %d-bit JVM."
-#define JRE_ERROR6      "Error: Verify all necessary Java SE components have been installed."
-#define JRE_ERROR7      "Error: Either 64-bit processes are not supported by this platform\nor the 64-bit components have not been installed."
-#define JRE_ERROR8      "Error: could not find "
-#define JRE_ERROR9      "Error: Unable to resolve %s"
-#define JRE_ERROR10     "Error: Unable to resolve current executable"
-#define JRE_ERROR11     "Error: Path length exceeds maximum length (PATH_MAX)"
-#define JRE_ERROR12     "Error: Exec of %s failed"
-#define JRE_ERROR13     "Error: String processing operation failed"
+#define LAUNCHER_ERROR1 "Error: Could not find Java SE Runtime Environment."
+#define LAUNCHER_ERROR2 "Error: could not find "
+#define LAUNCHER_ERROR3 "Error: Path length exceeds maximum length (PATH_MAX)"
+#define LAUNCHER_ERROR4 "Error: trying to exec %s.\nCheck if file exists and permissions are set correctly."
+#define LAUNCHER_ERROR5 "Error: String processing operation failed"
 
 #define DLL_ERROR1      "Error: dl failure on line %d"
 #define DLL_ERROR2      "Error: failed %s, because %s"
 #define DLL_ERROR3      "Error: could not find executable %s"
 #define DLL_ERROR4      "Error: Failed to load %s"
-
-#define REG_ERROR1      "Error: opening registry key '%s'"
-#define REG_ERROR2      "Error: Failed reading value of registry key:\n\t%s\\CurrentVersion"
-#define REG_ERROR3      "Error: Registry key '%s'\\CurrentVersion'\nhas value '%s', but '%s' is required."
-#define REG_ERROR4      "Failed reading value of registry key:\n\t%s\\%s\\JavaHome"
-
-#define SYS_ERROR1      "Error: CreateProcess(%s, ...) failed:"
-#define SYS_ERROR2      "Error: WaitForSingleObject() failed."
-
-
 
 #endif /* _EMESSAGES_H */

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -236,7 +236,7 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
     InvocationFunctions ifn;
     jlong start = 0, end = 0;
     char jvmpath[MAXPATHLEN];
-    char jrepath[MAXPATHLEN];
+    char jdkroot[MAXPATHLEN];
     char jvmcfg[MAXPATHLEN];
 
     _fVersion = fullversion;
@@ -265,9 +265,9 @@ JLI_Launch(int argc, char ** argv,              /* main argc, argv */
     }
 
     CreateExecutionEnvironment(&argc, &argv,
-                               jrepath, sizeof(jrepath),
+                               jdkroot, sizeof(jdkroot),
                                jvmpath, sizeof(jvmpath),
-                               jvmcfg,  sizeof(jvmcfg));
+                               jvmcfg, sizeof(jvmcfg));
 
     ifn.CreateJavaVM = 0;
     ifn.GetDefaultJavaVMInitArgs = 0;
@@ -2023,7 +2023,7 @@ PrintUsage(JNIEnv* env, jboolean doXUsage)
  * JVM on the command line.
  *
  * The intent of the jvm.cfg file is to allow several JVM libraries to
- * be installed in different subdirectories of a single JRE installation,
+ * be installed in different subdirectories of a single JDK installation,
  * for space-savings and convenience in testing.
  * The intent is explicitly not to provide a full aliasing or predicate
  * mechanism.

--- a/src/java.base/share/native/libjli/java.h
+++ b/src/java.base/share/native/libjli/java.h
@@ -111,15 +111,15 @@ GetApplicationHomeFromDll(char *buf, jint bufsize);
  * Different platforms will implement this, here
  * pargc is a pointer to the original argc,
  * pargv is a pointer to the original argv,
- * jrepath is an accessible path to the jre as determined by the call
- * so_jrepath is the length of the buffer jrepath
+ * jdkroot is an accessible path to the JDK installation root as determined by the call
+ * so_jdkroot is the length of the buffer jdkroot
  * jvmpath is an accessible path to the jvm as determined by the call
  * so_jvmpath is the length of the buffer jvmpath
  */
 void CreateExecutionEnvironment(int *argc, char ***argv,
-                                char *jrepath, jint so_jrepath,
+                                char *jdkroot, jint so_jdkroot,
                                 char *jvmpath, jint so_jvmpath,
-                                char *jvmcfg,  jint so_jvmcfg);
+                                char *jvmcfg, jint so_jvmcfg);
 
 /* Reports an error message to stderr or a window as appropriate. */
 JNIEXPORT void JNICALL

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -253,8 +253,8 @@ RequiresSetenv(const char *jvmpath) {
 
     /*
      * Prevent recursions. Since LD_LIBRARY_PATH is the one which will be set by
-     * previous versions of the JRE, thus it is the only path that matters here.
-     * So we check to see if the desired JRE is set.
+     * previous versions of the JDK, thus it is the only path that matters here.
+     * So we check to see if the desired JDK is set.
      */
     JLI_StrNCpy(jpath, jvmpath, PATH_MAX);
     p = JLI_StrRChr(jpath, '/');
@@ -273,7 +273,7 @@ RequiresSetenv(const char *jvmpath) {
 
 void
 CreateExecutionEnvironment(int *pargc, char ***pargv,
-                           char jrepath[], jint so_jrepath,
+                           char jdkroot[], jint so_jdkroot,
                            char jvmpath[], jint so_jvmpath,
                            char jvmcfg[],  jint so_jvmcfg) {
 
@@ -294,13 +294,13 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     SetExecname(*pargv);
 
     /* Check to see if the jvmpath exists */
-    /* Find out where the JRE is that we will be using. */
-    if (!GetJREPath(jrepath, so_jrepath, JNI_FALSE)) {
-        JLI_ReportErrorMessage(JRE_ERROR1);
+    /* Find out where the JDK is that we will be using. */
+    if (!GetJDKInstallRoot(jdkroot, so_jdkroot, JNI_FALSE)) {
+        JLI_ReportErrorMessage(LAUNCHER_ERROR1);
         exit(2);
     }
     JLI_Snprintf(jvmcfg, so_jvmcfg, "%s%slib%sjvm.cfg",
-            jrepath, FILESEP, FILESEP);
+            jdkroot, FILESEP, FILESEP);
     /* Find the specified JVM type */
     if (ReadKnownVMs(jvmcfg, JNI_FALSE) < 1) {
         JLI_ReportErrorMessage(CFG_ERROR7);
@@ -314,7 +314,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
         exit(4);
     }
 
-    if (!GetJVMPath(jrepath, jvmtype, jvmpath, so_jvmpath)) {
+    if (!GetJVMPath(jdkroot, jvmtype, jvmpath, so_jvmpath)) {
         JLI_ReportErrorMessage(CFG_ERROR8, jvmtype, jvmpath);
         exit(4);
     }
@@ -339,8 +339,8 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
          * We will set the LD_LIBRARY_PATH as follows:
          *
          *     o          $JVMPATH (directory portion only)
-         *     o          $JRE/lib
-         *     o          $JRE/../lib
+         *     o          $JDK/lib
+         *     o          $JDK/../lib
          *
          * followed by the user's previous effective LD_LIBRARY_PATH, if
          * any.
@@ -352,7 +352,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
         { /* New scope to declare local variable */
             char *new_jvmpath = JLI_StringDup(jvmpath);
             new_runpath_size = ((runpath != NULL) ? JLI_StrLen(runpath) : 0) +
-                    2 * JLI_StrLen(jrepath) +
+                    2 * JLI_StrLen(jdkroot) +
                     JLI_StrLen(new_jvmpath) + 52;
             new_runpath = JLI_MemAlloc(new_runpath_size);
             newpath = new_runpath + JLI_StrLen(LD_LIBRARY_PATH "=");
@@ -372,8 +372,8 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
                         "%s/lib:"
                         "%s/../lib",
                         new_jvmpath,
-                        jrepath,
-                        jrepath
+                        jdkroot,
+                        jdkroot
                         );
 
                 JLI_MemFree(new_jvmpath);
@@ -402,7 +402,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
         if (runpath != 0) {
             /* ensure storage for runpath + colon + NULL */
             if ((JLI_StrLen(runpath) + 1 + 1) > new_runpath_size) {
-                JLI_ReportErrorMessageSys(JRE_ERROR11);
+                JLI_ReportErrorMessageSys(LAUNCHER_ERROR3);
                 exit(1);
             }
             JLI_StrCat(new_runpath, ":");
@@ -437,14 +437,14 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
 #else /* !SETENV_REQUIRED */
         execv(newexec, argv);
 #endif /* SETENV_REQUIRED */
-        JLI_ReportErrorMessageSys(JRE_ERROR4, newexec);
+        JLI_ReportErrorMessageSys(LAUNCHER_ERROR4, newexec);
     }
     exit(1);
 }
 
 
 static jboolean
-GetJVMPath(const char *jrepath, const char *jvmtype,
+GetJVMPath(const char *jdkroot, const char *jvmtype,
            char *jvmpath, jint jvmpathsize)
 {
     struct stat s;
@@ -452,7 +452,7 @@ GetJVMPath(const char *jrepath, const char *jvmtype,
     if (JLI_StrChr(jvmtype, '/')) {
         JLI_Snprintf(jvmpath, jvmpathsize, "%s/" JVM_DLL, jvmtype);
     } else {
-        JLI_Snprintf(jvmpath, jvmpathsize, "%s/lib/%s/" JVM_DLL, jrepath, jvmtype);
+        JLI_Snprintf(jvmpath, jvmpathsize, "%s/lib/%s/" JVM_DLL, jdkroot, jvmtype);
     }
 
     JLI_TraceLauncher("Does `%s' exist ... ", jvmpath);
@@ -467,31 +467,31 @@ GetJVMPath(const char *jrepath, const char *jvmtype,
 }
 
 /*
- * Find path to JRE based on .exe's location or registry settings.
+ * Find path to the JDK installation root
  */
 static jboolean
-GetJREPath(char *path, jint pathsize, jboolean speculative)
+GetJDKInstallRoot(char *path, jint pathsize, jboolean speculative)
 {
     char libjava[MAXPATHLEN];
     struct stat s;
 
-    JLI_TraceLauncher("Attempt to get JRE path from launcher executable path\n");
+    JLI_TraceLauncher("Attempt to get JDK installation root from launcher executable path\n");
 
     if (GetApplicationHome(path, pathsize)) {
-        /* Is JRE co-located with the application? */
+        /* Is JDK co-located with the application? */
         JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
         if (access(libjava, F_OK) == 0) {
-            JLI_TraceLauncher("JRE path is %s\n", path);
+            JLI_TraceLauncher("JDK installation root path is %s\n", path);
             return JNI_TRUE;
         }
     }
 
-    JLI_TraceLauncher("Attempt to get JRE path from shared lib of the image\n");
+    JLI_TraceLauncher("Attempt to get JDK installation root path from shared lib of the image\n");
 
     if (GetApplicationHomeFromDll(path, pathsize)) {
         JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
         if (stat(libjava, &s) == 0) {
-            JLI_TraceLauncher("JRE path is %s\n", path);
+            JLI_TraceLauncher("JDK installation root path is %s\n", path);
             return JNI_TRUE;
         }
     }
@@ -501,14 +501,14 @@ GetJREPath(char *path, jint pathsize, jboolean speculative)
     if (GetApplicationHomeFromLibpath(path, pathsize)) {
         JLI_Snprintf(libjava, sizeof(libjava), "%s/lib/" JAVA_DLL, path);
         if (stat(libjava, &s) == 0) {
-            JLI_TraceLauncher("JRE path is %s\n", path);
+            JLI_TraceLauncher("JDK installation root path is %s\n", path);
             return JNI_TRUE;
         }
     }
 #endif
 
     if (!speculative)
-      JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);
+      JLI_ReportErrorMessage(LAUNCHER_ERROR2 JAVA_DLL);
     return JNI_FALSE;
 }
 
@@ -597,22 +597,22 @@ static void* hSplashLib = NULL;
 void* SplashProcAddress(const char* name) {
     if (!hSplashLib) {
         int ret;
-        char jrePath[MAXPATHLEN];
+        char jdkRoot[MAXPATHLEN];
         char splashPath[MAXPATHLEN];
 
-        if (!GetJREPath(jrePath, sizeof(jrePath), JNI_FALSE)) {
-            JLI_ReportErrorMessage(JRE_ERROR1);
+        if (!GetJDKInstallRoot(jdkRoot, sizeof(jdkRoot), JNI_FALSE)) {
+            JLI_ReportErrorMessage(LAUNCHER_ERROR1);
             return NULL;
         }
         ret = JLI_Snprintf(splashPath, sizeof(splashPath), "%s/lib/%s",
-                     jrePath, SPLASHSCREEN_SO);
+                           jdkRoot, SPLASHSCREEN_SO);
 
         if (ret >= (int) sizeof(splashPath)) {
-            JLI_ReportErrorMessage(JRE_ERROR11);
+            JLI_ReportErrorMessage(LAUNCHER_ERROR3);
             return NULL;
         }
         if (ret < 0) {
-            JLI_ReportErrorMessage(JRE_ERROR13);
+            JLI_ReportErrorMessage(LAUNCHER_ERROR4);
             return NULL;
         }
         hSplashLib = dlopen(splashPath, RTLD_LAZY | RTLD_GLOBAL);

--- a/src/java.base/unix/native/libjli/java_md.c
+++ b/src/java.base/unix/native/libjli/java_md.c
@@ -612,7 +612,7 @@ void* SplashProcAddress(const char* name) {
             return NULL;
         }
         if (ret < 0) {
-            JLI_ReportErrorMessage(LAUNCHER_ERROR4);
+            JLI_ReportErrorMessage(LAUNCHER_ERROR5);
             return NULL;
         }
         hSplashLib = dlopen(splashPath, RTLD_LAZY | RTLD_GLOBAL);

--- a/src/java.base/unix/native/libjli/java_md.h
+++ b/src/java.base/unix/native/libjli/java_md.h
@@ -55,9 +55,9 @@ int UnsetEnv(char *name);
 char *FindExecName(char *program);
 const char *SetExecname(char **argv);
 const char *GetExecName();
-static jboolean GetJVMPath(const char *jrepath, const char *jvmtype,
+static jboolean GetJVMPath(const char *jdkroot, const char *jvmtype,
                            char *jvmpath, jint jvmpathsize);
-static jboolean GetJREPath(char *path, jint pathsize, jboolean speculative);
+static jboolean GetJDKInstallRoot(char *path, jint pathsize, jboolean speculative);
 
 #if defined(_AIX)
 jboolean GetApplicationHomeFromLibpath(char *buf, jint bufsize);

--- a/src/java.base/unix/native/libjli/java_md_common.c
+++ b/src/java.base/unix/native/libjli/java_md_common.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ TruncatePath(char *buf, jboolean pathisdll)
 }
 
 /*
- * Retrieves the path to the JRE home by locating the executable file
+ * Retrieves the path to the JDK home by locating the executable file
  * of the current process and then truncating the path to the executable
  */
 jboolean
@@ -93,7 +93,7 @@ GetApplicationHome(char *buf, jint bufsize)
 }
 
 /*
- * Retrieves the path to the JRE home by locating the
+ * Retrieves the path to the JDK home by locating the
  * shared library and then truncating the path to it.
  */
 jboolean
@@ -124,7 +124,7 @@ LibjavaExists(const char *path)
 }
 
 /*
- * Retrieves the path to the JRE home by locating libjava.so in
+ * Retrieves the path to the JDK home by locating libjava.so in
  * LIBPATH and then truncating the path to it.
  */
 jboolean
@@ -262,7 +262,7 @@ JLI_ReportExceptionDescription(JNIEnv * env) {
 /*
  *      Since using the file system as a registry is a bit risky, perform
  *      additional sanity checks on the identified directory to validate
- *      it as a valid jre/sdk.
+ *      it as a valid JDK.
  *
  *      Return 0 if the tests fail; otherwise return non-zero (true).
  *

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -224,7 +224,7 @@ LoadMSVCRT()
     if (!loaded) {
         /*
          * The Microsoft C Runtime Library needs to be loaded first. A copy is
-         * assumed to be present in the JDK installation root directory.
+         * assumed to be present in the "bin" directory of the JDK installation root.
          * If it is not found there (or the JDK installation root fails to resolve),
          * skip the explicit load and let nature take its course, which is likely to
          * be a failure to execute. The makefiles will provide the correct lib contained
@@ -357,10 +357,10 @@ LoadJavaVM(const char *jvmpath, InvocationFunctions *ifn)
 
     /*
      * The Microsoft C Runtime Library needs to be loaded first. A copy is
-     * assumed to be present in the JDK installation root directory. If it
-     * is not found there (or the JDK installation root fails to resolve),
-     * skip the explicit load and let nature take its course, which is likely
-     * to be a failure to execute.
+     * assumed to be present within the JDK. If it is not found there
+     * (or the JDK installation root fails to resolve), skip the explicit
+     * load and let nature take its course, which is likely to be a failure
+     * to execute.
      *
      */
     LoadMSVCRT();

--- a/src/java.base/windows/native/libjli/java_md.c
+++ b/src/java.base/windows/native/libjli/java_md.c
@@ -45,9 +45,9 @@
 /*
  * Prototypes.
  */
-static jboolean GetJVMPath(const char *jrepath, const char *jvmtype,
+static jboolean GetJVMPath(const char *jdkroot, const char *jvmtype,
                            char *jvmpath, jint jvmpathsize);
-static jboolean GetJREPath(char *path, jint pathsize);
+static jboolean GetJDKInstallRoot(char *path, jint pathsize);
 
 /* We supports warmup for UI stack that is performed in parallel
  * to VM initialization.
@@ -152,7 +152,7 @@ IsJavaw()
  */
 void
 CreateExecutionEnvironment(int *pargc, char ***pargv,
-                           char *jrepath, jint so_jrepath,
+                           char *jdkroot, jint so_jdkroot,
                            char *jvmpath, jint so_jvmpath,
                            char *jvmcfg,  jint so_jvmcfg) {
 
@@ -160,14 +160,14 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     int i = 0;
     char** argv = *pargv;
 
-    /* Find out where the JRE is that we will be using. */
-    if (!GetJREPath(jrepath, so_jrepath)) {
-        JLI_ReportErrorMessage(JRE_ERROR1);
+    /* Find out where the JDK is that we will be using. */
+    if (!GetJDKInstallRoot(jdkroot, so_jdkroot)) {
+        JLI_ReportErrorMessage(LAUNCHER_ERROR1);
         exit(2);
     }
 
     JLI_Snprintf(jvmcfg, so_jvmcfg, "%s%slib%sjvm.cfg",
-        jrepath, FILESEP, FILESEP);
+        jdkroot, FILESEP, FILESEP);
 
     /* Find the specified JVM type */
     if (ReadKnownVMs(jvmcfg, JNI_FALSE) < 1) {
@@ -182,7 +182,7 @@ CreateExecutionEnvironment(int *pargc, char ***pargv,
     }
 
     jvmpath[0] = '\0';
-    if (!GetJVMPath(jrepath, jvmtype, jvmpath, so_jvmpath)) {
+    if (!GetJVMPath(jdkroot, jvmtype, jvmpath, so_jvmpath)) {
         JLI_ReportErrorMessage(CFG_ERROR8, jvmtype, jvmpath);
         exit(4);
     }
@@ -223,18 +223,18 @@ LoadMSVCRT()
 
     if (!loaded) {
         /*
-         * The Microsoft C Runtime Library needs to be loaded first.  A copy is
-         * assumed to be present in the "JRE path" directory.  If it is not found
-         * there (or "JRE path" fails to resolve), skip the explicit load and let
-         * nature take its course, which is likely to be a failure to execute.
-         * The makefiles will provide the correct lib contained in quotes in the
-         * macro MSVCR_DLL_NAME.
+         * The Microsoft C Runtime Library needs to be loaded first. A copy is
+         * assumed to be present in the JDK installation root directory.
+         * If it is not found there (or the JDK installation root fails to resolve),
+         * skip the explicit load and let nature take its course, which is likely to
+         * be a failure to execute. The makefiles will provide the correct lib contained
+         * in quotes in the macro MSVCR_DLL_NAME.
          */
 #ifdef MSVCR_DLL_NAME
-        if (GetJREPath(crtpath, MAXPATHLEN)) {
+        if (GetJDKInstallRoot(crtpath, MAXPATHLEN)) {
             if (JLI_StrLen(crtpath) + JLI_StrLen("\\bin\\") +
                     JLI_StrLen(MSVCR_DLL_NAME) >= MAXPATHLEN) {
-                JLI_ReportErrorMessage(JRE_ERROR11);
+                JLI_ReportErrorMessage(LAUNCHER_ERROR3);
                 return JNI_FALSE;
             }
             (void)JLI_StrCat(crtpath, "\\bin\\" MSVCR_DLL_NAME);   /* Add crt dll */
@@ -248,10 +248,10 @@ LoadMSVCRT()
         }
 #endif /* MSVCR_DLL_NAME */
 #ifdef VCRUNTIME_1_DLL_NAME
-        if (GetJREPath(crtpath, MAXPATHLEN)) {
+        if (GetJDKInstallRoot(crtpath, MAXPATHLEN)) {
             if (JLI_StrLen(crtpath) + JLI_StrLen("\\bin\\") +
                     JLI_StrLen(VCRUNTIME_1_DLL_NAME) >= MAXPATHLEN) {
-                JLI_ReportErrorMessage(JRE_ERROR11);
+                JLI_ReportErrorMessage(LAUNCHER_ERROR3);
                 return JNI_FALSE;
             }
             (void)JLI_StrCat(crtpath, "\\bin\\" VCRUNTIME_1_DLL_NAME);   /* Add crt dll */
@@ -265,10 +265,10 @@ LoadMSVCRT()
         }
 #endif /* VCRUNTIME_1_DLL_NAME */
 #ifdef MSVCP_DLL_NAME
-        if (GetJREPath(crtpath, MAXPATHLEN)) {
+        if (GetJDKInstallRoot(crtpath, MAXPATHLEN)) {
             if (JLI_StrLen(crtpath) + JLI_StrLen("\\bin\\") +
                     JLI_StrLen(MSVCP_DLL_NAME) >= MAXPATHLEN) {
-                JLI_ReportErrorMessage(JRE_ERROR11);
+                JLI_ReportErrorMessage(LAUNCHER_ERROR3);
                 return JNI_FALSE;
             }
             (void)JLI_StrCat(crtpath, "\\bin\\" MSVCP_DLL_NAME);   /* Add prt dll */
@@ -288,47 +288,47 @@ LoadMSVCRT()
 
 
 /*
- * Find path to JRE based on .exe's location or registry settings.
+ * Find path to JDK installation root based on .exe's location
  */
 jboolean
-GetJREPath(char *path, jint pathsize)
+GetJDKInstallRoot(char *path, jint pathsize)
 {
     char javadll[MAXPATHLEN];
     struct stat s;
 
-    JLI_TraceLauncher("Attempt to get JRE path from launcher executable path\n");
+    JLI_TraceLauncher("Attempt to get JDK installation root path from launcher executable path\n");
 
     if (GetApplicationHome(path, pathsize)) {
-        /* Is JRE co-located with the application? */
+        /* Is the JDK co-located with the application? */
         JLI_Snprintf(javadll, sizeof(javadll), "%s\\bin\\" JAVA_DLL, path);
         if (stat(javadll, &s) == 0) {
-            JLI_TraceLauncher("JRE path is %s\n", path);
+            JLI_TraceLauncher("JDK installation root path is %s\n", path);
             return JNI_TRUE;
         }
     }
 
-    JLI_TraceLauncher("Attempt to get JRE path from shared lib of the image\n");
+    JLI_TraceLauncher("Attempt to get JDK installation root path from shared lib of the image\n");
 
-    /* Try getting path to JRE from path to JLI.DLL */
+    /* Try getting path to JDK from path to JLI.DLL */
     if (GetApplicationHomeFromDll(path, pathsize)) {
         JLI_Snprintf(javadll, sizeof(javadll), "%s\\bin\\" JAVA_DLL, path);
         if (stat(javadll, &s) == 0) {
-            JLI_TraceLauncher("JRE path is %s\n", path);
+            JLI_TraceLauncher("JDK installation root path is %s\n", path);
             return JNI_TRUE;
         }
     }
 
-    JLI_ReportErrorMessage(JRE_ERROR8 JAVA_DLL);
+    JLI_ReportErrorMessage(LAUNCHER_ERROR2 JAVA_DLL);
     return JNI_FALSE;
 }
 
 /*
- * Given a JRE location and a JVM type, construct what the name the
+ * Given a JDK installation location and a JVM type, construct what the name the
  * JVM shared library will be.  Return true, if such a library
  * exists, false otherwise.
  */
 static jboolean
-GetJVMPath(const char *jrepath, const char *jvmtype,
+GetJVMPath(const char *jdkroot, const char *jvmtype,
            char *jvmpath, jint jvmpathsize)
 {
     struct stat s;
@@ -336,7 +336,7 @@ GetJVMPath(const char *jrepath, const char *jvmtype,
         JLI_Snprintf(jvmpath, jvmpathsize, "%s\\" JVM_DLL, jvmtype);
     } else {
         JLI_Snprintf(jvmpath, jvmpathsize, "%s\\bin\\%s\\" JVM_DLL,
-                     jrepath, jvmtype);
+                     jdkroot, jvmtype);
     }
     if (stat(jvmpath, &s) == 0) {
         return JNI_TRUE;
@@ -356,10 +356,11 @@ LoadJavaVM(const char *jvmpath, InvocationFunctions *ifn)
     JLI_TraceLauncher("JVM path is %s\n", jvmpath);
 
     /*
-     * The Microsoft C Runtime Library needs to be loaded first.  A copy is
-     * assumed to be present in the "JRE path" directory.  If it is not found
-     * there (or "JRE path" fails to resolve), skip the explicit load and let
-     * nature take its course, which is likely to be a failure to execute.
+     * The Microsoft C Runtime Library needs to be loaded first. A copy is
+     * assumed to be present in the JDK installation root directory. If it
+     * is not found there (or the JDK installation root fails to resolve),
+     * skip the explicit load and let nature take its course, which is likely
+     * to be a failure to execute.
      *
      */
     LoadMSVCRT();
@@ -403,7 +404,7 @@ TruncatePath(char *buf)
 }
 
 /*
- * Retrieves the path to the JRE home by locating the executable file
+ * Retrieves the path to the JDK home by locating the executable file
  * of the current process and then truncating the path to the executable
  */
 jboolean
@@ -414,7 +415,7 @@ GetApplicationHome(char *buf, jint bufsize)
 }
 
 /*
- * Retrieves the path to the JRE home by locating JLI.DLL and
+ * Retrieves the path to the JDK home by locating JLI.DLL and
  * then truncating the path to JLI.DLL
  */
 jboolean
@@ -424,7 +425,7 @@ GetApplicationHomeFromDll(char *buf, jint bufsize)
     DWORD flags = GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
                   GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT;
 
-    if (GetModuleHandleEx(flags, (LPCSTR)&GetJREPath, &module) != 0) {
+    if (GetModuleHandleEx(flags, (LPCSTR)&GetJDKInstallRoot, &module) != 0) {
         if (GetModuleFileName(module, buf, bufsize) != 0) {
             return TruncatePath(buf);
         }
@@ -659,7 +660,7 @@ static HMODULE hSplashLib = NULL;
 void* SplashProcAddress(const char* name) {
     char libraryPath[MAXPATHLEN]; /* some extra space for JLI_StrCat'ing SPLASHSCREEN_SO */
 
-    if (!GetJREPath(libraryPath, MAXPATHLEN)) {
+    if (!GetJDKInstallRoot(libraryPath, MAXPATHLEN)) {
         return NULL;
     }
     if (JLI_StrLen(libraryPath)+JLI_StrLen(SPLASHSCREEN_SO) >= MAXPATHLEN) {
@@ -830,7 +831,7 @@ int AWTPreload(const char *funcName)
     if (hPreloadAwt == NULL) {
         /* awt.dll is not loaded yet */
         char libraryPath[MAXPATHLEN];
-        size_t jrePathLen = 0;
+        size_t jdkRootPathLen = 0;
         HMODULE hJava = NULL;
         HMODULE hVerify = NULL;
 
@@ -839,18 +840,18 @@ int AWTPreload(const char *funcName)
              * jvm.dll is already loaded, so we need only java.dll;
              * java.dll depends on MSVCRT lib & verify.dll.
              */
-            if (!GetJREPath(libraryPath, MAXPATHLEN)) {
+            if (!GetJDKInstallRoot(libraryPath, MAXPATHLEN)) {
                 break;
             }
 
             /* save path length */
-            jrePathLen = JLI_StrLen(libraryPath);
+            jdkRootPathLen = JLI_StrLen(libraryPath);
 
-            if (jrePathLen + JLI_StrLen("\\bin\\verify.dll") >= MAXPATHLEN) {
-              /* jre path is too long, the library path will not fit there;
+            if (jdkRootPathLen + JLI_StrLen("\\bin\\verify.dll") >= MAXPATHLEN) {
+              /* path is too long, the library path will not fit there;
                * report and abort preloading
                */
-              JLI_ReportErrorMessage(JRE_ERROR11);
+              JLI_ReportErrorMessage(LAUNCHER_ERROR3);
               break;
             }
 
@@ -864,8 +865,8 @@ int AWTPreload(const char *funcName)
                 break;
             }
 
-            /* restore jrePath */
-            libraryPath[jrePathLen] = 0;
+            /* restore libraryPath */
+            libraryPath[jdkRootPathLen] = 0;
             /* load java.dll */
             JLI_StrCat(libraryPath, "\\bin\\" JAVA_DLL);
             hJava = LoadLibrary(libraryPath);
@@ -873,8 +874,8 @@ int AWTPreload(const char *funcName)
                 break;
             }
 
-            /* restore jrePath */
-            libraryPath[jrePathLen] = 0;
+            /* restore libraryPath */
+            libraryPath[jdkRootPathLen] = 0;
             /* load awt.dll */
             JLI_StrCat(libraryPath, "\\bin\\awt.dll");
             hPreloadAwt = LoadLibrary(libraryPath);


### PR DESCRIPTION
Can I please get a review of this change which cleans up references to "JRE" from the launcher's code?

No functional changes have been introduced in this change.

No new tests have been introduced and existing tests in tier1, tier2 and tier3 continue to pass in our CI against Linux, macosx and Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343040](https://bugs.openjdk.org/browse/JDK-8343040): Clean up references to JRE in the launcher code (**Bug** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) Review applies to [d98b1d97](https://git.openjdk.org/jdk/pull/21704/files/d98b1d9715ed4ce6b6e491270187ec45dee3e42e)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21704/head:pull/21704` \
`$ git checkout pull/21704`

Update a local copy of the PR: \
`$ git checkout pull/21704` \
`$ git pull https://git.openjdk.org/jdk.git pull/21704/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21704`

View PR using the GUI difftool: \
`$ git pr show -t 21704`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21704.diff">https://git.openjdk.org/jdk/pull/21704.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21704#issuecomment-2437025105)