### PR TITLE
8343754: Problemlist jdk/jfr/event/oldobject/TestShenandoah.java after JDK-8279016

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -773,6 +773,7 @@ jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-
 # jdk_jfr
 
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-all
+jdk/jfr/event/oldobject/TestShenandoah.java                     8342951 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 


### PR DESCRIPTION
See comment in [JDK-8279016](https://bugs.openjdk.org/browse/JDK-8279016). I overlooked the case when we just run with Shenandoah without explicitly specifying -XX:+UseShenandoahGC. The test should be disabled in that mode as well.

Additional testing:
 - [x] Affected test is now skipped
 - [x] `jdk_jfr` out of the box, now passes
 - [x] `jdk_jfr` with `-XX:+UseShenandoahGC`, still passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343754](https://bugs.openjdk.org/browse/JDK-8343754): Problemlist jdk/jfr/event/oldobject/TestShenandoah.java after JDK-8279016 (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21947/head:pull/21947` \
`$ git checkout pull/21947`

Update a local copy of the PR: \
`$ git checkout pull/21947` \
`$ git pull https://git.openjdk.org/jdk.git pull/21947/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21947`

View PR using the GUI difftool: \
`$ git pr show -t 21947`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21947.diff">https://git.openjdk.org/jdk/pull/21947.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21947#issuecomment-2461954589)
</details>
