### PR TITLE
8341923: Modernize the j.util.Locale specification

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -115,8 +115,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <dd>- <em>Case convention:</em> {@code language} is case insensitive, but
  *   {@code Locale} always canonicalizes to lower case.</dd>
  *
- *   <dd>- <em>Syntax:</em> {@code [a-zA-Z]{2,8}}. Note: this is not the full
- *   BCP 47 language production, since it excludes
+ *   <dd>- <em>Syntax:</em> Well-formed language values have the form {@code [a-zA-Z]{2,8}}.
+ *   Note: this is not the full BCP 47 language production, since it excludes
  *   <a href="https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.2">extlang</a>
  *   (deprecated by modern three-letter language codes).</dd>
  *
@@ -131,7 +131,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   letter is upper case and the rest of the letters are lower
  *   case).</dd>
  *
- *   <dd>- <em>Syntax:</em> {@code [a-zA-Z]{4}}</dd>
+ *   <dd>- <em>Syntax:</em> Well-formed script values have the form {@code
+ *   [a-zA-Z]{4}}</dd>
  *
  *   <dd>- <em>Example:</em> "Latn" (Latin), "Cyrl" (Cyrillic)</dd>
  *
@@ -142,7 +143,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <dd>- <em>Case convention:</em> {@code country (region)} is case insensitive, but
  *   {@code Locale} always canonicalizes to upper case.</dd>
  *
- *   <dd>- <em>Syntax:</em> {@code [a-zA-Z]{2} | [0-9]{3}}</dd>
+ *   <dd>- <em>Syntax:</em> Well-formed country (region) values have the form {@code
+ *   [a-zA-Z]{2} | [0-9]{3}}</dd>
  *
  *   <dd>- <em>Example:</em> "US" (United States), "FR" (France), "029"
  *   (Caribbean)</dd>
@@ -167,7 +169,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <dd>- <em>Case convention:</em> {@code variant} is case sensitive. Note: BCP 47 treats the variant
  *   field as case insensitive.</dd>
  *
- *   <dd>- <em>Syntax:</em> {@code SUBTAG (('_'|'-') SUBTAG)*} where {@code SUBTAG =
+ *   <dd>- <em>Syntax:</em> Well-formed variant values have the form {@code
+ *   SUBTAG (('_'|'-') SUBTAG)*} where {@code SUBTAG =
  *   [0-9][0-9a-zA-Z]{3} | [0-9a-zA-Z]{5,8}}. Note: BCP 47 only
  *   uses hyphen ('-') as a delimiter, {@code Locale} is more lenient.</dd>
  *
@@ -185,8 +188,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   case insensitive, but {@code Locale} canonicalizes all
  *   extension keys and values to lower case.</dd>
  *
- *   <dd>- <em>Syntax:</em> keys are single characters from the set
- *   {@code [0-9a-zA-Z]}.  Values have the form
+ *   <dd>- <em>Syntax:</em> Well-formed keys are single characters from the set
+ *   {@code [0-9a-zA-Z]}.  Well-formed values have the form
  *   {@code SUBTAG ('-' SUBTAG)*} where for the key 'x'
  *   {@code SUBTAG = [0-9a-zA-Z]{1,8}} and for other keys
  *   {@code SUBTAG = [0-9a-zA-Z]{2,8}} (that is, 'x' allows

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -116,7 +116,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <dd>- <em>Case convention:</em> {@code language} is case insensitive, but
  *   {@code Locale} always canonicalizes to lower case.</dd>
  *
- *   <dd>- <em>Syntax:</em> Well-formed language values have the form {@code [a-zA-Z]{2,8}}.
+ *   <dd>- <em>Syntax:</em> Well-formed {@code language} values have the form {@code [a-zA-Z]{2,8}}.
  *   BCP 47 deviation: this is not the full BCP 47 language production, since it excludes
  *   <a href="https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.2">extlang</a>
  *   (as modern three-letter language codes are preferred).</dd>
@@ -132,7 +132,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   letter is upper case and the rest of the letters are lower
  *   case).</dd>
  *
- *   <dd>- <em>Syntax:</em> Well-formed script values have the form {@code
+ *   <dd>- <em>Syntax:</em> Well-formed {@code script} values have the form {@code
  *   [a-zA-Z]{4}}</dd>
  *
  *   <dd>- <em>Example:</em> "Latn" (Latin), "Cyrl" (Cyrillic)</dd>
@@ -144,7 +144,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <dd>- <em>Case convention:</em> {@code country (region)} is case insensitive, but
  *   {@code Locale} always canonicalizes to upper case.</dd>
  *
- *   <dd>- <em>Syntax:</em> Well-formed country (region) values have the form {@code
+ *   <dd>- <em>Syntax:</em> Well-formed {@code country (region)} values have the form {@code
  *   [a-zA-Z]{2} | [0-9]{3}}</dd>
  *
  *   <dd>- <em>Example:</em> "US" (United States), "FR" (France), "029"
@@ -170,7 +170,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <dd>- <em>Case convention:</em> {@code variant} is case sensitive. BCP 47
  *   deviation: BCP 47 treats the variant field as case insensitive.</dd>
  *
- *   <dd>- <em>Syntax:</em> Well-formed variant values have the form {@code
+ *   <dd>- <em>Syntax:</em> Well-formed {@code variant} values have the form {@code
  *   SUBTAG (('_'|'-') SUBTAG)*} where {@code SUBTAG =
  *   [0-9][0-9a-zA-Z]{3} | [0-9a-zA-Z]{5,8}}. BCP 47 deviation: BCP 47 only
  *   uses hyphen ('-') as a delimiter, {@code Locale} is more lenient.</dd>

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -387,8 +387,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *     NumberFormat.getCurrencyInstance(Locale.JAPAN).format(number); // returns "\u00A51,000""
  *     // Localized date format
  *     var date = LocalDate.of(2024, 1, 1);
- *     DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).localizedBy(Locale.JAPAN).format(date); // returns "2024\u5e741\u67081\u65e5"
  *     DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).localizedBy(Locale.US).format(date); // returns "January 1, 2024"
+ *     DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).localizedBy(Locale.JAPAN).format(date); // returns "2024\u5e741\u67081\u65e5"
  * }
  *
  * <h2><a id="LocaleMatching">Locale Matching</a></h2>

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -383,13 +383,13 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * {@snippet lang = java:
  *     // Localized currency format
  *     var number = 1000;
- *     NumberFormat.getCurrencyInstance(Locale.US).format(1000); // returns "$1,000"
- *     NumberFormat.getCurrencyInstance(Locale.JAPAN).format(1000); // returns "\u00A51,000""
+ *     NumberFormat.getCurrencyInstance(Locale.US).format(number); // returns "$1,000"
+ *     NumberFormat.getCurrencyInstance(Locale.JAPAN).format(number); // returns "\u00A51,000""
  *     // Localized date format
  *     var date = LocalDate.of(2024, 1, 1);
- *     DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).localizedBy(Locale.JAPAN).format(date); // returns "2024\u5e7410\u670823\u65e5"
- *     DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).localizedBy(Locale.US).format(date); // returns "October 23, 2024"
- *}
+ *     DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).localizedBy(Locale.JAPAN).format(date); // returns "2024\u5e741\u67081\u65e5"
+ *     DateTimeFormatter.ofLocalizedDate(FormatStyle.LONG).localizedBy(Locale.US).format(date); // returns "January 1, 2024"
+ * }
  *
  * <h2><a id="LocaleMatching">Locale Matching</a></h2>
  *

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -2050,7 +2050,6 @@ public final class Locale implements Cloneable, Serializable {
      * getDisplayLanguage() will return "anglais".
      * If the name returned cannot be localized for the default
      * {@link Locale.Category#DISPLAY DISPLAY} locale,
-     * (say, we don't have a Japanese name for Croatian),
      * this function falls back on the English name, and uses the ISO code as a last-resort
      * value.  If the locale doesn't specify a language, this function returns the empty string.
      *
@@ -2068,7 +2067,6 @@ public final class Locale implements Cloneable, Serializable {
      * is en_US, getDisplayLanguage() will return "French"; if the locale is en_US and
      * inLocale is fr_FR, getDisplayLanguage() will return "anglais".
      * If the name returned cannot be localized according to inLocale,
-     * (say, we don't have a Japanese name for Croatian),
      * this function falls back on the English name, and finally
      * on the ISO code as a last-resort value.  If the locale doesn't specify a language,
      * this function returns the empty string.
@@ -2123,7 +2121,6 @@ public final class Locale implements Cloneable, Serializable {
      * getDisplayCountry() will return "Etats-Unis".
      * If the name returned cannot be localized for the default
      * {@link Locale.Category#DISPLAY DISPLAY} locale,
-     * (say, we don't have a Japanese name for Croatia),
      * this function falls back on the English name, and uses the ISO code as a last-resort
      * value.  If the locale doesn't specify a country, this function returns the empty string.
      *
@@ -2141,7 +2138,6 @@ public final class Locale implements Cloneable, Serializable {
      * is en_US, getDisplayCountry() will return "France"; if the locale is en_US and
      * inLocale is fr_FR, getDisplayCountry() will return "Etats-Unis".
      * If the name returned cannot be localized according to inLocale.
-     * (say, we don't have a Japanese name for Croatia),
      * this function falls back on the English name, and finally
      * on the ISO code as a last-resort value.  If the locale doesn't specify a country,
      * this function returns the empty string.

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -102,7 +102,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * <a href="https://tools.ietf.org/html/rfc5646">RFC 5646</a>
  * combines subtags from various ISO (639, 3166, 15924) standards which are also
  * included in the composition of {@code Locale}.
- * Additionally, you can find the full list of valid codes for each field in the
+ * Additionally, the full list of valid codes for each field can be found in the
  * <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">
  * IANA Language Subtag Registry</a> (e.g. search for "Type: region").
  *
@@ -229,7 +229,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * String representing this information, for example, "nu-thai".  The
  * {@code Locale} class also provides {@link
  * #getUnicodeLocaleAttributes}, {@link #getUnicodeLocaleKeys}, and
- * {@link #getUnicodeLocaleType} which allow you to access Unicode
+ * {@link #getUnicodeLocaleType} which provides access to the Unicode
  * locale attributes and key/type pairs directly.  When represented as
  * a string, the Unicode Locale Extension lists attributes
  * alphabetically, followed by key/type sequences with keys listed
@@ -327,9 +327,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * <dl>
  *  <dt><b>Locale Constants</b></dt>
  *  <dd>The {@code Locale} class provides a number of convenient constants
- *  that you can use to obtain {@code Locale} objects for commonly used
- *  locales. For example, {@link Locale#US Locale.US} is the {@code Locale} object
- *  for the United States.</dd>
+ *  that return {@code Locale} objects for commonly used locales. For example,
+ *  {@link Locale#US Locale.US} is the {@code Locale} object for the United States.</dd>
  *  <dt><b>Factory Methods</b></dt>
  *  <dd>The method {@link #of(String, String, String)} and its overloads obtain a
  *  {@code Locale} object from the given {@code language}, {@code country},
@@ -350,12 +349,12 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *
  * <h2>Usage Examples</h2>
  *
- * <p>Once you've {@linkplain ##ObtainingLocale obtained} a {@code Locale},
- * you can query it for information about itself. For example, use {@link
+ * <p>Once a {@code Locale} is {@linkplain ##ObtainingLocale obtained},
+ * it can be queried for information about itself. For example, use {@link
  * #getCountry} to get the country (or region) code and {@link #getLanguage} to
- * get the language. You can use {@link #getDisplayCountry} to get the
+ * get the language. {@link #getDisplayCountry} can be used to get the
  * name of the country suitable for displaying to the user. Similarly,
- * you can use {@link #getDisplayLanguage()} to get the name of
+ * use {@link #getDisplayLanguage()} to get the name of
  * the language suitable for displaying to the user. The {@code getDisplayXXX}
  * methods are themselves <em>locale-sensitive</em> and have two variants; one with an explicit
  * locale parameter, and one without. The latter uses the default {@link
@@ -1588,8 +1587,8 @@ public final class Locale implements Cloneable, Serializable {
      * Java 6 and prior.
      *
      * <p>If both the language and country fields are missing, this function will return
-     * the empty string, even if the variant, script, or extensions field is present (you
-     * can't have a locale with just a variant, the variant must accompany a well-formed
+     * the empty string, even if the variant, script, or extensions field is present
+     * (a locale with just a variant is not allowed, the variant must accompany a well-formed
      * language or country code).
      *
      * <p>If script or extensions are present and variant is missing, no underscore is

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -118,7 +118,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <dd>- <em>Syntax:</em> Well-formed language values have the form {@code [a-zA-Z]{2,8}}.
  *   Note: this is not the full BCP 47 language production, since it excludes
  *   <a href="https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.2">extlang</a>
- *   (deprecated by modern three-letter language codes).</dd>
+ *   (as modern three-letter language codes are preferred).</dd>
  *
  *   <dd>- <em>Example:</em> "en" (English), "ja" (Japanese), "kok" (Konkani)</dd>
  *

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -343,6 +343,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * {@snippet lang=java :
  *     // The following are all equivalent
  *     Locale.US;
+ *     Locale.of("en", "US")
  *     Locale.forLanguageTag("en-US");
  *     new Locale.Builder().setLanguage("en").setRegion("US").build();
  * }

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -98,9 +98,9 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * the United States using the Latin alphabet and numerics for use in POSIX
  * environments.
  * {@code Locale} implements IETF BCP 47 and any deviations should be observed
- * by the comments prefixed by <em>"Note:"</em>. The various ISO (639, 3166, 15924)
- * standards included in the composition of {@code Locale} are defined in
- * <a href="https://tools.ietf.org/html/rfc5646">RFC 5646</a>.
+ * by the comments prefixed by <em>"Note:"</em>. <a href="https://tools.ietf.org/html/rfc5646">RFC 5646</a>
+ * combines subtags from various ISO (639, 3166, 15924) standards which are also
+ * included in the composition of {@code Locale}.
  * Additionally, you can find the full list of valid codes for each field in the
  * <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">
  * IANA Language Subtag Registry</a> (e.g. search for "Type: region").

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -383,7 +383,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * {@snippet lang = java:
  *     // Localized currency format
  *     var number = 1000;
- *     NumberFormat.getCurrencyInstance(Locale.US).format(number); // returns "$1,000"
+ *     NumberFormat.getCurrencyInstance(Locale.US).format(number); // returns "$1,000.00"
  *     NumberFormat.getCurrencyInstance(Locale.JAPAN).format(number); // returns "\u00A51,000""
  *     // Localized date format
  *     var date = LocalDate.of(2024, 1, 1);

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -153,8 +153,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <dt><a id="def_variant"><b>variant</b></a></dt>
  *
  *   <dd>- Any arbitrary value used to indicate a variation of a
- *   {@code Locale}. When multiple variant values exist, they should be ordered
- *   by higher importance values preceding the other variant values. BCP 47 deviation:
+ *   {@code Locale}. When multiple variants exist, they should be ordered with
+ *   higher importance values preceding the others. BCP 47 deviation:
  *   BCP 47 subtags are strictly used to indicate
  *   additional variations that define a language or its dialects that
  *   are not covered by any combinations of language, script and

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -474,8 +474,9 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *
  * <h2>Compatibility</h2>
  * @implNote
- * <p>Applications on the latest release of the reference implementation using the recommended
- * {@code Locale} API may not be concerned with the following compatibility commentary.
+ * <p> The following commentary is provided for apps that want to ensure
+ * interoperability with older releases of {@code Locale} provided by the
+ * reference implementation.
  * <h3><a id="locale_behavior">Locale Behavior</a></h3>
  * In order to maintain compatibility, Locale's
  * (deprecated) constructors retain their behavior prior to the Java Runtime

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -325,10 +325,6 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * It is advised against using the deprecated {@code Locale} constructors.
  *
  * <dl>
- *  <dt><b>Default Locale</b></dt>
- *  <dd>The {@code Locale} class provides the default {@code Locale} with
- *  {@link Locale#getDefault()} and {@link Locale#getDefault(Category)}. See the
- *  {@linkplain ##default_locale Default Locale} section for more information.</dd>
  *  <dt><b>Locale Constants</b></dt>
  *  <dd>The {@code Locale} class provides a number of convenient constants
  *  that you can use to obtain {@code Locale} objects for commonly used
@@ -346,7 +342,6 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *
  * {@snippet lang=java :
  *     // The following are all equivalent
- *     Locale.getDefault(); // (Host environment provides en-US locale)
  *     Locale.US;
  *     Locale.forLanguageTag("en-US");
  *     new Locale.Builder().setLanguage("en").setRegion("US").build();

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -93,10 +93,10 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * {@code Locale} need not have all such fields. For example, {@link
  * Locale#ENGLISH Locale.ENGLISH} is only comprised of the <em>language</em> field.
  * Contrarily, a {@code Locale} such as the one returned by {@code
- * Locale.forLanguageTag("en-Latn-US-oxendict-u-nu-latn")} would be comprised of all
- * the fields below. This particular {@code Locale} would
- * represent English in the United States using the Latin alphabet and numerics with
- * Oxford English Dictionary spelling.
+ * Locale.forLanguageTag("en-Latn-US-POSIX-u-nu-latn")} would be comprised of all
+ * the fields below. This particular {@code Locale} would represent English in
+ * the United States using the Latin alphabet and numerics for use in POSIX
+ * environments.
  * {@code Locale} implements IETF BCP 47 and any deviations should be observed
  * by the comments prefixed by <em>"Note:"</em>. The various ISO (639, 3166, 15924)
  * standards included in the composition of {@code Locale} are defined in

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -45,7 +45,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
 import java.io.Serializable;
-import java.text.DateFormat;
+import java.text.NumberFormat;
 import java.text.MessageFormat;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -70,131 +70,143 @@ import sun.util.locale.provider.LocaleServiceProviderPool;
 import sun.util.locale.provider.TimeZoneNameUtility;
 
 /**
- * A {@code Locale} object represents a specific geographical, political,
- * or cultural region. An operation that requires a {@code Locale} to perform
- * its task is called <em>locale-sensitive</em> and uses the {@code Locale}
- * to tailor information for the user. For example, displaying a number
- * is a locale-sensitive operation&mdash; the number should be formatted
- * according to the customs and conventions of the user's native country,
- * region, or culture.
+ * A {@code Locale} represents a specific geographical, political,
+ * or cultural region. An API that requires a {@code Locale} to perform
+ * its task is <em>locale-sensitive</em> and uses the {@code Locale}
+ * to tailor information for the user. These <em>locale-sensitive</em> APIs
+ * are principally in the <i>java.text</i> and <i>java.util</i> packages.
+ * For example, displaying a number is a <em>locale-sensitive</em> operation&mdash;
+ * the number should be formatted according to the customs and conventions of the
+ * user's native country, region, or culture.
  *
- * <p> The {@code Locale} class implements IETF BCP 47 which is composed of
+ * <p>The {@code Locale} class implements IETF BCP 47 which is composed of
  * <a href="https://tools.ietf.org/html/rfc4647">RFC 4647 "Matching of Language
  * Tags"</a> and <a href="https://tools.ietf.org/html/rfc5646">RFC 5646 "Tags
  * for Identifying Languages"</a> with support for the LDML (UTS#35, "Unicode
  * Locale Data Markup Language") BCP 47-compatible extensions for locale data
- * exchange.
+ * exchange. Each {@code Locale} is associated with locale data which is retrieved
+ * by the installed {@link java.util.spi.LocaleServiceProvider LocaleServiceProvider}
+ * implementations. Depending on the implementation, such data may vary by release.
  *
- * <p> A {@code Locale} object logically consists of the fields
- * described below.
+ * <h2 id="loc_comp">Locale Composition</h2>
+ * <p> A {@code Locale} is composed of the bolded fields described below; note that a
+ * {@code Locale} need not have all such fields. For example, {@link
+ * Locale#ENGLISH Locale.ENGLISH} is only comprised of the <em>language</em> field.
+ * Contrarily, a {@code Locale} such as the one returned by {@code
+ * Locale.forLanguageTag("en-Latn-US-oxendict-u-nu-latn")} would be comprised of all
+ * the fields below. This particular {@code Locale} would
+ * represent English in the United States using the Latin alphabet and numerics with
+ * Oxford English Dictionary spelling.
+ * {@code Locale} largely implements IETF BCP 47 and any differences should be observed
+ * by the comments prefixed by <em>"Note:"</em>. The various ISO (639, 3166, 15924)
+ * standards included in the composition of {@code Locale} are defined in
+ * <a href="https://tools.ietf.org/html/rfc5646">RFC 5646</a>.
+ * Additionally, you can find the full list of valid codes for each field in the
+ * <a href="https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry">
+ * IANA Language Subtag Registry</a> (e.g. search for "Type: region").
  *
  * <dl>
  *   <dt><a id="def_language"><b>language</b></a></dt>
- *
- *   <dd>ISO 639 alpha-2 or alpha-3 language code, or registered
- *   language subtags up to 8 alpha letters (for future enhancements).
+ *   <dd>- ISO 639 alpha-2/alpha-3 language code or a registered
+ *   language subtag up to 8 alpha letters (for future enhancements).
  *   When a language has both an alpha-2 code and an alpha-3 code, the
- *   alpha-2 code must be used.  You can find a full list of valid
- *   language codes in the IANA Language Subtag Registry (search for
- *   "Type: language").  The language field is case insensitive, but
+ *   alpha-2 code must be used.</dd>
+ *
+ *   <dd>- <em>Case convention:</em> {@code language} is case insensitive, but
  *   {@code Locale} always canonicalizes to lower case.</dd>
  *
- *   <dd>Well-formed language values have the form
- *   <code>[a-zA-Z]{2,8}</code>.  Note that this is not the full
- *   BCP47 language production, since it excludes extlang.  They are
- *   not needed since modern three-letter language codes replace
- *   them.</dd>
+ *   <dd>- <em>Syntax:</em> {@code [a-zA-Z]{2,8}}. Note: this is not the full
+ *   BCP 47 language production, since it excludes
+ *   <a href="https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.2">extlang</a>
+ *   (deprecated by modern three-letter language codes).</dd>
  *
- *   <dd>Example: "en" (English), "ja" (Japanese), "kok" (Konkani)</dd>
+ *   <dd>- <em>Example:</em> "en" (English), "ja" (Japanese), "kok" (Konkani)</dd>
  *
  *   <dt><a id="def_script"><b>script</b></a></dt>
  *
- *   <dd>ISO 15924 alpha-4 script code.  You can find a full list of
- *   valid script codes in the IANA Language Subtag Registry (search
- *   for "Type: script").  The script field is case insensitive, but
+ *   <dd>- ISO 15924 alpha-4 script code.</dd>
+ *
+ *   <dd>- <em>Case convention:</em> {@code script} is case insensitive, but
  *   {@code Locale} always canonicalizes to title case (the first
  *   letter is upper case and the rest of the letters are lower
  *   case).</dd>
  *
- *   <dd>Well-formed script values have the form
- *   <code>[a-zA-Z]{4}</code></dd>
+ *   <dd>- <em>Syntax:</em> {@code [a-zA-Z]{4}}</dd>
  *
- *   <dd>Example: "Latn" (Latin), "Cyrl" (Cyrillic)</dd>
+ *   <dd>- <em>Example:</em> "Latn" (Latin), "Cyrl" (Cyrillic)</dd>
  *
  *   <dt><a id="def_region"><b>country (region)</b></a></dt>
  *
- *   <dd>ISO 3166 alpha-2 country code or UN M.49 numeric-3 area code.
- *   You can find a full list of valid country and region codes in the
- *   IANA Language Subtag Registry (search for "Type: region").  The
- *   country (region) field is case insensitive, but
+ *   <dd>- ISO 3166 alpha-2 country code or UN M.49 numeric-3 area code.</dd>
+ *
+ *   <dd>- <em>Case convention:</em> {@code country (region)} is case insensitive, but
  *   {@code Locale} always canonicalizes to upper case.</dd>
  *
- *   <dd>Well-formed country/region values have
- *   the form <code>[a-zA-Z]{2} | [0-9]{3}</code></dd>
+ *   <dd>- <em>Syntax:</em> {@code [a-zA-Z]{2} | [0-9]{3}}</dd>
  *
- *   <dd>Example: "US" (United States), "FR" (France), "029"
+ *   <dd>- <em>Example:</em> "US" (United States), "FR" (France), "029"
  *   (Caribbean)</dd>
  *
  *   <dt><a id="def_variant"><b>variant</b></a></dt>
  *
- *   <dd>Any arbitrary value used to indicate a variation of a
- *   {@code Locale}.  Where there are two or more variant values
- *   each indicating its own semantics, these values should be ordered
- *   by importance, with most important first, separated by
- *   underscore('_').  The variant field is case sensitive.</dd>
- *
- *   <dd>Note: IETF BCP 47 places syntactic restrictions on variant
- *   subtags.  Also BCP 47 subtags are strictly used to indicate
+ *   <dd>- Any arbitrary value used to indicate a variation of a
+ *   {@code Locale}. When multiple variant values exist, they should be ordered
+ *   by higher importance values preceding the other variant values. Note:
+ *   BCP 47 subtags are strictly used to indicate
  *   additional variations that define a language or its dialects that
  *   are not covered by any combinations of language, script and
- *   region subtags.  You can find a full list of valid variant codes
- *   in the IANA Language Subtag Registry (search for "Type: variant").
- *
- *   <p>However, the variant field in {@code Locale} has
+ *   region subtags. However, the variant field in {@code Locale} has
  *   historically been used for any kind of variation, not just
  *   language variations.  For example, some supported variants
  *   available in Java SE Runtime Environments indicate alternative
  *   cultural behaviors such as calendar type or number script.  In
- *   BCP 47 this kind of information, which does not identify the
+ *   BCP 47, this kind of information which does not identify the
  *   language, is supported by extension subtags or private use
  *   subtags.</dd>
  *
- *   <dd>Well-formed variant values have the form <code>SUBTAG
- *   (('_'|'-') SUBTAG)*</code> where <code>SUBTAG =
- *   [0-9][0-9a-zA-Z]{3} | [0-9a-zA-Z]{5,8}</code>. (Note: BCP 47 only
- *   uses hyphen ('-') as a delimiter, this is more lenient).</dd>
+ *   <dd>- <em>Case convention:</em> {@code variant} is case sensitive. Note: BCP 47 treats the variant
+ *   field as case insensitive.</dd>
  *
- *   <dd>Example: "polyton" (Polytonic Greek), "POSIX"</dd>
+ *   <dd>- <em>Syntax:</em> {@code SUBTAG (('_'|'-') SUBTAG)*} where {@code SUBTAG =
+ *   [0-9][0-9a-zA-Z]{3} | [0-9a-zA-Z]{5,8}}. Note: BCP 47 only
+ *   uses hyphen ('-') as a delimiter, {@code Locale} is more lenient.</dd>
+ *
+ *   <dd>- <em>Example:</em> "polyton" (Polytonic Greek), "POSIX"</dd>
  *
  *   <dt><a id="def_extensions"><b>extensions</b></a></dt>
  *
- *   <dd>A map from single character keys to string values, indicating
- *   extensions apart from language identification.  The extensions in
+ *   <dd>- A map from single character keys to string values, indicating
+ *   extensions apart from language identification. Note: The {@code extensions} in
  *   {@code Locale} implement the semantics and syntax of BCP 47
- *   extension subtags and private use subtags. The extensions are
- *   case insensitive, but {@code Locale} canonicalizes all
- *   extension keys and values to lower case. Note that extensions
- *   cannot have empty values.</dd>
+ *   extension subtags <em>and</em> private use subtags. The {@code extensions}
+ *   field cannot have empty values. </dd>
  *
- *   <dd>Well-formed keys are single characters from the set
- *   {@code [0-9a-zA-Z]}.  Well-formed values have the form
+ *   <dd>- <em>Case convention:</em> {@code extensions} are
+ *   case insensitive, but {@code Locale} canonicalizes all
+ *   extension keys and values to lower case.</dd>
+ *
+ *   <dd>- <em>Syntax:</em> keys are single characters from the set
+ *   {@code [0-9a-zA-Z]}.  Values have the form
  *   {@code SUBTAG ('-' SUBTAG)*} where for the key 'x'
- *   <code>SUBTAG = [0-9a-zA-Z]{1,8}</code> and for other keys
- *   <code>SUBTAG = [0-9a-zA-Z]{2,8}</code> (that is, 'x' allows
+ *   {@code SUBTAG = [0-9a-zA-Z]{1,8}} and for other keys
+ *   {@code SUBTAG = [0-9a-zA-Z]{2,8}} (that is, 'x' allows
  *   single-character subtags).</dd>
  *
- *   <dd>Example: key="u"/value="ca-japanese" (Japanese Calendar),
+ *   <dd>- <em>Example:</em> key="u"/value="ca-japanese" (Japanese Calendar),
  *   key="x"/value="java-1-7"</dd>
  * </dl>
  *
  * <b>Note:</b> Although BCP 47 requires field values to be registered
  * in the IANA Language Subtag Registry, the {@code Locale} class
- * does not provide any validation features.  The {@code Builder}
+ * does not validate this requirement. For example, the variant code <em>"foobar"</em>
+ * is well-formed since it is composed of 5 to 8 alphanumerics, but is not defined
+ * the IANA Language Subtag Registry. The {@link Builder}
  * only checks if an individual field satisfies the syntactic
  * requirement (is well-formed), but does not validate the value
- * itself.  See {@link Builder} for details.
+ * itself. Conversely, the {@link #of(String, String, String)} overloads do not
+ * make any syntactic checks on the input.
  *
- * <h2><a id="def_locale_extension">Unicode locale/language extension</a></h2>
+ * <h3><a id="def_locale_extension">Unicode locale/language extension</a></h3>
  *
  * <p>UTS#35, "Unicode Locale Data Markup Language" defines optional
  * attributes and keywords to override or refine the default behavior
@@ -221,11 +233,11 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * fixed when the type is defined)
  *
  * <p>A well-formed locale key has the form
- * <code>[0-9a-zA-Z]{2}</code>.  A well-formed locale type has the
- * form <code>"" | [0-9a-zA-Z]{3,8} ('-' [0-9a-zA-Z]{3,8})*</code> (it
+ * {@code [0-9a-zA-Z]{2}}.  A well-formed locale type has the
+ * form {@code "" | [0-9a-zA-Z]{3,8} ('-' [0-9a-zA-Z]{3,8})*} (it
  * can be empty, or a series of subtags 3-8 alphanums in length).  A
  * well-formed locale attribute has the form
- * <code>[0-9a-zA-Z]{3,8}</code> (it is a single subtag with the same
+ * {@code [0-9a-zA-Z]{3,8}} (it is a single subtag with the same
  * form as a locale type subtag).
  *
  * <p>The Unicode locale extension specifies optional behavior in
@@ -234,36 +246,11 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * implementations in a Java Runtime Environment might not support any
  * particular Unicode locale attributes or key/type pairs.
  *
- * <h3><a id="ObtainingLocale">Obtaining a Locale</a></h3>
+ * <h2><a id="default_locale">Default Locale</a></h2>
  *
- * <p>There are several ways to obtain a {@code Locale}
- * object.
- *
- * <h4>Builder</h4>
- *
- * <p>Using {@link Builder} you can construct a {@code Locale} object
- * that conforms to BCP 47 syntax.
- *
- * <h4>Factory Methods</h4>
- *
- * <p>The method {@link #forLanguageTag} obtains a {@code Locale}
- * object for a well-formed BCP 47 language tag. The method
- * {@link #of(String, String, String)} and its overloads obtain a
- * {@code Locale} object from given {@code language}, {@code country},
- * and/or {@code variant} defined above.
- *
- * <h4>Locale Constants</h4>
- *
- * <p>The {@code Locale} class provides a number of convenient constants
- * that you can use to obtain {@code Locale} objects for commonly used
- * locales. For example, {@code Locale.US} is the {@code Locale} object
- * for the United States.
- *
- * <h3><a id="default_locale">Default Locale</a></h3>
- *
- * <p>The default Locale is provided for any locale-sensitive methods if no
+ * <p>The default Locale is provided for any <em>locale-sensitive</em> methods if no
  * {@code Locale} is explicitly specified as an argument, such as
- * {@link DateFormat#getInstance()}. The default Locale is determined at startup
+ * {@link NumberFormat#getInstance()}. The default Locale is determined at startup
  * of the Java runtime and established in the following three phases:
  * <ol>
  * <li>The locale-related system properties listed below are established from the
@@ -316,6 +303,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * system properties are not altered. It is not recommended that applications read
  * these system properties and parse or interpret them as their values may be out of date.
  *
+ * <h3>Locale Category</h3>
  * <p>There are finer-grained default Locales specific for each {@link Locale.Category}.
  * These category specific default Locales can be queried by {@link #getDefault(Category)},
  * and set by {@link #setDefault(Category, Locale)}. Construction of these category
@@ -327,19 +315,96 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * category. In the absence of category specific system properties, the "category-less"
  * system properties are used, such as {@code user.language} in the previous example.
  *
- * <h3><a id="LocaleMatching">Locale Matching</a></h3>
+ * <h2><a id="ObtainingLocale">Obtaining a Locale</a></h2>
  *
- * <p>If an application or a system is internationalized and provides localized
+ * <p>There are several ways to obtain a {@code Locale} object.
+ * It is advised against using the deprecated {@code Locale} constructors.
+ *
+ * <dl>
+ *  <dt><b>Default Locale</b></dt>
+ *  <dd>The {@code Locale} class provides the default {@code Locale} with
+ *  {@link Locale#getDefault()} and {@link Locale#getDefault(Category)}. See the
+ *  {@linkplain ##default_locale Default Locale} section for more information.</dd>
+ *  <dt><b>Locale Constants</b></dt>
+ *  <dd>The {@code Locale} class provides a number of convenient constants
+ *  that you can use to obtain {@code Locale} objects for commonly used
+ *  locales. For example, {@link Locale#US Locale.US} is the {@code Locale} object
+ *  for the United States.</dd>
+ *  <dt><b>Factory Methods</b></dt>
+ *  <dd>The method {@link #of(String, String, String)} and its overloads obtain a
+ *  {@code Locale} object from the given {@code language}, {@code country},
+ *  and/or {@code variant}. The method {@link #forLanguageTag} obtains a {@code Locale}
+ *  object for a well-formed BCP 47 language tag.</dd>
+ *  <dt><b>Builder</b></dt>
+ *  <dd>{@link Builder} is used to construct a {@code Locale} object that conforms
+ *  to BCP 47 syntax. Use a builder to enforce syntactic restrictions on the input.</dd>
+ * </dl>
+ *
+ * {@snippet lang=java :
+ *     // The following are all equivalent
+ *     Locale.getDefault(); // (Host environment provides en-US locale)
+ *     Locale.US;
+ *     Locale.forLanguageTag("en-US");
+ *     new Locale.Builder().setLanguage("en").setRegion("US").build();
+ * }
+ *
+ * <h2>Usage Examples</h2>
+ *
+ * <p>Once you've {@linkplain ##ObtainingLocale obtained} a {@code Locale},
+ * you can query it for information about itself. For example, use {@link
+ * #getCountry} to get the country (or region) code and {@link #getLanguage} to
+ * get the language. You can use {@link #getDisplayCountry} to get the
+ * name of the country suitable for displaying to the user. Similarly,
+ * you can use {@link #getDisplayLanguage()} to get the name of
+ * the language suitable for displaying to the user. The {@code getDisplayXXX}
+ * methods are themselves <em>locale-sensitive</em> and have two variants; one with an explicit
+ * locale parameter, and one without. The latter uses the default {@link
+ * Locale.Category#DISPLAY DISPLAY} locale :
+ * {@snippet lang=java :
+ *     // The following are equivalent
+ *     Locale.getDefault().getDisplayCountry();
+ *     Locale.getDefault().getDisplayCountry(Locale.getDefault(Locale.Category.DISPLAY));
+ * }
+ *
+ * <p>The Java Platform provides a number of classes that perform locale-sensitive
+ * operations. For example, the {@code NumberFormat} class formats
+ * numbers, currency, and percentages in a <em>locale-sensitive</em> manner. Classes such
+ * as {@code NumberFormat} have several factory methods for creating a default object
+ * of that type. These methods generally have two variants; one with an explicit
+ * locale parameter, and one without. The latter uses the default {@link
+ * Locale.Category#FORMAT FORMAT} locale :
+ * {@snippet lang=java :
+ *     // The following are equivalent
+ *     NumberFormat.getCurrencyInstance();
+ *     NumberFormat.getCurrencyInstance(Locale.getDefault(Locale.Category.FORMAT));
+ * }
+ *
+ * <p>
+ * The following example demonstrates <em>locale-sensitive</em> operations with different locales :
+ * {@snippet lang = java:
+ *     // Localized currency format
+ *     var number = 1000;
+ *     NumberFormat.getCurrencyInstance(Locale.US).format(1000); // returns "$1,000"
+ *     NumberFormat.getCurrencyInstance(Locale.JAPAN).format(1000); // returns "\u00A51,000""
+ *     // Localized date format
+ *     var date = LocalDate.of(2024, 1, 1);
+ *     DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).localizedBy(Locale.JAPAN).format(date); // returns "2024\u5e7410\u670823\u65e5"
+ *     DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).localizedBy(Locale.US).format(date); // returns "October 23, 2024"
+ *}
+ *
+ * <h2><a id="LocaleMatching">Locale Matching</a></h2>
+ *
+ * <p>If an application is internationalized and provides localized
  * resources for multiple locales, it sometimes needs to find one or more
  * locales (or language tags) which meet each user's specific preferences. Note
- * that a term "language tag" is used interchangeably with "locale" in this
+ * that the term "language tag" is used interchangeably with "locale" in the following
  * locale matching documentation.
  *
- * <p>In order to do matching a user's preferred locales to a set of language
+ * <p>In order to match a user's preferred locales to a set of language
  * tags, <a href="https://tools.ietf.org/html/rfc4647">RFC 4647 Matching of
  * Language Tags</a> defines two mechanisms: filtering and lookup.
  * <em>Filtering</em> is used to get all matching locales, whereas
- * <em>lookup</em> is to choose the best matching locale.
+ * <em>lookup</em> is to select the best matching locale.
  * Matching is done case-insensitively. These matching mechanisms are described
  * in the following sections.
  *
@@ -348,7 +413,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * language ranges: basic and extended. See
  * {@link Locale.LanguageRange Locale.LanguageRange} for details.
  *
- * <h4>Filtering</h4>
+ *
+ * <h3>Filtering</h3>
  *
  * <p>The filtering operation returns all matching language tags. It is defined
  * in RFC 4647 as follows:
@@ -366,7 +432,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * {@link Locale.FilteringMode} is a parameter to specify how filtering should
  * be done.
  *
- * <h4>Lookup</h4>
+ * <h3>Lookup</h3>
  *
  * <p>The lookup operation returns the best matching language tags. It is
  * defined in RFC 4647 as follows:
@@ -398,76 +464,49 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * an {@link Iterator} over a {@link Collection} of language tags is treated as
  * the best matching one.
  *
- * <h3>Use of Locale</h3>
+ * <h3>Serialization</h3>
  *
- * <p>Once you've obtained a {@code Locale} you can query it for information
- * about itself. Use {@code getCountry} to get the country (or region)
- * code and {@code getLanguage} to get the language code.
- * You can use {@code getDisplayCountry} to get the
- * name of the country suitable for displaying to the user. Similarly,
- * you can use {@code getDisplayLanguage} to get the name of
- * the language suitable for displaying to the user. Interestingly,
- * the {@code getDisplayXXX} methods are themselves locale-sensitive
- * and have two versions: one that uses the default
- * {@link Locale.Category#DISPLAY DISPLAY} locale and one
- * that uses the locale specified as an argument.
+ * <p>During serialization, writeObject writes all fields to the output
+ * stream, including extensions.
  *
- * <p>The Java Platform provides a number of classes that perform locale-sensitive
- * operations. For example, the {@code NumberFormat} class formats
- * numbers, currency, and percentages in a locale-sensitive manner. Classes
- * such as {@code NumberFormat} have several convenience methods
- * for creating a default object of that type. For example, the
- * {@code NumberFormat} class provides these three convenience methods
- * for creating a default {@code NumberFormat} object:
- * {@snippet lang=java :
- *     NumberFormat.getInstance();
- *     NumberFormat.getCurrencyInstance();
- *     NumberFormat.getPercentInstance();
- * }
- * Each of these methods has two variants; one with an explicit locale
- * and one without; the latter uses the default
- * {@link Locale.Category#FORMAT FORMAT} locale:
- * {@snippet lang=java :
- *     NumberFormat.getInstance(myLocale);
- *     NumberFormat.getCurrencyInstance(myLocale);
- *     NumberFormat.getPercentInstance(myLocale);
- * }
- * A {@code Locale} is the mechanism for identifying the kind of object
- * ({@code NumberFormat}) that you would like to get. The locale is
- * <STRONG>just</STRONG> a mechanism for identifying objects,
- * <STRONG>not</STRONG> a container for the objects themselves.
+ * <p>During deserialization, readResolve adds extensions as described
+ * in {@linkplain ##special_cases_constructor Special Cases}, only
+ * for the two cases th_TH_TH and ja_JP_JP.
  *
- * <h3>Compatibility</h3>
- *
- * <p>In order to maintain compatibility, Locale's
- * constructors retain their behavior prior to the Java Runtime
- * Environment version 1.7.  The same is largely true for the
- * {@code toString} method. Thus Locale objects can continue to
- * be used as they were. In particular, clients who parse the output
- * of toString into language, country, and variant fields can continue
- * to do so (although this is strongly discouraged), although the
- * variant field will have additional information in it if script or
- * extensions are present.
+ * <h2>Compatibility</h2>
+ * @implNote
+ * <p>Applications on the latest release of the reference implementation using the recommended
+ * {@code Locale} API may not be concerned with the following compatibility commentary.
+ * <h3><a id="locale_behavior">Locale Behavior</a></h3>
+ * In order to maintain compatibility, Locale's
+ * (deprecated) constructors retain their behavior prior to the Java Runtime
+ * Environment version 1.7. That is, a length constraint is not imposed on any of
+ * the input parameters. Similarly, the same preservation of past behavior is largely true
+ * for the {@link #toString()} method.
+ * Apps that previously parsed the output of {@link #toString()} into language,
+ * country, and variant fields can continue to do so (although this is strongly
+ * discouraged). A caveat is that the variant field will have additional
+ * information in it if script or extensions are present.
  *
  * <p>In addition, BCP 47 imposes syntax restrictions that are not
  * imposed by Locale's constructors. This means that conversions
  * between some Locales and BCP 47 language tags cannot be made without
- * losing information. Thus {@code toLanguageTag} cannot
+ * losing information. Thus {@link #toLanguageTag} cannot
  * represent the state of locales whose language, country, or variant
  * do not conform to BCP 47.
  *
- * <p>Because of these issues, it is recommended that clients migrate
+ * <p>Because of these issues, it is recommended that apps migrate
  * away from constructing non-conforming locales and use the
- * {@code forLanguageTag} and {@code Locale.Builder} APIs instead.
- * Clients desiring a string representation of the complete locale can
- * then always rely on {@code toLanguageTag} for this purpose.
+ * {@link #forLanguageTag} and {@link Locale.Builder} APIs instead.
+ * Apps desiring a string representation of the complete locale can
+ * then always rely on {@link #toLanguageTag} for this purpose.
  *
- * <h4><a id="special_cases_constructor">Special cases</a></h4>
+ * <h3><a id="special_cases_constructor">Special cases</a></h3>
  *
  * <p>For compatibility reasons, two
  * non-conforming locales are treated as special cases.  These are
  * <b>{@code ja_JP_JP}</b> and <b>{@code th_TH_TH}</b>. These are ill-formed
- * in BCP 47 since the variants are too short. To ease migration to BCP 47,
+ * in BCP 47 since the {@linkplain ##def_variant variants} are too short. To ease migration to BCP 47,
  * these are treated specially during construction.  These two cases (and only
  * these) cause a constructor to generate an extension, all other values behave
  * exactly as they did prior to Java 7.
@@ -487,25 +526,16 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * constructor is called with the arguments "th", "TH", "TH", the
  * extension "u-nu-thai" is automatically added.
  *
- * <h4>Serialization</h4>
+ * <h3><a id="legacy_language_codes">Legacy language codes</a></h3>
  *
- * <p>During serialization, writeObject writes all fields to the output
- * stream, including extensions.
- *
- * <p>During deserialization, readResolve adds extensions as described
- * in {@linkplain ##special_cases_constructor Special Cases}, only
- * for the two cases th_TH_TH and ja_JP_JP.
- *
- * <h4><a id="legacy_language_codes">Legacy language codes</a></h4>
- *
- * <p>Locale's constructor has always converted three language codes to
+ * <p>Locale's constructors have always converted three language codes to
  * their earlier, obsoleted forms: {@code he} maps to {@code iw},
  * {@code yi} maps to {@code ji}, and {@code id} maps to
  * {@code in}. Since Java SE 17, this is no longer the case. Each
  * language maps to its new form; {@code iw} maps to {@code he}, {@code ji}
  * maps to {@code yi}, and {@code in} maps to {@code id}.
  *
- * <p>For the backward compatible behavior, the system property
+ * <p>For backwards compatible behavior, the system property
  * {@systemProperty java.locale.useOldISOCodes} reverts the behavior
  * back to that of before Java SE 17. If the system property is set to
  * {@code true}, those three current language codes are mapped to their
@@ -523,18 +553,6 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * API is used to construct them. Java's default resource bundle
  * lookup mechanism also implements this mapping, so that resources
  * can be named using either convention, see {@link ResourceBundle.Control}.
- *
- * <h4>Three-letter language/country(region) codes</h4>
- *
- * <p>The Locale constructors have always specified that the language
- * and the country param be two characters in length, although in
- * practice they have accepted any length.  The specification has now
- * been relaxed to allow language codes of two to eight characters and
- * country (region) codes of two to three characters, and in
- * particular, three-letter language codes and three-digit region
- * codes as specified in the IANA Language Subtag Registry.  For
- * compatibility, the implementation still does not impose a length
- * constraint.
  *
  * @spec https://www.rfc-editor.org/info/rfc4647
  *      RFC 4647: Matching of Language Tags
@@ -1651,7 +1669,7 @@ public final class Locale implements Cloneable, Serializable {
      * (delimited by '-' or '_') is emitted as a subtag.  Otherwise:
      * <ul>
      *
-     * <li>if all sub-segments match <code>[0-9a-zA-Z]{1,8}</code>
+     * <li>if all sub-segments match {@code [0-9a-zA-Z]{1,8}}
      * (for example "WIN" or "Oracle_JDK_Standard_Edition"), the first
      * ill-formed sub-segment and all following will be appended to
      * the private use subtag.  The first appended subtag will be
@@ -1660,7 +1678,7 @@ public final class Locale implements Cloneable, Serializable {
      * "Oracle-x-lvariant-JDK-Standard-Edition".
      *
      * <li>if any sub-segment does not match
-     * <code>[0-9a-zA-Z]{1,8}</code>, the variant will be truncated
+     * {@code [0-9a-zA-Z]{1,8}}, the variant will be truncated
      * and the problematic sub-segment and all following sub-segments
      * will be omitted.  If the remainder is non-empty, it will be
      * emitted as a private use subtag as above (even if the remainder

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -97,7 +97,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * the fields below. This particular {@code Locale} would
  * represent English in the United States using the Latin alphabet and numerics with
  * Oxford English Dictionary spelling.
- * {@code Locale} largely implements IETF BCP 47 and any differences should be observed
+ * {@code Locale} implements IETF BCP 47 and any deviations should be observed
  * by the comments prefixed by <em>"Note:"</em>. The various ISO (639, 3166, 15924)
  * standards included in the composition of {@code Locale} are defined in
  * <a href="https://tools.ietf.org/html/rfc5646">RFC 5646</a>.

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -342,7 +342,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * {@snippet lang=java :
  *     // The following are all equivalent
  *     Locale.US;
- *     Locale.of("en", "US")
+ *     Locale.of("en", "US");
  *     Locale.forLanguageTag("en-US");
  *     new Locale.Builder().setLanguage("en").setRegion("US").build();
  * }

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -98,7 +98,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * the United States using the Latin alphabet and numerics for use in POSIX
  * environments.
  * {@code Locale} implements IETF BCP 47 and any deviations should be observed
- * by the comments prefixed by <em>"Note:"</em>. <a href="https://tools.ietf.org/html/rfc5646">RFC 5646</a>
+ * by the comments prefixed by <em>"BCP 47 deviation:"</em>.
+ * <a href="https://tools.ietf.org/html/rfc5646">RFC 5646</a>
  * combines subtags from various ISO (639, 3166, 15924) standards which are also
  * included in the composition of {@code Locale}.
  * Additionally, you can find the full list of valid codes for each field in the
@@ -116,7 +117,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   {@code Locale} always canonicalizes to lower case.</dd>
  *
  *   <dd>- <em>Syntax:</em> Well-formed language values have the form {@code [a-zA-Z]{2,8}}.
- *   Note: this is not the full BCP 47 language production, since it excludes
+ *   BCP 47 deviation: this is not the full BCP 47 language production, since it excludes
  *   <a href="https://datatracker.ietf.org/doc/html/rfc5646#section-2.2.2">extlang</a>
  *   (as modern three-letter language codes are preferred).</dd>
  *
@@ -153,7 +154,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *
  *   <dd>- Any arbitrary value used to indicate a variation of a
  *   {@code Locale}. When multiple variant values exist, they should be ordered
- *   by higher importance values preceding the other variant values. Note:
+ *   by higher importance values preceding the other variant values. BCP 47 deviation:
  *   BCP 47 subtags are strictly used to indicate
  *   additional variations that define a language or its dialects that
  *   are not covered by any combinations of language, script and
@@ -166,12 +167,12 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   language, is supported by extension subtags or private use
  *   subtags.</dd>
  *
- *   <dd>- <em>Case convention:</em> {@code variant} is case sensitive. Note: BCP 47 treats the variant
- *   field as case insensitive.</dd>
+ *   <dd>- <em>Case convention:</em> {@code variant} is case sensitive. BCP 47
+ *   deviation: BCP 47 treats the variant field as case insensitive.</dd>
  *
  *   <dd>- <em>Syntax:</em> Well-formed variant values have the form {@code
  *   SUBTAG (('_'|'-') SUBTAG)*} where {@code SUBTAG =
- *   [0-9][0-9a-zA-Z]{3} | [0-9a-zA-Z]{5,8}}. Note: BCP 47 only
+ *   [0-9][0-9a-zA-Z]{3} | [0-9a-zA-Z]{5,8}}. BCP 47 deviation: BCP 47 only
  *   uses hyphen ('-') as a delimiter, {@code Locale} is more lenient.</dd>
  *
  *   <dd>- <em>Example:</em> "polyton" (Polytonic Greek), "POSIX"</dd>
@@ -179,8 +180,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   <dt><a id="def_extensions"><b>extensions</b></a></dt>
  *
  *   <dd>- A map from single character keys to string values, indicating
- *   extensions apart from language identification. Note: The {@code extensions} in
- *   {@code Locale} implement the semantics and syntax of BCP 47
+ *   extensions apart from language identification. BCP 47 deviation: The {@code
+ *   extensions} in {@code Locale} implement the semantics and syntax of BCP 47
  *   extension subtags <em>and</em> private use subtags. The {@code extensions}
  *   field cannot have empty values. </dd>
  *
@@ -199,7 +200,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  *   key="x"/value="java-1-7"</dd>
  * </dl>
  *
- * <b>Note:</b> Although BCP 47 requires field values to be registered
+ * <b>BCP 47 deviation:</b> Although BCP 47 requires field values to be registered
  * in the IANA Language Subtag Registry, the {@code Locale} class
  * does not validate this requirement. For example, the variant code <em>"foobar"</em>
  * is well-formed since it is composed of 5 to 8 alphanumerics, but is not defined

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -207,7 +207,7 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * the IANA Language Subtag Registry. The {@link Builder}
  * only checks if an individual field satisfies the syntactic
  * requirement (is well-formed), but does not validate the value
- * itself. Conversely, the {@link #of(String, String, String)} overloads do not
+ * itself. Conversely, {@link #of(String, String, String)} and its overloads do not
  * make any syntactic checks on the input.
  *
  * <h3><a id="def_locale_extension">Unicode locale/language extension</a></h3>
@@ -478,8 +478,8 @@ import sun.util.locale.provider.TimeZoneNameUtility;
  * interoperability with older releases of {@code Locale} provided by the
  * reference implementation.
  * <h3><a id="locale_behavior">Locale Behavior</a></h3>
- * In order to maintain compatibility, Locale's
- * (deprecated) constructors retain their behavior prior to the Java Runtime
+ * In order to maintain compatibility, Locale's (deprecated) constructors,
+ * {@link #of(String, String, String)}, and its overloads retain their behavior prior to the Java Runtime
  * Environment version 1.7. That is, a length constraint is not imposed on any of
  * the input parameters. Similarly, the same preservation of past behavior is largely true
  * for the {@link #toString()} method.


### PR DESCRIPTION
WIP of [JDK-8341923](https://bugs.openjdk.org/browse/JDK-8341923).

Updates so far,
- The Javadoc headers on the left only list Unicode extensions as a a header. The header tags need to be updated so that the relevant headers can be listed.
- The concept of Locale Data and data changes from release to release should be mentioned. LSP can do the heavy lifting here, but a mention of LSP in Locale would help.
- Further clarifications for BCP 47 in regards to the Locale tag definitions. There is a lack of commentary to properly introduce the components of a Locale.
- Compatibility wording should be explicitly designated as implementation specific to the reference implementation.
- Less emphasis on compatibility. The docs are for JDK24+, an entire paragraph solely for the deprecated Locale constructor behavior is not needed.
- Update the Obtaining Locale and Use of Locale sections to provide better examples and more meaningful commentary.
- DateFormat mentions replaced with NumberFormat and date examples use java.time.
- General typo fixes, wording improvement, and reformatting.

To help with reviewing,
The API Diff -> https://cr.openjdk.org/~jlu/8341923_apidiff/java.base/java/util/Locale.html
The built docs -> https://cr.openjdk.org/~jlu/api/java.base/java/util/Locale.html

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8343445](https://bugs.openjdk.org/browse/JDK-8343445) to be approved

### Issues
 * [JDK-8341923](https://bugs.openjdk.org/browse/JDK-8341923): Modernize the j.util.Locale specification (**Enhancement** - P4)
 * [JDK-8343445](https://bugs.openjdk.org/browse/JDK-8343445): Modernize the j.util.Locale specification (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21717/head:pull/21717` \
`$ git checkout pull/21717`

Update a local copy of the PR: \
`$ git checkout pull/21717` \
`$ git pull https://git.openjdk.org/jdk.git pull/21717/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21717`

View PR using the GUI difftool: \
`$ git pr show -t 21717`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21717.diff">https://git.openjdk.org/jdk/pull/21717.diff</a>

</details>
