### PR TITLE
8343742: Test TestShenandoah.java fails Could not find leaking object

### DIFF
--- a/test/jdk/ProblemList-shenandoah.txt
+++ b/test/jdk/ProblemList-shenandoah.txt
@@ -49,7 +49,6 @@ jdk/jfr/event/oldobject/TestParallel.java               8342951     generic-all
 jdk/jfr/event/oldobject/TestReferenceChainLimit.java    8342951     generic-all
 jdk/jfr/event/oldobject/TestSanityDefault.java          8342951     generic-all
 jdk/jfr/event/oldobject/TestSerial.java                 8342951     generic-all
-jdk/jfr/event/oldobject/TestShenandoah.java             8342951     generic-all
 jdk/jfr/event/oldobject/TestThreadLocalLeak.java        8342951     generic-all
 jdk/jfr/event/oldobject/TestZ.java                      8342951     generic-all
 jdk/jfr/jcmd/TestJcmdDump.java                          8342951     generic-all

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -775,6 +775,7 @@ jdk/incubator/vector/LoadJsvmlTest.java                         8305390 windows-
 jdk/jfr/event/compiler/TestCodeSweeper.java                     8338127 generic-all
 jdk/jfr/event/runtime/TestResidentSetSizeEvent.java             8309846 aix-ppc64
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
+jdk/jfr/event/oldobject/TestShenandoah.java                     8342951 generic-all
 
 ############################################################################
 

--- a/test/jdk/jdk/jfr/event/oldobject/TestShenandoah.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestShenandoah.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import jdk.test.lib.jfr.Events;
  * @summary Test leak profiler with Shenandoah
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestShenandoah
+ * @run main/othervm  -XX:TLABSize=2k -XX:+UseShenandoahGC jdk.jfr.event.oldobject.TestShenandoah
  */
 public class TestShenandoah {
 

--- a/test/jdk/jdk/jfr/event/oldobject/TestShenandoah.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestShenandoah.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,7 +39,7 @@ import jdk.test.lib.jfr.Events;
  * @summary Test leak profiler with Shenandoah
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
- * @run main/othervm  -XX:TLABSize=2k -XX:+UseShenandoahGC jdk.jfr.event.oldobject.TestShenandoah
+ * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestShenandoah
  */
 public class TestShenandoah {
 


### PR DESCRIPTION
Hi all,
 Test `jdk/jfr/event/oldobject/TestShenandoah.java` run timed out after [JDK-8279016](https://bugs.openjdk.org/browse/JDK-8279016), because of infinite loop of `Could not find leaking object, retrying...`
In [JDK-8279016](https://bugs.openjdk.org/browse/JDK-8279016), this test has been Problemlisted by [ProblemList-shenandoah.txt
](https://github.com/openjdk/jdk/blame/master/test/jdk/ProblemList-shenandoah.txt#L52), because of the LeakProfiler tests not suitable for run with `-XX:+UseShenandoahGC` after [JDK-8279016](https://bugs.openjdk.org/browse/JDK-8279016).
But in the VM option `-XX:+UseShenandoahGC` set inside the test tag cause the Problemlist mechanism will not take effect. The problemlist only take effect when the VM option set from command line such as `make TEST JTREG="JAVA_OPTIONS=-XX:+UseShenandoahGC"`.
So in this PR move Problemlist entry `jdk/jfr/event/oldobject/TestShenandoah.java` from `test/jdk/ProblemList-shenandoah.txt` to `test/jdk/ProblemList.txt` to make this test could by excluded normally.
The other optional solution is delete the VM option `-XX:+UseShenandoahGC` in test file to make test run passed. After [JDK-8342951](https://bugs.openjdk.org/browse/JDK-8342951) has been resolved, the change should be backouted. This PR choice the previous one solution.

Test-fix only, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343742](https://bugs.openjdk.org/browse/JDK-8343742): Test TestShenandoah.java fails Could not find leaking object (**Bug** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21951/head:pull/21951` \
`$ git checkout pull/21951`

Update a local copy of the PR: \
`$ git checkout pull/21951` \
`$ git pull https://git.openjdk.org/jdk.git pull/21951/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21951`

View PR using the GUI difftool: \
`$ git pr show -t 21951`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21951.diff">https://git.openjdk.org/jdk/pull/21951.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21951#issuecomment-2462155747)
</details>
