### PR TITLE
8343755: Unproblemlist java/lang/Thread/jni/AttachCurrentThread/AttachTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -518,8 +518,6 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-all
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id0    8343244 generic-all
-java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1    8343244 generic-all
 
 ############################################################################
 


### PR DESCRIPTION
As the change responsible for this test's failure has been backed out, we can now unproblemlist this test.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343755](https://bugs.openjdk.org/browse/JDK-8343755): Unproblemlist java/lang/Thread/jni/AttachCurrentThread/AttachTest.java (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21946/head:pull/21946` \
`$ git checkout pull/21946`

Update a local copy of the PR: \
`$ git checkout pull/21946` \
`$ git pull https://git.openjdk.org/jdk.git pull/21946/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21946`

View PR using the GUI difftool: \
`$ git pr show -t 21946`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21946.diff">https://git.openjdk.org/jdk/pull/21946.diff</a>

</details>
