### PR TITLE
8343379: [BACKOUT] 8343190 GHA: Try building JTReg several times

### DIFF
--- a/.github/actions/build-jtreg/action.yml
+++ b/.github/actions/build-jtreg/action.yml
@@ -52,24 +52,8 @@ runs:
 
     - name: 'Build JTReg'
       run: |
-        # Try building JTReg several times, backing off exponentially on failure.
-        # ~500 seconds in total should be enough to capture most of the transient
-        # failures.
-        for I in `seq 0 8`; do
-          rm -rf build/images/jtreg
-          bash make/build.sh --jdk "$JAVA_HOME_17_X64" && break
-          S=$(( 2 ** $I ))
-          echo "Failure. Waiting $S seconds before retrying"
-          sleep $S
-        done
-
-        # Check if build was successful
-        if [ ! -d build/images/jtreg ]; then
-          echo "Build failed"
-          exit 1;
-        fi
-
-        # Move files to the proper locations
+        # Build JTReg and move files to the proper locations
+        bash make/build.sh --jdk "$JAVA_HOME_17_X64"
         mkdir ../installed
         mv build/images/jtreg/* ../installed
       working-directory: jtreg/src


### PR DESCRIPTION
[JDK-8343190](https://bugs.openjdk.org/browse/JDK-8343190) was in mainline for a few days. I have now caught the case where JTReg fails to build due to network failure (wget exit code 4):

```
Run # Try building JTReg several times, backing off exponentially on failure.
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk/jdk/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Failure. Waiting 1 seconds before retrying
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk/jdk/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Failure. Waiting 2 seconds before retrying
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk/jdk/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Failure. Waiting 4 seconds before retrying
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk/jdk/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Failure. Waiting 8 seconds before retrying
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk/jdk/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Failure. Waiting 16 seconds before retrying
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk/jdk/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Failure. Waiting 32 seconds before retrying
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk/jdk/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Failure. Waiting 64 seconds before retrying
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk/jdk/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Failure. Waiting 128 seconds before retrying
[build.sh][INFO] CYGWIN_OR_MSYS=0
[build.sh][INFO] JAVA_HOME: /usr/lib/jvm/temurin-17-jdk-amd64
[build.sh][INFO] Downloading https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.8-bin.zip to /home/runner/work/jdk/jdk/jtreg/src/make/../build/deps/apache-ant-1.10.8-bin.zip
Error: sh][ERROR] wget exited with exit code 4
Failure. Waiting 256 seconds before retrying
Build failed
Error: Process completed with exit code 1.
```

It does not look that retries added by [JDK-8343190](https://bugs.openjdk.org/browse/JDK-8343190) work: we retried for 25 minutes and then failed anyway.

So I would suspect that is a worker configuration issue rather than transient network issue. It does not make sense to wait for 25 minutes without a high chance of success. This means we are better off without [JDK-8343190](https://bugs.openjdk.org/browse/JDK-8343190), and can back it out. Users should then see their GHA jobs fail almost immediately and can restart right away.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343379](https://bugs.openjdk.org/browse/JDK-8343379): [BACKOUT] 8343190 GHA: Try building JTReg several times (**Sub-task** - P4)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21803/head:pull/21803` \
`$ git checkout pull/21803`

Update a local copy of the PR: \
`$ git checkout pull/21803` \
`$ git pull https://git.openjdk.org/jdk.git pull/21803/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21803`

View PR using the GUI difftool: \
`$ git pr show -t 21803`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21803.diff">https://git.openjdk.org/jdk/pull/21803.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21803#issuecomment-2449706564)
</details>
