### PR TITLE
8343296: IGV: Show pre/main/post at CountedLoopNodes

### DIFF
--- a/src/hotspot/share/opto/idealGraphPrinter.cpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.cpp
@@ -509,6 +509,10 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
       print_prop("idealOpcode", (const char *)NodeClassNames[node->as_Mach()->ideal_Opcode()]);
     }
 
+    if (node->is_CountedLoop()) {
+      print_loop_kind(node->as_CountedLoop());
+    }
+
     print_field(node);
 
     buffer[0] = 0;
@@ -636,6 +640,20 @@ void IdealGraphPrinter::visit_node(Node *n, bool edges, VectorSet* temp_set) {
 
     tail(PROPERTIES_ELEMENT);
     tail(NODE_ELEMENT);
+  }
+}
+
+void IdealGraphPrinter::print_loop_kind(const CountedLoopNode* counted_loop) {
+  const char* loop_kind = nullptr;
+  if (counted_loop->is_pre_loop()) {
+    loop_kind = "pre";
+  } else if (counted_loop->is_main_loop()) {
+    loop_kind = "main";
+  } else if (counted_loop->is_post_loop()) {
+    loop_kind = "post";
+  }
+  if (loop_kind != nullptr) {
+    print_prop("loop_kind", loop_kind);
   }
 }
 

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -34,6 +34,7 @@
 #ifndef PRODUCT
 
 class Compile;
+class CountedLoopNode;
 class PhaseIFG;
 class PhaseChaitin;
 class Matcher;
@@ -124,6 +125,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   IdealGraphPrinter();
   ~IdealGraphPrinter();
 
+  void print_loop_kind(const CountedLoopNode* counted_loop);
  public:
   IdealGraphPrinter(Compile* compile, const char* file_name = nullptr, bool append = false);
   static void clean_up();

--- a/src/hotspot/share/opto/idealGraphPrinter.hpp
+++ b/src/hotspot/share/opto/idealGraphPrinter.hpp
@@ -126,6 +126,7 @@ class IdealGraphPrinter : public CHeapObj<mtCompiler> {
   ~IdealGraphPrinter();
 
   void print_loop_kind(const CountedLoopNode* counted_loop);
+
  public:
   IdealGraphPrinter(Compile* compile, const char* file_name = nullptr, bool append = false);
   static void clean_up();

--- a/src/utils/IdealGraphVisualizer/Filter/src/main/resources/com/sun/hotspot/igv/filter/helper.js
+++ b/src/utils/IdealGraphVisualizer/Filter/src/main/resources/com/sun/hotspot/igv/filter/helper.js
@@ -57,6 +57,11 @@ function hasAnyNode(selector) {
     return new AnySelector(selector);
 }
 
+// Select the nodes for which the given property is defined.
+function hasProperty(property) {
+    return new MatcherSelector(new Properties.InvertPropertyMatcher(new Properties.RegexpPropertyMatcher(property, "")));
+}
+
 // Select the nodes whose given property matches a given regular expression.
 function matches(property, regexp) {
     return new MatcherSelector(new Properties.RegexpPropertyMatcher(property, regexp));

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/customNodeInfo.filter
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/customNodeInfo.filter
@@ -34,4 +34,3 @@ editProperty(matches("name", "CallLeafDirect|CallLeafDirectVector|CallLeafNoFPDi
 // Show pre/main/post at CountedLoopNodes.
 editProperty(hasProperty("loop_kind"), ["loop_kind"], "extra_label",
              function(loop_kind) { return loop_kind[0]; });
-

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/customNodeInfo.filter
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/customNodeInfo.filter
@@ -30,3 +30,8 @@ editProperty(matches("name", "CallLeaf|CallLeafNoFP"), ["dump_spec"], "extra_lab
              function(dump_spec) {return callLeafInfo(dump_spec[0], 1);});
 editProperty(matches("name", "CallLeafDirect|CallLeafDirectVector|CallLeafNoFPDirect"), ["dump_spec"], "extra_label",
              function(dump_spec) {return callLeafInfo(dump_spec[0], 0);});
+
+// Show pre/main/post at CountedLoopNodes.
+editProperty(hasProperty("loop_kind"), ["loop_kind"], "extra_label",
+             function(loop_kind) { return loop_kind[0]; });
+


### PR DESCRIPTION
It's sometimes difficult to keep track of which counted loops are pre, main or post loops. This patch adds this property to `CountedLoops`, similarly to the other node info that we print, for example, like a method name for a `CallStaticJava`.

This is achieved by emitting a new property to `CountedLoopNodes` and then extending the node info filter in IGV. This will show the pre/main/post info like the other node info below the node name:

![image](https://github.com/user-attachments/assets/69abe3f4-3e97-4dfe-983a-0153057b1a8d)

Thanks to @robcasloz for helping me with the IGV filter changes!

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343296](https://bugs.openjdk.org/browse/JDK-8343296): IGV: Show pre/main/post at CountedLoopNodes (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Contributors
 * Roberto Castañeda Lozano `<rcastanedalo@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21788/head:pull/21788` \
`$ git checkout pull/21788`

Update a local copy of the PR: \
`$ git checkout pull/21788` \
`$ git pull https://git.openjdk.org/jdk.git pull/21788/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21788`

View PR using the GUI difftool: \
`$ git pr show -t 21788`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21788.diff">https://git.openjdk.org/jdk/pull/21788.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21788#issuecomment-2447204814)