### PR TITLE
8343540: Report preview error for inherited effectively-preview methods

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -4718,7 +4718,7 @@ public class Attr extends JCTree.Visitor {
                 chk.checkDeprecated(tree.pos(), env.info.scope.owner, sym);
                 chk.checkSunAPI(tree.pos(), sym);
                 chk.checkProfile(tree.pos(), sym);
-                chk.checkPreview(tree.pos(), env.info.scope.owner, sym);
+                chk.checkPreview(tree.pos(), env.info.scope.owner, site, sym);
             }
 
             if (pt.isErroneous()) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -1845,7 +1845,8 @@ public class Check {
         }
 
         if (shouldCheckPreview(m, other, origin)) {
-            checkPreview(tree.pos(), m, other);
+            checkPreview(TreeInfo.diagnosticPositionFor(m, tree),
+                         m, origin.type, other);
         }
 
         Type mt = types.memberType(origin.type, m);
@@ -1925,7 +1926,8 @@ public class Check {
         private boolean shouldCheckPreview(MethodSymbol m, MethodSymbol other, ClassSymbol origin) {
             if (m.owner != origin ||
                 //performance - only do the expensive checks when the overridden method is a Preview API:
-                (other.flags() & PREVIEW_API) == 0) {
+                ((other.flags() & PREVIEW_API) == 0 &&
+                 (other.owner.flags() & PREVIEW_API) == 0)) {
                 return false;
             }
 
@@ -3841,6 +3843,8 @@ public class Check {
                    site.tsym != null &&
                    (site.tsym.flags() & PREVIEW_API) == 0 &&
                    (s.owner.flags() & PREVIEW_API) != 0) {
+            //calling a method, or using a field, whose owner is a preview, but
+            //using a site that is not a preview. Also produce an error or warning:
             sIsPreview = true;
             previewSymbol = s.owner;
         } else {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -3828,8 +3828,27 @@ public class Check {
     }
 
     void checkPreview(DiagnosticPosition pos, Symbol other, Symbol s) {
-        if ((s.flags() & PREVIEW_API) != 0 && !preview.participatesInPreview(syms, other, s) && !disablePreviewCheck) {
-            if ((s.flags() & PREVIEW_REFLECTIVE) == 0) {
+        checkPreview(pos, other, Type.noType, s);
+    }
+
+    void checkPreview(DiagnosticPosition pos, Symbol other, Type site, Symbol s) {
+        boolean sIsPreview;
+        Symbol previewSymbol;
+        if ((s.flags() & PREVIEW_API) != 0) {
+            sIsPreview = true;
+            previewSymbol=  s;
+        } else if ((s.kind == Kind.MTH || s.kind == Kind.VAR) &&
+                   site.tsym != null &&
+                   (site.tsym.flags() & PREVIEW_API) == 0 &&
+                   (s.owner.flags() & PREVIEW_API) != 0) {
+            sIsPreview = true;
+            previewSymbol = s.owner;
+        } else {
+            sIsPreview = false;
+            previewSymbol = null;
+        }
+        if (sIsPreview && !preview.participatesInPreview(syms, other, s) && !disablePreviewCheck) {
+            if ((previewSymbol.flags() & PREVIEW_REFLECTIVE) == 0) {
                 if (!preview.isEnabled()) {
                     log.error(pos, Errors.IsPreview(s));
                 } else {

--- a/test/langtools/tools/javac/preview/PreviewTest.java
+++ b/test/langtools/tools/javac/preview/PreviewTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8282823
+ * @bug 8282823 8343540
  * @library /tools/lib
  * @enablePreview
  * @modules
@@ -463,7 +463,7 @@ public class PreviewTest extends TestRunner {
         }
     }
 
-    @Test
+    @Test //JDK-8343540:
     public void nonPreviewImplementsPreview(Path base) throws Exception {
         Path apiSrc = base.resolve("api-src");
         tb.writeJavaFiles(apiSrc,

--- a/test/langtools/tools/javac/preview/PreviewTest.java
+++ b/test/langtools/tools/javac/preview/PreviewTest.java
@@ -229,13 +229,13 @@ public class PreviewTest extends TestRunner {
                 .getOutputLines(Task.OutputKind.DIRECT);
 
         List<String> expected =
-                List.of("IUseIntf2P.java:3:8: compiler.err.is.preview: test()",
-                        "IUseIntfDef2P.java:3:8: compiler.err.is.preview: test()",
+                List.of("IUseIntf2P.java:4:25: compiler.err.is.preview: test()",
+                        "IUseIntfDef2P.java:4:25: compiler.err.is.preview: test()",
                         "UseClass2P.java:4:17: compiler.err.is.preview: test()",
-                        "UseIntf2P.java:3:8: compiler.err.is.preview: test()",
-                        "UseIntfDef2P.java:3:8: compiler.err.is.preview: test()",
+                        "UseIntf2P.java:4:17: compiler.err.is.preview: test()",
+                        "UseIntfDef2P.java:4:17: compiler.err.is.preview: test()",
                         "UseSubClass12P.java:3:17: compiler.err.is.preview: test()",
-                        "UseSubIntfDef12P.java:2:8: compiler.err.is.preview: test()",
+                        "UseSubIntfDef12P.java:3:17: compiler.err.is.preview: test()",
                         "7 errors");
 
         if (!log.equals(expected))
@@ -257,13 +257,13 @@ public class PreviewTest extends TestRunner {
                 .getOutputLines(Task.OutputKind.DIRECT);
 
         expected =
-                List.of("IUseIntf2P.java:3:8: compiler.warn.is.preview: test()",
-                        "IUseIntfDef2P.java:3:8: compiler.warn.is.preview: test()",
+                List.of("IUseIntf2P.java:4:25: compiler.warn.is.preview: test()",
+                        "IUseIntfDef2P.java:4:25: compiler.warn.is.preview: test()",
                         "UseClass2P.java:4:17: compiler.warn.is.preview: test()",
-                        "UseIntf2P.java:3:8: compiler.warn.is.preview: test()",
-                        "UseIntfDef2P.java:3:8: compiler.warn.is.preview: test()",
+                        "UseIntf2P.java:4:17: compiler.warn.is.preview: test()",
+                        "UseIntfDef2P.java:4:17: compiler.warn.is.preview: test()",
                         "UseSubClass12P.java:3:17: compiler.warn.is.preview: test()",
-                        "UseSubIntfDef12P.java:2:8: compiler.warn.is.preview: test()",
+                        "UseSubIntfDef12P.java:3:17: compiler.warn.is.preview: test()",
                         "7 warnings");
 
         if (!log.equals(expected))
@@ -392,7 +392,7 @@ public class PreviewTest extends TestRunner {
                 .getOutputLines(Task.OutputKind.DIRECT);
 
         List<String> expected =
-                List.of("AbstractP.java:3:17: compiler.err.is.preview: test()",
+                List.of("AbstractP.java:4:26: compiler.err.is.preview: test()",
                         "ReabstractP.java:4:26: compiler.err.is.preview: test()",
                         "2 errors");
 
@@ -415,7 +415,7 @@ public class PreviewTest extends TestRunner {
                 .getOutputLines(Task.OutputKind.DIRECT);
 
         expected =
-                List.of("AbstractP.java:3:17: compiler.warn.is.preview: test()",
+                List.of("AbstractP.java:4:26: compiler.warn.is.preview: test()",
                         "ReabstractP.java:4:26: compiler.warn.is.preview: test()",
                         "2 warnings");
 
@@ -502,8 +502,7 @@ public class PreviewTest extends TestRunner {
 
         new JavacTask(tb, Task.Mode.CMDLINE)
                 .outdir(apiClasses)
-                .options("-XDrawDiagnostics", "-doe",
-                         "--patch-module", "java.base=" + apiSrc.toString(),
+                .options("--patch-module", "java.base=" + apiSrc.toString(),
                          "-Werror")
                 .files(tb.findJavaFiles(apiSrc))
                 .run()
@@ -543,6 +542,13 @@ public class PreviewTest extends TestRunner {
                                   acceptRunnable(p::test);
                                   accept(Preview::test);
                               }
+                              private static class ExtendsNonPreview extends NonPreview {
+                                  public void test() {} //error/warning here:
+                              }
+                              private static class ImplementsPreview implements Preview {
+                                  //no error/warning (already was on Preview after implements)
+                                  public void test() {}
+                              }
                               private void acceptRunnable(Runnable r) {}
                               private void accept(Accept<NonPreview> accept) {}
                               interface Accept<T> {
@@ -567,6 +573,7 @@ public class PreviewTest extends TestRunner {
         List<String> expected =
                 List.of("Test.java:4:19: compiler.err.is.preview: preview.api.Preview",
                         "Test.java:26:22: compiler.err.is.preview: preview.api.Preview",
+                        "Test.java:34:55: compiler.err.is.preview: preview.api.Preview",
                         "Test.java:9:11: compiler.err.is.preview: test()",
                         "Test.java:10:24: compiler.err.is.preview: test()",
                         "Test.java:11:16: compiler.err.is.preview: test()",
@@ -578,7 +585,9 @@ public class PreviewTest extends TestRunner {
                         "Test.java:21:11: compiler.err.is.preview: test()",
                         "Test.java:24:11: compiler.warn.is.preview.reflective: test()",
                         "Test.java:29:16: compiler.err.is.preview: preview.api.Preview",
-                        "12 errors",
+                        "Test.java:32:21: compiler.err.is.preview: test()",
+                        "Test.java:36:21: compiler.err.is.preview: test()",
+                        "15 errors",
                         "1 warning");
 
         if (!log.equals(expected))

--- a/test/langtools/tools/javac/preview/PreviewTest.java
+++ b/test/langtools/tools/javac/preview/PreviewTest.java
@@ -549,6 +549,12 @@ public class PreviewTest extends TestRunner {
                                   //no error/warning (already was on Preview after implements)
                                   public void test() {}
                               }
+                              private static class ImplicitReceiver extends NonPreview {
+                                  public void g() {
+                                      test(); //implicit this - error/warning
+                                      int i = FIELD; //implicit this - error/warning
+                                  }
+                              }
                               private void acceptRunnable(Runnable r) {}
                               private void accept(Accept<NonPreview> accept) {}
                               interface Accept<T> {
@@ -587,7 +593,9 @@ public class PreviewTest extends TestRunner {
                         "Test.java:29:16: compiler.err.is.preview: preview.api.Preview",
                         "Test.java:32:21: compiler.err.is.preview: test()",
                         "Test.java:36:21: compiler.err.is.preview: test()",
-                        "15 errors",
+                        "Test.java:40:13: compiler.err.is.preview: test()",
+                        "Test.java:41:21: compiler.err.is.preview: FIELD",
+                        "17 errors",
                         "1 warning");
 
         if (!log.equals(expected))


### PR DESCRIPTION
Consider a case where a new preview interface is introduced to JDK, and an existing non-preview class is retrofitted to use it. I.e. a case like:

```
//JDK types:
@PreviewFeature(...)
public interface NewAPI {
    public default void test() {}
}
public class ExistingRetrofittedClass implements NewAPI {}

//user type:
class Test {
    void t(ExistingRetrofittedClass c) {
        c.test();
    }
}
```

There is currently no error or warning about the invocation of the test method, as the method itself is not marked as preview, and the receiver is not preview either.

The proposal herein is that invoking a method on a receiver that is not of preview type itself, but the method is declared in a preview class or interface, the method will be considered to be a preview method, and the appropriate error or warning will be printed. Similar behavior is implementing for dereferencing fields.


Similarly when implementing or overriding such "effectively" preview methods, like:

```
//user types:
class Test1 extends ExistingRetrofittedClass {
    public void test() {}
}
```

java also does not produce any error or warning. If the method itself would be marked as preview, an error or warning would be printed.

The proposal herein is to produce an error or warning for a method declared inside a non-preview class or interface, which directly overrides a method declared inside a preview class or interface.

In particular, for the two example above, javac is currently producing no errors. With the change proposed herein, javac will produce output like (with no `--enable-preview`):

```
src/Test1.java:4: error: test() is a preview API and is disabled by default.
    public void test() {}
                ^
  (use --enable-preview to enable preview APIs)
src/Test.java:5: error: test() is a preview API and is disabled by default.
        c.test();
         ^
  (use --enable-preview to enable preview APIs)
2 errors
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8343695](https://bugs.openjdk.org/browse/JDK-8343695) to be approved

### Issues
 * [JDK-8343540](https://bugs.openjdk.org/browse/JDK-8343540): Report preview error for inherited effectively-preview methods (**Task** - P4)
 * [JDK-8343695](https://bugs.openjdk.org/browse/JDK-8343695): Report preview error for inherited effectively-preview methods (**CSR**)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21953/head:pull/21953` \
`$ git checkout pull/21953`

Update a local copy of the PR: \
`$ git checkout pull/21953` \
`$ git pull https://git.openjdk.org/jdk.git pull/21953/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21953`

View PR using the GUI difftool: \
`$ git pr show -t 21953`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21953.diff">https://git.openjdk.org/jdk/pull/21953.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21953#issuecomment-2462569651)
</details>
