### PR TITLE
8346036: Unnecessary Hashtable usage in javax.swing.text.html.parser.Entity

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/parser/Entity.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/parser/Entity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,7 @@
 
 package javax.swing.text.html.parser;
 
-import java.util.Hashtable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.io.CharArrayReader;
-import java.net.URL;
+import java.util.Map;
 
 /**
  * An entity is described in a DTD using the ENTITY construct.
@@ -40,8 +34,7 @@ import java.net.URL;
  * @see DTD
  * @author Arthur van Hoff
  */
-public final
-class Entity implements DTDConstants {
+public final class Entity implements DTDConstants {
     /**
      * The name of the entity.
      */
@@ -117,20 +110,17 @@ class Entity implements DTDConstants {
         return new String(data);
     }
 
-
-    static Hashtable<String, Integer> entityTypes = new Hashtable<String, Integer>();
-
-    static {
-        entityTypes.put("PUBLIC", Integer.valueOf(PUBLIC));
-        entityTypes.put("CDATA", Integer.valueOf(CDATA));
-        entityTypes.put("SDATA", Integer.valueOf(SDATA));
-        entityTypes.put("PI", Integer.valueOf(PI));
-        entityTypes.put("STARTTAG", Integer.valueOf(STARTTAG));
-        entityTypes.put("ENDTAG", Integer.valueOf(ENDTAG));
-        entityTypes.put("MS", Integer.valueOf(MS));
-        entityTypes.put("MD", Integer.valueOf(MD));
-        entityTypes.put("SYSTEM", Integer.valueOf(SYSTEM));
-    }
+    private static final Map<String, Integer> entityTypes = Map.of(
+        "PUBLIC", PUBLIC,
+        "CDATA", CDATA,
+        "SDATA", SDATA,
+        "PI", PI,
+        "STARTTAG", STARTTAG,
+        "ENDTAG", ENDTAG,
+        "MS", MS,
+        "MD", MD,
+        "SYSTEM", SYSTEM
+    );
 
     /**
      * Converts <code>nm</code> string to the corresponding
@@ -144,7 +134,6 @@ class Entity implements DTDConstants {
      *   to "CDATA", if none exists
      */
     public static int name2type(String nm) {
-        Integer i = entityTypes.get(nm);
-        return (i == null) ? CDATA : i.intValue();
+        return entityTypes.getOrDefault(nm, CDATA);
     }
 }


### PR DESCRIPTION
The Hashtable `javax.swing.text.html.parser.Entity#entityTypes` is modified only within `<clinit>` block.
We can replace it with immutable map to avoid Hashtable synchronization overhead.
Similar to what we did in #21825.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8346036](https://bugs.openjdk.org/browse/JDK-8346036): Unnecessary Hashtable usage in javax.swing.text.html.parser.Entity (**Enhancement** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21831/head:pull/21831` \
`$ git checkout pull/21831`

Update a local copy of the PR: \
`$ git checkout pull/21831` \
`$ git pull https://git.openjdk.org/jdk.git pull/21831/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21831`

View PR using the GUI difftool: \
`$ git pr show -t 21831`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21831.diff">https://git.openjdk.org/jdk/pull/21831.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21831#issuecomment-2537005046)
</details>
