### PR TITLE
8343153: compiler/codecache/CheckLargePages.java fails on linux with huge pages configured but its number set to 0

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -55,7 +55,6 @@ compiler/c2/Test8004741.java 8235801 generic-all
 compiler/c2/irTests/TestDuplicateBackedge.java 8318904 generic-all
 
 compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
-compiler/codecache/CheckLargePages.java 8332654 linux-x64
 
 compiler/vectorapi/reshape/TestVectorReinterpret.java 8320897 aix-ppc64,linux-ppc64le
 compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x64

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -111,8 +111,14 @@ public class CheckLargePages {
         out.shouldNotContain("CodeHeap 'profiled nmethods'");
         out.shouldNotContain("CodeHeap 'non-profiled nmethods'");
         out.shouldContain("UseLargePages=1, UseTransparentHugePages=0");
-        out.shouldMatch("CodeCache:  min=1[gG] max=1[gG] base=[^ ]+ size=1[gG] page_size=1[gG]");
+        out.shouldMatch("Large page support enabled\\. Usable page sizes: .*1[gG].*\\. Default large page size: .*\\.");
+        out.shouldMatch(
+                // 1GB large pages configured and available
+                "CodeCache:\\s+min=1[gG] max=1[gG] base=[^ ]+ size=1[gG] page_size=1[gG]|" +
+                // 1GB large pages configured but none available
+                "Failed to reserve and commit memory with given page size\\. req_addr: [^ ]+ size: 1[gG], page size: 1[gG], \\(errno = 12\\)");
     }
+
     public static void main(String[] args) throws Exception {
         if (isLargePageSizeEqual(LP_1G)) {
             testSegmented2GbCodeCacheWith1GbPage();

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -41,6 +41,7 @@ import jdk.test.lib.process.ProcessTools;
 import jdk.test.whitebox.WhiteBox;
 import java.util.Scanner;
 import java.io.File;
+import java.io.FileNotFoundException;
 
 import java.util.Arrays;
 import java.util.List;

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -131,7 +131,7 @@ public class CheckLargePages {
     public static void main(String[] args) throws Exception {
         if (isLargePageSizeEqual(LP_1G)) {
             testSegmented2GbCodeCacheWith1GbPage();
-            if (numberOfLargePages(LP_1G) > 0) {
+            if (numberOfLargePages(LP_1G) >= 1) {
                 testDefaultCodeCacheWith1GbLargePages();
                 testNonSegmented1GbCodeCacheWith1GbLargePages();
             } else {

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -118,6 +118,11 @@ public class CheckLargePages {
                 // 1GB large pages configured but none available
                 "Failed to reserve and commit memory with given page size\\. " +
                 "req_addr: [^ ]+ size: 1[gG], page size: 1[gG], \\(errno = 12\\)");
+        out.shouldMatch(
+                // 1GB large pages configured and available
+                "CodeCache:\\s+min=1[gG] max=1[gG] base=[^ ]+ size=1[gG] page_size=1[gG]|" +
+                // 1GB large pages configured but only 2MB pages available
+                "CodeCache:\\s+min=1[gG] max=1[gG] base=[^ ]+ size=1[gG] page_size=2[mM]");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -116,7 +116,8 @@ public class CheckLargePages {
                 // 1GB large pages configured and available
                 "CodeCache:\\s+min=1[gG] max=1[gG] base=[^ ]+ size=1[gG] page_size=1[gG]|" +
                 // 1GB large pages configured but none available
-                "Failed to reserve and commit memory with given page size\\. req_addr: [^ ]+ size: 1[gG], page size: 1[gG], \\(errno = 12\\)");
+                "Failed to reserve and commit memory with given page size\\. " +
+                "req_addr: [^ ]+ size: 1[gG], page size: 1[gG], \\(errno = 12\\)");
     }
 
     public static void main(String[] args) throws Exception {

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -67,7 +67,7 @@ public class CheckLargePages {
             if (scanner.hasNextInt()) {
                 return scanner.nextInt();
             }
-        } catch (FileNotFoundException e);
+        } catch (FileNotFoundException e) { };
         return 0;
     }
 

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -63,10 +63,11 @@ public class CheckLargePages {
 
     private static int numberOfLargePages(long size) {
         String largePageNumberFile = String.format(LARGE_PAGE_NUMBER_FILE_BASE, size / 1024);
-        Scanner scanner = new Scanner(new File(largePageNumberFile));
-        if (scanner.hasNextInt()) {
-            return scanner.nextInt();
-        }
+        try (Scanner scanner = new Scanner(new File(largePageNumberFile))) {
+            if (scanner.hasNextInt()) {
+                return scanner.nextInt();
+            }
+        } catch (FileNotFoundException e);
         return 0;
     }
 

--- a/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
+++ b/test/hotspot/jtreg/compiler/codecache/CheckLargePages.java
@@ -40,6 +40,7 @@ import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.whitebox.WhiteBox;
 import java.util.Scanner;
+import java.io.File;
 
 import java.util.Arrays;
 import java.util.List;


### PR DESCRIPTION
# Issue

The third test of `compiler/codecache/CheckLargePages.java` checks that non-segmented 1GB code cache can be allocated with 1GB large pages.

On linux (the only supported platform) in order to allocate them, 1GB huge pages have to be enabled (checkable from `/proc/meminfo` and `/sys/kernel/mm/hugepages/hugepages-xxxx`) and their number has to be set to >0 (checkable from `/sys/kernel/mm/hugepages/hugepages-xxxx/nr_hugepages`).

If 1GB huge pages are enabled but their number is 0, the test fails because it looks for a string that matches `CodeCache: min=1[gG] max=1[gG] base=[^ ]+ size=1[gG] page_size=1[gG]` but the actual output is `CodeCache: min=1G max=1G base=0x00007f4040000000 size=1G page_size=2M`. This happens because the VM tries to allocate 1GB huge pages but it fails beause the number of allocatable ones is 0 and the VM reverts to smaller large page sizes (2MB).

# Solution

The problem might be attributed to the VM only checking for 1GB huge pages to be supported, not how many there currently are. Nevertheless, this seems to be the correct behaviour, not least because their number can be changed dynamically.
So, the correct thing to do seems to be to "relax" the check made by the test to include both cases:
* when 1GB huge pages are supported and can be allocated correctly
* when 1GB huge pages are supported but cannot be allocated correctly (because there are none available) and the VM reverts to 2MB huge pages (if there are no 2MB pages available the test doesn't run at all).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343153](https://bugs.openjdk.org/browse/JDK-8343153): compiler/codecache/CheckLargePages.java fails on linux with huge pages configured but its number set to 0 (**Bug** - P4)


### Reviewers
 * [Evgeny Astigeevich](https://openjdk.org/census#eastigeevich) (@eastig - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21757/head:pull/21757` \
`$ git checkout pull/21757`

Update a local copy of the PR: \
`$ git checkout pull/21757` \
`$ git pull https://git.openjdk.org/jdk.git pull/21757/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21757`

View PR using the GUI difftool: \
`$ git pr show -t 21757`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21757.diff">https://git.openjdk.org/jdk/pull/21757.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21757#issuecomment-2447734537)
</details>
