### PR TITLE
8343507: Parallel: Fail if verify_complete finds incorrect states

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1913,16 +1913,16 @@ void PSParallelCompact::verify_complete(SpaceId space_id) {
   for (cur_region = beg_region; cur_region < new_top_region; ++cur_region) {
     const RegionData* const c = sd.region(cur_region);
     if (!c->completed()) {
-      log_warning(gc)("region " SIZE_FORMAT " not filled: destination_count=%u",
-                      cur_region, c->destination_count());
+      fatal("region %zu not filled: destination_count=%u",
+             cur_region, c->destination_count());
     }
   }
 
   for (cur_region = new_top_region; cur_region < old_top_region; ++cur_region) {
     const RegionData* const c = sd.region(cur_region);
     if (!c->available()) {
-      log_warning(gc)("region " SIZE_FORMAT " not empty: destination_count=%u",
-                      cur_region, c->destination_count());
+      fatal("region %zu not empty: destination_count=%u",
+             cur_region, c->destination_count());
     }
   }
 }

--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1912,18 +1912,14 @@ void PSParallelCompact::verify_complete(SpaceId space_id) {
   size_t cur_region;
   for (cur_region = beg_region; cur_region < new_top_region; ++cur_region) {
     const RegionData* const c = sd.region(cur_region);
-    if (!c->completed()) {
-      fatal("region %zu not filled: destination_count=%u",
-             cur_region, c->destination_count());
-    }
+    assert(c->completed(), "region %zu not filled: destination_count=%u",
+           cur_region, c->destination_count());
   }
 
   for (cur_region = new_top_region; cur_region < old_top_region; ++cur_region) {
     const RegionData* const c = sd.region(cur_region);
-    if (!c->available()) {
-      fatal("region %zu not empty: destination_count=%u",
-             cur_region, c->destination_count());
-    }
+    assert(c->available(), "region %zu not empty: destination_count=%u",
+           cur_region, c->destination_count());
   }
 }
 #endif  // #ifdef ASSERT


### PR DESCRIPTION
Trivial change of replacing `log_warning` with `fatal`, because incorrect `destination_count` always indicate some problem.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343507](https://bugs.openjdk.org/browse/JDK-8343507): Parallel: Fail if verify_complete finds incorrect states (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21865/head:pull/21865` \
`$ git checkout pull/21865`

Update a local copy of the PR: \
`$ git checkout pull/21865` \
`$ git pull https://git.openjdk.org/jdk.git pull/21865/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21865`

View PR using the GUI difftool: \
`$ git pr show -t 21865`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21865.diff">https://git.openjdk.org/jdk/pull/21865.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21865#issuecomment-2453863092)
</details>
