### PR TITLE
8283664: Remove jtreg tag manual=yesno for java/awt/print/PrinterJob/PrintTextTest.java

### DIFF
--- a/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
@@ -21,12 +21,14 @@
  * questions.
  */
 
-/**
+/*
  * @test
  * @bug 6425068 7157659 8132890
  * @key printer
  * @summary Confirm that text prints where we expect to the length we expect.
- * @run main/manual=yesno PrintTextTest
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @run main/manual PrintTextTest
  */
 
 import java.awt.*;
@@ -40,36 +42,32 @@ import javax.swing.*;
 
 public class PrintTextTest extends Component implements Printable {
 
+    static final String INSTRUCTIONS = """
+        This tests that printed text renders similarly to on-screen under a variety
+        of APIs and graphics and font transforms.
+        1. Print to your preferred printer.
+        2. Collect the output.
+        3. Refer to the onscreen buttons to cycle through the on-screen content.
+        4. For each page, confirm that the printed content corresponds to the
+           on-screen rendering for that *same* page. Some cases may look odd but
+           its intentional. Verify it looks the same on screen and on the printer.
+        Note that text does not scale linearly from screen to printer so some
+        differences are normal and not a bug.
+        The easiest way to spot real problems is to check that any underlines are
+        the same length as the underlined text and that any rotations are the same
+        in each case.
+        Note that each on-screen page is printed in both portrait and landscape mode.
+        So for example, Page 1/Portrait, and Page 1/Landscape when rotated to view
+        properly, should both match Page 1 on screen.
+        """;
+
     static int preferredSize;
     Font textFont;
     AffineTransform gxTx;
     String page;
     boolean useFM;
 
-    public static void main(String args[]) {
-        String[] instructions =
-        {
-            "This tests that printed text renders similarly to on-screen",
-            "under a variety of APIs and graphics and font transforms",
-            "Print to your preferred printer. Collect the output.",
-            "Refer to the onscreen buttons to cycle through the on-screen",
-            "content",
-            "For each page, confirm that the printed content corresponds to",
-            "the on-screen rendering for that *same* page.",
-            "Some cases may look odd but its intentional. Verify",
-            "it looks the same on screen and on the printer.",
-            "Note that text does not scale linearly from screen to printer",
-            "so some differences are normal and not a bug.",
-            "The easiest way to spot real problems is to check that",
-            "any underlines are the same length as the underlined text",
-            "and that any rotations are the same in each case.",
-            "Note that each on-screen page is printed in both portrait",
-            "and landscape mode",
-            "So for example, Page 1/Portrait, and Page 1/Landscape when",
-            "rotated to view properly, should both match Page 1 on screen.",
-        };
-        Sysout.createDialogWithInstructions(instructions);
-
+    public static void main(String args[]) throws Exception {
 
         PrinterJob pjob = PrinterJob.getPrinterJob();
         PageFormat portrait = pjob.defaultPage();
@@ -85,21 +83,21 @@ public class PrintTextTest extends Component implements Printable {
 
         int page = 1;
         Font font = new Font("Dialog", Font.PLAIN, 18);
-        String name = "Page " + new Integer(page++);
+        String name = "Page " + page++;
         PrintTextTest ptt = new PrintTextTest(name, font, null, false);
         p.add(name, ptt);
         book.append(ptt, portrait);
         book.append(ptt, landscape);
 
         font = new Font("Dialog", Font.PLAIN, 18);
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, font, null, true);
         p.add(name, ptt);
         book.append(ptt, portrait);
         book.append(ptt, landscape);
 
         font = getPhysicalFont();
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, font, null, false);
         p.add(name, ptt);
         book.append(ptt, portrait);
@@ -108,7 +106,7 @@ public class PrintTextTest extends Component implements Printable {
         font = getPhysicalFont();
         AffineTransform rotTx = AffineTransform.getRotateInstance(0.15);
         rotTx.translate(60,0);
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, font, rotTx, false);
         p.add(name, ptt);
         book.append(ptt, portrait);
@@ -116,7 +114,7 @@ public class PrintTextTest extends Component implements Printable {
 
         font = new Font("Dialog", Font.PLAIN, 18);
         AffineTransform scaleTx = AffineTransform.getScaleInstance(1.25, 1.25);
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, font, scaleTx, false);
         p.add(name, ptt);
         book.append(ptt, portrait);
@@ -125,7 +123,7 @@ public class PrintTextTest extends Component implements Printable {
         font = new Font("Dialog", Font.PLAIN, 18);
         scaleTx = AffineTransform.getScaleInstance(-1.25, 1.25);
         scaleTx.translate(-preferredSize/1.25, 0);
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, font, scaleTx, false);
         p.add(name, ptt);
         book.append(ptt, portrait);
@@ -134,14 +132,14 @@ public class PrintTextTest extends Component implements Printable {
         font = new Font("Dialog", Font.PLAIN, 18);
         scaleTx = AffineTransform.getScaleInstance(1.25, -1.25);
         scaleTx.translate(0, -preferredSize/1.25);
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, font, scaleTx, false);
         p.add(name, ptt);
         book.append(ptt, portrait);
         book.append(ptt, landscape);
 
         font = font.deriveFont(rotTx);
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, font, null, false);
         p.add(ptt, BorderLayout.CENTER);
         p.add(name, ptt);
@@ -149,7 +147,7 @@ public class PrintTextTest extends Component implements Printable {
         book.append(ptt, landscape);
 
         font = new Font("Monospaced", Font.PLAIN, 12);
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, font, null, false);
         p.add(ptt, BorderLayout.CENTER);
         p.add(name, ptt);
@@ -157,7 +155,7 @@ public class PrintTextTest extends Component implements Printable {
         book.append(ptt, landscape);
 
         Font xfont = font.deriveFont(AffineTransform.getScaleInstance(1.5, 1));
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, xfont, null, false);
         p.add(ptt, BorderLayout.CENTER);
         p.add(name, ptt);
@@ -165,7 +163,7 @@ public class PrintTextTest extends Component implements Printable {
         book.append(ptt, landscape);
 
         Font yfont = font.deriveFont(AffineTransform.getScaleInstance(1, 1.5));
-        name = "Page " + new Integer(page++);
+        name = "Page " + page++;
         ptt = new PrintTextTest(name, yfont, null, false);
         p.add(ptt, BorderLayout.CENTER);
         p.add(name, ptt);
@@ -174,7 +172,7 @@ public class PrintTextTest extends Component implements Printable {
 
         if (System.getProperty("os.name").startsWith("Windows")) {
             font = new Font("MS Gothic", Font.PLAIN, 12);
-            name = "Page " + new Integer(page++);
+            name = "Page " + page++;
             ptt = new PrintJAText(name, font, null, true);
             p.add(ptt, BorderLayout.CENTER);
             p.add(name, ptt);
@@ -182,7 +180,7 @@ public class PrintTextTest extends Component implements Printable {
             book.append(ptt, landscape);
 
             font = new Font("MS Gothic", Font.PLAIN, 12);
-            name = "Page " + new Integer(page++);
+            name = "Page " + page++;
             rotTx = AffineTransform.getRotateInstance(0.15);
             ptt = new PrintJAText(name, font, rotTx, true);
             p.add(ptt, BorderLayout.CENTER);
@@ -193,21 +191,29 @@ public class PrintTextTest extends Component implements Printable {
 
         pjob.setPageable(book);
 
+        JButton printButton = new JButton("Print");
+        printButton.addActionListener(event -> {
+            try {
+                if (pjob.printDialog()) {
+                    pjob.print();
+                }
+            } catch (PrinterException e) {
+                throw new RuntimeException(e.getMessage());
+            }
+        });
+
         JFrame f = new JFrame();
         f.add(BorderLayout.CENTER, p);
-        f.addWindowListener(new WindowAdapter() {
-            public void windowClosing(WindowEvent e) {System.exit(0);}
-        });
+        f.add(BorderLayout.SOUTH, printButton);
         f.pack();
-        f.show();
 
-        try {
-            if (pjob.printDialog()) {
-                pjob.print();
-            }
-        } catch (PrinterException e) {
-            throw new RuntimeException(e.getMessage());
-        }
+        PassFailJFrame.builder()
+            .title("Print Text Test")
+            .instructions(INSTRUCTIONS)
+            .columns(60)
+            .testUI(f)
+            .build()
+            .awaitAndCheck();
     }
 
     // The test needs a physical font that supports Latin.
@@ -284,7 +290,6 @@ public class PrintTextTest extends Component implements Printable {
         /* fill with white before any transformation is applied */
         g.setColor(Color.white);
         g.fillRect(0, 0, getSize().width, getSize().height);
-
 
         Graphics2D g2d = (Graphics2D) g;
         if (gxTx != null) {
@@ -396,7 +401,6 @@ public class PrintTextTest extends Component implements Printable {
 
 class PrintJAText extends PrintTextTest {
 
-
     public PrintJAText(String page, Font font, AffineTransform gxTx,
                          boolean fm) {
         super(page, font, gxTx, fm);
@@ -406,13 +410,11 @@ class PrintJAText extends PrintTextTest {
         "\u3042\u3044\u3046\u3048\u304a\u30a4\u30ed\u30cf" +
         "\u30cb\u30db\u30d8\u30c8\u4e00\u4e01\u4e02\u4e05\uff08";
 
-
     public void paint(Graphics g) {
 
         /* fill with white before any transformation is applied */
         g.setColor(Color.white);
         g.fillRect(0, 0, getSize().width, getSize().height);
-
 
         Graphics2D g2d = (Graphics2D) g;
         if (gxTx != null) {
@@ -440,119 +442,3 @@ class PrintJAText extends PrintTextTest {
         }
     }
 }
-
-class Sysout
- {
-   private static TestDialog dialog;
-
-   public static void createDialogWithInstructions( String[] instructions )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      dialog.printInstructions( instructions );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-   public static void createDialog( )
-    {
-      dialog = new TestDialog( new Frame(), "Instructions" );
-      String[] defInstr = { "Instructions will appear here. ", "" } ;
-      dialog.printInstructions( defInstr );
-      dialog.show();
-      println( "Any messages for the tester will display here." );
-    }
-
-
-   public static void printInstructions( String[] instructions )
-    {
-      dialog.printInstructions( instructions );
-    }
-
-
-   public static void println( String messageIn )
-    {
-      dialog.displayMessage( messageIn );
-    }
-
- }// Sysout  class
-
-/**
-  This is part of the standard test machinery.  It provides a place for the
-   test instructions to be displayed, and a place for interactive messages
-   to the user to be displayed.
-  To have the test instructions displayed, see Sysout.
-  To have a message to the user be displayed, see Sysout.
-  Do not call anything in this dialog directly.
-  */
-class TestDialog extends Dialog
- {
-
-   TextArea instructionsText;
-   TextArea messageText;
-   int maxStringLength = 80;
-
-   //DO NOT call this directly, go through Sysout
-   public TestDialog( Frame frame, String name )
-    {
-      super( frame, name );
-      int scrollBoth = TextArea.SCROLLBARS_BOTH;
-      instructionsText = new TextArea( "", 20, maxStringLength, scrollBoth );
-      add( "North", instructionsText );
-
-      messageText = new TextArea( "", 5, maxStringLength, scrollBoth );
-      add("South", messageText);
-
-      pack();
-
-      show();
-    }// TestDialog()
-
-   //DO NOT call this directly, go through Sysout
-   public void printInstructions( String[] instructions )
-    {
-      //Clear out any current instructions
-      instructionsText.setText( "" );
-
-      //Go down array of instruction strings
-
-      String printStr, remainingStr;
-      for( int i=0; i < instructions.length; i++ )
-       {
-     //chop up each into pieces maxSringLength long
-     remainingStr = instructions[ i ];
-     while( remainingStr.length() > 0 )
-      {
-        //if longer than max then chop off first max chars to print
-        if( remainingStr.length() >= maxStringLength )
-         {
-           //Try to chop on a word boundary
-           int posOfSpace = remainingStr.
-          lastIndexOf( ' ', maxStringLength - 1 );
-
-           if( posOfSpace <= 0 ) posOfSpace = maxStringLength - 1;
-
-           printStr = remainingStr.substring( 0, posOfSpace + 1 );
-           remainingStr = remainingStr.substring( posOfSpace + 1 );
-         }
-        //else just print
-        else
-         {
-           printStr = remainingStr;
-           remainingStr = "";
-         }
-
-            instructionsText.append( printStr + "\n" );
-
-      }// while
-
-       }// for
-
-    }//printInstructions()
-
-   //DO NOT call this directly, go through Sysout
-   public void displayMessage( String messageIn )
-    {
-      messageText.append( messageIn + "\n" );
-    }
-
-}// TestDialog  class


### PR DESCRIPTION
There are multiple issue with this test case
1) Parser error due to yesno in @run main/manual=yesno
2) User can only compare the UI rendering and compare with the print out. User can't mark the test as pass or fail due to pass or fail buttons are missing.
3) When the test is executed using jtreg after user click on the print button on the print dialog the whole test UIs ( frames) gets dispose and user cannot compare the printout with the UI. But this works as expected in test is running individually using java PrintTextTest