### PR TITLE
8343378: Exceptions in javax/management DeadLockTest.java do not cause test failure

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/connection/DeadLockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DeadLockTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,21 +46,23 @@ public class DeadLockTest {
     public static void main(String[] args) {
         System.out.println(">>> test on a client notification deadlock.");
 
-        boolean ok = true;
+        boolean fail = false;
         for (int i = 0; i < protocols.length; i++) {
             try {
                 test(protocols[i]);
             } catch (Exception e) {
+                fail = true; // any one protocol failure, fails the test
                 System.out.println(">>> Test failed for " + protocols[i]);
                 e.printStackTrace(System.out);
             }
         }
-
+        if (fail) {
+            throw new RuntimeException("FAILED");
+        }
         System.out.println(">>> Test passed");
     }
 
-    private static void test(String proto)
-            throws Exception {
+    private static void test(String proto) throws Exception {
         System.out.println(">>> Test for protocol " + proto);
 
         JMXServiceURL u = null;
@@ -78,6 +80,7 @@ public class DeadLockTest {
             server = JMXConnectorServerFactory.newJMXConnectorServer(u, env, mbs);
         } catch (MalformedURLException e) {
             System.out.println(">>> Skipping unsupported URL " + proto);
+            return; // skip testing this protocol
         }
 
         server.start();
@@ -101,10 +104,10 @@ public class DeadLockTest {
             // which should be closed by the server.
             conn.getDefaultDomain();
 
-            // allow the listner to have time to work
+            // allow the listener to have time to work
             Thread.sleep(100);
 
-            // get a closed notif, should no block.
+            // get a closed notif, should not block.
             client.close();
             Thread.sleep(100);
 


### PR DESCRIPTION
Test update: fail when it hits an Exception.

This test still references jmxmp and iiop, which are of course redundant, there are various tests that still do this.
I am working on http, so we may revisit these tests in future to change their list of protocols.

For now, I'd like to simply make this test fail if any of the protocols it tests have failures.
Fix a few typos while we are here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343378](https://bugs.openjdk.org/browse/JDK-8343378): Exceptions in javax/management DeadLockTest.java do not cause test failure (**Bug** - P4)


### Reviewers
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21804/head:pull/21804` \
`$ git checkout pull/21804`

Update a local copy of the PR: \
`$ git checkout pull/21804` \
`$ git pull https://git.openjdk.org/jdk.git pull/21804/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21804`

View PR using the GUI difftool: \
`$ git pr show -t 21804`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21804.diff">https://git.openjdk.org/jdk/pull/21804.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21804#issuecomment-2449711101)
</details>
