### PR TITLE
8343781: Add since checker test to the Serviceability area modules

### DIFF
--- a/test/jdk/tools/sincechecker/modules/java.instrument/JavaInstrumentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.instrument/JavaInstrumentCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in java.instrument module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker java.instrument
+ */

--- a/test/jdk/tools/sincechecker/modules/java.instrument/JavaInstrumentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.instrument/JavaInstrumentCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in java.instrument module
+ * @summary Test for @since in java.instrument module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker java.instrument
  */

--- a/test/jdk/tools/sincechecker/modules/java.instrument/JavaInstrumentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.instrument/JavaInstrumentCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in java.instrument module
+ * @summary Test for `@since` in java.instrument module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker java.instrument
  */

--- a/test/jdk/tools/sincechecker/modules/java.management.rmi/JavaManagementRmiCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.management.rmi/JavaManagementRmiCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in java.management.rmi module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker java.management.rmi
+ */

--- a/test/jdk/tools/sincechecker/modules/java.management.rmi/JavaManagementRmiCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.management.rmi/JavaManagementRmiCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in java.management.rmi module
+ * @summary Test for @since in java.management.rmi module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker java.management.rmi
  */

--- a/test/jdk/tools/sincechecker/modules/java.management.rmi/JavaManagementRmiCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.management.rmi/JavaManagementRmiCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in java.management.rmi module
+ * @summary Test for `@since` in java.management.rmi module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker java.management.rmi
  */

--- a/test/jdk/tools/sincechecker/modules/java.management/JavaManagementCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.management/JavaManagementCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in java.management module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker java.management
+ */

--- a/test/jdk/tools/sincechecker/modules/java.management/JavaManagementCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.management/JavaManagementCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in java.management module
+ * @summary Test for `@since` in java.management module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker java.management
  */

--- a/test/jdk/tools/sincechecker/modules/java.management/JavaManagementCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/java.management/JavaManagementCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in java.management module
+ * @summary Test for @since in java.management module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker java.management
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.attach/JdkAttachCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.attach/JdkAttachCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in jdk.attach module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.attach
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.attach/JdkAttachCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.attach/JdkAttachCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in jdk.attach module
+ * @summary Test for @since in jdk.attach module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.attach
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.attach/JdkAttachCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.attach/JdkAttachCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in jdk.attach module
+ * @summary Test for `@since` in jdk.attach module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.attach
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in jdk.hotspot.agent module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.hotspot.agent
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in jdk.hotspot.agent module
+ * @summary Test for `@since` in jdk.hotspot.agent module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.hotspot.agent
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in jdk.hotspot.agent module
+ * @summary Test for @since in jdk.hotspot.agent module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.hotspot.agent
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jcmd/JdkJcmdCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jcmd/JdkJcmdCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in jdk.jcmd module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.jcmd
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.jcmd/JdkJcmdCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jcmd/JdkJcmdCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in jdk.jcmd module
+ * @summary Test for @since in jdk.jcmd module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jcmd
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jcmd/JdkJcmdCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jcmd/JdkJcmdCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in jdk.jcmd module
+ * @summary Test for `@since` in jdk.jcmd module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jcmd
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jconsole/JdkJconsoleCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jconsole/JdkJconsoleCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in jdk.jconsole module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.jartool
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.jconsole/JdkJconsoleCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jconsole/JdkJconsoleCheckSince.java
@@ -26,5 +26,5 @@
  * @bug 8343781
  * @summary Test for `@since` in jdk.jconsole module
  * @library /test/lib /test/jdk/tools/sincechecker
- * @run main SinceChecker jdk.jartool
+ * @run main SinceChecker jdk.jconsole
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jconsole/JdkJconsoleCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jconsole/JdkJconsoleCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in jdk.jconsole module
+ * @summary Test for @since in jdk.jconsole module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jartool
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jconsole/JdkJconsoleCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jconsole/JdkJconsoleCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in jdk.jconsole module
+ * @summary Test for `@since` in jdk.jconsole module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jartool
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jdi/JdkJdiCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jdi/JdkJdiCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in jdk.jdi module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.jdi
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.jdi/JdkJdiCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jdi/JdkJdiCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in jdk.jdi module
+ * @summary Test for `@since` in jdk.jdi module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jdi
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jdi/JdkJdiCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jdi/JdkJdiCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in jdk.jdi module
+ * @summary Test for @since in jdk.jdi module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jdi
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jdwp.agent/JdkJdwpAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jdwp.agent/JdkJdwpAgentCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in jdk.jdwp.agent module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.jdwp.agent
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.jdwp.agent/JdkJdwpAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jdwp.agent/JdkJdwpAgentCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in jdk.jdwp.agent module
+ * @summary Test for @since in jdk.jdwp.agent module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jdwp.agent
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jdwp.agent/JdkJdwpAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jdwp.agent/JdkJdwpAgentCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in jdk.jdwp.agent module
+ * @summary Test for `@since` in jdk.jdwp.agent module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jdwp.agent
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jstatd/JdkJstatdCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jstatd/JdkJstatdCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in jdk.jstatd module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.jstatd
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.jstatd/JdkJstatdCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jstatd/JdkJstatdCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in jdk.jstatd module
+ * @summary Test for `@since` in jdk.jstatd module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jstatd
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.jstatd/JdkJstatdCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.jstatd/JdkJstatdCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in jdk.jstatd module
+ * @summary Test for @since in jdk.jstatd module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.jstatd
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.management.agent/JdkManagementAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.management.agent/JdkManagementAgentCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in jdk.management.agent module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.management.agent
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.management.agent/JdkManagementAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.management.agent/JdkManagementAgentCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in jdk.management.agent module
+ * @summary Test for `@since` in jdk.management.agent module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.management.agent
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.management.agent/JdkManagementAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.management.agent/JdkManagementAgentCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in jdk.management.agent module
+ * @summary Test for @since in jdk.management.agent module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.management.agent
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.management/JdkManagementCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.management/JdkManagementCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343781
+ * @summary Test for `@since` in jdk.management module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.management
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.management/JdkManagementCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.management/JdkManagementCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for @since in jdk.management module
+ * @summary Test for `@since` in jdk.management module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.management
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.management/JdkManagementCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.management/JdkManagementCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343781
- * @summary Test for `@since` in jdk.management module
+ * @summary Test for @since in jdk.management module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.management
  */


### PR DESCRIPTION
Can I please get a review for this PR that add tests to verify the value of `@since` tags to the Serviceability area modules. The test is described in this [email](https://mail.openjdk.org/pipermail/jdk-dev/2024-October/009474.html). This issue is similar to JDK-8341399, JDK-8331051 and JDK-8343442.

The benefit from this is helping API authors and reviewer validate the accuracy of `@since` in their source code (and subsequently, in the generated documentation). And lessen the burden on Reviewers.

The test has been added for `java.base` and a few other modules and has helped catch some bugs before they make it to the JDK.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343781](https://bugs.openjdk.org/browse/JDK-8343781): Add since checker test to the Serviceability area modules (**Sub-task** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) Review applies to [0abe3080](https://git.openjdk.org/jdk/pull/21983/files/0abe3080391e83cae62253f56c28d98efa0ed253)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21983/head:pull/21983` \
`$ git checkout pull/21983`

Update a local copy of the PR: \
`$ git checkout pull/21983` \
`$ git pull https://git.openjdk.org/jdk.git pull/21983/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21983`

View PR using the GUI difftool: \
`$ git pr show -t 21983`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21983.diff">https://git.openjdk.org/jdk/pull/21983.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21983#issuecomment-2465056833)
</details>
