### PR TITLE
8343037: Missing @since tag on JColorChooser.showDialog overload

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/JColorChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JColorChooser.java
@@ -175,7 +175,9 @@ public class JColorChooser extends JComponent implements Accessible {
      * @return the selected color or <code>null</code> if the user opted out
      * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
+     * 
      * @see java.awt.GraphicsEnvironment#isHeadless
+     * @since 9
      */
     @SuppressWarnings("deprecation")
     public static Color showDialog(Component component, String title,

--- a/src/java.desktop/share/classes/javax/swing/JColorChooser.java
+++ b/src/java.desktop/share/classes/javax/swing/JColorChooser.java
@@ -175,7 +175,7 @@ public class JColorChooser extends JComponent implements Accessible {
      * @return the selected color or <code>null</code> if the user opted out
      * @throws HeadlessException if GraphicsEnvironment.isHeadless()
      * returns true.
-     * 
+     *
      * @see java.awt.GraphicsEnvironment#isHeadless
      * @since 9
      */

--- a/src/java.desktop/share/classes/javax/swing/colorchooser/AbstractColorChooserPanel.java
+++ b/src/java.desktop/share/classes/javax/swing/colorchooser/AbstractColorChooserPanel.java
@@ -229,6 +229,7 @@ public abstract class AbstractColorChooserPanel extends JPanel {
      *
      * @param b true if the transparency of a color can be selected
      * @see #isColorTransparencySelectionEnabled()
+     * @since 9
      */
     @BeanProperty(description
             = "Sets the transparency of a color selection on or off.")
@@ -241,6 +242,7 @@ public abstract class AbstractColorChooserPanel extends JPanel {
      *
      * @return true if the transparency of a color can be selected
      * @see #setColorTransparencySelectionEnabled(boolean)
+     * @since 9
      */
     public boolean isColorTransparencySelectionEnabled(){
         return true;


### PR DESCRIPTION
[JDK-8051548](https://bugs.openjdk.org/browse/JDK-8051548) in Java 9 added a new overload of `JColorChooser.showDialog` but `@since` tag is missing..The fix also added couple of new methods to AbstractColorChooserPanel.java where also `@since` tag is added

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343037](https://bugs.openjdk.org/browse/JDK-8343037): Missing @<!---->since tag on JColorChooser.showDialog overload (**Bug** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21754/head:pull/21754` \
`$ git checkout pull/21754`

Update a local copy of the PR: \
`$ git checkout pull/21754` \
`$ git pull https://git.openjdk.org/jdk.git pull/21754/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21754`

View PR using the GUI difftool: \
`$ git pr show -t 21754`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21754.diff">https://git.openjdk.org/jdk/pull/21754.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21754#issuecomment-2443619281)