### PR TITLE
8340532: C2: assert(is_OuterStripMinedLoop()) failed: invalid node class: IfTrue

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -1524,6 +1524,14 @@ Node* IfNode::Ideal(PhaseGVN *phase, bool can_reshape) {
   Node* prev_dom = search_identical(dist, igvn);
 
   if (prev_dom != nullptr) {
+    // Dominating CountedLoopEnd (left over from some now dead loop) will become the new loop exit. Outer strip mined
+    // loop will go away. Mark this loop as no longer strip mined.
+    if (is_CountedLoopEnd()) {
+      CountedLoopNode* counted_loop_node = as_CountedLoopEnd()->loopnode();
+      if (counted_loop_node != nullptr) {
+        counted_loop_node->clear_strip_mined();
+      }
+    }
     // Replace dominated IfNode
     return dominated_by(prev_dom, igvn, false);
   }

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -758,7 +758,6 @@ void PhaseIdealLoop::do_peeling(IdealLoopTree *loop, Node_List &old_new) {
 #endif
     }
   }
-  Node* entry = head->in(LoopNode::EntryControl);
 
   // Step 1: Clone the loop body.  The clone becomes the peeled iteration.
   //         The pre-loop illegally has 2 control users (old & new loops).

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestIdenticalDominatingCLE.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestIdenticalDominatingCLE.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8340532
+ * @summary C2: assert(is_OuterStripMinedLoop()) failed: invalid node class: IfTrue
+ *
+ * @run main/othervm -XX:CompileOnly=TestIdenticalDominatingCLE::* -XX:CompileThreshold=100 -Xcomp -XX:-TieredCompilation
+ *                   -XX:-RangeCheckElimination -XX:LoopMaxUnroll=0 TestIdenticalDominatingCLE
+ *
+ */
+
+
+public class TestIdenticalDominatingCLE {
+    boolean bFld;
+    long lFld;
+    float[][] fArr = new float[6][6];
+
+    public static void main(String[] var0) {
+        TestIdenticalDominatingCLE t = new TestIdenticalDominatingCLE();
+        t.test();
+    }
+
+    void test() {
+        int i = 0;
+        do {
+            for (int j = 0; j < 2; j++) {
+                float f = fArr[j][3] / Float.valueOf((float)1.318095814E9);
+                switch (i) {
+                    case 1:
+                        if (bFld ^ bFld) {
+                        } else {
+                            for (int k = 0; k < 600; k++) {
+                            }
+                        }
+                        break;
+                    default:
+                        if (bFld) {
+                        }
+                }
+            }
+            lFld = ++i;
+        } while (i < 6);
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopstripmining/TestIdenticalDominatingCLE.java
+++ b/test/hotspot/jtreg/compiler/loopstripmining/TestIdenticalDominatingCLE.java
@@ -25,7 +25,7 @@
  * @test
  * @bug 8340532
  * @summary C2: assert(is_OuterStripMinedLoop()) failed: invalid node class: IfTrue
- *
+ * @requires vm.compiler2.enabled
  * @run main/othervm -XX:CompileOnly=TestIdenticalDominatingCLE::* -XX:CompileThreshold=100 -Xcomp -XX:-TieredCompilation
  *                   -XX:-RangeCheckElimination -XX:LoopMaxUnroll=0 TestIdenticalDominatingCLE
  *


### PR DESCRIPTION
A `CountedLoopEnd` (that marks the end of a still existing
`CountedLoop`) is optimized out because a dominating identical
`CountedLoopEnd` (that no longer marks the end of an existing
`CountedLoop` but was left behind by previous loop opts) is
found. That causes the path out of `CountedLoopEnd` to become dead
including the `OuterStripMinedLoopEnd`. The `OuterStripMinedLoop`
looses its backedge as a consequence. The `CountedLoop` is still
marked as strip mined but the outer loop doesn't exist anymore.

The fix I propose for this corner case is to simply detect when that
happens (during igvn AFAICT) and clear the strip mined flag from the
`CountedLoop`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340532](https://bugs.openjdk.org/browse/JDK-8340532): C2: assert(is_OuterStripMinedLoop()) failed: invalid node class: IfTrue (**Bug** - P3)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21956/head:pull/21956` \
`$ git checkout pull/21956`

Update a local copy of the PR: \
`$ git checkout pull/21956` \
`$ git pull https://git.openjdk.org/jdk.git pull/21956/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21956`

View PR using the GUI difftool: \
`$ git pr show -t 21956`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21956.diff">https://git.openjdk.org/jdk/pull/21956.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21956#issuecomment-2462424494)
</details>
