### PR TITLE
8344023: Unnecessary Hashtable usage in LdapClient.defaultBinaryAttrs

### DIFF
--- a/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
+++ b/src/java.naming/share/classes/com/sun/jndi/ldap/LdapClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,6 +28,7 @@ package com.sun.jndi.ldap;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Locale;
+import java.util.Set;
 import java.util.Vector;
 import java.util.Hashtable;
 import java.util.concurrent.locks.ReentrantLock;
@@ -86,32 +87,23 @@ public final class LdapClient implements PooledConnection {
     static final boolean caseIgnore = true;
 
     // Default list of binary attributes
-    private static final Hashtable<String, Boolean> defaultBinaryAttrs =
-            new Hashtable<>(23,0.75f);
-    static {
-        defaultBinaryAttrs.put("userpassword", Boolean.TRUE);      //2.5.4.35
-        defaultBinaryAttrs.put("javaserializeddata", Boolean.TRUE);
-                                                //1.3.6.1.4.1.42.2.27.4.1.8
-        defaultBinaryAttrs.put("javaserializedobject", Boolean.TRUE);
-                                                // 1.3.6.1.4.1.42.2.27.4.1.2
-        defaultBinaryAttrs.put("jpegphoto", Boolean.TRUE);
-                                                //0.9.2342.19200300.100.1.60
-        defaultBinaryAttrs.put("audio", Boolean.TRUE);  //0.9.2342.19200300.100.1.55
-        defaultBinaryAttrs.put("thumbnailphoto", Boolean.TRUE);
-                                                //1.3.6.1.4.1.1466.101.120.35
-        defaultBinaryAttrs.put("thumbnaillogo", Boolean.TRUE);
-                                                //1.3.6.1.4.1.1466.101.120.36
-        defaultBinaryAttrs.put("usercertificate", Boolean.TRUE);     //2.5.4.36
-        defaultBinaryAttrs.put("cacertificate", Boolean.TRUE);       //2.5.4.37
-        defaultBinaryAttrs.put("certificaterevocationlist", Boolean.TRUE);
-                                                //2.5.4.39
-        defaultBinaryAttrs.put("authorityrevocationlist", Boolean.TRUE); //2.5.4.38
-        defaultBinaryAttrs.put("crosscertificatepair", Boolean.TRUE);    //2.5.4.40
-        defaultBinaryAttrs.put("photo", Boolean.TRUE);   //0.9.2342.19200300.100.1.7
-        defaultBinaryAttrs.put("personalsignature", Boolean.TRUE);
-                                                //0.9.2342.19200300.100.1.53
-        defaultBinaryAttrs.put("x500uniqueidentifier", Boolean.TRUE); //2.5.4.45
-    }
+    private static final Set<String> defaultBinaryAttrs = Set.of(
+            "userpassword",             //2.5.4.35
+            "javaserializeddata",       //1.3.6.1.4.1.42.2.27.4.1.8
+            "javaserializedobject",     //1.3.6.1.4.1.42.2.27.4.1.2
+            "jpegphoto",                //0.9.2342.19200300.100.1.60
+            "audio",                    //0.9.2342.19200300.100.1.55
+            "thumbnailphoto",           //1.3.6.1.4.1.1466.101.120.35
+            "thumbnaillogo",            //1.3.6.1.4.1.1466.101.120.36
+            "usercertificate",          //2.5.4.36
+            "cacertificate",            //2.5.4.37
+            "certificaterevocationlist",//2.5.4.39
+            "authorityrevocationlist",  //2.5.4.38
+            "crosscertificatepair",     //2.5.4.40
+            "photo",                    //0.9.2342.19200300.100.1.7
+            "personalsignature",        //0.9.2342.19200300.100.1.53
+            "x500uniqueidentifier"      //2.5.4.45
+    );
 
     private static final String DISCONNECT_OID = "1.3.6.1.4.1.1466.20036";
 
@@ -790,7 +782,7 @@ public final class LdapClient implements PooledConnection {
         String id = attrid.toLowerCase(Locale.ENGLISH);
 
         return id.contains(";binary") ||
-            defaultBinaryAttrs.containsKey(id) ||
+            defaultBinaryAttrs.contains(id) ||
             ((binaryAttrs != null) && (binaryAttrs.containsKey(id)));
     }
 


### PR DESCRIPTION
Content of Hashtable `com.sun.jndi.ldap.LdapClient#defaultBinaryAttrs` is fully initialized in `<clinit>` block.
It means we can replace legacy synchronized `Hashtable` with immutable set.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344023](https://bugs.openjdk.org/browse/JDK-8344023): Unnecessary Hashtable usage in LdapClient.defaultBinaryAttrs (**Enhancement** - P5)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21903/head:pull/21903` \
`$ git checkout pull/21903`

Update a local copy of the PR: \
`$ git checkout pull/21903` \
`$ git pull https://git.openjdk.org/jdk.git pull/21903/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21903`

View PR using the GUI difftool: \
`$ git pr show -t 21903`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21903.diff">https://git.openjdk.org/jdk/pull/21903.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21903#issuecomment-2470280336)
</details>
