### PR TITLE
8343380: C2: assert(iff->in(1)->is_OpaqueNotNull()) failed: must be OpaqueNotNull

### DIFF
--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -574,14 +574,13 @@ bool ConnectionGraph::can_reduce_check_users(Node* n, uint nesting) const {
         // CmpP/N used by the If controlling the cast.
         if (use->in(0)->is_IfTrue() || use->in(0)->is_IfFalse()) {
           Node* iff = use->in(0)->in(0);
-          // We may have an OpaqueNotNull node between If and Bool nodes. Bail out in such case.
+          // We may have an OpaqueNotNull node between If and Bool nodes. But we could also have a sub class of IfNode,
+          // for example, an OuterStripMinedLoopEnd or a Parse Predicate. Bail out in all these cases.
           bool can_reduce = (iff->Opcode() == Op_If) && iff->in(1)->is_Bool() && iff->in(1)->in(1)->is_Cmp();
           if (can_reduce) {
             Node* iff_cmp = iff->in(1)->in(1);
             int opc = iff_cmp->Opcode();
             can_reduce = (opc == Op_CmpP || opc == Op_CmpN) && can_reduce_cmp(n, iff_cmp);
-          } else {
-            assert(iff->in(1)->is_OpaqueNotNull(), "must be OpaqueNotNull");
           }
           if (!can_reduce) {
 #ifndef PRODUCT

--- a/test/hotspot/jtreg/compiler/escapeAnalysis/TestCanReduceCheckUsersDifferentIfs.java
+++ b/test/hotspot/jtreg/compiler/escapeAnalysis/TestCanReduceCheckUsersDifferentIfs.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8343380
+ * @summary Test that can_reduce_check_users() can handle different If nodes and that we bail out properly if it's not
+ *          an actual IfNode.
+ * @run main/othervm -XX:CompileCommand=compileonly,compiler.escapeAnalysis.TestCanReduceCheckUsersDifferentIfs::test*
+ *                   -Xcomp compiler.escapeAnalysis.TestCanReduceCheckUsersDifferentIfs
+ */
+
+package compiler.escapeAnalysis;
+
+public class TestCanReduceCheckUsersDifferentIfs {
+    static int iFld, iFld2;
+    static boolean flag;
+
+    public static void main(String[] args) {
+        // Make sure classes are loaded.
+        new B();
+        new C();
+        testParsePredicate();
+        testOuterStripMinedLoopEnd();
+    }
+
+    static void testOuterStripMinedLoopEnd() {
+        // (1) phi1 for a: phi(CheckCastPP(B), CheckCastPP(c)) with type A:NotNull
+        A a = flag ? new B() : new C();
+
+        // (4) Loop removed in PhaseIdealLoop before EA and we know that x == 77.
+        int x = 77;
+        int y = 0;
+        do {
+            x--;
+            y++;
+        } while (x > 0);
+
+        // (L)
+        for (int i = 0; i < 100; i++) {
+            iFld += 34;
+        }
+        // (6) CastPP(phi1) ends up at IfFalse of OuterStripMinedLoopEnd of loop (L).
+        // (7) EA tries to reduce phi1(CheckCastPP(B), CheckCastPP(c)) and looks at
+        //     OuterStripMinedLoopEnd and asserts that if it's not an IfNode that it has
+        //     an OpaqueNotNull which obviously is not the case and the assert fails.
+
+        // (5) Found to be false after PhaseIdealLoop before EA and is folded away.
+        if (y == 76) {
+            a = (B) a; // (2) a = CheckCastPP(phi1)
+        }
+        // (3) phi2 for a: phi(if, else) = phi(CheckCastPP(phi1), phi1)
+        //     phi(CheckCastPP(phi1), phi1) is replaced in PhiNode::Ideal with a CastPP:
+        //     a = CastPP(phi1) with type A:NotNull
+        iFld2 = a.iFld;
+    }
+
+    // Same as testOuterStripMinedLoopEnd() but we find in (7) a ParsePredicate from the
+    // removed loop (L) which also does not have an OpaqueNotNull and the assert fails.
+    static void testParsePredicate() {
+        A a = flag ? new B() : new C();
+
+        int x = 77;
+        int y = 0;
+        // (L)
+        do {
+            x--;
+            y++;
+        } while (x > 0);
+
+        if (y == 76) {
+            a = (B) a;
+        }
+        iFld2 = a.iFld;
+    }
+}
+
+class A {
+    int iFld;
+}
+
+class B extends A {
+}
+
+class C extends A {
+}


### PR DESCRIPTION
The assert added in [JDK-8342043](https://bugs.openjdk.org/browse/JDK-8342043) turns out to be too strong as shown with the test cases. I was unsure about that in the first place when I added it here:

https://github.com/openjdk/jdk/pull/21608#discussion_r1808732859

The assert was more of a best guess and just an additional guarantee that does not provide any benefit. I've found two cases where we have once an `OuterStripMinedLoopEnd` node and once a `ParsePredicate` in `ConnectionGraph::can_reduce_check_users()` which trigger the assert. How we end up with such a graph is explained in the comments at the test cases. 

I don't think it's worth to tweak the assert as we simply bail out afterwards anyway. I therefore propose to simply get rid of the assert again.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343380](https://bugs.openjdk.org/browse/JDK-8343380): C2: assert(iff-&gt;in(1)-&gt;is_OpaqueNotNull()) failed: must be OpaqueNotNull (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21805/head:pull/21805` \
`$ git checkout pull/21805`

Update a local copy of the PR: \
`$ git checkout pull/21805` \
`$ git pull https://git.openjdk.org/jdk.git pull/21805/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21805`

View PR using the GUI difftool: \
`$ git pr show -t 21805`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21805.diff">https://git.openjdk.org/jdk/pull/21805.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21805#issuecomment-2449737726)
</details>
