### PR TITLE
8342561: Metaspace for generated reflection classes is no longer needed

### DIFF
--- a/src/hotspot/share/memory/metaspace.hpp
+++ b/src/hotspot/share/memory/metaspace.hpp
@@ -56,7 +56,6 @@ public:
     StandardMetaspaceType = ZeroMetaspaceType,
     BootMetaspaceType = StandardMetaspaceType + 1,
     ClassMirrorHolderMetaspaceType = BootMetaspaceType + 1,
-    ReflectionMetaspaceType = ClassMirrorHolderMetaspaceType + 1,
     MetaspaceTypeCount
   };
 

--- a/src/hotspot/share/memory/metaspace/metaspaceArenaGrowthPolicy.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceArenaGrowthPolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -61,17 +61,6 @@ static const chunklevel_t g_sequ_anon_class[] = {
     // .. repeat last
 };
 
-static const chunklevel_t g_sequ_refl_non_class[] = {
-    chunklevel::CHUNK_LEVEL_2K,
-    chunklevel::CHUNK_LEVEL_1K
-    // .. repeat last
-};
-
-static const chunklevel_t g_sequ_refl_class[] = {
-    chunklevel::CHUNK_LEVEL_1K,
-    // .. repeat last
-};
-
 // Boot class loader: give it large chunks: beyond commit granule size
 // (typically 64K) the costs for large chunks largely diminishes since
 // they are committed on the fly.
@@ -95,15 +84,12 @@ const ArenaGrowthPolicy* ArenaGrowthPolicy::policy_for_space_type(Metaspace::Met
   DEFINE_CLASS_FOR_ARRAY(standard_class)
   DEFINE_CLASS_FOR_ARRAY(anon_non_class)
   DEFINE_CLASS_FOR_ARRAY(anon_class)
-  DEFINE_CLASS_FOR_ARRAY(refl_non_class)
-  DEFINE_CLASS_FOR_ARRAY(refl_class)
   DEFINE_CLASS_FOR_ARRAY(boot_non_class)
   DEFINE_CLASS_FOR_ARRAY(boot_class)
 
   if (is_class) {
     switch(space_type) {
     case Metaspace::StandardMetaspaceType:          return &chunk_alloc_sequence_standard_class;
-    case Metaspace::ReflectionMetaspaceType:        return &chunk_alloc_sequence_refl_class;
     case Metaspace::ClassMirrorHolderMetaspaceType: return &chunk_alloc_sequence_anon_class;
     case Metaspace::BootMetaspaceType:              return &chunk_alloc_sequence_boot_class;
     default: ShouldNotReachHere();
@@ -111,7 +97,6 @@ const ArenaGrowthPolicy* ArenaGrowthPolicy::policy_for_space_type(Metaspace::Met
   } else {
     switch(space_type) {
     case Metaspace::StandardMetaspaceType:          return &chunk_alloc_sequence_standard_non_class;
-    case Metaspace::ReflectionMetaspaceType:        return &chunk_alloc_sequence_refl_non_class;
     case Metaspace::ClassMirrorHolderMetaspaceType: return &chunk_alloc_sequence_anon_non_class;
     case Metaspace::BootMetaspaceType:              return &chunk_alloc_sequence_boot_non_class;
     default: ShouldNotReachHere();

--- a/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceReporter.cpp
@@ -49,7 +49,6 @@ static const char* describe_spacetype(Metaspace::MetaspaceType st) {
     case Metaspace::StandardMetaspaceType: s = "Standard"; break;
     case Metaspace::BootMetaspaceType: s = "Boot"; break;
     case Metaspace::ClassMirrorHolderMetaspaceType: s = "ClassMirrorHolder"; break;
-    case Metaspace::ReflectionMetaspaceType: s = "Reflection"; break;
     default: ShouldNotReachHere();
   }
   return s;

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -1751,7 +1751,7 @@ WB_ENTRY(jlong, WB_GetTotalUsedWordsInMetaspaceTestContext(JNIEnv* env, jobject 
 WB_END
 
 WB_ENTRY(jlong, WB_CreateArenaInTestContext(JNIEnv* env, jobject wb, jlong context, jboolean is_micro))
-  const Metaspace::MetaspaceType type = is_micro ? Metaspace::ReflectionMetaspaceType : Metaspace::StandardMetaspaceType;
+  const Metaspace::MetaspaceType type = is_micro ? Metaspace::ClassMirrorHolderMetaspaceType : Metaspace::StandardMetaspaceType;
   metaspace::MetaspaceTestContext* context0 = (metaspace::MetaspaceTestContext*) context;
   return (jlong)p2i(context0->create_arena(type));
 WB_END

--- a/test/hotspot/gtest/metaspace/test_arenagrowthpolicy.cpp
+++ b/test/hotspot/gtest/metaspace/test_arenagrowthpolicy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -61,8 +61,6 @@ TEST_VM(metaspace, arena_growth_policy_##spacetype##_##is_class) { \
   test_arena_growth_policy(Metaspace::spacetype, is_class); \
 }
 
-DEFINE_GROWTH_POLICY_TEST(ReflectionMetaspaceType, true)
-DEFINE_GROWTH_POLICY_TEST(ReflectionMetaspaceType, false)
 DEFINE_GROWTH_POLICY_TEST(ClassMirrorHolderMetaspaceType, true)
 DEFINE_GROWTH_POLICY_TEST(ClassMirrorHolderMetaspaceType, false)
 DEFINE_GROWTH_POLICY_TEST(StandardMetaspaceType, true)

--- a/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
+++ b/test/hotspot/gtest/metaspace/test_metaspacearena_stress.cpp
@@ -227,7 +227,7 @@ class MetaspaceArenaTest {
   void create_random_test_bed_at(int slotindex) {
     SizeRange allocation_range(1, 100); // randomize too?
     const ArenaGrowthPolicy* growth_policy = ArenaGrowthPolicy::policy_for_space_type(
-        (fifty_fifty() ? Metaspace::StandardMetaspaceType : Metaspace::ReflectionMetaspaceType),
+        (fifty_fifty() ? Metaspace::StandardMetaspaceType : Metaspace::ClassMirrorHolderMetaspaceType),
          fifty_fifty());
     create_new_test_bed_at(slotindex, growth_policy, allocation_range);
    }


### PR DESCRIPTION
Removed code and test for the special metaspace size for reflection DelegatingClassLoader which only had one class.  Now that it's gone, we don't need the special size.  I changed some of the test cases to use ClassMirrorHolderMetaspaceType as a smaller alternate type instead and the tests seem fine with that.
Tested with tier1-4