### PR TITLE
8343125: Correct the documentation for TreeMap's getFloorEntry and getCeilingEntry

### DIFF
--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -420,9 +420,8 @@ public class TreeMap<K,V>
     }
 
     /**
-     * Gets the entry corresponding to the specified key; returns the entry for
-     * the least key greater than the specified key; if no such entry exists
-     * (i.e., the greatest key in the Tree is less than the specified key),
+     * Returns the entry for the least key greater than or equal to the specified key;
+     * if no such entry exists (i.e. the specified key is greater than any key in the tree),
      * returns {@code null}.
      */
     final Entry<K,V> getCeilingEntry(K key) {
@@ -453,9 +452,8 @@ public class TreeMap<K,V>
     }
 
     /**
-     * Gets the entry corresponding to the specified key; returns the entry for
-     * the greatest key less than the specified key; if no such entry exists
-     * (i.e., the least key in the Tree is greater than the specified key),
+     * Returns the entry for the greatest key less than or equal to the specified key;
+     * if no such entry exists (i.e. the specified key is less than any key in the tree),
      * returns {@code null}.
      */
     final Entry<K,V> getFloorEntry(K key) {
@@ -512,6 +510,8 @@ public class TreeMap<K,V>
                     }
                     return parent;
                 }
+            } else {
+                return p;
             }
         }
         return null;

--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -510,8 +510,6 @@ public class TreeMap<K,V>
                     }
                     return parent;
                 }
-            } else {
-                return p;
             }
         }
         return null;

--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -421,8 +421,8 @@ public class TreeMap<K,V>
 
     /**
      * Returns the entry for the least key greater than or equal to the specified key;
-     * if no such entry exists (i.e. the specified key is greater than any key in the tree),
-     * returns {@code null}.
+     * if no such entry exists (i.e. the specified key is greater than any key in the tree,
+     * or the tree is empty), returns {@code null}.
      */
     final Entry<K,V> getCeilingEntry(K key) {
         Entry<K,V> p = root;
@@ -453,8 +453,8 @@ public class TreeMap<K,V>
 
     /**
      * Returns the entry for the greatest key less than or equal to the specified key;
-     * if no such entry exists (i.e. the specified key is less than any key in the tree),
-     * returns {@code null}.
+     * if no such entry exists (i.e. the specified key is less than any key in the tree,
+     * or the tree is empty), returns {@code null}.
      */
     final Entry<K,V> getFloorEntry(K key) {
         Entry<K,V> p = root;

--- a/src/java.base/share/classes/java/util/TreeMap.java
+++ b/src/java.base/share/classes/java/util/TreeMap.java
@@ -420,10 +420,10 @@ public class TreeMap<K,V>
     }
 
     /**
-     * Gets the entry corresponding to the specified key; if no such entry
-     * exists, returns the entry for the least key greater than the specified
-     * key; if no such entry exists (i.e., the greatest key in the Tree is less
-     * than the specified key), returns {@code null}.
+     * Gets the entry corresponding to the specified key; returns the entry for
+     * the least key greater than the specified key; if no such entry exists
+     * (i.e., the greatest key in the Tree is less than the specified key),
+     * returns {@code null}.
      */
     final Entry<K,V> getCeilingEntry(K key) {
         Entry<K,V> p = root;
@@ -453,10 +453,10 @@ public class TreeMap<K,V>
     }
 
     /**
-     * Gets the entry corresponding to the specified key; if no such entry
-     * exists, returns the entry for the greatest key less than the specified
-     * key; if no such entry exists (i.e., the least key in the Tree is greater
-     * than the specified key), returns {@code null}.
+     * Gets the entry corresponding to the specified key; returns the entry for
+     * the greatest key less than the specified key; if no such entry exists
+     * (i.e., the least key in the Tree is greater than the specified key),
+     * returns {@code null}.
      */
     final Entry<K,V> getFloorEntry(K key) {
         Entry<K,V> p = root;


### PR DESCRIPTION
As the documentation of getCeilingEntry currently reads, the inference is misleading as follows:

if no such entry exists, returns the entry for the least key greater than the specified key;
if no such entry exists (i.e., the greatest key in the Tree is less than the specified key), returns {@code null}
Have modified the first section to ensure that its clear that the value returned is upon existence of the key. Added a similar change for getFloorEntry.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343125](https://bugs.openjdk.org/browse/JDK-8343125): Correct the documentation for TreeMap's getFloorEntry and getCeilingEntry (**Bug** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Archie Cobbs](https://openjdk.org/census#acobbs) (@archiecobbs - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21729/head:pull/21729` \
`$ git checkout pull/21729`

Update a local copy of the PR: \
`$ git checkout pull/21729` \
`$ git pull https://git.openjdk.org/jdk.git pull/21729/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21729`

View PR using the GUI difftool: \
`$ git pr show -t 21729`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21729.diff">https://git.openjdk.org/jdk/pull/21729.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21729#issuecomment-2474216291)
</details>
