### PR TITLE
8343724: [PPC64] Disallow OptoScheduling

### DIFF
--- a/src/hotspot/cpu/ppc/c2_init_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c2_init_ppc.cpp
@@ -34,26 +34,5 @@
 // Processor dependent initialization of C2 compiler for ppc.
 
 void Compile::pd_compiler2_init() {
-
-  // Power7 and later.
-  if (PowerArchitecturePPC64 > 6) {
-    if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
-      FLAG_SET_ERGO(UsePopCountInstruction, true);
-    }
-  }
-
-  if (!VM_Version::has_isel() && FLAG_IS_DEFAULT(ConditionalMoveLimit)) {
-    FLAG_SET_ERGO(ConditionalMoveLimit, 0);
-  }
-
-  if (OptimizeFill) {
-    warning("OptimizeFill is not supported on this CPU.");
-    FLAG_SET_DEFAULT(OptimizeFill, false);
-  }
-
-  if (OptoScheduling) {
-    // The OptoScheduling information is not maintained in ppd.ad.
-    warning("OptoScheduling is not supported on this CPU.");
-    FLAG_SET_DEFAULT(OptoScheduling, false);
-  }
+  guarantee(CodeEntryAlignment >= InteriorEntryAlignment, "");
 }

--- a/src/hotspot/cpu/ppc/c2_init_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c2_init_ppc.cpp
@@ -51,4 +51,9 @@ void Compile::pd_compiler2_init() {
     FLAG_SET_DEFAULT(OptimizeFill, false);
   }
 
+  if (OptoScheduling) {
+    // The OptoScheduling information is not maintained in ppd.ad.
+    warning("OptoScheduling is not supported on this CPU.");
+    FLAG_SET_DEFAULT(OptoScheduling, false);
+  }
 }

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -110,6 +110,17 @@ void VM_Version::initialize() {
     FLAG_SET_ERGO(TrapBasedRangeChecks, false);
   }
 
+  // Power7 and later.
+  if (PowerArchitecturePPC64 > 6) {
+    if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
+      FLAG_SET_ERGO(UsePopCountInstruction, true);
+    }
+  }
+
+  if (!VM_Version::has_isel() && FLAG_IS_DEFAULT(ConditionalMoveLimit)) {
+    FLAG_SET_ERGO(ConditionalMoveLimit, 0);
+  }
+
   if (PowerArchitecturePPC64 >= 8) {
     if (FLAG_IS_DEFAULT(SuperwordUseVSX)) {
       FLAG_SET_ERGO(SuperwordUseVSX, true);
@@ -168,17 +179,6 @@ void VM_Version::initialize() {
       warning("UseByteReverseInstructions specified, but needs at least Power10.");
       FLAG_SET_DEFAULT(UseByteReverseInstructions, false);
     }
-  }
-
-  // Power7 and later.
-  if (PowerArchitecturePPC64 > 6) {
-    if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
-      FLAG_SET_ERGO(UsePopCountInstruction, true);
-    }
-  }
-
-  if (!VM_Version::has_isel() && FLAG_IS_DEFAULT(ConditionalMoveLimit)) {
-    FLAG_SET_ERGO(ConditionalMoveLimit, 0);
   }
 
   if (OptimizeFill) {

--- a/src/hotspot/cpu/ppc/vm_version_ppc.cpp
+++ b/src/hotspot/cpu/ppc/vm_version_ppc.cpp
@@ -169,6 +169,28 @@ void VM_Version::initialize() {
       FLAG_SET_DEFAULT(UseByteReverseInstructions, false);
     }
   }
+
+  // Power7 and later.
+  if (PowerArchitecturePPC64 > 6) {
+    if (FLAG_IS_DEFAULT(UsePopCountInstruction)) {
+      FLAG_SET_ERGO(UsePopCountInstruction, true);
+    }
+  }
+
+  if (!VM_Version::has_isel() && FLAG_IS_DEFAULT(ConditionalMoveLimit)) {
+    FLAG_SET_ERGO(ConditionalMoveLimit, 0);
+  }
+
+  if (OptimizeFill) {
+    warning("OptimizeFill is not supported on this CPU.");
+    FLAG_SET_DEFAULT(OptimizeFill, false);
+  }
+
+  if (OptoScheduling) {
+    // The OptoScheduling information is not maintained in ppd.ad.
+    warning("OptoScheduling is not supported on this CPU.");
+    FLAG_SET_DEFAULT(OptoScheduling, false);
+  }
 #endif
 
   // Create and print feature-string.


### PR DESCRIPTION
Force off OptoScheduling for PPC64. It should be properly maintained before allowing users to switch it on. It's probably not important for this platform. Also see JBS issue for motivation.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343724](https://bugs.openjdk.org/browse/JDK-8343724): [PPC64] Disallow OptoScheduling (**Bug** - P4)


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21935/head:pull/21935` \
`$ git checkout pull/21935`

Update a local copy of the PR: \
`$ git checkout pull/21935` \
`$ git pull https://git.openjdk.org/jdk.git pull/21935/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21935`

View PR using the GUI difftool: \
`$ git pr show -t 21935`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21935.diff">https://git.openjdk.org/jdk/pull/21935.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21935#issuecomment-2460229036)
</details>
