### PR TITLE
8343186: hsdis build libopcodes and libbfd are not found

### DIFF
--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -266,8 +266,8 @@ AC_DEFUN([LIB_SETUP_HSDIS_BINUTILS],
     HSDIS_CFLAGS="-DLIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB"
   elif test "x$BINUTILS_INSTALL_DIR" != x; then
     disasm_header="\"$BINUTILS_INSTALL_DIR/include/dis-asm.h\""
-    if test -e $BINUTILS_INSTALL_DIR/lib/libbfd.a && \
-        test -e $BINUTILS_INSTALL_DIR/lib/libopcodes.a && \
+    if (test -e $BINUTILS_INSTALL_DIR/lib/libbfd.a || test -e $BINUTILS_INSTALL_DIR/lib64/libbfd.a) && \
+        (test -e $BINUTILS_INSTALL_DIR/lib/libopcodes.a || test -e $BINUTILS_INSTALL_DIR/lib64/libopcodes.a) && \
         (test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a || \
         test -e $BINUTILS_INSTALL_DIR/lib64/libiberty.a || \
         test -e $BINUTILS_INSTALL_DIR/lib32/libiberty.a); then
@@ -275,7 +275,19 @@ AC_DEFUN([LIB_SETUP_HSDIS_BINUTILS],
 
       # libiberty ignores --libdir and may be installed in $BINUTILS_INSTALL_DIR/lib, $BINUTILS_INSTALL_DIR/lib32
       # or $BINUTILS_INSTALL_DIR/lib64, depending on system setup
+      LIBOPCODES_LIB=""
+      LIBBFD_LIB=""
       LIBIBERTY_LIB=""
+      if test -e $BINUTILS_INSTALL_DIR/lib/libbfd.a; then
+        LIBBFD_LIB="$BINUTILS_INSTALL_DIR/lib/libbfd.a"
+      else
+        LIBBFD_LIB="$BINUTILS_INSTALL_DIR/lib64/libbfd.a"
+      fi
+      if test -e $BINUTILS_INSTALL_DIR/lib/libopcodes.a; then
+        LIBOPCODES_LIB="$BINUTILS_INSTALL_DIR/lib/libopcodes.a"
+      else
+        LIBOPCODES_LIB="$BINUTILS_INSTALL_DIR/lib64/libopcodes.a"
+      fi
       if test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a; then
         LIBIBERTY_LIB="$BINUTILS_INSTALL_DIR/lib/libiberty.a"
       elif test -e $BINUTILS_INSTALL_DIR/lib32/libiberty.a; then
@@ -283,7 +295,7 @@ AC_DEFUN([LIB_SETUP_HSDIS_BINUTILS],
       else
         LIBIBERTY_LIB="$BINUTILS_INSTALL_DIR/lib64/libiberty.a"
       fi
-      HSDIS_LIBS="$BINUTILS_INSTALL_DIR/lib/libbfd.a $BINUTILS_INSTALL_DIR/lib/libopcodes.a $LIBIBERTY_LIB"
+      HSDIS_LIBS="$LIBBFD_LIB $LIBOPCODES_LIB $LIBIBERTY_LIB"
       # If we have libsframe add it.
       if test -e $BINUTILS_INSTALL_DIR/lib/libsframe.a; then
         HSDIS_LIBS="$HSDIS_LIBS $BINUTILS_INSTALL_DIR/lib/libsframe.a"

--- a/make/autoconf/lib-hsdis.m4
+++ b/make/autoconf/lib-hsdis.m4
@@ -266,8 +266,10 @@ AC_DEFUN([LIB_SETUP_HSDIS_BINUTILS],
     HSDIS_CFLAGS="-DLIBARCH_$OPENJDK_TARGET_CPU_LEGACY_LIB"
   elif test "x$BINUTILS_INSTALL_DIR" != x; then
     disasm_header="\"$BINUTILS_INSTALL_DIR/include/dis-asm.h\""
-    if (test -e $BINUTILS_INSTALL_DIR/lib/libbfd.a || test -e $BINUTILS_INSTALL_DIR/lib64/libbfd.a) && \
-        (test -e $BINUTILS_INSTALL_DIR/lib/libopcodes.a || test -e $BINUTILS_INSTALL_DIR/lib64/libopcodes.a) && \
+    if (test -e $BINUTILS_INSTALL_DIR/lib/libbfd.a || \
+        test -e $BINUTILS_INSTALL_DIR/lib64/libbfd.a) && \
+        (test -e $BINUTILS_INSTALL_DIR/lib/libopcodes.a || \
+        test -e $BINUTILS_INSTALL_DIR/lib64/libopcodes.a) && \
         (test -e $BINUTILS_INSTALL_DIR/lib/libiberty.a || \
         test -e $BINUTILS_INSTALL_DIR/lib64/libiberty.a || \
         test -e $BINUTILS_INSTALL_DIR/lib32/libiberty.a); then


### PR DESCRIPTION
On SUSE with precompiled binutils this error occurs :

configure: error: "/mydir/binutils-2.39-s15/lib64 must contain libbfd.a, libopcodes.a and libiberty.a"

But the libs are present; the error message and detection is wrong.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8343186: hsdis build libopcodes and libbfd are not found`

### Issue
 * [JDK-8343186](https://bugs.openjdk.org/browse/JDK-8343186): hsdis build libopcodes and libbfd are not found (**Bug** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21755/head:pull/21755` \
`$ git checkout pull/21755`

Update a local copy of the PR: \
`$ git checkout pull/21755` \
`$ git pull https://git.openjdk.org/jdk.git pull/21755/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21755`

View PR using the GUI difftool: \
`$ git pr show -t 21755`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21755.diff">https://git.openjdk.org/jdk/pull/21755.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21755#issuecomment-2443685316)