### PR TITLE
8343417: (fs) BasicFileAttributeView.setTimes uses microsecond precision with NOFOLLOW_LINKS

### DIFF
--- a/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -139,11 +139,13 @@ class UnixConstants {
 #endif
 
     // flags used with openat/unlinkat/etc.
-#if defined(AT_SYMLINK_NOFOLLOW) && defined(AT_REMOVEDIR)
+#if defined(AT_FDCWD) && defined(AT_SYMLINK_NOFOLLOW) && defined(AT_REMOVEDIR)
+    static final int PREFIX_AT_FDCWD = AT_FDCWD;
     static final int PREFIX_AT_SYMLINK_NOFOLLOW = AT_SYMLINK_NOFOLLOW;
     static final int PREFIX_AT_REMOVEDIR = AT_REMOVEDIR;
 #else
     // not supported (dummy values will not be used at runtime).
+    static final int PREFIX_AT_FDCWD = 00;
     static final int PREFIX_AT_SYMLINK_NOFOLLOW = 00;
     static final int PREFIX_AT_REMOVEDIR = 00;
 #endif

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
@@ -134,7 +134,7 @@ class UnixFileAttributeViews {
                     } else if (useLutimes) {
                         lutimes(file, accessValue, modValue);
                     } else if (useUtimensat) {
-                        utimensat(file, accessValue, modValue);
+                        utimensat(AT_FDCWD, file, accessValue, modValue, AT_SYMLINK_NOFOLLOW);
                     } else {
                         utimes(file, accessValue, modValue);
                     }
@@ -159,7 +159,7 @@ class UnixFileAttributeViews {
                         } else if (useLutimes) {
                             lutimes(file, accessValue, modValue);
                         } else if (useUtimensat) {
-                            utimensat(file, accessValue, modValue);
+                            utimensat(AT_FDCWD, file, accessValue, modValue, AT_SYMLINK_NOFOLLOW);
                         } else {
                             utimes(file, accessValue, modValue);
                         }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -392,6 +392,22 @@ class UnixNativeDispatcher {
         throws UnixException;
 
     /**
+     * utimensat(int fd, const char* path,
+     *           const struct timeval times[2], int flags)
+     *
+     * We hard code fd to FD_ATCWD and flags to AT_SYMLINK_NOFOLLOW.
+     */
+    static void utimensat(UnixPath path, long times0, long times1)
+        throws UnixException
+    {
+        try (NativeBuffer buffer = copyToNativeBuffer(path)) {
+            utimensat0(buffer.address(), times0, times1);
+        }
+    }
+    private static native void utimensat0(long pathAddress, long times0, long times1)
+        throws UnixException;
+
+    /**
      * DIR *opendir(const char* dirname)
      */
     static long opendir(UnixPath path) throws UnixException {
@@ -557,7 +573,8 @@ class UnixNativeDispatcher {
     private static final int SUPPORTS_FUTIMES       = 1 << 2;
     private static final int SUPPORTS_FUTIMENS      = 1 << 3;
     private static final int SUPPORTS_LUTIMES       = 1 << 4;
-    private static final int SUPPORTS_XATTR         = 1 << 5;
+    private static final int SUPPORTS_UTIMENSAT     = 1 << 5;
+    private static final int SUPPORTS_XATTR         = 1 << 6;
     private static final int SUPPORTS_BIRTHTIME     = 1 << 16; // other features
     private static final int capabilities;
 
@@ -587,6 +604,13 @@ class UnixNativeDispatcher {
      */
     static boolean lutimesSupported() {
         return (capabilities & SUPPORTS_LUTIMES) != 0;
+    }
+
+    /**
+     * Supports utimensat
+     */
+    static boolean utimensatSupported() {
+        return (capabilities & SUPPORTS_UTIMENSAT) != 0;
     }
 
     /**

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -394,17 +394,15 @@ class UnixNativeDispatcher {
     /**
      * utimensat(int fd, const char* path,
      *           const struct timeval times[2], int flags)
-     *
-     * We hard code fd to FD_ATCWD and flags to AT_SYMLINK_NOFOLLOW.
      */
-    static void utimensat(UnixPath path, long times0, long times1)
+    static void utimensat(int fd, UnixPath path, long times0, long times1, int flags)
         throws UnixException
     {
         try (NativeBuffer buffer = copyToNativeBuffer(path)) {
-            utimensat0(buffer.address(), times0, times1);
+            utimensat0(fd, buffer.address(), times0, times1, flags);
         }
     }
-    private static native void utimensat0(long pathAddress, long times0, long times1)
+    private static native void utimensat0(int fd, long pathAddress, long times0, long times1, int flags)
         throws UnixException;
 
     /**

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -211,6 +211,8 @@ typedef DIR* fdopendir_func(int);
 #if defined(__linux__)
 typedef int statx_func(int dirfd, const char *restrict pathname, int flags,
                        unsigned int mask, struct my_statx *restrict statxbuf);
+typedef int utimensat_func(int dirfd, const char *pathname,
+                           const struct timespec[2], int flags);
 #endif
 
 static openat_func* my_openat_func = NULL;
@@ -223,6 +225,7 @@ static lutimes_func* my_lutimes_func = NULL;
 static fdopendir_func* my_fdopendir_func = NULL;
 #if defined(__linux__)
 static statx_func* my_statx_func = NULL;
+static utimensat_func* my_utimensat_func = NULL;
 #endif
 
 /**
@@ -431,6 +434,10 @@ Java_sun_nio_fs_UnixNativeDispatcher_init(JNIEnv* env, jclass this)
     my_statx_func = (statx_func*) dlsym(RTLD_DEFAULT, "statx");
     if (my_statx_func != NULL) {
         capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_BIRTHTIME;
+    }
+    my_utimensat_func = (utimensat_func*) dlsym(RTLD_DEFAULT, "utimensat");
+    if (my_utimensat_func != NULL) {
+        capabilities |= sun_nio_fs_UnixNativeDispatcher_SUPPORTS_UTIMENSAT;
     }
 #endif
 
@@ -974,6 +981,34 @@ Java_sun_nio_fs_UnixNativeDispatcher_lutimes0(JNIEnv* env, jclass this,
     if (err == -1) {
         throwUnixException(env, errno);
     }
+}
+
+JNIEXPORT void JNICALL
+Java_sun_nio_fs_UnixNativeDispatcher_utimensat0(JNIEnv* env, jclass this,
+    jlong pathAddress, jlong accessTime, jlong modificationTime) {
+#if defined(__linux__)
+    int err;
+    struct timespec times[2];
+    const char* path = (const char*)jlong_to_ptr(pathAddress);
+
+    times[0].tv_sec = accessTime / 1000000000;
+    times[0].tv_nsec = accessTime % 1000000000;
+
+    times[1].tv_sec = modificationTime / 1000000000;
+    times[1].tv_nsec = modificationTime % 1000000000;
+
+    if (my_utimensat_func == NULL) {
+        JNU_ThrowInternalError(env, "my_utimensat_func is NULL");
+        return;
+    }
+    RESTARTABLE((*my_utimensat_func)(AT_FDCWD, path, &times[0], AT_SYMLINK_NOFOLLOW), err);
+
+    if (err == -1) {
+        throwUnixException(env, errno);
+    }
+#else
+    JNU_ThrowInternalError(env, "should not reach here");
+#endif
 }
 
 JNIEXPORT jlong JNICALL

--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -985,7 +985,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_lutimes0(JNIEnv* env, jclass this,
 
 JNIEXPORT void JNICALL
 Java_sun_nio_fs_UnixNativeDispatcher_utimensat0(JNIEnv* env, jclass this,
-    jlong pathAddress, jlong accessTime, jlong modificationTime) {
+    jint fd, jlong pathAddress, jlong accessTime, jlong modificationTime, jint flags) {
 #if defined(__linux__)
     int err;
     struct timespec times[2];
@@ -1001,7 +1001,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_utimensat0(JNIEnv* env, jclass this,
         JNU_ThrowInternalError(env, "my_utimensat_func is NULL");
         return;
     }
-    RESTARTABLE((*my_utimensat_func)(AT_FDCWD, path, &times[0], AT_SYMLINK_NOFOLLOW), err);
+    RESTARTABLE((*my_utimensat_func)(fd, path, &times[0], flags), err);
 
     if (err == -1) {
         throwUnixException(env, errno);

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.FileTime;
+import java.util.List;
 import java.util.Set;
 
 import static java.nio.file.LinkOption.*;
@@ -132,19 +133,23 @@ public class SetTimesNanos {
             var newTime = FileTime.from(1730417633157646106L, NANOSECONDS);
             System.out.println("newTime: " + newTime.to(NANOSECONDS));
 
-            var symlinkView = Files.getFileAttributeView
-                (symlink, BasicFileAttributeView.class, NOFOLLOW_LINKS);
-            symlinkView.setTimes(newTime, newTime, null);
-            var symlinkAttrs = symlinkView.readAttributes();
+            for (Path p : List.of(target, symlink)) {
+                System.out.println("p: " + p);
 
-            if (!symlinkAttrs.lastAccessTime().equals(newTime))
-                throw new RuntimeException("Last access time "
-                                           + symlinkAttrs.lastAccessTime()
-                                           + " != " + newTime);
-            if (!symlinkAttrs.lastAccessTime().equals(newTime))
-                throw new RuntimeException("Last modified time "
-                                           + symlinkAttrs.lastModifiedTime()
-                                           + " != " + newTime);
+                var view = Files.getFileAttributeView(p,
+                    BasicFileAttributeView.class, NOFOLLOW_LINKS);
+                view.setTimes(newTime, newTime, null);
+                var attrs = view.readAttributes();
+
+                if (!attrs.lastAccessTime().equals(newTime))
+                    throw new RuntimeException("Last access time "
+                                               + attrs.lastAccessTime()
+                                               + " != " + newTime);
+                if (!attrs.lastAccessTime().equals(newTime))
+                    throw new RuntimeException("Last modified time "
+                                               + attrs.lastModifiedTime()
+                                               + " != " + newTime);
+            }
         } finally {
             Files.deleteIfExists(target);
             Files.deleteIfExists(symlink);

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -22,10 +22,13 @@
  */
 
 /* @test
- * @bug 8181493 8231174
+ * @bug 8181493 8231174 8343417
  * @summary Verify that nanosecond precision is maintained for file timestamps
  * @requires (os.family == "linux") | (os.family == "mac") | (os.family == "windows")
+ * @library ../.. /test/lib
+ * @build jdk.test.lib.Platform
  * @modules java.base/sun.nio.fs:+open
+ * @run main SetTimesNanos
  */
 
 import java.io.IOException;
@@ -37,14 +40,17 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
+
+import static java.nio.file.LinkOption.*;
+import static java.util.concurrent.TimeUnit.*;
+
+import jdk.test.lib.Platform;
+import jtreg.SkippedException;
 
 public class SetTimesNanos {
-    private static final boolean IS_WINDOWS =
-        System.getProperty("os.name").startsWith("Windows");
 
     public static void main(String[] args) throws Exception {
-        if (!IS_WINDOWS) {
+        if (!Platform.isWindows()) {
             // Check whether futimens() system call is supported
             Class unixNativeDispatcherClass =
                 Class.forName("sun.nio.fs.UnixNativeDispatcher");
@@ -52,8 +58,7 @@ public class SetTimesNanos {
                 unixNativeDispatcherClass.getDeclaredMethod("futimensSupported");
             futimensSupported.setAccessible(true);
             if (!(boolean)futimensSupported.invoke(null)) {
-                System.err.println("futimens() not supported; skipping test");
-                return;
+                throw new SkippedException("futimens() not supported");
             }
         }
 
@@ -63,30 +68,34 @@ public class SetTimesNanos {
         System.out.format("FileStore: \"%s\" on %s (%s)%n",
             dir, store.name(), store.type());
 
-        Set<String> testedTypes = IS_WINDOWS ?
+        Set<String> testedTypes = Platform.isWindows() ?
             Set.of("NTFS") : Set.of("apfs", "ext4", "xfs", "zfs");
         if (!testedTypes.contains(store.type())) {
-            System.err.format("%s not in %s; skipping test", store.type(), testedTypes);
-            return;
+            throw new SkippedException(store.type() + " not in " + testedTypes);
         }
 
         testNanos(dir);
 
         Path file = Files.createFile(dir.resolve("test.dat"));
         testNanos(file);
+
+        if (Platform.isLinux()) {
+            testNanosLink(false);
+            testNanosLink(true);
+        }
     }
 
     private static void testNanos(Path path) throws IOException {
         // Set modification and access times
         // Time stamp = "2017-01-01 01:01:01.123456789";
         long timeNanos = 1_483_261_261L*1_000_000_000L + 123_456_789L;
-        FileTime pathTime = FileTime.from(timeNanos, TimeUnit.NANOSECONDS);
+        FileTime pathTime = FileTime.from(timeNanos, NANOSECONDS);
         BasicFileAttributeView view =
             Files.getFileAttributeView(path, BasicFileAttributeView.class);
         view.setTimes(pathTime, pathTime, null);
 
         // Windows file time resolution is 100ns so truncate
-        if (IS_WINDOWS) {
+        if (Platform.isWindows()) {
             timeNanos = 100L*(timeNanos/100L);
         }
 
@@ -99,12 +108,46 @@ public class SetTimesNanos {
         FileTime[] times = new FileTime[] {attrs.lastModifiedTime(),
             attrs.lastAccessTime()};
         for (int i = 0; i < timeNames.length; i++) {
-            long nanos = times[i].to(TimeUnit.NANOSECONDS);
+            long nanos = times[i].to(NANOSECONDS);
             if (nanos != timeNanos) {
                 throw new RuntimeException("Expected " + timeNames[i] +
                     " timestamp to be '" + timeNanos + "', but was '" +
                     nanos + "'");
             }
+        }
+    }
+
+    private static void testNanosLink(boolean absolute) throws IOException {
+        System.out.println("absolute: " + absolute);
+
+        var target = Path.of("target");
+        var symlink = Path.of("symlink");
+        if (absolute)
+            symlink = symlink.toAbsolutePath();
+
+        try {
+            Files.createFile(target);
+            Files.createSymbolicLink(symlink, target);
+
+            var newTime = FileTime.from(1730417633157646106L, NANOSECONDS);
+            System.out.println("newTime: " + newTime.to(NANOSECONDS));
+
+            var symlinkView = Files.getFileAttributeView
+                (symlink, BasicFileAttributeView.class, NOFOLLOW_LINKS);
+            symlinkView.setTimes(newTime, newTime, null);
+            var symlinkAttrs = symlinkView.readAttributes();
+
+            if (!symlinkAttrs.lastAccessTime().equals(newTime))
+                throw new RuntimeException("Last access time "
+                                           + symlinkAttrs.lastAccessTime()
+                                           + " != " + newTime);
+            if (!symlinkAttrs.lastAccessTime().equals(newTime))
+                throw new RuntimeException("Last modified time "
+                                           + symlinkAttrs.lastModifiedTime()
+                                           + " != " + newTime);
+        } finally {
+            Files.deleteIfExists(target);
+            Files.deleteIfExists(symlink);
         }
     }
 }


### PR DESCRIPTION
Add support for setting the last access and last modification times of symbolic links with nanosecond precision on Linux where the system call `utimensat(2)` is available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343417](https://bugs.openjdk.org/browse/JDK-8343417): (fs) BasicFileAttributeView.setTimes uses microsecond precision with NOFOLLOW_LINKS (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21886/head:pull/21886` \
`$ git checkout pull/21886`

Update a local copy of the PR: \
`$ git checkout pull/21886` \
`$ git pull https://git.openjdk.org/jdk.git pull/21886/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21886`

View PR using the GUI difftool: \
`$ git pr show -t 21886`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21886.diff">https://git.openjdk.org/jdk/pull/21886.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21886#issuecomment-2455542080)
</details>
