### PR TITLE
8343473: Update copyright year of AddmodsOption.java

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
The newly added test `runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java` on `Thu Oct 31 2024`, the copyright year should be 2024.
Trivial fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343473](https://bugs.openjdk.org/browse/JDK-8343473): Update copyright year of AddmodsOption.java (**Bug** - P5)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21848/head:pull/21848` \
`$ git checkout pull/21848`

Update a local copy of the PR: \
`$ git checkout pull/21848` \
`$ git pull https://git.openjdk.org/jdk.git pull/21848/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21848`

View PR using the GUI difftool: \
`$ git pr show -t 21848`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21848.diff">https://git.openjdk.org/jdk/pull/21848.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21848#issuecomment-2452961903)
</details>
