### PR TITLE
8343057: JFR: Sorting in 'jfr view' can violate contract

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableSorter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableSorter.java
@@ -89,7 +89,7 @@ final class TableSorter {
                 if (isIntegralType(n1)) {
                     if (isIntegralType(n2)) {
                         return Long.compare(n1.longValue(), n2.longValue());
-                    } 
+                    }
                     if (isFractionalType(n2)) {
                         return compare(n1.longValue(), n2.doubleValue());
                     }
@@ -100,7 +100,7 @@ final class TableSorter {
                     }
                     if (isIntegralType(n2)) {
                         return - compare(n2.longValue(), n1.doubleValue());
-                    } 
+                    }
                 }
             }
             // Use something that is stable if there is any other type of mix

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableSorter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableSorter.java
@@ -93,7 +93,7 @@ final class TableSorter {
                     if (isFractionalType(n2)) {
                         return compare(n1.longValue(), n2.doubleValue());
                     }
-                } 
+                }
                 if (isFractionalType(n1)) {
                     if (isFractionalType(n2)) {
                         return Double.compare(n1.doubleValue(), n2.doubleValue());

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableSorter.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/TableSorter.java
@@ -80,9 +80,8 @@ final class TableSorter {
             if (b == null) {
                 return 1;
             }
-            // Comparison with the same class
-            if (a.getClass() == b.getClass() && a instanceof Comparable c1) {
-                return c1.compareTo((Comparable)b);
+            if (a instanceof String s1 && b instanceof String s2) {
+                return s1.compareTo(s2);
             }
 
             if (a instanceof Number n1 && b instanceof Number n2) {
@@ -103,7 +102,23 @@ final class TableSorter {
                     }
                 }
             }
-            // Use something that is stable if there is any other type of mix
+            if (a instanceof Number) {
+                return 1;
+            }
+            if (b instanceof Number) {
+                return -1;
+            }
+            // Comparison with the same class
+            if (a.getClass() == b.getClass() && a instanceof Comparable c1) {
+                return c1.compareTo((Comparable)b);
+            }
+            if (a instanceof Comparable) {
+                return 1;
+            }
+            if (b instanceof Comparable) {
+                return -1;
+            }
+            // Use something that is stable if it's not null, comparable or numeric
             return Integer.compare(System.identityHashCode(a), System.identityHashCode(b));
         }
 


### PR DESCRIPTION
Could I have a review of a change that improves the comparator used with 'jfr view'?

Testing: jdk/jdk/jfr + comparison of output from 'jfr view all-views' before and after the change


Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343057](https://bugs.openjdk.org/browse/JDK-8343057): JFR: Sorting in 'jfr view' can violate contract (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21713/head:pull/21713` \
`$ git checkout pull/21713`

Update a local copy of the PR: \
`$ git checkout pull/21713` \
`$ git pull https://git.openjdk.org/jdk.git pull/21713/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21713`

View PR using the GUI difftool: \
`$ git pr show -t 21713`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21713.diff">https://git.openjdk.org/jdk/pull/21713.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21713#issuecomment-2437829689)
</details>
