### PR TITLE
8343827: RISC-V: set AlignVector as false if applicable to enable SLP

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -171,7 +171,7 @@ void VM_Version::common_initialize() {
   }
 
   if (FLAG_IS_DEFAULT(AlignVector)) {
-    AlignVector = AvoidUnalignedAccesses;
+    FLAG_SET_DEFAULT(AlignVector, AvoidUnalignedAccesses);
   }
 
   // See JDK-8026049

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -166,11 +166,12 @@ void VM_Version::common_initialize() {
   }
 
   if (FLAG_IS_DEFAULT(AvoidUnalignedAccesses)) {
-    if (unaligned_access.value() != MISALIGNED_FAST) {
-      FLAG_SET_DEFAULT(AvoidUnalignedAccesses, true);
-    } else {
-      FLAG_SET_DEFAULT(AvoidUnalignedAccesses, false);
-    }
+    FLAG_SET_DEFAULT(AvoidUnalignedAccesses,
+      unaligned_access.value() != MISALIGNED_FAST);
+  }
+
+  if (FLAG_IS_DEFAULT(AlignVector)) {
+    AlignVector = AvoidUnalignedAccesses;
   }
 
   // See JDK-8026049


### PR DESCRIPTION
Hi,
Can you help to review this patch?

SLP vectorization in C2 checks the data alignment optionally, if fast misaliged access is supported by CPU it will skip the alignment check in SLP, this is good for both C2 compile time and run time (as more loops can be potentially vectorized. And the performance of vector implementation is good enough, which was already verified by existing tests (array copy, crc32, ...)).
On the other hand, we have some existing tests which verify that generated IRs should contain some specific Nodes, with the intrdocution of Compact Object Header, some tests related to SLP was observed failure which is due to the data offset change which is due to header change in the JEP, by enabling C2 SLP when fast misaliged access is supported, we should be able to resolve these issues. Although riscv support misaligned access optionally, started from RVA22 it's mandatory.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343827](https://bugs.openjdk.org/browse/JDK-8343827): RISC-V: set AlignVector as false if applicable to enable SLP (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer) Review applies to [696972ec](https://git.openjdk.org/jdk/pull/21974/files/696972ec364ec71ed5327c417c8651e35afc2285)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21974/head:pull/21974` \
`$ git checkout pull/21974`

Update a local copy of the PR: \
`$ git checkout pull/21974` \
`$ git pull https://git.openjdk.org/jdk.git pull/21974/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21974`

View PR using the GUI difftool: \
`$ git pr show -t 21974`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21974.diff">https://git.openjdk.org/jdk/pull/21974.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21974#issuecomment-2464526629)
</details>
