### PR TITLE
8344246: Unnecessary Hashtable usage in EventSupport.notifiers

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/EventSupport.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/EventSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,10 @@
 
 package com.sun.jndi.ldap;
 
-import java.util.Hashtable;
+import java.util.HashMap;
 import java.util.Vector;
 import java.util.EventObject;
 import java.util.Iterator;
-import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
 
 import javax.naming.*;
@@ -124,8 +123,8 @@ final class EventSupport {
     /**
      * NamingEventNotifiers; hashed by search arguments;
      */
-    private Hashtable<NotifierArgs, NamingEventNotifier> notifiers =
-            new Hashtable<>(11);
+    private HashMap<NotifierArgs, NamingEventNotifier> notifiers =
+            new HashMap<>(11);
 
     /**
      * List of unsolicited notification listeners.


### PR DESCRIPTION
The field `com.sun.jndi.ldap.EventSupport#notifiers` is always accessed under `lock`. It means extra synchronization from `Hashtable` is not needed.
Subtle difference in Hashtable vs Hashmap behavior is that Hashtable doesn't allow `null` keys and `null` values. I've checked all usages of it - only non-null keys and values are put into it. So, replacement is safe.

One thing which was suspicous for me is `null` check of value in the `com.sun.jndi.ldap.EventSupport#removeNamingListener` method:
https://github.com/openjdk/jdk/blob/b54bd824b59b6b5dff9278ddebab4e9e2dfaf57b/src/java.naming/share/classes/com/sun/jndi/ldap/EventSupport.java#L230-L235
The condition `notifier != null` is always `true`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344246](https://bugs.openjdk.org/browse/JDK-8344246): Unnecessary Hashtable usage in EventSupport.notifiers (**Enhancement** - P5)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21894/head:pull/21894` \
`$ git checkout pull/21894`

Update a local copy of the PR: \
`$ git checkout pull/21894` \
`$ git pull https://git.openjdk.org/jdk.git pull/21894/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21894`

View PR using the GUI difftool: \
`$ git pr show -t 21894`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21894.diff">https://git.openjdk.org/jdk/pull/21894.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21894#issuecomment-2477266696)
</details>
