### PR TITLE
8343190: GHA: Try building JTReg several times

### DIFF
--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -52,8 +52,24 @@ runs:
 
     - name: 'Build JTReg'
       run: |
-        # Build JTReg and move files to the proper locations
-        bash make/build.sh --jdk "$JAVA_HOME_17_X64"
+        # Try building JTReg several times, backing off exponentially on failure.
+        # ~500 seconds in total should be enough to capture most of the transient
+        # failures.
+        for I in `seq 0 8`; do
+          rm -rf build/images/jtreg
+          bash make/build.sh --jdk "$JAVA_HOME_17_X64" && break
+          S=$(( 2 ** $I ))
+          echo "Failure. Waiting $S seconds before retrying"
+          sleep $S
+        done
+
+        # Check if build was successful
+        if [ ! -d build/images/jtreg ]; then
+          echo "Build failed"
+          exit 1;
+        fi
+
+        # Move files to the proper locations
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src


### PR DESCRIPTION
We still sometimes have problems checking out JTReg build dependencies. [JDK-8342988](https://bugs.openjdk.org/browse/JDK-8342988) makes it less pronounced, but it still happens. We might need to do a retries for JTReg builds to make them more reliable.

Additional testing:
 - [x] GHA (seeing retries with deliberately broken JTReg build)
 - [x] GHA (passing JTReg build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343190](https://bugs.openjdk.org/browse/JDK-8343190): GHA: Try building JTReg several times (**Enhancement** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21758/head:pull/21758` \
`$ git checkout pull/21758`

Update a local copy of the PR: \
`$ git checkout pull/21758` \
`$ git pull https://git.openjdk.org/jdk.git pull/21758/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21758`

View PR using the GUI difftool: \
`$ git pr show -t 21758`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21758.diff">https://git.openjdk.org/jdk/pull/21758.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21758#issuecomment-2444131506)