### PR TITLE
8340586: JdkJfrEvent::get_all_klasses stores non-strong oops in JNI handles

### DIFF
--- a/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
+++ b/src/hotspot/share/jfr/support/jfrJdkJfrEvent.cpp
@@ -35,6 +35,7 @@
 #include "oops/klass.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/javaThread.hpp"
+#include "runtime/safepointVerifiers.hpp"
 #include "utilities/stack.inline.hpp"
 
 static jobject empty_java_util_arraylist = nullptr;
@@ -80,27 +81,22 @@ static bool is_allowed(const Klass* k) {
   return !(k->is_abstract() || k->should_be_initialized());
 }
 
-static void fill_klasses(GrowableArray<const void*>& event_subklasses, const InstanceKlass* event_klass, JavaThread* thread) {
+static void fill_klasses(GrowableArray<jclass>& event_subklasses, const InstanceKlass* event_klass, JavaThread* thread) {
   assert(event_subklasses.length() == 0, "invariant");
   assert(event_klass != nullptr, "invariant");
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(thread));
+  // Do not safepoint while walking the ClassHierarchy, keeping klasses alive and storing their mirrors in JNI handles.
+  NoSafepointVerifier nsv;
 
   for (ClassHierarchyIterator iter(const_cast<InstanceKlass*>(event_klass)); !iter.done(); iter.next()) {
     Klass* subk = iter.klass();
     if (is_allowed(subk)) {
-      event_subklasses.append(subk);
+      // We are walking the class hierarchy and saving the relevant klasses in JNI handles.
+      // To be allowed to store the java mirror, we must ensure that the klass and its oops are kept alive,
+      // and perform the store before the next safepoint.
+      subk->keep_alive();
+      event_subklasses.append((jclass)JfrJavaSupport::local_jni_handle(subk->java_mirror(), thread));
     }
-  }
-}
-
-static void transform_klasses_to_local_jni_handles(GrowableArray<const void*>& event_subklasses, JavaThread* thread) {
-  assert(event_subklasses.is_nonempty(), "invariant");
-  DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_vm(thread));
-
-  for (int i = 0; i < event_subklasses.length(); ++i) {
-    const InstanceKlass* k = static_cast<const InstanceKlass*>(event_subklasses.at(i));
-    assert(is_allowed(k), "invariant");
-    event_subklasses.at_put(i, JfrJavaSupport::local_jni_handle(k->java_mirror(), thread));
   }
 }
 
@@ -126,14 +122,12 @@ jobject JdkJfrEvent::get_all_klasses(TRAPS) {
   }
 
   ResourceMark rm(THREAD);
-  GrowableArray<const void*> event_subklasses(initial_array_size);
+  GrowableArray<jclass> event_subklasses(initial_array_size);
   fill_klasses(event_subklasses, InstanceKlass::cast(klass), THREAD);
 
   if (event_subklasses.is_empty()) {
     return empty_java_util_arraylist;
   }
-
-  transform_klasses_to_local_jni_handles(event_subklasses, THREAD);
 
   Handle h_array_list(THREAD, new_java_util_arraylist(THREAD));
   if (h_array_list.is_null()) {
@@ -152,7 +146,7 @@ jobject JdkJfrEvent::get_all_klasses(TRAPS) {
 
   JavaValue result(T_BOOLEAN);
   for (int i = 0; i < event_subklasses.length(); ++i) {
-    const jclass clazz = (jclass)event_subklasses.at(i);
+    const jclass clazz = event_subklasses.at(i);
     assert(JdkJfrEvent::is_subklass(clazz), "invariant");
     JfrJavaArguments args(&result, array_list_klass, add_method_sym, add_method_sig_sym);
     args.set_receiver(h_array_list());

--- a/src/hotspot/share/oops/klass.hpp
+++ b/src/hotspot/share/oops/klass.hpp
@@ -586,6 +586,8 @@ protected:
 
   inline oop klass_holder() const;
 
+  inline void keep_alive() const;
+
  protected:
 
   // Error handling when length > max_length or length < 0

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -39,7 +39,7 @@ inline oop Klass::klass_holder() const {
 inline void Klass::keep_alive() const {
   // Resolving the holder (a WeakHandle) will keep the klass alive until the next safepoint.
   // Making the klass's CLD handle oops (e.g. the java_mirror), safe to store in the object
-  // graph and it's roots (e.g. Handles).
+  // graph and its roots (e.g. Handles).
   static_cast<void>(klass_holder());
 }
 

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -38,7 +38,8 @@ inline oop Klass::klass_holder() const {
 
 inline void Klass::keep_alive() const {
   // Resolving the holder (a WeakHandle) will keep the klass alive until the next safepoint.
-  // Making the klass's CLD handle oops (e.g. the java_mirror), safe to store in the object graph.
+  // Making the klass's CLD handle oops (e.g. the java_mirror), safe to store in the object
+  // graph and it's roots (e.g. Handles).
   static_cast<void>(klass_holder());
 }
 

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -58,6 +58,7 @@ inline bool Klass::is_loader_alive() const {
   return class_loader_data()->is_alive();
 }
 
+// Loading the java_mirror does not keep its holder alive. See Klass::keep_alive().
 inline oop Klass::java_mirror() const {
   return _java_mirror.resolve();
 }

--- a/src/hotspot/share/oops/klass.inline.hpp
+++ b/src/hotspot/share/oops/klass.inline.hpp
@@ -36,6 +36,12 @@ inline oop Klass::klass_holder() const {
   return class_loader_data()->holder();
 }
 
+inline void Klass::keep_alive() const {
+  // Resolving the holder (a WeakHandle) will keep the klass alive until the next safepoint.
+  // Making the klass's CLD handle oops (e.g. the java_mirror), safe to store in the object graph.
+  static_cast<void>(klass_holder());
+}
+
 inline bool Klass::is_non_strong_hidden() const {
   return is_hidden() && class_loader_data()->has_class_mirror_holder();
 }


### PR DESCRIPTION
JdkJfrEvent::get_all_klasses walks the class hierarchy of the Event class to find all event sub klasses. The mirrors of these classes are then stored in JNI handles and eventually transfered to an arraylist which is returned to the java caller.

Because the klasses are found by walking the class hierarchy, their is no guarantee that the klass is strongly reachable, and thus that the java_mirror load is strong. So we must explicitly keep the klass alive (and not have a safepoint between the load and the store into the object graph).

Having both `fill_klasses` and `transform_klasses_to_local_jni_handles` made the call to `keep_alive` and the comment explaining the reason why somewhat obscured, so I merged them. (The split seems to have served no purpose except to introduce the need for a lot of const and reinterpret casts.)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340586](https://bugs.openjdk.org/browse/JDK-8340586): JdkJfrEvent::get_all_klasses stores non-strong oops in JNI handles (**Bug** - P2)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**) Review applies to [f8ebdbf1](https://git.openjdk.org/jdk/pull/21893/files/f8ebdbf123f7964081c261f047f1c56fb713ede8)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21893/head:pull/21893` \
`$ git checkout pull/21893`

Update a local copy of the PR: \
`$ git checkout pull/21893` \
`$ git pull https://git.openjdk.org/jdk.git pull/21893/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21893`

View PR using the GUI difftool: \
`$ git pr show -t 21893`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21893.diff">https://git.openjdk.org/jdk/pull/21893.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21893#issuecomment-2456358008)
</details>
