### PR TITLE
8341788: Fix ExceptionOccurred in hotspot

### DIFF
--- a/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
+++ b/src/hotspot/share/jfr/instrumentation/jfrJvmtiAgent.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -133,7 +133,7 @@ static void log_and_throw(jvmtiError error, TRAPS) {
 
 static void check_exception_and_log(JNIEnv* env, TRAPS) {
   assert(env != nullptr, "invariant");
-  if (env->ExceptionOccurred()) {
+  if (env->ExceptionCheck()) {
     // array index out of bound
     DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_native(THREAD));
     ThreadInVMfromNative tvmfn(THREAD);

--- a/src/hotspot/share/prims/methodHandles.cpp
+++ b/src/hotspot/share/prims/methodHandles.cpp
@@ -1464,15 +1464,15 @@ JVM_ENTRY(void, JVM_RegisterMethodHandleMethods(JNIEnv *env, jclass MHN_class)) 
     ThreadToNativeFromVM ttnfv(thread);
 
     int status = env->RegisterNatives(MHN_class, MHN_methods, sizeof(MHN_methods)/sizeof(JNINativeMethod));
-    guarantee(status == JNI_OK && !env->ExceptionOccurred(),
+    guarantee(status == JNI_OK && !env->ExceptionCheck(),
               "register java.lang.invoke.MethodHandleNative natives");
 
     status = env->RegisterNatives(MH_class, MH_methods, sizeof(MH_methods)/sizeof(JNINativeMethod));
-    guarantee(status == JNI_OK && !env->ExceptionOccurred(),
+    guarantee(status == JNI_OK && !env->ExceptionCheck(),
               "register java.lang.invoke.MethodHandle natives");
 
     status = env->RegisterNatives(VH_class, VH_methods, sizeof(VH_methods)/sizeof(JNINativeMethod));
-    guarantee(status == JNI_OK && !env->ExceptionOccurred(),
+    guarantee(status == JNI_OK && !env->ExceptionCheck(),
               "register java.lang.invoke.VarHandle natives");
   }
 

--- a/src/hotspot/share/prims/nativeEntryPoint.cpp
+++ b/src/hotspot/share/prims/nativeEntryPoint.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,6 +116,6 @@ static JNINativeMethod NEP_methods[] = {
 JNI_ENTRY(void, JVM_RegisterNativeEntryPointMethods(JNIEnv *env, jclass NEP_class))
   ThreadToNativeFromVM ttnfv(thread);
   int status = env->RegisterNatives(NEP_class, NEP_methods, sizeof(NEP_methods)/sizeof(JNINativeMethod));
-  guarantee(status == JNI_OK && !env->ExceptionOccurred(),
+  guarantee(status == JNI_OK && !env->ExceptionCheck(),
             "register jdk.internal.foreign.abi.NativeEntryPoint natives");
 JNI_END

--- a/src/hotspot/share/prims/unsafe.cpp
+++ b/src/hotspot/share/prims/unsafe.cpp
@@ -669,7 +669,7 @@ static jclass Unsafe_DefineClass_impl(JNIEnv *env, jstring name, jbyteArray data
   }
 
   env->GetByteArrayRegion(data, offset, length, body);
-  if (env->ExceptionOccurred()) {
+  if (env->ExceptionCheck()) {
     goto free_body;
   }
 

--- a/src/hotspot/share/prims/upcallLinker.cpp
+++ b/src/hotspot/share/prims/upcallLinker.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -187,6 +187,6 @@ static JNINativeMethod UL_methods[] = {
 JNI_ENTRY(void, JVM_RegisterUpcallLinkerMethods(JNIEnv *env, jclass UL_class))
   ThreadToNativeFromVM ttnfv(thread);
   int status = env->RegisterNatives(UL_class, UL_methods, sizeof(UL_methods)/sizeof(JNINativeMethod));
-  guarantee(status == JNI_OK && !env->ExceptionOccurred(),
+  guarantee(status == JNI_OK && !env->ExceptionCheck(),
             "register jdk.internal.foreign.abi.UpcallLinker natives");
 JNI_END

--- a/src/hotspot/share/prims/upcallStubs.cpp
+++ b/src/hotspot/share/prims/upcallStubs.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ static JNINativeMethod UH_methods[] = {
  */
 JVM_LEAF(void, JVM_RegisterUpcallHandlerMethods(JNIEnv *env, jclass UH_class))
   int status = env->RegisterNatives(UH_class, UH_methods, sizeof(UH_methods)/sizeof(JNINativeMethod));
-  guarantee(status == JNI_OK && !env->ExceptionOccurred(),
+  guarantee(status == JNI_OK && !env->ExceptionCheck(),
             "register jdk.internal.foreign.abi.UpcallStubs natives");
 JVM_END
 

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -428,5 +428,5 @@ void CONT_RegisterNativeMethods(JNIEnv *env, jclass cls) {
     ThreadToNativeFromVM trans(thread);
     int status = env->RegisterNatives(cls, CONT_methods, sizeof(CONT_methods)/sizeof(JNINativeMethod));
     guarantee(status == JNI_OK, "register jdk.internal.vm.Continuation natives");
-    guarantee(!env->ExceptionOccurred(), "register jdk.internal.vm.Continuation natives");
+    guarantee(!env->ExceptionCheck(), "register jdk.internal.vm.Continuation natives");
 }


### PR DESCRIPTION
A trivial JNI refactoring in Hotspot to use `ExceptionCheck()` over `ExceptionOccurred()` when the usage is treating the return value as a boolean. This is part of the bigger umbrella issue: [JDK-8341542](https://bugs.openjdk.org/browse/JDK-8341542). 



>     ExceptionCheck
>     We introduce a convenience function to check for pending exceptions without creating a local reference to the exception object.
> 
>     jboolean ExceptionCheck(JNIEnv *env);
> 
>     Returns JNI_TRUE when there is a pending exception; otherwise, returns JNI_FALSE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341788](https://bugs.openjdk.org/browse/JDK-8341788): Fix ExceptionOccurred in hotspot (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21724/head:pull/21724` \
`$ git checkout pull/21724`

Update a local copy of the PR: \
`$ git checkout pull/21724` \
`$ git pull https://git.openjdk.org/jdk.git pull/21724/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21724`

View PR using the GUI difftool: \
`$ git pr show -t 21724`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21724.diff">https://git.openjdk.org/jdk/pull/21724.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21724#issuecomment-2438935657)