### PR TITLE
8343415: RISC-V: Increase maximum size of C2EntryBarrierStub by four

### DIFF
--- a/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
@@ -63,7 +63,7 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   // emits auipc + jalr for address inside code cache
   __ far_call(StubRoutines::method_entry_barrier());
 
-  // emits auipc + jr assumming continuation is not near
+  // emits auipc + jr assuming continuation is not near
   __ j(continuation());
 
   // make guard value 4-byte aligned so that it can be accessed atomically

--- a/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp
@@ -55,7 +55,7 @@ void C2SafepointPollStub::emit(C2_MacroAssembler& masm) {
 
 int C2EntryBarrierStub::max_size() const {
   // 4 bytes for alignment
-  return 3 * NativeInstruction::instruction_size + 4 + 4;
+  return 4 * NativeInstruction::instruction_size + 4 + 4;
 }
 
 void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
@@ -63,6 +63,7 @@ void C2EntryBarrierStub::emit(C2_MacroAssembler& masm) {
   // emits auipc + jalr for address inside code cache
   __ far_call(StubRoutines::method_entry_barrier());
 
+  // emits auipc + jr assumming continuation is not near
   __ j(continuation());
 
   // make guard value 4-byte aligned so that it can be accessed atomically


### PR DESCRIPTION
Hi, please consider this small change.

There is one jump to continuation (after nmethod entry barriers) in C2EntryBarrierStub [1].
The current max_size setting assumes the distance is within 1MB, which means a simple `jal` instruction [2].
So I just count one for this jump in [JDK-8343121](https://bugs.openjdk.org/browse/JDK-8343121). This doesn't seem to break for various tests. But I don't think there is a good reason for that assumption to stand. Instead, we should remove this constraint assuming a `auipc+jr` pair for this jump.

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/riscv/c2_CodeStubs_riscv.cpp#L66
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp#L965

Testing on linux-riscv64:
- [x] tier1 (fastdebug build)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343415](https://bugs.openjdk.org/browse/JDK-8343415): RISC-V: Increase maximum size of C2EntryBarrierStub by four (**Enhancement** - P4)


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer) Review applies to [b133d081](https://git.openjdk.org/jdk/pull/21818/files/b133d081d2c785c3cc08a36677934fc36f36afc8)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21818/head:pull/21818` \
`$ git checkout pull/21818`

Update a local copy of the PR: \
`$ git checkout pull/21818` \
`$ git pull https://git.openjdk.org/jdk.git pull/21818/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21818`

View PR using the GUI difftool: \
`$ git pr show -t 21818`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21818.diff">https://git.openjdk.org/jdk/pull/21818.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21818#issuecomment-2451182294)
</details>
