### PR TITLE
8343805: RISC-V: JVM crashes on startup when disabling compressed instructions

### DIFF
--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
@@ -39,7 +39,7 @@ enum platform_dependent_constants {
   // simply increase sizes if too small (assembler will crash if too small)
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
-  _compiler_stubs_code_size     = 25000 ZGC_ONLY(+5000),
+  _compiler_stubs_code_size     = 35000 ZGC_ONLY(+5000),
   _final_stubs_code_size        = 20000 ZGC_ONLY(+10000)
 };
 

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
@@ -39,7 +39,7 @@ enum platform_dependent_constants {
   // simply increase sizes if too small (assembler will crash if too small)
   _initial_stubs_code_size      = 10000,
   _continuation_stubs_code_size =  2000,
-  _compiler_stubs_code_size     = 35000 ZGC_ONLY(+5000),
+  _compiler_stubs_code_size     = 45000,
   _final_stubs_code_size        = 20000 ZGC_ONLY(+10000)
 };
 


### PR DESCRIPTION
Hello, please review this trivial change.

The reason of the crash is that we will use more space for compiler stubs during stubRoutines generation when compressed instructions is disabled expecially when the CPU is not equipped with the RISC-V B extension. So this simply increases the reserved size of compiler stubs for this CPU platform. After this change, we have (without B extension):

```
$ java -Xlog:stubs -XX:-UseRVC -version
[0.010s][info][stubs] StubRoutines (initial stubs)       [0x0000003f8f3cf340, 0x0000003f8f3d1cd0] used: 604, free: 10036
[0.117s][info][stubs] StubRoutines (continuation stubs)  [0x0000003f8f3d25c0, 0x0000003f8f3d3010] used: 628, free: 2012
[0.153s][info][stubs] StubRoutines (final stubs)         [0x0000003f8f4025c0, 0x0000003f8f409d70] used: 9380, free: 21260
[0.199s][info][stubs] StubRoutines (compiler stubs)      [0x0000003f8f4d7c40, 0x0000003f8f4e3180] used: 38924, free: 7476
```

(PS: Same issue also triggers when building without ZGC (`--disable-jvm-feature-zgc`))

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343805](https://bugs.openjdk.org/browse/JDK-8343805): RISC-V: JVM crashes on startup when disabling compressed instructions (**Bug** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21966/head:pull/21966` \
`$ git checkout pull/21966`

Update a local copy of the PR: \
`$ git checkout pull/21966` \
`$ git pull https://git.openjdk.org/jdk.git pull/21966/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21966`

View PR using the GUI difftool: \
`$ git pr show -t 21966`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21966.diff">https://git.openjdk.org/jdk/pull/21966.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21966#issuecomment-2463623417)
</details>
