### PR TITLE
8343844: Add benchmarks for superword/autovectorization in FFM BulkOperations

### DIFF
--- a/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkFill.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkFill.java
@@ -38,6 +38,7 @@ import org.openjdk.jmh.annotations.Warmup;
 
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
@@ -74,6 +75,20 @@ public class SegmentBulkFill {
         Arrays.fill(array, (byte) 0);
     }
 
+    @Benchmark
+    public void arraysFillLoop() {
+        for (int i = 0; i < array.length; i++) {
+            array[i] = 0;
+        }
+    }
+
+    @Benchmark
+    public void bufferFillLoop() {
+        for (int i = 0; i < array.length; i++) {
+            buffer.put(i, (byte)0);
+        }
+    }
+
     @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.fill=31"})
     @Benchmark
     public void heapSegmentFillJava() {
@@ -84,6 +99,13 @@ public class SegmentBulkFill {
     @Benchmark
     public void heapSegmentFillUnsafe() {
         heapSegment.fill((byte) 0);
+    }
+
+    @Benchmark
+    public void heapSegmentFillLoop() {
+        for (long i = 0; i < heapSegment.byteSize(); i++) {
+            heapSegment.set(ValueLayout.JAVA_BYTE, i, (byte) 0);
+        }
     }
 
     @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.fill=31"})
@@ -98,6 +120,13 @@ public class SegmentBulkFill {
         nativeSegment.fill((byte) 0);
     }
 
+    @Benchmark
+    public void nativeSegmentFillLoop() {
+        for (long i = 0; i < nativeSegment.byteSize(); i++) {
+            nativeSegment.set(ValueLayout.JAVA_BYTE, i, (byte) 0);
+        }
+    }
+
     @Fork(value = 3, jvmArgs = {"-Djava.lang.foreign.native.threshold.power.fill=31"})
     @Benchmark
     public void unalignedSegmentFillJava() {
@@ -108,6 +137,13 @@ public class SegmentBulkFill {
     @Benchmark
     public void unalignedSegmentFillUnsafe() {
         unalignedSegment.fill((byte) 0);
+    }
+
+    @Benchmark
+    public void unalignedSegmentFillLoop() {
+        for (long i = 0; i < unalignedSegment.byteSize(); i++) {
+            unalignedSegment.set(ValueLayout.JAVA_BYTE, i, (byte) 0);
+        }
     }
 
 }


### PR DESCRIPTION
This PR proposed to add a few benchmarks using  superword/autovectorization

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343844](https://bugs.openjdk.org/browse/JDK-8343844): Add benchmarks for superword/autovectorization in FFM BulkOperations (**Enhancement** - P5)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21988/head:pull/21988` \
`$ git checkout pull/21988`

Update a local copy of the PR: \
`$ git checkout pull/21988` \
`$ git pull https://git.openjdk.org/jdk.git pull/21988/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21988`

View PR using the GUI difftool: \
`$ git pr show -t 21988`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21988.diff">https://git.openjdk.org/jdk/pull/21988.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21988#issuecomment-2465191733)
</details>
