### PR TITLE
8342945: Replace predicate walking code in get_assertion_predicates() used for Loop Unswitching and cleaning useless Template Assertion Predicates with a predicate visitor

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4469,7 +4469,7 @@ void PhaseIdealLoop::collect_useful_template_assertion_predicates_for_loop(Ideal
   if (UseProfiledLoopPredicate) {
     const PredicateBlock* profiled_loop_predicate_block = predicates.profiled_loop_predicate_block();
     if (profiled_loop_predicate_block->has_parse_predicate()) {
-      IfProjNode* parse_predicate_proj = profiled_loop_predicate_block->parse_predicate_success_proj();
+      ParsePredicateSuccessProj* parse_predicate_proj = profiled_loop_predicate_block->parse_predicate_success_proj();
       get_assertion_predicates(parse_predicate_proj, useful_predicates, true);
     }
   }
@@ -4477,7 +4477,7 @@ void PhaseIdealLoop::collect_useful_template_assertion_predicates_for_loop(Ideal
   if (UseLoopPredicate) {
     const PredicateBlock* loop_predicate_block = predicates.loop_predicate_block();
     if (loop_predicate_block->has_parse_predicate()) {
-      IfProjNode* parse_predicate_proj = loop_predicate_block->parse_predicate_success_proj();
+      ParsePredicateSuccessProj* parse_predicate_proj = loop_predicate_block->parse_predicate_success_proj();
       get_assertion_predicates(parse_predicate_proj, useful_predicates, true);
     }
   }

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -947,7 +947,7 @@ private:
   DEBUG_ONLY(static bool assertion_predicate_has_loop_opaque_node(IfNode* iff);)
  private:
   DEBUG_ONLY(static void count_opaque_loop_nodes(Node* n, uint& init, uint& stride);)
-  static void get_assertion_predicates(Node* predicate, Unique_Node_List& list, bool get_opaque = false);
+  static void get_assertion_predicates(ParsePredicateSuccessProj* parse_predicate_proj, Unique_Node_List& list, bool get_opaque = false);
   void update_main_loop_assertion_predicates(Node* ctrl, CountedLoopNode* loop_head, Node* init, int stride_con);
   void initialize_assertion_predicates_for_peeled_loop(CountedLoopNode* peeled_loop_head,
                                                        CountedLoopNode* remaining_loop_head,
@@ -1672,7 +1672,7 @@ private:
   IfProjNode* clone_parse_predicate_to_unswitched_loop(ParsePredicateSuccessProj* parse_predicate_proj, Node* new_entry,
                                                        Deoptimization::DeoptReason reason, bool slow_loop);
   void clone_assertion_predicates_to_unswitched_loop(IdealLoopTree* loop, const Node_List& old_new,
-                                                     Deoptimization::DeoptReason reason, IfProjNode* old_predicate_proj,
+                                                     Deoptimization::DeoptReason reason, ParsePredicateSuccessProj* old_parse_predicate_proj,
                                                      ParsePredicateSuccessProj* fast_loop_parse_predicate_proj,
                                                      ParsePredicateSuccessProj* slow_loop_parse_predicate_proj);
   IfProjNode* clone_assertion_predicate_for_unswitched_loops(IfNode* template_assertion_predicate, IfProjNode* predicate,

--- a/src/hotspot/share/opto/predicates.hpp
+++ b/src/hotspot/share/opto/predicates.hpp
@@ -1010,4 +1010,26 @@ class CreateAssertionPredicatesVisitor : public PredicateVisitor {
   }
 };
 
+// This visitor collects all Template Assertion Predicates If nodes or the corresponding Opaque nodes, depending on the
+// provided 'get_opaque' flag, to the provided list.
+class TemplateAssertionPredicateCollector : public PredicateVisitor {
+  Unique_Node_List& _list;
+  const bool _get_opaque;
+
+ public:
+  TemplateAssertionPredicateCollector(Unique_Node_List& list, const bool get_opaque)
+      : _list(list),
+        _get_opaque(get_opaque) {}
+
+  using PredicateVisitor::visit;
+
+  void visit(const TemplateAssertionPredicate& template_assertion_predicate) override {
+    if (_get_opaque) {
+      _list.push(template_assertion_predicate.opaque_node());
+    } else {
+      _list.push(template_assertion_predicate.tail());
+    }
+  }
+};
+
 #endif // SHARE_OPTO_PREDICATES_HPP


### PR DESCRIPTION
#### Replacing the Remaining Predicate Walking and Cloning Code
The goal is to replace and unify all the remaining custom predicate walking and cloning code currently used for:
-  <s>[JDK-8341977](https://bugs.openjdk.org/browse/JDK-8341977): Loop Peeling</s> (integrated with https://github.com/openjdk/jdk/pull/21679))
- [<s>JDK-8342943](https://bugs.openjdk.org/browse/JDK-8342943): Main and Post Loop</s> (integrated with https://github.com/openjdk/jdk/pull/21790)
- [JDK-8342945](https://bugs.openjdk.org/browse/JDK-8342945): `PhaseIdealLoop::get_assertion_predicates()` used for Loop Unswitching and removing useless Template Assertion Predicate (this PR)
- [JDK-8342946](https://bugs.openjdk.org/browse/JDK-8342946): Loop Unrolling (upcoming)

---
(Sections taken over from https://github.com/openjdk/jdk/pull/21679 / https://github.com/openjdk/jdk/pull/21790))

#### Single Template Assertion Predicate Check
This replacement allows us to have a single `TemplateAssertionPredicate::is_predicate()` check that is called for all predicate matching code. This enables the removal of uncommon traps for Template Assertion Predicates with [JDK-8342047](https://bugs.openjdk.org/browse/JDK-8342047) which is a missing piece in order to fix the remaining problems with Assertion Predicates ([JDK-8288981](https://bugs.openjdk.org/browse/JDK-8288981)).

#### Common Refactorings for all the Patches in this Series
In each of the patch, I will do similar refactoring ideas:
- Replace the existing code in the corresponding `PhaseIdealLoop` method with call to a new (or existing) predicate visitor which extends the `PredicateVisitor` interface. 
- The visitor implements the Assertion Predicate `visit()` methods to implement the cloning and initialization of the Template Assertion Predicates.
- The predicate visitor is then passed to the `PredicateIterator` which walks through all predicates found at a loop and applies the visitor for each predicate. 
- The visitor creates new nodes (if there are Template Assertion Predicates) either in place or at the loop entry of a target loop. In the latter case, the calling code of the `PredicateIterator` must make sure to connect the tail of the newly created predicate chain after the old loop entry to the target loop head.
- Keep the semantics which includes to only apply the Template Assertion Predicate processing if there are Parse Predicates. This limitation should eventually be removed. But I want to do that separately at a later point.
---

#### Refactorings of this Patch
- This patch replaces the predicate walking in `PhaseIdealLoop::get_assertion_predicates()` which is used for Loop Unswitching and removing useless Template Assertion Predicates (called from `PhaseIdealLoop::collect_useful_template_assertion_predicates_for_loop()`). 
- Note that the cloning code in Loop Unswitching is not replaced, yet, because we clone the Template Assertion Predicates in the original order as currently found in the graph which also allowed us to use `PhaseIdealLoop::create_new_if_for_predicate()`. 
This means that we first walk from the loop entry to the last Template Assertion Predicate and then start cloning them in the reverse order (which ensures that we keep the original order of the Template Assertion Predicates). I don't think that keeping the original order is a strong requirement.
Once we replace the UCTs with halt nodes, we do not require to call `create_new_if_for_predicate()` anymore and could theoretically just clone and initialize the Template Assertion Predicates in the opposite order as originally found in the graph which is easier to implement. This is currently also done for the other loop opts that require Assertion Predicates cloning/initialization. I think it's probably safe to do this for Loop Unswitching as well once we replace UCTs with halt nodes (@rwestrel what do you think?). 
If at some point, we need to keep the Assertion Predicate order, we can just add this functionality to the `PredicateIterator` classes. Anyhow, I'm leaving this code in`clone_assertion_predicates_to_unswitched_loop()` as it is for now and revisit it later again.

Thanks,
Christian