### PR TITLE
8343244: Aarch64: Internal Error virtualMemoryTracker.cpp:444 assert(reserved_rgn != nullptr) failed: Add committed region, No reserved region found

### DIFF
--- a/src/hotspot/os/posix/perfMemory_posix.cpp
+++ b/src/hotspot/os/posix/perfMemory_posix.cpp
@@ -1086,7 +1086,7 @@ static char* mmap_create_shared(size_t size) {
 static void unmap_shared(char* addr, size_t bytes) {
   int res;
   if (MemTracker::enabled()) {
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     res = ::munmap(addr, bytes);
     if (res == 0) {
       MemTracker::record_virtual_memory_release((address)addr, bytes);

--- a/src/hotspot/os/windows/perfMemory_windows.cpp
+++ b/src/hotspot/os/windows/perfMemory_windows.cpp
@@ -1803,7 +1803,7 @@ void PerfMemory::detach(char* addr, size_t bytes) {
 
   if (MemTracker::enabled()) {
     // it does not go through os api, the operation has to record from here
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     remove_file_mapping(addr);
     MemTracker::record_virtual_memory_release((address)addr, bytes);
   } else {

--- a/src/hotspot/share/nmt/memBaseline.cpp
+++ b/src/hotspot/share/nmt/memBaseline.cpp
@@ -141,7 +141,7 @@ void MemBaseline::baseline_summary() {
   MallocMemorySummary::snapshot(&_malloc_memory_snapshot);
   VirtualMemorySummary::snapshot(&_virtual_memory_snapshot);
   {
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     MemoryFileTracker::Instance::summary_snapshot(&_virtual_memory_snapshot);
   }
 

--- a/src/hotspot/share/nmt/memReporter.cpp
+++ b/src/hotspot/share/nmt/memReporter.cpp
@@ -465,7 +465,7 @@ void MemDetailReporter::report_virtual_memory_region(const ReservedMemoryRegion*
 void MemDetailReporter::report_memory_file_allocations() {
   stringStream st;
   {
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     MemoryFileTracker::Instance::print_all_reports_on(&st, scale());
   }
   output()->print_raw(st.freeze());

--- a/src/hotspot/share/nmt/memTracker.hpp
+++ b/src/hotspot/share/nmt/memTracker.hpp
@@ -218,7 +218,7 @@ class MemTracker : AllStatic {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {
-      NmtVirtualMemoryLocker ml;
+      VirtualMemoryTracker::Locker l;
       VirtualMemoryTracker::set_reserved_region_type((address)addr, mem_tag);
     }
   }

--- a/src/hotspot/share/nmt/memTracker.hpp
+++ b/src/hotspot/share/nmt/memTracker.hpp
@@ -124,7 +124,7 @@ class MemTracker : AllStatic {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {
-      NmtVirtualMemoryLocker ml;
+      VirtualMemoryTracker::Locker l;
       VirtualMemoryTracker::add_reserved_region((address)addr, size, stack, mem_tag);
     }
   }
@@ -150,7 +150,7 @@ class MemTracker : AllStatic {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {
-      NmtVirtualMemoryLocker ml;
+      VirtualMemoryTracker::Locker l;
       VirtualMemoryTracker::add_reserved_region((address)addr, size, stack, mem_tag);
       VirtualMemoryTracker::add_committed_region((address)addr, size, stack);
     }
@@ -161,7 +161,7 @@ class MemTracker : AllStatic {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {
-      NmtVirtualMemoryLocker ml;
+      VirtualMemoryTracker::Locker l;
       VirtualMemoryTracker::add_committed_region((address)addr, size, stack);
     }
   }
@@ -169,7 +169,7 @@ class MemTracker : AllStatic {
   static inline MemoryFileTracker::MemoryFile* register_file(const char* descriptive_name) {
     assert_post_init();
     if (!enabled()) return nullptr;
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     return MemoryFileTracker::Instance::make_file(descriptive_name);
   }
 
@@ -177,7 +177,7 @@ class MemTracker : AllStatic {
     assert_post_init();
     if (!enabled()) return;
     assert(file != nullptr, "must be");
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     MemoryFileTracker::Instance::free_file(file);
   }
 
@@ -186,7 +186,7 @@ class MemTracker : AllStatic {
     assert_post_init();
     if (!enabled()) return;
     assert(file != nullptr, "must be");
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     MemoryFileTracker::Instance::allocate_memory(file, offset, size, stack, mem_tag);
   }
 
@@ -195,7 +195,7 @@ class MemTracker : AllStatic {
     assert_post_init();
     if (!enabled()) return;
     assert(file != nullptr, "must be");
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     MemoryFileTracker::Instance::free_memory(file, offset, size);
   }
 
@@ -209,7 +209,7 @@ class MemTracker : AllStatic {
     assert_post_init();
     if (!enabled()) return;
     if (addr != nullptr) {
-      NmtVirtualMemoryLocker ml;
+      VirtualMemoryTracker::Locker l;
       VirtualMemoryTracker::split_reserved_region((address)addr, size, split, mem_tag, split_tag);
     }
   }

--- a/src/hotspot/share/nmt/nmtCommon.hpp
+++ b/src/hotspot/share/nmt/nmtCommon.hpp
@@ -139,13 +139,4 @@ class NMTUtil : AllStatic {
   static S _strings[mt_number_of_tags];
 };
 
-// Same as MutexLocker but can be used during VM init.
-// Performs no action if given a null mutex or with detached threads.
-class NmtVirtualMemoryLocker: public ConditionalMutexLocker {
-public:
-    NmtVirtualMemoryLocker() :
-            ConditionalMutexLocker(NmtVirtualMemory_lock, Thread::current_or_null_safe() != nullptr, Mutex::_no_safepoint_check_flag) {
-    }
-};
-
 #endif // SHARE_NMT_NMTCOMMON_HPP

--- a/src/hotspot/share/nmt/threadStackTracker.cpp
+++ b/src/hotspot/share/nmt/threadStackTracker.cpp
@@ -52,7 +52,7 @@ void ThreadStackTracker::new_thread_stack(void* base, size_t size, const NativeC
   assert(base != nullptr, "Should have been filtered");
   align_thread_stack_boundaries_inward(base, size);
 
-  NmtVirtualMemoryLocker ml;
+  VirtualMemoryTracker::Locker l;
   VirtualMemoryTracker::add_reserved_region((address)base, size, stack, mtThreadStack);
   _thread_count++;
 }
@@ -62,7 +62,7 @@ void ThreadStackTracker::delete_thread_stack(void* base, size_t size) {
   assert(base != nullptr, "Should have been filtered");
   align_thread_stack_boundaries_inward(base, size);
 
-  NmtVirtualMemoryLocker ml;
+  VirtualMemoryTracker::Locker l;
   VirtualMemoryTracker::remove_released_region((address)base, size);
   _thread_count--;
 }

--- a/src/hotspot/share/nmt/virtualMemoryTracker.cpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.cpp
@@ -34,6 +34,9 @@
 
 VirtualMemorySnapshot VirtualMemorySummary::_snapshot;
 
+PlatformMutex* VirtualMemoryTracker::Locker::_lock = nullptr;
+Thread* VirtualMemoryTracker::Locker::_owner = nullptr;
+
 void VirtualMemory::update_peak(size_t size) {
   size_t peak_sz = peak_size();
   while (peak_sz < size) {

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -403,7 +403,7 @@ class VirtualMemoryTracker : AllStatic {
       return _lock != nullptr;
     }
 
-    static bool force_unlock() {
+    static void force_unlock() {
       assert(Thread::current_or_null_safe() == _owner, "must own the lock to force unlock");
       _lock->unlock();
     }

--- a/src/hotspot/share/nmt/virtualMemoryTracker.hpp
+++ b/src/hotspot/share/nmt/virtualMemoryTracker.hpp
@@ -386,7 +386,6 @@ class VirtualMemoryTracker : AllStatic {
 
     Locker(Thread* owner = Thread::current_or_null_safe()) {
       assert(_lock != nullptr, "must");
-      assert(_owner == nullptr, "lock is not recursive");
       _lock->lock();
       _owner = owner;
     }

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -135,7 +135,6 @@ Mutex*   SharedDecoder_lock           = nullptr;
 Mutex*   DCmdFactory_lock             = nullptr;
 Mutex*   NMTQuery_lock                = nullptr;
 Mutex*   NMTCompilationCostHistory_lock = nullptr;
-Mutex*   NmtVirtualMemory_lock          = nullptr;
 
 #if INCLUDE_CDS
 #if INCLUDE_JVMTI
@@ -294,11 +293,10 @@ void mutex_init() {
   MUTEX_DEFN(CodeHeapStateAnalytics_lock     , PaddedMutex  , safepoint);
   MUTEX_DEFN(ThreadsSMRDelete_lock           , PaddedMonitor, service-2); // Holds ConcurrentHashTableResize_lock
   MUTEX_DEFN(ThreadIdTableCreate_lock        , PaddedMutex  , safepoint);
-  MUTEX_DEFN(SharedDecoder_lock              , PaddedMutex  , service-5); // Must be lower than NmtVirtualMemory_lock due to MemTracker::print_containing_region
+  MUTEX_DEFN(SharedDecoder_lock              , PaddedMutex  , service-5);
   MUTEX_DEFN(DCmdFactory_lock                , PaddedMutex  , nosafepoint);
   MUTEX_DEFN(NMTQuery_lock                   , PaddedMutex  , safepoint);
   MUTEX_DEFN(NMTCompilationCostHistory_lock  , PaddedMutex  , nosafepoint);
-  MUTEX_DEFN(NmtVirtualMemory_lock           , PaddedMutex  , service-4);
 #if INCLUDE_CDS
 #if INCLUDE_JVMTI
   MUTEX_DEFN(CDSClassFileStream_lock         , PaddedMutex  , safepoint);

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -117,7 +117,7 @@ extern Mutex*   SharedDecoder_lock;              // serializes access to the dec
 extern Mutex*   DCmdFactory_lock;                // serialize access to DCmdFactory information
 extern Mutex*   NMTQuery_lock;                   // serialize NMT Dcmd queries
 extern Mutex*   NMTCompilationCostHistory_lock;  // guards NMT compilation cost history
-extern Mutex*   NmtVirtualMemory_lock;           // guards NMT virtual memory updates
+
 #if INCLUDE_CDS
 #if INCLUDE_JVMTI
 extern Mutex*   CDSClassFileStream_lock;         // FileMapInfo::open_stream_for_jvmti

--- a/src/hotspot/share/runtime/os.cpp
+++ b/src/hotspot/share/runtime/os.cpp
@@ -2166,7 +2166,7 @@ bool os::uncommit_memory(char* addr, size_t bytes, bool executable) {
   assert_nonempty_range(addr, bytes);
   bool res;
   if (MemTracker::enabled()) {
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     res = pd_uncommit_memory(addr, bytes, executable);
     if (res) {
       MemTracker::record_virtual_memory_uncommit((address)addr, bytes);
@@ -2188,7 +2188,7 @@ bool os::release_memory(char* addr, size_t bytes) {
   assert_nonempty_range(addr, bytes);
   bool res;
   if (MemTracker::enabled()) {
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     res = pd_release_memory(addr, bytes);
     if (res) {
       MemTracker::record_virtual_memory_release((address)addr, bytes);
@@ -2273,7 +2273,7 @@ char* os::map_memory(int fd, const char* file_name, size_t file_offset,
 bool os::unmap_memory(char *addr, size_t bytes) {
   bool result;
   if (MemTracker::enabled()) {
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     result = pd_unmap_memory(addr, bytes);
     if (result) {
       MemTracker::record_virtual_memory_release((address)addr, bytes);
@@ -2312,7 +2312,7 @@ char* os::reserve_memory_special(size_t size, size_t alignment, size_t page_size
 bool os::release_memory_special(char* addr, size_t bytes) {
   bool res;
   if (MemTracker::enabled()) {
-    NmtVirtualMemoryLocker ml;
+    VirtualMemoryTracker::Locker l;
     res = pd_release_memory_special(addr, bytes);
     if (res) {
       MemTracker::record_virtual_memory_release((address)addr, bytes);

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -717,9 +717,10 @@ void VMError::report(outputStream* st, bool _verbose) {
   address lastpc = nullptr;
 
   BEGIN
-  if (MemTracker::enabled() && NmtVirtualMemory_lock != nullptr && NmtVirtualMemory_lock->owned_by_self()) {
+  if (MemTracker::enabled() && VirtualMemoryTracker::Locker::is_initialized() &&
+      VirtualMemoryTracker::Locker::owned_by(Thread::current_or_null_safe())) {
     // Manually unlock to avoid reentrancy due to mallocs in detailed mode.
-    NmtVirtualMemory_lock->unlock();
+    VirtualMemoryTracker::Locker::force_unlock();
   }
 
   STEP("printing fatal error message")


### PR DESCRIPTION
Hi,

Ping @roberttoyonaga , @tstuefe , @afshin-zafari , @dholmes-ora , @gerard-ziemski

We are seeing issues with the transition to one of our 'fat' mutexes. Specifically, we do have `os::commit_memory` that occurs during the running `Thread`'s initialization, see the following stack trace:

```
Stack: [0x0000ffff686ae000,0x0000ffff687ae000], sp=0x0000ffff687ac5f0, free space=1017k
Native frames: (J=compiled Java code, j=interpreted, Vv=VM code, C=native code)
V [libjvm.so+0x16aa67c] VirtualMemoryTracker::add_committed_region(unsigned char*, unsigned long, NativeCallStack const&)+0x38c (virtualMemoryTracker.cpp:444)
V [libjvm.so+0x131134c] os::commit_memory(char*, unsigned long, bool)+0x198 (memTracker.hpp:165)
V [libjvm.so+0x14ddf54] StackOverflow::create_stack_guard_pages()+0x70 (stackOverflow.cpp:97)
V [libjvm.so+0xe2e0dc] attach_current_thread.isra.0+0x11c (jni.cpp:3809)
C [libExplicitAttach.so+0xa64] thread_main+0x34 (libExplicitAttach.c:45)
C [libc.so.6+0x806b8] start_thread+0x2d8
```

This, in turn, causes issues where the lock isn't actually taken, causing issues with the VMT. I'd like to suggest that we switch out the `Mutex` to a `PlatformMutex`. Platform mutexes are identical in construction to `ThreadCritical`, but are at least not shared globally and can be owned by the `VirtualMemoryTracker`.

If you do not agree with this change, then I suggest that we back out [8304824](https://bugs.openjdk.org/browse/JDK-8304824) ASAP and wait for a better solution.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343244](https://bugs.openjdk.org/browse/JDK-8343244): Aarch64: Internal Error virtualMemoryTracker.cpp:444 assert(reserved_rgn != nullptr) failed: Add committed region, No reserved region found (**Bug** - P2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21928/head:pull/21928` \
`$ git checkout pull/21928`

Update a local copy of the PR: \
`$ git checkout pull/21928` \
`$ git pull https://git.openjdk.org/jdk.git pull/21928/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21928`

View PR using the GUI difftool: \
`$ git pr show -t 21928`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21928.diff">https://git.openjdk.org/jdk/pull/21928.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21928#issuecomment-2459981981)
</details>
