### PR TITLE
Update documentation for clarity

### DIFF
--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -420,10 +420,9 @@ public class TreeMap<K,V>
     }
 
     /**
-     * Gets the entry corresponding to the specified key; if no such entry
-     * exists, returns the entry for the least key greater than the specified
-     * key; if no such entry exists (i.e., the greatest key in the Tree is less
-     * than the specified key), returns {@code null}.
+     * Gets the entry corresponding to the specified key; returns the entry for 
+     * the least key greater than the specified key; if no such entry exists 
+     * (i.e., the greatest key in the Tree is less than the specified key), returns {@code null}.
      */
     final Entry<K,V> getCeilingEntry(K key) {
         Entry<K,V> p = root;
@@ -453,10 +452,9 @@ public class TreeMap<K,V>
     }
 
     /**
-     * Gets the entry corresponding to the specified key; if no such entry
-     * exists, returns the entry for the greatest key less than the specified
-     * key; if no such entry exists (i.e., the least key in the Tree is greater
-     * than the specified key), returns {@code null}.
+     * Gets the entry corresponding to the specified key; returns the entry for
+     * the greatest key less than the specified key; if no such entry exists
+     * (i.e., the least key in the Tree is greater than the specified key), returns {@code null}.
      */
     final Entry<K,V> getFloorEntry(K key) {
         Entry<K,V> p = root;


### PR DESCRIPTION
As the documentation of `getCeilingEntry` currently reads, the inference is misleading as follows:
- if no such entry exists, returns the entry for the least key greater than the specified key;
- if no such entry exists (i.e., the greatest key in the Tree is less than the specified key), returns {@code null}

Have modified the first section to ensure that its clear that the value returned is upon existence of the key. Added a similar change for `getFloorEntry`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21727/head:pull/21727` \
`$ git checkout pull/21727`

Update a local copy of the PR: \
`$ git checkout pull/21727` \
`$ git pull https://git.openjdk.org/jdk.git pull/21727/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21727`

View PR using the GUI difftool: \
`$ git pr show -t 21727`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21727.diff">https://git.openjdk.org/jdk/pull/21727.diff</a>

</details>
