### PR TITLE
8341796: Fix ExceptionOccurred in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/linux/native/libsaproc/DwarfParser.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/DwarfParser.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2021, NTT DATA.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,7 +28,7 @@
 #include "dwarf.hpp"
 #include "libproc.h"
 
-#define CHECK_EXCEPTION if (env->ExceptionOccurred()) { return; }
+#define CHECK_EXCEPTION if (env->ExceptionCheck()) { return; }
 
 static jfieldID p_dwarf_context_ID = 0;
 static jint sa_RAX = -1;
@@ -102,7 +102,7 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_debugger_linux_amd64_DwarfParser_cr
   DwarfParser *parser = new DwarfParser(reinterpret_cast<lib_info *>(lib));
   if (!parser->is_parseable()) {
     jclass ex_cls = env->FindClass("sun/jvm/hotspot/debugger/DebuggerException");
-    if (!env->ExceptionOccurred()) {
+    if (!env->ExceptionCheck()) {
         env->ThrowNew(ex_cls, "DWARF not found");
     }
     delete parser;
@@ -147,7 +147,7 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_debugger_linux_amd64_DwarfParser_pro
   DwarfParser *parser = reinterpret_cast<DwarfParser *>(get_dwarf_context(env, this_obj));
   if (!parser->process_dwarf(pc)) {
     jclass ex_cls = env->FindClass("sun/jvm/hotspot/debugger/DebuggerException");
-    if (!env->ExceptionOccurred()) {
+    if (!env->ExceptionCheck()) {
         env->ThrowNew(ex_cls, "Could not find PC in DWARF");
     }
     return;

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -101,8 +101,8 @@ static jmethodID listAdd_ID = 0;
  */
 static char *saaltroot = NULL;
 
-#define CHECK_EXCEPTION_(value) if (env->ExceptionOccurred()) { return value; }
-#define CHECK_EXCEPTION if (env->ExceptionOccurred()) { return;}
+#define CHECK_EXCEPTION_(value) if (env->ExceptionCheck()) { return value; }
+#define CHECK_EXCEPTION if (env->ExceptionCheck()) { return;}
 #define THROW_NEW_DEBUGGER_EXCEPTION_(str, value) { throw_new_debugger_exception(env, str); return value; }
 #define THROW_NEW_DEBUGGER_EXCEPTION(str) { throw_new_debugger_exception(env, str); return;}
 

--- a/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
+++ b/src/jdk.hotspot.agent/linux/native/libsaproc/LinuxDebuggerLocal.cpp
@@ -70,7 +70,7 @@ class AutoJavaString {
   const char* m_buf;
 
 public:
-  // check env->ExceptionOccurred() after ctor
+  // check env->ExceptionCheck() after ctor
   AutoJavaString(JNIEnv* env, jstring str)
     : m_env(env), m_str(str), m_buf(str == NULL ? NULL : env->GetStringUTFChars(str, NULL)) {
   }

--- a/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
+++ b/src/jdk.hotspot.agent/macosx/native/libsaproc/MacosxDebuggerLocal.m
@@ -140,13 +140,13 @@ static task_t getTask(JNIEnv *env, jobject this_obj) {
   return (task_t)ptr;
 }
 
-#define CHECK_EXCEPTION_(value) if ((*env)->ExceptionOccurred(env)) { return value; }
-#define CHECK_EXCEPTION if ((*env)->ExceptionOccurred(env)) { return;}
+#define CHECK_EXCEPTION_(value) if ((*env)->ExceptionCheck(env)) { return value; }
+#define CHECK_EXCEPTION if ((*env)->ExceptionCheck(env)) { return;}
 #define THROW_NEW_DEBUGGER_EXCEPTION_(str, value) { throw_new_debugger_exception(env, str); return value; }
 #define THROW_NEW_DEBUGGER_EXCEPTION(str) { throw_new_debugger_exception(env, str); return;}
-#define CHECK_EXCEPTION_CLEAR if ((*env)->ExceptionOccurred(env)) { (*env)->ExceptionClear(env); }
-#define CHECK_EXCEPTION_CLEAR_VOID if ((*env)->ExceptionOccurred(env)) { (*env)->ExceptionClear(env); return; }
-#define CHECK_EXCEPTION_CLEAR_(value) if ((*env)->ExceptionOccurred(env)) { (*env)->ExceptionClear(env); return value; }
+#define CHECK_EXCEPTION_CLEAR if ((*env)->ExceptionCheck(env)) { (*env)->ExceptionClear(env); }
+#define CHECK_EXCEPTION_CLEAR_VOID if ((*env)->ExceptionCheck(env)) { (*env)->ExceptionClear(env); return; }
+#define CHECK_EXCEPTION_CLEAR_(value) if ((*env)->ExceptionCheck(env)) { (*env)->ExceptionClear(env); return value; }
 
 static void throw_new_debugger_exception(JNIEnv* env, const char* errMsg) {
   jclass exceptionClass = (*env)->FindClass(env, "sun/jvm/hotspot/debugger/DebuggerException");
@@ -238,7 +238,7 @@ jlong lookupByNameIncore(
     CHECK_EXCEPTION_(0);
   }
   symbolName_cstr = (*env)->GetStringUTFChars(env, symbolName, &isCopy);
-  if ((*env)->ExceptionOccurred(env)) {
+  if ((*env)->ExceptionCheck(env)) {
     if (objectName_cstr != NULL) {
       (*env)->ReleaseStringUTFChars(env, objectName, objectName_cstr);
     }
@@ -1136,7 +1136,7 @@ Java_sun_jvm_hotspot_debugger_bsd_BsdDebuggerLocal_attach0__Ljava_lang_String_2L
   execName_cstr = (*env)->GetStringUTFChars(env, execName, &isCopy);
   CHECK_EXCEPTION;
   coreName_cstr = (*env)->GetStringUTFChars(env, coreName, &isCopy);
-  if ((*env)->ExceptionOccurred(env)) {
+  if ((*env)->ExceptionCheck(env)) {
     (*env)->ReleaseStringUTFChars(env, execName, execName_cstr);
     return;
   }

--- a/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
@@ -85,7 +85,7 @@ JNIEXPORT jlong JNICALL Java_sun_jvm_hotspot_asm_Disassembler_load_1library(JNIE
 #endif
 
   libname = (*env)->GetStringUTFChars(env, libname_s, NULL);
-  if (libname == NULL || (*env)->ExceptionOccurred(env)) {
+  if (libname == NULL || (*env)->ExceptionCheck(env)) {
     return 0;
   }
 
@@ -139,13 +139,13 @@ static void* event_to_env(void* env_pv, const char* event, void* arg) {
   decode_env* denv = (decode_env*)env_pv;
   JNIEnv* env = denv->env;
   jstring event_string = (*env)->NewStringUTF(env, event);
-  if ((*env)->ExceptionOccurred(env)) {
+  if ((*env)->ExceptionCheck(env)) {
     return NULL;
   }
 
   result = (*env)->CallLongMethod(env, denv->dis, denv->handle_event, denv->visitor,
                                   event_string, (jlong) (uintptr_t)arg);
-  if ((*env)->ExceptionOccurred(env)) {
+  if ((*env)->ExceptionCheck(env)) {
     /* ignore exceptions for now */
     (*env)->ExceptionClear(env);
     return NULL;
@@ -176,11 +176,11 @@ static int printf_to_env(void* env_pv, const char* format, ...) {
   }
   if (raw != NULL) {
     jstring output = (*env)->NewStringUTF(env, raw);
-    if (!(*env)->ExceptionOccurred(env)) {
+    if (!(*env)->ExceptionCheck(env)) {
       /* make sure that UTF allocation doesn't cause OOM */
       (*env)->CallVoidMethod(env, denv->dis, denv->raw_print, denv->visitor, output);
     }
-    if ((*env)->ExceptionOccurred(env)) {
+    if ((*env)->ExceptionCheck(env)) {
       /* ignore exceptions for now */
         (*env)->ExceptionClear(env);
     }
@@ -191,12 +191,12 @@ static int printf_to_env(void* env_pv, const char* format, ...) {
   va_end(ap);
 
   output = (*env)->NewStringUTF(env, denv->buffer);
-  if (!(*env)->ExceptionOccurred(env)) {
+  if (!(*env)->ExceptionCheck(env)) {
     /* make sure that UTF allocation doesn't cause OOM */
     (*env)->CallVoidMethod(env, denv->dis, denv->raw_print, denv->visitor, output);
   }
 
-  if ((*env)->ExceptionOccurred(env)) {
+  if ((*env)->ExceptionCheck(env)) {
     /* ignore exceptions for now */
     (*env)->ExceptionClear(env);
   }
@@ -223,12 +223,12 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_asm_Disassembler_decode(JNIEnv * env
   decode_env denv;
 
   start = (*env)->GetByteArrayElements(env, code, NULL);
-  if ((*env)->ExceptionOccurred(env)) {
+  if ((*env)->ExceptionCheck(env)) {
     return;
   }
   end = start + (*env)->GetArrayLength(env, code);
   options = (*env)->GetStringUTFChars(env, options_s, NULL);
-  if ((*env)->ExceptionOccurred(env)) {
+  if ((*env)->ExceptionCheck(env)) {
     (*env)->ReleaseByteArrayElements(env, code, start, JNI_ABORT);
     return;
   }
@@ -241,7 +241,7 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_asm_Disassembler_decode(JNIEnv * env
   /* find Disassembler.handleEvent callback */
   denv.handle_event = (*env)->GetMethodID(env, disclass, "handleEvent",
                                           "(Lsun/jvm/hotspot/asm/InstructionVisitor;Ljava/lang/String;J)J");
-  if ((*env)->ExceptionOccurred(env)) {
+  if ((*env)->ExceptionCheck(env)) {
     (*env)->ReleaseByteArrayElements(env, code, start, JNI_ABORT);
     (*env)->ReleaseStringUTFChars(env, options_s, options);
     return;
@@ -250,7 +250,7 @@ JNIEXPORT void JNICALL Java_sun_jvm_hotspot_asm_Disassembler_decode(JNIEnv * env
   /* find Disassembler.rawPrint callback */
   denv.raw_print = (*env)->GetMethodID(env, disclass, "rawPrint",
                                        "(Lsun/jvm/hotspot/asm/InstructionVisitor;Ljava/lang/String;)V");
-  if ((*env)->ExceptionOccurred(env)) {
+  if ((*env)->ExceptionCheck(env)) {
     (*env)->ReleaseByteArrayElements(env, code, start, JNI_ABORT);
     (*env)->ReleaseStringUTFChars(env, options_s, options);
     return;

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -164,8 +164,8 @@ static jmethodID addThread_ID                   = 0;
 static jmethodID createClosestSymbol_ID         = 0;
 static jmethodID setThreadIntegerRegisterSet_ID = 0;
 
-#define CHECK_EXCEPTION_(value) if (env->ExceptionOccurred()) { return value; }
-#define CHECK_EXCEPTION if (env->ExceptionOccurred()) { return; }
+#define CHECK_EXCEPTION_(value) if (env->ExceptionCheck()) { return value; }
+#define CHECK_EXCEPTION if (env->ExceptionCheck()) { return; }
 
 #define THROW_NEW_DEBUGGER_EXCEPTION_(str, value) { \
                           throwNewDebuggerException(env, str); return value; }

--- a/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
+++ b/src/jdk.hotspot.agent/windows/native/libsaproc/sawindbg.cpp
@@ -99,7 +99,7 @@ class AutoJavaString {
   const char* m_buf;
 
 public:
-  // check env->ExceptionOccurred() after ctor
+  // check env->ExceptionCheck() after ctor
   AutoJavaString(JNIEnv* env, jstring str)
     : m_env(env), m_str(str), m_buf(str == nullptr ? nullptr : env->GetStringUTFChars(str, nullptr)) {
   }
@@ -122,7 +122,7 @@ class AutoJavaByteArray {
   jint releaseMode;
 
 public:
-  // check env->ExceptionOccurred() after ctor
+  // check env->ExceptionCheck() after ctor
   AutoJavaByteArray(JNIEnv* env, jbyteArray byteArray, jint releaseMode = JNI_ABORT)
     : env(env), byteArray(byteArray),
       bytePtr(env->GetByteArrayElements(byteArray, nullptr)),


### PR DESCRIPTION
Please review this PR which is a JNI cleanup to replace incorrect usages of `jthrowable ExceptionOccurred(JNIEnv *env)` with `jboolean ExceptionCheck(JNIEnv *env)` in _jdk.hotspot.agent_.

This is part of the bigger umbrella issue: https://bugs.openjdk.org/browse/JDK-8341542. This change only modifies instances where the exception object is not needed, and the method return value is being treated as if it were a boolean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341796](https://bugs.openjdk.org/browse/JDK-8341796): Fix ExceptionOccurred in jdk.hotspot.agent (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21813/head:pull/21813` \
`$ git checkout pull/21813`

Update a local copy of the PR: \
`$ git checkout pull/21813` \
`$ git pull https://git.openjdk.org/jdk.git pull/21813/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21813`

View PR using the GUI difftool: \
`$ git pr show -t 21813`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21813.diff">https://git.openjdk.org/jdk/pull/21813.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21813#issuecomment-2450709833)
</details>
