### PR TITLE
8343055: Problemlist compiler/c2/irTests/TestVectorizationMismatchedAccess.java on big-endian platforms

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -53,6 +53,7 @@ compiler/loopopts/TestUnreachableInnerLoop.java 8288981 linux-s390x
 
 compiler/c2/Test8004741.java 8235801 generic-all
 compiler/c2/irTests/TestDuplicateBackedge.java 8318904 generic-all
+compiler/c2/irTests/TestVectorizationMismatchedAccess.java 8342489 generic-ppc64,linux-s390x
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 compiler/codecache/CheckLargePages.java 8332654 linux-x64


### PR DESCRIPTION
Currently the HS test compiler/c2/irTests/TestVectorizationMismatchedAccess.java works only on LE platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343055](https://bugs.openjdk.org/browse/JDK-8343055): Problemlist compiler/c2/irTests/TestVectorizationMismatchedAccess.java on big-endian platforms (**Sub-task** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21708/head:pull/21708` \
`$ git checkout pull/21708`

Update a local copy of the PR: \
`$ git checkout pull/21708` \
`$ git pull https://git.openjdk.org/jdk.git pull/21708/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21708`

View PR using the GUI difftool: \
`$ git pr show -t 21708`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21708.diff">https://git.openjdk.org/jdk/pull/21708.diff</a>

</details>
