### PR TITLE
8326369: Bimorphic inlining not applied at a call site that was initially monomorphic

### DIFF
--- a/test/hotspot/jtreg/compiler/inlining/InlineBimorphicVirtualCallAfterMorphismChanged.java
+++ b/test/hotspot/jtreg/compiler/inlining/InlineBimorphicVirtualCallAfterMorphismChanged.java
@@ -44,22 +44,26 @@ public class InlineBimorphicVirtualCallAfterMorphismChanged {
             return new FirstClass(); 
         }
 
-	    private static AbstractBase secondInstance() { 
+        private static AbstractBase secondInstance() {
             return new SecondClass(); 
         }
     }
 
     public final static class FirstClass extends AbstractBase {
-	    public int inlinee() { return 1; }
+        public int inlinee() {
+            return 1;
+        }
     }
 
     public final static class SecondClass extends AbstractBase {
-	    public int inlinee() { return 2; };
+        public int inlinee() {
+            return 2;
+        };
     }
 
     public static void main(String[] args) throws Exception {
         test("-XX:-TieredCompilation");
-	    test("-XX:+TieredCompilation");
+        test("-XX:+TieredCompilation");
     }
 
     private static void test(String option) throws Exception {

--- a/test/hotspot/jtreg/compiler/inlining/InlineBimorphicVirtualCallAfterMorphismChanged.java
+++ b/test/hotspot/jtreg/compiler/inlining/InlineBimorphicVirtualCallAfterMorphismChanged.java
@@ -1,0 +1,86 @@
+/**
+ * @test
+ * bug 
+ * @summary C2 doesn't perform bimorphic inlining on a call site that was monomorphic during tier 3 compilation.
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib
+ * @requires vm.flagless
+ *
+ * @run driver compiler.inlining.InlineBimorphicVirtualCallAfterMorphismChanged
+ */
+package compiler.inlining;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+public class InlineBimorphicVirtualCallAfterMorphismChanged {
+    public static abstract class AbstractBase {
+        public final int callSiteHolder() {
+            return inlinee();
+        }
+
+        public abstract int inlinee();
+
+        public static void main(String[] args) {
+            AbstractBase[] classes = new AbstractBase[] { firstInstance() };
+            // first step: trigger a compilation while call site is monomorphic
+            for (int i = 0; i < 10000; i++) {
+                for (AbstractBase instance : classes) {
+                    instance.callSiteHolder();
+                }
+            }
+        
+            // second step: trigger recompilation by loading a second instance,
+            // also make the call site bimorphic
+            classes = new AbstractBase[] { firstInstance(), secondInstance() };
+            for (int i = 0; i < 10000; i++) {
+                for (AbstractBase instance : classes) {
+                    instance.callSiteHolder();
+                }
+            }
+        }
+
+        private static AbstractBase firstInstance() { 
+            return new FirstClass(); 
+        }
+
+	    private static AbstractBase secondInstance() { 
+            return new SecondClass(); 
+        }
+    }
+
+    public final static class FirstClass extends AbstractBase {
+	    public int inlinee() { return 1; }
+    }
+
+    public final static class SecondClass extends AbstractBase {
+	    public int inlinee() { return 2; };
+    }
+
+    public static void main(String[] args) throws Exception {
+        test("-XX:-TieredCompilation");
+	    test("-XX:+TieredCompilation");
+    }
+
+    private static void test(String option) throws Exception {
+        ProcessBuilder pb = ProcessTools.createLimitedTestJavaProcessBuilder(
+            "-server", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
+            "-XX:CompileCommand=compileonly,*::callSiteHolder", option,
+            AbstractBase.class.getName()
+        );
+        
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+        analyzer.shouldHaveExitValue(0);
+
+        String re = ".*AbstractBase::inlinee.+virtual call.*";
+        boolean virtualInliningFailed = analyzer.asLines().stream()
+                .anyMatch(s -> s.matches(re));
+
+        if (virtualInliningFailed) {
+            analyzer.outputTo(System.out);
+            throw new Exception(
+                "Bimorphic virtual call was not inlined with '" + option + "'"
+            );
+        }
+    }
+}


### PR DESCRIPTION
This issue was fixed by JDK-8339299 indirectly (see [PR](https://github.com/openjdk/jdk/pull/20786)), but the PR for 8339299 didn't include any new tests, so I'm sending this PR with the test that Filipp added in 8326369 so that such issue doesn't come back inadvertently. I've added him as co-author and applied some small formatting changes.