### PR TITLE
8341904: Search tag in inherited doc comment creates additional index item

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/InheritDocTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/InheritDocTaglet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -128,7 +128,7 @@ public class InheritDocTaglet extends BaseTaglet {
                     d = docFinder.search(src, m -> extractMainDescription(m, isFirstSentence, utils));
                 }
                 if (d instanceof Result.Conclude<Documentation> doc) {
-                    replacement = writer.commentTagsToOutput(doc.value().method, null,
+                    replacement = writer.commentTagsToOutput(doc.value().method, inheritDoc,
                             doc.value().mainDescription, isFirstSentence);
                 }
             } catch (DocFinder.NoOverriddenMethodFound e) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
@@ -369,21 +369,22 @@ public class TagletWriter {
 
     @SuppressWarnings("preview")
     Content createAnchorAndSearchIndex(Element element, String tagText, Content tagContent, String desc, DocTree tree) {
-        Content result;
-        if (context.isFirstSentence && context.inSummary || context.inTags.contains(DocTree.Kind.INDEX)
+        // Only create index item for tags in their native location.
+        if (context.isFirstSentence && context.inSummary
+                || context.inTags.contains(DocTree.Kind.INDEX)
+                || context.inTags.contains(DocTree.Kind.INHERIT_DOC)
+                || isDifferentTypeElement(element)
                 || !htmlWriter.isIndexable()) {
-            result = tagContent;
-        } else {
-            HtmlId id = HtmlIds.forText(tagText, htmlWriter.indexAnchorTable);
-            result = HtmlTree.SPAN(id, HtmlStyles.searchTagResult, tagContent);
-            if (options.createIndex() && !tagText.isEmpty()) {
-                String holder = getHolderName(element);
-                IndexItem item = IndexItem.of(element, tree, tagText, holder, desc,
-                        new DocLink(htmlWriter.path, id.name()));
-                configuration.indexBuilder.add(item);
-            }
+            return tagContent;
         }
-        return result;
+        HtmlId id = HtmlIds.forText(tagText, htmlWriter.indexAnchorTable);
+        if (options.createIndex() && !tagText.isEmpty()) {
+            String holder = getHolderName(element);
+            IndexItem item = IndexItem.of(element, tree, tagText, holder, desc,
+                    new DocLink(htmlWriter.path, id.name()));
+            configuration.indexBuilder.add(item);
+        }
+        return HtmlTree.SPAN(id, HtmlStyles.searchTagResult, tagContent);
     }
 
     public String getHolderName(Element element) {
@@ -471,5 +472,16 @@ public class TagletWriter {
                 .replaceAll("&#?[A-Za-z0-9]+;", " ")  // entities count as a single character
                 .replaceAll("\\R", "\n");             // normalize newlines
         return s.length() > TAG_LIST_ITEM_MAX_INLINE_LENGTH || s.contains(",");
+    }
+
+    // Test if element is the same as or belongs to the current page element
+    private boolean isDifferentTypeElement(Element element) {
+        if (element.getKind().isClass() || element.getKind().isInterface()) {
+            return element != getCurrentPageElement();
+        } else if (element.getKind() == ElementKind.OTHER) {
+            return false;
+        } else {
+            return utils.getEnclosingTypeElement(element) != getCurrentPageElement();
+        }
     }
 }

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/taglets/TagletWriter.java
@@ -476,7 +476,7 @@ public class TagletWriter {
 
     // Test if element is the same as or belongs to the current page element
     private boolean isDifferentTypeElement(Element element) {
-        if (element.getKind().isClass() || element.getKind().isInterface()) {
+        if (element.getKind().isDeclaredType()) {
             return element != getCurrentPageElement();
         } else if (element.getKind() == ElementKind.OTHER) {
             return false;

--- a/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberInheritance/TestMemberInheritance.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 4638588 4635809 6256068 6270645 8025633 8026567 8162363 8175200
- *      8192850 8182765 8220217 8224052 8237383
+ *      8192850 8182765 8220217 8224052 8237383 8341904
  * @summary Test to make sure that members are inherited properly in the Javadoc.
  *          Verify that inheritance labels are correct.
  * @library ../../lib
@@ -152,8 +152,7 @@ public class TestMemberInheritance extends JavadocTester {
                                                               throws <span class="exceptions">java.lang.IllegalArgumentException,
                     java.lang.InterruptedException,
                     java.lang.IllegalStateException</span></div>
-                    <div class="block">Returns some value with an <span id="inheritedsearchtag" clas\
-                    s="search-tag-result">inherited search tag</span>.</div>""");
+                    <div class="block">Returns some value with an inherited search tag.</div>""");
 
         checkOutput("pkg2/DocumentedNonGenericChild.html", true,
                 """
@@ -218,10 +217,8 @@ public class TestMemberInheritance extends JavadocTester {
                     {"p":"pkg2","c":"DocumentedNonGenericChild","l":"parentField"}""",
                 """
                     {"p":"pkg2","c":"DocumentedNonGenericChild","l":"parentMethod(String)","u":"parentMethod(T)"}""");
-        checkOutput("tag-search-index.js", true,
-                """
-                    {"l":"inherited search tag","h":"pkg2.UndocumentedGenericParent.parentMethod(Str\
-                    ing)","u":"pkg2/DocumentedNonGenericChild.html#inheritedsearchtag"}""");
+        // Search tags from inherited doc comments are not added to the index (8341904).
+        checkOutput("tag-search-index.js", true, "tagSearchIndex = []");
 
     }
 
@@ -246,8 +243,7 @@ public class TestMemberInheritance extends JavadocTester {
                                                               throws <span class="exceptions">java.lang.IllegalArgumentException,
                     java.lang.InterruptedException,
                     java.lang.IllegalStateException</span></div>
-                    <div class="block">Returns some value with an <span id="inheritedsearchtag" clas\
-                    s="search-tag-result">inherited search tag</span>.</div>""");
+                    <div class="block">Returns some value with an inherited search tag.</div>""");
 
         checkOutput("index-files/index-9.html", true,
                 """
@@ -270,10 +266,8 @@ public class TestMemberInheritance extends JavadocTester {
                     {"p":"pkg2","c":"DocumentedNonGenericChild","l":"parentField"}""",
                 """
                     {"p":"pkg2","c":"DocumentedNonGenericChild","l":"parentMethod(String)","u":"parentMethod(T)"}""");
-        checkOutput("tag-search-index.js", true,
-                """
-                    {"l":"inherited search tag","h":"pkg2.UndocumentedGenericParent.parentMethod(Str\
-                    ing)","u":"pkg2/DocumentedNonGenericChild.html#inheritedsearchtag"}""");
+        // Search tags from inherited doc comments are not added to the index (8341904).
+        checkOutput("tag-search-index.js", true, "tagSearchIndex = []");
     }
 
 }

--- a/test/langtools/jdk/javadoc/doclet/testMemberInheritance/pkg2/DocumentedNonGenericChild.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberInheritance/pkg2/DocumentedNonGenericChild.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testMemberInheritance/pkg2/DocumentedNonGenericChild.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberInheritance/pkg2/DocumentedNonGenericChild.java
@@ -25,4 +25,9 @@ package pkg2;
 
 public abstract class DocumentedNonGenericChild extends UndocumentedGenericParent<String, InterruptedException, IllegalArgumentException> {
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void parentMethod2() {}
 }

--- a/test/langtools/jdk/javadoc/doclet/testMemberInheritance/pkg2/UndocumentedGenericParent.java
+++ b/test/langtools/jdk/javadoc/doclet/testMemberInheritance/pkg2/UndocumentedGenericParent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,4 +38,9 @@ abstract class UndocumentedGenericParent<T, E extends Throwable, F extends Throw
      * @throws IllegalStateException illegal state
      */
     protected abstract T parentMethod(T t) throws F, E, IllegalStateException;
+
+    /**
+     * Method with systemProperty tag. {@systemProperty parent.system.prop}.
+     */
+    public abstract void parentMethod2();
 }


### PR DESCRIPTION
Please review a change to avoid generation of index items for comments inherited from overridden methods. This affects `{@index}`, `{@systemProperty}`, and `@spec` tags in both implicitly and explicitly doc comments. 

The change adds two additional means for avoiding generation of index items which partially overlap:

 - Adding the `inheritDoc` tag to the current `TagletWriter.Context` when rendering an inherited doc comment
 - Comparing the element's type element with the type element currently being documented

The second check is necessary for implicitly inherited doc comments (e.g. overriding a method without doc comment), while usage of `{@inheritDoc}` tag is detected by checks. I still decided to add the `inheritDoc` tag constant to `TagletWriter.Context` since it is explicit, uses a mechanism that was created for the purpose, and might be useful in other places. 

There was a test case for the previous (buggy) behaviour to add a search tag index item using the overridden method signature as label. I changed the expected behaviour and added another method to cover usage of the `{@systemProperty}` tag in combination with `{@inheritDoc}`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341904](https://bugs.openjdk.org/browse/JDK-8341904): Search tag in inherited doc comment creates additional index item (**Bug** - P4)


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21765/head:pull/21765` \
`$ git checkout pull/21765`

Update a local copy of the PR: \
`$ git checkout pull/21765` \
`$ git pull https://git.openjdk.org/jdk.git pull/21765/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21765`

View PR using the GUI difftool: \
`$ git pr show -t 21765`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21765.diff">https://git.openjdk.org/jdk/pull/21765.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21765#issuecomment-2444513293)
</details>
