### PR TITLE
8343452: Incorrect WINDOWS build variable is used in macroAssembler_x86.cpp

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4092,7 +4092,7 @@ RegSet MacroAssembler::call_clobbered_gp_registers() {
   RegSet regs;
 #ifdef _LP64
   regs += RegSet::of(rax, rcx, rdx);
-#ifndef WINDOWS
+#ifndef _WINDOWS
   regs += RegSet::of(rsi, rdi);
 #endif
   regs += RegSet::range(r8, r11);
@@ -4109,7 +4109,7 @@ RegSet MacroAssembler::call_clobbered_gp_registers() {
 
 XMMRegSet MacroAssembler::call_clobbered_xmm_registers() {
   int num_xmm_registers = XMMRegister::available_xmm_registers();
-#if defined(WINDOWS) && defined(_LP64)
+#if defined(_WINDOWS) && defined(_LP64)
   XMMRegSet result = XMMRegSet::range(xmm0, xmm5);
   if (num_xmm_registers > 16) {
      result += XMMRegSet::range(xmm16, as_XMMRegister(num_xmm_registers - 1));


### PR DESCRIPTION
From JBS:

> HotSpot VM build macro defines _WINDOWS env variable only.
> call_clobbered_gp_registers() and call_clobbered_xmm_registers() incorrectly use WINDOWS (without underscore).
> RSI and RDI are missing from list of clobbered register on windows due to that and may cause issue when calling native code which modifies them.
> 
> AMM register are less affected because all XMM registers are listed as clobbered.
> 
> The code was added by [JDK-8283327](https://bugs.openjdk.org/browse/JDK-8283327) changes in JDK 19.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343452](https://bugs.openjdk.org/browse/JDK-8343452): Incorrect WINDOWS build variable is used in macroAssembler_x86.cpp (**Bug** - P4)


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21901/head:pull/21901` \
`$ git checkout pull/21901`

Update a local copy of the PR: \
`$ git checkout pull/21901` \
`$ git pull https://git.openjdk.org/jdk.git pull/21901/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21901`

View PR using the GUI difftool: \
`$ git pr show -t 21901`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21901.diff">https://git.openjdk.org/jdk/pull/21901.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21901#issuecomment-2457157617)
</details>
