### PR TITLE
8343394: Make MemorySessionImpl.state a stable field

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/GlobalSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/GlobalSession.java
@@ -42,17 +42,13 @@ non-sealed class GlobalSession extends MemorySessionImpl {
 
     public GlobalSession() {
         super(null, null);
+        this.state = NONCLOSEABLE;
     }
 
     @Override
     @ForceInline
     public void release0() {
         // do nothing
-    }
-
-    @Override
-    public boolean isCloseable() {
-        return false;
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/ImplicitSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ImplicitSession.java
@@ -42,6 +42,7 @@ final class ImplicitSession extends SharedSession {
 
     public ImplicitSession(Cleaner cleaner) {
         super();
+        this.state = NONCLOSEABLE;
         cleaner.register(this, resourceList);
     }
 
@@ -53,11 +54,6 @@ final class ImplicitSession extends SharedSession {
     @Override
     public void acquire0() {
         // do nothing
-    }
-
-    @Override
-    public boolean isCloseable() {
-        return false;
     }
 
     @Override

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -56,6 +56,13 @@ import jdk.internal.vm.annotation.Stable;
 public abstract sealed class MemorySessionImpl
         implements Scope
         permits ConfinedSession, GlobalSession, SharedSession {
+
+    /**
+     * The value of the {@code state} of a {@code MemorySessionImpl}. The only possible transition
+     * is OPEN -> CLOSED. As a result, the states CLOSED and UNCLOSEABLE are stable. This allows us
+     * to annotate {@code state} with {@link Stable} and elide liveness check on non-closeable
+     * constant scopes, such as {@code GLOBAL_SESSION}.
+     */
     static final int OPEN = 0;
     static final int CLOSED = -1;
     static final int NONCLOSEABLE = 1;

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -67,6 +67,7 @@ public abstract sealed class MemorySessionImpl
     static final int CLOSED = -1;
     static final int NONCLOSEABLE = 1;
 
+    static final VarHandle STATE = MhUtil.findVarHandle(MethodHandles.lookup(), "state", int.class);
     static final VarHandle ACQUIRE_COUNT = MhUtil.findVarHandle(MethodHandles.lookup(), "acquireCount", int.class);
 
     static final int MAX_FORKS = Integer.MAX_VALUE;

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -59,8 +59,8 @@ public abstract sealed class MemorySessionImpl
 
     /**
      * The value of the {@code state} of a {@code MemorySessionImpl}. The only possible transition
-     * is OPEN -> CLOSED. As a result, the states CLOSED and UNCLOSEABLE are stable. This allows us
-     * to annotate {@code state} with {@link Stable} and elide liveness check on non-closeable
+     * is OPEN -> CLOSED. As a result, the states CLOSED and NONCLOSEABLE are stable. This allows
+     * us to annotate {@code state} with {@link Stable} and elide liveness check on non-closeable
      * constant scopes, such as {@code GLOBAL_SESSION}.
      */
     static final int OPEN = 0;

--- a/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
@@ -87,7 +87,7 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
             throw alreadyAcquired(acquireCount);
         }
 
-        STATE.setOpaque(this, CLOSED);
+        STATE.setVolatile(this, CLOSED);
         SCOPED_MEMORY_ACCESS.closeScope(this, ALREADY_CLOSED);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SharedSession.java
@@ -44,6 +44,8 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
 
     private static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
+    private static final int CLOSED_ACQUIRE_COUNT = -1;
+
     SharedSession() {
         super(null, new SharedResourceList());
     }
@@ -53,15 +55,15 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
     public void acquire0() {
         int value;
         do {
-            value = (int) STATE.getVolatile(this);
-            if (value < OPEN) {
+            value = (int) ACQUIRE_COUNT.getVolatile(this);
+            if (value < 0) {
                 //segment is not open!
                 throw alreadyClosed();
             } else if (value == MAX_FORKS) {
                 //overflow
                 throw tooManyAcquires();
             }
-        } while (!STATE.compareAndSet(this, value, value + 1));
+        } while (!ACQUIRE_COUNT.compareAndSet(this, value, value + 1));
     }
 
     @Override
@@ -69,21 +71,23 @@ sealed class SharedSession extends MemorySessionImpl permits ImplicitSession {
     public void release0() {
         int value;
         do {
-            value = (int) STATE.getVolatile(this);
-            if (value <= OPEN) {
+            value = (int) ACQUIRE_COUNT.getVolatile(this);
+            if (value <= 0) {
                 //cannot get here - we can't close segment twice
                 throw alreadyClosed();
             }
-        } while (!STATE.compareAndSet(this, value, value - 1));
+        } while (!ACQUIRE_COUNT.compareAndSet(this, value, value - 1));
     }
 
     void justClose() {
-        int prevState = (int) STATE.compareAndExchange(this, OPEN, CLOSED);
-        if (prevState < 0) {
+        int acquireCount = (int) ACQUIRE_COUNT.compareAndExchange(this, 0, CLOSED_ACQUIRE_COUNT);
+        if (acquireCount < 0) {
             throw alreadyClosed();
-        } else if (prevState != OPEN) {
-            throw alreadyAcquired(prevState);
+        } else if (acquireCount > 0) {
+            throw alreadyAcquired(acquireCount);
         }
+
+        state = CLOSED;
         SCOPED_MEMORY_ACCESS.closeScope(this, ALREADY_CLOSED);
     }
 

--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -28,12 +28,6 @@
  */
 
 import java.lang.foreign.Arena;
-
-import jdk.internal.foreign.MemorySessionImpl;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-import static org.testng.Assert.*;
-
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +35,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 import java.util.stream.IntStream;
+import jdk.internal.foreign.MemorySessionImpl;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 public class TestMemorySession {
 
@@ -317,6 +316,70 @@ public class TestMemorySession {
         Thread otherThread = new Thread();
         boolean isCloseableByOther = sessionImpl.isCloseable() && !"ConfinedSession".equals(sessionImpl.getClass().getSimpleName());
         assertEquals(sessionImpl.isCloseableBy(otherThread), isCloseableByOther);
+    }
+
+    /**
+     * Test that a thread failing to acquire a scope will not observe it as alive afterwards.
+     */
+    @Test
+    public void testAcquireCloseRace() throws InterruptedException {
+        int iteration = 1000;
+        AtomicInteger lock = new AtomicInteger();
+        boolean[] result = new boolean[1];
+        lock.set(-2);
+        MemorySessionImpl[] scopes = new MemorySessionImpl[iteration];
+        for (int i = 0; i < iteration; i++) {
+            scopes[i] = MemorySessionImpl.toMemorySession(Arena.ofShared());
+        }
+
+        // This thread tries to close the scopes
+        Thread t1 = new Thread(() -> {
+            for (int i = 0; i < iteration; i++) {
+                MemorySessionImpl scope = scopes[i];
+                while (true) {
+                    try {
+                        scope.close();
+                        break;
+                    } catch (IllegalStateException e) {}
+                }
+                // Keep the 2 threads operating on the same scope
+                int k = lock.getAndAdd(1) + 1;
+                while (k != i * 2) {
+                    Thread.onSpinWait();
+                    k = lock.get();
+                }
+            }
+        });
+
+        // This thread tries to acquire the scopes, then check if it is alive after an acquire failure
+        Thread t2 = new Thread(() -> {
+            for (int i = 0; i < iteration; i++) {
+                MemorySessionImpl scope = scopes[i];
+                while (true) {
+                    try {
+                        scope.acquire0();
+                    } catch (IllegalStateException e) {
+                        if (scope.isAlive()) {
+                            result[0] = true;
+                        }
+                        break;
+                    }
+                    scope.release0();
+                }
+                // Keep the 2 threads operating on the same scope
+                int k = lock.getAndAdd(1) + 1;
+                while (k != i * 2) {
+                    Thread.onSpinWait();
+                    k = lock.get();
+                }
+            }
+        });
+
+        t1.start();
+        t2.start();
+        t1.join();
+        t2.join();
+        assertFalse(result[0]);
     }
 
     private void waitSomeTime() {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverRandom.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverRandom.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.bench.java.lang.foreign;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.TearDown;
+import sun.misc.Unsafe;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(org.openjdk.jmh.annotations.Scope.Thread)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
+public class LoopOverRandom extends JavaLayouts {
+
+    static final int ELEM_SIZE = 1_000;
+    static final long ALLOC_SIZE = ELEM_SIZE * ValueLayout.JAVA_INT.byteSize();
+
+    static final Unsafe unsafe = Utils.unsafe;
+
+    Arena arena;
+    MemorySegment segment;
+    int[] indices;
+
+    static final MemorySegment ALL = MemorySegment.NULL.reinterpret(Long.MAX_VALUE);
+
+    @Setup
+    public void setup() {
+        indices = new Random().ints(0, ELEM_SIZE).limit(ELEM_SIZE).toArray();
+        arena = Arena.ofConfined();
+        segment = arena.allocate(ALLOC_SIZE);
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            segment.setAtIndex(ValueLayout.JAVA_INT, i, i);
+        }
+    }
+
+    @TearDown
+    public void tearDown() {
+        arena.close();
+    }
+
+    @Benchmark
+    public long segment_loop() {
+        int sum = 0;
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            sum += segment.getAtIndex(ValueLayout.JAVA_INT_UNALIGNED, indices[i]);
+            target_dontInline();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long segment_loop_all() {
+        int sum = 0;
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            sum += ALL.get(ValueLayout.JAVA_INT_UNALIGNED, ValueLayout.JAVA_INT.scale(segment.address(), indices[i]));
+            target_dontInline();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long segment_loop_asUnchecked() {
+        int sum = 0;
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            sum += asUnchecked(segment).getAtIndex(ValueLayout.JAVA_INT_UNALIGNED, indices[i]);
+            target_dontInline();
+        }
+        return sum;
+    }
+
+    @Benchmark
+    public long unsafe_loop() {
+        int sum = 0;
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            sum += unsafe.getInt(ValueLayout.JAVA_INT.scale(segment.address(), indices[i]));
+            target_dontInline();
+        }
+        return sum;
+    }
+
+    MemorySegment asUnchecked(MemorySegment segment) {
+        return MemorySegment.ofAddress(segment.address()).reinterpret(Long.MAX_VALUE);
+    }
+
+    @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+    public void target_dontInline() {
+        // this method was intentionally left blank
+    }
+}

--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverRandom.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverRandom.java
@@ -47,6 +47,7 @@ import sun.misc.Unsafe;
 @OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Fork(value = 3, jvmArgsAppend = { "--enable-native-access=ALL-UNNAMED" })
 public class LoopOverRandom extends JavaLayouts {
+    static final int SEED = 0;
 
     static final long ELEM_SIZE = ValueLayout.JAVA_INT.byteSize();
     static final int ELEM_COUNT = 1_000;
@@ -62,7 +63,7 @@ public class LoopOverRandom extends JavaLayouts {
 
     @Setup
     public void setup() {
-        indices = new Random().ints(0, ELEM_COUNT).limit(ELEM_COUNT).toArray();
+        indices = new Random(SEED).ints(0, ELEM_COUNT).limit(ELEM_COUNT).toArray();
         arena = Arena.ofConfined();
         segment = arena.allocate(ALLOC_SIZE);
         for (int i = 0; i < ELEM_COUNT; i++) {


### PR DESCRIPTION
Hi,

This patch makes `MemorySessionImpl.state` a `Stable` field so that liveness check of non-closeable scopes such as the global scope can be elided.

Currently, the `state` field is overloaded with 2 responsibilities, to act as a communication device between `close` and `checkValidState`, as well as a communication device between `close`, `acquire`, and `release`. This patch separates those concerns into `state` and `acquireCount`, allowing `state` to be marked as `@Stable`.

With the patch, in `MemorySegmentGetUnsafe`, `panama` is able to be on par with `unsafe`:

    Benchmark                      Mode  Cnt  Score   Error  Units
    MemorySegmentGetUnsafe.panama  avgt   30  0.340 ± 0.008  ns/op
    MemorySegmentGetUnsafe.unsafe  avgt   30  0.332 ± 0.004  ns/op

For reference this is the results without this patch:

    Benchmark                      Mode  Cnt  Score   Error  Units
    MemorySegmentGetUnsafe.panama  avgt   30  0.420 ± 0.019  ns/op
    MemorySegmentGetUnsafe.unsafe  avgt   30  0.329 ± 0.003  ns/op

Please kindly review, thanks very much.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8343394](https://bugs.openjdk.org/browse/JDK-8343394): Make MemorySessionImpl.state a stable field (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Contributors
 * Maurizio Cimadamore `<mcimadamore@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21810/head:pull/21810` \
`$ git checkout pull/21810`

Update a local copy of the PR: \
`$ git checkout pull/21810` \
`$ git pull https://git.openjdk.org/jdk.git pull/21810/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21810`

View PR using the GUI difftool: \
`$ git pr show -t 21810`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21810.diff">https://git.openjdk.org/jdk/pull/21810.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21810#issuecomment-2450238165)
</details>
