### PR TITLE
8343086: [BACKOUT] JDK-8295269 G1: Improve slow startup due to predictor initialization

### DIFF
--- a/src/hotspot/share/gc/g1/g1AnalyticsSequences.hpp
+++ b/src/hotspot/share/gc/g1/g1AnalyticsSequences.hpp
@@ -35,7 +35,6 @@ class G1Predictions;
 // Container for TruncatedSeqs that need separate predictors by GC phase.
 class G1PhaseDependentSeq {
   TruncatedSeq _young_only_seq;
-  double _initial_value;
   TruncatedSeq _mixed_seq;
 
   NONCOPYABLE(G1PhaseDependentSeq);

--- a/src/hotspot/share/gc/g1/g1AnalyticsSequences.inline.hpp
+++ b/src/hotspot/share/gc/g1/g1AnalyticsSequences.inline.hpp
@@ -34,7 +34,6 @@ bool G1PhaseDependentSeq::enough_samples_to_use_mixed_seq() const {
 
 G1PhaseDependentSeq::G1PhaseDependentSeq(int length) :
   _young_only_seq(length),
-  _initial_value(0.0),
   _mixed_seq(length)
 { }
 
@@ -43,7 +42,7 @@ TruncatedSeq* G1PhaseDependentSeq::seq_raw(bool use_young_only_phase_seq) {
 }
 
 void G1PhaseDependentSeq::set_initial(double value) {
-  _initial_value = value;
+  _young_only_seq.add(value);
 }
 
 void G1PhaseDependentSeq::add(double value, bool for_young_only_phase) {
@@ -52,12 +51,8 @@ void G1PhaseDependentSeq::add(double value, bool for_young_only_phase) {
 
 double G1PhaseDependentSeq::predict(const G1Predictions* predictor, bool use_young_only_phase_seq) const {
   if (use_young_only_phase_seq || !enough_samples_to_use_mixed_seq()) {
-    if (_young_only_seq.num() == 0) {
-      return _initial_value;
-    }
     return predictor->predict(&_young_only_seq);
   } else {
-    assert(_mixed_seq.num() > 0, "must not ask this with no samples");
     return predictor->predict(&_mixed_seq);
   }
 }


### PR DESCRIPTION
Hi all,

  please review this revert of JDK-8295269 because it makes the runtime/cds/DeterministicCDSDump.java test fail due to differences in startup behavior.

This is a clean revert.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343086](https://bugs.openjdk.org/browse/JDK-8343086): [BACKOUT] JDK-8295269 G1: Improve slow startup due to predictor initialization (**Bug** - P4)


### Reviewers
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21718/head:pull/21718` \
`$ git checkout pull/21718`

Update a local copy of the PR: \
`$ git checkout pull/21718` \
`$ git pull https://git.openjdk.org/jdk.git pull/21718/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21718`

View PR using the GUI difftool: \
`$ git pr show -t 21718`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21718.diff">https://git.openjdk.org/jdk/pull/21718.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21718#issuecomment-2438529609)