### PR TITLE
8343439: [JVMCI] Fix javadoc of Services.getSavedProperties

### DIFF
--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/services/Services.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/services/Services.java
@@ -86,10 +86,12 @@ public final class Services {
     }
 
     /**
-     * Gets an unmodifiable copy of the system properties parsed by {@code arguments.cpp}
-     * plus {@code java.specification.version}, {@code os.name} and {@code os.arch}.
-     * The latter two are forced to be the real OS and architecture. That is, values
-     * for these two properties set on the command line are ignored.
+     * Gets an unmodifiable copy of the system properties as of VM startup.
+     *
+     * If running on Hotspot, this will be the system properties parsed by {@code arguments.cpp}
+     * plus {@code java.specification.version}, {@code os.name} and {@code os.arch}. The latter two
+     * are forced to be the real OS and architecture. That is, values for these two properties set
+     * on the command line are ignored.
      */
     public static Map<String, String> getSavedProperties() {
         checkJVMCIEnabled();


### PR DESCRIPTION
The javadoc of `jdk.vm.ci.services.Services.getSavedProperties` is currently:
```
    /**
     * Gets an unmodifiable copy of the system properties parsed by {@code arguments.cpp}
     * plus {@code java.specification.version}, {@code os.name} and {@code os.arch}.
     * The latter two are forced to be the real OS and architecture. That is, values
     * for these two properties set on the command line are ignored.
     */
```
The details about how the copy is initialized are specific to the HotSpot VM. On SVM, the semantics can be different. This PR separates out the HotSpot specific part.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343439](https://bugs.openjdk.org/browse/JDK-8343439): [JVMCI] Fix javadoc of Services.getSavedProperties (**Bug** - P4)


### Reviewers
 * [Tom Rodriguez](https://openjdk.org/census#never) (@tkrodriguez - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21832/head:pull/21832` \
`$ git checkout pull/21832`

Update a local copy of the PR: \
`$ git checkout pull/21832` \
`$ git pull https://git.openjdk.org/jdk.git pull/21832/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21832`

View PR using the GUI difftool: \
`$ git pr show -t 21832`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21832.diff">https://git.openjdk.org/jdk/pull/21832.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21832#issuecomment-2451988512)
</details>
