### PR TITLE
8343505: Problemlist java/lang/Thread/jni/AttachCurrentThread/AttachTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -774,6 +774,10 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id0    8343244 linux-aarch64,linux-ppc64le
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1    8343244 linux-aarch64,linux-ppc64le
+jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java         8343244 linux-aarch64,linux-ppc64le
+
 ############################################################################
 
 # jdk_internal

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -774,8 +774,8 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id0    8343244 linux-all
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1    8343244 linux-all
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id0    8343244 generic-all
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1    8343244 generic-all
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -518,6 +518,8 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-all
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id0    8343244 generic-all
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1    8343244 generic-all
 
 ############################################################################
 
@@ -773,9 +775,6 @@ jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
-
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id0    8343244 generic-all
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1    8343244 generic-all
 
 ############################################################################
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -774,9 +774,8 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id0    8343244 linux-aarch64,linux-ppc64le
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1    8343244 linux-aarch64,linux-ppc64le
-jdk/jfr/event/gc/detailed/TestZPageAllocationEvent.java         8343244 linux-aarch64,linux-ppc64le
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id0    8343244 linux-all
+java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1    8343244 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
Hi all,
To make less CI noisy, before the root cause of [JDK-8343244](https://bugs.openjdk.org/browse/JDK-8343244) has fixed, should we problemlist the failure tests, include AttachTest.java and TestZPageAllocationEvent.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343505](https://bugs.openjdk.org/browse/JDK-8343505): Problemlist java/lang/Thread/jni/AttachCurrentThread/AttachTest.java (**Sub-task** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21917/head:pull/21917` \
`$ git checkout pull/21917`

Update a local copy of the PR: \
`$ git checkout pull/21917` \
`$ git pull https://git.openjdk.org/jdk.git pull/21917/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21917`

View PR using the GUI difftool: \
`$ git pr show -t 21917`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21917.diff">https://git.openjdk.org/jdk/pull/21917.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21917#issuecomment-2458623429)
</details>
