### PR TITLE
8343471: RISC-V: compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java fails after JDK-8334999

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -122,11 +122,6 @@ void VM_Version::common_initialize() {
     FLAG_SET_DEFAULT(AllocatePrefetchDistance, 0);
   }
 
-  if (UseAESCTRIntrinsics) {
-    warning("AES/CTR intrinsics are not available on this CPU");
-    FLAG_SET_DEFAULT(UseAESCTRIntrinsics, false);
-  }
-
   if (UseZba) {
     if (FLAG_IS_DEFAULT(UseCRC32Intrinsics)) {
       FLAG_SET_DEFAULT(UseCRC32Intrinsics, true);
@@ -428,14 +423,23 @@ void VM_Version::c2_initialize() {
       warning("UseAESIntrinsics enabled, but UseAES not, enabling");
       UseAES = true;
     }
-  } else if (UseAESIntrinsics || UseAES) {
-    if (!FLAG_IS_DEFAULT(UseAESIntrinsics) || !FLAG_IS_DEFAULT(UseAES)) {
-      warning("AES intrinsics require Zvkn extension (not available on this CPU).");
+  } else {
+    if (UseAES) {
+      warning("AES instructions are not available on this CPU");
+      FLAG_SET_DEFAULT(UseAES, false);
     }
-    FLAG_SET_DEFAULT(UseAES, false);
-    FLAG_SET_DEFAULT(UseAESIntrinsics, false);
+    if (UseAESIntrinsics) {
+      warning("AES intrinsics are not available on this CPU");
+      FLAG_SET_DEFAULT(UseAESIntrinsics, false);
+    }
+  }
+
+  if (UseAESCTRIntrinsics) {
+    warning("AES/CTR intrinsics are not available on this CPU");
+    FLAG_SET_DEFAULT(UseAESCTRIntrinsics, false);
   }
 }
+
 #endif // COMPILER2
 
 void VM_Version::initialize_cpu_information(void) {


### PR DESCRIPTION
Hi, please review this small change.

The test expects a message like `warning: AES instructions are not available on this CPU` for all cpu platforms without AES support. After https://bugs.openjdk.org/browse/JDK-8334999, we report this `warning: AES intrinsics require Zvkn extension (not available on this CPU)` on RISC-V platforms where `Zvkn` extension is not available. Patch fixes this message making it consistent with other CPU platforms. Same test passes with this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343471](https://bugs.openjdk.org/browse/JDK-8343471): RISC-V: compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java fails after JDK-8334999 (**Bug** - P4)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21847/head:pull/21847` \
`$ git checkout pull/21847`

Update a local copy of the PR: \
`$ git checkout pull/21847` \
`$ git pull https://git.openjdk.org/jdk.git pull/21847/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21847`

View PR using the GUI difftool: \
`$ git pr show -t 21847`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21847.diff">https://git.openjdk.org/jdk/pull/21847.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21847#issuecomment-2453271563)
</details>
