### PR TITLE
8343298: Improve stability of runtime/cds/DeterministicDump.java test

### DIFF
--- a/src/hotspot/share/cds/archiveHeapWriter.cpp
+++ b/src/hotspot/share/cds/archiveHeapWriter.cpp
@@ -558,9 +558,12 @@ void ArchiveHeapWriter::update_header_for_requested_obj(oop requested_obj, oop s
   oop fake_oop = cast_to_oop(buffered_addr);
   fake_oop->set_narrow_klass(nk);
 
+  if (src_obj == nullptr) {
+    return;
+  }
   // We need to retain the identity_hash, because it may have been used by some hashtables
   // in the shared heap.
-  if (src_obj != nullptr && !src_obj->fast_no_hash_check()) {
+  if (!src_obj->fast_no_hash_check()) {
     intptr_t src_hash = src_obj->identity_hash();
     fake_oop->set_mark(markWord::prototype().copy_set_hash(src_hash));
     assert(fake_oop->mark().is_unlocked(), "sanity");
@@ -568,6 +571,8 @@ void ArchiveHeapWriter::update_header_for_requested_obj(oop requested_obj, oop s
     DEBUG_ONLY(intptr_t archived_hash = fake_oop->identity_hash());
     assert(src_hash == archived_hash, "Different hash codes: original " INTPTR_FORMAT ", archived " INTPTR_FORMAT, src_hash, archived_hash);
   }
+  // Strip age bits.
+  fake_oop->set_mark(fake_oop->mark().set_age(0));
 }
 
 class ArchiveHeapWriter::EmbeddedOopRelocator: public BasicOopIterateClosure {

--- a/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
@@ -65,6 +65,7 @@ public class DeterministicDump {
         }
 
         String baseArchive = dump(baseArgs);
+
         // (1) Dump with the same args. Should produce the same archive.
         String baseArchive2 = dump(baseArgs);
         compare(baseArchive, baseArchive2);

--- a/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
@@ -53,10 +53,7 @@ public class DeterministicDump {
         // Try to reduce indeterminism of GC heap sizing and evacuation.
         baseArgs.add("-Xmx128M");
         baseArgs.add("-Xms128M");
-        baseArgs.add("-Xmn128M");
-        baseArgs.add("-XX:ParallelGCThreads=1");
-        baseArgs.add("-XX:-ResizeTLAB");
-        baseArgs.add("-XX:-ResizePLAB");
+        baseArgs.add("-Xmn120M");
 
         if (Platform.is64bit()) {
             // This option is available only on 64-bit.

--- a/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
@@ -50,8 +50,13 @@ public class DeterministicDump {
     public static void doTest(boolean compressed) throws Exception {
         ArrayList<String> baseArgs = new ArrayList<>();
 
-        // Use the same heap size as make/Images.gmk
+        // Try to reduce indeterminism of GC heap sizing and evacuation.
         baseArgs.add("-Xmx128M");
+        baseArgs.add("-Xms128M");
+        baseArgs.add("-Xmn128M");
+        baseArgs.add("-XX:ParallelGCThreads=1");
+        baseArgs.add("-XX:-ResizeTLAB");
+        baseArgs.add("-XX:-ResizePLAB");
 
         if (Platform.is64bit()) {
             // This option is available only on 64-bit.
@@ -60,7 +65,6 @@ public class DeterministicDump {
         }
 
         String baseArchive = dump(baseArgs);
-
         // (1) Dump with the same args. Should produce the same archive.
         String baseArchive2 = dump(baseArgs);
         compare(baseArchive, baseArchive2);
@@ -80,7 +84,7 @@ public class DeterministicDump {
         String mapName = logName + ".map";
         CDSOptions opts = (new CDSOptions())
             .addPrefix("-Xint") // Override any -Xmixed/-Xcomp flags from jtreg -vmoptions
-            .addPrefix("-Xlog:cds=debug")
+            .addPrefix("-Xlog:cds=debug,gc=debug")
             .addPrefix("-Xlog:cds+map*=trace:file=" + mapName + ":none:filesize=0")
             .setArchiveName(archiveName)
             .addSuffix(args)


### PR DESCRIPTION
Hi all,

  please review this change to make `runtime/cds/DeterministicDump.java` more reliable in presence of GC changes (which https://bugs.openjdk.org/browse/JDK-8295269 stumbled over).

This includes some change to strip the gc age from the dumped objects, but mainly trying to fix heap sizes etc so that GCs are executed consistently (i.e. not at all) in this test.

Testing: tier5, running the test a few thousand times

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343298](https://bugs.openjdk.org/browse/JDK-8343298): Improve stability of runtime/cds/DeterministicDump.java test (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21871/head:pull/21871` \
`$ git checkout pull/21871`

Update a local copy of the PR: \
`$ git checkout pull/21871` \
`$ git pull https://git.openjdk.org/jdk.git pull/21871/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21871`

View PR using the GUI difftool: \
`$ git pr show -t 21871`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21871.diff">https://git.openjdk.org/jdk/pull/21871.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21871#issuecomment-2454272362)
</details>
