### PR TITLE
8345616: Unnecessary Hashtable usage in javax.swing.text.html.parser.Element

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Element.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Element.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
 
 package javax.swing.text.html.parser;
 
-import java.util.Hashtable;
+import java.io.Serializable;
 import java.util.BitSet;
-import java.io.*;
+import java.util.Map;
 import sun.awt.AppContext;
 
 /**
@@ -41,8 +41,7 @@ import sun.awt.AppContext;
  * @author Arthur van Hoff
  */
 @SuppressWarnings("serial") // Same-version serialization only
-public final
-class Element implements DTDConstants, Serializable {
+public final class Element implements DTDConstants, Serializable {
 
     /**
      * The element index
@@ -234,15 +233,12 @@ class Element implements DTDConstants, Serializable {
         return null;
     }
 
-
-    static Hashtable<String, Integer> contentTypes = new Hashtable<String, Integer>();
-
-    static {
-        contentTypes.put("CDATA", Integer.valueOf(CDATA));
-        contentTypes.put("RCDATA", Integer.valueOf(RCDATA));
-        contentTypes.put("EMPTY", Integer.valueOf(EMPTY));
-        contentTypes.put("ANY", Integer.valueOf(ANY));
-    }
+    private static final Map<String, Integer> contentTypes = Map.of(
+            "CDATA", CDATA,
+            "RCDATA", RCDATA,
+            "EMPTY", EMPTY,
+            "ANY", ANY
+    );
 
     /**
      * Converts {@code nm} to type. Returns appropriate DTDConstants
@@ -253,7 +249,6 @@ class Element implements DTDConstants, Serializable {
      * CDATA, RCDATA, EMPTY or ANY, 0 otherwise.
      */
     public static int name2type(String nm) {
-        Integer val = contentTypes.get(nm);
-        return (val != null) ? val.intValue() : 0;
+        return contentTypes.getOrDefault(nm, 0);
     }
 }


### PR DESCRIPTION
The Hashtable `javax.swing.text.html.parser.Element#contentTypes` is initialized only within `<clinit>` block.
We can replace it with immutable map to avoid Hashtable `synchronized` overhead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345616](https://bugs.openjdk.org/browse/JDK-8345616): Unnecessary Hashtable usage in javax.swing.text.html.parser.Element (**Enhancement** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21825/head:pull/21825` \
`$ git checkout pull/21825`

Update a local copy of the PR: \
`$ git checkout pull/21825` \
`$ git pull https://git.openjdk.org/jdk.git pull/21825/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21825`

View PR using the GUI difftool: \
`$ git pr show -t 21825`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21825.diff">https://git.openjdk.org/jdk/pull/21825.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21825#issuecomment-2521229185)
</details>
