### PR TITLE
8343122: RISC-V: C2: Small improvement for real runtime callouts

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1259,13 +1259,13 @@ int MachCallRuntimeNode::ret_addr_offset() {
   //   jal(addr)
   // or with far branches
   //   jal(trampoline_stub)
-  // for real runtime callouts it will be 11 instructions
+  // for real runtime callouts it will be 9 instructions
   // see riscv_enc_java_to_runtime
   //   la(t0, retaddr)                ->  auipc + addi
-  //   la(t1, RuntimeAddress(addr))   ->  lui + addi + slli + addi + slli + addi
   //   addi(sp, sp, -2 * wordSize)    ->  addi
-  //   sd(t1, Address(sp, wordSize))  ->  sd
-  //   jalr(t1)                       ->  jalr
+  //   sd(t0, Address(sp, wordSize))  ->  sd
+  //   movptr(t1, addr, offset, t0)   ->  lui + lui + slli + add
+  //   jalr(t1, offset)               ->  jalr
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
   if (cb != nullptr) {
     if (UseTrampolines) {
@@ -1273,7 +1273,7 @@ int MachCallRuntimeNode::ret_addr_offset() {
     }
     return 3 * NativeInstruction::instruction_size;
   } else {
-    return 11 * NativeInstruction::instruction_size;
+    return 9 * NativeInstruction::instruction_size;
   }
 }
 
@@ -2505,11 +2505,13 @@ encode %{
     } else {
       Label retaddr;
       __ la(t0, retaddr);
-      __ la(t1, RuntimeAddress(entry));
       // Leave a breadcrumb for JavaFrameAnchor::capture_last_Java_pc()
       __ addi(sp, sp, -2 * wordSize);
       __ sd(t0, Address(sp, wordSize));
-      __ jalr(t1);
+      int32_t offset = 0;
+      // No relocation needed
+      __ movptr(t1, entry, offset, t0); // lui + lui + slli + add
+      __ jalr(t1, offset);
       __ bind(retaddr);
       __ post_call_nop();
       __ addi(sp, sp, 2 * wordSize);


### PR DESCRIPTION
Hi, please review this small improvement.

Currently, we do 11 instructions for real C2 runtime callouts (See riscv_enc_java_to_runtime).
Seems we can materialize the pointer faster with `movptr2`, which will help reduce 2 instructions.
But we will need to reorder the original calling sequence a bit to make `t0` available for `movptr2`.

Testing on linux-riscv64 platform:
- [x] tier1-tier3 (release)
- [x] hotspot:tier1 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343122](https://bugs.openjdk.org/browse/JDK-8343122): RISC-V: C2: Small improvement for real runtime callouts (**Enhancement** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21733/head:pull/21733` \
`$ git checkout pull/21733`

Update a local copy of the PR: \
`$ git checkout pull/21733` \
`$ git pull https://git.openjdk.org/jdk.git pull/21733/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21733`

View PR using the GUI difftool: \
`$ git pr show -t 21733`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21733.diff">https://git.openjdk.org/jdk/pull/21733.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21733#issuecomment-2440543172)
</details>
