### PR TITLE
8342642: Class loading failure due to archived map issue in ModuleLoaderMap.Mapper

### DIFF
--- a/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
@@ -51,14 +51,14 @@ public final class ModuleLoaderMap {
         private static final ClassLoader APP_CLASSLOADER =
                 ClassLoaders.appClassLoader();
 
-        private static final Integer PLATFORM_LOADER_INDEX = 1;
-        private static final Integer APP_LOADER_INDEX      = 2;
+        private static final String PLATFORM_LOADER_INDEX = "PLATFORM";
+        private static final String APP_LOADER_INDEX      = "APP";
 
         /**
          * Map from module to a class loader index. The index is resolved to the
          * actual class loader in {@code apply}.
          */
-        private final Map<String, Integer> map;
+        private final Map<String, String> map;
 
         /**
          * Creates a Mapper to map module names in the given Configuration to
@@ -69,7 +69,7 @@ public final class ModuleLoaderMap {
          * so that we can cheaply do identity comparisons during bootstrap.
          */
         Mapper(Configuration cf) {
-            var map = new HashMap<String, Integer>();
+            var map = new HashMap<String, String>();
             for (ResolvedModule resolvedModule : cf.modules()) {
                 String mn = resolvedModule.name();
                 if (!Modules.bootModules.contains(mn)) {
@@ -85,7 +85,7 @@ public final class ModuleLoaderMap {
 
         @Override
         public ClassLoader apply(String name) {
-            Integer loader = map.get(name);
+            String loader = map.get(name);
             if (loader == APP_LOADER_INDEX) {
                 return APP_CLASSLOADER;
             } else if (loader == PLATFORM_LOADER_INDEX) {

--- a/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
@@ -51,11 +51,11 @@ public final class ModuleLoaderMap {
         private static final ClassLoader APP_CLASSLOADER =
                 ClassLoaders.appClassLoader();
 
-        private static final String PLATFORM_LOADER_INDEX = "PLATFORM";
-        private static final String APP_LOADER_INDEX      = "APP";
+        private static final String PLATFORM_LOADER_NAME = "PLATFORM";
+        private static final String APP_LOADER_NAME      = "APP";
 
         /**
-         * Map from module to a class loader index. The index is resolved to the
+         * Map from module to a class loader name. The name is resolved to the
          * actual class loader in {@code apply}.
          */
         private final Map<String, String> map;
@@ -65,8 +65,7 @@ public final class ModuleLoaderMap {
          * built-in classloaders.
          *
          * As a proxy for the actual classloader, we store an easily archiveable
-         * index value in the internal map. The index is stored as a boxed value
-         * so that we can cheaply do identity comparisons during bootstrap.
+         * loader name in the internal map.
          */
         Mapper(Configuration cf) {
             var map = new HashMap<String, String>();
@@ -74,9 +73,9 @@ public final class ModuleLoaderMap {
                 String mn = resolvedModule.name();
                 if (!Modules.bootModules.contains(mn)) {
                     if (Modules.platformModules.contains(mn)) {
-                        map.put(mn, PLATFORM_LOADER_INDEX);
+                        map.put(mn, PLATFORM_LOADER_NAME);
                     } else {
-                        map.put(mn, APP_LOADER_INDEX);
+                        map.put(mn, APP_LOADER_NAME);
                     }
                 }
             }
@@ -86,9 +85,9 @@ public final class ModuleLoaderMap {
         @Override
         public ClassLoader apply(String name) {
             String loader = map.get(name);
-            if (loader == APP_LOADER_INDEX) {
+            if (APP_LOADER_NAME.equals(loader)) {
                 return APP_CLASSLOADER;
-            } else if (loader == PLATFORM_LOADER_INDEX) {
+            } else if (PLATFORM_LOADER_NAME.equals(loader)) {
                 return PLATFORM_CLASSLOADER;
             } else { // BOOT_LOADER_INDEX
                 return null;

--- a/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
@@ -55,7 +55,7 @@ public final class ModuleLoaderMap {
         private static final String APP_LOADER_NAME      = "APP";
 
         /**
-         * Map from module to a class loader name. The name is resolved to the
+         * Map from module name to class loader name. The name is resolved to the
          * actual class loader in {@code apply}.
          */
         private final Map<String, String> map;

--- a/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleLoaderMap.java
@@ -89,7 +89,7 @@ public final class ModuleLoaderMap {
                 return APP_CLASSLOADER;
             } else if (PLATFORM_LOADER_NAME.equals(loader)) {
                 return PLATFORM_CLASSLOADER;
-            } else { // BOOT_LOADER_INDEX
+            } else {
                 return null;
             }
         }


### PR DESCRIPTION
Moved from https://github.com/openjdk/jdk/pull/21672/commits/ade90fb51d1e3652910a3b46775522b730306e16:

Please review the fix that uses String type for the mapped value in ModuleLoaderMap.Mapper map (Map<String, String>). Please see details in https://bugs.openjdk.org/browse/JDK-8342642, thanks.

Existing comment threads from closed https://github.com/openjdk/jdk/pull/21672/commits/ade90fb51d1e3652910a3b46775522b730306e16:
- https://github.com/openjdk/jdk/pull/21672#issuecomment-2436358591
- https://github.com/openjdk/jdk/pull/21672#issuecomment-2437465648
- https://github.com/openjdk/jdk/pull/21672#issuecomment-2438567642
- https://github.com/openjdk/jdk/pull/21672#issuecomment-2436262114
- https://github.com/openjdk/jdk/pull/21672#issuecomment-2437501231

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342642](https://bugs.openjdk.org/browse/JDK-8342642): Class loading failure due to archived map issue in ModuleLoaderMap.Mapper (**Bug** - P3)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**) Review applies to [3234aa23](https://git.openjdk.org/jdk/pull/21722/files/3234aa237ec65f6df037b7635b7d462a0b37777a)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [3234aa23](https://git.openjdk.org/jdk/pull/21722/files/3234aa237ec65f6df037b7635b7d462a0b37777a)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21722/head:pull/21722` \
`$ git checkout pull/21722`

Update a local copy of the PR: \
`$ git checkout pull/21722` \
`$ git pull https://git.openjdk.org/jdk.git pull/21722/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21722`

View PR using the GUI difftool: \
`$ git pr show -t 21722`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21722.diff">https://git.openjdk.org/jdk/pull/21722.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21722#issuecomment-2438908079)
</details>
