### PR TITLE
8343437: ClassDesc.of incorrectly permitting empty names

### DIFF
--- a/src/java.base/share/classes/java/lang/constant/ClassDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/ClassDesc.java
@@ -120,7 +120,7 @@ public sealed interface ClassDesc
      * not in the correct format
      */
     static ClassDesc of(String packageName, String className) {
-        validateBinaryClassName(packageName);
+        validateBinaryPackageName(packageName);
         validateMemberName(className, false);
         if (packageName.isEmpty()) {
             return internalNameToDesc(className);

--- a/src/java.base/share/classes/java/lang/constant/PackageDesc.java
+++ b/src/java.base/share/classes/java/lang/constant/PackageDesc.java
@@ -55,7 +55,7 @@ public sealed interface PackageDesc
      * @see PackageDesc#ofInternalName(String)
      */
     static PackageDesc of(String name) {
-        ConstantUtils.validateBinaryPackageName(requireNonNull(name));
+        ConstantUtils.validateBinaryPackageName(name);
         return new PackageDescImpl(ConstantUtils.binaryToInternal(name));
     }
 
@@ -75,7 +75,7 @@ public sealed interface PackageDesc
      * @see PackageDesc#of(String)
      */
     static PackageDesc ofInternalName(String name) {
-        ConstantUtils.validateInternalPackageName(requireNonNull(name));
+        ConstantUtils.validateInternalPackageName(name);
         return new PackageDescImpl(name);
     }
 

--- a/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
@@ -183,12 +183,22 @@ public final class ConstantUtils {
      * @throws NullPointerException if class name is {@code null}
      */
     public static String validateBinaryClassName(String name) {
-        for (int i = 0; i < name.length(); i++) {
+        int afterSeparator = 0;
+        int len = name.length();
+        for (int i = 0; i < len; i++) {
             char ch = name.charAt(i);
-            if (ch == ';' || ch == '[' || ch == '/'
-                    || ch == '.' && (i == 0 || i + 1 == name.length() || name.charAt(i - 1) == '.'))
+            if (ch == ';' || ch == '[' || ch == '/')
                 throw invalidClassName(name);
+            if (ch == '.') {
+                if (i == afterSeparator) {
+                    throw invalidClassName(name);
+                } else {
+                    afterSeparator = i + 1;
+                }
+            }
         }
+        if (len == afterSeparator)
+            throw invalidClassName(name);
         return name;
     }
 
@@ -202,12 +212,22 @@ public final class ConstantUtils {
      * @throws NullPointerException if class name is {@code null}
      */
     public static String validateInternalClassName(String name) {
-        for (int i = 0; i < name.length(); i++) {
+        int afterSeparator = 0;
+        int len = name.length();
+        for (int i = 0; i < len; i++) {
             char ch = name.charAt(i);
-            if (ch == ';' || ch == '[' || ch == '.'
-                    || ch == '/' && (i == 0 || i + 1 == name.length() || name.charAt(i - 1) == '/'))
+            if (ch == ';' || ch == '[' || ch == '.')
                 throw invalidClassName(name);
+            if (ch == '/') {
+                if (i == afterSeparator) {
+                    throw invalidClassName(name);
+                } else {
+                    afterSeparator = i + 1;
+                }
+            }
         }
+        if (len == afterSeparator)
+            throw invalidClassName(name);
         return name;
     }
 
@@ -222,12 +242,10 @@ public final class ConstantUtils {
      * @throws NullPointerException if the package name is {@code null}
      */
     public static String validateBinaryPackageName(String name) {
-        for (int i = 0; i < name.length(); i++) {
-            char ch = name.charAt(i);
-            if (ch == ';' || ch == '[' || ch == '/')
-                throw new IllegalArgumentException("Invalid package name: " + name);
-        }
-        return name;
+        // Empty names are explicitly allowed
+        if (name.isEmpty())
+            return name;
+        return validateBinaryClassName(name);
     }
 
     /**
@@ -241,12 +259,10 @@ public final class ConstantUtils {
      * @throws NullPointerException if the package name is {@code null}
      */
     public static String validateInternalPackageName(String name) {
-        for (int i = 0; i < name.length(); i++) {
-            char ch = name.charAt(i);
-            if (ch == ';' || ch == '[' || ch == '.')
-                throw new IllegalArgumentException("Invalid package name: " + name);
-        }
-        return name;
+        // Empty names are explicitly allowed
+        if (name.isEmpty())
+            return name;
+        return validateInternalClassName(name);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ConstantUtils.java
@@ -174,24 +174,23 @@ public final class ConstantUtils {
     }
 
     /**
-     * Validates the correctness of a path-based name, which is a class or
-     * interface name or a package name.
+     * Validates the correctness of a class or interface name or a package name.
      * In particular checks for the presence of invalid characters,
-     * consecutive, leading, or trailing separator char,
-     * and the empty string for class or interface names.
+     * consecutive, leading, or trailing separator char, for both non-internal
+     * and internal forms, and the empty string for class or interface names.
      *
      * @param name the name
-     * @param usesSlash {@code true} means {@code /} is the separator char,
-     *     otherwise {@code .} is the separator char
-     * @param allowsEmpty {@code true} means the empty string is a valid name
+     * @param slashSeparator {@code true} means {@code /} is the separator char
+     *     (internal form); otherwise {@code .} is the separator char
+     * @param allowEmpty {@code true} means the empty string is a valid name
      * @return the name passed if valid
      * @throws IllegalArgumentException if the name is invalid
      * @throws NullPointerException if name is {@code null}
      */
-    private static String validatePathBasedName(String name, boolean usesSlash, boolean allowsEmpty) {
+    private static String validateClassOrPackageName(String name, boolean slashSeparator, boolean allowEmpty) {
         int len = name.length();  // implicit null check
         // empty name special rule
-        if (allowsEmpty && len == 0)
+        if (allowEmpty && len == 0)
             return name;
         // state variable for detection of illegal states of
         // empty name, consecutive, leading, or trailing separators
@@ -206,7 +205,7 @@ public final class ConstantUtils {
             if (foundSlash || ch == '.') {
                 // reject the other separator char
                 // reject consecutive or leading separators
-                if (foundSlash != usesSlash || i == afterSeparator)
+                if (foundSlash != slashSeparator || i == afterSeparator)
                     throw invalidClassName(name);
                 afterSeparator = i + 1;
             }
@@ -228,7 +227,7 @@ public final class ConstantUtils {
      * @throws NullPointerException if class name is {@code null}
      */
     public static String validateBinaryClassName(String name) {
-        return validatePathBasedName(name, false, false);
+        return validateClassOrPackageName(name, false, false);
     }
 
     /**
@@ -242,7 +241,7 @@ public final class ConstantUtils {
      * @throws NullPointerException if class name is {@code null}
      */
     public static String validateInternalClassName(String name) {
-        return validatePathBasedName(name, true, false);
+        return validateClassOrPackageName(name, true, false);
     }
 
     /**
@@ -256,7 +255,7 @@ public final class ConstantUtils {
      * @throws NullPointerException if the package name is {@code null}
      */
     public static String validateBinaryPackageName(String name) {
-        return validatePathBasedName(name, false, true);
+        return validateClassOrPackageName(name, false, true);
     }
 
     /**
@@ -270,7 +269,7 @@ public final class ConstantUtils {
      * @throws NullPointerException if the package name is {@code null}
      */
     public static String validateInternalPackageName(String name) {
-        return validatePathBasedName(name, true, true);
+        return validateClassOrPackageName(name, true, true);
     }
 
     /**

--- a/test/jdk/java/lang/constant/ClassDescTest.java
+++ b/test/jdk/java/lang/constant/ClassDescTest.java
@@ -279,7 +279,8 @@ public class ClassDescTest extends SymbolicDescTest {
     public void testBadClassDescs() {
         List<String> badDescriptors = List.of("II", "I;", "Q", "L", "",
                                               "java.lang.String", "[]", "Ljava/lang/String",
-                                              "Ljava.lang.String;", "java/lang/String");
+                                              "Ljava.lang.String;", "java/lang/String", "L;",
+                                              "La//b;", "L/a;", "La/;");
 
         for (String d : badDescriptors) {
             try {

--- a/test/jdk/java/lang/constant/ClassDescTest.java
+++ b/test/jdk/java/lang/constant/ClassDescTest.java
@@ -292,7 +292,7 @@ public class ClassDescTest extends SymbolicDescTest {
         }
 
         List<String> badBinaryNames = List.of("I;", "[]", "Ljava/lang/String",
-                "Ljava.lang.String;", "java/lang/String");
+                "Ljava.lang.String;", "java/lang/String", "");
         for (String d : badBinaryNames) {
             try {
                 ClassDesc constant = ClassDesc.of(d);
@@ -303,7 +303,7 @@ public class ClassDescTest extends SymbolicDescTest {
         }
 
         List<String> badInternalNames = List.of("I;", "[]", "[Ljava/lang/String;",
-                "Ljava.lang.String;", "java.lang.String");
+                "Ljava.lang.String;", "java.lang.String", "");
         for (String d : badInternalNames) {
             try {
                 ClassDesc constant = ClassDesc.ofInternalName(d);

--- a/test/jdk/java/lang/constant/PackageDescTest.java
+++ b/test/jdk/java/lang/constant/PackageDescTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,13 +35,13 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PackageDescTest {
     @ParameterizedTest
-    @ValueSource(strings = {"a/b.d", "a[]", "a;"})
+    @ValueSource(strings = {"a/b.d", "a[]", "a;", "a..b", "a.b.", ".a.b"})
     void testInvalidPackageNames(String pkg) {
         assertThrows(IllegalArgumentException.class, () -> PackageDesc.of(pkg));
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {"a/b.d", "a[]", "a;"})
+    @ValueSource(strings = {"a/b.d", "a[]", "a;", "a//b", "a/b/", "/a/b"})
     void testInvalidInternalPackageNames(String pkg) {
         assertThrows(IllegalArgumentException.class, () -> PackageDesc.ofInternalName(pkg));
     }


### PR DESCRIPTION
In the patch for [JDK-8338544](https://bugs.openjdk.org/browse/JDK-8338544) #20665, the validation methods `validateBinaryClassName` and `validateInternalClassName` only checks if a separator char is the initial or final char, or if it immediately follows another chars.  This omitted the case of empty strings, and allowed creation of invalid ClassDesc with empty binary name, which is otherwise rejected by `ofDescriptor`.

To better check for the separator char, the tracking mechanism is updated to indicate a position where a separator char shouldn't appear, or where the name string should not terminate.  This is initially set to the initial position 0, and upon each time of encountering a separator, this is updated to the next char.

This logic is similar to the existing one in `skipOverFieldSignature`, which uses a boolean `legal` variable.  Both reject empty strings, leading and trailing separators, or consecutive separators.  The new logic, however, does not require repeated updates to the new `afterSeparator` variable upon scanning each character.

In addition, I noted the package name validation erroneously does not prohibit leading, trailing, or consecutive separator chars.  (Package names are derived from class or interface names, so the same restrictions shall apply)  This patch also makes package name validation reuse class or interface name validation in non-empty (unnamed package) cases, and added those cases to the test suite.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343437](https://bugs.openjdk.org/browse/JDK-8343437): ClassDesc.of incorrectly permitting empty names (**Bug** - P3)


### Reviewers
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21830/head:pull/21830` \
`$ git checkout pull/21830`

Update a local copy of the PR: \
`$ git checkout pull/21830` \
`$ git pull https://git.openjdk.org/jdk.git pull/21830/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21830`

View PR using the GUI difftool: \
`$ git pr show -t 21830`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21830.diff">https://git.openjdk.org/jdk/pull/21830.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21830#issuecomment-2451925307)
</details>
