### PR TITLE
8339128: Cannot resolve user specified tool properly after JDK-8338304

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -73,7 +73,9 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
     if test "x$OPENJDK_TARGET_OS" = xlinux; then
       # Clang needs the lld linker to work correctly
       BASIC_LDFLAGS="-fuse-ld=lld -Wl,--exclude-libs,ALL"
-      UTIL_REQUIRE_PROGS(LLD, lld)
+      if test "x$USE_USER_SUPPLIED_COMPILER" = xfalse; then
+        UTIL_REQUIRE_PROGS(LLD, lld)
+      fi
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then
       BASIC_LDFLAGS="-Wl,-b64 -Wl,-brtl -Wl,-bnorwexec -Wl,-bnolibpath -Wl,-bnoexpall \

--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -73,7 +73,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
     if test "x$OPENJDK_TARGET_OS" = xlinux; then
       # Clang needs the lld linker to work correctly
       BASIC_LDFLAGS="-fuse-ld=lld -Wl,--exclude-libs,ALL"
-      if test "x$USE_USER_SUPPLIED_COMPILER" = xfalse; then
+      if test "x$CXX_IS_USER_SUPPLIED" = xfalse && test "x$CC_IS_USER_SUPPLIED" = xfalse; then
         UTIL_REQUIRE_PROGS(LLD, lld)
       fi
     fi

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -445,7 +445,7 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
         AC_MSG_ERROR([User supplied compiler $1=[$]$1 does not exist])
       fi
     fi
-    USE_USER_SUPPLIED_COMPILER=true
+    $1_IS_USER_SUPPLIED=true
   else
     # No user supplied value. Locate compiler ourselves.
 
@@ -463,7 +463,7 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
       HELP_MSG_MISSING_DEPENDENCY([devkit])
       AC_MSG_ERROR([Could not find a $COMPILER_NAME compiler. $HELP_MSG])
     fi
-    USE_USER_SUPPLIED_COMPILER=false
+    $1_IS_USER_SUPPLIED=false
   fi
 
   # Now we have a compiler binary in $1. Make sure it's okay.

--- a/make/autoconf/toolchain.m4
+++ b/make/autoconf/toolchain.m4
@@ -445,6 +445,7 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
         AC_MSG_ERROR([User supplied compiler $1=[$]$1 does not exist])
       fi
     fi
+    USE_USER_SUPPLIED_COMPILER=true
   else
     # No user supplied value. Locate compiler ourselves.
 
@@ -462,6 +463,7 @@ AC_DEFUN([TOOLCHAIN_FIND_COMPILER],
       HELP_MSG_MISSING_DEPENDENCY([devkit])
       AC_MSG_ERROR([Could not find a $COMPILER_NAME compiler. $HELP_MSG])
     fi
+    USE_USER_SUPPLIED_COMPILER=false
   fi
 
   # Now we have a compiler binary in $1. Make sure it's okay.


### PR DESCRIPTION
Please review this PR that fixes JDK build configure failure when using clang after JDK-8338304:

```
Found candidate GCC installation: <snip>
Selected GCC installation: <snip>
...
clang: error: unsupported option '-V -static-libgcc'
configure:85215: $? = 1
configure:85204: <snip> -qversion >&5
clang: error: unknown argument '-qversion'; did you mean '--version'?
...
```

Tool from Clang GCC installation is being picked up unexpectedly (JDK build configured with `--with-toolchain-type=clang`). With this fix, it avoids `UTIL_REQUIRE_PROGS(LLD, lld)` if user supplies compiler toolchain. The user supplied compiler toolchain is used by setting `CXX=<user_specified_path_to_tools_script>` during configuration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339128](https://bugs.openjdk.org/browse/JDK-8339128): Cannot resolve user specified tool properly after JDK-8338304 (**Bug** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21817/head:pull/21817` \
`$ git checkout pull/21817`

Update a local copy of the PR: \
`$ git checkout pull/21817` \
`$ git pull https://git.openjdk.org/jdk.git pull/21817/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21817`

View PR using the GUI difftool: \
`$ git pr show -t 21817`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21817.diff">https://git.openjdk.org/jdk/pull/21817.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21817#issuecomment-2451052648)
</details>
