### PR TITLE
8343503: Problemlist support fastdebug/slowdebug build

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -856,6 +856,11 @@ define SetupRunJtregTestBody
     JTREG_AUTO_PROBLEM_LISTS += ProblemList-zgc.txt
   endif
 
+  ifneq ($$(DEBUG_LEVEL), release)
+    JTREG_AUTO_PROBLEM_LISTS += ProblemList-debug.txt
+    JTREG_AUTO_TIMEOUT_FACTOR := 10
+  endif
+
   ifneq ($$(JTREG_EXTRA_PROBLEM_LISTS), )
     # Accept both absolute paths as well as relative to the current test root.
     $1_JTREG_BASIC_OPTIONS += $$(addprefix $$(JTREG_PROBLEM_LIST_PREFIX), $$(wildcard \


### PR DESCRIPTION
Hi all,
Sometimes some tests only fails or crash run by fastdebug/slowdebug jdk binary, such as `java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1` which has been recorded by [JDK-8343244](https://bugs.openjdk.org/browse/JDK-8343244). To make less CI noisy, we can disable these tests by add tag such as `@requires vm.debug == false`, but I think put the releated tests to Problemlist is a better way before the root cause failure has been fixed.
Thus I think it's necessary support Problemlist for fastdebug/slowdebug build, the Problemlist only work for fastdebug/slowdebug build.
By the way, the timeout factor with fastdebug/slowdebug should larger than release build, this PR also make jtreg timeoutFactor to 10 if the tested jdk is fastdebug/slowdebug build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343503](https://bugs.openjdk.org/browse/JDK-8343503): Problemlist support fastdebug/slowdebug build (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21862/head:pull/21862` \
`$ git checkout pull/21862`

Update a local copy of the PR: \
`$ git checkout pull/21862` \
`$ git pull https://git.openjdk.org/jdk.git pull/21862/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21862`

View PR using the GUI difftool: \
`$ git pr show -t 21862`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21862.diff">https://git.openjdk.org/jdk/pull/21862.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21862#issuecomment-2453769718)
</details>
