### PR TITLE
8343650: Reuse StringLatin1::putCharsAt and StringUTF16::putCharsAt

### DIFF
--- a/src/java.base/share/classes/java/lang/StringConcatHelper.java
+++ b/src/java.base/share/classes/java/lang/StringConcatHelper.java
@@ -236,17 +236,10 @@ final class StringConcatHelper {
         if (indexCoder < UTF16) {
             if (value) {
                 index -= 4;
-                buf[index] = 't';
-                buf[index + 1] = 'r';
-                buf[index + 2] = 'u';
-                buf[index + 3] = 'e';
+                StringLatin1.putCharsAt(buf, index, 't', 'r', 'u', 'e');
             } else {
                 index -= 5;
-                buf[index] = 'f';
-                buf[index + 1] = 'a';
-                buf[index + 2] = 'l';
-                buf[index + 3] = 's';
-                buf[index + 4] = 'e';
+                StringLatin1.putCharsAt(buf, index, 'f', 'a', 'l', 's', 'e');
             }
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
@@ -254,17 +247,10 @@ final class StringConcatHelper {
         } else {
             if (value) {
                 index -= 4;
-                StringUTF16.putChar(buf, index, 't');
-                StringUTF16.putChar(buf, index + 1, 'r');
-                StringUTF16.putChar(buf, index + 2, 'u');
-                StringUTF16.putChar(buf, index + 3, 'e');
+                StringUTF16.putCharsAt(buf, index, 't', 'r', 'u', 'e');
             } else {
                 index -= 5;
-                StringUTF16.putChar(buf, index, 'f');
-                StringUTF16.putChar(buf, index + 1, 'a');
-                StringUTF16.putChar(buf, index + 2, 'l');
-                StringUTF16.putChar(buf, index + 3, 's');
-                StringUTF16.putChar(buf, index + 4, 'e');
+                StringUTF16.putCharsAt(buf, index, 'f', 'a', 'l', 's', 'e');
             }
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);
@@ -638,34 +624,20 @@ final class StringConcatHelper {
         if (coder == String.LATIN1) {
             if (value) {
                 index -= 4;
-                buf[index] = 't';
-                buf[index + 1] = 'r';
-                buf[index + 2] = 'u';
-                buf[index + 3] = 'e';
+                StringLatin1.putCharsAt(buf, index, 't', 'r', 'u', 'e');
             } else {
                 index -= 5;
-                buf[index] = 'f';
-                buf[index + 1] = 'a';
-                buf[index + 2] = 'l';
-                buf[index + 3] = 's';
-                buf[index + 4] = 'e';
+                StringLatin1.putCharsAt(buf, index, 'f', 'a', 'l', 's', 'e');
             }
             index -= prefix.length();
             prefix.getBytes(buf, index, String.LATIN1);
         } else {
             if (value) {
                 index -= 4;
-                StringUTF16.putChar(buf, index, 't');
-                StringUTF16.putChar(buf, index + 1, 'r');
-                StringUTF16.putChar(buf, index + 2, 'u');
-                StringUTF16.putChar(buf, index + 3, 'e');
+                StringUTF16.putCharsAt(buf, index, 't', 'r', 'u', 'e');
             } else {
                 index -= 5;
-                StringUTF16.putChar(buf, index, 'f');
-                StringUTF16.putChar(buf, index + 1, 'a');
-                StringUTF16.putChar(buf, index + 2, 'l');
-                StringUTF16.putChar(buf, index + 3, 's');
-                StringUTF16.putChar(buf, index + 4, 'e');
+                StringUTF16.putCharsAt(buf, index, 'f', 'a', 'l', 's', 'e');
             }
             index -= prefix.length();
             prefix.getBytes(buf, index, String.UTF16);


### PR DESCRIPTION
Reuse the optimized putCharsAt method of StringLatin1 and StringUTF16 in PR #19626 to simplify the code, eliminate boundary checks, and improve performance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343650](https://bugs.openjdk.org/browse/JDK-8343650): Reuse StringLatin1::putCharsAt and StringUTF16::putCharsAt (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21907/head:pull/21907` \
`$ git checkout pull/21907`

Update a local copy of the PR: \
`$ git checkout pull/21907` \
`$ git pull https://git.openjdk.org/jdk.git pull/21907/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21907`

View PR using the GUI difftool: \
`$ git pr show -t 21907`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21907.diff">https://git.openjdk.org/jdk/pull/21907.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21907#issuecomment-2458471541)
</details>
