### PR TITLE
8343211: Compile error: redefinition of 'Assembler::evmovdquw(XMMRegister,KRegister,XMMRegister,bool,int)'

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -3590,18 +3590,6 @@ void Assembler::evmovdquw(XMMRegister dst, XMMRegister src, int vector_len) {
   evmovdquw(dst, k0, src, /*merge*/ false, vector_len);
 }
 
-void Assembler::evmovdquw(XMMRegister dst, KRegister mask, XMMRegister src, bool merge, int vector_len) {
-  assert(vector_len <= AVX_256bit ? VM_Version::supports_avx512vlbw() : VM_Version::supports_avx512bw(), "");
-  InstructionAttr attributes(vector_len, /* vex_w */ true, /* legacy_mode */ false, /* no_mask_reg */ false, /* uses_vl */ true);
-  attributes.set_embedded_opmask_register_specifier(mask);
-  attributes.set_is_evex_instruction();
-  if (merge) {
-    attributes.reset_is_clear_context();
-  }
-  int encode = vex_prefix_and_encode(dst->encoding(), 0, src->encoding(), VEX_SIMD_F2, VEX_OPCODE_0F, &attributes);
-  emit_int16(0x6F, (0xC0 | encode));
-}
-
 void Assembler::evmovdquw(XMMRegister dst, Address src, int vector_len) {
   // Unmasked instruction
   evmovdquw(dst, k0, src, /*merge*/ false, vector_len);

--- a/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
+++ b/test/hotspot/jtreg/compiler/testlibrary/sha/predicate/IntrinsicPredicates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Hi all,
On linux-x64 gcc generate compile error: `src/hotspot/cpu/x86/assembler_x86.cpp:3646:6: error: redefinition of 'void Assembler::evmovdquw(XMMRegister, KRegister, XMMRegister, bool, int)'` after [JDK-8341527](https://bugs.openjdk.org/browse/JDK-8341527) and [JDK-8338021](https://bugs.openjdk.org/browse/JDK-8338021).
The both PRs add the same C++ function implementation `void Assembler::evmovdquw(XMMRegister, KRegister, XMMRegister, bool, int)`.
I think the newly added functions can be merged to one.
I choose to delete the implementation added by [JDK-8341527](https://bugs.openjdk.org/browse/JDK-8341527). And I verify the releated tests of [JDK-8341527](https://bugs.openjdk.org/browse/JDK-8341527), after this PR the releated tests of [JDK-8341527](https://bugs.openjdk.org/browse/JDK-8341527) run passed.

Additonal testing:

- [x] linux x64 build with release/fastdebug/slowdebug configure
- [ ] jtreg tests(include tier1/2/3 etc.) on linux x64 with release build

The releated tests of [JDK-8341527](https://bugs.openjdk.org/browse/JDK-8341527) shows below:
```
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256Intrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA256MultiBlockIntrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512Intrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA512MultiBlockIntrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5MultiBlockIntrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3Intrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA3MultiBlockIntrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA1MultiBlockIntrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestSHA1Intrinsics.java
test/hotspot/jtreg/compiler/intrinsics/sha/sanity/TestMD5Intrinsics.java
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343211](https://bugs.openjdk.org/browse/JDK-8343211): Compile error: redefinition of 'Assembler::evmovdquw(XMMRegister,KRegister,XMMRegister,bool,int)' (**Bug** - P1)


### Reviewers
 * [Volodymyr Paprotski](https://openjdk.org/census#vpaprotski) (@vpaprotsk - Author)
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21768/head:pull/21768` \
`$ git checkout pull/21768`

Update a local copy of the PR: \
`$ git checkout pull/21768` \
`$ git pull https://git.openjdk.org/jdk.git pull/21768/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21768`

View PR using the GUI difftool: \
`$ git pr show -t 21768`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21768.diff">https://git.openjdk.org/jdk/pull/21768.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21768#issuecomment-2444865472)