### PR TITLE
ZoneId::ofWithPrefix use local variables to avoid double calls

### DIFF
--- a/src/java.base/share/classes/java/time/ZoneId.java
+++ b/src/java.base/share/classes/java/time/ZoneId.java
@@ -424,7 +424,8 @@ public abstract sealed class ZoneId implements Serializable permits ZoneOffset, 
         if (zoneId.length() == prefixLength) {
             return ofOffset(prefix, ZoneOffset.UTC);
         }
-        if (zoneId.charAt(prefixLength) != '+' && zoneId.charAt(prefixLength) != '-') {
+        char sign = zoneId.charAt(prefixLength);
+        if (sign != '+' && sign != '-') {
             return ZoneRegion.ofId(zoneId, checkAvailable);  // drop through to ZoneRulesProvider
         }
         try {


### PR DESCRIPTION
A minor improvement, using a local variable to save one charAt call.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21889/head:pull/21889` \
`$ git checkout pull/21889`

Update a local copy of the PR: \
`$ git checkout pull/21889` \
`$ git pull https://git.openjdk.org/jdk.git pull/21889/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21889`

View PR using the GUI difftool: \
`$ git pr show -t 21889`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21889.diff">https://git.openjdk.org/jdk/pull/21889.diff</a>

</details>
