### PR TITLE
8343442: Add since checker tests to the networking area modules

### DIFF
--- a/test/jdk/tools/sincechecker/modules/java_net_http/CheckSince_javaNetHttp.java
+++ b/test/jdk/tools/sincechecker/modules/java_net_http/CheckSince_javaNetHttp.java
@@ -24,11 +24,11 @@
 /*
  * @test
  * @bug 8343442
- * @summary Test for `@since` for java.base module
+ * @summary Test for `@since` for java.net.http module
  * @library /test/lib
  *          /test/jdk/tools/sincechecker
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.util
  *          jdk.compiler/com.sun.tools.javac.code
- * @run main SinceChecker java.base --exclude java.lang.classfile
+ * @run main SinceChecker java.net.http
  */

--- a/test/jdk/tools/sincechecker/modules/jdk_httpserver/CheckSince_jdkHttpserver.java
+++ b/test/jdk/tools/sincechecker/modules/jdk_httpserver/CheckSince_jdkHttpserver.java
@@ -24,11 +24,11 @@
 /*
  * @test
  * @bug 8343442
- * @summary Test for `@since` for java.base module
+ * @summary Test for `@since` for jdk.httpserver module
  * @library /test/lib
  *          /test/jdk/tools/sincechecker
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.util
  *          jdk.compiler/com.sun.tools.javac.code
- * @run main SinceChecker java.base --exclude java.lang.classfile
+ * @run main SinceChecker jdk.httpserver
  */

--- a/test/jdk/tools/sincechecker/modules/jdk_net/CheckSince_jdkNet.java
+++ b/test/jdk/tools/sincechecker/modules/jdk_net/CheckSince_jdkNet.java
@@ -23,12 +23,12 @@
 
 /*
  * @test
- * @bug 8343442
- * @summary Test for `@since` for java.base module
+ * @bug 8331051
+ * @summary Test for `@since` for jdk.net module
  * @library /test/lib
  *          /test/jdk/tools/sincechecker
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.util
  *          jdk.compiler/com.sun.tools.javac.code
- * @run main SinceChecker java.base --exclude java.lang.classfile
+ * @run main SinceChecker jdk.net
  */


### PR DESCRIPTION
Can I please get a review for this patch that brings the `@since` test described [here](https://mail.openjdk.org/pipermail/jdk-dev/2024-October/009474.html) to the networking area modules.

The benefit from this is helping API authors and reviewer validate the accuracy of `@since` in their source code (and subsequently, in the generated documentation).

The test has been added for `java.base` 2 weeks ago and has helped catch some bugs before they make it to the JDK.

TIA