### PR TITLE
8343506: [s390x] multiple test failures with ubsan

### DIFF
--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -2547,7 +2547,7 @@ operand uimmI8() %{
 //   operand type int
 // Unsigned Integer Immediate: 9-bit
 operand SSlenDW() %{
-  predicate(Immediate::is_uimm8(n->get_long()-1));
+  predicate(Immediate::is_uimm8((julong)n->get_long()-1));
   match(ConL);
   op_cost(1);
   format %{ %}


### PR DESCRIPTION
This is trivial patch which fixes the error I am seeing on s390x, while running tier1 with ubsan enabled. Please see JBS for more details.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343506](https://bugs.openjdk.org/browse/JDK-8343506): [s390x] multiple test failures with ubsan (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21864/head:pull/21864` \
`$ git checkout pull/21864`

Update a local copy of the PR: \
`$ git checkout pull/21864` \
`$ git pull https://git.openjdk.org/jdk.git pull/21864/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21864`

View PR using the GUI difftool: \
`$ git pr show -t 21864`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21864.diff">https://git.openjdk.org/jdk/pull/21864.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21864#issuecomment-2453950431)
</details>
