### PR TITLE
8343658: Parallel: Implement block_start for Young generation

### DIFF
--- a/src/hotspot/share/gc/parallel/mutableSpace.cpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.cpp
@@ -230,6 +230,24 @@ void MutableSpace::object_iterate(ObjectClosure* cl) {
   }
 }
 
+HeapWord* MutableSpace::block_start(const void* addr) const {
+  if (addr >= top()) {
+    return nullptr;
+  }
+
+  HeapWord* cur_addr = bottom();
+  while (cur_addr <= addr) {
+    oop obj = cast_to_oop(cur_addr);
+    assert(oopDesc::is_oop(obj), PTR_FORMAT " should be an object start", p2i(cur_addr));
+    size_t obj_size = obj->size();
+    if (cur_addr + obj_size > addr) {
+      return cur_addr;
+    }
+    cur_addr += obj_size;
+  }
+  ShouldNotReachHere();
+}
+
 void MutableSpace::print_short() const { print_short_on(tty); }
 void MutableSpace::print_short_on( outputStream* st) const {
   st->print(" space " SIZE_FORMAT "K, %d%% used", capacity_in_bytes() / K,

--- a/src/hotspot/share/gc/parallel/mutableSpace.hpp
+++ b/src/hotspot/share/gc/parallel/mutableSpace.hpp
@@ -136,6 +136,8 @@ class MutableSpace: public CHeapObj<mtGC> {
   void oop_iterate(OopIterateClosure* cl);
   void object_iterate(ObjectClosure* cl);
 
+  HeapWord* block_start(const void* addr) const;
+
   // Debugging
   virtual void print() const;
   virtual void print_on(outputStream* st) const;

--- a/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
+++ b/src/hotspot/share/gc/parallel/parallelScavengeHeap.cpp
@@ -669,11 +669,14 @@ HeapWord* ParallelScavengeHeap::block_start(const void* addr) const {
   if (young_gen()->is_in_reserved(addr)) {
     assert(young_gen()->is_in(addr),
            "addr should be in allocated part of young gen");
-    // called from os::print_location by find or VMError
-    if (DebuggingContext::is_enabled() || VMError::is_error_reported()) {
-      return nullptr;
+    if (young_gen()->eden_space()->contains(addr)) {
+      return young_gen()->eden_space()->block_start(addr);
     }
-    Unimplemented();
+    if (young_gen()->from_space()->contains(addr)) {
+      return young_gen()->from_space()->block_start(addr);
+    }
+    assert(young_gen()->to_space()->contains(addr), "inv");
+    return young_gen()->to_space()->block_start(addr);
   } else if (old_gen()->is_in_reserved(addr)) {
     assert(old_gen()->is_in(addr),
            "addr should be in allocated part of old gen");


### PR DESCRIPTION
Simple block_start implementation for Parallel young-gen. Related to https://github.com/openjdk/jdk/pull/21870

Test: tier1-3

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343658](https://bugs.openjdk.org/browse/JDK-8343658): Parallel: Implement block_start for Young generation (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21919/head:pull/21919` \
`$ git checkout pull/21919`

Update a local copy of the PR: \
`$ git checkout pull/21919` \
`$ git pull https://git.openjdk.org/jdk.git pull/21919/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21919`

View PR using the GUI difftool: \
`$ git pr show -t 21919`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21919.diff">https://git.openjdk.org/jdk/pull/21919.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21919#issuecomment-2458954553)
</details>
