### PR TITLE
8343194: Avoid redundant Hashtable.containsKey call in CodeSource.readObject

### DIFF
--- a/src/java.base/share/classes/java/security/CodeSource.java
+++ b/src/java.base/share/classes/java/security/CodeSource.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -556,7 +556,6 @@ public class CodeSource implements java.io.Serializable {
     private void readObject(java.io.ObjectInputStream ois)
         throws IOException, ClassNotFoundException
     {
-        CertificateFactory cf;
         Hashtable<String, CertificateFactory> cfs = null;
         List<java.security.cert.Certificate> certList = null;
 
@@ -577,10 +576,8 @@ public class CodeSource implements java.io.Serializable {
             // read the certificate type, and instantiate a certificate
             // factory of that type (reuse existing factory if possible)
             String certType = ois.readUTF();
-            if (cfs.containsKey(certType)) {
-                // reuse certificate factory
-                cf = cfs.get(certType);
-            } else {
+            CertificateFactory cf = cfs.get(certType);
+            if (cf == null) {
                 // create new certificate factory
                 try {
                     cf = CertificateFactory.getInstance(certType);


### PR DESCRIPTION
`Hashtable` doesn't allow `null` values.
It means we can replace containsKey+get with get+null check.
It's clearer and a bit faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343194](https://bugs.openjdk.org/browse/JDK-8343194): Avoid redundant Hashtable.containsKey call in CodeSource.readObject (**Enhancement** - P5)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21753/head:pull/21753` \
`$ git checkout pull/21753`

Update a local copy of the PR: \
`$ git checkout pull/21753` \
`$ git pull https://git.openjdk.org/jdk.git pull/21753/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21753`

View PR using the GUI difftool: \
`$ git pr show -t 21753`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21753.diff">https://git.openjdk.org/jdk/pull/21753.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21753#issuecomment-2443966798)