### PR TITLE
8343601: javax/swing/JMenuItem/8158566/CloseOnMouseClickPropertyTest.java fails in ubuntu 22.04

### DIFF
--- a/test/jdk/javax/swing/JMenuItem/8158566/CloseOnMouseClickPropertyTest.java
+++ b/test/jdk/javax/swing/JMenuItem/8158566/CloseOnMouseClickPropertyTest.java
@@ -44,7 +44,7 @@ import javax.swing.UIManager;
  * @key headful
  * @bug 8158566 8160879 8160977 8158566
  * @summary Provide a Swing property which modifies MenuItemUI behaviour
- * @run main/othervm/timeout=360 CloseOnMouseClickPropertyTest
+ * @run main/othervm/timeout=240 CloseOnMouseClickPropertyTest
  */
 
 public class CloseOnMouseClickPropertyTest {
@@ -109,7 +109,6 @@ public class CloseOnMouseClickPropertyTest {
         try {
             SwingUtilities.invokeAndWait(() -> createAndShowGUI(item));
             robot.waitForIdle();
-            robot.delay(1000);
 
             Point point = getClickPoint(true);
             robot.mouseMove(point.x, point.y);

--- a/test/jdk/javax/swing/JMenuItem/8158566/CloseOnMouseClickPropertyTest.java
+++ b/test/jdk/javax/swing/JMenuItem/8158566/CloseOnMouseClickPropertyTest.java
@@ -44,7 +44,7 @@ import javax.swing.UIManager;
  * @key headful
  * @bug 8158566 8160879 8160977 8158566
  * @summary Provide a Swing property which modifies MenuItemUI behaviour
- * @run main/othervm/timeout=600 CloseOnMouseClickPropertyTest
+ * @run main/othervm/timeout=360 CloseOnMouseClickPropertyTest
  */
 
 public class CloseOnMouseClickPropertyTest {
@@ -116,14 +116,12 @@ public class CloseOnMouseClickPropertyTest {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
-            robot.delay(500);
 
             point = getClickPoint(false);
             robot.mouseMove(point.x, point.y);
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK);
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK);
             robot.waitForIdle();
-            robot.delay(500);
 
             SwingUtilities.invokeAndWait(() -> {
                 JMenuItem menuItem = menu.getItem(0);

--- a/test/jdk/javax/swing/JMenuItem/8158566/CloseOnMouseClickPropertyTest.java
+++ b/test/jdk/javax/swing/JMenuItem/8158566/CloseOnMouseClickPropertyTest.java
@@ -138,6 +138,7 @@ public class CloseOnMouseClickPropertyTest {
         menuBar.add(menu);
 
         frame.setJMenuBar(menuBar);
+        frame.setLocationRelativeTo(null);
         frame.setVisible(true);
     }
 


### PR DESCRIPTION
It is seen that javax/swing/JMenuItem/8158566/CloseOnMouseClickPropertyTest.java fails in ubuntu 22.04 OCI instance. It is seen that test frame is being rendered at top-left of screen instead of at the center, and robot mouseMove is being used to point and click on radiobutton, checkbox etc and linux left dock placement can be a problem with this top-left rendering.

Fix is made to render the frame at the center.
Repeated iteration of the test run in 22.04 OCI instance is ok.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343601](https://bugs.openjdk.org/browse/JDK-8343601): javax/swing/JMenuItem/8158566/CloseOnMouseClickPropertyTest.java fails in ubuntu 22.04 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21896/head:pull/21896` \
`$ git checkout pull/21896`

Update a local copy of the PR: \
`$ git checkout pull/21896` \
`$ git pull https://git.openjdk.org/jdk.git pull/21896/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21896`

View PR using the GUI difftool: \
`$ git pr show -t 21896`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21896.diff">https://git.openjdk.org/jdk/pull/21896.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21896#issuecomment-2456703400)
</details>
