### PR TITLE
8343475: RISC-V: Test TestAESIntrinsicsOnUnsupportedConfig.java fails

### DIFF
--- a/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java
+++ b/test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,10 +45,11 @@ import static jdk.test.lib.cli.CommandLineOptionTest.*;
 
 public class TestAESIntrinsicsOnUnsupportedConfig extends AESIntrinsicsBase {
 
+    // RISC-V: warning: AES intrinsics require Zvkn extension (not available on this CPU).
     private static final String INTRINSICS_NOT_AVAILABLE_MSG = "warning: AES "
-            + "intrinsics are not available on this CPU";
+            + "intrinsics .*not available on this CPU";
     private static final String AES_NOT_AVAILABLE_MSG = "warning: AES "
-            + "instructions are not available on this CPU";
+            + "(intrinsics|instructions) .*not available on this CPU";
 
     protected void runTestCases() throws Throwable {
         testUseAES();


### PR DESCRIPTION
Hi all,
Test `test/hotspot/jtreg/compiler/cpuflags/TestAESIntrinsicsOnUnsupportedConfig.java` fails on linux-riscv64, the expected output is: 
`warning: AES instructions are not available on this CPU`
or:
`warning: AES intrinsics are not available on this CPU`
But the actual output on linux-riscv64 both is:
`warning: AES intrinsics require Zvkn extension (not available on this CPU).`

This PR adopt the output for linux-riscv64. The change has been verified locally, test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343475](https://bugs.openjdk.org/browse/JDK-8343475): RISC-V: Test TestAESIntrinsicsOnUnsupportedConfig.java fails (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21849/head:pull/21849` \
`$ git checkout pull/21849`

Update a local copy of the PR: \
`$ git checkout pull/21849` \
`$ git pull https://git.openjdk.org/jdk.git pull/21849/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21849`

View PR using the GUI difftool: \
`$ git pr show -t 21849`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21849.diff">https://git.openjdk.org/jdk/pull/21849.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21849#issuecomment-2452992903)
</details>
