### PR TITLE
8343237: Improve the copying of the available set of Currencies

### DIFF
--- a/src/java.base/share/classes/java/util/Currency.java
+++ b/src/java.base/share/classes/java/util/Currency.java
@@ -494,10 +494,7 @@ public final class Currency implements Serializable {
                 }
             }
         }
-
-        @SuppressWarnings("unchecked")
-        Set<Currency> result = (Set<Currency>) available.clone();
-        return result;
+        return new HashSet<>(available);
     }
 
     /**


### PR DESCRIPTION
Please review this PR which is a small cleanup in `Currency.getAvailableCurrencies()`. We can use the `HashSet` constructor over `clone()` to make the defensive copy of the set of available currencies. This gets rid of the unsightly unchecked cast and SuppressWarnings annotation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343237](https://bugs.openjdk.org/browse/JDK-8343237): Improve the copying of the available set of Currencies (**Bug** - P4)


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21845/head:pull/21845` \
`$ git checkout pull/21845`

Update a local copy of the PR: \
`$ git checkout pull/21845` \
`$ git pull https://git.openjdk.org/jdk.git pull/21845/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21845`

View PR using the GUI difftool: \
`$ git pr show -t 21845`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21845.diff">https://git.openjdk.org/jdk/pull/21845.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21845#issuecomment-2452711368)
</details>
