### PR TITLE
8337114: DocType checker for generated documentation

### DIFF
--- a/test/docs/jdk/javadoc/doccheck/DocCheck.java
+++ b/test/docs/jdk/javadoc/doccheck/DocCheck.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import doccheckutils.FileChecker;
+import doccheckutils.FileProcessor;
+import doccheckutils.HtmlFileChecker;
+import doccheckutils.checkers.BadCharacterChecker;
+import doccheckutils.checkers.DocTypeChecker;
+import doccheckutils.checkers.LinkChecker;
+import doccheckutils.checkers.TidyChecker;
+import toolbox.TestRunner;
+
+import java.nio.file.Path;
+import java.util.*;
+
+/**
+ * DocCheck
+ *
+ *  For the sake of brefity, to run all of these checkers use
+ *
+ *      `make test-docs_all TEST_DEPS=docs-jdk`
+ *
+ *  This collection of tests provide a variety of checks for JDK documentation bundle.
+ *
+ *  It is meant to provide a convenient way to alert users of any errors in their documentation
+ *  before a push and verify the quality of the documentation.
+ *  It is not meant to replace more authoritative checkers; instead,
+ *  it is more focused on providing a convenient, easy overview of any possible issues.
+ *
+ *  It supports the following checks:
+ *
+ *  *HTML* -- We use the standard `tidy` utility to check for HTML compliance,
+ *            according to the declared version of HTML.
+ *     The output from `tidy` is analysed to generate a report summarizing any issues that were found.
+ *
+ *     Version `5.9.20` of `tidy` is expected, or the output from the `--version` option should contain the string `version 5`.
+ *     The test warns the user if he is using an earlier version.
+ *
+ *  *Bad Characters* -- We assumee that HTML files are encoded in UTF-8,
+ *     and reports any character encoding issues that it finds.
+ *
+ *  *DocType* --  We assume that HTML files should use HTML5, and reports
+ *     any files for which that is not the case.
+ *
+ *  *Links* -- We check links within a set of files, and reports on links
+ *     to external resources, without otherwise checking them.
+ *
+ *  TODO (not yet added)
+ *  *External Links* -- We scan the files for URLs that refer to
+ *     external resources, and validates those references using a "golden file" that includes a list of vetted links.
+ *
+ *     Each external reference is only checked once; but if an issue is found, all the files containing the
+ *     reference will be reported.
+ *
+ */
+public class DocCheck extends TestRunner {
+    private static final Path DIR = Path.of(System.getProperty("doccheck.dir"));
+    private static final Set <String> EXCLUDE_LIST = new HashSet<>();
+    private static Path DOCS_DIR;
+
+    private static boolean  html;
+    private static boolean  links;
+    private static boolean  badchars;
+    private static boolean  doctype;
+
+    private List<Path> files;
+
+    public DocCheck() {
+        super(System.err);
+        init();
+    }
+
+    public static void main(String... args) throws Exception {
+        chooseCheckers();
+        DocCheck docCheck = new DocCheck();
+        docCheck.runTests();
+    }
+
+    private static void chooseCheckers() {
+        final String checks = System.getProperty("doccheck.checks");
+
+        if (!checks.isEmpty()) {
+            if (checks.contains(",")) {
+                EXCLUDE_LIST.addAll(Arrays.asList(checks.split(",")));
+            } else {
+                EXCLUDE_LIST.add(checks);
+            }
+        }
+
+        if (checks.contains("all")){
+            html = true;
+            links = true;
+            badchars = true;
+            doctype = true;
+        }else {
+            if(checks.contains("html")){
+                html=true;
+            }
+            if(checks.contains("links")){
+                links=true;
+            }
+            if(checks.contains("badchars")){
+                badchars=true;
+            }
+            if(checks.contains("doctype")){
+                doctype=true;
+            }
+        }
+    }
+
+    public void init() {
+        var fileTester = new FileProcessor();
+        DOCS_DIR = DocTester.resolveDocs();
+        var baseDir = DOCS_DIR.resolve(DIR);
+        fileTester.processFiles(baseDir);
+        files = fileTester.getFiles();
+    }
+
+    public List<FileChecker> getCheckers() {
+
+        List<FileChecker> checkers = new ArrayList<>();
+        if(html){
+            checkers.add(new TidyChecker());
+        }
+        if(links){
+            var linkChecker = new LinkChecker();
+            linkChecker.setBaseDirWereChecking(DOCS_DIR);
+            checkers.add(new HtmlFileChecker(linkChecker, DOCS_DIR));
+        }
+
+        // there should be almost nothing reported from these two checkers
+        // most reports should be broken anchors/links, missing files and errors in html
+        if(badchars){
+            checkers.add(new BadCharacterChecker());
+        }
+        if(doctype){
+            checkers.add(new HtmlFileChecker(new DocTypeChecker(), DOCS_DIR));
+        }
+
+        return checkers;
+    }
+
+    @Test
+    public void test() throws Exception {
+        List<FileChecker> checkers = getCheckers();
+        runCheckersSequentially(checkers);
+    }
+
+    private void runCheckersSequentially(List<FileChecker> checkers) throws Exception {
+        List<Throwable> exceptions = new ArrayList<>();
+
+        for (FileChecker checker : checkers) {
+            try (checker) {
+                checker.checkFiles(files);
+            } catch (Exception e) {
+                exceptions.add(e);
+            }
+        }
+
+        if (!exceptions.isEmpty()) {
+            throw new Exception("One or more HTML checkers failed: " + exceptions);
+        }
+    }
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/Checker.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/Checker.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils;
+
+import java.io.Closeable;
+
+/**
+ * Base class for {@link FileChecker file checkers} and
+ */
+public interface Checker extends Closeable {
+
+    /**
+     * Writes a report at the end of a run, to summarize the results of the
+     * checking done by this checker.
+     */
+    void report();
+
+    boolean isOK();
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/FileChecker.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/FileChecker.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public interface FileChecker extends Checker {
+    void checkFiles(List<Path> files);
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/FileProcessor.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/FileProcessor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+
+public class FileProcessor {
+    private final List<Path> files;
+
+    public FileProcessor() {
+        files = new ArrayList<>();
+    }
+
+    public List<Path> getFiles() {
+        return files;
+    }
+
+    public void processFiles(Path directory) {
+        try {
+            Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    if (file.toString().endsWith(".html"))
+                        files.add(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/HtmlChecker.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/HtmlChecker.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Base class for HTML checkers.
+ * <p>
+ * For details on HTML syntax and the terms used in this API, see
+ * W3C <a href="https://www.w3.org/TR/html5/syntax.html#syntax">The HTML syntax</a>.
+ */
+public interface HtmlChecker extends Checker {
+    /**
+     * Starts checking a new file,
+     * <p>
+     * The file becomes the <em>current</em> file until {@link #endFile endFile}
+     * is called.
+     *
+     * @param path the file.
+     */
+    void startFile(Path path);
+
+    /**
+     * Ends checking the current file.
+     */
+    void endFile();
+
+    /**
+     * Checks the content of a {@code <?xml ... ?>} declaration in the
+     * current file.
+     *
+     * @param line  the line number on which the declaration was found
+     * @param attrs the content of the declaration
+     */
+    void xml(int line, Map<String, String> attrs);
+
+    /**
+     * Checks the content of a {@code <!doctype ... >} declaration in the
+     * current file.
+     *
+     * @param line    the line number on which the declaration was found
+     * @param docType the content of the declaration
+     */
+    void docType(int line, String docType);
+
+    /**
+     * Checks the start of an HTML tag in the current file.
+     *
+     * @param line        the line number on which the start tag for an element was found
+     * @param name        the name of the tag
+     * @param attrs       the attributes of the tag
+     * @param selfClosing whether or not the tag is self-closing
+     */
+    void startElement(int line, String name, Map<String, String> attrs, boolean selfClosing);
+
+    /**
+     * Checks the end of an HTML tag in the current file.
+     *
+     * @param line the line number on which the end tag for an element was found
+     * @param name the name of the tag
+     */
+    void endElement(int line, String name);
+
+    /**
+     * Checks the content appearing in between HTML tags.
+     *
+     * @param line    the line number on which the content was found
+     * @param content the content
+     */
+    default void content(int line, String content) {
+    }
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/HtmlFileChecker.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/HtmlFileChecker.java
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * Reads an HTML file, and calls a series of{@link HtmlChecker HTML checkers}
+ * for the HTML constructs found therein.
+ */
+public class HtmlFileChecker implements FileChecker {
+    private final CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.IGNORE)
+            .onUnmappableCharacter(CodingErrorAction.IGNORE);
+
+    private final Log log;
+    private final HtmlChecker htmlChecker;
+    private Path path;
+    private BufferedReader in;
+    private int ch;
+    private int lineNumber;
+    private boolean inScript;
+    private boolean xml;
+
+    public HtmlFileChecker(HtmlChecker htmlChecker, Path BaseDir) {
+        this.log = new Log();
+        log.setBaseDirectory(BaseDir);
+        this.htmlChecker = htmlChecker;
+    }
+
+    @Override
+    public void checkFiles(List<Path> files) {
+        for (Path file : files) {
+            read(file);
+        }
+    }
+
+    @Override
+    public void report() {
+        System.err.println(log);
+    }
+
+    @Override
+    public void close() throws IOException {
+//        report();
+        htmlChecker.close();
+    }
+
+    private void read(Path path) {
+        try (BufferedReader r = new BufferedReader(
+                new InputStreamReader(Files.newInputStream(path), decoder))) {
+            this.path = path;
+            this.in = r;
+            StringBuilder content = new StringBuilder();
+
+            startFile(path);
+            try {
+                lineNumber = 1;
+                xml = false;
+                nextChar();
+
+                while (ch != -1) {
+                    if (ch == '<') {
+                        content(content.toString());
+                        content.setLength(0);
+                        html();
+                    } else {
+                        content.append((char) ch);
+                        if (ch == '\n') {
+                            content(content.toString());
+                            content.setLength(0);
+                        }
+                        nextChar();
+                    }
+                }
+            } finally {
+                endFile();
+            }
+        } catch (IOException e) {
+            log.log(path, lineNumber, e);
+        } catch (Throwable t) {
+            log.log(path, lineNumber, t);
+            log.log(String.valueOf(t));
+        }
+    }
+
+    private void startFile(Path path) {
+        htmlChecker.startFile(path);
+    }
+
+    private void endFile() {
+        htmlChecker.endFile();
+    }
+
+    private void docType(String s) {
+        htmlChecker.docType(lineNumber, s);
+    }
+
+    private void startElement(String name, Map<String, String> attrs, boolean selfClosing) {
+        htmlChecker.startElement(lineNumber, name, attrs, selfClosing);
+    }
+
+    private void endElement(String name) {
+        htmlChecker.endElement(lineNumber, name);
+    }
+
+    private void content(String s) {
+        htmlChecker.content(lineNumber, s);
+    }
+
+    private void nextChar() throws IOException {
+        ch = in.read();
+        if (ch == '\n')
+            lineNumber++;
+    }
+
+    /**
+     * Read the start or end of an HTML tag, or an HTML comment
+     * {@literal <identifier attrs> } or {@literal </identifier> }
+     *
+     * @throws IOException if there is a problem reading the file
+     */
+    protected void html() throws IOException {
+        nextChar();
+        if (isIdentifierStart((char) ch)) {
+            String name = readIdentifier().toLowerCase(Locale.US);
+            Map<String, String> attrs = htmlAttrs();
+            if (attrs != null) {
+                boolean selfClosing = false;
+                if (ch == '/') {
+                    nextChar();
+                    selfClosing = true;
+                }
+                if (ch == '>') {
+                    nextChar();
+                    startElement(name, attrs, selfClosing);
+                    if (name.equals("script")) {
+                        inScript = true;
+                    }
+                    return;
+                }
+            }
+        } else if (ch == '/') {
+            nextChar();
+            if (isIdentifierStart((char) ch)) {
+                String name = readIdentifier().toLowerCase(Locale.US);
+                skipWhitespace();
+                if (ch == '>') {
+                    nextChar();
+                    endElement(name);
+                    if (name.equals("script")) {
+                        inScript = false;
+                    }
+                    return;
+                }
+            }
+        } else if (ch == '!') {
+            nextChar();
+            if (ch == '-') {
+                nextChar();
+                if (ch == '-') {
+                    nextChar();
+                    while (ch != -1) {
+                        int dash = 0;
+                        while (ch == '-') {
+                            dash++;
+                            nextChar();
+                        }
+                        // Strictly speaking, a comment should not contain "--"
+                        // so dash > 2 is an error, dash == 2 implies ch == '>'
+                        // See http://www.w3.org/TR/html-markup/syntax.html#syntax-comments
+                        // for more details.
+                        if (dash >= 2 && ch == '>') {
+                            nextChar();
+                            return;
+                        }
+
+                        nextChar();
+                    }
+                }
+            } else if (ch == '[') {
+                nextChar();
+                if (ch == 'C') {
+                    nextChar();
+                    if (ch == 'D') {
+                        nextChar();
+                        if (ch == 'A') {
+                            nextChar();
+                            if (ch == 'T') {
+                                nextChar();
+                                if (ch == 'A') {
+                                    nextChar();
+                                    if (ch == '[') {
+                                        while (true) {
+                                            nextChar();
+                                            if (ch == ']') {
+                                                nextChar();
+                                                if (ch == ']') {
+                                                    nextChar();
+                                                    if (ch == '>') {
+                                                        nextChar();
+                                                        return;
+                                                    }
+                                                }
+                                            }
+                                        }
+
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } else {
+                StringBuilder sb = new StringBuilder();
+                while (ch != -1 && ch != '>') {
+                    sb.append((char) ch);
+                    nextChar();
+                }
+                Pattern p = Pattern.compile("(?is)doctype\\s+html\\s?.*");
+                String s = sb.toString();
+                if (p.matcher(s).matches()) {
+                    xml = s.contains("XHTML");
+                    docType(s);
+                    return;
+                }
+            }
+        } else if (ch == '?') {
+            nextChar();
+            if (ch == 'x') {
+                nextChar();
+                if (ch == 'm') {
+                    nextChar();
+                    if (ch == 'l') {
+                        nextChar();
+                        if (ch == '?') {
+                            nextChar();
+                            if (ch == '>') {
+                                nextChar();
+                                xml = true;
+                                return;
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+
+        if (!inScript) {
+            log.log(path, lineNumber, "bad html");
+        }
+    }
+
+    /**
+     * Read a series of HTML attributes, terminated by {@literal > }.
+     * Each attribute is of the form {@literal identifier[=value] }.
+     * "value" may be unquoted, single-quoted, or double-quoted.
+     */
+    protected Map<String, String> htmlAttrs() throws IOException {
+        Map<String, String> map = new LinkedHashMap<>();
+        skipWhitespace();
+
+        while (isIdentifierStart((char) ch)) {
+            String name = readAttributeName().toLowerCase(Locale.US);
+            skipWhitespace();
+            String value = null;
+            if (ch == '=') {
+                nextChar();
+                skipWhitespace();
+                if (ch == '\'' || ch == '"') {
+                    char quote = (char) ch;
+                    nextChar();
+                    StringBuilder sb = new StringBuilder();
+                    while (ch != -1 && ch != quote) {
+//                            if (ch == '\n') {
+//                                error(path, lineNumber, "unterminated string");
+//                                // No point trying to read more.
+//                                // In fact, all attrs get discarded by the caller
+//                                // and superseded by a malformed.html node because
+//                                // the html tag itself is not terminated correctly.
+//                                break loop;
+//                            }
+                        sb.append((char) ch);
+                        nextChar();
+                    }
+                    value = sb.toString() // hack to replace common entities
+                            .replace("&lt;", "<")
+                            .replace("&gt;", ">")
+                            .replace("&amp;", "&");
+                    nextChar();
+                } else {
+                    StringBuilder sb = new StringBuilder();
+                    while (ch != -1 && !isUnquotedAttrValueTerminator((char) ch)) {
+                        sb.append((char) ch);
+                        nextChar();
+                    }
+                    value = sb.toString();
+                }
+                skipWhitespace();
+            }
+            map.put(name, value);
+        }
+
+        return map;
+    }
+
+    protected boolean isIdentifierStart(char ch) {
+        return Character.isUnicodeIdentifierStart(ch);
+    }
+
+    protected String readIdentifier() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append((char) ch);
+        nextChar();
+        while (ch != -1 && Character.isUnicodeIdentifierPart(ch)) {
+            sb.append((char) ch);
+            nextChar();
+        }
+        return sb.toString();
+    }
+
+    protected String readAttributeName() throws IOException {
+        StringBuilder sb = new StringBuilder();
+        sb.append((char) ch);
+        nextChar();
+        while ((ch != -1 && Character.isUnicodeIdentifierPart(ch))
+                || ch == '-'
+                || (xml && ch == ':')) {
+            sb.append((char) ch);
+            nextChar();
+        }
+        return sb.toString();
+    }
+
+    protected boolean isWhitespace(char ch) {
+        return Character.isWhitespace(ch);
+    }
+
+    protected void skipWhitespace() throws IOException {
+        while (isWhitespace((char) ch)) {
+            nextChar();
+        }
+    }
+
+    protected boolean isUnquotedAttrValueTerminator(char ch) {
+        return switch (ch) {
+            case '\f', '\n', '\r', '\t', ' ', '"', '\'', '`', '=', '<', '>' -> true;
+            default -> false;
+        };
+    }
+
+    @Override
+    public boolean isOK() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/Log.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/Log.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Log {
+    private final ArrayList<String> errors;
+
+    private Path baseDir;
+
+    public Log() {
+        errors = new ArrayList<>();
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void log(Path path, int line, String message, Object... args) {
+        errors.add(formatErrorMessage(path, line, message, args));
+    }
+
+
+    public String formatErrorMessage(Path path, int line, String message, Object... args) {
+        return path + ":" + line + ": " + formatErrorMessage(message, args);
+    }
+
+    public String formatErrorMessage(Path path, int line, Throwable t) {
+        return path + ":" + line + ": " + t;
+    }
+
+    public String formatErrorMessage(Path path, Throwable t) {
+        return path + ": " + t;
+    }
+
+
+    public String formatErrorMessage(String message, Object... args) {
+        return String.format(message, args);
+    }
+
+    public void log(String message) {
+        errors.add(message);
+    }
+
+    public void log(Path path, int lineNumber, String s, int errorsOnLine) {
+        log(formatErrorMessage(path, lineNumber, s, errorsOnLine));
+    }
+
+    public void log(Path path, int line, Throwable t) {
+        log(formatErrorMessage(path, line, t));
+    }
+
+    public void log(Path path, Throwable t) {
+        log(formatErrorMessage(path, t));
+    }
+
+    public void log(String message, Object... args) {
+        log(formatErrorMessage(message, args));
+    }
+
+    public void setBaseDirectory(Path baseDir) {
+        this.baseDir = baseDir.toAbsolutePath();
+    }
+
+    public Path againstBaseDir(Path path) {
+        return baseDir != null && path.startsWith(baseDir) ? baseDir.relativize(path) : path;
+    }
+
+    public boolean noErrors() {
+        return errors.isEmpty();
+    }
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/BadCharacterChecker.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/BadCharacterChecker.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils.checkers;
+
+import doccheckutils.FileChecker;
+import doccheckutils.Log;
+
+import java.io.*;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Checks the contents of an HTML file for bad/unmappable characters.
+ * <p>
+ * The file encoding is determined from the file contents.
+ */
+public class BadCharacterChecker implements FileChecker, AutoCloseable {
+    private static final Pattern doctype = Pattern.compile("(?i)<!doctype html>");
+    private static final Pattern metaCharset = Pattern.compile("(?i)<meta\\s+charset=\"([^\"]+)\">");
+    private static final Pattern metaContentType = Pattern.compile("(?i)<meta\\s+http-equiv=\"Content-Type\"\\s+content=\"text/html;charset=([^\"]+)\">");
+    private final Log errors;
+    private int files = 0;
+    private int badFiles = 0;
+
+    public BadCharacterChecker() {
+        errors = new Log();
+    }
+
+    public void checkFile(Path path) {
+        files++;
+        boolean ok = true;
+        try (InputStream in = new BufferedInputStream(Files.newInputStream(path))) {
+            CharsetDecoder d = getCharset(in).newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPLACE)
+                    .onUnmappableCharacter(CodingErrorAction.REPLACE);
+            BufferedReader r = new BufferedReader(new InputStreamReader(in, d));
+            int lineNumber = 0;
+            String line;
+            try {
+                while ((line = r.readLine()) != null) {
+                    lineNumber++;
+                    int errorsOnLine = 0;
+                    for (int i = 0; i < line.length(); i++) {
+                        char ch = line.charAt(i);
+                        if (ch == 0xFFFD) {
+                            errorsOnLine++;
+                        }
+                    }
+                    if (errorsOnLine > 0) {
+                        errors.log(path, lineNumber, "found %d invalid characters", errorsOnLine);
+                        ok = false;
+                    }
+                }
+            } catch (IOException e) {
+                errors.log(path, lineNumber, e);
+                ok = false;
+
+            }
+        } catch (IOException e) {
+            errors.log(path, e);
+            ok = false;
+        }
+        if (!ok)
+            badFiles++;
+    }
+
+    @Override
+    public void checkFiles(List<Path> files) {
+        for (Path file : files) {
+            checkFile(file);
+        }
+    }
+
+    private Charset getCharset(InputStream in) throws IOException {
+        CharsetDecoder initial = StandardCharsets.US_ASCII.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPLACE)
+                .onUnmappableCharacter(CodingErrorAction.REPLACE);
+
+        in.mark(1024);
+        try {
+            BufferedReader r = new BufferedReader(new InputStreamReader(in, initial));
+            char[] buf = new char[1024];
+            int n = r.read(buf, 0, buf.length);
+            String head = new String(buf, 0, n);
+            boolean html5 = doctype.matcher(head).find();
+            Matcher m1 = metaCharset.matcher(head);
+            if (m1.find()) {
+                return Charset.forName(m1.group(1));
+            }
+            Matcher m2 = metaContentType.matcher(head);
+            if (m2.find()) {
+                return Charset.forName(m2.group(1));
+            }
+            return html5 ? StandardCharsets.UTF_8 : StandardCharsets.ISO_8859_1;
+        } finally {
+            in.reset();
+        }
+    }
+
+    @Override
+    public void report() {
+        if (!errors.noErrors() && files > 0) {
+            System.err.println("Bad characters found in the generated HTML");
+
+            System.err.println(MessageFormat.format(
+                    """
+                            Bad Characters Report
+                            {0} files read
+                                {1} files contained bad characters"
+                                {2} bad characters or other errors found
+                            """,
+                    files, badFiles, files));
+
+            for (String s : errors.getErrors()) {
+                System.err.println(s);
+            }
+            throw new RuntimeException("Bad character found in the generated HTML");
+        }
+    }
+
+    @Override
+    public boolean isOK() {
+        return errors.noErrors();
+    }
+
+    @Override
+    public void close() throws IOException {
+        report();
+    }
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/DocTypeChecker.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/DocTypeChecker.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils.checkers;
+
+import doccheckutils.HtmlChecker;
+import doccheckutils.Log;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Checks the DocType declared at the head of an HTML file.
+ *
+ * @see <a href="https://www.w3.org/TR/html5/syntax.html#syntax-doctype">
+ * W3C HTML5 8.1.1 The DOCTYPE</a>
+ */
+public class DocTypeChecker implements HtmlChecker {
+    private final Log log;
+    private final Map<String, Integer> counts = new HashMap<>();
+    private int html5;
+    private int html5_legacy;
+    private int xml;
+    private int other;
+
+    private Path path;
+
+    public DocTypeChecker() {
+        log = new Log();
+    }
+
+    @Override
+    public void startFile(Path path) {
+        this.path = path;
+    }
+
+    @Override
+    public void endFile() {
+    }
+
+    @Override
+    public void xml(int line, Map<String, String> attrs) {
+        xml++;
+    }
+
+    @Override
+    public void docType(int line, String docType) {
+        if (docType.equalsIgnoreCase("doctype html")) {
+            html5++;
+        } else {
+            Pattern p = Pattern.compile("(?i)doctype"
+                    + "\\s+html"
+                    + "\\s+([a-z]+)"
+                    + "\\s+\"([^\"]+)\""
+                    + "(?:\\s+\"([^\"]+)\")?"
+                    + "\\s*");
+            Matcher m = p.matcher(docType);
+            if (m.matches()) {
+                // See http://www.w3.org/tr/html52/syntax.html#the-doctype
+                if (m.group(1).equalsIgnoreCase("system")
+                        && m.group(2).equals("about:legacy-compat")) {
+                    html5_legacy++;
+                } else {
+                    String version = m.group(2);
+                    List<String> allowedVersions = List.of(
+                            "-//W3C//DTD XHTML 1.0 Strict//EN"
+                    );
+                    if (allowedVersions.stream().noneMatch(v -> v.equals(version))) {
+                        log.log(path, line, "unexpected doctype: " + version);
+                    }
+                    counts.put(version, counts.getOrDefault(version, 0) + 1);
+                }
+            } else {
+                log.log(path, line, "doctype not recognized: " + docType);
+                other++;
+            }
+        }
+    }
+
+    @Override
+    public void startElement(int line, String name, Map<String, String> attrs, boolean selfClosing) {
+    }
+
+    @Override
+    public void endElement(int line, String name) {
+    }
+
+    @Override
+    public void report() {
+        log.log("DocType Report");
+        if (xml > 0) {
+            log.log("%6d: XHTML%n", xml);
+        }
+        if (html5 > 0) {
+            log.log("%6d: HTML5%n", html5);
+        }
+        if (html5_legacy > 0) {
+            log.log("%6d: HTML5 (legacy)%n", html5_legacy);
+        }
+
+        Map<Integer, Set<String>> sortedCounts = new TreeMap<>(Comparator.reverseOrder());
+
+        for (Map.Entry<String, Integer> e : counts.entrySet()) {
+            String s = e.getKey();
+            Integer n = e.getValue();
+            Set<String> set = sortedCounts.computeIfAbsent(n, k -> new TreeSet<>());
+            set.add(s);
+        }
+
+        for (Map.Entry<Integer, Set<String>> e : sortedCounts.entrySet()) {
+            for (String p : e.getValue()) {
+                log.log("%6d: %s%n", e.getKey(), p);
+            }
+        }
+
+        if (other > 0) {
+            log.log("%6d: other/unrecognized%n", other);
+        }
+
+        for (var line : log.getErrors()) {
+            System.err.println(line);
+        }
+    }
+
+    @Override
+    public boolean isOK() {
+        return counts.isEmpty() && (other == 0);
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (!isOK()) {
+            report();
+            throw new RuntimeException("Found HTML files with missing doctype declaration");
+        }
+    }
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/LinkChecker.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/LinkChecker.java
@@ -1,0 +1,474 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils.checkers;
+
+
+import doccheckutils.HtmlChecker;
+import doccheckutils.Log;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Checks the links defined by and referenced in HTML files.
+ */
+public class LinkChecker implements HtmlChecker {
+
+    private final Log log;
+    private final Map<Path, IDTable> allFiles;
+    private final Map<URI, IDTable> allURIs;
+    private boolean checkInwardReferencesOnly;
+    private int files;
+    private int links;
+    private int duplicateIds;
+    private int missingFiles;
+    private int missingIds;
+    private int badSchemes;
+    private Path currFile;
+    private IDTable currTable;
+    private boolean html5;
+    private boolean xml;
+    public LinkChecker() {
+        this.log = new Log();
+        allFiles = new HashMap<>();
+        allURIs = new HashMap<>();
+    }
+
+    public void setBaseDirWereChecking(Path dir) {
+        log.setBaseDirectory(dir);
+    }
+
+    public void setCheckInwardReferencesOnly(boolean checkInwardReferencesOnly) {
+        this.checkInwardReferencesOnly = checkInwardReferencesOnly;
+    }
+
+    @Override
+    public void startFile(Path path) {
+        currFile = path.toAbsolutePath().normalize();
+        currTable = allFiles.computeIfAbsent(currFile, p -> new IDTable(log.againstBaseDir(p)));
+        html5 = false;
+        files++;
+    }
+
+    @Override
+    public void endFile() {
+        currTable.check();
+    }
+
+
+    //unused
+    public List<Path> getUncheckedFiles() {
+        return allFiles.entrySet().stream()
+                .filter(e -> !e.getValue().checked
+                        && e.getKey().toString().endsWith(".html")
+                        && Files.exists(e.getKey()))
+                .map(Map.Entry::getKey)
+                .toList();
+    }
+
+    public List<Path> getMissingFiles() {
+        return allFiles.keySet().stream()
+                .filter(idTable -> !Files.exists(idTable)).toList();
+    }
+
+    @Override
+    public void xml(int line, Map<String, String> attrs) {
+        xml = true;
+    }
+
+    @Override
+    public void docType(int line, String doctype) {
+        html5 = doctype.matches("(?i)<\\?doctype\\s+html>");
+    }
+
+    @Override
+    @SuppressWarnings("fallthrough")
+    public void startElement(int line, String name, Map<String, String> attrs, boolean selfClosing) {
+        switch (name) {
+            case "a":
+                String nameAttr = html5 ? null : attrs.get("name");
+                if (nameAttr != null) {
+                    foundAnchor(line, nameAttr);
+                }
+                // fallthrough
+            case "link":
+                String href = attrs.get("href");
+                if (href != null && !checkInwardReferencesOnly) {
+                    foundReference(line, href);
+                }
+                break;
+        }
+
+        String idAttr = attrs.get("id");
+        if (idAttr != null) {
+            foundAnchor(line, idAttr);
+        }
+    }
+
+    @Override
+    public void endElement(int line, String name) {
+    }
+
+    @Override
+    public void content(int line, String content) {
+        HtmlChecker.super.content(line, content);
+    }
+
+    @Override
+    public void report() {
+        List<Path> pathList = getMissingFiles();
+        log.log("");
+        log.log("Link Checker Report");
+
+        if (!pathList.isEmpty()) {
+            log.log("");
+            log.log("Missing files: (" + pathList.size() + ")");
+            pathList.stream()
+                    .sorted()
+                    .forEach(this::reportMissingFile);
+        }
+
+        int anchors = 0;
+        for (IDTable t : allFiles.values()) {
+            anchors += t.map.values().stream()
+                    .filter(e -> !e.getReferences().isEmpty())
+                    .count();
+        }
+        for (IDTable t : allURIs.values()) {
+            anchors += t.map.values().stream()
+                    .filter(e -> !e.references.isEmpty())
+                    .count();
+        }
+
+        log.log("Checked " + files + " files.");
+        log.log("Found " + links + " references to " + anchors + " anchors "
+                + "in " + allFiles.size() + " files and " + allURIs.size() + " other URIs.");
+        if (!pathList.isEmpty()) {
+            log.log("%6d missing files", pathList.size());
+        }
+        if (duplicateIds > 0) {
+            log.log("%6d duplicate ids", duplicateIds);
+
+        }
+        if (missingIds > 0) {
+            log.log("%6d missing ids", missingIds);
+
+        }
+
+        Map<String, Integer> hostCounts = new TreeMap<>(new HostComparator());
+        for (URI uri : allURIs.keySet()) {
+            String host = uri.getHost();
+            if (host != null) {
+                hostCounts.put(host, hostCounts.computeIfAbsent(host, h -> 0) + 1);
+            }
+        }
+
+        if (hostCounts.size() > 0) {
+            log.log("");
+            log.log("Hosts");
+            hostCounts.forEach((h, n) -> log.log("%6d %s", n, h));
+        }
+
+
+        for (String message : log.getErrors()) {
+            System.err.println(message);
+        }
+
+    }
+
+    private void reportMissingFile(Path file) {
+        log.log(log.againstBaseDir(file).toString());
+        IDTable table = allFiles.get(file);
+        Set<Path> refs = new TreeSet<>();
+        for (IDInfo id : table.map.values()) {
+            if (id.references != null) {
+                for (Position ref : id.references) {
+                    refs.add(ref.path);
+                }
+            }
+        }
+        int n = 0;
+        int MAX_REFS = 10;
+        for (Path ref : refs) {
+            log.log("    in " + log.againstBaseDir(ref));
+            if (++n == MAX_REFS) {
+                log.log("    ... and %d more", refs.size() - n);
+                break;
+            }
+        }
+        missingFiles++;
+    }
+
+    @Override
+    public boolean isOK() {
+        return duplicateIds == 0
+                && missingIds == 0
+                && missingFiles == 0
+                && badSchemes == 0;
+    }
+
+    @Override
+    public void close() throws IOException {
+        report();
+        if (!isOK()) {
+            throw new RuntimeException(
+                    "LinkChecker encountered errors. Duplicate IDs: "
+                            + duplicateIds + ", Missing IDs: " + missingIds
+                            + ", Missing Files: " + missingFiles + ", Bad Schemes: " + badSchemes);
+        }
+    }
+
+    private void foundAnchor(int line, String name) {
+        currTable.addID(line, name);
+    }
+
+    private void foundReference(int line, String ref) {
+        links++;
+        try {
+            String uriPath = ref;
+            String fragment = null;
+
+            // The checker runs into a problem with links that have more than one hash character.
+            // You cannot create a URI unless you convert the second hash character into
+
+            int firstHashIndex = ref.indexOf('#');
+            int lastHashIndex = ref.lastIndexOf('#');
+            if (firstHashIndex != -1 && firstHashIndex != lastHashIndex) {
+                uriPath = ref.substring(0, firstHashIndex);
+                fragment = ref.substring(firstHashIndex + 1).replace("#", "%23");
+            } else if (firstHashIndex != -1) {
+                uriPath = ref.substring(0, firstHashIndex);
+                fragment = ref.substring(firstHashIndex + 1);
+            }
+
+            URI uri = new URI(uriPath);
+            if (fragment != null) {
+                uri = new URI(uri + "#" + fragment);
+            }
+
+            if (uri.isAbsolute()) {
+                foundReference(line, uri);
+            } else {
+                Path p;
+                String resolvedUriPath = uri.getPath();
+                if (resolvedUriPath == null || resolvedUriPath.isEmpty()) {
+                    p = currFile;
+                } else {
+                    p = currFile.getParent().resolve(resolvedUriPath).normalize();
+                }
+
+                if (fragment != null && !fragment.isEmpty()) {
+                    foundReference(line, p, fragment);
+                }
+            }
+        } catch (URISyntaxException e) {
+            log.log(currFile, line, "invalid URI: " + e);
+            System.err.println("Failed to create URI: " + ref);
+        }
+    }
+
+
+    private void foundReference(int line, Path p, String fragment) {
+        IDTable t = allFiles.computeIfAbsent(p, key -> new IDTable(log.againstBaseDir(key)));
+        t.addReference(fragment, currFile, line);
+    }
+
+    private void foundReference(int line, URI uri) {
+        if (!isSchemeOK(uri.getScheme()) && !checkInwardReferencesOnly) {
+            log.log(currFile, line, "bad scheme in URI");
+            badSchemes++;
+        }
+
+        String fragment = uri.getRawFragment();
+        if (fragment != null && !fragment.isEmpty()) {
+            try {
+                URI noFrag = new URI(uri.toString().replaceAll("#\\Q" + fragment + "\\E$", ""));
+                IDTable t = allURIs.computeIfAbsent(noFrag, IDTable::new);
+                t.addReference(fragment, currFile, line);
+            } catch (URISyntaxException e) {
+                throw new Error(e);
+            }
+        }
+    }
+
+    private boolean isSchemeOK(String uriScheme) {
+        if (uriScheme == null) {
+            return true;
+        }
+
+        return switch (uriScheme) {
+            case "ftp", "http", "https", "javascript" -> true;
+            default -> false;
+        };
+    }
+
+    static class Position implements Comparable<Position> {
+        Path path;
+        int line;
+
+        Position(Path path, int line) {
+            this.path = path;
+            this.line = line;
+        }
+
+        @Override
+        public int compareTo(Position o) {
+            int v = path.compareTo(o.path);
+            return v != 0 ? v : Integer.compare(line, o.line);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            } else if (obj == null || getClass() != obj.getClass()) {
+                return false;
+            } else {
+                final Position other = (Position) obj;
+                return Objects.equals(this.path, other.path)
+                        && this.line == other.line;
+            }
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(path) * 37 + line;
+        }
+    }
+
+    static class IDInfo {
+        boolean declared;
+        Set<Position> references;
+
+        Set<Position> getReferences() {
+            return references == null ? Collections.emptySet() : references;
+        }
+    }
+
+    static class URIComparator implements Comparator<URI> {
+        final HostComparator hostComparator = new HostComparator();
+
+        @Override
+        public int compare(URI o1, URI o2) {
+            if (o1.isOpaque() || o2.isOpaque()) {
+                return o1.compareTo(o2);
+            }
+            String h1 = o1.getHost();
+            String h2 = o2.getHost();
+            String s1 = o1.getScheme();
+            String s2 = o2.getScheme();
+            if (h1 == null || h1.isEmpty() || s1 == null || s1.isEmpty()
+                    || h2 == null || h2.isEmpty() || s2 == null || s2.isEmpty()) {
+                return o1.compareTo(o2);
+            }
+            int v = hostComparator.compare(h1, h2);
+            if (v != 0) {
+                return v;
+            }
+            v = s1.compareTo(s2);
+            if (v != 0) {
+                return v;
+            }
+            return o1.compareTo(o2);
+        }
+    }
+
+    static class HostComparator implements Comparator<String> {
+        @Override
+        public int compare(String h1, String h2) {
+            List<String> l1 = new ArrayList<>(Arrays.asList(h1.split("\\.")));
+            Collections.reverse(l1);
+            String r1 = String.join(".", l1);
+            List<String> l2 = new ArrayList<>(Arrays.asList(h2.split("\\.")));
+            Collections.reverse(l2);
+            String r2 = String.join(".", l2);
+            return r1.compareTo(r2);
+        }
+    }
+
+    class IDTable {
+        private final Map<String, IDInfo> map = new HashMap<>();
+        private final String pathOrURI;
+        private boolean checked;
+
+        IDTable(Path path) {
+            this.pathOrURI = path.toString();
+        }
+
+        IDTable(URI uri) {
+            this.pathOrURI = uri.toString();
+        }
+
+        void addID(int line, String name) {
+            if (checked) {
+                throw new IllegalStateException("Adding ID after file has been");
+            }
+            Objects.requireNonNull(name);
+            IDInfo info = map.computeIfAbsent(name, _ -> new IDInfo());
+            if (info.declared) {
+                if (info.references != null || !checkInwardReferencesOnly) {
+                    // don't report error if we're only checking inbound references
+                    // and there are no references to this ID.
+                    log.log(log.againstBaseDir(currFile), line, "name already declared: " + name);
+                    duplicateIds++;
+                }
+            } else {
+                info.declared = true;
+            }
+        }
+
+        void addReference(String name, Path from, int line) {
+            if (checked) {
+                if (name != null) {
+                    IDInfo id = map.get(name);
+                    if (id == null || !id.declared) {
+                        log.log(log.againstBaseDir(from), line, "id not found: " + this.pathOrURI + "#" + name);
+                    }
+                }
+            } else {
+                IDInfo id = map.computeIfAbsent(name, x -> new IDInfo());
+                if (id.references == null) {
+                    id.references = new TreeSet<>();
+                }
+                id.references.add(new Position(from, line));
+            }
+        }
+
+        void check() {
+            map.forEach((name, id) -> {
+                if (name != null && !id.declared) {
+                    for (Position ref : id.references) {
+                        log.log(log.againstBaseDir(ref.path), ref.line, "id not found: " + this.pathOrURI + "#" + name);
+                    }
+                    missingIds++;
+                }
+            });
+            checked = true;
+        }
+    }
+}

--- a/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/TidyChecker.java
+++ b/test/docs/jdk/javadoc/doccheck/doccheckutils/checkers/TidyChecker.java
@@ -1,0 +1,261 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package doccheckutils.checkers;
+
+
+import doccheckutils.FileChecker;
+import doccheckutils.Log;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.text.MessageFormat;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class TidyChecker implements FileChecker, AutoCloseable {
+    private final Path TIDY;
+    Map<Pattern, Integer> counts = new HashMap<>();
+    Pattern okPattern = Pattern.compile("No warnings or errors were found.");
+    Pattern countPattern = Pattern.compile("([0-9]+) warnings, ([0-9]+) errors were found!.*?(Not all warnings/errors were shown.)?");
+    Pattern countPattern2 = Pattern.compile("Tidy found ([0-9]+) warning[s]? and ([0-9]+) error[s]?!.*?(Not all warnings/errors were shown.)?");
+    Pattern cssPattern = Pattern.compile("You are recommended to use CSS.*");
+    Pattern guardPattern = Pattern.compile("(line [0-9]+ column [0-9]+ - |[^:]+:[0-9]+:[0-9]+: )(Error|Warning):.*");
+
+    Pattern[] patterns = {
+            Pattern.compile(".*Error: <.*> is not recognized!"),
+            Pattern.compile(".*Error: missing quote mark for attribute value"),
+            Pattern.compile(".*Warning: '<' \\+ '/' \\+ letter not allowed here"),
+            Pattern.compile(".*Warning: <.*> anchor \".*\" already defined"),
+            Pattern.compile(".*Warning: <.*> attribute \".*\" has invalid value \".*\""),
+            Pattern.compile(".*Warning: <.*> attribute \".*\" lacks value"),
+            Pattern.compile(".*Warning: <.*> attribute \".*\" lacks value"),
+            Pattern.compile(".*Warning: <.*> attribute with missing trailing quote mark"),
+            Pattern.compile(".*Warning: <.*> dropping value \".*\" for repeated attribute \".*\""),
+            Pattern.compile(".*Warning: <.*> inserting \".*\" attribute"),
+            Pattern.compile(".*Warning: <.*> is probably intended as </.*>"),
+            Pattern.compile(".*Warning: <.*> isn't allowed in <.*> elements"),
+            Pattern.compile(".*Warning: <.*> lacks \".*\" attribute"),
+            Pattern.compile(".*Warning: <.*> missing '>' for end of tag"),
+            Pattern.compile(".*Warning: <.*> proprietary attribute \".*\""),
+            Pattern.compile(".*Warning: <.*> unexpected or duplicate quote mark"),
+            Pattern.compile(".*Warning: <a> id and name attribute value mismatch"),
+            Pattern.compile(".*Warning: <a> cannot copy name attribute to id"),
+            Pattern.compile(".*Warning: <a> escaping malformed URI reference"),
+            Pattern.compile(".*Warning: <blockquote> proprietary attribute \"pre\""),
+            Pattern.compile(".*Warning: discarding unexpected <.*>"),
+            Pattern.compile(".*Warning: discarding unexpected </.*>"),
+            Pattern.compile(".*Warning: entity \".*\" doesn't end in ';'"),
+            Pattern.compile(".*Warning: inserting implicit <.*>"),
+            Pattern.compile(".*Warning: inserting missing 'title' element"),
+            Pattern.compile(".*Warning: missing <!DOCTYPE> declaration"),
+            Pattern.compile(".*Warning: missing <.*>"),
+            Pattern.compile(".*Warning: missing </.*> before <.*>"),
+            Pattern.compile(".*Warning: nested emphasis <.*>"),
+            Pattern.compile(".*Warning: plain text isn't allowed in <.*> elements"),
+            Pattern.compile(".*Warning: removing whitespace preceding XML Declaration"),
+            Pattern.compile(".*Warning: replacing <p> (by|with) <br>"),
+            Pattern.compile(".*Warning: replacing invalid numeric character reference .*"),
+            Pattern.compile(".*Warning: replacing obsolete element <xmp> with <pre>"),
+            Pattern.compile(".*Warning: replacing unexpected .* (by|with) </.*>"),
+            Pattern.compile(".*Warning: trimming empty <.*>"),
+            Pattern.compile(".*Warning: unescaped & or unknown entity \".*\""),
+            Pattern.compile(".*Warning: unescaped & which should be written as &amp;"),
+            Pattern.compile(".*Warning: using <br> in place of <p>"),
+            Pattern.compile(".*Warning: <.*> element removed from HTML5"),
+            Pattern.compile(".*Warning: <.*> attribute \".*\" not allowed for HTML5"),
+            Pattern.compile(".*Warning: The summary attribute on the <table> element is obsolete in HTML5"),
+            Pattern.compile(".*Warning: replacing invalid UTF-8 bytes \\(char. code U\\+.*\\)")
+    };
+    private final Log errors;
+    private Path path;
+    private int files = 0;
+    private int ok;
+    private int warns;
+    private int errs;
+    private int css;
+    private int overflow;
+
+    public TidyChecker() {
+        TIDY = initTidy();
+        errors = new Log();
+    }
+
+    @Override
+    public void checkFiles(List<Path> sb) {
+        files += sb.size();
+        try {
+            for (int i = 0; i < sb.size(); i += 1024) {
+                List<String> command = new ArrayList<>();
+                command.add(TIDY.toString());
+                command.add("-q");
+                command.add("-e");
+                command.add("--gnu-emacs");
+                command.add("true");
+                List<Path> sublist = sb.subList(i, Math.min(i + 1024, sb.size()));
+                for (Path p : sublist) {
+                    command.add(p.toString());
+                }
+                Process p = new ProcessBuilder()
+                        .command(command)
+                        .redirectErrorStream(true)
+                        .start();
+                try (BufferedReader r =
+                             new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                    String line;
+                    while ((line = r.readLine()) != null) {
+                        checkLine(line);
+                    }
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    private Path initTidy() {
+        Path tidyExePath;
+        String tidyProperty = System.getProperty("tidy");
+        if (tidyProperty != null) {
+            tidyExePath = Path.of(tidyProperty);
+            if (!Files.exists(tidyExePath)) {
+                System.err.println("tidy not found: " + tidyExePath);
+            }
+            if (!Files.isExecutable(tidyExePath)) {
+                System.err.println("tidy not executable: " + tidyExePath);
+            }
+        } else {
+            boolean isWindows = System.getProperty("os.name")
+                    .toLowerCase(Locale.US)
+                    .startsWith("windows");
+            String tidyExe = isWindows ? "tidy.exe" : "tidy";
+            Optional<Path> p = Stream.of(System.getenv("PATH")
+                            .split(File.pathSeparator))
+                    .map(Path::of)
+                    .map(d -> d.resolve(tidyExe))
+                    .filter(Files::exists)
+                    .filter(Files::isExecutable)
+                    .findFirst();
+            if (p.isPresent()) {
+                tidyExePath = p.get();
+            } else {
+                System.err.println("tidy not found on PATH");
+                return Path.of("tidy"); //non-null placeholder return; exception would be better
+            }
+        }
+
+        try {
+            Process p = new ProcessBuilder()
+                    .command(tidyExePath.toString(), "-version")
+                    .redirectErrorStream(true)
+                    .start();
+            try (BufferedReader r =
+                         new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8))) {
+                List<String> lines = r.lines().collect(Collectors.toList());
+                // Look for a line containing "version" and a dotted identifier beginning 5.
+                // If not found, look for known old/bad versions, to report in error message
+                Pattern version = Pattern.compile("version.* [5678]\\.\\d+(\\.\\d+)");
+                if (lines.stream().noneMatch(line -> version.matcher(line).find())) {
+                    Pattern oldVersion = Pattern.compile("2006");  // 2006 implies old macOS version
+                    String lineSep = System.lineSeparator();
+                    String message = lines.stream().anyMatch(line -> oldVersion.matcher(line).find())
+                            ? "old version of 'tidy' found on the PATH\n"
+                            : "could not determine the version of 'tidy' on the PATH\n";
+                    System.err.println(message + String.join(lineSep, lines));
+                }
+            }
+        } catch (IOException e) {
+            System.err.println("Could not execute 'tidy -version': " + e);
+        }
+
+        return tidyExePath;
+    }
+
+    @Override
+    public void report() {
+        if (files > 0) {
+            System.err.println("Tidy found errors in the generated HTML");
+            if (!errors.noErrors()) {
+                for (String s : errors.getErrors()) {
+                    System.err.println(s);
+                }
+                System.err.println("Tidy output end.");
+                System.err.println();
+                System.err.println();
+                throw new RuntimeException("Tidy found errors in the generated HTML");
+            }
+        }
+    }
+
+    @Override
+    public boolean isOK() {
+        return (ok == files)
+                && (overflow == 0)
+                && (errs == 0)
+                && (warns == 0)
+                && (css == 0);
+    }
+
+    void checkLine(String line) {
+        Matcher m;
+        if (okPattern.matcher(line).matches()) {
+            ok++;
+        } else if ((m = countPattern.matcher(line)).matches() || (m = countPattern2.matcher(line)).matches()) {
+            warns += Integer.parseInt(m.group(1));
+            errs += Integer.parseInt(m.group(2));
+            if (m.group(3) != null)
+                overflow++;
+        } else if (guardPattern.matcher(line).matches()) {
+            boolean found = false;
+            for (Pattern p : patterns) {
+                if (p.matcher(line).matches()) {
+                    errors.log("%s", line);
+                    found = true;
+                    count(p);
+                    break;
+                }
+            }
+            if (!found)
+                errors.log(path + "unrecognized line: " + line);
+        } else if (cssPattern.matcher(line).matches()) {
+            css++;
+        }
+    }
+
+    void count(Pattern p) {
+        Integer i = counts.get(p);
+        counts.put(p, (i == null) ? 1 : i + 1);
+    }
+
+    @Override
+    public void close() {
+        report();
+    }
+}

--- a/test/docs/jdk/javadoc/doccheck/modules/fullAPICheck.java
+++ b/test/docs/jdk/javadoc/doccheck/modules/fullAPICheck.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8337109
+ * @summary Check doctype and character encoding on the full docs
+ * @library /test/langtools/tools/lib ../../doccheck /test/lib ../../../../tools/tester
+ * @build DocTester toolbox.TestRunner
+ * @run main/othervm -Ddoccheck.dir= -Ddoccheck.checks=doctype,badchars DocCheck
+ */

--- a/test/docs/jdk/javadoc/doccheck/modules/jdkJavadocCheckDocs.java
+++ b/test/docs/jdk/javadoc/doccheck/modules/jdkJavadocCheckDocs.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8337109
+ * @summary Running Doccheck on generated HTML
+ * @library /test/langtools/tools/lib ../../doccheck /test/lib ../../../../tools/tester
+ * @build DocTester toolbox.TestRunner
+ * @run main/othervm -Ddoccheck.dir=api/java.base -Ddoccheck.checks=links,html,badchars,doctype DocCheck
+ */


### PR DESCRIPTION
Doccheck's human-generated reports are great at previewing a "chessboard" of results. Giving reader a quick glimpse at the quality/health of the documentation. But these tests needed to be automated and they didn't easily translate to something that can be integrated into a CI.

This PR includes an HTML and internal link test on `api/java.base` and a BadChars and Doctype test on the entire generated documentation bundle.

Here is an example of the output after running all tests on `api/java.base`

Note: There is an active PR to fix the broken anchors left in `java.base` so this is not a blocker.


```
STDOUT:
STDERR:
test: test
Tidy found errors in the generated HTML
/Users/nizarbenalla/Work/jdk-repos/jdk1/build/macosx-aarch64/images/docs/api/java.base/java/lang/Class.html:323:87: Warning: <a> anchor "nest" already defined
Tidy output end.


api/java.base/java/util/concurrent/StructuredTaskScope.ShutdownOnFailure.html:245: id not found: api/java.base/java/util/concurrent/StructuredTaskScope.ShutdownOnFailure.html#TreeStructure
api/java.base/java/util/concurrent/StructuredTaskScope.ShutdownOnSuccess.html:242: id not found: api/java.base/java/util/concurrent/StructuredTaskScope.ShutdownOnSuccess.html#TreeStructure
api/java.base/java/lang/Class.html:323: name already declared: nest
api/java.base/java/lang/Module.html:291: id not found: api/java.base/java/lang/foreign/package-summary.html#restricted
api/java.base/java/lang/Module.html:434: id not found: api/java.base/java/lang/foreign/package-summary.html#restricted
api/java.base/java/lang/foreign/MemorySegment.html:725: id not found: api/java.base/java/lang/foreign/package-summary.html#restricted

Link Checker Report
Checked 3446 files.
Found 445059 references to 48205 anchors in 5770 files and 64 other URIs.
     1 duplicate ids
     3 missing ids

Hosts
    20 docs.oracle.com
     1 tools.ietf.org
     1 www.ietf.org
     1 jcp.org
     4 www.rfc-editor.org
     7 unicode.org
    10 www.unicode.org
    20 www.w3.org
Exception running test test: java.lang.Exception: One or more HTML checkers failed: [java.lang.RuntimeException: Tidy found errors in the generated HTML, java.lang.RuntimeException: LinkChecker encountered errors. Duplicate IDs: 1, Missing IDs: 3, Missing Files: 0, Bad Schemes: 0]
java.lang.Exception: One or more HTML checkers failed: [java.lang.RuntimeException: Tidy found errors in the generated HTML, java.lang.RuntimeException: LinkChecker encountered errors. Duplicate IDs: 1, Missing IDs: 3, Missing Files: 0, Bad Schemes: 0]
        at DocCheck.runCheckersSequentially(DocCheck.java:181)
        at DocCheck.test(DocCheck.java:166)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:573)
        at toolbox.TestRunner.runTests(TestRunner.java:91)
        at toolbox.TestRunner.runTests(TestRunner.java:73)
        at DocCheck.main(DocCheck.java:128)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:573)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1576)

1 errors
java.lang.Exception: 1 errors found
        at toolbox.TestRunner.runTests(TestRunner.java:119)
        at toolbox.TestRunner.runTests(TestRunner.java:73)
        at DocCheck.main(DocCheck.java:128)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:573)
        at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
        at java.base/java.lang.Thread.run(Thread.java:1576)

JavaTest Message: Test threw exception: java.lang.Exception: 1 errors found
JavaTest Message: shutting down test
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337114](https://bugs.openjdk.org/browse/JDK-8337114): DocType checker for generated documentation (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21878/head:pull/21878` \
`$ git checkout pull/21878`

Update a local copy of the PR: \
`$ git checkout pull/21878` \
`$ git pull https://git.openjdk.org/jdk.git pull/21878/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21878`

View PR using the GUI difftool: \
`$ git pr show -t 21878`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21878.diff">https://git.openjdk.org/jdk/pull/21878.diff</a>

</details>
