### PR TITLE
8343460: ZGC: Crash in ZRemembered::scan_page_and_clear_remset

### DIFF
--- a/src/hotspot/share/gc/z/zHeap.cpp
+++ b/src/hotspot/share/gc/z/zHeap.cpp
@@ -248,10 +248,6 @@ void ZHeap::free_page(ZPage* page, bool allow_defragment) {
   // Remove page table entry
   _page_table.remove(page);
 
-  if (page->is_old()) {
-    page->remset_delete();
-  }
-
   // Free page
   _page_allocator.free_page(page, allow_defragment);
 }
@@ -262,9 +258,6 @@ size_t ZHeap::free_empty_pages(const ZArray<ZPage*>* pages) {
   ZArrayIterator<ZPage*> iter(pages);
   for (ZPage* page; iter.next(&page);) {
     _page_table.remove(page);
-    if (page->is_old()) {
-      page->remset_delete();
-    }
     freed += page->size();
   }
 

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -897,7 +897,7 @@ void ZPageAllocator::free_pages_alloc_failed(ZPageAllocation* allocation) {
   ZListRemoveIterator<ZPage> iter(allocation->pages());
   for (ZPage* page; iter.next(&page);) {
     freed += page->size();
-    _cache.free_page(page);
+    recycle_page(page);
   }
 
   // Adjust capacity and used to reflect the failed capacity increase

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -826,6 +826,11 @@ void ZPageAllocator::free_page(ZPage* page, bool allow_defragment) {
   // Prepare page for recycling before taking the lock
   ZPage* const to_recycle = prepare_to_recycle(page, allow_defragment);
 
+  // Remove the remset before recycling
+  if (to_recycle->is_old() && to_recycle == page) {
+    to_recycle->remset_delete();
+  }
+
   ZLocker<ZLock> locker(&_lock);
 
   // Update used statistics
@@ -857,6 +862,11 @@ void ZPageAllocator::free_pages(const ZArray<ZPage*>* pages) {
 
     // Prepare to recycle
     ZPage* const to_recycle = prepare_to_recycle(page, true /* allow_defragment */);
+
+    // Remove the remset before recycling
+    if (to_recycle->is_old() && to_recycle == page) {
+      to_recycle->remset_delete();
+    }
 
     // Register for recycling
     to_recycle_pages.push(to_recycle);

--- a/src/hotspot/share/gc/z/zPageAllocator.cpp
+++ b/src/hotspot/share/gc/z/zPageAllocator.cpp
@@ -885,6 +885,9 @@ void ZPageAllocator::free_pages(const ZArray<ZPage*>* pages) {
 }
 
 void ZPageAllocator::free_pages_alloc_failed(ZPageAllocation* allocation) {
+  // The page(s) in the allocation are either taken from the cache or a newly
+  // created, mapped and commited ZPage. These page(s) have not been inserted in
+  // the page table, nor allocated a remset, so prepare_to_recycle is not required.
   ZLocker<ZLock> locker(&_lock);
 
   // Only decrease the overall used and not the generation used,


### PR DESCRIPTION
`free_page` may concurrently delete the remset while `scan_page_and_clear_remset` is scanning the page.  Move it to after the `_safe_recycle.register_and_clone_if_activated`. Doing the deletion on the new cloned page will not occur as it not old. And the registered page's remset will be deleted by the destructor when the `_safe_recycle` scope quest up the `safe_destroy`. 

To be able to push the deletion all the way into `prepare_to_recycle` the unnecessary use of this mechanism had to be removed. `free_pages_alloc_failed` does not need to protect the pages, as they are not yet present in the PageTable. We have simply taken them out of the cache, but failed to commit or map some memory, so we are putting these pages back into the cache. See bed9c260bbc9bd208b03d7eedd4e2cfa151b58f2

The fix works without this last commit. So we must be careful to check that these pages cannot be reached by some other means. The FoundOld bitmap iteration goes through the PageTable so even if an old page was registered, we would not find these pages.

There is a scary lack of a fence between the removal of the page from the PageTable and the lock in `register_and_clone_if_activated`.

The stress test will deterministically crash with this modified code 0756e0056b44ee16bee81256f556c8df981ceaf9 and using these options `-XX:+UseZGC -XX:+UseNewCode -XX:ZCollectionIntervalMinor=0.1 -XX:ZCollectionIntervalMajor=1 -XX:ZFragmentationLimit=0 -XX:-CreateCoredumpOnCrash`, and no longer does after with this patch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343460](https://bugs.openjdk.org/browse/JDK-8343460): ZGC: Crash in ZRemembered::scan_page_and_clear_remset (**Bug** - P2)


### Reviewers
 * [Joel Sikström](https://openjdk.org/census#jsikstro) (@jsikstro - Committer)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**)
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21905/head:pull/21905` \
`$ git checkout pull/21905`

Update a local copy of the PR: \
`$ git checkout pull/21905` \
`$ git pull https://git.openjdk.org/jdk.git pull/21905/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21905`

View PR using the GUI difftool: \
`$ git pr show -t 21905`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21905.diff">https://git.openjdk.org/jdk/pull/21905.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21905#issuecomment-2457300782)
</details>
