### PR TITLE
Optimize ArrayClassDescImpl computeDescriptor

### DIFF
--- a/src/java.base/share/classes/jdk/internal/constant/ArrayClassDescImpl.java
+++ b/src/java.base/share/classes/jdk/internal/constant/ArrayClassDescImpl.java
@@ -115,11 +115,7 @@ public final class ArrayClassDescImpl implements ClassDesc {
     }
 
     private String computeDescriptor() {
-        var componentDesc = elementType.descriptorString();
-        StringBuilder sb = new StringBuilder(rank + componentDesc.length());
-        sb.repeat('[', rank);
-        sb.append(componentDesc);
-        return sb.toString();
+        return "[".repeat(rank).concat(elementType.descriptorString());
     }
 
     @Override


### PR DESCRIPTION
A small improvement to ArrayClassDescImpl#computeDescriptor that avoids intermediate object allocation in the common rank 1 scenario.