### PR TITLE
8343488: Test VectorRebracket128Test.java can't exclude by test/hotspot/jtreg/ProblemList.txt

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -58,7 +58,7 @@ compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-all
 
 compiler/vectorapi/reshape/TestVectorReinterpret.java 8320897 aix-ppc64,linux-ppc64le
 compiler/vectorapi/VectorLogicalOpIdentityTest.java 8302459 linux-x64,windows-x64
-compiler/vectorapi/VectorRebracket128Test.java#Z 8330538 generic-all
+compiler/vectorapi/VectorRebracket128Test.java 8330538 generic-all
 
 compiler/jvmci/TestUncaughtErrorInCompileMethod.java 8309073 generic-all
 compiler/jvmci/jdk.vm.ci.code.test/src/jdk/vm/ci/code/test/DataPatchTest.java 8331704 linux-riscv64

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorRebracket128Test.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorRebracket128Test.java
@@ -35,7 +35,7 @@ import jdk.incubator.vector.*;
 import jdk.internal.vm.annotation.ForceInline;
 
 /*
- * @test id=Z
+ * @test
  * @bug 8260473
  * @requires vm.gc.Z
  * @modules jdk.incubator.vector


### PR DESCRIPTION
Hi all,
The test `test/hotspot/jtreg/compiler/vectorapi/VectorRebracket128Test.java` can't exclude from `test/hotspot/jtreg/ProblemList.txt` correctly. The test only contains a single test, so it do not need to set test suffix.
This PR remove the test suffix to make the Problemlist work normally, trivial fix, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343488](https://bugs.openjdk.org/browse/JDK-8343488): Test VectorRebracket128Test.java can't exclude by test/hotspot/jtreg/ProblemList.txt (**Bug** - P5)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21968/head:pull/21968` \
`$ git checkout pull/21968`

Update a local copy of the PR: \
`$ git checkout pull/21968` \
`$ git pull https://git.openjdk.org/jdk.git pull/21968/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21968`

View PR using the GUI difftool: \
`$ git pr show -t 21968`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21968.diff">https://git.openjdk.org/jdk/pull/21968.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21968#issuecomment-2463895954)
</details>
