### PR TITLE
8343599: Kmem limit and max values swapped when printing container information

### DIFF
--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -301,8 +301,8 @@ void CgroupV1MemoryController::print_version_specific_info(outputStream* st, jul
   jlong kmem_max_usage = kernel_memory_max_usage_in_bytes();
 
   OSContainer::print_container_helper(st, kmem_usage, "kernel_memory_usage_in_bytes");
-  OSContainer::print_container_helper(st, kmem_limit, "kernel_memory_max_usage_in_bytes");
-  OSContainer::print_container_helper(st, kmem_max_usage, "kernel_memory_limit_in_bytes");
+  OSContainer::print_container_helper(st, kmem_limit, "kernel_memory_limit_in_bytes");
+  OSContainer::print_container_helper(st, kmem_max_usage, "kernel_memory_max_usage_in_bytes");
 }
 
 char* CgroupV1Subsystem::cpu_cpuset_cpus() {

--- a/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
+++ b/src/hotspot/os/linux/cgroupV1Subsystem_linux.cpp
@@ -300,8 +300,8 @@ void CgroupV1MemoryController::print_version_specific_info(outputStream* st, jul
   jlong kmem_limit = kernel_memory_limit_in_bytes(phys_mem);
   jlong kmem_max_usage = kernel_memory_max_usage_in_bytes();
 
-  OSContainer::print_container_helper(st, kmem_usage, "kernel_memory_usage_in_bytes");
   OSContainer::print_container_helper(st, kmem_limit, "kernel_memory_limit_in_bytes");
+  OSContainer::print_container_helper(st, kmem_usage, "kernel_memory_usage_in_bytes");
   OSContainer::print_container_helper(st, kmem_max_usage, "kernel_memory_max_usage_in_bytes");
 }
 


### PR DESCRIPTION
Hi all, 

This is a small patch addressing [8343599](https://bugs.openjdk.org/browse/JDK-8343599). 

Cheers, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343599](https://bugs.openjdk.org/browse/JDK-8343599): Kmem limit and max values swapped when printing container information (**Bug** - P3)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21906/head:pull/21906` \
`$ git checkout pull/21906`

Update a local copy of the PR: \
`$ git checkout pull/21906` \
`$ git pull https://git.openjdk.org/jdk.git pull/21906/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21906`

View PR using the GUI difftool: \
`$ git pr show -t 21906`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21906.diff">https://git.openjdk.org/jdk/pull/21906.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21906#issuecomment-2458001111)
</details>
