### PR TITLE
8317542: Specjvm::xml have scalability issue for high vCPU numbers

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
@@ -2029,7 +2029,7 @@ public class RegularExpression implements java.io.Serializable {
 
         private void resetCommon(int nofclosures) {
             assert (inuse == true);
-            
+
             this.length = this.limit-this.start;
             this.match = null;
             if (this.closureContexts == null || this.closureContexts.length != nofclosures) {

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
@@ -710,11 +710,11 @@ public class RegularExpression implements java.io.Serializable {
             if (this.context == null)
                 this.context = new Context();
         }
-        Context con = null;
-        synchronized (this.context) {
-            con = this.context.inuse ? new Context() : this.context;
-            con.reset(target, start, end, this.numberOfClosures);
+        Context con = this.context;
+        if (!con.claim()) {
+            con = new Context();
         }
+        con.reset(target, start, end, this.numberOfClosures);
         if (match != null) {
             match.setNumberOfGroups(this.nofparen);
             match.setSource(target);
@@ -734,7 +734,7 @@ public class RegularExpression implements java.io.Serializable {
                     con.match.setBeginning(0, con.start);
                     con.match.setEnd(0, matchEnd);
                 }
-                con.setInUse(false);
+                con.release();
                 return true;
             }
             return false;
@@ -752,10 +752,10 @@ public class RegularExpression implements java.io.Serializable {
                     con.match.setBeginning(0, o);
                     con.match.setEnd(0, o+this.fixedString.length());
                 }
-                con.setInUse(false);
+                con.release();
                 return true;
             }
-            con.setInUse(false);
+            con.release();
             return false;
         }
 
@@ -768,7 +768,7 @@ public class RegularExpression implements java.io.Serializable {
             int o = this.fixedStringTable.matches(target, con.start, con.limit);
             if (o < 0) {
                 //System.err.println("Non-match in fixed-string search.");
-                con.setInUse(false);
+                con.release();
                 return false;
             }
         }
@@ -839,10 +839,10 @@ public class RegularExpression implements java.io.Serializable {
                 con.match.setBeginning(0, matchStart);
                 con.match.setEnd(0, matchEnd);
             }
-            con.setInUse(false);
+            con.release();
             return true;
         } else {
-            con.setInUse(false);
+            con.release();
             return false;
         }
     }
@@ -895,11 +895,11 @@ public class RegularExpression implements java.io.Serializable {
             if (this.context == null)
                 this.context = new Context();
         }
-        Context con = null;
-        synchronized (this.context) {
-            con = this.context.inuse ? new Context() : this.context;
-            con.reset(target, start, end, this.numberOfClosures);
+        Context con = this.context;
+        if (!con.claim()) {
+            con = new Context();
         }
+        con.reset(target, start, end, this.numberOfClosures);
         if (match != null) {
             match.setNumberOfGroups(this.nofparen);
             match.setSource(target);
@@ -925,7 +925,7 @@ public class RegularExpression implements java.io.Serializable {
                     con.match.setBeginning(0, con.start);
                     con.match.setEnd(0, matchEnd);
                 }
-                con.setInUse(false);
+                con.release();
                 return true;
             }
             return false;
@@ -943,10 +943,10 @@ public class RegularExpression implements java.io.Serializable {
                     con.match.setBeginning(0, o);
                     con.match.setEnd(0, o+this.fixedString.length());
                 }
-                con.setInUse(false);
+                con.release();
                 return true;
             }
-            con.setInUse(false);
+            con.release();
             return false;
         }
 
@@ -959,7 +959,7 @@ public class RegularExpression implements java.io.Serializable {
             int o = this.fixedStringTable.matches(target, con.start, con.limit);
             if (o < 0) {
                 //System.err.println("Non-match in fixed-string search.");
-                con.setInUse(false);
+                con.release();
                 return false;
             }
         }
@@ -1030,10 +1030,10 @@ public class RegularExpression implements java.io.Serializable {
                 con.match.setBeginning(0, matchStart);
                 con.match.setEnd(0, matchEnd);
             }
-            con.setInUse(false);
+            con.release();
             return true;
         } else {
-            con.setInUse(false);
+            con.release();
             return false;
         }
     }
@@ -1575,11 +1575,11 @@ public class RegularExpression implements java.io.Serializable {
             if (this.context == null)
                 this.context = new Context();
         }
-        Context con = null;
-        synchronized (this.context) {
-            con = this.context.inuse ? new Context() : this.context;
-            con.reset(target, start, end, this.numberOfClosures);
+        Context con = this.context;
+        if (!con.claim()) {
+            con = new Context();
         }
+        con.reset(target, start, end, this.numberOfClosures);
         if (match != null) {
             match.setNumberOfGroups(this.nofparen);
             match.setSource(target);
@@ -1599,7 +1599,7 @@ public class RegularExpression implements java.io.Serializable {
                     con.match.setBeginning(0, con.start);
                     con.match.setEnd(0, matchEnd);
                 }
-                con.setInUse(false);
+                con.release();
                 return true;
             }
             return false;
@@ -1617,10 +1617,10 @@ public class RegularExpression implements java.io.Serializable {
                     con.match.setBeginning(0, o);
                     con.match.setEnd(0, o+this.fixedString.length());
                 }
-                con.setInUse(false);
+                con.release();
                 return true;
             }
-            con.setInUse(false);
+            con.release();
             return false;
         }
 
@@ -1633,7 +1633,7 @@ public class RegularExpression implements java.io.Serializable {
             int o = this.fixedStringTable.matches(target, con.start, con.limit);
             if (o < 0) {
                 //System.err.println("Non-match in fixed-string search.");
-                con.setInUse(false);
+                con.release();
                 return false;
             }
         }
@@ -1704,10 +1704,10 @@ public class RegularExpression implements java.io.Serializable {
                 con.match.setBeginning(0, matchStart);
                 con.match.setEnd(0, matchEnd);
             }
-            con.setInUse(false);
+            con.release();
             return true;
         } else {
-            con.setInUse(false);
+            con.release();
             return false;
         }
     }
@@ -2015,7 +2015,7 @@ public class RegularExpression implements java.io.Serializable {
         int limit;
         int length;
         Match match;
-        boolean inuse = false;
+        private volatile boolean inuse = true;
         ClosureContext[] closureContexts;
 
         private StringTarget stringTarget;
@@ -2028,8 +2028,9 @@ public class RegularExpression implements java.io.Serializable {
         }
 
         private void resetCommon(int nofclosures) {
+            assert (inuse == true);
+            
             this.length = this.limit-this.start;
-            setInUse(true);
             this.match = null;
             if (this.closureContexts == null || this.closureContexts.length != nofclosures) {
                 this.closureContexts = new ClosureContext[nofclosures];
@@ -2082,9 +2083,27 @@ public class RegularExpression implements java.io.Serializable {
             this.limit = limit;
             this.resetCommon(nofclosures);
         }
-        synchronized void setInUse(boolean inUse) {
-            this.inuse = inUse;
+
+        boolean claim() {
+            if (inuse) {
+                return false;
+            }
+            synchronized (this) {
+                if (inuse) {
+                    return false;
+                } else {
+                    inuse = true;
+                    return true;
+                }
+            }
         }
+
+        void release() {
+            assert (inuse == true);
+            inuse = false;
+        }
+
+        boolean inUse() { return inuse; }
     }
 
     /**

--- a/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xerces/internal/impl/xpath/regex/RegularExpression.java
@@ -2016,7 +2016,7 @@ public class RegularExpression implements java.io.Serializable {
         int limit;
         int length;
         Match match;
-        private Semaphore inuse = new Semaphore(1, true);
+        private final Semaphore inuse = new Semaphore(1);
         ClosureContext[] closureContexts;
 
         private StringTarget stringTarget;


### PR DESCRIPTION
The synchronization block may be substituted by the 'volatile' variable smaller synchronization block.
It reduce the total blocking time for the specjvm2008::xml.validation workload and improve the reported score.
Scores for the 112vCPU on the with 28GB heap increased from 17915.83 to 22943.2.
Unit tests was not affected:
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jaxp                                     516   516     0     0
   jtreg:test/jdk/javax/xml                             70    70     0     0
==============================
TEST SUCCESS

The tier1 is OK too.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8317542](https://bugs.openjdk.org/browse/JDK-8317542): Specjvm::xml have scalability issue for high vCPU numbers (**Bug** - P3)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21815/head:pull/21815` \
`$ git checkout pull/21815`

Update a local copy of the PR: \
`$ git checkout pull/21815` \
`$ git pull https://git.openjdk.org/jdk.git pull/21815/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21815`

View PR using the GUI difftool: \
`$ git pr show -t 21815`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21815.diff">https://git.openjdk.org/jdk/pull/21815.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21815#issuecomment-2452748503)
</details>
