### PR TITLE
8343772: Expected IAPE not thrown in KDF.getInstance (TCK)

### DIFF
--- a/src/java.base/share/classes/javax/crypto/KDF.java
+++ b/src/java.base/share/classes/javax/crypto/KDF.java
@@ -467,8 +467,8 @@ public final class KDF {
             throws NoSuchAlgorithmException,
                    InvalidAlgorithmParameterException {
         Throwable cause = e.getCause();
-        if (cause instanceof InvalidAlgorithmParameterException) {
-            throw (InvalidAlgorithmParameterException) cause;
+        if (cause instanceof InvalidAlgorithmParameterException iape) {
+            throw iape;
         }
         throw e;
     }
@@ -686,7 +686,8 @@ public final class KDF {
         if (hasOne) throw new InvalidAlgorithmParameterException(
                 "The KDFParameters supplied could not be used in combination "
                 + "with the supplied algorithm for the selected Provider");
-        else throw new NoSuchAlgorithmException();
+        else throw new NoSuchAlgorithmException(
+                "No available provider supports the specified algorithm");
     }
 
     private static boolean checkSpiNonNull(Delegate d) {

--- a/src/java.base/share/classes/javax/crypto/KDF.java
+++ b/src/java.base/share/classes/javax/crypto/KDF.java
@@ -396,19 +396,21 @@ public final class KDF {
                    InvalidAlgorithmParameterException {
         Objects.requireNonNull(algorithm, "algorithm must not be null");
         Objects.requireNonNull(provider, "provider must not be null");
-
-        Instance instance = GetInstance.getInstance("KDF", KDFSpi.class,
-                                                    algorithm,
-                                                    kdfParameters,
-                                                    provider);
-        if (!JceSecurity.canUseProvider(instance.provider)) {
-            String msg = "JCE cannot authenticate the provider "
-                         + instance.provider.getName();
-            throw new NoSuchProviderException(msg);
+        try {
+            Instance instance = GetInstance.getInstance("KDF", KDFSpi.class,
+                                                        algorithm,
+                                                        kdfParameters,
+                                                        provider);
+            if (!JceSecurity.canUseProvider(instance.provider)) {
+                String msg = "JCE cannot authenticate the provider "
+                             + instance.provider.getName();
+                throw new NoSuchProviderException(msg);
+            }
+            return new KDF(new Delegate((KDFSpi) instance.impl,
+                                        instance.provider), algorithm);
+        } catch (NoSuchAlgorithmException nsae) {
+            return handleException(nsae);
         }
-        return new KDF(new Delegate((KDFSpi) instance.impl,
-                                    instance.provider), algorithm
-        );
     }
 
     /**
@@ -444,18 +446,31 @@ public final class KDF {
                    InvalidAlgorithmParameterException {
         Objects.requireNonNull(algorithm, "algorithm must not be null");
         Objects.requireNonNull(provider, "provider must not be null");
-        Instance instance = GetInstance.getInstance("KDF", KDFSpi.class,
-                                                    algorithm,
-                                                    kdfParameters,
-                                                    provider);
-        if (!JceSecurity.canUseProvider(instance.provider)) {
-            String msg = "JCE cannot authenticate the provider "
-                         + instance.provider.getName();
-            throw new SecurityException(msg);
+        try {
+            Instance instance = GetInstance.getInstance("KDF", KDFSpi.class,
+                                                        algorithm,
+                                                        kdfParameters,
+                                                        provider);
+            if (!JceSecurity.canUseProvider(instance.provider)) {
+                String msg = "JCE cannot authenticate the provider "
+                             + instance.provider.getName();
+                throw new SecurityException(msg);
+            }
+            return new KDF(new Delegate((KDFSpi) instance.impl,
+                                        instance.provider), algorithm);
+        } catch (NoSuchAlgorithmException nsae) {
+            return handleException(nsae);
         }
-        return new KDF(new Delegate((KDFSpi) instance.impl,
-                                    instance.provider), algorithm
-        );
+    }
+
+    private static KDF handleException(NoSuchAlgorithmException e)
+            throws NoSuchAlgorithmException,
+                   InvalidAlgorithmParameterException {
+        Throwable cause = e.getCause();
+        if (cause instanceof InvalidAlgorithmParameterException) {
+            throw (InvalidAlgorithmParameterException) cause;
+        }
+        throw e;
     }
 
     /**

--- a/test/jdk/com/sun/crypto/provider/KDF/HKDFExhaustiveTest.java
+++ b/test/jdk/com/sun/crypto/provider/KDF/HKDFExhaustiveTest.java
@@ -69,6 +69,8 @@ public class HKDFExhaustiveTest {
   private static final int LARGE_LENGTH = 1000;
   private static final int NEGATIVE_LENGTH = -1;
 
+  static class TestKDFParams implements KDFParameters {}
+
   private static final KdfVerifier<String, String, AlgorithmParameterSpec> KdfGetInstanceVerifier =
       (a, p, s) -> {
 
@@ -304,6 +306,9 @@ public class HKDFExhaustiveTest {
     Utils.runAndCheckException(
         () -> KDF.getInstance(KDF_ALGORITHMS[0], null, INVALID_STRING),
         NoSuchProviderException.class);
+    Utils.runAndCheckException(
+        () -> KDF.getInstance(KDF_ALGORITHMS[0], new TestKDFParams(), SUNJCE),
+        InvalidAlgorithmParameterException.class);
 
     // getInstance(String algorithm, KDFParameters kdfParameters, Provider provider)
     Utils.runAndCheckException(

--- a/test/jdk/com/sun/crypto/provider/KDF/HKDFExhaustiveTest.java
+++ b/test/jdk/com/sun/crypto/provider/KDF/HKDFExhaustiveTest.java
@@ -309,6 +309,9 @@ public class HKDFExhaustiveTest {
     Utils.runAndCheckException(
         () -> KDF.getInstance(KDF_ALGORITHMS[0], new TestKDFParams(), SUNJCE),
         InvalidAlgorithmParameterException.class);
+    Utils.runAndCheckException(
+        () -> KDF.getInstance(KDF_ALGORITHMS[0], new TestKDFParams(), SUNJCE_PROVIDER),
+        InvalidAlgorithmParameterException.class);
 
     // getInstance(String algorithm, KDFParameters kdfParameters, Provider provider)
     Utils.runAndCheckException(


### PR DESCRIPTION
TCK/spec compliance fix for two `getInstance` methods in KDF - unwrap a wrapped IAPE from an NSAE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343772](https://bugs.openjdk.org/browse/JDK-8343772): Expected IAPE not thrown in KDF.getInstance (TCK) (**Bug** - P4)


### Reviewers
 * [Valerie Peng](https://openjdk.org/census#valeriep) (@valeriepeng - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21961/head:pull/21961` \
`$ git checkout pull/21961`

Update a local copy of the PR: \
`$ git checkout pull/21961` \
`$ git pull https://git.openjdk.org/jdk.git pull/21961/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21961`

View PR using the GUI difftool: \
`$ git pr show -t 21961`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21961.diff">https://git.openjdk.org/jdk/pull/21961.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21961#issuecomment-2462694069)
</details>
