### PR TITLE
8344637: Fix Page8 of manual test java/awt/print/PrinterJob/PrintTextTest.java on Linux and Windows

### DIFF
--- a/src/java.desktop/share/classes/sun/print/PathGraphics.java
+++ b/src/java.desktop/share/classes/sun/print/PathGraphics.java
@@ -943,9 +943,9 @@ public abstract class PathGraphics extends ProxyGraphics2D {
          * and we can avoid penalising the more common case - although
          * this is already a minority case.
          * If we do use "drawString" on each character, we need to use a
-         * font without advance transform, since the font advance transform
-         * will already be reflected in the glyph positions, and we do not
-         * want to apply the advance twice.
+         * font without translation transform, since the font translation
+         * transform will already be reflected in the glyph positions, and
+         * we do not want to apply the translation twice.
          */
         if (numGlyphs > 10 && printGlyphVector(g, x, y)) {
             return true;

--- a/src/java.desktop/share/classes/sun/print/PathGraphics.java
+++ b/src/java.desktop/share/classes/sun/print/PathGraphics.java
@@ -934,7 +934,7 @@ public abstract class PathGraphics extends ProxyGraphics2D {
 
         /* If we reach here we have mapped all the glyphs back
          * one-to-one to simple unicode chars that we know are in the font.
-         * We can call "drawChars" on each one of them in turn, setting
+         * We can call "drawString" on each one of them in turn, setting
          * the position based on the glyph positions.
          * There's typically overhead in this. If numGlyphs is 'large',
          * it may even be better to try printGlyphVector() in this case.
@@ -942,15 +942,28 @@ public abstract class PathGraphics extends ProxyGraphics2D {
          * should be able to recover the text from simple glyph vectors
          * and we can avoid penalising the more common case - although
          * this is already a minority case.
+         * If we do use "drawString" on each character, we need to use a
+         * font without advance transform, since the font advance transform
+         * will already be reflected in the glyph positions, and we do not
+         * want to apply the advance twice.
          */
         if (numGlyphs > 10 && printGlyphVector(g, x, y)) {
             return true;
         }
 
+        Font font2 = font;
+        if (font.isTransformed()) {
+            AffineTransform t = font.getTransform();
+            if ((t.getType() & AffineTransform.TYPE_TRANSLATION) != 0) {
+                t.setTransform(t.getScaleX(), t.getShearY(), t.getShearX(), t.getScaleY(), 0, 0);
+                font2 = font.deriveFont(t);
+            }
+        }
+
         for (int i=0; i<numGlyphs; i++) {
             String s = new String(chars, i, 1);
             drawString(s, x+positions[i*2], y+positions[i*2+1],
-                       font, gvFrc, 0f);
+                       font2, gvFrc, 0f);
         }
         return true;
     }

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
@@ -526,6 +526,7 @@ final class WPathGraphics extends PathGraphics {
 
         float awScale = getAwScale(scaleFactorX, scaleFactorY);
         int iangle = getAngle(ptx);
+        double devangle = Math.atan2(deviceTransform.getShearY(), deviceTransform.getScaleY());
 
         ptx = new Point2D.Double(1.0, 0.0);
         deviceTransform.deltaTransform(ptx, ptx);
@@ -537,7 +538,7 @@ final class WPathGraphics extends PathGraphics {
         Font2D font2D = FontUtilities.getFont2D(font);
         if (font2D instanceof TrueTypeFont) {
             textOut(str, font, (TrueTypeFont)font2D, frc,
-                    scaledFontSizeY, iangle, awScale,
+                    scaledFontSizeY, iangle, devangle, awScale,
                     advanceScaleX, advanceScaleY,
                     x, y, devpos.x, devpos.y, targetW);
         } else if (font2D instanceof CompositeFont) {
@@ -568,7 +569,7 @@ final class WPathGraphics extends PathGraphics {
                 String substr = new String(chars, startChar,endChar-startChar);
                 PhysicalFont slotFont = compFont.getSlotFont(slot);
                 textOut(substr, font, slotFont, frc,
-                        scaledFontSizeY, iangle, awScale,
+                        scaledFontSizeY, iangle, devangle, awScale,
                         advanceScaleX, advanceScaleY,
                         userx, usery, devx, devy, 0f);
                 Rectangle2D bds = font.getStringBounds(substr, frc);
@@ -680,6 +681,7 @@ final class WPathGraphics extends PathGraphics {
 
         float awScale = getAwScale(scaleFactorX, scaleFactorY);
         int iangle = getAngle(ptx);
+        double devangle = Math.atan2(deviceTransform.getShearY(), deviceTransform.getScaleY());
 
         ptx = new Point2D.Double(1.0, 0.0);
         deviceTransform.deltaTransform(ptx, ptx);
@@ -746,7 +748,8 @@ final class WPathGraphics extends PathGraphics {
          */
         AffineTransform advanceTransform =
            AffineTransform.getScaleInstance(advanceScaleX, advanceScaleY);
-        advanceTransform.rotate(iangle * Math.PI / 1800.0);
+        advanceTransform.rotate(devangle); // radians
+        advanceTransform.rotate(iangle * Math.PI / 1800.0); // 1/10 degrees -> radians
         float[] glyphAdvPos = new float[glyphPos.length];
 
         advanceTransform.transform(glyphPos, 0,         //source
@@ -823,7 +826,8 @@ final class WPathGraphics extends PathGraphics {
     private void textOut(String str,
                           Font font, PhysicalFont font2D,
                           FontRenderContext frc,
-                          float deviceSize, int rotation, float awScale,
+                          float deviceSize, int iangle, double devangle,
+                          float awScale,
                           double scaleFactorX, double scaleFactorY,
                           float userx, float usery,
                           float devx, float devy, float targetW) {
@@ -831,8 +835,7 @@ final class WPathGraphics extends PathGraphics {
          String family = font2D.getFamilyName(null);
          int style = font.getStyle() | font2D.getStyle();
          WPrinterJob wPrinterJob = (WPrinterJob)getPrinterJob();
-         boolean setFont = wPrinterJob.setFont(family, deviceSize, style,
-                                               rotation, awScale);
+         boolean setFont = wPrinterJob.setFont(family, deviceSize, style, iangle, awScale);
          if (!setFont) {
              super.drawString(str, userx, usery, font, frc, targetW);
              return;
@@ -866,7 +869,8 @@ final class WPathGraphics extends PathGraphics {
               */
              AffineTransform advanceTransform =
                 AffineTransform.getScaleInstance(scaleFactorX, scaleFactorY);
-             advanceTransform.rotate(rotation * Math.PI / 1800.0);
+             advanceTransform.rotate(devangle); // radians
+             advanceTransform.rotate(iangle * Math.PI / 1800.0); // 1/10 degrees -> radians
              float[] glyphAdvPos = new float[glyphPos.length];
 
              advanceTransform.transform(glyphPos, 0,         //source

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
@@ -532,7 +532,7 @@ final class WPathGraphics extends PathGraphics {
         double advanceScaleX = Math.sqrt(ptx.x*ptx.x+ptx.y*ptx.y);
         pty = new Point2D.Double(0.0, 1.0);
         deviceTransform.deltaTransform(pty, pty);
-        double advanceScaleY = Math.sqrt(pty.x*pty.x+pty.y*pty.y);
+        double advanceScaleY = -Math.sqrt(pty.x*pty.x+pty.y*pty.y);
 
         Font2D font2D = FontUtilities.getFont2D(font);
         if (font2D instanceof TrueTypeFont) {
@@ -697,7 +697,7 @@ final class WPathGraphics extends PathGraphics {
         double advanceScaleX = Math.sqrt(ptx.x*ptx.x+ptx.y*ptx.y);
         pty = new Point2D.Double(0.0, 1.0);
         deviceTransform.deltaTransform(pty, pty);
-        double advanceScaleY = Math.sqrt(pty.x*pty.x+pty.y*pty.y);
+        double advanceScaleY = -Math.sqrt(pty.x*pty.x+pty.y*pty.y);
 
         int numGlyphs = gv.getNumGlyphs();
         int[] glyphCodes = gv.getGlyphCodes(0, numGlyphs, null);
@@ -757,6 +757,7 @@ final class WPathGraphics extends PathGraphics {
          */
         AffineTransform advanceTransform =
            AffineTransform.getScaleInstance(advanceScaleX, advanceScaleY);
+        advanceTransform.rotate(iangle * Math.PI / 1800.0);
         float[] glyphAdvPos = new float[glyphPos.length];
 
         advanceTransform.transform(glyphPos, 0,         //source
@@ -876,6 +877,7 @@ final class WPathGraphics extends PathGraphics {
               */
              AffineTransform advanceTransform =
                 AffineTransform.getScaleInstance(scaleFactorX, scaleFactorY);
+             advanceTransform.rotate(iangle * Math.PI / 1800.0);
              float[] glyphAdvPos = new float[glyphPos.length];
 
              advanceTransform.transform(glyphPos, 0,         //source

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
@@ -877,7 +877,7 @@ final class WPathGraphics extends PathGraphics {
               */
              AffineTransform advanceTransform =
                 AffineTransform.getScaleInstance(scaleFactorX, scaleFactorY);
-             advanceTransform.rotate(iangle * Math.PI / 1800.0);
+             advanceTransform.rotate(rotation * Math.PI / 1800.0);
              float[] glyphAdvPos = new float[glyphPos.length];
 
              advanceTransform.transform(glyphPos, 0,         //source

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPathGraphics.java
@@ -631,22 +631,11 @@ final class WPathGraphics extends PathGraphics {
          */
         Point2D.Float userpos = new Point2D.Float(x, y);
         /* Add the position of the first glyph - its not always 0,0 */
+        /* This glyph position includes the font's transform translation, if any */
         Point2D g0pos = gv.getGlyphPosition(0);
         userpos.x += (float)g0pos.getX();
         userpos.y += (float)g0pos.getY();
         Point2D.Float devpos = new Point2D.Float();
-
-        /* Already have the translate from the deviceTransform,
-         * but the font may have a translation component too.
-         */
-        if (font.isTransformed()) {
-            AffineTransform fontTx = font.getTransform();
-            float translateX = (float)(fontTx.getTranslateX());
-            float translateY = (float)(fontTx.getTranslateY());
-            if (Math.abs(translateX) < 0.00001) translateX = 0f;
-            if (Math.abs(translateY) < 0.00001) translateY = 0f;
-            userpos.x += translateX; userpos.y += translateY;
-        }
         deviceTransform.transform(userpos, devpos);
 
         if (getClip() != null) {

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -806,7 +806,7 @@ java/awt/image/VolatileImage/VolatileImageConfigurationTest.java 8171069 macosx-
 java/awt/Modal/InvisibleParentTest/InvisibleParentTest.java 8172245 linux-all
 java/awt/Frame/FrameStateTest/FrameStateTest.java 8203920 macosx-all,linux-all
 java/awt/print/PrinterJob/ScaledText/ScaledText.java 8231226 macosx-all
-java/awt/print/PrinterJob/PrintTextTest.java 8148334 generic-all
+java/awt/print/PrinterJob/PrintTextTest.java 8148334 macosx-all
 java/awt/font/TextLayout/TestJustification.java 8250791 macosx-all
 java/awt/TrayIcon/DragEventSource/DragEventSource.java 8252242 macosx-all
 java/awt/FileDialog/DefaultFocusOwner/DefaultFocusOwner.java 7187728 macosx-all,linux-all

--- a/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6425068 7157659 8029204 8132890 8148334
+ * @bug 6425068 7157659 8029204 8132890 8148334 8344637
  * @key printer
  * @summary Confirm that text prints where we expect to the length we expect.
  * @library /java/awt/regtesthelpers

--- a/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
+++ b/test/jdk/java/awt/print/PrinterJob/PrintTextTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6425068 7157659 8132890
+ * @bug 6425068 7157659 8029204 8132890 8148334
  * @key printer
  * @summary Confirm that text prints where we expect to the length we expect.
  * @library /java/awt/regtesthelpers


### PR DESCRIPTION
This PR fixes the issue identified in JDK-8148334 in screenshots `Page8_landscape.JPG` and `Page8_portrait.JPG`.

It does not address `mac_Page1.png` or `mac_Page8.png`, which I'm not even sure are still issues (I have no access to a Mac).

The method in question, `PathGraphics.printedSimpleGlyphVector(...)` is quite complex, with many special cases being handled in different ways. In this specific scenario (page 8 of `PrintTextTest`), all special case checks fail, and we fall through all the way to the final handling block, which draws the individual characters one by one. It looks like the problem is that the font transform translation is applied twice, once via the glyph positions, and again by `drawString(...)` via the font. The proposed fix is to provide `drawString(...)` a font without any translation transform.

Testing looks good on Linux, but needs to be done on Mac and Windows.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8344637](https://bugs.openjdk.org/browse/JDK-8344637): Fix Page8 of manual test java/awt/print/PrinterJob/PrintTextTest.java on Linux and Windows (**Bug** - P3)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21980/head:pull/21980` \
`$ git checkout pull/21980`

Update a local copy of the PR: \
`$ git checkout pull/21980` \
`$ git pull https://git.openjdk.org/jdk.git pull/21980/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21980`

View PR using the GUI difftool: \
`$ git pr show -t 21980`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21980.diff">https://git.openjdk.org/jdk/pull/21980.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21980#issuecomment-2464948928)
</details>
