### PR TITLE
8343551: Missing copyright header update in Charset-X-Coder.java.template

### DIFF
--- a/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
+++ b/src/java.base/share/classes/java/nio/charset/Charset-X-Coder.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Please review this trivial patch to fix a missed copyright header update in the fix for [JDK-8343484](https://bugs.openjdk.org/browse/JDK-8343551).
