### PR TITLE
8343085: [macos] jpackage verbose output on macOS contains numerous "Running /usr/bin/codesign" entries

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Executor.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/Executor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -112,7 +112,10 @@ public final class Executor {
             pb.redirectOutput(ProcessBuilder.Redirect.DISCARD);
         }
 
-        Log.verbose(String.format("Running %s", createLogMessage(pb, true)));
+        if (!quietCommand) {
+            Log.verbose(String.format("Running %s", createLogMessage(pb, true)));
+        }
+
         Process p = pb.start();
 
         int code = 0;


### PR DESCRIPTION
- All verbose log messages in Executor will only be shown if mode is not quite to eliminate partial and unnecessary log messages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343085](https://bugs.openjdk.org/browse/JDK-8343085): [macos] jpackage verbose output on macOS contains numerous "Running /usr/bin/codesign" entries (**Bug** - P4)


### Reviewers
 * [Alexey Semenyuk](https://openjdk.org/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21779/head:pull/21779` \
`$ git checkout pull/21779`

Update a local copy of the PR: \
`$ git checkout pull/21779` \
`$ git pull https://git.openjdk.org/jdk.git pull/21779/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21779`

View PR using the GUI difftool: \
`$ git pr show -t 21779`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21779.diff">https://git.openjdk.org/jdk/pull/21779.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21779#issuecomment-2445603144)
</details>
