### PR TITLE
8343508: Parallel: Use ordinary klass accessor in verify_filler_in_dense_prefix

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -1890,7 +1890,7 @@ void PSParallelCompact::verify_filler_in_dense_prefix() {
     oop obj = cast_to_oop(cur_addr);
     oopDesc::verify(obj);
     if (!mark_bitmap()->is_marked(cur_addr)) {
-      Klass* k = cast_to_oop(cur_addr)->klass_without_asserts();
+      Klass* k = cast_to_oop(cur_addr)->klass();
       assert(k == Universe::fillerArrayKlass() || k == vmClasses::FillerObject_klass(), "inv");
     }
     cur_addr += obj->size();


### PR DESCRIPTION
One line change to use the common API to make the caller logic less obtrusive.

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343508](https://bugs.openjdk.org/browse/JDK-8343508): Parallel: Use ordinary klass accessor in verify_filler_in_dense_prefix (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21866/head:pull/21866` \
`$ git checkout pull/21866`

Update a local copy of the PR: \
`$ git checkout pull/21866` \
`$ git pull https://git.openjdk.org/jdk.git pull/21866/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21866`

View PR using the GUI difftool: \
`$ git pr show -t 21866`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21866.diff">https://git.openjdk.org/jdk/pull/21866.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21866#issuecomment-2453903504)
</details>
