### PR TITLE
8347370: Unnecessary Hashtable usage in javax.swing.text.html.HTML

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/HTML.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,7 @@ import java.io.ObjectInputStream;
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Hashtable;
+import java.util.Map;
 
 import javax.swing.text.AttributeSet;
 import javax.swing.text.StyleConstants;
@@ -1169,7 +1170,16 @@ public class HTML {
     private static final Hashtable<String, Tag> tagHashtable = new Hashtable<String, Tag>(73);
 
     /** Maps from StyleConstant key to HTML.Tag. */
-    private static final Hashtable<Object, Tag> scMapping = new Hashtable<Object, Tag>(8);
+    private static final Map<Object, Tag> scMapping = Map.of(
+            StyleConstants.Bold, Tag.B,
+            StyleConstants.Italic, Tag.I,
+            StyleConstants.Underline, Tag.U,
+            StyleConstants.StrikeThrough, Tag.STRIKE,
+            StyleConstants.Superscript, Tag.SUP,
+            StyleConstants.Subscript, Tag.SUB,
+            StyleConstants.FontFamily, Tag.FONT,
+            StyleConstants.FontSize, Tag.FONT
+    );
 
     static {
 
@@ -1185,14 +1195,6 @@ public class HTML {
                                                     allAttributes[i]);
         }
         StyleContext.registerStaticAttributeKey(HTML.NULL_ATTRIBUTE_VALUE);
-        scMapping.put(StyleConstants.Bold, Tag.B);
-        scMapping.put(StyleConstants.Italic, Tag.I);
-        scMapping.put(StyleConstants.Underline, Tag.U);
-        scMapping.put(StyleConstants.StrikeThrough, Tag.STRIKE);
-        scMapping.put(StyleConstants.Superscript, Tag.SUP);
-        scMapping.put(StyleConstants.Subscript, Tag.SUB);
-        scMapping.put(StyleConstants.FontFamily, Tag.FONT);
-        scMapping.put(StyleConstants.FontSize, Tag.FONT);
     }
 
     /**


### PR DESCRIPTION
The Hashtable `javax.swing.text.html.HTML.scMapping` is modified only within `<clinit>` block.
We can replace it with immutable map to avoid Hashtable synchronization overhead.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8347370](https://bugs.openjdk.org/browse/JDK-8347370): Unnecessary Hashtable usage in javax.swing.text.html.HTML (**Enhancement** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21842/head:pull/21842` \
`$ git checkout pull/21842`

Update a local copy of the PR: \
`$ git checkout pull/21842` \
`$ git pull https://git.openjdk.org/jdk.git pull/21842/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21842`

View PR using the GUI difftool: \
`$ git pr show -t 21842`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21842.diff">https://git.openjdk.org/jdk/pull/21842.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21842#issuecomment-2581015335)
</details>
