### PR TITLE
8344024: Unnecessary Hashtable usage in RSAPSSSignature.DIGEST_LENGTHS

### DIFF
--- a/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
+++ b/src/java.base/share/classes/sun/security/rsa/RSAPSSSignature.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import java.security.spec.MGF1ParameterSpec;
 import java.security.interfaces.*;
 
 import java.util.Arrays;
-import java.util.Hashtable;
+import java.util.Map;
 
 import sun.security.util.*;
 import sun.security.jca.JCAUtil;
@@ -81,21 +81,19 @@ public class RSAPSSSignature extends SignatureSpi {
 
     private static final byte[] EIGHT_BYTES_OF_ZEROS = new byte[8];
 
-    private static final Hashtable<KnownOIDs, Integer> DIGEST_LENGTHS =
-            new Hashtable<>();
-    static {
-        DIGEST_LENGTHS.put(KnownOIDs.SHA_1, 20);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA_224, 28);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA_256, 32);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA_384, 48);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA_512, 64);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA_512$224, 28);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA_512$256, 32);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA3_224, 28);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA3_256, 32);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA3_384, 48);
-        DIGEST_LENGTHS.put(KnownOIDs.SHA3_512, 64);
-    }
+    private static final Map<KnownOIDs, Integer> DIGEST_LENGTHS = Map.ofEntries(
+            Map.entry(KnownOIDs.SHA_1, 20),
+            Map.entry(KnownOIDs.SHA_224, 28),
+            Map.entry(KnownOIDs.SHA_256, 32),
+            Map.entry(KnownOIDs.SHA_384, 48),
+            Map.entry(KnownOIDs.SHA_512, 64),
+            Map.entry(KnownOIDs.SHA_512$224, 28),
+            Map.entry(KnownOIDs.SHA_512$256, 32),
+            Map.entry(KnownOIDs.SHA3_224, 28),
+            Map.entry(KnownOIDs.SHA3_256, 32),
+            Map.entry(KnownOIDs.SHA3_384, 48),
+            Map.entry(KnownOIDs.SHA3_512, 64)
+    );
 
     // message digest implementation we use for hashing the data
     private MessageDigest md;


### PR DESCRIPTION
The field `sun.security.rsa.RSAPSSSignature#DIGEST_LENGTHS` is modified only in `<clinit>`. It means we can use Immutable Map instead of Hashtable.
Hashtable is legacy synchronized class, which have `synchronized` on its `get` method. It's not needed in our case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344024](https://bugs.openjdk.org/browse/JDK-8344024): Unnecessary Hashtable usage in RSAPSSSignature.DIGEST_LENGTHS (**Enhancement** - P5)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21823/head:pull/21823` \
`$ git checkout pull/21823`

Update a local copy of the PR: \
`$ git checkout pull/21823` \
`$ git pull https://git.openjdk.org/jdk.git pull/21823/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21823`

View PR using the GUI difftool: \
`$ git pr show -t 21823`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21823.diff">https://git.openjdk.org/jdk/pull/21823.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21823#issuecomment-2470306092)
</details>
