### PR TITLE
8343128: PassFailJFrame.java test result: Error. Bad action for script: build}

### DIFF
--- a/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
+++ b/test/jdk/java/awt/regtesthelpers/PassFailJFrame.java
@@ -184,21 +184,23 @@ import static javax.swing.SwingUtilities.isEventDispatchThread;
  *
  * <p id="jtregTagsForTest">
  * Add the following jtreg tags before the test class declaration
- * {@snippet :
+ * <pre><code>
  * /*
- *  * @test
+ *  * &#64;test
  *  * @summary Sample manual test
  *  * @library /java/awt/regtesthelpers
  *  * @build PassFailJFrame
  *  * @run main/manual SampleManualTest
- * }
- * and the closing comment tag <code>*&#47;</code>.
+ *  *&#47;
+ * </code></pre>
  * <p>
  * The {@code @library} tag points to the location of the
  * {@code PassFailJFrame} class in the source code;
  * the {@code @build} tag makes jtreg compile the {@code PassFailJFrame} class,
  * and finally the {@code @run} tag specifies it is a manual
  * test and the class to run.
+ * <p>
+ * Don't forget to update the name of the class to run in the {@code @run} tag.
  *
  * <h2 id="usingBuilder">Using {@code Builder}</h2>
  * Use methods of the {@link Builder Builder} class to set or change


### PR DESCRIPTION
After updating documentation for `PassFailJFrame.java` in [JDK-8340785](https://bugs.openjdk.org/browse/JDK-8340785) / #21162, jtreg interprets the file as a test because it finds `@test` tag in the file. This results in a failed test.

I didn't find a way to avoid this problem when using [`@snippet` feature](https://docs.oracle.com/en/java/javase/21/javadoc/programmers-guide-snippets.html#GUID-1B435AA6-84D5-4693-AF5E-6470EEE970FC) of the javadoc (see also [JavaDoc Code Snippet API - Sip of Java](https://inside.java/2022/04/04/sip46/), so I used the old friends `<pre><code>`.

Now, `@` is represented as an HTML character entity, and jtreg no longer finds the `@test` marker in the file.

With this update, I inlined the end comment into the same code block with `/` represented as a character entity. This makes the jtreg tags comment complete, ready to copy and paste.

I've updated the generated javadoc for [`PassFailJFrame`](https://cr.openjdk.org/~aivanov/PassFailJFrame/api/PassFailJFrame.html); this version includes javadoc for [`WindowLayouts`](https://cr.openjdk.org/~aivanov/PassFailJFrame/api/WindowLayouts.html).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343128](https://bugs.openjdk.org/browse/JDK-8343128): PassFailJFrame.java test result: Error. Bad action for script: build} (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21766/head:pull/21766` \
`$ git checkout pull/21766`

Update a local copy of the PR: \
`$ git checkout pull/21766` \
`$ git pull https://git.openjdk.org/jdk.git pull/21766/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21766`

View PR using the GUI difftool: \
`$ git pr show -t 21766`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21766.diff">https://git.openjdk.org/jdk/pull/21766.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21766#issuecomment-2444594418)