### PR TITLE
8343549: SeededSecureRandomTest needn't be in a package

### DIFF
--- a/test/lib-test/jdk/test/lib/security/SeededSecureRandomTest.java
+++ b/test/lib-test/jdk/test/lib/security/SeededSecureRandomTest.java
@@ -20,14 +20,13 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package jdk.test.lib.security;
-
 import jdk.test.lib.Asserts;
+import jdk.test.lib.security.SeededSecureRandom;
 
 /*
  * @test
  * @library /test/lib
- * @run main/othervm jdk.test.lib.security.SeededSecureRandomTest
+ * @run main/othervm SeededSecureRandomTest
  */
 public class SeededSecureRandomTest {
 


### PR DESCRIPTION
The test was mistakenly put in a package as the library class it's testing. This is unnecessary since there is no internal field/method it needs access to.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343549](https://bugs.openjdk.org/browse/JDK-8343549): SeededSecureRandomTest needn't be in a package (**Bug** - P4)


### Reviewers
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21881/head:pull/21881` \
`$ git checkout pull/21881`

Update a local copy of the PR: \
`$ git checkout pull/21881` \
`$ git pull https://git.openjdk.org/jdk.git pull/21881/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21881`

View PR using the GUI difftool: \
`$ git pr show -t 21881`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21881.diff">https://git.openjdk.org/jdk/pull/21881.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21881#issuecomment-2455134127)
</details>
