### PR TITLE
8323803: ConstantOopReadValue::print_on should print 'null' instead of 'nullptr'

### DIFF
--- a/src/hotspot/share/code/debugInfo.cpp
+++ b/src/hotspot/share/code/debugInfo.cpp
@@ -382,7 +382,7 @@ void ConstantOopReadValue::print_on(outputStream* st) const {
   if (value()() != nullptr) {
     value()()->print_value_on(st);
   } else {
-    st->print("nullptr");
+    st->print("null");
   }
 }
 


### PR DESCRIPTION
Printing incorrectly printed `nullptr` instead of `null`

Buggy:

```
ScopeDesc(pc=0x0000000104c05468 offset=2e8):
   java.lang.Class::desiredAssertionStatus@20 (line 3984)
   Locals
    - l0: reg rfp [58],oop
    - l1: stack[0],oop
    - l2: nullptr
    - l3: empty
   Expression stack
    - @0: nullptr
```

Fixed:

```
ScopeDesc(pc=0x0000000106fdd468 offset=2e8):
   java.lang.Class::desiredAssertionStatus@20 (line 3984)
   Locals
    - l0: reg rfp [58],oop
    - l1: stack[0],oop
    - l2: null
    - l3: empty
   Expression stack
    - @0: null
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8323803](https://bugs.openjdk.org/browse/JDK-8323803): ConstantOopReadValue::print_on should print 'null' instead of 'nullptr' (**Bug** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21869/head:pull/21869` \
`$ git checkout pull/21869`

Update a local copy of the PR: \
`$ git checkout pull/21869` \
`$ git pull https://git.openjdk.org/jdk.git pull/21869/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21869`

View PR using the GUI difftool: \
`$ git pr show -t 21869`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21869.diff">https://git.openjdk.org/jdk/pull/21869.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21869#issuecomment-2457162089)
</details>
