### PR TITLE
8343531: Improve print_location for invalid heap pointers

### DIFF
--- a/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
+++ b/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
@@ -51,9 +51,9 @@ oop BlockLocationPrinter<CollectedHeapT>::base_oop_or_null(void* addr) {
 
 template <typename CollectedHeapT>
 bool BlockLocationPrinter<CollectedHeapT>::print_location(outputStream* st, void* addr) {
-  bool in_heap = false;
   // Check if addr points into Java heap.
-  if (CollectedHeapT::heap()->is_in(addr)) {
+  bool in_heap = CollectedHeapT::heap()->is_in(addr);
+  if (in_heap) {
     // base_oop_or_null() might be unimplemented and return NULL for some GCs/generations
     oop o = base_oop_or_null(addr);
     if (o != nullptr) {
@@ -65,7 +65,6 @@ bool BlockLocationPrinter<CollectedHeapT>::print_location(outputStream* st, void
       o->print_on(st);
       return true;
     }
-    in_heap = true; // We at least know by now, that addr points into the heap
   } else if (CollectedHeapT::heap()->is_in_reserved(addr)) {
     st->print_cr(PTR_FORMAT " is an unallocated location in the heap", p2i(addr));
     return true;


### PR DESCRIPTION
Currently `BlockLocationPrinter<CollectedHeapT>::print_location()` checks for a pointer if it points into the heap and if that's true, it either prints it as an oop if `is_valid_obj()` is true or it tries to find the the start address of an oop for that pointer by calling `CollectedHeapT::heap()->block_start()`.

However, the `block_start()` functionality is not fully implemented for all GCs (e.g. the young generation of `ParallelScavengeHeap`) and for these cases `block_start()` returns NULL. Because of this NULL return value `os::print_location()` will finally qualify the corresponding pointer as pointing "into unknown readable memory" although we already know that it actually points into an invalid heap area.

In such cases, print at least that the pointer is pointing into an unknown part of the heap instead of just saying that it points into unknown memory. 

I've manually tested the new functionality in GDB.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343531](https://bugs.openjdk.org/browse/JDK-8343531): Improve print_location for invalid heap pointers (**New Feature** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21870/head:pull/21870` \
`$ git checkout pull/21870`

Update a local copy of the PR: \
`$ git checkout pull/21870` \
`$ git pull https://git.openjdk.org/jdk.git pull/21870/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21870`

View PR using the GUI difftool: \
`$ git pr show -t 21870`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21870.diff">https://git.openjdk.org/jdk/pull/21870.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21870#issuecomment-2454242811)
</details>
