### PR TITLE
8343067: C2: revisit constant-offset AddP chains after successful input idealizations

### DIFF
--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1641,9 +1641,9 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
   if (use_op == Op_AddP) {
     for (DUIterator_Fast i2max, i2 = use->fast_outs(i2max); i2 < i2max; i2++) {
       Node* u = use->fast_out(i2);
-      if (u->is_Mem())
+      if (u->is_Mem()) {
         worklist.push(u);
-      if (UseNewCode && u->is_AddP() && u->in(AddPNode::Offset)->is_Con()) {
+      } else if (UseNewCode && u->is_AddP() && u->in(AddPNode::Offset)->is_Con()) {
         worklist.push(u);
       }
     }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1640,12 +1640,12 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
   // - if the changed input is the offset, check constant-offset AddP users for
   //   address expression flattening.
   if (use_op == Op_AddP) {
+    bool offset_changed = n == use->in(AddPNode::Offset);
     for (DUIterator_Fast i2max, i2 = use->fast_outs(i2max); i2 < i2max; i2++) {
       Node* u = use->fast_out(i2);
       if (u->is_Mem()) {
         worklist.push(u);
-      } else if (n == use->in(AddPNode::Offset) &&
-                 u->is_AddP() && u->in(AddPNode::Offset)->is_Con()) {
+      } else if (offset_changed && u->is_AddP() && u->in(AddPNode::Offset)->is_Con()) {
         worklist.push(u);
       }
     }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1643,7 +1643,7 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
       Node* u = use->fast_out(i2);
       if (u->is_Mem()) {
         worklist.push(u);
-      } else if (UseNewCode && u->is_AddP() && u->in(AddPNode::Offset)->is_Con()) {
+      } else if (u->is_AddP() && u->in(AddPNode::Offset)->is_Con()) {
         worklist.push(u);
       }
     }

--- a/src/hotspot/share/opto/phaseX.cpp
+++ b/src/hotspot/share/opto/phaseX.cpp
@@ -1637,13 +1637,15 @@ void PhaseIterGVN::add_users_of_use_to_worklist(Node* n, Node* use, Unique_Node_
   }
   // If changed AddP inputs:
   // - check Stores for loop invariant, and
-  // - check constant-offset AddP users for address expression flattening.
+  // - if the changed input is the offset, check constant-offset AddP users for
+  //   address expression flattening.
   if (use_op == Op_AddP) {
     for (DUIterator_Fast i2max, i2 = use->fast_outs(i2max); i2 < i2max; i2++) {
       Node* u = use->fast_out(i2);
       if (u->is_Mem()) {
         worklist.push(u);
-      } else if (u->is_AddP() && u->in(AddPNode::Offset)->is_Con()) {
+      } else if (n == use->in(AddPNode::Offset) &&
+                 u->is_AddP() && u->in(AddPNode::Offset)->is_Con()) {
         worklist.push(u);
       }
     }

--- a/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestCombineAddPWithConstantOffsets.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestCombineAddPWithConstantOffsets.java
@@ -28,7 +28,7 @@ import jdk.test.lib.Asserts;
 /*
  * @test
  * @bug 8343067
- * @requires os.simpleArch == "x64"
+ * @requires os.simpleArch == "x64" | os.simpleArch == "aarch64"
  * @requires vm.debug == true
  * @requires vm.compiler2.enabled
  * @summary Test that chains of AddP nodes with constant offsets are idealized
@@ -43,7 +43,11 @@ public class TestCombineAddPWithConstantOffsets {
     }
 
     @Test
-    @IR(failOn = IRNode.ADD_P_MACH,
+    @IR(applyIfPlatform = {"x64", "true"},
+        failOn = {IRNode.ADD_P_OF, ".*"},
+        phase = CompilePhase.FINAL_CODE)
+    @IR(applyIfPlatform = {"aarch64", "true"},
+        failOn = {IRNode.ADD_P_OF, "reg_imm"},
         phase = CompilePhase.FINAL_CODE)
     static void testCombineAddPWithConstantOffsets(int[] arr) {
         for (long i = 6; i < 14; i++) {

--- a/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestCombineAddPWithConstantOffsets.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestCombineAddPWithConstantOffsets.java
@@ -23,13 +23,11 @@
 package compiler.c2.irTests.igvn;
 
 import compiler.lib.ir_framework.*;
-import jdk.test.lib.Asserts;
 
 /*
  * @test
  * @bug 8343067
  * @requires os.simpleArch == "x64" | os.simpleArch == "aarch64"
- * @requires vm.debug == true
  * @requires vm.compiler2.enabled
  * @summary Test that chains of AddP nodes with constant offsets are idealized
  *          when their offset input changes.
@@ -43,12 +41,8 @@ public class TestCombineAddPWithConstantOffsets {
     }
 
     @Test
-    @IR(applyIfPlatform = {"x64", "true"},
-        failOn = {IRNode.ADD_P_OF, ".*"},
-        phase = CompilePhase.FINAL_CODE)
-    @IR(applyIfPlatform = {"aarch64", "true"},
-        failOn = {IRNode.ADD_P_OF, "reg_imm"},
-        phase = CompilePhase.FINAL_CODE)
+    @IR(applyIfPlatform = {"x64", "true"}, failOn = {IRNode.ADD_P_OF, ".*"})
+    @IR(applyIfPlatform = {"aarch64", "true"}, failOn = {IRNode.ADD_P_OF, "reg_imm"})
     static void testCombineAddPWithConstantOffsets(int[] arr) {
         for (long i = 6; i < 14; i++) {
             arr[(int)i] = 1;

--- a/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestCombineAddPWithConstantOffsets.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/igvn/TestCombineAddPWithConstantOffsets.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package compiler.c2.irTests.igvn;
+
+import compiler.lib.ir_framework.*;
+import jdk.test.lib.Asserts;
+
+/*
+ * @test
+ * @bug 8343067
+ * @requires os.simpleArch == "x64"
+ * @requires vm.debug == true
+ * @requires vm.compiler2.enabled
+ * @summary Test that chains of AddP nodes with constant offsets are idealized
+ *          when their offset input changes.
+ * @library /test/lib /
+ * @run driver compiler.c2.irTests.igvn.TestCombineAddPWithConstantOffsets
+ */
+public class TestCombineAddPWithConstantOffsets {
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test
+    @IR(failOn = IRNode.ADD_P_MACH,
+        phase = CompilePhase.FINAL_CODE)
+    static void testCombineAddPWithConstantOffsets(int[] arr) {
+        for (long i = 6; i < 14; i++) {
+            arr[(int)i] = 1;
+        }
+    }
+
+    @Run(test = {"testCombineAddPWithConstantOffsets"})
+    public void runTests() {
+        testCombineAddPWithConstantOffsets(new int[14]);
+    }
+}

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -274,9 +274,10 @@ public class IRNode {
         superWordNodes(ADD_REDUCTION_VL, "AddReductionVL");
     }
 
-    public static final String ADD_P_MACH = PREFIX + "ADD_P_MACH" + POSTFIX;
+    public static final String ADD_P_OF = COMPOSITE_PREFIX + "ADD_P_OF" + POSTFIX;
     static {
-        machOnlyNameRegex(ADD_P_MACH, "addP");
+        String regex = START + "addP_" + IS_REPLACED + MID + ".*" + END;
+        machOnly(ADD_P_OF, regex);
     }
 
     public static final String ALLOC = PREFIX + "ALLOC" + POSTFIX;

--- a/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
+++ b/test/hotspot/jtreg/compiler/lib/ir_framework/IRNode.java
@@ -274,6 +274,11 @@ public class IRNode {
         superWordNodes(ADD_REDUCTION_VL, "AddReductionVL");
     }
 
+    public static final String ADD_P_MACH = PREFIX + "ADD_P_MACH" + POSTFIX;
+    static {
+        machOnlyNameRegex(ADD_P_MACH, "addP");
+    }
+
     public static final String ALLOC = PREFIX + "ALLOC" + POSTFIX;
     static {
         String optoRegex = "(.*precise .*\\R((.*(?i:mov|mv|xorl|nop|spill).*|\\s*)\\R)*.*(?i:call,static).*wrapper for: C2 Runtime new_instance" + END;


### PR DESCRIPTION
This changeset re-adds a constant-offset AddP node (`u`) to C2's IGVN worklist when its address is given by another AddP node (`use`) whose offset has changed. This makes it possible for `AddPNode::Ideal` to flatten the address computation in cases where the offset of the latter (`use->in(AddPNode::Offset)`) is found to be constant during IGVN:

![idealization](https://github.com/user-attachments/assets/6b632642-c037-457f-bd19-6b30f24e6ac6)

The end result is the generation of fewer explicit address computation instructions.

#### Testing

##### Functionality

- tier1-5 (linux-x64, windows-x64, macosx-x64, linux-aarch64, macosx-aarch64; release and debug mode).

##### Performance

- Tested performance on a set of standard benchmark suites (DaCapo, SPECjbb2015, SPECjvm2008). No significant change was observed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343067](https://bugs.openjdk.org/browse/JDK-8343067): C2: revisit constant-offset AddP chains after successful input idealizations (**Enhancement** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21898/head:pull/21898` \
`$ git checkout pull/21898`

Update a local copy of the PR: \
`$ git checkout pull/21898` \
`$ git pull https://git.openjdk.org/jdk.git pull/21898/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21898`

View PR using the GUI difftool: \
`$ git pr show -t 21898`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21898.diff">https://git.openjdk.org/jdk/pull/21898.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21898#issuecomment-2457760229)
</details>
