### PR TITLE
8343297: Vector unsigned min/max test are failing with -Xcomp

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -6564,10 +6564,10 @@ instruct vector_uminmaxq_reg(vec dst, vec a, vec b, vec xtmp1, vec xtmp2) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vector_uminmax_reg_masked(vec dst, vec src1, vec src2, kReg mask) %{
-  match(Set dst (UMinV (Binary src1 src2) mask));
-  match(Set dst (UMaxV (Binary src1 src2) mask));
-  format %{ "vector_uminmax_masked $dst, $src1, $src2, $mask\t! umin/max masked operation" %}
+instruct vector_uminmax_reg_masked(vec dst, vec src2, kReg mask) %{
+  match(Set dst (UMinV (Binary dst src2) mask));
+  match(Set dst (UMaxV (Binary dst src2) mask));
+  format %{ "vector_uminmax_masked $dst, $dst, $src2, $mask\t! umin/max masked operation" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
     BasicType bt = Matcher::vector_element_basic_type(this);
@@ -6578,16 +6578,16 @@ instruct vector_uminmax_reg_masked(vec dst, vec src1, vec src2, kReg mask) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct vector_uminmax_mem_masked(vec dst, vec src1, memory src2, kReg mask) %{
-  match(Set dst (UMinV (Binary src1 (LoadVector src2)) mask));
-  match(Set dst (UMaxV (Binary src1 (LoadVector src2)) mask));
+instruct vector_uminmax_mem_masked(vec dst, memory src2, kReg mask) %{
+  match(Set dst (UMinV (Binary dst (LoadVector src2)) mask));
+  match(Set dst (UMaxV (Binary dst (LoadVector src2)) mask));
   format %{ "vector_uminmax_masked $dst, $dst, $src2, $mask\t! umin/max masked operation" %}
   ins_encode %{
     int vlen_enc = vector_length_encoding(this);
     BasicType bt = Matcher::vector_element_basic_type(this);
     int opc = this->ideal_Opcode();
     __ evmasked_op(opc, bt, $mask$$KRegister, $dst$$XMMRegister,
-                   $src1$$XMMRegister, $src2$$Address, true, vlen_enc);
+                   $dst$$XMMRegister, $src2$$Address, true, vlen_enc);
   %}
   ins_pipe( pipe_slow );
 %}


### PR DESCRIPTION
This bugfix patch fixes the incorrect predicated UMinV/UMaxV pattern.
All existing VectorAPI jtreg regressions are now passing with -Xcomp.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343297](https://bugs.openjdk.org/browse/JDK-8343297): Vector unsigned min/max test are failing with -Xcomp (**Bug** - P3)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21819/head:pull/21819` \
`$ git checkout pull/21819`

Update a local copy of the PR: \
`$ git checkout pull/21819` \
`$ git pull https://git.openjdk.org/jdk.git pull/21819/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21819`

View PR using the GUI difftool: \
`$ git pr show -t 21819`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21819.diff">https://git.openjdk.org/jdk/pull/21819.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21819#issuecomment-2451242387)
</details>
