### PR TITLE
8343177: JFR: Remove critical section for thread id assignment

### DIFF
--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -98,6 +98,10 @@ void Jfr::on_java_thread_start(JavaThread* starter, JavaThread* startee) {
 
 void Jfr::on_set_current_thread(JavaThread* jt, oop thread) {
   JfrThreadLocal::on_set_current_thread(jt, thread);
+}
+
+void Jfr::initialize_primordial_thread(JavaThread* jt) {
+  JfrThreadLocal::initialize_primordial_thread(jt);
 }
 
 void Jfr::on_resolution(const CallInfo& info, TRAPS) {

--- a/src/hotspot/share/jfr/jfr.cpp
+++ b/src/hotspot/share/jfr/jfr.cpp
@@ -100,8 +100,8 @@ void Jfr::on_set_current_thread(JavaThread* jt, oop thread) {
   JfrThreadLocal::on_set_current_thread(jt, thread);
 }
 
-void Jfr::initialize_primordial_thread(JavaThread* jt) {
-  JfrThreadLocal::initialize_primordial_thread(jt);
+void Jfr::initialize_main_thread(JavaThread* jt) {
+  JfrThreadLocal::initialize_main_thread(jt);
 }
 
 void Jfr::on_resolution(const CallInfo& info, TRAPS) {

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -71,7 +71,7 @@ class Jfr : AllStatic {
   static bool on_flight_recorder_option(const JavaVMOption** option, char* delimiter);
   static bool on_start_flight_recording_option(const JavaVMOption** option, char* delimiter);
   static void on_backpatching(const Method* callee_method, JavaThread* jt);
-  static void initialize_primordial_thread(JavaThread* jt);
+  static void initialize_main_thread(JavaThread* jt);
 };
 
 #endif // SHARE_JFR_JFR_HPP

--- a/src/hotspot/share/jfr/jfr.hpp
+++ b/src/hotspot/share/jfr/jfr.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,6 +71,7 @@ class Jfr : AllStatic {
   static bool on_flight_recorder_option(const JavaVMOption** option, char* delimiter);
   static bool on_start_flight_recording_option(const JavaVMOption** option, char* delimiter);
   static void on_backpatching(const Method* callee_method, JavaThread* jt);
+  static void initialize_primordial_thread(JavaThread* jt);
 };
 
 #endif // SHARE_JFR_JFR_HPP

--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrType.cpp
@@ -114,7 +114,7 @@ void JfrCheckpointThreadClosure::do_thread(Thread* t) {
 
 void JfrThreadConstantSet::serialize(JfrCheckpointWriter& writer) {
   JfrCheckpointThreadClosure tc(writer);
-  JfrJavaThreadIterator javathreads(false); // include not yet live threads (_thread_new)
+  JfrJavaThreadIterator javathreads;
   while (javathreads.has_next()) {
     tc.do_thread(javathreads.next());
   }

--- a/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
+++ b/src/hotspot/share/jfr/recorder/jfrRecorder.cpp
@@ -210,7 +210,7 @@ bool JfrRecorder::on_create_vm_2() {
     return true;
   }
   JavaThread* const thread = JavaThread::current();
-  JfrThreadLocal::assign_thread_id(thread, thread->jfr_thread_local());
+  assert(JfrThreadLocal::jvm_thread_id(thread) != 0, "invariant");
 
   if (!JfrOptionSet::initialize(thread)) {
     return false;

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -71,7 +71,6 @@ JfrThreadLocal::JfrThreadLocal() :
   _wallclock_time(os::javaTimeNanos()),
   _stackdepth(0),
   _entering_suspend_flag(0),
-  _critical_section(0),
   _vthread_epoch(0),
   _vthread_excluded(false),
   _jvm_thread_excluded(false),
@@ -98,6 +97,13 @@ void JfrThreadLocal::set_thread_blob(const JfrBlobHandle& ref) {
 
 const JfrBlobHandle& JfrThreadLocal::thread_blob() const {
   return _thread;
+}
+
+void JfrThreadLocal::initialize_primordial_thread(JavaThread* jt) {
+  assert(jt != nullptr, "invariant");
+  assert(Thread::is_starting_thread(jt), "invariant");
+  assert(jt->threadObj() == nullptr, "invariant");
+  jt->jfr_thread_local()->_jvm_thread_id = 1;
 }
 
 static void send_java_thread_start_event(JavaThread* jt) {
@@ -394,13 +400,13 @@ traceid JfrThreadLocal::thread_id(const Thread* t) {
   if (is_impersonating(t)) {
     return t->jfr_thread_local()->_thread_id_alias;
   }
-  JfrThreadLocal* const tl = t->jfr_thread_local();
+  const JfrThreadLocal* const tl = t->jfr_thread_local();
   if (!t->is_Java_thread()) {
-    return jvm_thread_id(t, tl);
+    return jvm_thread_id(tl);
   }
   const JavaThread* jt = JavaThread::cast(t);
   if (!is_vthread(jt)) {
-    return jvm_thread_id(t, tl);
+    return jvm_thread_id(tl);
   }
   // virtual thread
   const traceid tid = vthread_id(jt);
@@ -421,19 +427,31 @@ traceid JfrThreadLocal::external_thread_id(const Thread* t) {
   return JfrRecorder::is_recording() ? thread_id(t) : jvm_thread_id(t);
 }
 
-inline traceid load_java_thread_id(const Thread* t) {
+static inline traceid load_java_thread_id(const Thread* t) {
   assert(t != nullptr, "invariant");
   assert(t->is_Java_thread(), "invariant");
   oop threadObj = JavaThread::cast(t)->threadObj();
   return threadObj != nullptr ? AccessThreadTraceId::id(threadObj) : 0;
 }
 
+#ifdef ASSERT
+static bool assignment_precondition(const Thread* t, JfrThreadLocal* tl) {
+  assert(t != nullptr, "invariant");
+  assert(tl != nullptr, "invariant");
+  if (!t->is_Java_thread()) {
+    return true;
+  }
+  const JavaThread* jt = JavaThread::cast(t);
+  return jt->thread_state() == _thread_new || jt->is_attaching_via_jni();
+}
+#endif
+
 traceid JfrThreadLocal::assign_thread_id(const Thread* t, JfrThreadLocal* tl) {
   assert(t != nullptr, "invariant");
   assert(tl != nullptr, "invariant");
-  JfrSpinlockHelper spinlock(&tl->_critical_section);
   traceid tid = tl->_jvm_thread_id;
   if (tid == 0) {
+    assert(assignment_precondition(t, tl), "invariant");
     if (t->is_Java_thread()) {
       tid = load_java_thread_id(t);
       tl->_jvm_thread_id = tid;
@@ -446,15 +464,14 @@ traceid JfrThreadLocal::assign_thread_id(const Thread* t, JfrThreadLocal* tl) {
   return tid;
 }
 
-traceid JfrThreadLocal::jvm_thread_id(const Thread* t, JfrThreadLocal* tl) {
-  assert(t != nullptr, "invariant");
+traceid JfrThreadLocal::jvm_thread_id(const JfrThreadLocal* tl) {
   assert(tl != nullptr, "invariant");
-  return tl->_jvm_thread_id != 0 ? tl->_jvm_thread_id : JfrThreadLocal::assign_thread_id(t, tl);
+  return tl->_jvm_thread_id;
 }
 
 traceid JfrThreadLocal::jvm_thread_id(const Thread* t) {
   assert(t != nullptr, "invariant");
-  return jvm_thread_id(t, t->jfr_thread_local());
+  return jvm_thread_id(t->jfr_thread_local());
 }
 
 bool JfrThreadLocal::is_vthread(const JavaThread* jt) {

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -99,7 +99,7 @@ const JfrBlobHandle& JfrThreadLocal::thread_blob() const {
   return _thread;
 }
 
-void JfrThreadLocal::initialize_primordial_thread(JavaThread* jt) {
+void JfrThreadLocal::initialize_main_thread(JavaThread* jt) {
   assert(jt != nullptr, "invariant");
   assert(Thread::is_starting_thread(jt), "invariant");
   assert(jt->threadObj() == nullptr, "invariant");

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.cpp
@@ -103,6 +103,7 @@ void JfrThreadLocal::initialize_primordial_thread(JavaThread* jt) {
   assert(jt != nullptr, "invariant");
   assert(Thread::is_starting_thread(jt), "invariant");
   assert(jt->threadObj() == nullptr, "invariant");
+  assert(jt->jfr_thread_local()->_jvm_thread_id == 0, "invariant");
   jt->jfr_thread_local()->_jvm_thread_id = 1;
 }
 
@@ -435,9 +436,8 @@ static inline traceid load_java_thread_id(const Thread* t) {
 }
 
 #ifdef ASSERT
-static bool assignment_precondition(const Thread* t, JfrThreadLocal* tl) {
+static bool can_assign(const Thread* t) {
   assert(t != nullptr, "invariant");
-  assert(tl != nullptr, "invariant");
   if (!t->is_Java_thread()) {
     return true;
   }
@@ -451,7 +451,7 @@ traceid JfrThreadLocal::assign_thread_id(const Thread* t, JfrThreadLocal* tl) {
   assert(tl != nullptr, "invariant");
   traceid tid = tl->_jvm_thread_id;
   if (tid == 0) {
-    assert(assignment_precondition(t, tl), "invariant");
+    assert(can_assign(t), "invariant");
     if (t->is_Java_thread()) {
       tid = load_java_thread_id(t);
       tl->_jvm_thread_id = tid;

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ class JfrThreadLocal {
   friend class Jfr;
   friend class JfrIntrinsicSupport;
   friend class JfrJavaSupport;
-  friend class JfrRecorder;
   friend class JVMCIVMStructs;
  private:
   jobject _java_event_writer;
@@ -65,7 +64,6 @@ class JfrThreadLocal {
   jlong _wallclock_time;
   mutable u4 _stackdepth;
   volatile jint _entering_suspend_flag;
-  mutable volatile int _critical_section;
   u2 _vthread_epoch;
   bool _vthread_excluded;
   bool _jvm_thread_excluded;
@@ -78,11 +76,13 @@ class JfrThreadLocal {
   JfrStackFrame* install_stackframes() const;
   void release(Thread* t);
   static void release(JfrThreadLocal* tl, Thread* t);
+  static void initialize_primordial_thread(JavaThread* jt);
 
   static void set(bool* excluded_field, bool state);
   static traceid assign_thread_id(const Thread* t, JfrThreadLocal* tl);
   static traceid vthread_id(const Thread* t);
   static void set_vthread_epoch(const JavaThread* jt, traceid id, u2 epoch);
+  static traceid jvm_thread_id(const JfrThreadLocal* tl);
   bool is_vthread_excluded() const;
   static void exclude_vthread(const JavaThread* jt);
   static void include_vthread(const JavaThread* jt);
@@ -175,7 +175,6 @@ class JfrThreadLocal {
 
   // Non-volatile thread id, for Java carrier threads and non-java threads.
   static traceid jvm_thread_id(const Thread* t);
-  static traceid jvm_thread_id(const Thread* t, JfrThreadLocal* tl);
 
   // To impersonate is to temporarily masquerade as another thread.
   // For example, when writing an event that should be attributed to some other thread.

--- a/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
+++ b/src/hotspot/share/jfr/support/jfrThreadLocal.hpp
@@ -76,7 +76,7 @@ class JfrThreadLocal {
   JfrStackFrame* install_stackframes() const;
   void release(Thread* t);
   static void release(JfrThreadLocal* tl, Thread* t);
-  static void initialize_primordial_thread(JavaThread* jt);
+  static void initialize_main_thread(JavaThread* jt);
 
   static void set(bool* excluded_field, bool state);
   static traceid assign_thread_id(const Thread* t, JfrThreadLocal* tl);

--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -3849,6 +3849,9 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
     return JNI_ERR;
   }
 
+  // Want this inside 'attaching via jni'.
+  JFR_ONLY(Jfr::on_thread_start(thread);)
+
   // mark the thread as no longer attaching
   // this uses a fence to push the change through so we don't have
   // to regrab the threads_lock
@@ -3862,8 +3865,6 @@ static jint attach_current_thread(JavaVM *vm, void **penv, void *_args, bool dae
   if (JvmtiExport::should_post_thread_life()) {
     JvmtiExport::post_thread_start(thread);
   }
-
-  JFR_ONLY(Jfr::on_thread_start(thread);)
 
   *(JNIEnv**)penv = thread->jni_environment();
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -163,9 +163,6 @@ class Thread: public ThreadShadow {
   // const char* _exception_file;                   // file information for exception (debugging only)
   // int         _exception_line;                   // line information for exception (debugging only)
  protected:
-
-  DEBUG_ONLY(static Thread* _starting_thread;)
-
   // JavaThread lifecycle support:
   friend class SafeThreadsListPtr;  // for _threads_list_ptr, cmpxchg_threads_hazard_ptr(), {dec_,inc_,}nested_threads_hazard_ptr_cnt(), {g,s}et_threads_hazard_ptr(), inc_nested_handle_cnt(), tag_hazard_ptr() access
   friend class ScanHazardPtrGatherProtectedThreadsClosure;  // for cmpxchg_threads_hazard_ptr(), get_threads_hazard_ptr(), is_hazard_ptr_tagged() access
@@ -211,12 +208,15 @@ class Thread: public ThreadShadow {
   static bool is_JavaThread_protected_by_TLH(const JavaThread* target);
 
  private:
+  DEBUG_ONLY(static Thread* _starting_thread;)
   DEBUG_ONLY(bool _suspendible_thread;)
   DEBUG_ONLY(bool _indirectly_suspendible_thread;)
   DEBUG_ONLY(bool _indirectly_safepoint_thread;)
 
  public:
 #ifdef ASSERT
+  static bool is_starting_thread(const Thread* t);
+
   void set_suspendible_thread()   { _suspendible_thread = true; }
   void clear_suspendible_thread() { _suspendible_thread = false; }
   bool is_suspendible_thread()    { return _suspendible_thread; }
@@ -500,9 +500,9 @@ class Thread: public ThreadShadow {
     return is_in_stack_range_incl(adr, os::current_stack_pointer());
   }
 
-  // Sets this thread as starting thread. Returns failure if thread
+  // Sets the argument thread as starting thread. Returns failure if thread
   // creation fails due to lack of memory, too many threads etc.
-  bool set_as_starting_thread();
+  static bool set_as_starting_thread(JavaThread* jt);
 
 protected:
   // OS data associated with the thread

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -167,7 +167,7 @@ static void create_initial_thread(Handle thread_group, JavaThread* thread,
                           CHECK);
 
   JFR_ONLY(assert(JFR_JVM_THREAD_ID(thread) == static_cast<traceid>(java_lang_Thread::thread_id(thread_oop())),
-             "primordial tid mismatch");)
+             "initial tid mismatch");)
 
   // Set thread status to running since main thread has
   // been started and running.
@@ -543,7 +543,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
     return JNI_ENOMEM;
   }
 
-  JFR_ONLY(Jfr::initialize_primordial_thread(main_thread);)
+  JFR_ONLY(Jfr::initialize_main_thread(main_thread);)
 
   // Enable guard page *after* os::create_main_thread(), otherwise it would
   // crash Linux VM, see notes in os_linux.cpp.

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -166,6 +166,9 @@ static void create_initial_thread(Handle thread_group, JavaThread* thread,
                           string,
                           CHECK);
 
+  JFR_ONLY(assert(JFR_JVM_THREAD_ID(thread) == static_cast<traceid>(java_lang_Thread::thread_id(thread_oop())),
+             "primordial tid mismatch");)
+
   // Set thread status to running since main thread has
   // been started and running.
   java_lang_Thread::set_thread_status(thread_oop(),
@@ -532,13 +535,15 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   main_thread->set_active_handles(JNIHandleBlock::allocate_block());
   MACOS_AARCH64_ONLY(main_thread->init_wx());
 
-  if (!main_thread->set_as_starting_thread()) {
+  if (!Thread::set_as_starting_thread(main_thread)) {
     vm_shutdown_during_initialization(
                                       "Failed necessary internal allocation. Out of swap space");
     main_thread->smr_delete();
     *canTryAgain = false; // don't let caller call JNI_CreateJavaVM again
     return JNI_ENOMEM;
   }
+
+  JFR_ONLY(Jfr::initialize_primordial_thread(main_thread);)
 
   // Enable guard page *after* os::create_main_thread(), otherwise it would
   // crash Linux VM, see notes in os_linux.cpp.


### PR DESCRIPTION
Greetings,

With Loom, JFR had to change the assignment of unique thread IDs to threads. For JavaThreads, a dependency exists on the threadObj before the thread ID can be determined and assigned. We currently have a lazy assignment scheme that assigns on first use. Several threads, such as thread iterators and sampling threads, can issue the first use. Hence, a critical section protects assignments.

However, a critical section at this location makes it challenging to build robust signal handlers, for example, because we cannot read the thread ID.

We can remove this critical section with careful rearrangements, ensuring threads are only assigned a thread ID in thread state _thread_new (a thread state that at least the JFR sampler and the JFR iterators exclude).

The problem child is JNI attaching threads, created directly into state _thread_in_vm and added to the threads list before the creation and assignment of the threadObj. We can also manage this case by being careful when we sample such a thread, alternatively allowing for a thread ID of 0 or taking account of the 'attaching via jni' property. 

Testing: jdk_jfr Tier 1- 3, Stress testing

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343177](https://bugs.openjdk.org/browse/JDK-8343177): JFR: Remove critical section for thread id assignment (**Enhancement** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21756/head:pull/21756` \
`$ git checkout pull/21756`

Update a local copy of the PR: \
`$ git checkout pull/21756` \
`$ git pull https://git.openjdk.org/jdk.git pull/21756/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21756`

View PR using the GUI difftool: \
`$ git pr show -t 21756`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21756.diff">https://git.openjdk.org/jdk/pull/21756.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21756#issuecomment-2443841338)
</details>
