### PR TITLE
8343167: Unnecessary define checks in InterpreterRuntime after JDK-8199809

### DIFF
--- a/src/hotspot/cpu/x86/interpreterRT_x86_32.cpp
+++ b/src/hotspot/cpu/x86/interpreterRT_x86_32.cpp
@@ -42,16 +42,6 @@
 InterpreterRuntime::SignatureHandlerGenerator::SignatureHandlerGenerator(const methodHandle& method, CodeBuffer* buffer) :
     NativeSignatureIterator(method) {
   _masm = new MacroAssembler(buffer);
-#ifdef AMD64
-#ifdef _WIN64
-  _num_args = (method->is_static() ? 1 : 0);
-  _stack_offset = (Argument::n_int_register_parameters_c+1)* wordSize; // don't overwrite return address
-#else
-  _num_int_args = (method->is_static() ? 1 : 0);
-  _num_fp_args = 0;
-  _stack_offset = wordSize; // don't overwrite return address
-#endif // _WIN64
-#endif // AMD64
 }
 
 void InterpreterRuntime::SignatureHandlerGenerator::pass_int() {

--- a/src/hotspot/cpu/x86/interpreterRT_x86_64.cpp
+++ b/src/hotspot/cpu/x86/interpreterRT_x86_64.cpp
@@ -41,7 +41,6 @@
 InterpreterRuntime::SignatureHandlerGenerator::SignatureHandlerGenerator(const methodHandle& method, CodeBuffer* buffer) :
     NativeSignatureIterator(method) {
   _masm = new MacroAssembler(buffer);
-#ifdef AMD64
 #ifdef _WIN64
   _num_args = (method->is_static() ? 1 : 0);
   _stack_offset = (Argument::n_int_register_parameters_c+1)* wordSize; // don't overwrite return address
@@ -50,7 +49,6 @@ InterpreterRuntime::SignatureHandlerGenerator::SignatureHandlerGenerator(const m
   _num_fp_args = 0;
   _stack_offset = wordSize; // don't overwrite return address
 #endif // _WIN64
-#endif // AMD64
 }
 
 Register InterpreterRuntime::SignatureHandlerGenerator::from() { return r14; }


### PR DESCRIPTION
[JDK-8199809](https://bugs.openjdk.org/browse/JDK-8199809) left a few unnecessary things in InterpreterRuntime::SignatureHandlerGenerator::SignatureHandlerGenerator. In `interpreterRT_x86_64.cpp`: no need for `AMD64` checks. In `interpreterRT_x86_32.cpp`: no need for `AMD64` and `WIN64` checks. 

Additional testing:
 - [x] Linux x86_64 server fastdebug, `make bootcycle-images`
 - [x] Linux x86_32 server fastdebug, `make bootcycle-images`
 - [x] GHA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343167](https://bugs.openjdk.org/browse/JDK-8343167): Unnecessary define checks in InterpreterRuntime after JDK-8199809 (**Enhancement** - P4)


### Reviewers
 * [Paul Hohensee](https://openjdk.org/census#phh) (@phohensee - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21747/head:pull/21747` \
`$ git checkout pull/21747`

Update a local copy of the PR: \
`$ git checkout pull/21747` \
`$ git pull https://git.openjdk.org/jdk.git pull/21747/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21747`

View PR using the GUI difftool: \
`$ git pr show -t 21747`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21747.diff">https://git.openjdk.org/jdk/pull/21747.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21747#issuecomment-2442516574)
</details>
