### PR TITLE
8343547: Restore accidentally removed annotations in LambdaForm from ClassFile API port

### DIFF
--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -526,7 +526,9 @@ class InvokerBytecodeGenerator {
     // Suppress method in backtraces displayed to the user, mark this method as
     // a compiled LambdaForm, then either force or prohibit inlining.
     public static final RuntimeVisibleAnnotationsAttribute LF_DONTINLINE_ANNOTATIONS = RuntimeVisibleAnnotationsAttribute.of(HIDDEN, LF_COMPILED, DONTINLINE);
+    public static final RuntimeVisibleAnnotationsAttribute LF_DONTINLINE_PROFILE_ANNOTATIONS = RuntimeVisibleAnnotationsAttribute.of(HIDDEN, LF_COMPILED, DONTINLINE, INJECTEDPROFILE);
     public static final RuntimeVisibleAnnotationsAttribute LF_FORCEINLINE_ANNOTATIONS = RuntimeVisibleAnnotationsAttribute.of(HIDDEN, LF_COMPILED, FORCEINLINE);
+    public static final RuntimeVisibleAnnotationsAttribute LF_FORCEINLINE_PROFILE_ANNOTATIONS = RuntimeVisibleAnnotationsAttribute.of(HIDDEN, LF_COMPILED, FORCEINLINE, INJECTEDPROFILE);
 
     /**
      * Generate an invoker method for the passed {@link LambdaForm}.
@@ -586,7 +588,11 @@ class InvokerBytecodeGenerator {
                                     if (PROFILE_GWT) {
                                         assert(name.arguments[0] instanceof Name n &&
                                                 n.refersTo(MethodHandleImpl.class, "profileBoolean"));
-                                        mb.with(RuntimeVisibleAnnotationsAttribute.of(List.of(INJECTEDPROFILE)));
+                                        if (lambdaForm.forceInline) {
+                                            mb.with(LF_FORCEINLINE_PROFILE_ANNOTATIONS);
+                                        } else {
+                                            mb.with(LF_DONTINLINE_PROFILE_ANNOTATIONS);
+                                        }
                                     }
                                     onStack = emitSelectAlternative(cob, name, lambdaForm.names[i+1]);
                                     i++;  // skip MH.invokeBasic of the selectAlternative result


### PR DESCRIPTION
These two annotations are found to be lost during the ClassFile API port of LambdaForm generation.  I seem not able to reproduce the master issue in a current build but could reproduce before when the change is first made.  Anyways this restoration is always a right thing, better commit it and further investigate.

Old Stable on BMH impl class static species field: https://github.com/openjdk/jdk/pull/17108/files#diff-3d6c6bed9cbcb47fe292bdb0c795ab77e56783fdbb144decc6f00857b020c092L612-L615

Incorrect way to add InjectedProfile annotation: https://github.com/openjdk/jdk/pull/17108/files#diff-3b05b61400e7766115409b3f508d839fb51e450423822252ab2e18543427c764R618

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343547](https://bugs.openjdk.org/browse/JDK-8343547): Restore accidentally removed annotations in LambdaForm from ClassFile API port (**Sub-task** - P4)


### Reviewers
 * [Adam Sotona](https://openjdk.org/census#asotona) (@asotona - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21880/head:pull/21880` \
`$ git checkout pull/21880`

Update a local copy of the PR: \
`$ git checkout pull/21880` \
`$ git pull https://git.openjdk.org/jdk.git pull/21880/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21880`

View PR using the GUI difftool: \
`$ git pr show -t 21880`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21880.diff">https://git.openjdk.org/jdk/pull/21880.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21880#issuecomment-2455073512)
</details>
