### PR TITLE
8343056: C2: Micro-optimize Node lists grow

### DIFF
--- a/src/hotspot/share/libadt/vectset.cpp
+++ b/src/hotspot/share/libadt/vectset.cpp
@@ -49,9 +49,7 @@ void VectorSet::init(Arena* arena) {
 // Expand the existing set to a bigger size
 void VectorSet::grow(uint new_word_capacity) {
   _nesting.check(_set_arena); // Check if a potential reallocation in the arena is safe
-  if (new_word_capacity < _size) {
-    return; // No need to grow
-  }
+  assert(new_word_capacity >= _size, "Should have been checked before, use maybe_grow?");
   assert(new_word_capacity < (1U << 30), "");
   uint x = next_power_of_2(new_word_capacity);
   if (x > _data_size) {
@@ -66,9 +64,7 @@ void VectorSet::grow(uint new_word_capacity) {
 void VectorSet::insert(uint elem) {
   uint32_t word = elem >> word_bits;
   uint32_t mask = 1U << (elem & bit_mask);
-  if (word >= _size) {
-    grow(word);
-  }
+  maybe_grow(word);
   _data[word] |= mask;
 }
 

--- a/src/hotspot/share/libadt/vectset.hpp
+++ b/src/hotspot/share/libadt/vectset.hpp
@@ -49,8 +49,15 @@ private:
   ReallocMark _nesting; // Safety checks for arena reallocation
 
   void init(Arena* arena);
+
   // Grow vector to required word capacity
+  void maybe_grow(uint new_word_capacity) {
+    if (new_word_capacity >= _size) {
+      grow(new_word_capacity);
+    }
+  }
   void grow(uint new_word_capacity);
+
 public:
   VectorSet();
   VectorSet(Arena* arena);
@@ -78,7 +85,7 @@ public:
   //
   bool test_set(uint elem) {
     uint32_t word = elem >> word_bits;
-    grow(word);
+    maybe_grow(word);
     uint32_t mask = 1U << (elem & bit_mask);
     uint32_t data = _data[word];
     _data[word] = data | mask;
@@ -107,7 +114,7 @@ public:
   // Fast inlined set
   void set(uint elem) {
     uint32_t word = elem >> word_bits;
-    grow(word);
+    maybe_grow(word);
     uint32_t mask = 1U << (elem & bit_mask);
     _data[word] |= mask;
   }

--- a/src/hotspot/share/opto/node.cpp
+++ b/src/hotspot/share/opto/node.cpp
@@ -2770,9 +2770,7 @@ const RegMask &Node::in_RegMask(uint) const {
 
 void Node_Array::grow(uint i) {
   _nesting.check(_a); // Check if a potential reallocation in the arena is safe
-  if (i < _max) {
-    return; // No need to grow
-  }
+  assert(i >= _max, "Should have been checked before, use maybe_grow?");
   assert(_max > 0, "invariant");
   uint old = _max;
   _max = next_power_of_2(i);

--- a/src/hotspot/share/opto/node.hpp
+++ b/src/hotspot/share/opto/node.hpp
@@ -1610,7 +1610,14 @@ protected:
   Node** _nodes;
   ReallocMark _nesting;         // Safety checks for arena reallocation
 
-  void   grow( uint i );        // Grow array node to fit
+  // Grow array to required capacity
+  void maybe_grow(uint i) {
+    if (i >= _max) {
+      grow(i);
+    }
+  }
+  void grow(uint i);
+
 public:
   Node_Array(Arena* a, uint max = OptoNodeListSize) : _a(a), _max(max) {
     _nodes = NEW_ARENA_ARRAY(a, Node*, max);
@@ -1628,7 +1635,7 @@ public:
   Node* at(uint i) const { assert(i<_max,"oob"); return _nodes[i]; }
   Node** adr() { return _nodes; }
   // Extend the mapping: index i maps to Node *n.
-  void map( uint i, Node *n ) { grow(i); _nodes[i] = n; }
+  void map( uint i, Node *n ) { maybe_grow(i); _nodes[i] = n; }
   void insert( uint i, Node *n );
   void remove( uint i );        // Remove, preserving order
   // Clear all entries in _nodes to null but keep storage


### PR DESCRIPTION
Seen this in Leyden profiles, but it is a generic issue. The profiles show `Node::grow` and `VectorSet::grow` as hot methods. The methods are small, and since they are implementing doubling-the-array scheme, we often exit early without actually growing. Outlining the actual growing part from the capacity check would allow inlining the common case.

I'll put some performance data in the comments.

Additional testing:
 - [x] Linux x86_64 server fastdebug, `tier1`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343056](https://bugs.openjdk.org/browse/JDK-8343056): C2: Micro-optimize Node lists grow (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Claes Redestad](https://openjdk.org/census#redestad) (@cl4es - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21707/head:pull/21707` \
`$ git checkout pull/21707`

Update a local copy of the PR: \
`$ git checkout pull/21707` \
`$ git pull https://git.openjdk.org/jdk.git pull/21707/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21707`

View PR using the GUI difftool: \
`$ git pr show -t 21707`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21707.diff">https://git.openjdk.org/jdk/pull/21707.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21707#issuecomment-2437525398)