### PR TITLE
8343513: Forward declare Thread in mutexLocker.hpp

### DIFF
--- a/src/hotspot/share/nmt/nmtCommon.hpp
+++ b/src/hotspot/share/nmt/nmtCommon.hpp
@@ -30,6 +30,7 @@
 #include "memory/allStatic.hpp"
 #include "nmt/memTag.hpp"
 #include "runtime/mutexLocker.hpp"
+#include "runtime/thread.hpp"
 #include "utilities/align.hpp"
 #include "utilities/globalDefinitions.hpp"
 

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
- * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * DO NO ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as
@@ -28,7 +28,8 @@
 #include "memory/allocation.hpp"
 #include "runtime/flags/flagSetting.hpp"
 #include "runtime/mutex.hpp"
-#include "runtime/thread.hpp"
+
+class Thread;
 
 // Mutexes used in the VM.
 

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
- * DO NO ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License version 2 only, as


### PR DESCRIPTION
Hi,

Let's explicitly forward declare `Thread` in `mutexLocker.hpp` instead of including `thread.hpp`. Previously we got the forward declaration from `memory/allocation.hpp`, but let's be explicit about forward declarations being used when we can.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343513](https://bugs.openjdk.org/browse/JDK-8343513): Forward declare Thread in mutexLocker.hpp (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21868/head:pull/21868` \
`$ git checkout pull/21868`

Update a local copy of the PR: \
`$ git checkout pull/21868` \
`$ git pull https://git.openjdk.org/jdk.git pull/21868/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21868`

View PR using the GUI difftool: \
`$ git pr show -t 21868`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21868.diff">https://git.openjdk.org/jdk/pull/21868.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21868#issuecomment-2454040136)
</details>
