### PR TITLE
8342105: JVM Crash when Jacoco and JFR are active

### DIFF
--- a/src/hotspot/share/jfr/support/jfrDeprecationManager.cpp
+++ b/src/hotspot/share/jfr/support/jfrDeprecationManager.cpp
@@ -223,11 +223,14 @@ static inline bool is_invoke_bytecode(const Method* sender, int bci) {
   const Bytecodes::Code bc = (Bytecodes::Code)*sender->bcp_from(bci);
   switch (bc) {
     case Bytecodes::_invokevirtual:
-    case Bytecodes::_invokespecial:
     case Bytecodes::_invokestatic:
     case Bytecodes::_invokeinterface:
+    case Bytecodes::_invokespecial:
     case Bytecodes::_invokedynamic: {
       return true;
+    }
+    default: {
+      return false;
     }
   }
   return false;

--- a/src/hotspot/share/jfr/support/jfrDeprecationManager.cpp
+++ b/src/hotspot/share/jfr/support/jfrDeprecationManager.cpp
@@ -24,6 +24,7 @@
 
 #include "precompiled.hpp"
 #include "classfile/moduleEntry.hpp"
+#include "interpreter/bytecodes.hpp"
 #include "jfrfiles/jfrEventIds.hpp"
 #include "jfr/jni/jfrJavaSupport.hpp"
 #include "jfr/recorder/jfrRecorder.hpp"
@@ -216,6 +217,22 @@ static bool should_record(const Method* method, const Method* sender, JavaThread
   return is_not_jdk_module(sender_module, jt) && max_limit_not_reached();
 }
 
+static inline bool is_invoke_bytecode(const Method* sender, int bci) {
+  assert(sender != nullptr, "invariant");
+  assert(sender->validate_bci(bci) >= 0, "invariant");
+  const Bytecodes::Code bc = (Bytecodes::Code)*sender->bcp_from(bci);
+  switch (bc) {
+    case Bytecodes::_invokevirtual:
+    case Bytecodes::_invokespecial:
+    case Bytecodes::_invokestatic:
+    case Bytecodes::_invokeinterface:
+    case Bytecodes::_invokedynamic: {
+      return true;
+    }
+  }
+  return false;
+}
+
 // This is the entry point for newly discovered edges in JfrResolution.cpp.
 void JfrDeprecationManager::on_link(const Method* method, Method* sender, int bci, u1 frame_type, JavaThread* jt) {
   assert(method != nullptr, "invariant");
@@ -224,10 +241,13 @@ void JfrDeprecationManager::on_link(const Method* method, Method* sender, int bc
   assert(!sender->is_native(), "invariant");
   assert(jt != nullptr, "invariant");
   assert(JfrRecorder::is_started_on_commandline(), "invariant");
-  if (JfrMethodData::mark_deprecated_call_site(sender, bci, jt)) {
-    if (should_record(method, sender, jt)) {
-      create_edge(method, sender, bci, frame_type, jt);
+  if (should_record(method, sender, jt)) {
+    if (is_invoke_bytecode(sender, bci)) {
+      if (!JfrMethodData::mark_deprecated_call_site(sender, bci, jt)) {
+        return;
+      }
     }
+    create_edge(method, sender, bci, frame_type, jt);
   }
 }
 


### PR DESCRIPTION
Greetings,

JFR hooking invocations of deprecated methods have a problem supporting Condy because these involve indirect invocations (via a bootstrap method) and do not have a reified bytecode invocation instruction (which gets support structures in the MDO).

The bytecode for a condy invocation is ldc or fast_aload (when the bytecode is rewritten), and no MDO support structures are added for these.

ConstantPool idx 0x55: ("Condy")

55 = Dynamic 0:54 // 0:$jacocoData:Ljava/lang/Object;

CONSTANT_Dynamic_info {
      u1 tag;
      u2 bootstrap_method_attr_index; [0]
      u2 name_and_type_index; [54]
}

For additional details, please take a look at the JIRA issue. 

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342105](https://bugs.openjdk.org/browse/JDK-8342105): JVM Crash when Jacoco and JFR are active (**Bug** - P3)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21902/head:pull/21902` \
`$ git checkout pull/21902`

Update a local copy of the PR: \
`$ git checkout pull/21902` \
`$ git pull https://git.openjdk.org/jdk.git pull/21902/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21902`

View PR using the GUI difftool: \
`$ git pr show -t 21902`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21902.diff">https://git.openjdk.org/jdk/pull/21902.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21902#issuecomment-2457051366)
</details>
