### PR TITLE
8343433: Update net.properties and java.net.http module-info.java after 8326949

### DIFF
--- a/src/java.base/share/conf/net.properties
+++ b/src/java.base/share/conf/net.properties
@@ -104,9 +104,7 @@ jdk.http.auth.tunneling.disabledSchemes=Basic
 # to be used in real deployments. Protocol errors or other undefined behavior is likely
 # to occur when using them. The property is not set by default.
 # Note also, that there may be other headers that are restricted from being set
-# depending on the context. This includes the "Authorization" header when the
-# relevant HttpClient has an authenticator set. These restrictions cannot be
-# overridden by this property.
+# depending on the context. These restrictions cannot be overridden by this property.
 #
 # jdk.httpclient.allowRestrictedHeaders=host
 #

--- a/src/java.net.http/share/classes/module-info.java
+++ b/src/java.net.http/share/classes/module-info.java
@@ -45,9 +45,7 @@
  * and whitespace is ignored. Note that this property is intended for testing and not for
  * real-world deployments. Protocol errors or other undefined behavior are likely to occur
  * when using this property. There may be other headers that are restricted from being set
- * depending on the context. This includes the "Authorization" header when the relevant
- * HttpClient has an authenticator set. These restrictions cannot be overridden by this
- * property.
+ * depending on the context. These restrictions cannot be overridden by this property.
  * </li>
  * <li><p><b>{@systemProperty jdk.httpclient.bufsize}</b> (default: 16384 bytes or 16 kB)<br>
  * The size to use for internal allocated buffers in bytes.


### PR DESCRIPTION
This change makes two small doc changes that should have been included in the CSR for JDK-8326949.
The associated CSR is at: https://bugs.openjdk.org/browse/JDK-8343434

The change is just to remove one sentence from the description of the jdk.httpclient.allowRestrictedHeaders
in the net.properties conf file and the module-info for java.net.http.

Thanks,
Michael

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8343434](https://bugs.openjdk.org/browse/JDK-8343434) to be approved

### Issues
 * [JDK-8343433](https://bugs.openjdk.org/browse/JDK-8343433): Update net.properties and java.net.http module-info.java after 8326949 (**Bug** - P4)
 * [JDK-8343434](https://bugs.openjdk.org/browse/JDK-8343434): Update net.properties and java.net.http module-info.java after 8326949 (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21827/head:pull/21827` \
`$ git checkout pull/21827`

Update a local copy of the PR: \
`$ git checkout pull/21827` \
`$ git pull https://git.openjdk.org/jdk.git pull/21827/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21827`

View PR using the GUI difftool: \
`$ git pr show -t 21827`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21827.diff">https://git.openjdk.org/jdk/pull/21827.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21827#issuecomment-2451909260)
</details>
