### PR TITLE
8343419: Assertion failure in long vector unsigned min/max with -XX:+UseKNLSetting

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2138,10 +2138,13 @@ bool Matcher::match_rule_supported_vector_masked(int opcode, int vlen, BasicType
     case Op_StoreVectorScatterMasked:
       return true;
 
-    case Op_MaxV:
-    case Op_MinV:
     case Op_UMinV:
     case Op_UMaxV:
+      if (size_in_bits < 512 && !VM_Version::supports_avx512vl()) {
+        return false;
+      } // fallthrough
+    case Op_MaxV:
+    case Op_MinV:
       if (is_subword_type(bt) && !VM_Version::supports_avx512bw()) {
         return false; // Implementation limitation
       }


### PR DESCRIPTION
KNL only supports AVX512F but not AVX512VL feature, thus vector operations with vector size less than or equal to 256 bits are generally emulated using AVX2 instructions.

This bugfix patch covers the following scenarios for LongVector unsigned min/ max over KNL targets:-
1.   Long species < 512 bits and non-predicated operation.
       - Operate at full vector width of 512 bits using VPMINUQ/VPMAXUQ instructions.
2.  Long species < 512 bits with memory operands and non-predicated operations.
       -  Load memory into exactly matching vector size.
       - Operate at full vector width of 512 bits
3.  Long species < 512 bits and predicated operation.
       - Emulate operation using AVX2 instructions 
       - Blend the result with the first source vector using the predication mask.
       - Existing opmask population mechanism expects the existence of AVX512BW/DQ features missing on KNL target.
4. Long species  == 512 bits,  both predicated and non-predicated operations.
    - Directly uses 512  bits VPMINUQ/VPMAXUQ instructions.

All existing jtreg regressions are passing with -XX:+UseKNLSetting and -Xcomp flags.

Kindly review.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343419](https://bugs.openjdk.org/browse/JDK-8343419): Assertion failure in long vector unsigned min/max with -XX:+UseKNLSetting (**Bug** - P4)


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.org/census#sviswanathan) (@sviswa7 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21821/head:pull/21821` \
`$ git checkout pull/21821`

Update a local copy of the PR: \
`$ git checkout pull/21821` \
`$ git pull https://git.openjdk.org/jdk.git pull/21821/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21821`

View PR using the GUI difftool: \
`$ git pr show -t 21821`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21821.diff">https://git.openjdk.org/jdk/pull/21821.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21821#issuecomment-2451774281)
</details>
