### PR TITLE
8343497: Missing DEF_STATIC_JNI_OnLoad in libjimage and libsaproc native libraries

### DIFF
--- a/src/java.base/share/native/libjimage/jimage.cpp
+++ b/src/java.base/share/native/libjimage/jimage.cpp
@@ -40,7 +40,9 @@
 /*
  * Declare jimage library specific JNI_Onload entry for static build.
  */
-extern "C" DEF_STATIC_JNI_OnLoad
+extern "C" {
+DEF_STATIC_JNI_OnLoad
+}
 
 /*
  * JImageOpen - Given the supplied full path file name, open an image file. This

--- a/src/java.base/share/native/libjimage/jimage.cpp
+++ b/src/java.base/share/native/libjimage/jimage.cpp
@@ -35,6 +35,13 @@
 
 #include "imageFile.hpp"
 
+#include "jni_util.h"
+
+/*
+ * Declare jimage library specific JNI_Onload entry for static build.
+ */
+extern "C" DEF_STATIC_JNI_OnLoad
+
 /*
  * JImageOpen - Given the supplied full path file name, open an image file. This
  * function will also initialize tables and retrieve meta-data necessary to

--- a/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
+++ b/src/jdk.hotspot.agent/share/native/libsaproc/sadis.c
@@ -66,6 +66,7 @@
 
 #include "jni_util.h"
 
+DEF_STATIC_JNI_OnLoad
 
 /*
  * Class:     sun_jvm_hotspot_asm_Disassembler


### PR DESCRIPTION
Please review this trivial fix that adds missing DEF_STATIC_JNI_OnLoad in libjimage and libsaproc native libraries. Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343497](https://bugs.openjdk.org/browse/JDK-8343497): Missing DEF_STATIC_JNI_OnLoad in libjimage and libsaproc native libraries (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21861/head:pull/21861` \
`$ git checkout pull/21861`

Update a local copy of the PR: \
`$ git checkout pull/21861` \
`$ git pull https://git.openjdk.org/jdk.git pull/21861/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21861`

View PR using the GUI difftool: \
`$ git pr show -t 21861`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21861.diff">https://git.openjdk.org/jdk/pull/21861.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21861#issuecomment-2453565740)
</details>
