### PR TITLE
8343071: Broken anchors to restricted method page and some redundant ids

### DIFF
--- a/src/java.base/share/classes/java/lang/Class.java
+++ b/src/java.base/share/classes/java/lang/Class.java
@@ -151,7 +151,7 @@ import sun.reflect.misc.ReflectUtil;
  * <p> Some methods of class {@code Class} expose whether the declaration of
  * a class or interface in Java source code was <em>enclosed</em> within
  * another declaration. Other methods describe how a class or interface
- * is situated in a <dfn>{@index "nest"}</dfn>. A <a id="nest">nest</a> is a set of
+ * is situated in a <dfn>{@index "nest"}</dfn>. A nest is a set of
  * classes and interfaces, in the same run-time package, that
  * allow mutual access to their {@code private} members.
  * The classes and interfaces are known as <dfn>{@index "nestmates"}</dfn>

--- a/src/java.base/share/classes/java/lang/Module.java
+++ b/src/java.base/share/classes/java/lang/Module.java
@@ -263,7 +263,7 @@ public final class Module implements AnnotatedElement {
 
     /**
      * Returns {@code true} if this module can access
-     * <a href="foreign/package-summary.html#restricted"><em>restricted</em></a> methods.
+     * <a href="{@docRoot}/java.base/java/lang/doc-files/RestrictedMethods.html#restricted"><em>restricted</em></a> methods.
      *
      * @return {@code true} if this module can access <em>restricted</em> methods.
      * @since 22

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -501,7 +501,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * All the methods that can be used to manipulate zero-length memory segments
  * ({@link #reinterpret(long)}, {@link #reinterpret(Arena, Consumer)}, {@link #reinterpret(long, Arena, Consumer)} and
  * {@link AddressLayout#withTargetLayout(MemoryLayout)}) are
- * <a href="package-summary.html#restricted"><em>restricted</em></a> methods, and should
+ * <a href="{@docRoot}/java.base/java/lang/doc-files/RestrictedMethods.html#restricted"><em>restricted</em></a> methods, and should
  * be used with caution: assigning a segment incorrect spatial and/or temporal bounds
  * could result in a VM crash when attempting to access the memory segment.
  *

--- a/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
+++ b/src/java.base/share/classes/java/util/concurrent/StructuredTaskScope.java
@@ -1007,9 +1007,9 @@ public class StructuredTaskScope<T> implements AutoCloseable {
          *
          * <p> Construction captures the current thread's {@linkplain ScopedValue scoped
          * value} bindings for inheritance by threads started in the task scope. The
-         * <a href="#TreeStructure">Tree Structure</a> section in the class description
-         * details how parent-child relations are established implicitly for the purpose
-         * of inheritance of scoped value bindings.
+         * {@linkplain StructuredTaskScope##TreeStructure Tree Structure} section
+         * in the class description details how parent-child relations are established
+         * implicitly for the purpose of inheritance of scoped value bindings.
          *
          * @param name the name of the task scope, can be null
          * @param factory the thread factory
@@ -1187,7 +1187,7 @@ public class StructuredTaskScope<T> implements AutoCloseable {
          *
          * <p> Construction captures the current thread's {@linkplain ScopedValue scoped
          * value} bindings for inheritance by threads started in the task scope. The
-         * <a href="#TreeStructure">Tree Structure</a> section in the class description
+         * {@linkplain StructuredTaskScope##TreeStructure Tree Structure} section in the class description
          * details how parent-child relations are established implicitly for the purpose
          * of inheritance of scoped value bindings.
          *


### PR DESCRIPTION
Can I get a review for this patch that brings the last changes to fix broken anchors in the source code.

The links updated in this patch can be grouped into 3 sections, they were minor so I grouped them into one PR.

1- Move some references from the old `foreign/package-summary.html#restricted` to the new `Restricted Methods` page, these were broken after https://github.com/openjdk/jdk/commit/f4dccfd4cf354f360b823c8cce15bb54ef90e9ca

2- Remove a redundant `<a>` tag in `Class.java`, the id not needed as we already created an index.

3- Fix some broken anchors in `StructuredTaskScope.java`, the text will be updated in a JEP but we can fix the current text now. 

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8343071](https://bugs.openjdk.org/browse/JDK-8343071): Broken anchors to restricted method page and some redundant ids (**Sub-task** - P4)
 * [JDK-8332747](https://bugs.openjdk.org/browse/JDK-8332747): Broken links in StructuredTaskScope (**Sub-task** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21839/head:pull/21839` \
`$ git checkout pull/21839`

Update a local copy of the PR: \
`$ git checkout pull/21839` \
`$ git pull https://git.openjdk.org/jdk.git pull/21839/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21839`

View PR using the GUI difftool: \
`$ git pr show -t 21839`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21839.diff">https://git.openjdk.org/jdk/pull/21839.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21839#issuecomment-2452347840)
</details>
