### PR TITLE
8343293: Remove the check for <apphome>/jre/lib/libjava.dylib from the launcher's java_md_macosx.m

### DIFF
--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -415,6 +415,8 @@ GetJDKInstallRoot(char *path, jint pathsize, jboolean speculative)
 {
     char libjava[MAXPATHLEN];
 
+    JLI_TraceLauncher("Attempt to get JDK installation root from launcher executable path\n");
+
     if (GetApplicationHome(path, pathsize)) {
         /* Is the JDK co-located with the application? */
         if (JLI_IsStaticallyLinked()) {

--- a/src/java.base/macosx/native/libjli/java_md_macosx.m
+++ b/src/java.base/macosx/native/libjli/java_md_macosx.m
@@ -429,18 +429,6 @@ GetJDKInstallRoot(char *path, jint pathsize, jboolean speculative)
                 return JNI_TRUE;
             }
         }
-        /* ensure storage for path + /jre + NULL */
-        if ((JLI_StrLen(path) + 4 + 1) > (size_t) pathsize) {
-            JLI_TraceLauncher("Insufficient space to store JRE path\n");
-            return JNI_FALSE;
-        }
-        /* Does the app ship a private JRE in <apphome>/jre directory? */
-        JLI_Snprintf(libjava, sizeof(libjava), "%s/jre/lib/" JAVA_DLL, path);
-        if (access(libjava, F_OK) == 0) {
-            JLI_StrCat(path, "/jre");
-            JLI_TraceLauncher("JRE path is %s\n", path);
-            return JNI_TRUE;
-        }
     }
 
     /* try to find ourselves instead */


### PR DESCRIPTION
Can I please get a review of this change which cleans up a leftover code from the launcher's java_md_macosx.m file?

In https://bugs.openjdk.org/browse/JDK-8329862 changes were done in the launcher code to remove checks for  `<apphome>/jre/lib/` when determining the JDK installation root. Those changes were done in the Unix and Windows files and the macosx one got left out, likely due to an oversight.

The commit in this PR removes that leftover code. No new tests have been added and existing tier1, tier2, tier3 tests continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8343293](https://bugs.openjdk.org/browse/JDK-8343293): Remove the check for &lt;apphome&gt;/jre/lib/libjava.dylib from the launcher's java_md_macosx.m (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21789/head:pull/21789` \
`$ git checkout pull/21789`

Update a local copy of the PR: \
`$ git checkout pull/21789` \
`$ git pull https://git.openjdk.org/jdk.git pull/21789/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21789`

View PR using the GUI difftool: \
`$ git pr show -t 21789`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21789.diff">https://git.openjdk.org/jdk/pull/21789.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21789#issuecomment-2447351988)
</details>
