### PR TITLE
8343206: Final graph reshaping should not compress abstract or interface class pointers

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3490,7 +3490,13 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
         } else if (t->isa_oopptr()) {
           new_in2 = ConNode::make(t->make_narrowoop());
         } else if (t->isa_klassptr()) {
-          new_in2 = ConNode::make(t->make_narrowklass());
+          ciKlass* klass = tkls->exact_klass();
+          if (klass->is_interface() || klass->is_abstract()) {
+            // CmpPNode::Ideal should always fold such comparisons
+            assert(false, "Interface or abstract class pointers should not be compressed");
+          } else {
+            new_in2 = ConNode::make(t->make_narrowklass());
+          }
         }
       }
       if (new_in2 != nullptr) {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3490,13 +3490,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
         } else if (t->isa_oopptr()) {
           new_in2 = ConNode::make(t->make_narrowoop());
         } else if (t->isa_klassptr()) {
-          ciKlass* klass = t->is_klassptr()->exact_klass();
-          if (klass->is_interface() || klass->is_abstract()) {
-            // CmpPNode::Ideal should always fold such comparisons
-            assert(false, "Interface or abstract class pointers should not be compressed");
-          } else {
-            new_in2 = ConNode::make(t->make_narrowklass());
-          }
+          new_in2 = ConNode::make(t->make_narrowklass());
         }
       }
       if (new_in2 != nullptr) {
@@ -3788,6 +3782,14 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
     }
     break;
   }
+#ifdef ASSERT
+  case Op_ConNKlass: {
+    const TypePtr* tp = n->as_Type()->type()->make_ptr();
+    ciKlass* klass = tp->is_klassptr()->exact_klass();
+    assert(!klass->is_interface() && !klass->is_abstract(), "Interface or abstract class pointers should not be compressed");
+    break;
+  }
+#endif
   default:
     assert(!n->is_Call(), "");
     assert(!n->is_Mem(), "");

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3786,7 +3786,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
   case Op_ConNKlass: {
     const TypePtr* tp = n->as_Type()->type()->make_ptr();
     ciKlass* klass = tp->is_klassptr()->exact_klass();
-    assert(klass->is_encodable(), "klass cannot be compressed");
+    assert(klass->is_in_encoding_range(), "klass cannot be compressed");
     break;
   }
 #endif

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3490,7 +3490,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
         } else if (t->isa_oopptr()) {
           new_in2 = ConNode::make(t->make_narrowoop());
         } else if (t->isa_klassptr()) {
-          ciKlass* klass = t->exact_klass();
+          ciKlass* klass = t->is_klassptr()->exact_klass();
           if (klass->is_interface() || klass->is_abstract()) {
             // CmpPNode::Ideal should always fold such comparisons
             assert(false, "Interface or abstract class pointers should not be compressed");

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3490,7 +3490,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
         } else if (t->isa_oopptr()) {
           new_in2 = ConNode::make(t->make_narrowoop());
         } else if (t->isa_klassptr()) {
-          ciKlass* klass = tkls->exact_klass();
+          ciKlass* klass = t->exact_klass();
           if (klass->is_interface() || klass->is_abstract()) {
             // CmpPNode::Ideal should always fold such comparisons
             assert(false, "Interface or abstract class pointers should not be compressed");

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -3786,7 +3786,7 @@ void Compile::final_graph_reshaping_main_switch(Node* n, Final_Reshape_Counts& f
   case Op_ConNKlass: {
     const TypePtr* tp = n->as_Type()->type()->make_ptr();
     ciKlass* klass = tp->is_klassptr()->exact_klass();
-    assert(!klass->is_interface() && !klass->is_abstract(), "Interface or abstract class pointers should not be compressed");
+    assert(klass->is_encodable(), "klass cannot be compressed");
     break;
   }
 #endif


### PR DESCRIPTION
@fisk found this problematic optimization in final graph reshaping where we would convert a `CmpP` into a `CmpN` by converting a constant class pointer operand to a narrow class pointer. After  [JDK-8338526](https://bugs.openjdk.org/browse/JDK-8338526), this is not valid if the class pointer refers to an interface or abstract class.

I think it's not an issue in current code though. The only way we can get a dynamic narrow class is when loading from an object at `oopDesc::klass_offset_in_bytes()`:
https://github.com/openjdk/jdk/blob/7131f053b0d26b62cbf0d8376ec117d6e8d79f9e/src/hotspot/share/opto/type.cpp#L3521-L3522

Comparisons of such loads with a constant class pointer of interface or abstract class type are always folded during GVN:
https://github.com/openjdk/jdk/blob/7131f053b0d26b62cbf0d8376ec117d6e8d79f9e/src/hotspot/share/opto/subnode.cpp#L1164-L1171

And therefore, the code in `Compile::final_graph_reshaping_main_switch` will never trigger.

I added a corresponding assert and bailout in product to be on the safe side. The assert never triggered in my testing.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343206](https://bugs.openjdk.org/browse/JDK-8343206): Final graph reshaping should not compress abstract or interface class pointers (**Bug** - P5)


### Reviewers
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) Review applies to [3da09500](https://git.openjdk.org/jdk/pull/21784/files/3da095009896902c857d010908b9d88f3990db7c)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [3da09500](https://git.openjdk.org/jdk/pull/21784/files/3da095009896902c857d010908b9d88f3990db7c)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21784/head:pull/21784` \
`$ git checkout pull/21784`

Update a local copy of the PR: \
`$ git checkout pull/21784` \
`$ git pull https://git.openjdk.org/jdk.git pull/21784/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21784`

View PR using the GUI difftool: \
`$ git pr show -t 21784`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21784.diff">https://git.openjdk.org/jdk/pull/21784.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21784#issuecomment-2446792285)
</details>
