### PR TITLE
8343218: Disable allocating interface and abstract classes in non-class metaspace

### DIFF
--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -456,7 +456,8 @@ InstanceKlass* InstanceKlass::allocate_instance_klass(const ClassFileParser& par
   InstanceKlass* ik;
   // Only Klasses that aren't interface or abstract classes are found in oop headers so they
   // are the only ones that require compression and allocation in the limited class metaspace
-  // region.  But ... there are C2 dependencies that all klasses are allocated to the class metaspace.
+  // region.  But ... there are C2 dependencies that all klasses are allocated to the class metaspace, so
+  // always use the class metaspace until JDK-NNNNNNN is resolved.
   const bool use_class_space = true;
 
   // Allocation

--- a/src/hotspot/share/oops/instanceKlass.cpp
+++ b/src/hotspot/share/oops/instanceKlass.cpp
@@ -454,7 +454,10 @@ InstanceKlass* InstanceKlass::allocate_instance_klass(const ClassFileParser& par
   assert(loader_data != nullptr, "invariant");
 
   InstanceKlass* ik;
-  const bool use_class_space = !parser.is_interface() && !parser.is_abstract();
+  // Only Klasses that aren't interface or abstract classes are found in oop headers so they
+  // are the only ones that require compression and allocation in the limited class metaspace
+  // region.  But ... there are C2 dependencies that all klasses are allocated to the class metaspace.
+  const bool use_class_space = true;
 
   // Allocation
   if (parser.is_instance_ref_klass()) {


### PR DESCRIPTION
Change the code to allocate all Klasses to class-metaspace until c2 dependencies are understood and fixed, and more urgent need arises when compressing klass pointers to smaller numbers of bits.
Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343218](https://bugs.openjdk.org/browse/JDK-8343218): Disable allocating interface and abstract classes in non-class metaspace (**Sub-task** - P4)


### Reviewers
 * [Thomas Stuefe](https://openjdk.org/census#stuefe) (@tstuefe - **Reviewer**) 🔄 Re-review required (review applies to [a30081ad](https://git.openjdk.org/jdk/pull/21769/files/a30081ade78a45d2ade632833982c065ad939456))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21769/head:pull/21769` \
`$ git checkout pull/21769`

Update a local copy of the PR: \
`$ git checkout pull/21769` \
`$ git pull https://git.openjdk.org/jdk.git pull/21769/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21769`

View PR using the GUI difftool: \
`$ git pr show -t 21769`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21769.diff">https://git.openjdk.org/jdk/pull/21769.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21769#issuecomment-2444904309)