### PR TITLE
8343770: Build fails due to use of sun.misc.Unsafe in LoopOverRandom

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverRandom.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/LoopOverRandom.java
@@ -27,6 +27,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -38,7 +39,7 @@ import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
-import sun.misc.Unsafe;
+import jdk.internal.misc.Unsafe;
 
 @BenchmarkMode(Mode.AverageTime)
 @Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)


### PR DESCRIPTION
This small PR fixes a build failure due to usage of sun.misc.Unsafe in a new benchmark.

FFM benchmarks appear to be broken -- because of JDK-8332744 -- but we will fix that separately.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343770](https://bugs.openjdk.org/browse/JDK-8343770): Build fails due to use of sun.misc.Unsafe in LoopOverRandom (**Bug** - P2)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21958/head:pull/21958` \
`$ git checkout pull/21958`

Update a local copy of the PR: \
`$ git checkout pull/21958` \
`$ git pull https://git.openjdk.org/jdk.git pull/21958/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21958`

View PR using the GUI difftool: \
`$ git pr show -t 21958`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21958.diff">https://git.openjdk.org/jdk/pull/21958.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21958#issuecomment-2462531800)
</details>
