### PR TITLE
8347916: Simplify javax.swing.text.html.CSS.LengthUnit.getValue

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -3083,27 +3083,15 @@ public class CSS implements Serializable {
         }
 
         float getValue(boolean w3cLengthUnits) {
-            Hashtable<String, Float> mapping = (w3cLengthUnits) ? w3cLengthMapping : lengthMapping;
-            float scale = 1;
-            if (units != null) {
-                Float scaleFloat = mapping.get(units);
-                if (scaleFloat != null) {
-                    scale = scaleFloat.floatValue();
-                }
-            }
-            return this.value * scale;
-
+            return getValue(value, units, w3cLengthUnits);
         }
 
-        static float getValue(float value, String units, Boolean w3cLengthUnits) {
-            Hashtable<String, Float> mapping = (w3cLengthUnits) ? w3cLengthMapping : lengthMapping;
-            float scale = 1;
-            if (units != null) {
-                Float scaleFloat = mapping.get(units);
-                if (scaleFloat != null) {
-                    scale = scaleFloat.floatValue();
-                }
+        static float getValue(float value, String units, boolean w3cLengthUnits) {
+            if (units == null) {
+                return value;
             }
+            Hashtable<String, Float> mapping = (w3cLengthUnits) ? w3cLengthMapping : lengthMapping;
+            float scale = mapping.getOrDefault(units, 1f);
             return value * scale;
         }
 


### PR DESCRIPTION
Static and non-static `CSS.LengthUnit.getValue` methods essentially do the same thing.
https://github.com/openjdk/jdk/blob/751a914b0a377d4e1dd30d2501f0ab4e327dea34/src/java.desktop/share/classes/javax/swing/text/html/CSS.java#L3085-L3096

https://github.com/openjdk/jdk/blob/751a914b0a377d4e1dd30d2501f0ab4e327dea34/src/java.desktop/share/classes/javax/swing/text/html/CSS.java#L3098-L3108

1. delegate one to another to reduce code duplication.
2. use primitive `boolean` type as parameter to avoid boxing
3. take advantage of `Map.getOrDefault()` to simplify code futher

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347916](https://bugs.openjdk.org/browse/JDK-8347916): Simplify javax.swing.text.html.CSS.LengthUnit.getValue (**Enhancement** - P5)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21833/head:pull/21833` \
`$ git checkout pull/21833`

Update a local copy of the PR: \
`$ git checkout pull/21833` \
`$ git pull https://git.openjdk.org/jdk.git pull/21833/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21833`

View PR using the GUI difftool: \
`$ git pr show -t 21833`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21833.diff">https://git.openjdk.org/jdk/pull/21833.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21833#issuecomment-2595382205)
</details>
