### PR TITLE
8334107: Specification for MemorySegment::get/setString could use some clarification

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1307,7 +1307,8 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      * @param offset  offset in bytes (relative to this segment address) at which this
      *                access operation will occur
      * @param charset the charset used to {@linkplain Charset#newDecoder() decode} the
-     *                string bytes
+     *                string bytes. The {@code charset} must be a
+     *                {@linkplain StandardCharsets standard charset}
      * @return a Java string constructed from the bytes read from the given starting
      *         address up to (but not including) the first {@code '\0'} terminator
      *         character (assuming one is found)
@@ -1375,7 +1376,9 @@ public sealed interface MemorySegment permits AbstractMemorySegmentImpl {
      *                access operation will occur, the final address of this write
      *                operation can be expressed as {@code address() + offset}
      * @param str     the Java string to be written into this segment
-     * @param charset the charset used to {@linkplain Charset#newEncoder() encode} the string bytes
+     * @param charset the charset used to {@linkplain Charset#newEncoder() encode} the
+     *                string bytes. The {@code charset} must be a
+     *                {@linkplain StandardCharsets standard charset}
      * @throws IndexOutOfBoundsException if {@code offset < 0}
      * @throws IndexOutOfBoundsException if {@code offset > byteSize() - (B + N)}, where:
      *         <ul>


### PR DESCRIPTION
This PR proposes to add additional text for the `@param charset` tags in the `MemorySegment.(get|set)String` overloads that take a `charset`. 

This PR does not need a CSR, as the specs already state that an exception will be thrown if the provided `charset` is not a standard charset.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8334107](https://bugs.openjdk.org/browse/JDK-8334107): Specification for MemorySegment::get/setString could use some clarification (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21927/head:pull/21927` \
`$ git checkout pull/21927`

Update a local copy of the PR: \
`$ git checkout pull/21927` \
`$ git pull https://git.openjdk.org/jdk.git pull/21927/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21927`

View PR using the GUI difftool: \
`$ git pr show -t 21927`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21927.diff">https://git.openjdk.org/jdk/pull/21927.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21927#issuecomment-2459973121)
</details>
