### PR TITLE
8343333: Parallel: Cleanup comment referring Solaris in MutableNUMASpace

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableNUMASpace.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,12 +53,10 @@
  * bytes that can be moved during the adaptation phase.
  *   Chunks may contain pages from a wrong locality group. The page-scanner has
  * been introduced to address the problem. Remote pages typically appear due to
- * the memory shortage in the target locality group. Besides Solaris would
- * allocate a large page from the remote locality group even if there are small
- * local pages available. The page-scanner scans the pages right after the
- * collection and frees remote pages in hope that subsequent reallocation would
- * be more successful. This approach proved to be useful on systems with high
- * load where multiple processes are competing for the memory.
+ * the memory shortage in the target locality group. The page-scanner scans the pages
+ * right after the collection and frees remote pages in hope that subsequent
+ * reallocation would be more successful. This approach proved to be useful on systems
+ * with high load where multiple processes are competing for the memory.
  */
 
 class MutableNUMASpace : public MutableSpace {


### PR DESCRIPTION
A trivial cleanup that removes comment referring Solaris.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343333](https://bugs.openjdk.org/browse/JDK-8343333): Parallel: Cleanup comment referring Solaris in MutableNUMASpace (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21796/head:pull/21796` \
`$ git checkout pull/21796`

Update a local copy of the PR: \
`$ git checkout pull/21796` \
`$ git pull https://git.openjdk.org/jdk.git pull/21796/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21796`

View PR using the GUI difftool: \
`$ git pr show -t 21796`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21796.diff">https://git.openjdk.org/jdk/pull/21796.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21796#issuecomment-2448881325)
</details>
