### PR TITLE
8317538: Potential bottleneck in Provider::getService: specjvm2008::crypto.rsa have scalability issue for high vCPU numbers

### DIFF
--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1279,12 +1279,7 @@ public abstract class Provider extends Properties {
      */
     public Service getService(String type, String algorithm) {
         checkInitialized();
-        // avoid allocating a new ServiceKey object if possible
-        ServiceKey key = previousKey;
-        if (!key.matches(type, algorithm)) {
-            key = new ServiceKey(type, algorithm, false);
-            previousKey = key;
-        }
+        ServiceKey key = new ServiceKey(type, algorithm, false);
 
         Service s = serviceMap.get(key);
         if (s == null) {
@@ -1304,15 +1299,6 @@ public abstract class Provider extends Properties {
 
         return s;
     }
-
-    // ServiceKey from previous getService() call
-    // by re-using it if possible we avoid allocating a new object
-    // and the toUpperCase() call.
-    // re-use will occur e.g. as the framework traverses the provider
-    // list and queries each provider with the same values until it finds
-    // a matching service
-    private static volatile ServiceKey previousKey =
-                                            new ServiceKey("", "", false);
 
     /**
      * Get an unmodifiable Set of all services supported by

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1279,7 +1279,12 @@ public abstract class Provider extends Properties {
      */
     public Service getService(String type, String algorithm) {
         checkInitialized();
-        ServiceKey key = new ServiceKey(type, algorithm, false);
+        // avoid allocating a new ServiceKey object if possible
+        ServiceKey key = previousKey;
+        if (!key.matches(type, algorithm)) {
+            key = new ServiceKey(type, algorithm, false);
+            previousKey = key;
+        }
 
         Service s = serviceMap.get(key);
         if (s == null) {
@@ -1299,6 +1304,15 @@ public abstract class Provider extends Properties {
 
         return s;
     }
+
+    // ServiceKey from previous getService() call
+    // by re-using it if possible we avoid allocating a new object
+    // and the toUpperCase() call.
+    // re-use will occur e.g. as the framework traverses the provider
+    // list and queries each provider with the same values until it finds
+    // a matching service
+    private transient ServiceKey previousKey =
+                                            new ServiceKey("", "", false);
 
     /**
      * Get an unmodifiable Set of all services supported by

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1082,7 +1082,8 @@ public abstract class Provider extends Properties {
     }
 
     // used as key in the serviceMap and legacyMap HashMaps
-    private static class ServiceKey {
+    private static class ServiceKey implements Serializable {
+        private static final long serialVersionUID = -4298000515446427739L;
         private final String type;
         private final String algorithm;
         private final String originalAlgorithm;
@@ -1311,7 +1312,7 @@ public abstract class Provider extends Properties {
     // re-use will occur e.g. as the framework traverses the provider
     // list and queries each provider with the same values until it finds
     // a matching service
-    private transient ServiceKey previousKey = new ServiceKey("", "", false);
+    private ServiceKey previousKey = new ServiceKey("", "", false);
 
     /**
      * Get an unmodifiable Set of all services supported by

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1311,8 +1311,7 @@ public abstract class Provider extends Properties {
     // re-use will occur e.g. as the framework traverses the provider
     // list and queries each provider with the same values until it finds
     // a matching service
-    private transient ServiceKey previousKey =
-                                            new ServiceKey("", "", false);
+    private transient ServiceKey previousKey = new ServiceKey("", "", false);
 
     /**
      * Get an unmodifiable Set of all services supported by

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1082,8 +1082,7 @@ public abstract class Provider extends Properties {
     }
 
     // used as key in the serviceMap and legacyMap HashMaps
-    private static class ServiceKey implements Serializable {
-        private static final long serialVersionUID = -4298000515446427739L;
+    private static class ServiceKey {
         private final String type;
         private final String algorithm;
         private final String originalAlgorithm;
@@ -1282,7 +1281,7 @@ public abstract class Provider extends Properties {
         checkInitialized();
         // avoid allocating a new ServiceKey object if possible
         ServiceKey key = previousKey;
-        if (!key.matches(type, algorithm)) {
+        if (key == null || !key.matches(type, algorithm)) {
             key = new ServiceKey(type, algorithm, false);
             previousKey = key;
         }
@@ -1312,7 +1311,7 @@ public abstract class Provider extends Properties {
     // re-use will occur e.g. as the framework traverses the provider
     // list and queries each provider with the same values until it finds
     // a matching service
-    private ServiceKey previousKey = new ServiceKey("", "", false);
+    private transient ServiceKey previousKey;
 
     /**
      * Get an unmodifiable Set of all services supported by

--- a/src/java.base/share/classes/java/security/Provider.java
+++ b/src/java.base/share/classes/java/security/Provider.java
@@ -1280,10 +1280,10 @@ public abstract class Provider extends Properties {
     public Service getService(String type, String algorithm) {
         checkInitialized();
         // avoid allocating a new ServiceKey object if possible
-        ServiceKey key = previousKey;
-        if (key == null || !key.matches(type, algorithm)) {
+        ServiceKey key = previousKey.get();
+        if (!key.matches(type, algorithm)) {
             key = new ServiceKey(type, algorithm, false);
-            previousKey = key;
+            previousKey.set(key);
         }
 
         Service s = serviceMap.get(key);
@@ -1311,7 +1311,8 @@ public abstract class Provider extends Properties {
     // re-use will occur e.g. as the framework traverses the provider
     // list and queries each provider with the same values until it finds
     // a matching service
-    private transient ServiceKey previousKey;
+    private static final ThreadLocal<ServiceKey> previousKey =
+        ThreadLocal.withInitial(() -> new ServiceKey("","", false));
 
     /**
      * Get an unmodifiable Set of all services supported by


### PR DESCRIPTION
This patch remove access to the shared variable to fix scalability issue in the multithread environment. According to testing by the specjvm2008::crypto.rsa the one thread performance reduced for less than 1% while the score for the multithread run increased in ~2x. For the 2 socket system with Xeon 8480+ numbers looks as:
•	1 thread: 643.15 for original version vs 642.54 for patched one;
•	224 threads: 22446.19 for original vs 46147.41 for patched.
The RSABench microbenchmark reports no score changes for the 1 thread (average for all testcases) and 2.4% improvement for the 224 threads.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317538](https://bugs.openjdk.org/browse/JDK-8317538): Potential bottleneck in Provider::getService: specjvm2008::crypto.rsa have scalability issue for high vCPU numbers (**Bug** - P3)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21719/head:pull/21719` \
`$ git checkout pull/21719`

Update a local copy of the PR: \
`$ git checkout pull/21719` \
`$ git pull https://git.openjdk.org/jdk.git pull/21719/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21719`

View PR using the GUI difftool: \
`$ git pr show -t 21719`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21719.diff">https://git.openjdk.org/jdk/pull/21719.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21719#issuecomment-2438543890)
</details>
