### PR TITLE
8343307: Throw ZipException instead of IAE in ZipFile.Source::initCEN

### DIFF
--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -1798,7 +1798,7 @@ public class ZipFile implements ZipConstants, Closeable {
                                     metaVersions = new HashMap<>();
                                 metaVersions.computeIfAbsent(hashCode, _ -> new BitSet()).set(version);
                             } catch (Exception e) {
-                                throw new IllegalArgumentException(e);
+                                zerror("invalid CEN header (bad entry name or comment)");
                             }
                         }
                     }


### PR DESCRIPTION
Please review this PR which makes `ZipFile.Source::initCEN` throw `java.util.zip.ZipException` instead of `java.lang.IllegalArgumentException` when calling `ZipCoder::checkedHash` during `META-INF/versions/` parsing.

This is a follow-up to #21489 where the IAE was introduced on the premise that the earlier call to `ZipCoder::checkedHash` in `checkAndAddEntry` would already have thrown `ZipException`, so this was more of a "will never happen" assertion.

However, it's better to just be consistent and throw `ZipException`.

Testing: Added `noreg-cleanup` to the JBS. Unclear how this exception could be tested since it's shadowed by the earlier invocation of `checkedHash`. ZIP tests run green locally, GHA pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343307](https://bugs.openjdk.org/browse/JDK-8343307): Throw ZipException instead of IAE in ZipFile.Source::initCEN (**Enhancement** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21791/head:pull/21791` \
`$ git checkout pull/21791`

Update a local copy of the PR: \
`$ git checkout pull/21791` \
`$ git pull https://git.openjdk.org/jdk.git pull/21791/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21791`

View PR using the GUI difftool: \
`$ git pr show -t 21791`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21791.diff">https://git.openjdk.org/jdk/pull/21791.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21791#issuecomment-2447916715)
</details>
