### PR TITLE
8341798: Fix ExceptionOccurred in jdk.jdwp.agent

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/ArrayReferenceImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/ArrayReferenceImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -215,7 +215,7 @@ writeObjectComponents(JNIEnv *env, PacketOutputStream *out,
 
         for (i = 0; i < length; i++) {
             component = JNI_FUNC_PTR(env,GetObjectArrayElement)(env, array, index + i);
-            if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+            if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
                 /* cleared by caller */
                 break;
             }
@@ -280,7 +280,7 @@ getValues(PacketInputStream *in, PacketOutputStream *out)
 
     } END_WITH_LOCAL_REFS(env);
 
-    if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+    if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
         outStream_setError(out, JDWP_ERROR(INTERNAL));
         JNI_FUNC_PTR(env,ExceptionClear)(env);
     }
@@ -470,7 +470,7 @@ readObjectComponents(JNIEnv *env, PacketInputStream *in,
         jobject object = inStream_readObjectRef(env, in);
 
         JNI_FUNC_PTR(env,SetObjectArrayElement)(env, array, index + i, object);
-        if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+        if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             /* caller will clear */
             break;
         }
@@ -529,7 +529,7 @@ setValues(PacketInputStream *in, PacketOutputStream *out)
         }
     } END_WITH_LOCAL_REFS(env);
 
-    if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+    if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
         /*
          * TO DO: Check exception type
          */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/ArrayTypeImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/ArrayTypeImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -124,7 +124,7 @@ writeNewObjectArray(JNIEnv *env, PacketOutputStream *out,
         } else {
 
             array = JNI_FUNC_PTR(env,NewObjectArray)(env, size, componentClass, 0);
-            if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+            if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
                 JNI_FUNC_PTR(env,ExceptionClear)(env);
                 array = NULL;
             }
@@ -188,7 +188,7 @@ writeNewPrimitiveArray(JNIEnv *env, PacketOutputStream *out,
                 break;
         }
 
-        if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+        if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             JNI_FUNC_PTR(env,ExceptionClear)(env);
             array = NULL;
         }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/ClassTypeImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/ClassTypeImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,7 +64,7 @@ readStaticFieldValue(JNIEnv *env, PacketInputStream *in, jclass clazz,
     if (isReferenceTag(typeKey)) {
         value.l = inStream_readObjectRef(env, in);
         JNI_FUNC_PTR(env,SetStaticObjectField)(env, clazz, field, value.l);
-        if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+        if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             return JDWP_ERROR(INTERNAL);
         }
         return JDWP_ERROR(NONE);
@@ -112,7 +112,7 @@ readStaticFieldValue(JNIEnv *env, PacketInputStream *in, jclass clazz,
             break;
     }
 
-    if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+    if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
         return JDWP_ERROR(INTERNAL);
     }
     return JDWP_ERROR(NONE);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/ObjectReferenceImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/ObjectReferenceImpl.c
@@ -76,7 +76,7 @@ readFieldValue(JNIEnv *env, PacketInputStream *in, jclass clazz,
     if (isReferenceTag(typeKey)) {
         value.l = inStream_readObjectRef(env, in);
         JNI_FUNC_PTR(env,SetObjectField)(env, object, field, value.l);
-        if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+        if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             return AGENT_ERROR_JNI_EXCEPTION;
         }
         return JVMTI_ERROR_NONE;
@@ -123,7 +123,7 @@ readFieldValue(JNIEnv *env, PacketInputStream *in, jclass clazz,
             break;
     }
 
-    if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+    if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
         return AGENT_ERROR_JNI_EXCEPTION;
     }
     return JVMTI_ERROR_NONE;

--- a/src/jdk.jdwp.agent/share/native/libjdwp/VirtualMachineImpl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/VirtualMachineImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -714,7 +714,7 @@ createString(PacketInputStream *in, PacketOutputStream *out)
         jstring string;
 
         string = JNI_FUNC_PTR(env,NewStringUTF)(env, cstring);
-        if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+        if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             outStream_setError(out, JDWP_ERROR(OUT_OF_MEMORY));
         } else {
             (void)outStream_writeObjectRef(env, out, string);

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHelper.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -890,7 +890,7 @@ saveEventInfoRefs(JNIEnv *env, EventInfo *evinfo)
             break;
     }
 
-    if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+    if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
         EXIT_ERROR(AGENT_ERROR_INVALID_EVENT_TYPE,"ExceptionOccurred");
     }
 }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -105,7 +105,7 @@ findClass(JNIEnv *env, const char * name)
         ERROR_MESSAGE(("JDWP Can't find class %s", name));
         EXIT_ERROR(AGENT_ERROR_NULL_POINTER,NULL);
     }
-    if ( JNI_FUNC_PTR(env,ExceptionOccurred)(env) ) {
+    if ( JNI_FUNC_PTR(env,ExceptionCheck)(env) ) {
         ERROR_MESSAGE(("JDWP Exception occurred finding class %s", name));
         EXIT_ERROR(AGENT_ERROR_NULL_POINTER,NULL);
     }
@@ -135,7 +135,7 @@ getMethod(JNIEnv *env, jclass clazz, const char * name, const char *signature)
                                 name, signature));
         EXIT_ERROR(AGENT_ERROR_NULL_POINTER,NULL);
     }
-    if ( JNI_FUNC_PTR(env,ExceptionOccurred)(env) ) {
+    if ( JNI_FUNC_PTR(env,ExceptionCheck)(env) ) {
         ERROR_MESSAGE(("JDWP Exception occurred finding method %s with signature %s",
                                 name, signature));
         EXIT_ERROR(AGENT_ERROR_NULL_POINTER,NULL);
@@ -166,7 +166,7 @@ getStaticMethod(JNIEnv *env, jclass clazz, const char * name, const char *signat
                                 name, signature));
         EXIT_ERROR(AGENT_ERROR_NULL_POINTER,NULL);
     }
-    if ( JNI_FUNC_PTR(env,ExceptionOccurred)(env) ) {
+    if ( JNI_FUNC_PTR(env,ExceptionCheck)(env) ) {
         ERROR_MESSAGE(("JDWP Exception occurred finding method %s with signature %s",
                                 name, signature));
         EXIT_ERROR(AGENT_ERROR_NULL_POINTER,NULL);
@@ -266,7 +266,7 @@ util_initialize(JNIEnv *env)
                                           (env, "jdk/internal/vm/VMSupport");
         if (localVMSupportClass == NULL) {
             gdata->agent_properties = NULL;
-            if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+            if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
                 JNI_FUNC_PTR(env,ExceptionClear)(env);
             }
         } else {
@@ -276,7 +276,7 @@ util_initialize(JNIEnv *env)
             localAgentProperties =
                 JNI_FUNC_PTR(env,CallStaticObjectMethod)
                             (env, localVMSupportClass, getAgentProperties);
-            if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+            if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
                 JNI_FUNC_PTR(env,ExceptionClear)(env);
                 EXIT_ERROR(AGENT_ERROR_INTERNAL,
                     "Exception occurred calling VMSupport.getAgentProperties");
@@ -855,7 +855,7 @@ spawnNewThread(jvmtiStartFunction func, void *arg, char *name)
         jstring nameString;
 
         nameString = JNI_FUNC_PTR(env,NewStringUTF)(env, name);
-        if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+        if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             JNI_FUNC_PTR(env,ExceptionClear)(env);
             error = AGENT_ERROR_OUT_OF_MEMORY;
             goto err;
@@ -864,7 +864,7 @@ spawnNewThread(jvmtiStartFunction func, void *arg, char *name)
         thread = JNI_FUNC_PTR(env,NewObject)
                         (env, gdata->threadClass, gdata->threadConstructor,
                                    gdata->systemThreadGroup, nameString);
-        if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+        if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             JNI_FUNC_PTR(env,ExceptionClear)(env);
             error = AGENT_ERROR_OUT_OF_MEMORY;
             goto err;
@@ -875,7 +875,7 @@ spawnNewThread(jvmtiStartFunction func, void *arg, char *name)
          */
         JNI_FUNC_PTR(env,CallVoidMethod)
                         (env, thread, gdata->threadSetDaemon, JNI_TRUE);
-        if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+        if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             JNI_FUNC_PTR(env,ExceptionClear)(env);
             error = AGENT_ERROR_JNI_EXCEPTION;
             goto err;
@@ -1593,14 +1593,14 @@ getPropertyValue(JNIEnv *env, char *propertyName)
 
     /* Create new String object to hold the property name */
     nameString = JNI_FUNC_PTR(env,NewStringUTF)(env, propertyName);
-    if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+    if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
         JNI_FUNC_PTR(env,ExceptionClear)(env);
         /* NULL will be returned below */
     } else {
         /* Call valueString = System.getProperty(nameString) */
         valueString = JNI_FUNC_PTR(env,CallStaticObjectMethod)
             (env, gdata->systemClass, gdata->systemGetProperty, nameString);
-        if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+        if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
             JNI_FUNC_PTR(env,ExceptionClear)(env);
             valueString = NULL;
         }
@@ -1647,7 +1647,7 @@ setAgentPropertyValue(JNIEnv *env, char *propertyName, char* propertyValue)
             }
         }
     }
-    if (JNI_FUNC_PTR(env,ExceptionOccurred)(env)) {
+    if (JNI_FUNC_PTR(env,ExceptionCheck)(env)) {
         JNI_FUNC_PTR(env,ExceptionClear)(env);
     }
 }


### PR DESCRIPTION
Please review this PR which is a JNI cleanup to replace incorrect usages of `jthrowable ExceptionOccurred(JNIEnv *env)` with `jboolean ExceptionCheck(JNIEnv *env)` in _jdk.jdwp.agent_.

This is part of the bigger umbrella issue: https://bugs.openjdk.org/browse/JDK-8341542. This change only modifies instances where the exception object is not needed, and the method return value is being treated as if it were a boolean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8341798](https://bugs.openjdk.org/browse/JDK-8341798): Fix ExceptionOccurred in jdk.jdwp.agent (**Sub-task** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21814/head:pull/21814` \
`$ git checkout pull/21814`

Update a local copy of the PR: \
`$ git checkout pull/21814` \
`$ git pull https://git.openjdk.org/jdk.git pull/21814/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21814`

View PR using the GUI difftool: \
`$ git pr show -t 21814`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21814.diff">https://git.openjdk.org/jdk/pull/21814.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21814#issuecomment-2450741853)
</details>
