### PR TITLE
8339288: Improve diagnostic logging runtime/cds/DeterministicDump.java

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
+++ b/test/hotspot/jtreg/runtime/cds/DeterministicDump.java
@@ -27,17 +27,31 @@
  * @summary The same JDK build should always generate the same archive file (no randomness).
  * @requires vm.cds & vm.flagless
  * @library /test/lib
- * @run driver DeterministicDump
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions
+ *                   -XX:+WhiteBoxAPI DeterministicDump
  */
 
+import jdk.test.lib.cds.CDSArchiveUtils;
 import jdk.test.lib.cds.CDSOptions;
 import jdk.test.lib.cds.CDSTestUtils;
 import jdk.test.lib.Platform;
+import java.io.BufferedReader;
+import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.util.ArrayList;
 
 public class DeterministicDump {
+
+    static long HEADER_SIZE;      // Size of header in bytes
+    static int HEADER_LEN = 106;  // Number of lines in CDS map file header
+    static int LINE_OFFSET = 22;  // Offset from address to first word of data
+    static int NUM_LINES = 5;     // Number of lines to be printed
+    static int WORD_LEN = 16 + 1; // Length of word in map file
+
     public static void main(String[] args) throws Exception {
         doTest(false);
 
@@ -60,6 +74,8 @@ public class DeterministicDump {
         }
 
         String baseArchive = dump(baseArgs);
+        File baseArchiveFile = new File(baseArchive + ".jsa");
+        HEADER_SIZE = CDSArchiveUtils.fileHeaderSize(baseArchiveFile);
 
         // (1) Dump with the same args. Should produce the same archive.
         String baseArchive2 = dump(baseArgs);
@@ -87,14 +103,14 @@ public class DeterministicDump {
             .addSuffix(more);
         CDSTestUtils.createArchiveAndCheck(opts);
 
-        return archiveName;
+        return logName;
     }
 
     static void compare(String file0, String file1) throws Exception {
         byte[] buff0 = new byte[4096];
         byte[] buff1 = new byte[4096];
-        try (FileInputStream in0 = new FileInputStream(file0);
-             FileInputStream in1 = new FileInputStream(file1)) {
+        try (FileInputStream in0 = new FileInputStream(file0 + ".jsa");
+             FileInputStream in1 = new FileInputStream(file1 + ".jsa")) {
             int total = 0;
             while (true) {
                 int n0 = read(in0, buff0);
@@ -111,7 +127,10 @@ public class DeterministicDump {
                     byte b0 = buff0[i];
                     byte b1 = buff1[i];
                     if (b0 != b1) {
-                        throw new RuntimeException("File content different at byte #" + (total + i) + ", b0 = " + b0 + ", b1 = " + b1);
+                        if (total + i > HEADER_SIZE) {
+                            print_diff(file0 + ".map", file1 + ".map", total + i);
+                            throw new RuntimeException("File content different at byte #" + (total + i) + ", b0 = " + b0 + ", b1 = " + b1);
+                        }
                     }
                 }
                 total += n0;
@@ -130,5 +149,69 @@ public class DeterministicDump {
         }
 
         return total;
+    }
+
+    // Read the mapfile and print out the lines associated with the location
+    static void print_diff(String mapName0, String mapName1, int location) throws Exception {
+        FileReader f0 = new FileReader(mapName0);
+        BufferedReader b0 = new BufferedReader(f0);
+
+        FileReader f1 = new FileReader(mapName1);
+        BufferedReader b1 = new BufferedReader(f1);
+
+        int line_num = HEADER_LEN;
+        int word = location / 8;
+        int word_offset = word % 4; // Each line in the map file prints four words
+
+        // Skip header text and go to first line
+        for (int i = 0; i < HEADER_LEN; i++) {
+            b0.readLine();
+            b1.readLine();
+        }
+
+        String s0 = "";
+        String s1 = "";
+        int count = 0;
+
+        // A line may contain 1-4 words so we iterate by word
+        do {
+            s0 = b0.readLine();
+            s1 = b1.readLine();
+            line_num++;
+            // Skip lines with headers e.g.
+            // [rw region          0x0000000800000000 - 0x00000008005a1f88   5906312 bytes]
+            // or
+            // 0x0000000800000b28: @@ TypeArrayU1       16
+            if (!s0.contains(": @@") && !s0.contains("bytes]")) {
+                int words = (s0.length() - LINE_OFFSET - 70) / 8;
+                count += words;
+            }
+        } while (count < word);
+
+        System.out.println("[First diff: map file #1 (" + mapName0 + ")]");
+        String diff_f0 = print_diff_helper(b0, word_offset, s0);
+
+        System.out.println("\n[First diff: map file #2 (" + mapName1 + ")]");
+        String diff_f1 = print_diff_helper(b1, word_offset, s1);
+
+        System.out.printf("\nByte #%d at line #%d word #%d:\n", location, line_num, word_offset);
+        System.out.printf("%s: %s\n%s: %s\n", mapName0, diff_f0, mapName1, diff_f1);
+
+        f0.close();
+        f1.close();
+    }
+
+    static String print_diff_helper(BufferedReader b, int word_offset, String line) throws Exception {
+        // Extract word from line
+        int start = LINE_OFFSET + WORD_LEN * word_offset;
+        int end = start + WORD_LEN;
+        String diff = line.substring(start, end);
+
+        // Print extra lines
+        System.out.println(line);
+        for (int i = 0; i < NUM_LINES; i++) {
+            System.out.println(b.readLine());
+        }
+        return diff;
     }
 }

--- a/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
@@ -145,6 +145,7 @@ public class CDSArchiveUtils {
     public static int dynamicArchiveHeaderSize()    { return dynamicArchiveHeaderSize;    }
     public static int cdsFileMapRegionSize()        { return cdsFileMapRegionSize;        }
     public static long alignment()                  { return alignment;                   }
+    public static int num_regions()                 { return num_regions;                 }
 
 
 
@@ -492,6 +493,12 @@ public class CDSArchiveUtils {
             transferFrom(inputChannel, outputChannel, offset, orgSize - bytesToDelete);
         }
         return dstFile;
+    }
+
+    // used region size
+    public static long usedRegionSize(File archiveFile, int region) throws Exception {
+        long offset = spOffset + cdsFileMapRegionSize * region + spUsedOffset;
+        return readInt(archiveFile, offset, sizetSize);
     }
 
     // used region size

--- a/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
+++ b/test/lib/jdk/test/lib/cds/CDSArchiveUtils.java
@@ -503,8 +503,7 @@ public class CDSArchiveUtils {
 
     // used region size
     public static long usedRegionSizeAligned(File archiveFile, int region) throws Exception {
-        long offset = spOffset + cdsFileMapRegionSize * region + spUsedOffset;
-        long used = readInt(archiveFile, offset, sizetSize);
+        long used = usedRegionSize(archiveFile, region);
         return alignUpWithAlignment(used);
     }
 }


### PR DESCRIPTION
The test `DeterministicDump.java` fails frequently since it is sensitive to changes in CDS, and with it's current logging, it is very difficult to diagnose the root cause of these failures. The current output looks like this:

```
[First diff: map file #1 (SharedArchiveFile0.map)]
[ro region          0x00000008005a2000 - 0x0000000800ea7058   9457752 bytes]
 [ro region          0x00000008005a2000 - 0x0000000800ea7058   9457752 bytes]
 0x00000008005a2000: @@ Symbol            40 [Ljdk/internal/vm/FillerElement;
>0x00000008005a2000:   4c5b0020e72fffff 65746e692f6b646a 2f6d762f6c616e72 6c4572656c6c6946   ../. .[Ljdk/internal/vm/FillerEl
 0x00000008005a2020:   00003b746e656d65                                                      ement;..
 0x00000008005a2028: @@ Symbol            8 [Z

[First diff: map file #2 (SharedArchiveFile1.map)]
[ro region          0x00000008005a2000 - 0x0000000800ea7058   9457752 bytes]
 [ro region          0x00000008005a2000 - 0x0000000800ea7058   9457752 bytes]
 0x00000008005a2000: @@ Symbol            40 [Ljdk/internal/vm/FillerElement;
>0x00000008005a2000:   4c5b00205d54ffff 65746e692f6b646a 2f6d762f6c616e72 6c4572656c6c6946   ..T] .[Ljdk/internal/vm/FillerEl
 0x00000008005a2020:   00003b746e656d65                                                      ement;..
 0x00000008005a2028: @@ Symbol            8 [Z

Byte #5910530 at line #235268 word #0:
SharedArchiveFile0.map: 4c5b0020e72fffff 
SharedArchiveFile1.map: 4c5b00205d54ffff 
```

This change was verified locally by generating non-deterministic archives and map files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339288](https://bugs.openjdk.org/browse/JDK-8339288): Improve diagnostic logging runtime/cds/DeterministicDump.java (**Sub-task** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**) Review applies to [1ba7318b](https://git.openjdk.org/jdk/pull/21913/files/1ba7318b035a6c98dbc1b68de38bd14d7d225b3d)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21913/head:pull/21913` \
`$ git checkout pull/21913`

Update a local copy of the PR: \
`$ git checkout pull/21913` \
`$ git pull https://git.openjdk.org/jdk.git pull/21913/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21913`

View PR using the GUI difftool: \
`$ git pr show -t 21913`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21913.diff">https://git.openjdk.org/jdk/pull/21913.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21913#issuecomment-2457999229)
</details>
