### PR TITLE
8343777: Add since checker tests to Internationalisation modules

### DIFF
--- a/test/jdk/tools/sincechecker/modules/jdk.charsets/JdkCharsetsCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.charsets/JdkCharsetsCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343777
+ * @summary Test for `@since` in jdk.charsets module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.charsets
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.charsets/JdkCharsetsCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.charsets/JdkCharsetsCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343777
- * @summary Test for `@since` in jdk.charsets module
+ * @summary Test for @since in jdk.charsets module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.charsets
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.charsets/JdkCharsetsCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.charsets/JdkCharsetsCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343777
- * @summary Test for @since in jdk.charsets module
+ * @summary Test for `@since` declaration in the module-info.java file of jdk.charsets
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.charsets
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.localedata/JdkLocaledataCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.localedata/JdkLocaledataCheckSince.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8343777
+ * @summary Test for `@since` in jdk.localedata module
+ * @library /test/lib /test/jdk/tools/sincechecker
+ * @run main SinceChecker jdk.localedata
+ */

--- a/test/jdk/tools/sincechecker/modules/jdk.localedata/JdkLocaledataCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.localedata/JdkLocaledataCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343777
- * @summary Test for `@since` in jdk.localedata module
+ * @summary Test for @since in jdk.localedata module
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.localedata
  */

--- a/test/jdk/tools/sincechecker/modules/jdk.localedata/JdkLocaledataCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.localedata/JdkLocaledataCheckSince.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @bug 8343777
- * @summary Test for @since in jdk.localedata module
+ * @summary Test for `@since` declaration in the module-info.java file of jdk.localedata
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.localedata
  */


### PR DESCRIPTION
Can I please get a review for this PR that add tests to verify the value of `@since` tags to the Internationalisation area modules. The test is described in this [email](https://mail.openjdk.org/pipermail/jdk-dev/2024-October/009474.html). This issue is similar to JDK-8341399, JDK-8331051 and JDK-8343442.

The benefit from this is helping API authors and reviewer validate the accuracy of `@since` in their source code (and subsequently, in the generated documentation). And lessen the burden on Reviewers.

The test has been added for `java.base` and a few other modules and has helped catch some bugs before they make it to the JDK.

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343777](https://bugs.openjdk.org/browse/JDK-8343777): Add since checker tests to Internationalisation modules (**Sub-task** - P4)


### Reviewers
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21985/head:pull/21985` \
`$ git checkout pull/21985`

Update a local copy of the PR: \
`$ git checkout pull/21985` \
`$ git pull https://git.openjdk.org/jdk.git pull/21985/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21985`

View PR using the GUI difftool: \
`$ git pr show -t 21985`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21985.diff">https://git.openjdk.org/jdk/pull/21985.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21985#issuecomment-2465055602)
</details>
