### PR TITLE
8343234: (bf) Move java/nio/Buffer/LimitDirectMemory.java from ProblemList.txt to ProblemList-Virtual.txt

### DIFF
--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -69,3 +69,6 @@ java/util/Properties/StoreReproducibilityTest.java 0000000 generic-all
 java/util/Properties/StoreReproducibilityTest.java 0000000 generic-all
 javax/management/ImplementationVersion/ImplVersionTest.java 0000000 generic-all
 javax/management/remote/mandatory/version/ImplVersionTest.java 0000000 generic-all
+
+# Direct buffer memory allocated before test launch
+java/nio/Buffer/LimitDirectMemory.java 8342849 generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -586,8 +586,6 @@ java/net/Socket/asyncClose/Race.java                            8317801 aix-ppc6
 
 # jdk_nio
 
-java/nio/Buffer/LimitDirectMemory.java                          8342849 generic-all
-
 java/nio/channels/AsynchronousSocketChannel/StressLoopback.java 8211851 aix-ppc64
 
 java/nio/channels/Channels/SocketChannelStreams.java            8317838 aix-ppc64

--- a/test/jdk/java/nio/Buffer/LimitDirectMemory.java
+++ b/test/jdk/java/nio/Buffer/LimitDirectMemory.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 4627316 6743526
  * @summary Test option to limit direct memory allocation
- * @requires (os.arch == "x86_64") | (os.arch == "amd64")
+ * @requires (os.arch == "x86_64") | (os.arch == "amd64") | (os.arch == "aarch64")
  * @library /test/lib
  *
  * @summary Test: memory is properly limited using multiple buffers


### PR DESCRIPTION
Move LimitDirectMemory to the problem list which best matches the observed failure mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343234](https://bugs.openjdk.org/browse/JDK-8343234): (bf) Move java/nio/Buffer/LimitDirectMemory.java from ProblemList.txt to ProblemList-Virtual.txt (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21773/head:pull/21773` \
`$ git checkout pull/21773`

Update a local copy of the PR: \
`$ git checkout pull/21773` \
`$ git pull https://git.openjdk.org/jdk.git pull/21773/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21773`

View PR using the GUI difftool: \
`$ git pr show -t 21773`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21773.diff">https://git.openjdk.org/jdk/pull/21773.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21773#issuecomment-2445380597)
</details>
