### PR TITLE
8342541: Exclude List/KeyEventsTest/KeyEventsTest.java from running on macOS

### DIFF
--- a/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
+++ b/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
@@ -21,17 +21,6 @@
  * questions.
  */
 
-/*
-  @test
-  @key headful
-  @bug 6190768 6190778
-  @summary Tests that triggering events on AWT list by pressing CTRL + HOME,
-           CTRL + END, PG-UP, PG-DOWN similar Motif behavior
-  @library /test/lib
-  @build jdk.test.lib.Platform
-  @run main KeyEventsTest
-*/
-
 import java.awt.BorderLayout;
 import java.awt.EventQueue;
 import java.awt.KeyboardFocusManager;
@@ -49,6 +38,18 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 
 import jdk.test.lib.Platform;
+
+/*
+*  @test
+*  @key headful
+*  @bug 6190768 6190778
+*  @requires os.family != "mac"
+*  @summary Tests that triggering events on AWT list by pressing CTRL + HOME,
+*           CTRL + END, PG-UP, PG-DOWN similar Motif behavior
+*  @library /test/lib
+*  @build jdk.test.lib.Platform
+*  @run main KeyEventsTest
+*/
 
 public class KeyEventsTest {
     TestState currentState;
@@ -264,9 +265,6 @@ public class KeyEventsTest {
         boolean isWin = false;
         if (Platform.isWindows()) {
             isWin = true;
-        } else if (Platform.isOSX()) {
-            System.out.println("Not for OS X");
-            return;
         }
 
         System.out.println("multiple? selectedMoved? ?scrollMoved keyID? template? action?");

--- a/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
+++ b/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
@@ -50,7 +50,6 @@ import jdk.test.lib.Platform;
  * @build jdk.test.lib.Platform
  * @run main KeyEventsTest
  */
-
 public class KeyEventsTest {
     TestState currentState;
     final Object LOCK = new Object();

--- a/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
+++ b/test/jdk/java/awt/List/KeyEventsTest/KeyEventsTest.java
@@ -40,16 +40,16 @@ import java.awt.event.KeyListener;
 import jdk.test.lib.Platform;
 
 /*
-*  @test
-*  @key headful
-*  @bug 6190768 6190778
-*  @requires os.family != "mac"
-*  @summary Tests that triggering events on AWT list by pressing CTRL + HOME,
-*           CTRL + END, PG-UP, PG-DOWN similar Motif behavior
-*  @library /test/lib
-*  @build jdk.test.lib.Platform
-*  @run main KeyEventsTest
-*/
+ * @test
+ * @key headful
+ * @bug 6190768 6190778
+ * @requires os.family != "mac"
+ * @summary Tests that triggering events on AWT list by pressing CTRL + HOME,
+ *          CTRL + END, PG-UP, PG-DOWN similar Motif behavior
+ * @library /test/lib
+ * @build jdk.test.lib.Platform
+ * @run main KeyEventsTest
+ */
 
 public class KeyEventsTest {
     TestState currentState;
@@ -262,10 +262,7 @@ public class KeyEventsTest {
 
     private void doTest() throws Exception {
 
-        boolean isWin = false;
-        if (Platform.isWindows()) {
-            isWin = true;
-        }
+        boolean isWin = Platform.isWindows();
 
         System.out.println("multiple? selectedMoved? ?scrollMoved keyID? template? action?");
         test(new TestState(false, false, false, KeyEvent.VK_PAGE_UP, isWin?false:false));


### PR DESCRIPTION
Hi Reviewers,

I have added the test tag  **@requires os.family != "mac"** and updated section with new format. 
Removed OSX check condition form the code.

Please review and let me know your suggestions if any.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342541](https://bugs.openjdk.org/browse/JDK-8342541): Exclude List/KeyEventsTest/KeyEventsTest.java from running on macOS (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21924/head:pull/21924` \
`$ git checkout pull/21924`

Update a local copy of the PR: \
`$ git checkout pull/21924` \
`$ git pull https://git.openjdk.org/jdk.git pull/21924/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21924`

View PR using the GUI difftool: \
`$ git pr show -t 21924`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21924.diff">https://git.openjdk.org/jdk/pull/21924.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21924#issuecomment-2459512955)
</details>
