### PR TITLE
8343810: [s390x] is_uimm* methods should take unsigned arguments

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -56,24 +56,23 @@ class Immediate {
     }
 
     // Test if x is within signed immediate range for nbits.
-    static bool is_uimm(int64_t x, unsigned int nbits) {
+    static bool is_uimm(uint64_t x, unsigned int nbits) {
       // nbits == 0  --> false
       // nbits >= 64 --> true
       assert(1 <= nbits && nbits < 64, "don't call, use statically known result");
-      const uint64_t xu       = (unsigned long)x;
       const uint64_t maxplus1 = 1UL << nbits;
-      return xu < maxplus1; // Unsigned comparison. Negative inputs appear to be very large.
+      return x < maxplus1; // Unsigned comparison. Negative inputs appear to be very large.
     }
-    static bool is_uimm32(int64_t x) {
+    static bool is_uimm32(uint64_t x) {
       return is_uimm(x, 32);
     }
-    static bool is_uimm16(int64_t x) {
+    static bool is_uimm16(uint64_t x) {
       return is_uimm(x, 16);
     }
-    static bool is_uimm12(int64_t x) {
+    static bool is_uimm12(uint64_t x) {
       return is_uimm(x, 12);
     }
-    static bool is_uimm8(int64_t x) {
+    static bool is_uimm8(uint64_t x) {
       return is_uimm(x,  8);
     }
 };


### PR DESCRIPTION
trivial patch which just updates the argument datatype of `is_uimm*` methods, from `int64_t` to `uint64_t`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343810](https://bugs.openjdk.org/browse/JDK-8343810): [s390x] is_uimm* methods should take unsigned arguments (**Enhancement** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21967/head:pull/21967` \
`$ git checkout pull/21967`

Update a local copy of the PR: \
`$ git checkout pull/21967` \
`$ git pull https://git.openjdk.org/jdk.git pull/21967/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21967`

View PR using the GUI difftool: \
`$ git pr show -t 21967`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21967.diff">https://git.openjdk.org/jdk/pull/21967.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21967#issuecomment-2463764567)
</details>
