### PR TITLE
8343345: Use -jvmArgsPrepend when running microbenchmarks in RunTests.gmk

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -604,7 +604,7 @@ define SetupRunMicroTestBody
     $1_JMH_JVM_ARGS += $$(MICRO_VM_OPTIONS) $$(MICRO_JAVA_OPTIONS)
   endif
 
-  $1_MICRO_VM_OPTIONS := -jvmArgs $(call ShellQuote,$$($1_JMH_JVM_ARGS))
+  $1_MICRO_VM_OPTIONS := -jvmArgsPrepend $(call ShellQuote,$$($1_JMH_JVM_ARGS))
 
   ifneq ($$(MICRO_ITER), )
     $1_MICRO_ITER := -i $$(MICRO_ITER)


### PR DESCRIPTION
Update RunTests.gmk to use `-jvmArgsPrepend` to avoid overwriting built-in micro `jvmArgs` flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343345](https://bugs.openjdk.org/browse/JDK-8343345): Use -jvmArgsPrepend when running microbenchmarks in RunTests.gmk (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21800/head:pull/21800` \
`$ git checkout pull/21800`

Update a local copy of the PR: \
`$ git checkout pull/21800` \
`$ git pull https://git.openjdk.org/jdk.git pull/21800/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21800`

View PR using the GUI difftool: \
`$ git pr show -t 21800`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21800.diff">https://git.openjdk.org/jdk/pull/21800.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21800#issuecomment-2449357680)
</details>
