### PR TITLE
8343321: Bad verify in LockStack::oops_do()

### DIFF
--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -216,7 +216,6 @@ inline bool LockStack::contains(oop o) const {
 }
 
 inline void LockStack::oops_do(OopClosure* cl) {
-  verify("pre-oops-do");
   int end = to_index(_top);
   for (int i = 0; i < end; i++) {
     cl->do_oop(&_base[i]);

--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -216,6 +216,9 @@ inline bool LockStack::contains(oop o) const {
 }
 
 inline void LockStack::oops_do(OopClosure* cl) {
+  // We dont perform pre oops_do verify here because this function
+  // is used by the GC to fix the oops.
+
   int end = to_index(_top);
   for (int i = 0; i < end; i++) {
     cl->do_oop(&_base[i]);

--- a/src/hotspot/share/runtime/lockStack.inline.hpp
+++ b/src/hotspot/share/runtime/lockStack.inline.hpp
@@ -216,7 +216,7 @@ inline bool LockStack::contains(oop o) const {
 }
 
 inline void LockStack::oops_do(OopClosure* cl) {
-  // We dont perform pre oops_do verify here because this function
+  // We don't perform pre oops_do verify here because this function
   // is used by the GC to fix the oops.
 
   int end = to_index(_top);


### PR DESCRIPTION
Hello,

Verifying the lock stack's consistency before calling do_oop on the content in the lock stack is unnecessary and may result in a crash. The call to do_oop will (potentially) only change oops already stored in the lock stack, not add or remove anything. If two (or more) oops were equal before doing do_oop on all oops, they will still be the equivalent after the operation. Hence, the consistensy check only needs to happen once, either before or after do_oops, and doing it before might crash, so I propose we remove it.

See exact crash details in the linked issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343321](https://bugs.openjdk.org/browse/JDK-8343321): Bad verify in LockStack::oops_do() (**Bug** - P3)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**) Review applies to [9b299ef0](https://git.openjdk.org/jdk/pull/21806/files/9b299ef053b8a88ea3a0dc23bfe4a952203d7384)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) Review applies to [9b299ef0](https://git.openjdk.org/jdk/pull/21806/files/9b299ef053b8a88ea3a0dc23bfe4a952203d7384)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21806/head:pull/21806` \
`$ git checkout pull/21806`

Update a local copy of the PR: \
`$ git checkout pull/21806` \
`$ git pull https://git.openjdk.org/jdk.git pull/21806/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21806`

View PR using the GUI difftool: \
`$ git pr show -t 21806`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21806.diff">https://git.openjdk.org/jdk/pull/21806.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21806#issuecomment-2449775622)
</details>
