### PR TITLE
8272780: ServerNotifForwarder.removeNotificationListener() incorrect exception handling

### DIFF
--- a/src/java.management/share/classes/com/sun/jmx/remote/internal/ServerNotifForwarder.java
+++ b/src/java.management/share/classes/com/sun/jmx/remote/internal/ServerNotifForwarder.java
@@ -169,7 +169,7 @@ public class ServerNotifForwarder {
             } catch (Exception e) {
                 // Give back the first exception
                 //
-                if (re != null) {
+                if (re == null) {
                     re = e;
                 }
             }


### PR DESCRIPTION
Long-standing nit where an Exception could fail to be reported.
One-character fix to a comparison.
Does not cause any different results in any javax/management tests.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272780](https://bugs.openjdk.org/browse/JDK-8272780): ServerNotifForwarder.removeNotificationListener() incorrect exception handling (**Bug** - P5)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21950/head:pull/21950` \
`$ git checkout pull/21950`

Update a local copy of the PR: \
`$ git checkout pull/21950` \
`$ git pull https://git.openjdk.org/jdk.git pull/21950/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21950`

View PR using the GUI difftool: \
`$ git pr show -t 21950`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21950.diff">https://git.openjdk.org/jdk/pull/21950.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21950#issuecomment-2462139381)
</details>
