### PR TITLE
8279931: Generate warning for wrong @param tag order

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/resources/doclint.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/resources/doclint.properties
@@ -60,6 +60,7 @@ dc.missing.throws = no @throws for {0}
 dc.no.alt.attr.for.image = no "alt" attribute for image
 dc.no.summary.or.caption.for.table=no caption for table
 dc.param.name.not.found = @param name not found
+dc.param.wrong.order = wrong order of @param tags
 dc.ref.not.found = reference not found
 dc.ref.in.missing.module = module for reference not found: {0}
 dc.return.not.first = '{@return} not at beginning of description

--- a/test/langtools/jdk/javadoc/doclet/testParamTaglet/TestParamTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testParamTaglet/TestParamTaglet.java
@@ -23,17 +23,20 @@
 
 /*
  * @test
- * @bug      4802275 4967243 8026567 8239804 8234682
+ * @bug      4802275 4967243 8026567 8239804 8234682 8279931
  * @summary  Make sure param tags are still printed even though they do not
  *           match up with a real parameters.
  *           Make sure inheritDoc cannot be used in an invalid param tag.
- * @library  ../../lib
+ * @library  /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
- * @build    javadoc.tester.*
+ * @build    toolbox.ToolBox javadoc.tester.*
  * @run main TestParamTaglet
  */
 
 import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.nio.file.Path;
 
 public class TestParamTaglet extends JavadocTester {
 
@@ -41,6 +44,8 @@ public class TestParamTaglet extends JavadocTester {
         var tester = new TestParamTaglet();
         tester.runTests();
     }
+
+    private final ToolBox tb = new ToolBox();
 
     @Test
     public void test() {
@@ -93,6 +98,82 @@ public class TestParamTaglet extends JavadocTester {
                 """
                     <dt>Type Parameters:</dt>
                     <dd><span id="type-param-T1"><code>T1</code> - type 1</span></dd>
+                    </dl>""");
+    }
+
+    @Test
+    public void testParamOrder(Path base) throws Exception {
+        String contents = """
+                package pkg;
+                
+                /**
+                 * Class with missing and unsorted param tags.
+                 *
+                 * @param <V> third type param
+                 * @param <T> second type param
+                 */
+                public class C<S, T, V>{
+                    /**
+                      * Method with unsorted param tags.
+                      *
+                      * @param i1 first param
+                      * @param d1 third param
+                      * @param i2 second param
+                      * @param d2 fourth param
+                      */
+                    public void paramOrder(int i1, int i2, double d1, double d2) {
+                    }
+                }
+                """;
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src, contents);
+
+        // Run with all doclint groups enabled
+        javadoc("-d", base.resolve("out-warn").toString(),
+                "-sourcepath", src.toString(),
+                "-Xdoclint:all",
+                "pkg");
+        checkExit(Exit.OK);
+        checkOutput(Output.OUT, true,
+                "C.java:9: warning: no @param for <S>",
+                "C.java:9: warning: wrong order of @param tags",
+                "C.java:18: warning: wrong order of @param tags");
+        checkOutput("pkg/C.html", true,
+                """
+                    <dt>Type Parameters:</dt>
+                    <dd><span id="type-param-T"><code>T</code> - second type param</span></dd>
+                    <dd><span id="type-param-V"><code>V</code> - third type param</span></dd>
+                    </dl>""",
+                """
+                    <dt>Parameters:</dt>
+                    <dd><code>i1</code> - first param</dd>
+                    <dd><code>i2</code> - second param</dd>
+                    <dd><code>d1</code> - third param</dd>
+                    <dd><code>d2</code> - fourth param</dd>
+                    </dl>""");
+
+        // Run with doclint enabled except for reference group
+        javadoc("-d", base.resolve("out-nowarn").toString(),
+                "-sourcepath", src.toString(),
+                "-Xdoclint:all,-reference",
+                "pkg");
+        checkExit(Exit.OK);
+        checkOutput(Output.OUT, true,
+                "C.java:9: warning: no @param for <S>");
+        checkOutput(Output.OUT, false,
+                "warning: wrong order");
+        checkOutput("pkg/C.html", true,
+                """
+                    <dt>Type Parameters:</dt>
+                    <dd><span id="type-param-T"><code>T</code> - second type param</span></dd>
+                    <dd><span id="type-param-V"><code>V</code> - third type param</span></dd>
+                    </dl>""",
+                """
+                    <dt>Parameters:</dt>
+                    <dd><code>i1</code> - first param</dd>
+                    <dd><code>i2</code> - second param</dd>
+                    <dd><code>d1</code> - third param</dd>
+                    <dd><code>d2</code> - fourth param</dd>
                     </dl>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testParamTaglet/TestParamTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testParamTaglet/TestParamTaglet.java
@@ -105,7 +105,7 @@ public class TestParamTaglet extends JavadocTester {
     public void testParamOrder(Path base) throws Exception {
         String contents = """
                 package pkg;
-                
+
                 /**
                  * Class with missing and unsorted param tags.
                  *


### PR DESCRIPTION
Please review a change to add a DocLint warning for JavaDoc `@param` tags that don't match the order of parameters in the documented element. The warning is part of the the DocLint "reference" group. 

The code to check order of `@param` tags is written to detect wrong order even if some tags are missing. The test therefore contains a case combining missing and unordered tags, and runs `javadoc` both with reference warnings enabled and disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8279931](https://bugs.openjdk.org/browse/JDK-8279931): Generate warning for wrong @<!---->param tag order (**Enhancement** - P4)
 * [JDK-8343542](https://bugs.openjdk.org/browse/JDK-8343542): Generate warning for wrong @<!---->param tag order (**CSR**) (Withdrawn)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21711/head:pull/21711` \
`$ git checkout pull/21711`

Update a local copy of the PR: \
`$ git checkout pull/21711` \
`$ git pull https://git.openjdk.org/jdk.git pull/21711/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21711`

View PR using the GUI difftool: \
`$ git pr show -t 21711`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21711.diff">https://git.openjdk.org/jdk/pull/21711.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21711#issuecomment-2437670232)
</details>
