### PR TITLE
8343412: Missing escapes for single quote marks in javac.properties

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -148,7 +148,7 @@ javac.opt.maxerrs=\
 javac.opt.maxwarns=\
     Set the maximum number of warnings to print
 javac.opt.nogj=\
-    Don't accept generics in the language
+    Don''t accept generics in the language
 javac.opt.moreinfo=\
     Print extended information for type variables
 javac.opt.printsearch=\
@@ -178,7 +178,7 @@ javac.opt.arg.Xlint=\
     <key>(,<key>)*
 javac.opt.Xlint.custom=\
     Warnings to enable or disable, separated by comma.\n\
-    Precede a key by '-' to disable the specified warning.\n\
+    Precede a key by ''-'' to disable the specified warning.\n\
     Use --help-lint to see the supported keys.
 javac.opt.Xlint.desc.auxiliaryclass=\
     Warn about an auxiliary class that is hidden in a source file, and is used from other files.
@@ -313,9 +313,9 @@ javac.opt.Xdoclint.package.args = \
 
 javac.opt.Xdoclint.package.desc=\
     Enable or disable checks in specific packages. Each <package> is either\n\
-    the qualified name of a package or a package name prefix followed by '.*',\n\
+    the qualified name of a package or a package name prefix followed by ''.*'',\n\
     which expands to all sub-packages of the given package. Each <package>\n\
-    can be prefixed with '-' to disable checks for the specified package(s).
+    can be prefixed with ''-'' to disable checks for the specified package(s).
 
 javac.opt.Xstdout=\
     Redirect standard output
@@ -382,7 +382,7 @@ javac.opt.default.module.for.created.files=\
     Fallback target module for files created by annotation processors,\n\
     if none specified or inferred.
 javac.opt.lineDocComments=\
-    Disable support for documentation comments with lines beginning '///'
+    Disable support for documentation comments with lines beginning ''///''
 
 ## messages
 

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/resources/javac.properties
@@ -313,7 +313,7 @@ javac.opt.Xdoclint.package.args = \
 
 javac.opt.Xdoclint.package.desc=\
     Enable or disable checks in specific packages. Each <package> is either\n\
-    the qualified name of a package or a package name prefix followed by ''.*'',\n\
+    a qualified package name or a package name prefix followed by ''.*'',\n\
     which expands to all sub-packages of the given package. Each <package>\n\
     can be prefixed with ''-'' to disable checks for the specified package(s).
 

--- a/test/langtools/tools/javac/diags/CheckResourceKeys.java
+++ b/test/langtools/tools/javac/diags/CheckResourceKeys.java
@@ -524,7 +524,7 @@ public class CheckResourceKeys {
     List<ResourceBundle> getMessageFormatBundles() {
         Module jdk_compiler = ModuleLayer.boot().findModule("jdk.compiler").get();
         List<ResourceBundle> results = new ArrayList<>();
-        for (String name : new String[]{"compiler", "launcher"}) {
+        for (String name : new String[]{"javac", "compiler", "launcher"}) {
             ResourceBundle b =
                     ResourceBundle.getBundle("com.sun.tools.javac.resources." + name, jdk_compiler);
             results.add(b);


### PR DESCRIPTION
Please review these simple syntax fixes for `javac.properties`.

The source file `javac.properties` contains the English message bundle for the javac tool. Since the strings in this file are `MessageFormat` format strings, any single quotes must be escaped by doubling them.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343412](https://bugs.openjdk.org/browse/JDK-8343412): Missing escapes for single quote marks in javac.properties (**Bug** - P5)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21816/head:pull/21816` \
`$ git checkout pull/21816`

Update a local copy of the PR: \
`$ git checkout pull/21816` \
`$ git pull https://git.openjdk.org/jdk.git pull/21816/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21816`

View PR using the GUI difftool: \
`$ git pr show -t 21816`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21816.diff">https://git.openjdk.org/jdk/pull/21816.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21816#issuecomment-2450880238)
</details>
