### PR TITLE
8343436: Regression in StackMapGenerator after JDK-8339205

### DIFF
--- a/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
+++ b/src/java.base/share/classes/jdk/internal/classfile/impl/StackMapGenerator.java
@@ -1111,7 +1111,7 @@ public final class StackMapGenerator {
         Frame decStack1PushStack(Type type1, Type type2) {
             int stackSize = this.stackSize - 1;
             if (stackSize < 0) throw stackUnderflow();
-            checkStack(stackSize + 2);
+            checkStack(stackSize + 1);
             stack[stackSize    ] = type1;
             stack[stackSize + 1] = type2;
             this.stackSize = stackSize + 2;

--- a/test/jdk/jdk/classfile/StackMapsTest.java
+++ b/test/jdk/jdk/classfile/StackMapsTest.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @summary Testing Classfile stack maps generator.
- * @bug 8305990 8320222 8320618 8335475 8338623 8338661
+ * @bug 8305990 8320222 8320618 8335475 8338623 8338661 8343436
  * @build testdata.*
  * @run junit StackMapsTest
  */
@@ -344,8 +344,27 @@ class StackMapsTest {
         }
     }
 
+    @ParameterizedTest
+    @EnumSource(ClassFile.StackMapsOption.class)
+    void testI2LCounters(ClassFile.StackMapsOption option) {
+        var cf = ClassFile.of(option);
+        var bytes = cf.build(ClassDesc.of("Test"), clb -> clb
+            .withMethodBody("a", MTD_long_int, ACC_STATIC, cob ->
+                    cob.iload(0)
+                       .i2l()
+                       .lreturn()));
+
+        var cm = ClassFile.of().parse(bytes);
+        for (var method : cm.methods()) {
+            var code = (CodeAttribute) method.code().orElseThrow();
+            assertEquals(1, code.maxLocals());
+            assertEquals(2, code.maxStack());
+        }
+    }
+
     private static final MethodTypeDesc MTD_int = MethodTypeDesc.of(CD_int);
     private static final MethodTypeDesc MTD_int_String = MethodTypeDesc.of(CD_int, CD_String);
+    private static final MethodTypeDesc MTD_long_int = MethodTypeDesc.of(CD_long, CD_int);
 
     @ParameterizedTest
     @EnumSource(ClassFile.StackMapsOption.class)


### PR DESCRIPTION
This patch fixes regression in StackMapGenerator caused by JDK-8339205 + added test.

Please review.

Thanks,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343436](https://bugs.openjdk.org/browse/JDK-8343436): Regression in StackMapGenerator after JDK-8339205 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21828/head:pull/21828` \
`$ git checkout pull/21828`

Update a local copy of the PR: \
`$ git checkout pull/21828` \
`$ git pull https://git.openjdk.org/jdk.git pull/21828/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21828`

View PR using the GUI difftool: \
`$ git pr show -t 21828`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21828.diff">https://git.openjdk.org/jdk/pull/21828.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21828#issuecomment-2451914462)
</details>
