### PR TITLE
8342489: compiler/c2/irTests/TestVectorizationMismatchedAccess.java fails on big-endian platforms

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -50,9 +50,6 @@ public class TestVectorizationMismatchedAccess {
     private final static WhiteBox wb = WhiteBox.getWhiteBox();
 
     public static void main(String[] args) {
-        if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-            throw new RuntimeException("fix test that was written for a little endian platform");
-        }
         TestFramework.runWithFlags("--add-modules", "java.base", "--add-exports", "java.base/jdk.internal.misc=ALL-UNNAMED");
     }
 
@@ -154,7 +151,11 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong1a(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i, value);
         }
     }
 
@@ -165,7 +166,11 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong1b(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * i, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * i, value);
         }
     }
 
@@ -175,7 +180,11 @@ public class TestVectorizationMismatchedAccess {
     public static void testByteLong1c(byte[] dest, long[] src) {
         long base = 64; // make sure it is big enough and 8 byte aligned (required for 32-bit)
         for (int i = 0; i < src.length - 8; i++) {
-            UNSAFE.putLongUnaligned(dest, base + 8 * i, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, base + 8 * i, value);
         }
     }
 
@@ -187,7 +196,11 @@ public class TestVectorizationMismatchedAccess {
     public static void testByteLong1d(byte[] dest, long[] src) {
         long base = 64; // make sure it is big enough and 8 byte aligned (required for 32-bit)
         for (int i = 0; i < src.length - 8; i++) {
-            UNSAFE.putLongUnaligned(dest, base + 8L * i, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, base + 8L * i, value);
         }
     }
 
@@ -207,7 +220,11 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong2a(byte[] dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i - 1), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i - 1), value);
         }
     }
 
@@ -218,7 +235,11 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong2b(byte[] dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i - 1), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i - 1), value);
         }
     }
 
@@ -236,7 +257,11 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong3a(byte[] dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + 1), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + 1), value);
         }
     }
 
@@ -247,7 +272,11 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong3b(byte[] dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + 1), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + 1), value);
         }
     }
 
@@ -267,7 +296,11 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testByteLong4a(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(dest, 8 * i + baseOffset, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, 8 * i + baseOffset, value);
         }
     }
 
@@ -280,7 +313,11 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testByteLong4b(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(dest, 8L * i + baseOffset, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, 8L * i + baseOffset, value);
         }
     }
 
@@ -299,7 +336,11 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong5a(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + baseOffset), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + baseOffset), value);
         }
     }
 
@@ -310,7 +351,11 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong5b(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + baseOffset), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + baseOffset), value);
         }
     }
 
@@ -454,7 +499,11 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong1a(long dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8 * i, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(null, dest + 8 * i, value);
         }
     }
 
@@ -465,7 +514,11 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong1b(long dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8L * i, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(null, dest + 8L * i, value);
         }
     }
 
@@ -482,7 +535,11 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong2a(long dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8 * (i - 1), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(null, dest + 8 * (i - 1), value);
         }
     }
 
@@ -493,7 +550,11 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong2b(long dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8L * (i - 1), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(null, dest + 8L * (i - 1), value);
         }
     }
 
@@ -510,7 +571,11 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong3a(long dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8 * (i + 1), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(null, dest + 8 * (i + 1), value);
         }
     }
 
@@ -521,7 +586,11 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong3b(long dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8L * (i + 1), src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(null, dest + 8L * (i + 1), value);
         }
     }
 
@@ -540,7 +609,11 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testOffHeapLong4a(long dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8 * i + baseOffset, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(null, dest + 8 * i + baseOffset, value);
         }
     }
 
@@ -553,7 +626,11 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testOffHeapLong4b(long dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            UNSAFE.putLongUnaligned(null, dest + 8L * i + baseOffset, src[i]);
+            long value = src[i];
+            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+                value = Long.reverseBytes(value);
+            }
+            UNSAFE.putLongUnaligned(null, dest + 8L * i + baseOffset, value);
         }
     }
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestVectorizationMismatchedAccess.java
@@ -74,6 +74,14 @@ public class TestVectorizationMismatchedAccess {
         }
     }
 
+    // Method to adjust the value for the native byte order
+    static private long handleByteOrder(long value) {
+        if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
+            value = Long.reverseBytes(value);
+        }
+        return value;
+    }
+
     static private void runAndVerify(Runnable test, int offset) {
         System.arraycopy(verifyLongArray, 0, longArray, 0, longArray.length);
         Arrays.fill(byteArray, (byte)0);
@@ -151,11 +159,7 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong1a(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i, value);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * i, handleByteOrder(src[i]));
         }
     }
 
@@ -166,11 +170,7 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong1b(byte[] dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * i, value);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * i, handleByteOrder(src[i]));
         }
     }
 
@@ -180,11 +180,7 @@ public class TestVectorizationMismatchedAccess {
     public static void testByteLong1c(byte[] dest, long[] src) {
         long base = 64; // make sure it is big enough and 8 byte aligned (required for 32-bit)
         for (int i = 0; i < src.length - 8; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, base + 8 * i, value);
+            UNSAFE.putLongUnaligned(dest, base + 8 * i, handleByteOrder(src[i]));
         }
     }
 
@@ -196,11 +192,7 @@ public class TestVectorizationMismatchedAccess {
     public static void testByteLong1d(byte[] dest, long[] src) {
         long base = 64; // make sure it is big enough and 8 byte aligned (required for 32-bit)
         for (int i = 0; i < src.length - 8; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, base + 8L * i, value);
+            UNSAFE.putLongUnaligned(dest, base + 8L * i, handleByteOrder(src[i]));
         }
     }
 
@@ -220,11 +212,7 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong2a(byte[] dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i - 1), value);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i - 1), handleByteOrder(src[i]));
         }
     }
 
@@ -235,11 +223,7 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong2b(byte[] dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i - 1), value);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i - 1), handleByteOrder(src[i]));
         }
     }
 
@@ -257,11 +241,7 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong3a(byte[] dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + 1), value);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + 1), handleByteOrder(src[i]));
         }
     }
 
@@ -272,11 +252,7 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong3b(byte[] dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + 1), value);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + 1), handleByteOrder(src[i]));
         }
     }
 
@@ -296,11 +272,7 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testByteLong4a(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, 8 * i + baseOffset, value);
+            UNSAFE.putLongUnaligned(dest, 8 * i + baseOffset, handleByteOrder(src[i]));
         }
     }
 
@@ -313,11 +285,7 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testByteLong4b(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, 8L * i + baseOffset, value);
+            UNSAFE.putLongUnaligned(dest, 8L * i + baseOffset, handleByteOrder(src[i]));
         }
     }
 
@@ -336,11 +304,7 @@ public class TestVectorizationMismatchedAccess {
     //         might get fixed with JDK-8325155.
     public static void testByteLong5a(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + baseOffset), value);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8 * (i + baseOffset), handleByteOrder(src[i]));
         }
     }
 
@@ -351,11 +315,7 @@ public class TestVectorizationMismatchedAccess {
     // 32-bit: address has ConvL2I for cast of long to address, not supported.
     public static void testByteLong5b(byte[] dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + baseOffset), value);
+            UNSAFE.putLongUnaligned(dest, UNSAFE.ARRAY_BYTE_BASE_OFFSET + 8L * (i + baseOffset), handleByteOrder(src[i]));
         }
     }
 
@@ -499,11 +459,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong1a(long dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(null, dest + 8 * i, value);
+            UNSAFE.putLongUnaligned(null, dest + 8 * i, handleByteOrder(src[i]));
         }
     }
 
@@ -514,11 +470,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong1b(long dest, long[] src) {
         for (int i = 0; i < src.length; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(null, dest + 8L * i, value);
+            UNSAFE.putLongUnaligned(null, dest + 8L * i, handleByteOrder(src[i]));
         }
     }
 
@@ -535,11 +487,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong2a(long dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(null, dest + 8 * (i - 1), value);
+            UNSAFE.putLongUnaligned(null, dest + 8 * (i - 1), handleByteOrder(src[i]));
         }
     }
 
@@ -550,11 +498,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong2b(long dest, long[] src) {
         for (int i = 1; i < src.length; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(null, dest + 8L * (i - 1), value);
+            UNSAFE.putLongUnaligned(null, dest + 8L * (i - 1), handleByteOrder(src[i]));
         }
     }
 
@@ -571,11 +515,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong3a(long dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(null, dest + 8 * (i + 1), value);
+            UNSAFE.putLongUnaligned(null, dest + 8 * (i + 1), handleByteOrder(src[i]));
         }
     }
 
@@ -586,11 +526,7 @@ public class TestVectorizationMismatchedAccess {
     // See: JDK-8331576
     public static void testOffHeapLong3b(long dest, long[] src) {
         for (int i = 0; i < src.length - 1; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(null, dest + 8L * (i + 1), value);
+            UNSAFE.putLongUnaligned(null, dest + 8L * (i + 1), handleByteOrder(src[i]));
         }
     }
 
@@ -609,11 +545,7 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testOffHeapLong4a(long dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(null, dest + 8 * i + baseOffset, value);
+            UNSAFE.putLongUnaligned(null, dest + 8 * i + baseOffset, handleByteOrder(src[i]));
         }
     }
 
@@ -626,11 +558,7 @@ public class TestVectorizationMismatchedAccess {
     // AlignVector cannot guarantee that invar is aligned.
     public static void testOffHeapLong4b(long dest, long[] src, int start, int stop) {
         for (int i = start; i < stop; i++) {
-            long value = src[i];
-            if (ByteOrder.nativeOrder() != ByteOrder.LITTLE_ENDIAN) {
-                value = Long.reverseBytes(value);
-            }
-            UNSAFE.putLongUnaligned(null, dest + 8L * i + baseOffset, value);
+            UNSAFE.putLongUnaligned(null, dest + 8L * i + baseOffset, handleByteOrder(src[i]));
         }
     }
 


### PR DESCRIPTION
Adjust TestVectorizationMismatchedAccess.java for Big Endian Platforms
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342489](https://bugs.openjdk.org/browse/JDK-8342489): compiler/c2/irTests/TestVectorizationMismatchedAccess.java fails on big-endian platforms (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21736/head:pull/21736` \
`$ git checkout pull/21736`

Update a local copy of the PR: \
`$ git checkout pull/21736` \
`$ git pull https://git.openjdk.org/jdk.git pull/21736/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21736`

View PR using the GUI difftool: \
`$ git pr show -t 21736`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21736.diff">https://git.openjdk.org/jdk/pull/21736.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21736#issuecomment-2441311910)