### PR TITLE
8321997: Increase upper limit of LoopOptsCount flag

### DIFF
--- a/src/hotspot/share/opto/c2_globals.hpp
+++ b/src/hotspot/share/opto/c2_globals.hpp
@@ -422,7 +422,7 @@
                                                                             \
   product(intx, LoopOptsCount, 43,                                          \
           "Set level of loop optimization for tier 1 compiles")             \
-          range(5, 43)                                                      \
+          range(5, max_jint)                                                \
                                                                             \
   product(bool, OptimizeUnstableIf, true, DIAGNOSTIC,                       \
           "Optimize UnstableIf traps")                                      \


### PR DESCRIPTION
Currently `LoopOptsCount` has a range of 5-43 with default value 43. For stress testing we want to set values higher than 43. Set to upper limit to 1000 or even max_jint.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8331727](https://bugs.openjdk.org/browse/JDK-8331727) to be approved

### Issues
 * [JDK-8321997](https://bugs.openjdk.org/browse/JDK-8321997): Increase upper limit of LoopOptsCount flag (**Enhancement** - P4)
 * [JDK-8331727](https://bugs.openjdk.org/browse/JDK-8331727): Increase upper limit of LoopOptsCount flag (**CSR**)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21921/head:pull/21921` \
`$ git checkout pull/21921`

Update a local copy of the PR: \
`$ git checkout pull/21921` \
`$ git pull https://git.openjdk.org/jdk.git pull/21921/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21921`

View PR using the GUI difftool: \
`$ git pr show -t 21921`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21921.diff">https://git.openjdk.org/jdk/pull/21921.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21921#issuecomment-2459090378)
</details>
