### PR TITLE
8343793: Test java/foreign/TestMemorySession.java is timing out

### DIFF
--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -326,52 +326,56 @@ public class TestMemorySession {
         int iteration = 1000;
         AtomicInteger lock = new AtomicInteger();
         boolean[] result = new boolean[1];
-        lock.set(-2);
         MemorySessionImpl[] scopes = new MemorySessionImpl[iteration];
         for (int i = 0; i < iteration; i++) {
             scopes[i] = MemorySessionImpl.toMemorySession(Arena.ofShared());
         }
 
+        // These two threads proceed the scopes array in a lock-step manner, the first thread wait
+        // for the second thread on the lock variable, while the second thread wait for the first
+        // thread on the closing of the current scope
+
         // This thread tries to close the scopes
         Thread t1 = new Thread(() -> {
-            for (int i = 0; i < iteration; i++) {
+            for (int i = 0; i < iteration;) {
                 MemorySessionImpl scope = scopes[i];
                 while (true) {
                     try {
                         scope.close();
+                        // Continue to the next iteration after a successful close
                         break;
-                    } catch (IllegalStateException e) {}
+                    } catch (IllegalStateException e) {
+                        // Wait for the release and try again
+                    }
                 }
-                // Keep the 2 threads operating on the same scope
-                int k = lock.getAndAdd(1) + 1;
-                while (k < i * 2) {
+                // Wait for the other thread to complete its iteration
+                int prev = i;
+                while (prev == i) {
+                    i = lock.get();
                     Thread.onSpinWait();
-                    k = lock.get();
                 }
             }
         });
 
         // This thread tries to acquire the scopes, then check if it is alive after an acquire failure
         Thread t2 = new Thread(() -> {
-            for (int i = 0; i < iteration; i++) {
+            for (int i = 0; i < iteration;) {
                 MemorySessionImpl scope = scopes[i];
                 while (true) {
                     try {
                         scope.acquire0();
                     } catch (IllegalStateException e) {
+                        // The scope has been closed, proceed to the next iteration
                         if (scope.isAlive()) {
                             result[0] = true;
                         }
                         break;
                     }
+                    // Release and try again
                     scope.release0();
                 }
-                // Keep the 2 threads operating on the same scope
-                int k = lock.getAndAdd(1) + 1;
-                while (k < i * 2) {
-                    Thread.onSpinWait();
-                    k = lock.get();
-                }
+                // Proceed to the next iteration
+                i = lock.getAndAdd(1) + 1;
             }
         });
 

--- a/test/jdk/java/foreign/TestMemorySession.java
+++ b/test/jdk/java/foreign/TestMemorySession.java
@@ -344,7 +344,7 @@ public class TestMemorySession {
                 }
                 // Keep the 2 threads operating on the same scope
                 int k = lock.getAndAdd(1) + 1;
-                while (k != i * 2) {
+                while (k < i * 2) {
                     Thread.onSpinWait();
                     k = lock.get();
                 }
@@ -368,7 +368,7 @@ public class TestMemorySession {
                 }
                 // Keep the 2 threads operating on the same scope
                 int k = lock.getAndAdd(1) + 1;
-                while (k != i * 2) {
+                while (k < i * 2) {
                     Thread.onSpinWait();
                     k = lock.get();
                 }


### PR DESCRIPTION
Hi,

This patch fixes the deadlock in `TestMemorySession#testAcquireCloseRace`. The lock-step spin lock is implemented as with `lock` being an `AtomicInteger`:

    // Keep the 2 threads operating on the same scope
    int k = lock.getAndAdd(1) + 1;
    while (k != i * 2) {
        Thread.onSpinWait();
        k = lock.get();
    }

Given the initial condition:

    Thread 1: i = 0
    Thread 2: i = 0
    lock: -2

The `lock` then undergoes the following operations:



        Thread 1          Thread 2         lock value
      getAndAdd(1)                            -1
                        getAndAdd(1)           0 -> Thread 2 then continues its next iteration, its i value is now 1
                        getAndAdd(1)           1 -> Thread 2 reaches the next iteration before thread 1 has a chance to read the value 0
          get()                                1 -> Thread 1 now cannot proceed because it missed the value 0
                           get()               1 -> Thread 2 now cannot proceed because lock can never reach 2


The solution is to not rely on the exact value of the lock but instead whether the lock has passed the expected value.

Testing: I have run this test several hundreds times and got no failure while without this patch I encountered a timeout every approximately 30 times.

Please take a look, thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343793](https://bugs.openjdk.org/browse/JDK-8343793): Test java/foreign/TestMemorySession.java is timing out (**Bug** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21976/head:pull/21976` \
`$ git checkout pull/21976`

Update a local copy of the PR: \
`$ git checkout pull/21976` \
`$ git pull https://git.openjdk.org/jdk.git pull/21976/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21976`

View PR using the GUI difftool: \
`$ git pr show -t 21976`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21976.diff">https://git.openjdk.org/jdk/pull/21976.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21976#issuecomment-2464576568)
</details>
