### PR TITLE
8343491: javax/management/remote/mandatory/connection/DeadLockTest.java failing with NoSuchObjectException: no such object in table

### DIFF
--- a/test/jdk/javax/management/remote/mandatory/connection/DeadLockTest.java
+++ b/test/jdk/javax/management/remote/mandatory/connection/DeadLockTest.java
@@ -27,6 +27,10 @@
  * @summary test on a client notification deadlock.
  * @author Shanliang JIANG
  *
+ * @requires vm.compMode != "Xcomp"
+ * @comment Running with -Xcomp is likely to cause a timeout while establishing the connection
+ *          (RMI: java.rmi.NoSuchObjectException: no such object in table).
+ *
  * @run clean DeadLockTest
  * @run build DeadLockTest
  * @run main DeadLockTest
@@ -139,7 +143,7 @@ public class DeadLockTest {
                     try {
                         conn.getDefaultDomain();
                     } catch (IOException ioe) {
-                        // Greate !
+                        // OK
                     }
 
                     synchronized(this) {


### PR DESCRIPTION
This test is sensitive to timing, and should not run with -Xcomp (like NotifReconnectDeadlockTest.java).

With -Xcomp, this test can fail on the the conn.getDefaultDomain() call, but if we handle that, it can also fail on the first iteration through the loop, at the call: JMXConnector client = JMXConnectorFactory.connect(addr, env);  

This test sets a short timeout value for connections, and -Xcomp slows things down greatly.  RMI is gone before the connection is established.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343491](https://bugs.openjdk.org/browse/JDK-8343491): javax/management/remote/mandatory/connection/DeadLockTest.java failing with NoSuchObjectException: no such object in table (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21884/head:pull/21884` \
`$ git checkout pull/21884`

Update a local copy of the PR: \
`$ git checkout pull/21884` \
`$ git pull https://git.openjdk.org/jdk.git pull/21884/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21884`

View PR using the GUI difftool: \
`$ git pr show -t 21884`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21884.diff">https://git.openjdk.org/jdk/pull/21884.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21884#issuecomment-2455411545)
</details>
