### PR TITLE
8343149: Cleanup os::print_tos_pc on AIX

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/os_aix_ppc.cpp
@@ -462,12 +462,6 @@ void os::print_tos_pc(outputStream *st, const void *context) {
   address pc = os::Posix::ucontext_get_pc(uc);
   print_instructions(st, pc);
   st->cr();
-
-  // Try to decode the instructions.
-  st->print_cr("Decoded instructions: (pc=" PTR_FORMAT ")", p2i(pc));
-  st->print("<TODO: PPC port - print_context>");
-  // TODO: PPC port Disassembler::decode(pc, 16, 16, st);
-  st->cr();
 }
 
 void os::print_register_info(outputStream *st, const void *context, int& continuation) {


### PR DESCRIPTION
The os::print_tos_pc on AIX has some TODO output, related to potential instruction decoding that can be removed.

On other platforms no instruction decoding (or TODO) is present at this place.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343149](https://bugs.openjdk.org/browse/JDK-8343149): Cleanup os::print_tos_pc on AIX (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21740/head:pull/21740` \
`$ git checkout pull/21740`

Update a local copy of the PR: \
`$ git checkout pull/21740` \
`$ git pull https://git.openjdk.org/jdk.git pull/21740/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21740`

View PR using the GUI difftool: \
`$ git pr show -t 21740`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21740.diff">https://git.openjdk.org/jdk/pull/21740.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21740#issuecomment-2441602929)