### PR TITLE
8343140

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJavaSupport.cpp
@@ -343,6 +343,8 @@ static void write_specialized_field(JfrJavaArguments* args, const Handle& h_oop,
     case T_BOOLEAN:
     case T_CHAR:
     case T_SHORT:
+      Unimplemented();
+      break;
     case T_INT:
       write_int_field(h_oop, fd, args->param(1).get_jint());
       break;
@@ -374,8 +376,14 @@ static void read_specialized_field(JavaValue* result, const Handle& h_oop, field
 
   switch(fd->field_type()) {
     case T_BOOLEAN:
+      result->set_jint(h_oop->bool_field(fd->offset()));
+      break;
     case T_CHAR:
+      result->set_jint(h_oop->char_field(fd->offset()));
+      break;
     case T_SHORT:
+      result->set_jint(h_oop->short_field(fd->offset()));
+      break;
     case T_INT:
       result->set_jint(h_oop->int_field(fd->offset()));
       break;


### PR DESCRIPTION
This test fixes the accessor used by `read_boolean_field` to access boolean fields of the `jdk.jfr.internal.dcmd.Argument` record. It also fixes the read accessors for `short` and `char` types, and marks the write accessors for `boolean`, `short` and `char` as unimplemented.

The existing accessor reads the boolean field as int. This results in unaligned access, and probably reads incorrect value on big-endian CPUs.

No new tests. I'm sure a test would be useful, but I have no idea how to write one. Existing tier1-3 tests continue to pass.