### PR TITLE
8343837: Remove unnecessary reinterpret_cast from C2AccessValuePtr

### DIFF
--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -94,7 +94,7 @@ public:
   C2AccessValuePtr(Node* node, const TypePtr* type) :
     C2AccessValue(node, type) {}
 
-  const TypePtr* type() const { return static_cast<const TypePtr*>(_type); }
+  const TypePtr* type() const { return _type->is_ptr(); }
 };
 
 // This class wraps a bunch of context parameters that are passed around in the

--- a/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
+++ b/src/hotspot/share/gc/shared/c2/barrierSetC2.hpp
@@ -92,9 +92,9 @@ class C2AccessValuePtr: public C2AccessValue {
 
 public:
   C2AccessValuePtr(Node* node, const TypePtr* type) :
-    C2AccessValue(node, reinterpret_cast<const Type*>(type)) {}
+    C2AccessValue(node, type) {}
 
-  const TypePtr* type() const { return reinterpret_cast<const TypePtr*>(_type); }
+  const TypePtr* type() const { return static_cast<const TypePtr*>(_type); }
 };
 
 // This class wraps a bunch of context parameters that are passed around in the


### PR DESCRIPTION
C2AccessValuePtr contains a reinterpret cast from TypePtr* to its base class Type*. This cast was added in [JDK-8202377](https://bugs.openjdk.org/browse/JDK-8202377), due to a circular dependency problem, which no longer exists. The code compiles fine without it and this cast was removed.

Furthermore, a downcast from Type* to TypePtr* exists in this class using reinterpret_cast. This is replaced with Type::is_ptr, which performs the downcast safely by including an assert.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343837](https://bugs.openjdk.org/browse/JDK-8343837): Remove unnecessary reinterpret_cast from C2AccessValuePtr (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21977/head:pull/21977` \
`$ git checkout pull/21977`

Update a local copy of the PR: \
`$ git checkout pull/21977` \
`$ git pull https://git.openjdk.org/jdk.git pull/21977/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21977`

View PR using the GUI difftool: \
`$ git pr show -t 21977`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21977.diff">https://git.openjdk.org/jdk/pull/21977.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21977#issuecomment-2464776201)
</details>
