### PR TITLE
8343783: Improve asserts in concurrentHashTable.inline.hpp

### DIFF
--- a/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
+++ b/src/hotspot/share/utilities/concurrentHashTable.inline.hpp
@@ -491,7 +491,7 @@ inline void ConcurrentHashTable<CONFIG, MT>::
   Node* ndel_stack[StackBufferSize];
   InternalTable* table = get_table();
   assert(start_idx < stop_idx, "Must be");
-  assert(stop_idx <= _table->_size, "Must be");
+  assert(stop_idx <= _table->_size, "stop_idx %zu larger than table size %zu", stop_idx, _table->_size);
   // Here manual do critical section since we don't want to take the cost of
   // locking the bucket if there is nothing to delete. But we can have
   // concurrent single deletes. The _invisible_epoch can only be used by the
@@ -1185,7 +1185,7 @@ inline bool ConcurrentHashTable<CONFIG, MT>::
   do_scan_for_range(FUNC& scan_f, size_t start_idx, size_t stop_idx, InternalTable* table)
 {
   assert(start_idx < stop_idx, "Must be");
-  assert(stop_idx <= table->_size, "Must be");
+  assert(stop_idx <= table->_size, "stop_idx %zu larger than table size %zu", stop_idx, table->_size);
 
   for (size_t bucket_it = start_idx; bucket_it < stop_idx; ++bucket_it) {
     Bucket* bucket = table->get_bucket(bucket_it);


### PR DESCRIPTION
Hi all,

  please review this simple change to improve the asserts in the CHT to get more information if/when there is a failure like in JDK-8337216.

Testing: gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343783](https://bugs.openjdk.org/browse/JDK-8343783): Improve asserts in concurrentHashTable.inline.hpp (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21970/head:pull/21970` \
`$ git checkout pull/21970`

Update a local copy of the PR: \
`$ git checkout pull/21970` \
`$ git pull https://git.openjdk.org/jdk.git pull/21970/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21970`

View PR using the GUI difftool: \
`$ git pr show -t 21970`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21970.diff">https://git.openjdk.org/jdk/pull/21970.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21970#issuecomment-2464143829)
</details>
