### PR TITLE
8343532: Test test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java fails on Linux ppc64le after JDK-8319343

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,7 +49,7 @@ public class AddmodsOption {
         final String allSystem = "ALL-SYSTEM";
         final String allModulePath = "ALL-MODULE-PATH";
         final String loggingOption = "-Xlog:cds=debug,cds+module=debug,cds+heap=info,module=trace";
-        final String versionPattern = "java.[0-9][0-9][-].*";
+        final String versionPattern = "java.[0-9][0-9].*";
         final String subgraphCannotBeUsed = "subgraph jdk.internal.module.ArchivedBootLayer cannot be used because full module graph is disabled";
         final String warningIncubator = "WARNING: Using incubator modules: jdk.incubator.vector";
         String archiveName = TestCommon.getNewArchiveName("addmods-option");
@@ -72,7 +72,7 @@ public class AddmodsOption {
             "-version");
         oa.shouldHaveExitValue(0)
           // version of the jdk.httpserver module, e.g. java 22-ea
-          //.shouldMatch(versionPattern)
+          .shouldMatch(versionPattern)
           .shouldMatch("cds,module.*Restored from archive: entry.0x.*name jdk.jconsole")
           .shouldMatch("cds,module.*Restored from archive: entry.0x.*name jdk.httpserver");
 
@@ -114,7 +114,7 @@ public class AddmodsOption {
         oa.shouldHaveExitValue(0)
           .shouldContain("--add-modules module name(s) specified during runtime but not found in archive: jdk.jconsole")
           // version of the jdk.httpserver module, e.g. java 22-ea
-          //.shouldMatch(versionPattern)
+          .shouldMatch(versionPattern)
           .shouldContain(subgraphCannotBeUsed);
 
         // dump an archive with an incubator module, -add-modules jdk.incubator.vector

--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,6 +27,7 @@
  * @summary Test handling of the --add-modules option.
  * @requires vm.cds.write.archived.java.heap
  * @requires vm.flagless
+ * @requires vm.jvmci
  * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver AddmodsOption
  */


### PR DESCRIPTION
Test test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java fails on Linux ppc64le after [JDK-8319343](https://bugs.openjdk.org/browse/JDK-8319343) with error message
"Unrecognized VM option 'EagerJVMCI" .
The test needs jvmci but this is not supported/available on Linux ppc64le.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343532](https://bugs.openjdk.org/browse/JDK-8343532): Test test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java fails on Linux ppc64le after JDK-8319343 (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) Review applies to [1d0d981d](https://git.openjdk.org/jdk/pull/21873/files/1d0d981d24cae3b2d7c2fec8ea5dc6bf529ec24d)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21873/head:pull/21873` \
`$ git checkout pull/21873`

Update a local copy of the PR: \
`$ git checkout pull/21873` \
`$ git pull https://git.openjdk.org/jdk.git pull/21873/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21873`

View PR using the GUI difftool: \
`$ git pr show -t 21873`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21873.diff">https://git.openjdk.org/jdk/pull/21873.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21873#issuecomment-2454564589)
</details>
