### PR TITLE
8211033: Clean up the processing -classpath argument not to set LM_CLASS

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -1198,9 +1198,6 @@ ParseArguments(int *pargc, char ***pargv,
                    JLI_StrCmp(arg, "-cp") == 0) {
             REPORT_ERROR (has_arg_any_len, ARG_ERROR1, arg);
             SetClassPath(value);
-            if (mode != LM_SOURCE) {
-                mode = LM_CLASS;
-            }
         } else if (JLI_StrCmp(arg, "--list-modules") == 0) {
             listModules = JNI_TRUE;
         } else if (JLI_StrCmp(arg, "--show-resolved-modules") == 0) {
@@ -1355,11 +1352,12 @@ ParseArguments(int *pargc, char ***pargv,
             *pret = 1;
         }
     } else if (mode == LM_UNKNOWN) {
-        /* default to LM_CLASS if -m, -jar and -cp options are
-         * not specified */
         if (!_have_classpath) {
             SetClassPath(".");
         }
+        /* If neither of -m, -jar, --source option is set, then the
+         * launcher mode is LM_UNKNOWN. In such cases, we determine the
+         * mode as LM_CLASS or LM_SOURCE per the input file. */
         mode = IsSourceFile(arg) ? LM_SOURCE : LM_CLASS;
     } else if (mode == LM_CLASS && IsSourceFile(arg)) {
         /* override LM_CLASS mode if given a source file */


### PR DESCRIPTION
Can I please get a review of this change which addresses https://bugs.openjdk.org/browse/JDK-8211033?

As noted in that issue, this is a clean up of the code which determines the "mode" through with the `java` application is being launched. In its current form the presence of `--classpath` (or its equivalent arguments) was unnecessary updating the mode to `LM_CLASS`. The commit in this PR removes that part to allow for the mode to be detected based merely on the presence (or absence) of `-m`, `-jar`, `--source` options. If neither is specified, the file extension is checked to determine the launch mode. 

Given the nature of this clean up, no new tests have been introduced. Existing tests in tier1, tier2, tier3 continue to pass with this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8211033](https://bugs.openjdk.org/browse/JDK-8211033): Clean up the processing -classpath argument not to set LM_CLASS (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21971/head:pull/21971` \
`$ git checkout pull/21971`

Update a local copy of the PR: \
`$ git checkout pull/21971` \
`$ git pull https://git.openjdk.org/jdk.git pull/21971/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21971`

View PR using the GUI difftool: \
`$ git pr show -t 21971`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21971.diff">https://git.openjdk.org/jdk/pull/21971.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21971#issuecomment-2464165806)
</details>
