### PR TITLE
8343730: JMX cleanups

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanServerDelegateImpl.java
+++ b/src/java.management/share/classes/com/sun/jmx/mbeanserver/MBeanServerDelegateImpl.java
@@ -100,7 +100,7 @@ final class MBeanServerDelegateImpl
         super();
         delegateInfo =
             new MBeanInfo("javax.management.MBeanServerDelegate",
-                          "Represents  the MBean server from the management "+
+                          "Represents the MBean server from the management "+
                           "point of view.",
                           MBeanServerDelegateImpl.attributeInfos, null,
                           null,getNotificationInfo());

--- a/src/java.management/share/classes/javax/management/MBeanServerDelegate.java
+++ b/src/java.management/share/classes/javax/management/MBeanServerDelegate.java
@@ -31,7 +31,7 @@ import com.sun.jmx.defaults.ServiceName;
 import com.sun.jmx.mbeanserver.Util;
 
 /**
- * Represents  the MBean server from the management point of view.
+ * Represents the MBean server from the management point of view.
  * The MBeanServerDelegate MBean emits the MBeanServerNotifications when
  * an MBean is registered/unregistered in the MBean server.
  *

--- a/src/java.management/share/classes/javax/management/Notification.java
+++ b/src/java.management/share/classes/javax/management/Notification.java
@@ -59,7 +59,7 @@ public class Notification extends EventObject {
     /**
      * @serialField type String The notification type.
      *              A string expressed in a dot notation similar to Java properties.
-     *              An example of a notification type is network.alarm.router
+     *              An example of a notification type is com.sun.management.gc.notification
      * @serialField sequenceNumber long The notification sequence number.
      *              A serial number which identify particular instance
      *              of notification in the context of the notification source.
@@ -83,7 +83,7 @@ public class Notification extends EventObject {
     /**
      * @serial The notification type.
      *         A string expressed in a dot notation similar to Java properties.
-     *         An example of a notification type is network.alarm.router
+     *         An example of a notification type is com.sun.management.gc.notification
      */
     private String type;
 
@@ -239,7 +239,7 @@ public class Notification extends EventObject {
      * @return The notification type. It's a string expressed in a dot notation
      * similar to Java properties. It is recommended that the notification type
      * should follow the reverse-domain-name convention used by Java package
-     * names.  An example of a notification type is com.example.alarm.router.
+     * names.  An example of a notification type is com.sun.management.gc.notification
      */
     public String getType() {
         return type ;

--- a/src/java.management/share/classes/javax/management/remote/JMXConnectionNotification.java
+++ b/src/java.management/share/classes/javax/management/remote/JMXConnectionNotification.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -159,12 +159,7 @@ public class JMXConnectionNotification extends Notification {
                                      long sequenceNumber,
                                      String message,
                                      Object userData) {
-        /* We don't know whether the parent class (Notification) will
-           throw an exception if the type or source is null, because
-           JMX 1.2 doesn't specify that.  So we make sure it is not
-           null, in case it would throw the wrong exception
-           (e.g. IllegalArgumentException instead of
-           NullPointerException).  Likewise for the sequence number.  */
+        // Do not pass null source to super, as EventObject will throw IllegalArgumentException.
         super((String) nonNull(type),
               nonNull(source),
               Math.max(0, sequenceNumber),


### PR DESCRIPTION
A few small cleanup changes in javax/management.
No logic changes, comments and text only.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343730](https://bugs.openjdk.org/browse/JDK-8343730): JMX cleanups (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21938/head:pull/21938` \
`$ git checkout pull/21938`

Update a local copy of the PR: \
`$ git checkout pull/21938` \
`$ git pull https://git.openjdk.org/jdk.git pull/21938/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21938`

View PR using the GUI difftool: \
`$ git pr show -t 21938`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21938.diff">https://git.openjdk.org/jdk/pull/21938.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21938#issuecomment-2460571374)
</details>
