### PR TITLE
8343129: Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values

### DIFF
--- a/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
+++ b/test/hotspot/gtest/runtime/test_ThreadsListHandle.cpp
@@ -171,8 +171,10 @@ TEST_VM(ThreadsListHandle, sanity) {
       // Verify the current thread refers to tlh2:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh2.list())
           << "thr->_threads_hazard_ptr must match tlh2.list()";
-      EXPECT_EQ(tlh1.list(), tlh2.list())
-          << "tlh1.list() must match tlh2.list()";
+    // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+    // util the root cause of test failure(JDK-8315141) has been fixed
+    //   EXPECT_EQ(tlh1.list(), tlh2.list())
+    //       << "tlh1.list() must match tlh2.list()";
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr2)
           << "thr->_threads_list_ptr must match list_ptr2";
       EXPECT_NE(list_ptr1, list_ptr2)
@@ -291,8 +293,10 @@ TEST_VM(ThreadsListHandle, sanity) {
       // Verify the current thread refers to tlh2:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh2.list())
           << "thr->_threads_hazard_ptr must match tlh2.list()";
-      EXPECT_EQ(tlh1.list(), tlh2.list())
-          << "tlh1.list() must match tlh2.list()";
+    // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+    // util the root cause of test failure(JDK-8315141) has been fixed
+    //   EXPECT_EQ(tlh1.list(), tlh2.list())
+    //       << "tlh1.list() must match tlh2.list()";
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr2)
           << "thr->_threads_list_ptr must match list_ptr2";
       EXPECT_NE(list_ptr1, list_ptr2)
@@ -339,8 +343,10 @@ TEST_VM(ThreadsListHandle, sanity) {
         // Verify the current thread refers to tlh3:
         EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh3.list())
             << "thr->_threads_hazard_ptr must match tlh3.list()";
-        EXPECT_EQ(tlh1.list(), tlh3.list())
-            << "tlh1.list() must match tlh3.list()";
+        // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+        // util the root cause of test failure(JDK-8315141) has been fixed
+        // EXPECT_EQ(tlh1.list(), tlh3.list())
+        //     << "tlh1.list() must match tlh3.list()";
         EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr3)
             << "thr->_threads_list_ptr must match list_ptr3";
         EXPECT_NE(list_ptr1, list_ptr3)
@@ -523,8 +529,10 @@ TEST_VM(ThreadsListHandle, sanity) {
       // Verify the current thread refers to tlh2a:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh2a.list())
           << "thr->_threads_hazard_ptr must match tlh2a.list()";
-      EXPECT_EQ(tlh1.list(), tlh2a.list())
-          << "tlh1.list() must match tlh2a.list()";
+    // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+    // util the root cause of test failure(JDK-8315141) has been fixed
+    //   EXPECT_EQ(tlh1.list(), tlh2a.list())
+    //       << "tlh1.list() must match tlh2a.list()";
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr2a)
           << "thr->_threads_list_ptr must match list_ptr2a";
       EXPECT_NE(list_ptr1, list_ptr2a)
@@ -601,8 +609,10 @@ TEST_VM(ThreadsListHandle, sanity) {
       // Verify the current thread refers to tlh2b:
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_hazard_ptr(thr), tlh2b.list())
           << "thr->_threads_hazard_ptr must match tlh2b.list()";
-      EXPECT_EQ(tlh1.list(), tlh2b.list())
-          << "tlh1.list() must match tlh2b.list()";
+    // Disable unstable check of ThreadsListHandle.sanity_vm ThreadList values,
+    // util the root cause of test failure(JDK-8315141) has been fixed
+    //   EXPECT_EQ(tlh1.list(), tlh2b.list())
+    //       << "tlh1.list() must match tlh2b.list()";
       EXPECT_EQ(ThreadsListHandleTest::get_Thread_threads_list_ptr(thr), list_ptr2b)
           << "thr->_threads_list_ptr must match list_ptr2b";
       EXPECT_NE(list_ptr1, list_ptr2b)


### PR DESCRIPTION
Hi all,
We have observed `ThreadsListHandle.sanity_vm failed with unequal ThreadList values` several times on linux-x64 and linux-aarch64, by jdk17u/jdk21u/jdk24 etc.
Before the root cause of the test failure has been fixed, should we disable the unstable check of ThreadsListHandle.sanity_vm ThreadList values, to make less of CI noisy.

Additional testing:

- [ ] release build and run the `gtest/GTestWrapper.java` on linux-x64
- [ ] fastdebug build and run the `gtest/GTestWrapper.java` on linux-x64
- [ ] slowdebug build and run the `gtest/GTestWrapper.java` on linux-x64