### PR TITLE
8342544: [macos] jpackage test helper should check for both "--app-image" and "--mac-sign" for signing predefined app image case

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageCommand.java
@@ -402,12 +402,14 @@ public final class JPackageCommand extends CommandArguments<JPackageCommand> {
     public Path outputBundle() {
         final String bundleName;
         if (isImagePackageType()) {
-            if (TKit.isOSX() && hasArgument("--app-image")) {
-                return Path.of(getArgumentValue("--app-image", () -> null));
-            }
-            String dirName = name();
-            if (TKit.isOSX()) {
-                dirName = dirName + ".app";
+            String dirName;
+            if (!TKit.isOSX()) {
+                dirName = name();
+            } else if (hasArgument("--app-image") && hasArgument("--mac-sign")) {
+                // Request to sign external app image, not to build a new one
+                dirName = getArgumentValue("--app-image");
+            } else {
+                dirName = name() + ".app";
             }
             bundleName = dirName;
         } else if (TKit.isLinux()) {


### PR DESCRIPTION
- Added check for "--mac-sign" argument in cases when we do in-place signing of predefined app image to avoid potential bugs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342544](https://bugs.openjdk.org/browse/JDK-8342544): [macos] jpackage test helper should check for both "--app-image" and "--mac-sign" for signing predefined app image case (**Bug** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21776/head:pull/21776` \
`$ git checkout pull/21776`

Update a local copy of the PR: \
`$ git checkout pull/21776` \
`$ git pull https://git.openjdk.org/jdk.git pull/21776/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21776`

View PR using the GUI difftool: \
`$ git pr show -t 21776`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21776.diff">https://git.openjdk.org/jdk/pull/21776.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21776#issuecomment-2445498034)