### PR TITLE
8343559: Optimize Class.getMethod(String, Class<?>...) for methods with no-arg

### DIFF
--- a/src/java.base/share/classes/java/lang/PublicMethods.java
+++ b/src/java.base/share/classes/java/lang/PublicMethods.java
@@ -105,17 +105,12 @@ final class PublicMethods {
                                String name, // may not be interned
                                Class<?>[] ptypes) {
             // check for matching param types length, then name, then param type equality
-            if (method.getParameterCount() == ptypes.length
-                    && method.getName().equals(name)) {
-                Class<?>[] classes = reflectionFactory.getExecutableSharedParameterTypes(method);
-                for (int i = 0; i < ptypes.length; i++) {
-                    if (ptypes[i] != classes[i]) {
-                        return false;
-                    }
-                }
-                return true;
-            }
-            return false;
+            return method.getParameterCount() == ptypes.length &&
+                   method.getName().equals(name) &&
+                   Arrays.equals(
+                       reflectionFactory.getExecutableSharedParameterTypes(method),
+                       ptypes
+                   );
         }
 
         @Override

--- a/src/java.base/share/classes/java/lang/PublicMethods.java
+++ b/src/java.base/share/classes/java/lang/PublicMethods.java
@@ -153,10 +153,6 @@ final class PublicMethods {
                     Key.matches(method, name, ptypes)) {
                     if (tail == null) {
                         head = tail = new MethodList(method);
-                        if (ptypes.length == 0) {
-                            // zero args can only have one match - stop looking
-                            break;
-                        }
                     } else {
                         tail = tail.next = new MethodList(method);
                     }

--- a/src/java.base/share/classes/java/lang/PublicMethods.java
+++ b/src/java.base/share/classes/java/lang/PublicMethods.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,11 +104,11 @@ final class PublicMethods {
         static boolean matches(Method method,
                                String name, // may not be interned
                                Class<?>[] ptypes) {
-            return method.getName().equals(name) &&
-                   Arrays.equals(
-                       reflectionFactory.getExecutableSharedParameterTypes(method),
-                       ptypes
-                   );
+            // check for matching param types length, then name, then param type equality
+            return method.getParameterCount() == ptypes.length &&
+                   method.getName().equals(name) &&
+                   Arrays.equals(reflectionFactory.getExecutableSharedParameterTypes(method),
+                           ptypes);
         }
 
         @Override
@@ -153,6 +153,10 @@ final class PublicMethods {
                     Key.matches(method, name, ptypes)) {
                     if (tail == null) {
                         head = tail = new MethodList(method);
+                        if (ptypes.length == 0) {
+                            // zero args can only have one match - stop looking
+                            break;
+                        }
                     } else {
                         tail = tail.next = new MethodList(method);
                     }

--- a/src/java.base/share/classes/java/lang/PublicMethods.java
+++ b/src/java.base/share/classes/java/lang/PublicMethods.java
@@ -105,10 +105,17 @@ final class PublicMethods {
                                String name, // may not be interned
                                Class<?>[] ptypes) {
             // check for matching param types length, then name, then param type equality
-            return method.getParameterCount() == ptypes.length &&
-                   method.getName().equals(name) &&
-                   Arrays.equals(reflectionFactory.getExecutableSharedParameterTypes(method),
-                           ptypes);
+            if (method.getParameterCount() == ptypes.length
+                    && method.getName().equals(name)) {
+                Class<?>[] classes = reflectionFactory.getExecutableSharedParameterTypes(method);
+                for (int i = 0; i < ptypes.length; i++) {
+                    if (ptypes[i] != classes[i]) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+            return false;
         }
 
         @Override

--- a/test/jdk/java/lang/Class/getMethod/ParameterCounts.java
+++ b/test/jdk/java/lang/Class/getMethod/ParameterCounts.java
@@ -1,0 +1,202 @@
+
+import java.lang.reflect.Method;
+
+import org.junit.Assert;
+import org.junit.jupiter.api.Test;
+
+public class ParameterCounts {
+    public static class ConcreteClass extends SuperClass implements TestIntf {
+        @Override
+        public void a_noiseMethod(byte[] bytes) {
+        }
+
+        public void a_noiseMethod(String s) {
+        }
+
+        @Override
+        public void b_noiseMethod(byte[] bytes) {
+        }
+
+        public void b_noiseMethod(String s) {
+        }
+
+        public void c_noiseMethod(String s) {
+        }
+
+        public void d_noiseMethod(String s) {
+        }
+
+        public void fiveArgs(Object one, Object two, Object three, Object four, Object five) {
+        }
+
+        public void noArgs() {
+        }
+
+        public void x_noiseMethod(String s) {
+        }
+
+        public void y_noiseMethod(String s) {
+        }
+
+        public void z_noiseMethod(String s) {
+        }
+
+    }
+
+    public static class SuperClass {
+        public void a_superNoiseMethod(String s) {
+        }
+
+        public void b_superNoiseMethod(String s) {
+        }
+
+        public void c_superNoiseMethod(String s) {
+        }
+
+        public void d_superNoiseMethod(String s) {
+        }
+
+        public void superFiveArgs(Object one, Object two, Object three, Object four, Object five) {
+        }
+
+        public void superNoArgs() {
+        }
+
+        public void x_superNoiseMethod(String s) {
+        }
+
+        public void y_superNoiseMethod(String s) {
+        }
+
+        public void z_superNoiseMethod(String s) {
+        }
+
+    }
+
+    public interface TestIntf {
+        public void a_noiseMethod(byte[] bytes);
+
+        public void b_noiseMethod(byte[] bytes);
+
+        default void defaultIntfFiveArgs(Object a, Object b, Object c, Object d, Object e) {
+        }
+
+        default void defaultIntfNoArgs() {
+        }
+
+        default void y_noiseMethod(byte[] bytes) {
+        }
+
+        default void z_noiseMethod(byte[] bytes) {
+        }
+    }
+
+    private static final Class<?>[] FIVE_ARG_CLASSES = new Class<?>[] { Object.class, Object.class, Object.class,
+            Object.class, Object.class };
+
+    /**
+     * Verifies correct lookup of a declared method with 5 params.
+     *
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     */
+    @Test
+    public void getConcreteFiveArg() throws NoSuchMethodException, SecurityException {
+        Method method = ConcreteClass.class.getMethod("fiveArgs", FIVE_ARG_CLASSES);
+        Assert.assertNotNull(method);
+        Assert.assertEquals("fiveArgs", method.getName());
+        Assert.assertEquals(5, method.getParameterCount());
+        Assert.assertEquals(ConcreteClass.class, method.getDeclaringClass());
+    }
+
+    /**
+     * Verifies correct lookup of a declared method with 0 params.
+     *
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     */
+    @Test
+    public void getConcreteNoArg() throws NoSuchMethodException, SecurityException {
+        Method method = ConcreteClass.class.getMethod("noArgs");
+        Assert.assertNotNull(method);
+        Assert.assertEquals("noArgs", method.getName());
+        Assert.assertEquals(0, method.getParameterCount());
+        Assert.assertEquals(ConcreteClass.class, method.getDeclaringClass());
+    }
+
+    /**
+     * Verifies correct lookup of an interface method with 5 params.
+     *
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     */
+    @Test
+    public void getIntfFiveArg() throws NoSuchMethodException, SecurityException {
+        Method method = ConcreteClass.class.getMethod("defaultIntfFiveArgs", FIVE_ARG_CLASSES);
+        Assert.assertNotNull(method);
+        Assert.assertEquals("defaultIntfFiveArgs", method.getName());
+        Assert.assertEquals(5, method.getParameterCount());
+        Assert.assertEquals(TestIntf.class, method.getDeclaringClass());
+    }
+
+    /**
+     * Verifies correct lookup of an interface method with 0 params.
+     *
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     */
+    @Test
+    public void getIntfNoArg() throws NoSuchMethodException, SecurityException {
+        Method method = ConcreteClass.class.getMethod("defaultIntfNoArgs");
+        Assert.assertNotNull(method);
+        Assert.assertEquals("defaultIntfNoArgs", method.getName());
+        Assert.assertEquals(0, method.getParameterCount());
+        Assert.assertEquals(TestIntf.class, method.getDeclaringClass());
+    }
+
+    /**
+     * Verifies correct lookup of a nonexistent method.
+     *
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     */
+    @Test
+    public void getNoSuchMethod() throws NoSuchMethodException, SecurityException {
+        try {
+            ConcreteClass.class.getMethod("noSuchMethod");
+            Assert.fail("Should've thrown an exception");
+        } catch (NoSuchMethodException nsme) {
+        }
+    }
+
+    /**
+     * Verifies correct lookup of a superclass method with 5 params.
+     *
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     */
+    @Test
+    public void getSuperFiveArg() throws NoSuchMethodException, SecurityException {
+        Method method = ConcreteClass.class.getMethod("superFiveArgs", FIVE_ARG_CLASSES);
+        Assert.assertNotNull(method);
+        Assert.assertEquals("superFiveArgs", method.getName());
+        Assert.assertEquals(5, method.getParameterCount());
+        Assert.assertEquals(SuperClass.class, method.getDeclaringClass());
+    }
+
+    /**
+     * Verifies correct lookup of a superclass method with 0 params.
+     *
+     * @throws NoSuchMethodException
+     * @throws SecurityException
+     */
+    @Test
+    public void getSuperNoArg() throws NoSuchMethodException, SecurityException {
+        Method method = ConcreteClass.class.getMethod("superNoArgs");
+        Assert.assertNotNull(method);
+        Assert.assertEquals("superNoArgs", method.getName());
+        Assert.assertEquals(0, method.getParameterCount());
+        Assert.assertEquals(SuperClass.class, method.getDeclaringClass());
+    }
+
+}

--- a/test/jdk/java/lang/Class/getMethod/ParameterCounts.java
+++ b/test/jdk/java/lang/Class/getMethod/ParameterCounts.java
@@ -50,6 +50,9 @@ public class ParameterCounts {
         public void fiveArgs(Object one, Object two, Object three, Object four, Object five) {
         }
 
+        public void fiveArgs(Integer one, Integer two, Integer three, Integer four, Integer five) {
+        }
+
         public void noArgs() {
         }
 
@@ -80,6 +83,9 @@ public class ParameterCounts {
         public void superFiveArgs(Object one, Object two, Object three, Object four, Object five) {
         }
 
+        public void superFiveArgs(Integer one, Integer two, Integer three, Integer four, Integer five) {
+        }
+
         public void superNoArgs() {
         }
 
@@ -100,6 +106,9 @@ public class ParameterCounts {
         public void b_noiseMethod(byte[] bytes);
 
         default void defaultIntfFiveArgs(Object a, Object b, Object c, Object d, Object e) {
+        }
+
+        default void defaultIntfFiveArgs(Integer a, Integer b, Integer c, Integer d, Integer e) {
         }
 
         default void defaultIntfNoArgs() {

--- a/test/jdk/java/lang/Class/getMethod/ParameterCounts.java
+++ b/test/jdk/java/lang/Class/getMethod/ParameterCounts.java
@@ -1,4 +1,25 @@
-
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 import java.lang.reflect.Method;
 
 import org.junit.Assert;

--- a/test/micro/org/openjdk/bench/java/lang/ClassGetMethod.java
+++ b/test/micro/org/openjdk/bench/java/lang/ClassGetMethod.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
 package org.openjdk.bench.java.lang;
 
 import java.lang.reflect.Method;

--- a/test/micro/org/openjdk/bench/java/lang/ClassGetMethod.java
+++ b/test/micro/org/openjdk/bench/java/lang/ClassGetMethod.java
@@ -1,0 +1,149 @@
+package org.openjdk.bench.java.lang;
+
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Warmup;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(2)
+@Warmup(iterations = 2, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+public class ClassGetMethod {
+    public static class ConcreteClass extends SuperClass implements TestIntf {
+        @Override
+        public void a_noiseMethod(byte[] bytes) {
+        }
+
+        public void a_noiseMethod(String s) {
+        }
+
+        @Override
+        public void b_noiseMethod(byte[] bytes) {
+        }
+
+        public void b_noiseMethod(String s) {
+        }
+
+        public void c_noiseMethod(String s) {
+        }
+
+        public void d_noiseMethod(String s) {
+        }
+
+        public void fiveArgs(Object one, Object two, Object three, Object four, Object five) {
+        }
+
+        public void noArgs() {
+        }
+
+        public void x_noiseMethod(String s) {
+        }
+
+        public void y_noiseMethod(String s) {
+        }
+
+        public void z_noiseMethod(String s) {
+        }
+
+    }
+
+    public static class SuperClass {
+        public void a_superNoiseMethod(String s) {
+        }
+
+        public void b_superNoiseMethod(String s) {
+        }
+
+        public void c_superNoiseMethod(String s) {
+        }
+
+        public void d_superNoiseMethod(String s) {
+        }
+
+        public void superFiveArgs(Object one, Object two, Object three, Object four, Object five) {
+        }
+
+        public void superNoArgs() {
+        }
+
+        public void x_superNoiseMethod(String s) {
+        }
+
+        public void y_superNoiseMethod(String s) {
+        }
+
+        public void z_superNoiseMethod(String s) {
+        }
+
+    }
+
+    public interface TestIntf {
+        public void a_noiseMethod(byte[] bytes);
+
+        public void b_noiseMethod(byte[] bytes);
+
+        default void defaultIntfFiveArgs(Object a, Object b, Object c, Object d, Object e) {
+        }
+
+        default void defaultIntfNoArgs() {
+        }
+
+        default void y_noiseMethod(byte[] bytes) {
+        }
+
+        default void z_noiseMethod(byte[] bytes) {
+        }
+    }
+
+    private static final Class<?>[] FIVE_ARG_CLASSES = new Class<?>[] { Object.class, Object.class, Object.class,
+            Object.class, Object.class };
+
+    @Benchmark
+    public Method getConcreteFiveArg() throws NoSuchMethodException, SecurityException {
+        return ConcreteClass.class.getMethod("fiveArgs", FIVE_ARG_CLASSES);
+    }
+
+    @Benchmark
+    public Method getConcreteNoArg() throws NoSuchMethodException, SecurityException {
+        return ConcreteClass.class.getMethod("noArgs");
+    }
+
+    @Benchmark
+    public Method getIntfFiveArg() throws NoSuchMethodException, SecurityException {
+        return ConcreteClass.class.getMethod("defaultIntfFiveArgs", FIVE_ARG_CLASSES);
+    }
+
+    @Benchmark
+    public Method getIntfNoArg() throws NoSuchMethodException, SecurityException {
+        return ConcreteClass.class.getMethod("defaultIntfNoArgs");
+    }
+
+    @Benchmark
+    @Measurement(iterations = 5, time = 3, timeUnit = TimeUnit.SECONDS)
+    public Method getNoSuchMethod() throws NoSuchMethodException, SecurityException {
+        try {
+            return ConcreteClass.class.getMethod("noSuchMethod");
+        } catch (NoSuchMethodException nsme) {
+            return null;
+        }
+    }
+
+    @Benchmark
+    public Method getSuperFiveArg() throws NoSuchMethodException, SecurityException {
+        return ConcreteClass.class.getMethod("superFiveArgs", FIVE_ARG_CLASSES);
+    }
+
+    @Benchmark
+    public Method getSuperNoArg() throws NoSuchMethodException, SecurityException {
+        return ConcreteClass.class.getMethod("superNoArgs");
+    }
+
+}

--- a/test/micro/org/openjdk/bench/java/lang/ClassGetMethod.java
+++ b/test/micro/org/openjdk/bench/java/lang/ClassGetMethod.java
@@ -63,6 +63,9 @@ public class ClassGetMethod {
         public void fiveArgs(Object one, Object two, Object three, Object four, Object five) {
         }
 
+        public void fiveArgs(Integer one, Integer two, Integer three, Integer four, Integer five) {
+        }
+
         public void noArgs() {
         }
 
@@ -93,6 +96,9 @@ public class ClassGetMethod {
         public void superFiveArgs(Object one, Object two, Object three, Object four, Object five) {
         }
 
+        public void superFiveArgs(Integer one, Integer two, Integer three, Integer four, Integer five) {
+        }
+
         public void superNoArgs() {
         }
 
@@ -115,6 +121,9 @@ public class ClassGetMethod {
         default void defaultIntfFiveArgs(Object a, Object b, Object c, Object d, Object e) {
         }
 
+        default void defaultIntfFiveArgs(Integer a, Integer b, Integer c, Integer d, Integer e) {
+        }
+
         default void defaultIntfNoArgs() {
         }
 
@@ -129,6 +138,8 @@ public class ClassGetMethod {
             Object.class, Object.class };
 
     @Benchmark
+    @Warmup(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 3, time = 2, timeUnit = TimeUnit.SECONDS)
     public Method getConcreteFiveArg() throws NoSuchMethodException, SecurityException {
         return ConcreteClass.class.getMethod("fiveArgs", FIVE_ARG_CLASSES);
     }


### PR DESCRIPTION
This change optimizes the runtime of `Class.getMethod(String, Class<?>[])` by reducing the cost of the existing search logic.  Specifically, while iterating across each Method to find a match (existing logic) it now compares parameter count before checking method name.  This check is substantially faster.

A benchmark and unit tests are included; benchmark results (below) show an improvement in all cases, and an especially large gain when the immediate class contains the no-arg target.

Base:
```
Benchmark                          Mode  Cnt     Score    Error  Units
ClassGetMethod.getConcreteFiveArg  avgt    6    94.586 ±  0.733  ns/op
ClassGetMethod.getConcreteNoArg    avgt    6    75.587 ± 11.300  ns/op
ClassGetMethod.getIntfFiveArg      avgt    6   215.794 ±  7.713  ns/op
ClassGetMethod.getIntfNoArg        avgt    6   200.418 ±  4.352  ns/op
ClassGetMethod.getNoSuchMethod     avgt   10  2207.928 ± 49.767  ns/op
ClassGetMethod.getSuperFiveArg     avgt    6   190.142 ±  1.995  ns/op
ClassGetMethod.getSuperNoArg       avgt    6   153.943 ±  7.491  ns/op
```

Modified:
```
Benchmark                          Mode  Cnt     Score    Error  Units
ClassGetMethod.getConcreteFiveArg  avgt    6    94.409 ±  1.642  ns/op
ClassGetMethod.getConcreteNoArg    avgt    6    77.748 ± 11.618  ns/op
ClassGetMethod.getIntfFiveArg      avgt    6   193.816 ±  4.250  ns/op
ClassGetMethod.getIntfNoArg        avgt    6   205.565 ±  9.140  ns/op
ClassGetMethod.getNoSuchMethod     avgt   10  2231.248 ± 67.711  ns/op
ClassGetMethod.getSuperFiveArg     avgt    6   169.971 ±  0.883  ns/op
ClassGetMethod.getSuperNoArg       avgt    6   129.188 ±  8.421  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343559](https://bugs.openjdk.org/browse/JDK-8343559): Optimize Class.getMethod(String, Class&lt;?&gt;...) for methods with no-arg (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21929/head:pull/21929` \
`$ git checkout pull/21929`

Update a local copy of the PR: \
`$ git checkout pull/21929` \
`$ git pull https://git.openjdk.org/jdk.git pull/21929/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21929`

View PR using the GUI difftool: \
`$ git pr show -t 21929`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21929.diff">https://git.openjdk.org/jdk/pull/21929.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21929#issuecomment-2459983730)
</details>
