### PR TITLE
Removed NPE when set is empty and added TCK test

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -3221,17 +3221,17 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
     }
     // factory method for KeySpliterator
     final KeySpliterator<K,V> keySpliterator() {
-        Index<K,V> h; Node<K,V> n; long est;
+        Index<K,V> h; Node<K,V> hn, n; long est;
         VarHandle.acquireFence();
-        if ((h = head) == null) {
+        if ((h = head) == null || (hn = h.node) == null) {
             n = null;
             est = 0L;
         }
         else {
-            n = h.node;
+            n = hn.next;
             est = getAdderCount();
         }
-        return new KeySpliterator<K,V>(comparator, h, n.next, null, est);
+        return new KeySpliterator<K,V>(comparator, h, n, null, est);
     }
 
     static final class ValueSpliterator<K,V> extends CSLMSpliterator<K,V>
@@ -3307,17 +3307,17 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
 
     // Almost the same as keySpliterator()
     final ValueSpliterator<K,V> valueSpliterator() {
-        Index<K,V> h; Node<K,V> n; long est;
+        Index<K,V> h; Node<K,V> hn, n; long est;
         VarHandle.acquireFence();
-        if ((h = head) == null) {
+        if ((h = head) == null || (hn = h.node) == null) {
             n = null;
             est = 0L;
         }
         else {
-            n = h.node;
+            n = hn.next;
             est = getAdderCount();
         }
-        return new ValueSpliterator<K,V>(comparator, h, n.next, null, est);
+        return new ValueSpliterator<K,V>(comparator, h, n, null, est);
     }
 
     static final class EntrySpliterator<K,V> extends CSLMSpliterator<K,V>
@@ -3411,17 +3411,17 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
 
     // Almost the same as keySpliterator()
     final EntrySpliterator<K,V> entrySpliterator() {
-        Index<K,V> h; Node<K,V> n; long est;
+        Index<K,V> h; Node<K,V> hn, n; long est;
         VarHandle.acquireFence();
-        if ((h = head) == null) {
+        if ((h = head) == null || (hn = h.node) == null) {
             n = null;
             est = 0L;
         }
         else {
-            n = h.node;
+            n = hn.next;
             est = getAdderCount();
         }
-        return new EntrySpliterator<K,V>(comparator, h, n.next, null, est);
+        return new EntrySpliterator<K,V>(comparator, h, n, null, est);
     }
 
     // VarHandle mechanics


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Dependency #21820 must be integrated first

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21883/head:pull/21883` \
`$ git checkout pull/21883`

Update a local copy of the PR: \
`$ git checkout pull/21883` \
`$ git pull https://git.openjdk.org/jdk.git pull/21883/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21883`

View PR using the GUI difftool: \
`$ git pr show -t 21883`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21883.diff">https://git.openjdk.org/jdk/pull/21883.diff</a>

</details>
