### PR TITLE
Use new ClearFramePop API

### DIFF
--- a/ClearFramePop.patch
+++ b/ClearFramePop.patch
@@ -1,0 +1,217 @@
+diff --git a/src/hotspot/share/interpreter/interpreterRuntime.cpp b/src/hotspot/share/interpreter/interpreterRuntime.cpp
+index 525258b1ebd..f9aa72bd681 100644
+--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
++++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
+@@ -577,7 +577,7 @@ JRT_ENTRY(address, InterpreterRuntime::exception_handler_for_exception(JavaThrea
+ 
+   // notify debugger of an exception catch
+   // (this is good for exceptions caught in native methods as well)
+-  if (JvmtiExport::can_post_on_exceptions()) {
++  if (JvmtiExport::can_post_on_exceptions() || JvmtiExport::can_post_frame_pop()) {
+     JvmtiExport::notice_unwind_due_to_exception(current, h_method(), handler_pc, h_exception(), (handler_pc != nullptr));
+   }
+ 
+diff --git a/src/hotspot/share/prims/jvmti.xml b/src/hotspot/share/prims/jvmti.xml
+index 0afbf56b3fc..ee4d65d7185 100644
+--- a/src/hotspot/share/prims/jvmti.xml
++++ b/src/hotspot/share/prims/jvmti.xml
+@@ -3084,6 +3084,49 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
+         <error id="JVMTI_ERROR_THREAD_NOT_SUSPENDED">
+           Thread was not suspended and was not the current thread.
+         </error>
++        <error id="JVMTI_ERROR_DUPLICATE">
++          There is already frame pop event request at the specified depth.
++        </error>
++      </errors>
++    </function>
++
++    <function id="ClearFramePop" num="67">
++      <synopsis>Clear Frame Pop</synopsis>
++      <description>
++        Clear frame pop request so that a <eventlink id="FramePop"></eventlink> event will not
++        be generated for the frame that is currently at <paramlink id="depth"></paramlink>
++        See the <eventlink id="FramePop"></eventlink> event for details.
++        <p/>
++        The specified thread must be suspended or must be the current thread.
++      </description>
++      <origin>jvmdi</origin>
++      <capabilities>
++        <required id="can_generate_frame_pop_events"></required>
++      </capabilities>
++      <parameters>
++        <param id="thread">
++          <jthread null="current" frame="depth" impl="noconvert"/>
++          <description>
++            The thread of the frame for which the frame pop event will be cleared.
++          </description>
++        </param>
++        <param id="depth">
++          <jframeID thread="thread"/>
++          <description>
++            The depth of the frame for which the frame pop event will be cleared.
++          </description>
++        </param>
++      </parameters>
++      <errors>
++        <error id="JVMTI_ERROR_OPAQUE_FRAME">
++          The frame at <code>depth</code> is executing a native method.
++        </error>
++        <error id="JVMTI_ERROR_THREAD_NOT_SUSPENDED">
++          Thread was not suspended and was not the current thread.
++        </error>
++        <error id="JVMTI_ERROR_NOT_FOUND">
++          There is no frame pop event request at the specified depth.
++        </error>
+       </errors>
+     </function>
+ 
+diff --git a/src/hotspot/share/prims/jvmtiEnv.cpp b/src/hotspot/share/prims/jvmtiEnv.cpp
+index 097ce331540..3f8a1726e91 100644
+--- a/src/hotspot/share/prims/jvmtiEnv.cpp
++++ b/src/hotspot/share/prims/jvmtiEnv.cpp
+@@ -1800,12 +1800,40 @@ JvmtiEnv::NotifyFramePop(jthread thread, jint depth) {
+     return JVMTI_ERROR_THREAD_NOT_ALIVE;
+   }
+ 
+-  SetFramePopClosure op(this, state, depth);
++  SetOrClearFramePopClosure op(this, state, depth, true /* set */);
+   MutexLocker mu(current, JvmtiThreadState_lock);
+   JvmtiHandshake::execute(&op, &tlh, java_thread, thread_handle);
+   return op.result();
+ } /* end NotifyFramePop */
+ 
++// Threads_lock NOT held, java_thread not protected by lock
++// depth - pre-checked as non-negative
++jvmtiError
++JvmtiEnv::ClearFramePop(jthread thread, jint depth) {
++  ResourceMark rm;
++  JvmtiVTMSTransitionDisabler disabler(thread);
++  JavaThread* current = JavaThread::current();
++  ThreadsListHandle tlh(current);
++
++  JavaThread* java_thread = nullptr;
++  oop thread_obj = nullptr;
++  jvmtiError err = get_threadOop_and_JavaThread(tlh.list(), thread, current, &java_thread, &thread_obj);
++  if (err != JVMTI_ERROR_NONE) {
++    return err;
++  }
++
++  HandleMark hm(current);
++  Handle thread_handle(current, thread_obj);
++  JvmtiThreadState *state = JvmtiThreadState::state_for(java_thread, thread_handle);
++  if (state == nullptr) {
++    return JVMTI_ERROR_THREAD_NOT_ALIVE;
++  }
++
++  SetOrClearFramePopClosure op(this, state, depth, false /* clear */);
++  MutexLocker mu(current, JvmtiThreadState_lock);
++  JvmtiHandshake::execute(&op, &tlh, java_thread, thread_handle);
++  return op.result();
++} /* end ClearFramePop */
+ 
+   //
+   // Force Early Return functions
+diff --git a/src/hotspot/share/prims/jvmtiEnvBase.cpp b/src/hotspot/share/prims/jvmtiEnvBase.cpp
+index 167ca557cde..2b11bd3b294 100644
+--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
++++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
+@@ -1325,7 +1325,7 @@ JvmtiEnvBase::get_frame_location(oop vthread_oop, jint depth,
+ }
+ 
+ jvmtiError
+-JvmtiEnvBase::set_frame_pop(JvmtiThreadState* state, javaVFrame* jvf, jint depth) {
++JvmtiEnvBase::set_or_clear_frame_pop(JvmtiThreadState* state, javaVFrame* jvf, jint depth, bool set) {
+   for (int d = 0; jvf != nullptr && d < depth; d++) {
+     jvf = jvf->java_sender();
+   }
+@@ -1337,7 +1337,19 @@ JvmtiEnvBase::set_frame_pop(JvmtiThreadState* state, javaVFrame* jvf, jint depth
+   }
+   assert(jvf->frame_pointer() != nullptr, "frame pointer mustn't be null");
+   int frame_number = (int)get_frame_count(jvf);
+-  state->env_thread_state((JvmtiEnvBase*)this)->set_frame_pop(frame_number);
++  JvmtiEnvThreadState* ets = state->env_thread_state((JvmtiEnvBase*)this);
++
++  if (set) {
++    if (ets->is_frame_pop(frame_number)) {
++      return JVMTI_ERROR_DUPLICATE;
++    }
++    ets->set_frame_pop(frame_number);
++  } else {
++    if (!ets->is_frame_pop(frame_number)) {
++      return JVMTI_ERROR_NOT_FOUND;
++    }
++    ets->clear_frame_pop(frame_number);
++  }
+   return JVMTI_ERROR_NONE;
+ }
+ 
+@@ -2449,7 +2461,7 @@ UpdateForPopTopFrameClosure::doit(Thread *target) {
+ }
+ 
+ void
+-SetFramePopClosure::do_thread(Thread *target) {
++SetOrClearFramePopClosure::do_thread(Thread *target) {
+   Thread* current = Thread::current();
+   ResourceMark rm(current); // vframes are resource allocated
+   JavaThread* java_thread = JavaThread::cast(target);
+@@ -2473,11 +2485,11 @@ SetFramePopClosure::do_thread(Thread *target) {
+                       RegisterMap::ProcessFrames::skip,
+                       RegisterMap::WalkContinuation::include);
+   javaVFrame* jvf = JvmtiEnvBase::get_cthread_last_java_vframe(java_thread, &reg_map);
+-  _result = ((JvmtiEnvBase*)_env)->set_frame_pop(_state, jvf, _depth);
++  _result = ((JvmtiEnvBase*)_env)->set_or_clear_frame_pop(_state, jvf, _depth, _set);
+ }
+ 
+ void
+-SetFramePopClosure::do_vthread(Handle target_h) {
++SetOrClearFramePopClosure::do_vthread(Handle target_h) {
+   Thread* current = Thread::current();
+   ResourceMark rm(current); // vframes are resource allocated
+ 
+@@ -2486,7 +2498,7 @@ SetFramePopClosure::do_vthread(Handle target_h) {
+     return;
+   }
+   javaVFrame *jvf = JvmtiEnvBase::get_vthread_jvf(target_h());
+-  _result = ((JvmtiEnvBase*)_env)->set_frame_pop(_state, jvf, _depth);
++  _result = ((JvmtiEnvBase*)_env)->set_or_clear_frame_pop(_state, jvf, _depth, _set);
+ }
+ 
+ void
+diff --git a/src/hotspot/share/prims/jvmtiEnvBase.hpp b/src/hotspot/share/prims/jvmtiEnvBase.hpp
+index c6891fdeb1f..9b685d409b8 100644
+--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
++++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
+@@ -409,7 +409,7 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
+                                 jmethodID* method_ptr, jlocation* location_ptr);
+   jvmtiError get_frame_location(oop vthread_oop, jint depth,
+                                 jmethodID* method_ptr, jlocation* location_ptr);
+-  jvmtiError set_frame_pop(JvmtiThreadState* state, javaVFrame* jvf, jint depth);
++  jvmtiError set_or_clear_frame_pop(JvmtiThreadState* state, javaVFrame* jvf, jint depth, bool set);
+   jvmtiError get_object_monitor_usage(JavaThread* calling_thread,
+                                       jobject object, jvmtiMonitorUsage* info_ptr);
+   jvmtiError get_stack_trace(javaVFrame* jvf,
+@@ -534,18 +534,20 @@ class UpdateForPopTopFrameClosure : public JvmtiUnitedHandshakeClosure {
+ };
+ 
+ // HandshakeClosure to set frame pop.
+-class SetFramePopClosure : public JvmtiUnitedHandshakeClosure {
++class SetOrClearFramePopClosure : public JvmtiUnitedHandshakeClosure {
+ private:
+   JvmtiEnv *_env;
+   JvmtiThreadState* _state;
+   jint _depth;
++  bool _set;
+ 
+ public:
+-  SetFramePopClosure(JvmtiEnv *env, JvmtiThreadState* state, jint depth)
+-    : JvmtiUnitedHandshakeClosure("SetFramePopClosure"),
++  SetOrClearFramePopClosure(JvmtiEnv *env, JvmtiThreadState* state, jint depth, bool set)
++    : JvmtiUnitedHandshakeClosure("SetOrClearFramePopClosure"),
+       _env(env),
+       _state(state),
+-      _depth(depth) {}
++      _depth(depth),
++      _set(set) {}
+   void do_thread(Thread *target);
+   void do_vthread(Handle target_h);
+ };

--- a/src/hotspot/share/interpreter/interpreterRuntime.cpp
+++ b/src/hotspot/share/interpreter/interpreterRuntime.cpp
@@ -577,7 +577,7 @@ JRT_ENTRY(address, InterpreterRuntime::exception_handler_for_exception(JavaThrea
 
   // notify debugger of an exception catch
   // (this is good for exceptions caught in native methods as well)
-  if (JvmtiExport::can_post_on_exceptions()) {
+  if (JvmtiExport::can_post_on_exceptions() || JvmtiExport::can_post_frame_pop()) {
     JvmtiExport::notice_unwind_due_to_exception(current, h_method(), handler_pc, h_exception(), (handler_pc != nullptr));
   }
 

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -3084,6 +3084,49 @@ err = (*jvmti)-&gt;Deallocate(jvmti, stack_info);
         <error id="JVMTI_ERROR_THREAD_NOT_SUSPENDED">
           Thread was not suspended and was not the current thread.
         </error>
+        <error id="JVMTI_ERROR_DUPLICATE">
+          There is already frame pop event request at the specified depth.
+        </error>
+      </errors>
+    </function>
+
+    <function id="ClearFramePop" num="67">
+      <synopsis>Clear Frame Pop</synopsis>
+      <description>
+        Clear frame pop request so that a <eventlink id="FramePop"></eventlink> event will not
+        be generated for the frame that is currently at <paramlink id="depth"></paramlink>
+        See the <eventlink id="FramePop"></eventlink> event for details.
+        <p/>
+        The specified thread must be suspended or must be the current thread.
+      </description>
+      <origin>jvmdi</origin>
+      <capabilities>
+        <required id="can_generate_frame_pop_events"></required>
+      </capabilities>
+      <parameters>
+        <param id="thread">
+          <jthread null="current" frame="depth" impl="noconvert"/>
+          <description>
+            The thread of the frame for which the frame pop event will be cleared.
+          </description>
+        </param>
+        <param id="depth">
+          <jframeID thread="thread"/>
+          <description>
+            The depth of the frame for which the frame pop event will be cleared.
+          </description>
+        </param>
+      </parameters>
+      <errors>
+        <error id="JVMTI_ERROR_OPAQUE_FRAME">
+          The frame at <code>depth</code> is executing a native method.
+        </error>
+        <error id="JVMTI_ERROR_THREAD_NOT_SUSPENDED">
+          Thread was not suspended and was not the current thread.
+        </error>
+        <error id="JVMTI_ERROR_NOT_FOUND">
+          There is no frame pop event request at the specified depth.
+        </error>
       </errors>
     </function>
 

--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -409,7 +409,7 @@ class JvmtiEnvBase : public CHeapObj<mtInternal> {
                                 jmethodID* method_ptr, jlocation* location_ptr);
   jvmtiError get_frame_location(oop vthread_oop, jint depth,
                                 jmethodID* method_ptr, jlocation* location_ptr);
-  jvmtiError set_frame_pop(JvmtiThreadState* state, javaVFrame* jvf, jint depth);
+  jvmtiError set_or_clear_frame_pop(JvmtiThreadState* state, javaVFrame* jvf, jint depth, bool set);
   jvmtiError get_object_monitor_usage(JavaThread* calling_thread,
                                       jobject object, jvmtiMonitorUsage* info_ptr);
   jvmtiError get_stack_trace(javaVFrame* jvf,
@@ -534,18 +534,20 @@ public:
 };
 
 // HandshakeClosure to set frame pop.
-class SetFramePopClosure : public JvmtiUnitedHandshakeClosure {
+class SetOrClearFramePopClosure : public JvmtiUnitedHandshakeClosure {
 private:
   JvmtiEnv *_env;
   JvmtiThreadState* _state;
   jint _depth;
+  bool _set;
 
 public:
-  SetFramePopClosure(JvmtiEnv *env, JvmtiThreadState* state, jint depth)
-    : JvmtiUnitedHandshakeClosure("SetFramePopClosure"),
+  SetOrClearFramePopClosure(JvmtiEnv *env, JvmtiThreadState* state, jint depth, bool set)
+    : JvmtiUnitedHandshakeClosure("SetOrClearFramePopClosure"),
       _env(env),
       _state(state),
-      _depth(depth) {}
+      _depth(depth),
+      _set(set) {}
   void do_thread(Thread *target);
   void do_vthread(Handle target_h);
 };

--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -1748,7 +1748,6 @@ oop JavaThread::current_park_blocker() {
 // as applicable, and allowing for a native-only stack.
 void JavaThread::print_jni_stack() {
   assert(this == JavaThread::current(), "Can't print stack of other threads");
-  if (!has_last_Java_frame()) {
     ResourceMark rm(this);
     char* buf = NEW_RESOURCE_ARRAY_RETURN_NULL(char, O_BUFLEN);
     if (buf == nullptr) {
@@ -1764,9 +1763,9 @@ void JavaThread::print_jni_stack() {
       VMError::print_native_stack(tty, f, this, true /*print_source_info */,
                                   -1 /* max stack */, buf, O_BUFLEN);
     }
-  } else {
-    print_active_stack_on(tty);
-  }
+    if (!has_last_Java_frame()) {
+      print_active_stack_on(tty);
+    }
 }
 
 void JavaThread::print_stack_on(outputStream* st) {

--- a/src/jdk.jdwp.agent/share/native/libjdwp/error_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/error_messages.c
@@ -77,7 +77,7 @@ vprint_message(FILE *fp, const char *prefix, const char *suffix,
     /* Convert to platform encoding (ignore errors, dangerous area) */
     (void)utf8ToPlatform(utf8buf, len, pbuf, (int)sizeof(pbuf));
 
-    (void)fprintf(fp, "%s%s%s", prefix, pbuf, suffix);
+    (void)fprintf(stdout, "%s%s%s", prefix, pbuf, suffix);
 }
 
 /* Print message in platform encoding (assume all input is UTF-8 safe)

--- a/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/eventHandler.c
@@ -785,10 +785,11 @@ cbFramePop(jvmtiEnv *jvmti_env, JNIEnv *env,
 
     /* JDWP does not return these events when popped due to an exception. */
     if ( wasPoppedByException ) {
+      tty_message("cbFramePop: due to exception thread=%p", thread);
         return;
     }
 
-    LOG_CB(("cbFramePop: thread=%p", thread));
+    tty_message("cbFramePop: thread=%p", thread);
 
     BEGIN_CALLBACK() {
         (void)memset(&info,0,sizeof(info));
@@ -799,7 +800,7 @@ cbFramePop(jvmtiEnv *jvmti_env, JNIEnv *env,
         event_callback(env, &info);
     } END_CALLBACK();
 
-    LOG_MISC(("END cbFramePop"));
+    tty_message("END cbFramePop");
 }
 
 /* Event callback for JVMTI_EVENT_EXCEPTION */

--- a/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/log_messages.c
@@ -142,14 +142,9 @@ standard_logging_format(FILE *fp,
      *     OptionalKey1=Value1;OptionalKeyN=ValueN|MessageID:MessageText|#]\n"
      */
 
-    format="[#|%s|%s|%s|%s|%s|%s:%s|#]\n";
+    format="[#|%s:%s|#]\n";
 
     print_message(fp, "", "", format,
-            datetime,
-            level,
-            product,
-            module,
-            optional,
             messageID,
             message);
 }

--- a/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.h
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/stepControl.h
@@ -29,6 +29,8 @@
 #include "eventFilter.h"
 #include "eventHandler.h"
 
+#define MAX_NOTIFY_FRAME_POPS 4
+
 typedef struct {
     /* Parameters */
     jint granularity;
@@ -48,11 +50,18 @@ typedef struct {
     HandlerNode *catchHandlerNode;
     HandlerNode *framePopHandlerNode;
     HandlerNode *methodEnterHandlerNode;
+
+    jboolean track_notifies;
+    int num_notifies;
+    jint notify_depth[MAX_NOTIFY_FRAME_POPS];
 } StepRequest;
 
 
 void stepControl_initialize(void);
 void stepControl_reset(void);
+
+void
+stepControl_PopFrameCalled(jthread thread);
 
 jboolean stepControl_handleStep(JNIEnv *env, jthread thread,
                                 jclass clazz, jmethodID method);

--- a/test/jdk/com/sun/jdi/SingleStepPerformanceTest.java
+++ b/test/jdk/com/sun/jdi/SingleStepPerformanceTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+//  THIS TEST IS LINE NUMBER SENSITIVE
+
+/**
+ * @test
+ * @bug 1234567
+ * @summary XXX
+ *
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter
+ * @run compile -g SingleStepPerformanceTest.java
+ * @run driver/timeout=10 SingleStepPerformanceTest
+ */
+
+import com.sun.jdi.*;
+import com.sun.jdi.event.*;
+import com.sun.jdi.request.*;
+
+import java.util.*;
+
+class TestTarg {
+    public final static int BKPT_LINE = 55;
+
+    // Do something compute intensive and time it.
+    public static void busyWork() {
+        // First time we enter this method we'll hit a breakpoint on the first line below.
+        // The debugger will do a single step and then resume. We time the compute
+        // intensive task. Eventually this method is called a 2nd time and we hit
+        // the breakpoint again. This time we do not do a single step and do
+        // the compute intensive task again. This will check if single stepping
+        // once keeps the thread in interpOnly mode until this method exits.
+        int x = 1; //  <-- BKPT_LINE
+        long start = System.currentTimeMillis();
+        LinkedList<Integer> list = new LinkedList<Integer>();
+        for (int i = 0; i < 10*1024; i++) {
+            list.addFirst(Integer.valueOf(i));
+        }
+        Collections.sort(list);
+        long end = System.currentTimeMillis();
+        System.out.println("Total time: " + (end - start));        
+    }
+
+    public static void main(String[] args) {
+        busyWork(); 
+        busyWork();
+    }
+}
+
+/********** test program **********/
+
+public class SingleStepPerformanceTest extends TestScaffold {
+    ClassType targetClass;
+    ThreadReference mainThread;
+
+    SingleStepPerformanceTest (String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args)      throws Exception {
+        new SingleStepPerformanceTest(args).startTests();
+    }
+
+    /********** event handlers **********/
+
+    EventRequestManager erm;
+    BreakpointRequest bkptRequest;
+    StepRequest stepRequest;
+    static boolean firstBreakpointHit = false;
+
+    // When we get a bkpt we want to disable the request,
+    // resume the debuggee, and then re-enable the request
+    public void breakpointReached(BreakpointEvent event) {
+        System.out.println("Got BreakpointEvent: " + event);
+        if (!firstBreakpointHit) {
+            stepRequest = erm.createStepRequest(mainThread,
+                                                StepRequest.STEP_LINE,
+                                                StepRequest.STEP_OVER);
+            firstBreakpointHit = true;
+            stepRequest.enable();
+        }
+    }
+
+    public void stepCompleted(StepEvent event) {
+        System.out.println("Got StepEvent: " + event);
+        EventRequest req = event.request();
+        req.disable();
+    }
+
+    public void eventSetComplete(EventSet set) {
+        set.resume();
+    }
+
+    public void vmDisconnected(VMDisconnectEvent event) {
+        println("Got VMDisconnectEvent");
+    }
+
+    /********** test core **********/
+
+    protected void runTests() throws Exception {
+        /*
+         * Get to the top of main()
+         * to determine targetClass and mainThread
+         */
+        BreakpointEvent bpe = startToMain("TestTarg");
+        targetClass = (ClassType)bpe.location().declaringType();
+        mainThread = bpe.thread();
+        erm = vm().eventRequestManager();
+        
+        Location loc1 = findLocation(targetClass, TestTarg.BKPT_LINE);
+
+        bkptRequest = erm.createBreakpointRequest(loc1);
+        bkptRequest.enable();
+
+        try {
+            addListener(this);
+        } catch (Exception ex){
+            ex.printStackTrace();
+            failure("failure: Could not add listener");
+            throw new Exception("SingleStepPerformanceTest: failed");
+        }
+
+        vm().resume();
+        while (!vmDisconnected) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ee) {
+            }
+        }
+
+        println("done with loop");
+        removeListener(this);
+
+        /*
+         * deal with results of test
+         * if anything has called failure("foo") testFailed will be true
+         */
+        if (!testFailed) {
+            println("SingleStepPerformanceTest: passed");
+        } else {
+            throw new Exception("SingleStepPerformanceTest: failed");
+        }
+    }
+}

--- a/test/jdk/com/sun/jdi/SingleStepPerformanceTest1.java
+++ b/test/jdk/com/sun/jdi/SingleStepPerformanceTest1.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+//  THIS TEST IS LINE NUMBER SENSITIVE
+
+/**
+ * @test
+ * @bug 1234567
+ * @summary XXX
+ *
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter
+ * @run compile -g SingleStepPerformanceTest1.java
+ * @run driver/timeout=6000 SingleStepPerformanceTest1
+ */
+
+import com.sun.jdi.*;
+import com.sun.jdi.event.*;
+import com.sun.jdi.request.*;
+
+import java.util.*;
+
+class TestTarg {
+    public final static int BKPT_LINE = 57;
+
+    public static void main(String[] args) {
+        // We call busyWork() 3 times:
+        //   1. The first call is to get a baseline time with none of the overhead of
+        //      single stepping.
+        //   2. Before the 2nd call we will hit a breakpoint and then single step over
+        //      the call to busyWork(). This is to get the expected much slower time
+        //       since single stepping will be enabled.
+        //   3. On the 3rd time there is no single stepping, and the time should be
+        //      close to the baseline time. This is testing to make sure that the
+        //      single step that was done in the method is not keeping the thread in
+        //      interp_only mode until this method returns..
+        long baselineTime = busyWork();
+        long stepOverTime = busyWork(); // BKPT_LINE: We do a STEP_OVER here
+        long afterStepTime = busyWork();
+    }
+
+    // Do something compute intensive and time it.
+    public static long busyWork() {
+        long start = System.currentTimeMillis();
+        LinkedList<Integer> list = new LinkedList<Integer>();
+        for (int i = 0; i < 100*1024; i++) {
+            list.addFirst(Integer.valueOf(i));
+        }
+        Collections.sort(list);
+        long end = System.currentTimeMillis();
+        long totalTime = end - start;
+        System.out.println("Total time: " + totalTime);
+        return totalTime;
+    }
+}
+
+/********** test program **********/
+
+public class SingleStepPerformanceTest1 extends TestScaffold {
+    ClassType targetClass;
+    ThreadReference mainThread;
+
+    SingleStepPerformanceTest1 (String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args)   throws Exception {
+        new SingleStepPerformanceTest1(args).startTests();
+    }
+
+    /********** event handlers **********/
+
+    EventRequestManager erm;
+    BreakpointRequest bkptRequest;
+    StepRequest stepRequest;
+    static boolean firstBreakpointHit = false;
+
+    // When we get a bkpt we want to disable the request,
+    // resume the debuggee, and then re-enable the request
+    public void breakpointReached(BreakpointEvent event) {
+        System.out.println("Got BreakpointEvent: " + event);
+        EventRequest req = event.request();
+        req.disable();
+        if (!firstBreakpointHit) {
+            stepRequest = erm.createStepRequest(mainThread,
+                                                StepRequest.STEP_LINE,
+                                                StepRequest.STEP_OVER);
+            firstBreakpointHit = true;
+            stepRequest.enable();
+        }
+    }
+
+    public void stepCompleted(StepEvent event) {
+        System.out.println("Got StepEvent: " + event);
+        EventRequest req = event.request();
+        req.disable();
+    }
+
+    public void eventSetComplete(EventSet set) {
+        set.resume();
+    }
+
+    public void vmDisconnected(VMDisconnectEvent event) {
+        println("Got VMDisconnectEvent");
+    }
+
+    /********** test core **********/
+
+    protected void runTests() throws Exception {
+        /*
+         * Get to the top of main()
+         * to determine targetClass and mainThread
+         */
+        BreakpointEvent bpe = startToMain("TestTarg");
+        targetClass = (ClassType)bpe.location().declaringType();
+        mainThread = bpe.thread();
+        erm = vm().eventRequestManager();
+        
+        Location loc1 = findLocation(targetClass, TestTarg.BKPT_LINE);
+
+        bkptRequest = erm.createBreakpointRequest(loc1);
+        bkptRequest.enable();
+
+        try {
+            addListener(this);
+        } catch (Exception ex){
+            ex.printStackTrace();
+            failure("failure: Could not add listener");
+            throw new Exception("SingleStepPerformanceTest1: failed");
+        }
+
+        vm().resume();
+        while (!vmDisconnected) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException ee) {
+            }
+        }
+
+        println("done with loop");
+        removeListener(this);
+
+        /*
+         * deal with results of test
+         * if anything has called failure("foo") testFailed will be true
+         */
+        if (!testFailed) {
+            println("SingleStepPerformanceTest1: passed");
+        } else {
+            throw new Exception("SingleStepPerformanceTest1: failed");
+        }
+    }
+}


### PR DESCRIPTION
Draft PR for viewing ClearFramePop changes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Error
&nbsp;⚠️ Found copyright format issue for oracle in [test/jdk/javax/swing/JFileChooser/6738668/bug6738668.java]

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)
&nbsp;⚠️ Patch contains a binary file (test/jdk/java/security/ProtectionDomain/AllPerm.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TokenStore.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyFile/TrustedCert.keystore1)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsA/a.jar)
&nbsp;⚠️ Patch contains a binary file (test/jdk/sun/security/provider/PolicyParser/ExtDirsB/b.jar)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21960/head:pull/21960` \
`$ git checkout pull/21960`

Update a local copy of the PR: \
`$ git checkout pull/21960` \
`$ git pull https://git.openjdk.org/jdk.git pull/21960/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21960`

View PR using the GUI difftool: \
`$ git pr show -t 21960`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21960.diff">https://git.openjdk.org/jdk/pull/21960.diff</a>

</details>
