### PR TITLE
8343178: Test BasicTest.java javac compile fails cannot find symbol

### DIFF
--- a/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
+++ b/test/jdk/tools/jpackage/share/jdk/jpackage/tests/BasicTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -317,7 +317,7 @@ public final class BasicTest {
             pkgTest.addBundleVerifier(cmd -> {
                 // Check jpackage used the supplied directory.
                 Path tempDir = getTempDirectory(cmd, tempRoot);
-                TKit.assertPathNotEmptyDirectory(tempDir);
+                TKit.assertDirectoryNotEmpty(tempDir);
             });
         }
 


### PR DESCRIPTION
Hi all,
The test `tools/jpackage/share/jdk/jpackage/tests/BasicTest.java` javac compile fails `cannot find symbol TKit.assertPathNotEmptyDirectory` after [JDK-8343101](https://bugs.openjdk.org/browse/JDK-8343101). I think we should use `TKit.assertDirectoryNotEmpty` instead of `TKit.assertPathNotEmptyDirectory`.
The change has been verified locally on linux-x64, test-fix only , no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343178](https://bugs.openjdk.org/browse/JDK-8343178): Test BasicTest.java javac compile fails cannot find symbol (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21750/head:pull/21750` \
`$ git checkout pull/21750`

Update a local copy of the PR: \
`$ git checkout pull/21750` \
`$ git pull https://git.openjdk.org/jdk.git pull/21750/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21750`

View PR using the GUI difftool: \
`$ git pr show -t 21750`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21750.diff">https://git.openjdk.org/jdk/pull/21750.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21750#issuecomment-2443106711)