### PR TITLE
8342576: [macos] AppContentTest still fails after JDK-8341443 for same reason on older macOS versions

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/TKit.java
@@ -296,7 +296,9 @@ final public class TKit {
             if (!path.toFile().exists()) {
                 return path;
             }
-            nameComponents[0] = String.format("%s.%d", baseName, i);
+            // Don't use period (.) as a separator. OSX codesign fails to sign folders
+            // with subfolders with names like "input.0".
+            nameComponents[0] = String.format("%s-%d", baseName, i);
         }
         throw new IllegalStateException(String.format(
                 "Failed to create unique file name from [%s] basename after %d attempts",

--- a/test/jdk/tools/jpackage/share/AppContentTest.java
+++ b/test/jdk/tools/jpackage/share/AppContentTest.java
@@ -22,22 +22,18 @@
  */
 
 import java.nio.file.Path;
-import java.nio.file.Files;
 import jdk.jpackage.internal.ApplicationLayout;
 import jdk.jpackage.test.PackageTest;
-import jdk.jpackage.test.PackageType;
 import jdk.jpackage.test.TKit;
 import jdk.jpackage.test.Annotations.Test;
-import jdk.jpackage.test.Annotations.Parameter;
 import jdk.jpackage.test.Annotations.Parameters;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import jdk.internal.util.OSVersion;
 
 /**
- * Tests generation of packages with input folder containing empty folders.
+ * Tests generation of packages with additional content in app image.
  */
 
 /*
@@ -82,13 +78,8 @@ public class AppContentTest {
 
     @Test
     public void test() throws Exception {
-
-        // On macOS signing may or may not work for modified app bundles.
-        // It works on macOS 15 and up, but fails on macOS below 15.
         final int expectedJPackageExitCode;
-        final boolean isMacOS15 = (OSVersion.current().compareTo(
-                                      new OSVersion(15, 0, 0)) > 0);
-        if (testPathArgs.contains(TEST_BAD) || (TKit.isOSX() && !isMacOS15)) {
+        if (testPathArgs.contains(TEST_BAD)) {
             expectedJPackageExitCode = 1;
         } else {
             expectedJPackageExitCode = 0;


### PR DESCRIPTION
Change suffixes produced by `TKit.createUniqueFileName()` function from `.<NUM>` to `-<NUM>` (e.g.: from `.0` to `-0`).
Apple's `codesign` tool can't sign directories with periods in their names as it interprets them as bundles. Directories produced by `TKit.createUniqueFileName()` may end up in an app image and become a subject for signing if used with `--app-content` jpackage parameter

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342576](https://bugs.openjdk.org/browse/JDK-8342576): [macos] AppContentTest still fails after JDK-8341443 for same reason on older macOS versions (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Contributors
 * Alexander Matveev `<almatvee@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21741/head:pull/21741` \
`$ git checkout pull/21741`

Update a local copy of the PR: \
`$ git checkout pull/21741` \
`$ git pull https://git.openjdk.org/jdk.git pull/21741/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21741`

View PR using the GUI difftool: \
`$ git pr show -t 21741`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21741.diff">https://git.openjdk.org/jdk/pull/21741.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21741#issuecomment-2441605382)