### PR TITLE
8277240: java/awt/Graphics2D/ScaledTransform/ScaledTransform.java dialog does not get disposed

### DIFF
--- a/test/jdk/java/awt/Graphics2D/ScaledTransform/ScaledTransform.java
+++ b/test/jdk/java/awt/Graphics2D/ScaledTransform/ScaledTransform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,6 +21,7 @@
  * questions.
  */
 import java.awt.Dialog;
+import java.awt.EventQueue;
 import java.awt.Frame;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -29,20 +30,25 @@ import java.awt.GraphicsDevice;
 import java.awt.GraphicsEnvironment;
 import java.awt.Panel;
 import java.awt.geom.AffineTransform;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /*
  * @test
- * @bug 8069361
+ * @bug 8069362
  * @key headful
  * @summary SunGraphics2D.getDefaultTransform() does not include scale factor
- * @author Alexander Scherbatiy
- * @run main ScaledTransform
+ * @run main/timeout=300 ScaledTransform
  */
 public class ScaledTransform {
 
+    private static volatile CountDownLatch painted = null;
     private static volatile boolean passed = false;
+    private static volatile Dialog dialog;
+    private static volatile long startTime = 0;
+    private static volatile long endTime = 0;
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         GraphicsEnvironment ge = GraphicsEnvironment.
                 getLocalGraphicsEnvironment();
 
@@ -51,41 +57,72 @@ public class ScaledTransform {
         }
 
         for (GraphicsDevice gd : ge.getScreenDevices()) {
-            for (GraphicsConfiguration gc : gd.getConfigurations()) {
-                testScaleFactor(gc);
+            System.out.println("Screen = " + gd);
+            test(gd.getDefaultConfiguration());
+            /* Don't want to run too long. Test the default and up to 10 more */
+            GraphicsConfiguration[] configs = gd.getConfigurations();
+            for (int c = 0; c < configs.length && c < 10; c++) {
+                test(configs[c]);
             }
         }
     }
 
-    private static void testScaleFactor(final GraphicsConfiguration gc) {
-        final Dialog dialog = new Dialog((Frame) null, "Test", true, gc);
-
+    static void test(GraphicsConfiguration gc) throws Exception {
         try {
-            dialog.setSize(100, 100);
-            Panel panel = new Panel() {
-
-                @Override
-                public void paint(Graphics g) {
-                    if (g instanceof Graphics2D) {
-                        AffineTransform gcTx = gc.getDefaultTransform();
-                        AffineTransform gTx
-                                = ((Graphics2D) g).getTransform();
-                        passed = gcTx.getScaleX() == gTx.getScaleX()
-                                && gcTx.getScaleY() == gTx.getScaleY();
-                    } else {
-                        passed = true;
-                    }
-                    dialog.setVisible(false);
-                }
-            };
-            dialog.add(panel);
-            dialog.setVisible(true);
-
+            /* reset vars for each run */
+            passed = false;
+            dialog = null;
+            painted = new CountDownLatch(1);
+            EventQueue.invokeLater(() -> showDialog(gc));
+            startTime = System.currentTimeMillis();
+            endTime = startTime;
+            if (!painted.await(5, TimeUnit.SECONDS)) {
+                throw new RuntimeException("Panel is not painted!");
+            }
+            System.out.println("Time to paint = " + (endTime - startTime) + "ms.");
             if (!passed) {
                 throw new RuntimeException("Transform is not scaled!");
             }
         } finally {
-            dialog.dispose();
+            EventQueue.invokeAndWait(() -> disposeDialog());
         }
+    }
+
+    private static void showDialog(final GraphicsConfiguration gc) {
+
+        System.out.println("Creating dialog for gc="+gc+" with tx="+gc.getDefaultTransform());
+
+        dialog = new Dialog((Frame) null, "Test", true, gc);
+
+        dialog.setSize(100, 100);
+        Panel panel = new Panel() {
+
+            @Override
+            public void paint(Graphics g) {
+                System.out.println("Painting panel");
+                if (g instanceof Graphics2D g2d) {
+                    AffineTransform gcTx = gc.getDefaultTransform();
+                    AffineTransform gTx = g2d.getTransform();
+                    System.out.println("GTX = " + gTx);
+                    passed = (gcTx.getScaleX() == gTx.getScaleX()) &&
+                             (gcTx.getScaleY() == gTx.getScaleY());
+                } else {
+                    passed = true;
+                }
+                painted.countDown();
+                endTime = System.currentTimeMillis();
+                System.out.println("Painted panel");
+            }
+        };
+        dialog.add(panel);
+        dialog.setVisible(true);
+    }
+
+    private static void disposeDialog() {
+       if (dialog != null) {
+            System.out.println("Disposing dialog");
+            dialog.setVisible(false);
+            dialog.dispose();
+       }
     }
 }

--- a/test/jdk/java/awt/Graphics2D/ScaledTransform/ScaledTransform.java
+++ b/test/jdk/java/awt/Graphics2D/ScaledTransform/ScaledTransform.java
@@ -35,26 +35,22 @@ import java.util.concurrent.TimeUnit;
 
 /*
  * @test
- * @bug 8069362
+ * @bug 8069361
  * @key headful
  * @summary SunGraphics2D.getDefaultTransform() does not include scale factor
  * @run main/timeout=300 ScaledTransform
  */
 public class ScaledTransform {
 
-    private static volatile CountDownLatch painted = null;
-    private static volatile boolean passed = false;
+    private static volatile CountDownLatch painted;
+    private static volatile boolean passed;
     private static volatile Dialog dialog;
-    private static volatile long startTime = 0;
-    private static volatile long endTime = 0;
+    private static volatile long startTime;
+    private static volatile long endTime;
 
     public static void main(String[] args) throws Exception {
         GraphicsEnvironment ge = GraphicsEnvironment.
                 getLocalGraphicsEnvironment();
-
-        if (ge.isHeadlessInstance()) {
-            return;
-        }
 
         for (GraphicsDevice gd : ge.getScreenDevices()) {
             System.out.println("Screen = " + gd);
@@ -89,12 +85,10 @@ public class ScaledTransform {
     }
 
     private static void showDialog(final GraphicsConfiguration gc) {
+        System.out.println("Creating dialog for gc=" + gc + " with tx=" + gc.getDefaultTransform());
+        dialog = new Dialog((Frame) null, "ScaledTransform", true, gc);
+        dialog.setSize(300, 100);
 
-        System.out.println("Creating dialog for gc="+gc+" with tx="+gc.getDefaultTransform());
-
-        dialog = new Dialog((Frame) null, "Test", true, gc);
-
-        dialog.setSize(100, 100);
         Panel panel = new Panel() {
 
             @Override
@@ -109,8 +103,8 @@ public class ScaledTransform {
                 } else {
                     passed = true;
                 }
-                painted.countDown();
                 endTime = System.currentTimeMillis();
+                painted.countDown();
                 System.out.println("Painted panel");
             }
         };
@@ -120,9 +114,9 @@ public class ScaledTransform {
 
     private static void disposeDialog() {
        if (dialog != null) {
-            System.out.println("Disposing dialog");
-            dialog.setVisible(false);
-            dialog.dispose();
+           System.out.println("Disposing dialog");
+           dialog.setVisible(false);
+           dialog.dispose();
        }
     }
 }


### PR DESCRIPTION
This test has had reports of failures over the years notably on Linux.
I think the large number of XVisuals may have something to do with it.
I've updated it quite a bit and limited the number of dialogs it creates - we really don't need to test 300 of them
This new version has passed hundreds of iterations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8277240](https://bugs.openjdk.org/browse/JDK-8277240): java/awt/Graphics2D/ScaledTransform/ScaledTransform.java dialog does not get disposed (**Bug** - P4)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21942/head:pull/21942` \
`$ git checkout pull/21942`

Update a local copy of the PR: \
`$ git checkout pull/21942` \
`$ git pull https://git.openjdk.org/jdk.git pull/21942/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21942`

View PR using the GUI difftool: \
`$ git pr show -t 21942`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21942.diff">https://git.openjdk.org/jdk/pull/21942.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21942#issuecomment-2461048256)
</details>
