### PR TITLE
8343774: Positive list platforms for ir checks of compiler/c2/TestCastX2NotProcessedIGVN.java

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
@@ -63,7 +63,7 @@ public class TestCastX2NotProcessedIGVN {
 
     @Test
     @IR(counts = {IRNode.LOAD_VECTOR_I, "> 1"},
-        applyIfPlatformOr = {"x64", "true", "aarch64", "true", "riscv64", "true"})
+        applyIfPlatformOr = {"x64", "true", "aarch64", "true"})
     public static int test2(int stop, int[] array) {
         int v = 0;
         stop = Math.min(stop, Integer.MAX_VALUE / 4);

--- a/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
@@ -30,7 +30,6 @@ import jdk.internal.misc.Unsafe;
  * @test
  * @bug 8343068
  * @summary C2: CastX2P Ideal transformation not always applied
- * @requires os.arch != "ppc64le" & os.arch != "ppc64"
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  * @run driver compiler.c2.TestCastX2NotProcessedIGVN
@@ -63,7 +62,8 @@ public class TestCastX2NotProcessedIGVN {
     }
 
     @Test
-    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 1"})
+    @IR(counts = {IRNode.LOAD_VECTOR_I, "> 1"},
+        applyIfPlatformOr = {"x64", "true", "aarch64", "true", "riscv64", "true"})
     public static int test2(int stop, int[] array) {
         int v = 0;
         stop = Math.min(stop, Integer.MAX_VALUE / 4);

--- a/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
+++ b/test/hotspot/jtreg/compiler/c2/TestCastX2NotProcessedIGVN.java
@@ -30,6 +30,7 @@ import jdk.internal.misc.Unsafe;
  * @test
  * @bug 8343068
  * @summary C2: CastX2P Ideal transformation not always applied
+ * @requires os.arch != "ppc64le" & os.arch != "ppc64"
  * @modules java.base/jdk.internal.misc
  * @library /test/lib /
  * @run driver compiler.c2.TestCastX2NotProcessedIGVN


### PR DESCRIPTION
Vectorization of the loop in `test2` does not work on ppc therefore I want to exclude it there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343774](https://bugs.openjdk.org/browse/JDK-8343774): Positive list platforms for ir checks of compiler/c2/TestCastX2NotProcessedIGVN.java (**Sub-task** - P4)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**) Review applies to [a7c2872b](https://git.openjdk.org/jdk/pull/21975/files/a7c2872b86ec6b43562cdc49403347cba16bdbc4)
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21975/head:pull/21975` \
`$ git checkout pull/21975`

Update a local copy of the PR: \
`$ git checkout pull/21975` \
`$ git pull https://git.openjdk.org/jdk.git pull/21975/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21975`

View PR using the GUI difftool: \
`$ git pr show -t 21975`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21975.diff">https://git.openjdk.org/jdk/pull/21975.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21975#issuecomment-2464893298)
</details>
