### PR TITLE
8345398: Avoid redundant Properties.containsKey call in Cursor.getSystemCustomCursor

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Cursor.java
+++ b/src/java.desktop/share/classes/java/awt/Cursor.java
@@ -298,9 +298,9 @@ public class Cursor implements java.io.Serializable {
             loadSystemCustomCursorProperties();
 
             String prefix = CURSOR_DOT_PREFIX + name;
-            String key    = prefix + DOT_FILE_SUFFIX;
 
-            String fileName = systemCustomCursorProperties.getProperty(key);
+            String fileName =
+                systemCustomCursorProperties.getProperty(prefix + DOT_FILE_SUFFIX);
 
             if (fileName == null) {
                 if (log.isLoggable(PlatformLogger.Level.FINER)) {
@@ -309,7 +309,7 @@ public class Cursor implements java.io.Serializable {
                 return null;
             }
 
-            final String localized = systemCustomCursorProperties.getProperty(
+            String localized = systemCustomCursorProperties.getProperty(
                     prefix + DOT_NAME_SUFFIX, name);
 
             String hotspot = systemCustomCursorProperties.getProperty(prefix + DOT_HOTSPOT_SUFFIX);

--- a/src/java.desktop/share/classes/java/awt/Cursor.java
+++ b/src/java.desktop/share/classes/java/awt/Cursor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -300,15 +300,14 @@ public class Cursor implements java.io.Serializable {
             String prefix = CURSOR_DOT_PREFIX + name;
             String key    = prefix + DOT_FILE_SUFFIX;
 
-            if (!systemCustomCursorProperties.containsKey(key)) {
+            String fileName = systemCustomCursorProperties.getProperty(key);
+
+            if (fileName == null) {
                 if (log.isLoggable(PlatformLogger.Level.FINER)) {
                     log.finer("Cursor.getSystemCustomCursor(" + name + ") returned null");
                 }
                 return null;
             }
-
-            final String fileName =
-                systemCustomCursorProperties.getProperty(key);
 
             final String localized = systemCustomCursorProperties.getProperty(
                     prefix + DOT_NAME_SUFFIX, name);


### PR DESCRIPTION
`Properties` doesn't allow `null` values.
We can replace containsKey+getProperty with getProperty+null check.
It's clearer and a bit faster.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345398](https://bugs.openjdk.org/browse/JDK-8345398): Avoid redundant Properties.containsKey call in Cursor.getSystemCustomCursor (**Enhancement** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21824/head:pull/21824` \
`$ git checkout pull/21824`

Update a local copy of the PR: \
`$ git checkout pull/21824` \
`$ git pull https://git.openjdk.org/jdk.git pull/21824/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21824`

View PR using the GUI difftool: \
`$ git pr show -t 21824`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21824.diff">https://git.openjdk.org/jdk/pull/21824.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21824#issuecomment-2514831550)
</details>
