### PR TITLE
8343250: ArrayBlockingQueue serialization not thread safe

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
+++ b/src/java.base/share/classes/java/util/concurrent/ArrayBlockingQueue.java
@@ -35,6 +35,7 @@
 
 package java.util.concurrent;
 
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.AbstractQueue;
 import java.util.Arrays;
@@ -1615,6 +1616,23 @@ public class ArrayBlockingQueue<E> extends AbstractQueue<E>
             && (count == 0 || items[takeIndex] != null)
             && (count == capacity || items[putIndex] == null)
             && (count == 0 || items[dec(putIndex, capacity)] != null);
+    }
+
+    /**
+     * Writes the queue to the stream whilst holding the locks to prevent
+     * broken invariants.
+     *
+     * @param s the stream
+     * @throws java.io.IOException if an I/O error occurs
+     */
+    private void writeObject(java.io.ObjectOutputStream s) throws IOException {
+        final ReentrantLock lock = this.lock;
+        lock.lock();
+        try {
+            s.defaultWriteObject();
+        } finally {
+            lock.unlock();
+        }
     }
 
     /**


### PR DESCRIPTION
The ArrayBlockingQueue has had a readObject() method since Java 7, which checks invariants of the deserialized object. However, it does not have a writeObject() method. This means that the ArrayBlockingQueue could be modified whilst it is being written, resulting in broken invariants. The readObject() method's invariant checking is not exhaustive, which means that it is possible to end up with ArrayBlockingQueue instances that contain null values, leading to a difference between "size()" and how many objects would be returned with "poll()".

The ABQ should get a writeObject() method that is locking on the same locks as the rest of the class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343250](https://bugs.openjdk.org/browse/JDK-8343250): ArrayBlockingQueue serialization not thread safe (**Enhancement** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @dmlloyd (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21783/head:pull/21783` \
`$ git checkout pull/21783`

Update a local copy of the PR: \
`$ git checkout pull/21783` \
`$ git pull https://git.openjdk.org/jdk.git pull/21783/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21783`

View PR using the GUI difftool: \
`$ git pr show -t 21783`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21783.diff">https://git.openjdk.org/jdk/pull/21783.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21783#issuecomment-2446242881)
</details>
