### PR TITLE
8251926: PPC: Remove an unused variable in assembler_ppc.cpp

### DIFF
--- a/src/hotspot/cpu/ppc/assembler_ppc.cpp
+++ b/src/hotspot/cpu/ppc/assembler_ppc.cpp
@@ -448,7 +448,6 @@ int Assembler::load_const_optimized(Register d, long x, Register tmp, bool retur
       xa = (x >> 48) & 0xffff;
       xb = (x >> 32) & 0xffff; // No sign compensation, we use lis+ori or li to allow usage of R0.
       bool xa_loaded = (xb & 0x8000) ? (xa != -1) : (xa != 0);
-      bool return_xd = false;
 
       if (xa_loaded) { lis(tmp, xa); }
       if (xc) { lis(d, xc); }


### PR DESCRIPTION
This PR removes an unused variable from load_const_optimized function in assembler_ppc.cpp file.

JBS Issue: [JDK-8251926](https://bugs.openjdk.org/browse/JDK-8251926)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8251926](https://bugs.openjdk.org/browse/JDK-8251926): PPC: Remove an unused variable in assembler_ppc.cpp (**Enhancement** - P5)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21874/head:pull/21874` \
`$ git checkout pull/21874`

Update a local copy of the PR: \
`$ git checkout pull/21874` \
`$ git pull https://git.openjdk.org/jdk.git pull/21874/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21874`

View PR using the GUI difftool: \
`$ git pr show -t 21874`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21874.diff">https://git.openjdk.org/jdk/pull/21874.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21874#issuecomment-2454578871)
</details>
