### PR TITLE
8340380: Improve source launcher's shebang script detection

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -758,10 +758,10 @@ checkMode(int mode, int newMode, const char *arg) {
  */
 static jboolean IsSourceFile(const char *arg) {
     struct stat st;
-    if (JLI_HasSuffix(arg, ".java") == JNI_TRUE)
-        return JNI_TRUE;
     if (stat(arg, &st) != 0)
         return JNI_FALSE;
+    if (JLI_HasSuffix(arg, ".java") == JNI_TRUE)
+        return JNI_TRUE;
     if (st.st_size < 2)
         return JNI_FALSE;
     /*

--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -758,7 +758,23 @@ checkMode(int mode, int newMode, const char *arg) {
  */
 static jboolean IsSourceFile(const char *arg) {
     struct stat st;
-    return (JLI_HasSuffix(arg, ".java") && stat(arg, &st) == 0);
+    if (JLI_HasSuffix(arg, ".java") == JNI_TRUE)
+        return JNI_TRUE;
+    if (stat(arg, &st) != 0)
+        return JNI_FALSE;
+    if (st.st_size < 2)
+        return JNI_FALSE;
+    /*
+     * In a shebang file, the first two bytes must be 0x23 0x21,
+     * the two-character ASCII encoding of #!.
+     */
+    FILE* file = fopen(arg, "r");
+    if (file == NULL)
+        return JNI_FALSE;
+    char c = fgetc(file);
+    char d = fgetc(file);
+    fclose(file);
+    return c == 0x23 && d == 0x21; // #!
 }
 
 /*

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2025, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8192920 8204588 8246774 8248843 8268869 8235876 8328339 8335896
+ * @bug 8192920 8204588 8246774 8248843 8268869 8235876 8328339 8335896 8340380
  * @summary Test source launcher
  * @library /tools/lib
  * @modules jdk.compiler/com.sun.tools.javac.api

--- a/test/langtools/tools/javac/launcher/SourceLauncherTest.java
+++ b/test/langtools/tools/javac/launcher/SourceLauncherTest.java
@@ -161,6 +161,20 @@ public class SourceLauncherTest extends TestRunner {
     }
 
     @Test
+    public void testHelloWorldWithShebangWithoutSource(Path base) throws IOException {
+        tb.writeJavaFiles(base,
+            "#!/usr/bin/java\n" + // without "--source N" for JDK-8340380
+            "import java.util.Arrays;\n" +
+            "class HelloWorld {\n" +
+            "    public static void main(String... args) {\n" +
+            "        System.out.println(\"Hello World! \" + Arrays.toString(args));\n" +
+            "    }\n" +
+            "}");
+        Files.copy(base.resolve("HelloWorld.java"), base.resolve("HelloWorld"));
+        testSuccess(base.resolve("HelloWorld"), "Hello World! [1, 2, 3]\n");
+    }
+
+    @Test
     public void testNoAnnoProcessing(Path base) throws IOException {
         Path annoSrc = base.resolve("annoSrc");
         tb.writeJavaFiles(annoSrc,


### PR DESCRIPTION
Please review this change that improves the launcher mode detection by reading the initial two characters from the started file for being a shebang script. It addresses the reported confusing error messages and also supports more shebang line variations. Including those line variations that omit the `--source` arguments like shown in the underlying issue description of JDK-8340380.

Tests of tier 1..3: _in progress_

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8340380](https://bugs.openjdk.org/browse/JDK-8340380)

### Issue
 * [JDK-8340380](https://bugs.openjdk.org/browse/JDK-8340380): Improve error message from shebang launcher for --enable-preview script (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21910/head:pull/21910` \
`$ git checkout pull/21910`

Update a local copy of the PR: \
`$ git checkout pull/21910` \
`$ git pull https://git.openjdk.org/jdk.git pull/21910/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21910`

View PR using the GUI difftool: \
`$ git pr show -t 21910`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21910.diff">https://git.openjdk.org/jdk/pull/21910.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21910#issuecomment-2578001450)
</details>
