### PR TITLE
8339303: C2: dead node after failing to match cloned address expression

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2514,7 +2514,7 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
     // Cheap to find it by looking for screwy base.
     if (adr->is_AddP() &&
         !adr->in(AddPNode::Base)->is_top() &&
-        (!UseNewCode || !adr->in(AddPNode::Offset)->is_Con()) &&
+        !adr->in(AddPNode::Offset)->is_Con() &&
         LP64_ONLY( off->get_long() == (int) (off->get_long()) && ) // immL32
         // Are there other uses besides address expressions?
         !is_visited(adr)) {

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -2509,11 +2509,12 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
     address_visited.test_set(m->_idx); // Flag as address_visited
     Node *adr = m->in(AddPNode::Address);
 
-    // Intel can handle 2 adds in addressing mode
+    // Intel can handle 2 adds in addressing mode, with one of them using an immediate offset.
     // AtomicAdd is not an addressing expression.
     // Cheap to find it by looking for screwy base.
     if (adr->is_AddP() &&
         !adr->in(AddPNode::Base)->is_top() &&
+        (!UseNewCode || !adr->in(AddPNode::Offset)->is_Con()) &&
         LP64_ONLY( off->get_long() == (int) (off->get_long()) && ) // immL32
         // Are there other uses besides address expressions?
         !is_visited(adr)) {

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -180,8 +180,8 @@ void Matcher::verify_new_nodes_only(Node* xroot) {
         worklist.push(in);
       }
     }
-    for (uint j = 0; j < n->outcnt(); j++) {
-      worklist.push(n->raw_out(j));
+    for (DUIterator_Fast jmax, j = n->fast_outs(jmax); j < jmax; j++) {
+      worklist.push(n->fast_out(j));
     }
   }
 }

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -170,16 +170,18 @@ void Matcher::verify_new_nodes_only(Node* xroot) {
   worklist.push(xroot);
   while (worklist.size() > 0) {
     Node* n = worklist.pop();
-    visited.set(n->_idx);
+    if (visited.test_set(n->_idx)) {
+      continue;
+    }
     assert(C->node_arena()->contains(n), "dead node");
     for (uint j = 0; j < n->req(); j++) {
       Node* in = n->in(j);
       if (in != nullptr) {
-        assert(C->node_arena()->contains(in), "dead node");
-        if (!visited.test(in->_idx)) {
-          worklist.push(in);
-        }
+        worklist.push(in);
       }
+    }
+    for (uint j = 0; j < n->outcnt(); j++) {
+      worklist.push(n->raw_out(j));
     }
   }
 }

--- a/test/hotspot/jtreg/compiler/c2/TestMatcherTwoImmOffsets.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMatcherTwoImmOffsets.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8339303
+ * @summary Test that the matcher does not create dead nodes when matching
+ *          address expressions with two immediate offsets.
+ * @requires os.maxMemory > 4G
+ *
+ * @run main/othervm -Xmx4g -Xbatch -XX:-TieredCompilation
+ *      -XX:CompileOnly=compiler.c2.TestMatcherTwoImmOffsets::test
+ *      compiler.c2.TestMatcherTwoImmOffsets
+ */
+
+package compiler.c2;
+
+public class TestMatcherTwoImmOffsets {
+    static final int[] a1 = new int[10];
+    int[] a2;
+    static TestMatcherTwoImmOffsets o = new TestMatcherTwoImmOffsets();
+
+    public static void test() {
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 100; j++) {
+                int[][] nArray = new int[10][];
+                for (int k = 0; k < nArray.length; k++) {}
+            }
+            for (long j = 1L; j < 3L; j++) {
+                a1[(int) j]--;
+            }
+            o.a2 = a1;
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10; i++) {
+            test();
+        }
+    }
+}


### PR DESCRIPTION
This changeset prevents the x86 platform-specific logic from cloning address expressions consisting of two chained `AddP` nodes with a small constant offset each, such as in the following example:

![example](https://github.com/user-attachments/assets/86c143a1-3895-4e0c-936b-0d22b7c80e73)

Such patterns cannot be fully subsumed into x86 complex addressing modes, and cloning them can cause the matcher to introduce dead nodes that trigger a segmentation fault in the subsequent global code motion phase. See a detailed analysis of the failure in the [JBS issue description](https://bugs.openjdk.org/browse/JDK-8339303).

The changeset additionally extends the post-matching verification logic to check that no old node is reachable by travesing both node inputs and outputs. This extension would have caused the original test case to fail directly after matching with an informative assertion message rather than an opaque segmentation fault in an unrelated code generation phase.

Note that the pattern causing the failure should be in general optimized by `AddPNode::Ideal` into a single `AddP` node with the constant sum of the offsets. While [JDK-8343067](https://bugs.openjdk.org/browse/JDK-8343067) should address the missing optimization, this changeset proposes a complementary solution that is easily backportable and avoids relying on specific optimizations for correctness.

#### Testing

##### Functionality

- tier1-5 (linux-x64, windows-x64, macosx-x64, linux-aarch64, macosx-aarch64; release and debug mode).

##### Performance

- Tested performance on a set of standard benchmark suites (DaCapo, SPECjbb2015, SPECjvm2008). No significant change was observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339303](https://bugs.openjdk.org/browse/JDK-8339303): C2: dead node after failing to match cloned address expression (**Bug** - P2)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**) Review applies to [e85ba7cb](https://git.openjdk.org/jdk/pull/21829/files/e85ba7cbf919f6aa43a57a2a91793e70226ff24e)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21829/head:pull/21829` \
`$ git checkout pull/21829`

Update a local copy of the PR: \
`$ git checkout pull/21829` \
`$ git pull https://git.openjdk.org/jdk.git pull/21829/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21829`

View PR using the GUI difftool: \
`$ git pr show -t 21829`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21829.diff">https://git.openjdk.org/jdk/pull/21829.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21829#issuecomment-2454233961)
</details>
