### PR TITLE
8318442: java/net/httpclient/ManyRequests2.java fails intermittently on Linux

### DIFF
--- a/test/jdk/java/net/httpclient/ManyRequests2.java
+++ b/test/jdk/java/net/httpclient/ManyRequests2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,16 +33,16 @@
  * @compile ../../../com/sun/net/httpserver/EchoHandler.java
  * @compile ../../../com/sun/net/httpserver/FileServerHandler.java
  * @build ManyRequests ManyRequests2
- * @run main/othervm/timeout=40 -Dtest.XFixed=true
+ * @run main/othervm/timeout=400  -Dsun.net.httpserver.idleInterval=400 -Dtest.XFixed=true
  *                              -Djdk.tracePinnedThreads=full
  *                              -Djdk.httpclient.HttpClient.log=channel ManyRequests2
- * @run main/othervm/timeout=40 -Dtest.XFixed=true -Dtest.insertDelay=true
+ * @run main/othervm/timeout=400  -Dsun.net.httpserver.idleInterval=400 -Dtest.XFixed=true -Dtest.insertDelay=true
  *                              -Djdk.tracePinnedThreads=full
  *                              -Djdk.httpclient.HttpClient.log=channel ManyRequests2
- * @run main/othervm/timeout=40 -Dtest.XFixed=true -Dtest.chunkSize=64
+ * @run main/othervm/timeout=400  -Dsun.net.httpserver.idleInterval=400 -Dtest.XFixed=true -Dtest.chunkSize=64
  *                              -Djdk.tracePinnedThreads=full
  *                              -Djdk.httpclient.HttpClient.log=channel ManyRequests2
- * @run main/othervm/timeout=400 -Djdk.internal.httpclient.debug=true
+ * @run main/othervm/timeout=400 -Dsun.net.httpserver.idleInterval=400 -Djdk.internal.httpclient.debug=true
  *                              -Djdk.tracePinnedThreads=full
  *                              -Djdk.httpclient.HttpClient.log=channel
  *                              -Dtest.XFixed=true -Dtest.insertDelay=true

--- a/test/jdk/java/net/httpclient/ManyRequests2.java
+++ b/test/jdk/java/net/httpclient/ManyRequests2.java
@@ -33,13 +33,13 @@
  * @compile ../../../com/sun/net/httpserver/EchoHandler.java
  * @compile ../../../com/sun/net/httpserver/FileServerHandler.java
  * @build ManyRequests ManyRequests2
- * @run main/othervm/timeout=400  -Dsun.net.httpserver.idleInterval=400 -Dtest.XFixed=true
+ * @run main/othervm/timeout=400 -Dsun.net.httpserver.idleInterval=400 -Dtest.XFixed=true
  *                              -Djdk.tracePinnedThreads=full
  *                              -Djdk.httpclient.HttpClient.log=channel ManyRequests2
- * @run main/othervm/timeout=400  -Dsun.net.httpserver.idleInterval=400 -Dtest.XFixed=true -Dtest.insertDelay=true
+ * @run main/othervm/timeout=400 -Dsun.net.httpserver.idleInterval=400 -Dtest.XFixed=true -Dtest.insertDelay=true
  *                              -Djdk.tracePinnedThreads=full
  *                              -Djdk.httpclient.HttpClient.log=channel ManyRequests2
- * @run main/othervm/timeout=400  -Dsun.net.httpserver.idleInterval=400 -Dtest.XFixed=true -Dtest.chunkSize=64
+ * @run main/othervm/timeout=400 -Dsun.net.httpserver.idleInterval=400 -Dtest.XFixed=true -Dtest.chunkSize=64
  *                              -Djdk.tracePinnedThreads=full
  *                              -Djdk.httpclient.HttpClient.log=channel ManyRequests2
  * @run main/othervm/timeout=400 -Dsun.net.httpserver.idleInterval=400 -Djdk.internal.httpclient.debug=true


### PR DESCRIPTION
On Linux ppc64le test machines (RHEL8.5, Ubuntu 22.04) we see intermittent failures of java/net/httpclient/ManyRequests2.java .
We mostly run fastdebug binaries for our tests on  Linux ppc64le; unfortunately those are very slow and the current timeouts of this test are not sufficient on this platform.
With these increased values the test was stable also on Linux ppc64le over the last few months .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318442](https://bugs.openjdk.org/browse/JDK-8318442): java/net/httpclient/ManyRequests2.java fails intermittently on Linux (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21900/head:pull/21900` \
`$ git checkout pull/21900`

Update a local copy of the PR: \
`$ git checkout pull/21900` \
`$ git pull https://git.openjdk.org/jdk.git pull/21900/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21900`

View PR using the GUI difftool: \
`$ git pr show -t 21900`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21900.diff">https://git.openjdk.org/jdk/pull/21900.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21900#issuecomment-2457013216)
</details>
