### PR TITLE
8343819: Link Float.NaN and Double.NaN to equivalence discussion in Double

### DIFF
--- a/src/java.base/share/classes/java/lang/Double.java
+++ b/src/java.base/share/classes/java/lang/Double.java
@@ -375,9 +375,9 @@ public final class Double extends Number
     public static final double NEGATIVE_INFINITY = -1.0 / 0.0;
 
     /**
-     * A constant holding a Not-a-Number (NaN) value of type
-     * {@code double}. It is equivalent to the value returned by
-     * {@code Double.longBitsToDouble(0x7ff8000000000000L)}.
+     * A constant holding a Not-a-Number (NaN) value of type {@code double}.
+     * It is {@linkplain Double##equivalenceRelation equivalent} to the
+     * value returned by {@code Double.longBitsToDouble(0x7ff8000000000000L)}.
      */
     public static final double NaN = 0.0d / 0.0;
 

--- a/src/java.base/share/classes/java/lang/Float.java
+++ b/src/java.base/share/classes/java/lang/Float.java
@@ -93,9 +93,9 @@ public final class Float extends Number
     public static final float NEGATIVE_INFINITY = -1.0f / 0.0f;
 
     /**
-     * A constant holding a Not-a-Number (NaN) value of type
-     * {@code float}.  It is equivalent to the value returned by
-     * {@code Float.intBitsToFloat(0x7fc00000)}.
+     * A constant holding a Not-a-Number (NaN) value of type {@code float}.
+     * It is {@linkplain Double##equivalenceRelation equivalent}
+     * to the value returned by{@code Float.intBitsToFloat(0x7fc00000)}.
      */
     public static final float NaN = 0.0f / 0.0f;
 


### PR DESCRIPTION
Please review this doc-only enhancement which links the word _equivalent_ in `Float.NaN` and `Double.NaN` constant field descriptions to the floating-point equivalence discussion in `Double`.  

> It is equivalent to the value returned by{@code Float.intBitsToFloat(0x7fc00000)}.

For readers not well-versed in floating point, it may not be immediatly clear what _equivalent to_ means here.

The smallest improvement I could think of is to simply make the word `equivalent` a plain link to the floating-point equivalence discussion in the class description of `java.lang.Double`.

Verification: This is a doc-only change. I ran `make docs` and verified that the links resolve.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343819](https://bugs.openjdk.org/browse/JDK-8343819): Link Float.NaN and Double.NaN to equivalence discussion in Double (**Enhancement** - P4)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21972/head:pull/21972` \
`$ git checkout pull/21972`

Update a local copy of the PR: \
`$ git checkout pull/21972` \
`$ git pull https://git.openjdk.org/jdk.git pull/21972/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21972`

View PR using the GUI difftool: \
`$ git pr show -t 21972`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21972.diff">https://git.openjdk.org/jdk/pull/21972.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21972#issuecomment-2464414319)
</details>
