### PR TITLE
8343785: (fs) Remove syscalls that set file times with microsecond precision

### DIFF
--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
@@ -29,12 +29,15 @@ import java.io.IOException;
 import java.nio.file.attribute.FileTime;
 import java.util.concurrent.TimeUnit;
 import static sun.nio.fs.BsdNativeDispatcher.*;
+import static sun.nio.fs.UnixConstants.ELOOP;
+import static sun.nio.fs.UnixConstants.ENXIO;
+import static sun.nio.fs.UnixNativeDispatcher.futimens;
 import static sun.nio.fs.UnixNativeDispatcher.utimensat;
 
 class BsdFileAttributeViews {
     //
-    // Use setattrlist(2) system call which can set creation, modification,
-    // and access times.
+    // Use the futimens(2)/utimensat(2) system calls to set the access and
+    // modification times, and setattrlist(2) to set the creation time.
     //
     private static void setTimes(UnixPath path, FileTime lastModifiedTime,
                                  FileTime lastAccessTime, FileTime createTime,
@@ -50,63 +53,95 @@ class BsdFileAttributeViews {
         // permission check
         path.checkWrite();
 
-        // not all volumes support setattrlist(2), so set the last
-        // modified and last access times using utimensat(2)
-        if (lastModifiedTime != null || lastAccessTime != null) {
-            // if not changing both attributes then need existing attributes
-            if (lastModifiedTime == null || lastAccessTime == null) {
-                try {
-                    UnixFileAttributes attrs = UnixFileAttributes.get(path, followLinks);
-                    if (lastModifiedTime == null)
-                        lastModifiedTime = attrs.lastModifiedTime();
-                    if (lastAccessTime == null)
-                        lastAccessTime = attrs.lastAccessTime();
-                } catch (UnixException x) {
-                    x.rethrowAsIOException(path);
-                }
-            }
-
-            // update times
-            long modValue = lastModifiedTime.to(TimeUnit.NANOSECONDS);
-            long accessValue= lastAccessTime.to(TimeUnit.NANOSECONDS);
-
-            boolean retry = false;
-            int flags = followLinks ? 0 : UnixConstants.AT_SYMLINK_NOFOLLOW;
-            try {
-                utimensat(UnixConstants.AT_FDCWD, path, accessValue,
-                          modValue, flags);
-            } catch (UnixException x) {
-                // if utimensat fails with EINVAL and one/both of the times is
-                // negative then we adjust the value to the epoch and retry.
-                if (x.errno() == UnixConstants.EINVAL &&
-                    (modValue < 0L || accessValue < 0L)) {
-                    retry = true;
-                } else {
-                    x.rethrowAsIOException(path);
-                }
-            }
-            if (retry) {
-                if (modValue < 0L) modValue = 0L;
-                if (accessValue < 0L) accessValue= 0L;
-                try {
-                    utimensat(UnixConstants.AT_FDCWD, path, accessValue,
-                              modValue, flags);
-                } catch (UnixException x) {
-                    x.rethrowAsIOException(path);
-                }
+        // use a file descriptor if possible to avoid a race due to accessing
+        // a path more than once as the file at that path could change.
+        // if path is a symlink, then the open should fail with ELOOP and
+        // the path will be used instead of the file descriptor.
+        boolean haveFd = false;
+        int fd = -1;
+        try {
+            fd = path.openForAttributeAccess(followLinks);
+            haveFd = true;
+        } catch (UnixException x) {
+            if (!(x.errno() == ENXIO || (x.errno() == ELOOP))) {
+                x.rethrowAsIOException(path);
             }
         }
 
-        // set the creation time using setattrlist
-        if (createTime != null) {
-            long createValue = createTime.to(TimeUnit.NANOSECONDS);
-            int commonattr = UnixConstants.ATTR_CMN_CRTIME;
-            try {
-                setattrlist(path, commonattr, 0L, 0L, createValue,
-                    followLinks ?  0 : UnixConstants.FSOPT_NOFOLLOW);
-            } catch (UnixException x) {
-                x.rethrowAsIOException(path);
+        try {
+            // not all volumes support setattrlist(2), so set the last
+            // modified and last access times use futimens(2)/utimensat(2)
+            if (lastModifiedTime != null || lastAccessTime != null) {
+                // if not changing both attributes then need existing attributes
+                if (lastModifiedTime == null || lastAccessTime == null) {
+                    try {
+                        UnixFileAttributes attrs = haveFd ?
+                            UnixFileAttributes.get(fd) :
+                            UnixFileAttributes.get(path, followLinks);
+                        if (lastModifiedTime == null)
+                            lastModifiedTime = attrs.lastModifiedTime();
+                        if (lastAccessTime == null)
+                            lastAccessTime = attrs.lastAccessTime();
+                    } catch (UnixException x) {
+                        x.rethrowAsIOException(path);
+                    }
+                }
+
+                // update times
+                long modValue = lastModifiedTime.to(TimeUnit.NANOSECONDS);
+                long accessValue= lastAccessTime.to(TimeUnit.NANOSECONDS);
+
+                boolean retry = false;
+                int flags = followLinks ? 0 : UnixConstants.AT_SYMLINK_NOFOLLOW;
+                try {
+                    if (haveFd)
+                        futimens(fd, accessValue, modValue);
+                    else
+                        utimensat(UnixConstants.AT_FDCWD, path, accessValue,
+                                  modValue, flags);
+                } catch (UnixException x) {
+                    // if futimens/utimensat fails with EINVAL and one/both of
+                    // the times is negative, then we adjust the value to the
+                    // epoch and retry.
+                    if (x.errno() == UnixConstants.EINVAL &&
+                        (modValue < 0L || accessValue < 0L)) {
+                        retry = true;
+                    } else {
+                        x.rethrowAsIOException(path);
+                    }
+                }
+                if (retry) {
+                    if (modValue < 0L) modValue = 0L;
+                    if (accessValue < 0L) accessValue= 0L;
+                    try {
+                        if (haveFd)
+                            futimens(fd, accessValue, modValue);
+                        else
+                            utimensat(UnixConstants.AT_FDCWD, path, accessValue,
+                                      modValue, flags);
+                    } catch (UnixException x) {
+                        x.rethrowAsIOException(path);
+                    }
+                }
             }
+
+            // set the creation time using setattrlist(2)
+            if (createTime != null) {
+                long createValue = createTime.to(TimeUnit.NANOSECONDS);
+                int commonattr = UnixConstants.ATTR_CMN_CRTIME;
+                try {
+                    if (haveFd)
+                        fsetattrlist(fd, commonattr, 0L, 0L, createValue,
+                                     followLinks ?  0 : UnixConstants.FSOPT_NOFOLLOW);
+                    else
+                        setattrlist(path, commonattr, 0L, 0L, createValue,
+                                    followLinks ?  0 : UnixConstants.FSOPT_NOFOLLOW);
+                } catch (UnixException x) {
+                    x.rethrowAsIOException(path);
+                }
+            }
+        } finally {
+            close(fd, e -> null);
         }
     }
 

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.nio.file.attribute.FileTime;
 import java.util.concurrent.TimeUnit;
 import static sun.nio.fs.BsdNativeDispatcher.*;
-import static sun.nio.fs.UnixNativeDispatcher.lutimes;
+import static sun.nio.fs.UnixNativeDispatcher.utimensat;
 
 class BsdFileAttributeViews {
     //
@@ -50,94 +50,63 @@ class BsdFileAttributeViews {
         // permission check
         path.checkWrite();
 
-        boolean useLutimes = false;
-        try {
-            useLutimes = !followLinks &&
-                UnixFileAttributes.get(path, false).isSymbolicLink();
-        } catch (UnixException x) {
-            x.rethrowAsIOException(path);
-        }
-
-        int fd = -1;
-        if (!useLutimes) {
-            try {
-                fd = path.openForAttributeAccess(followLinks);
-            } catch (UnixException x) {
-                x.rethrowAsIOException(path);
-            }
-        }
-
-        try {
-            // not all volumes support setattrlist(2), so set the last
-            // modified and last access times using futimens(2)/lutimes(3)
-            if (lastModifiedTime != null || lastAccessTime != null) {
-                // if not changing both attributes then need existing attributes
-                if (lastModifiedTime == null || lastAccessTime == null) {
-                    try {
-                        UnixFileAttributes attrs = UnixFileAttributes.get(fd);
-                        if (lastModifiedTime == null)
-                            lastModifiedTime = attrs.lastModifiedTime();
-                        if (lastAccessTime == null)
-                            lastAccessTime = attrs.lastAccessTime();
-                    } catch (UnixException x) {
-                        x.rethrowAsIOException(path);
-                    }
-                }
-
-                // update times
-                TimeUnit timeUnit = useLutimes ?
-                    TimeUnit.MICROSECONDS : TimeUnit.NANOSECONDS;
-                long modValue = lastModifiedTime.to(timeUnit);
-                long accessValue= lastAccessTime.to(timeUnit);
-
-                boolean retry = false;
+        // not all volumes support setattrlist(2), so set the last
+        // modified and last access times using utimensat(2)
+        if (lastModifiedTime != null || lastAccessTime != null) {
+            // if not changing both attributes then need existing attributes
+            if (lastModifiedTime == null || lastAccessTime == null) {
                 try {
-                    if (useLutimes)
-                        lutimes(path, accessValue, modValue);
-                    else
-                        futimens(fd, accessValue, modValue);
-                } catch (UnixException x) {
-                    // if futimens fails with EINVAL and one/both of the times is
-                    // negative then we adjust the value to the epoch and retry.
-                    if (x.errno() == UnixConstants.EINVAL &&
-                        (modValue < 0L || accessValue < 0L)) {
-                        retry = true;
-                    } else {
-                        x.rethrowAsIOException(path);
-                    }
-                }
-                if (retry) {
-                    if (modValue < 0L) modValue = 0L;
-                    if (accessValue < 0L) accessValue= 0L;
-                    try {
-                        if (useLutimes)
-                            lutimes(path, accessValue, modValue);
-                        else
-                            futimens(fd, accessValue, modValue);
-                    } catch (UnixException x) {
-                        x.rethrowAsIOException(path);
-                    }
-                }
-            }
-
-            // set the creation time using setattrlist
-            if (createTime != null) {
-                long createValue = createTime.to(TimeUnit.NANOSECONDS);
-                int commonattr = UnixConstants.ATTR_CMN_CRTIME;
-                try {
-                    if (useLutimes)
-                        setattrlist(path, commonattr, 0L, 0L, createValue,
-                            followLinks ?  0 : UnixConstants.FSOPT_NOFOLLOW);
-                    else
-                        fsetattrlist(fd, commonattr, 0L, 0L, createValue,
-                            followLinks ?  0 : UnixConstants.FSOPT_NOFOLLOW);
+                    UnixFileAttributes attrs = UnixFileAttributes.get(path, followLinks);
+                    if (lastModifiedTime == null)
+                        lastModifiedTime = attrs.lastModifiedTime();
+                    if (lastAccessTime == null)
+                        lastAccessTime = attrs.lastAccessTime();
                 } catch (UnixException x) {
                     x.rethrowAsIOException(path);
                 }
             }
-        } finally {
-            if (!useLutimes)
-                close(fd, e -> null);
+
+            // update times
+            long modValue = lastModifiedTime.to(TimeUnit.NANOSECONDS);
+            long accessValue= lastAccessTime.to(TimeUnit.NANOSECONDS);
+
+            boolean retry = false;
+            int flags = followLinks ? 0 : UnixConstants.AT_SYMLINK_NOFOLLOW;
+            try {
+                utimensat(UnixConstants.AT_FDCWD, path, accessValue,
+                          modValue, flags);
+            } catch (UnixException x) {
+                // if utimensat fails with EINVAL and one/both of the times is
+                // negative then we adjust the value to the epoch and retry.
+                if (x.errno() == UnixConstants.EINVAL &&
+                    (modValue < 0L || accessValue < 0L)) {
+                    retry = true;
+                } else {
+                    x.rethrowAsIOException(path);
+                }
+            }
+            if (retry) {
+                if (modValue < 0L) modValue = 0L;
+                if (accessValue < 0L) accessValue= 0L;
+                try {
+                    utimensat(UnixConstants.AT_FDCWD, path, accessValue,
+                              modValue, flags);
+                } catch (UnixException x) {
+                    x.rethrowAsIOException(path);
+                }
+            }
+        }
+
+        // set the creation time using setattrlist
+        if (createTime != null) {
+            long createValue = createTime.to(TimeUnit.NANOSECONDS);
+            int commonattr = UnixConstants.ATTR_CMN_CRTIME;
+            try {
+                setattrlist(path, commonattr, 0L, 0L, createValue,
+                    followLinks ?  0 : UnixConstants.FSOPT_NOFOLLOW);
+            } catch (UnixException x) {
+                x.rethrowAsIOException(path);
+            }
         }
     }
 

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
@@ -72,105 +72,48 @@ class UnixFileAttributeViews {
             // permission check
             file.checkWrite();
 
-            boolean haveFd = false;
-            boolean useFutimes = false;
-            boolean useFutimens = false;
-            boolean useLutimes = false;
-            boolean useUtimensat = false;
-            int fd = -1;
-            try {
-                if (!followLinks) {
-                    // these path-based syscalls also work if following links
-                    if (!(useUtimensat = utimensatSupported())) {
-                        useLutimes = lutimesSupported();
-                    }
-                }
-                if (!useUtimensat && !useLutimes) {
-                    fd = file.openForAttributeAccess(followLinks);
-                    if (fd != -1) {
-                        haveFd = true;
-                        if (!(useFutimens = futimensSupported())) {
-                            useFutimes = futimesSupported();
-                        }
-                    }
-                }
-            } catch (UnixException x) {
-                if (!(x.errno() == ENXIO ||
-                     (x.errno() == ELOOP && (useUtimensat || useLutimes)))) {
+            // if not changing both attributes then need existing attributes
+            if (lastModifiedTime == null || lastAccessTime == null) {
+                try {
+                    UnixFileAttributes attrs =
+                        UnixFileAttributes.get(file, followLinks);
+                    if (lastModifiedTime == null)
+                        lastModifiedTime = attrs.lastModifiedTime();
+                    if (lastAccessTime == null)
+                        lastAccessTime = attrs.lastAccessTime();
+                } catch (UnixException x) {
                     x.rethrowAsIOException(file);
                 }
             }
 
+            // update times
+            long modValue = lastModifiedTime.to(TimeUnit.NANOSECONDS);
+            long accessValue= lastAccessTime.to(TimeUnit.NANOSECONDS);
+
+            boolean retry = false;
             try {
-                // assert followLinks || !UnixFileAttributes.get(fd).isSymbolicLink();
-
-                // if not changing both attributes then need existing attributes
-                if (lastModifiedTime == null || lastAccessTime == null) {
-                    try {
-                        UnixFileAttributes attrs = haveFd ?
-                            UnixFileAttributes.get(fd) :
-                            UnixFileAttributes.get(file, followLinks);
-                        if (lastModifiedTime == null)
-                            lastModifiedTime = attrs.lastModifiedTime();
-                        if (lastAccessTime == null)
-                            lastAccessTime = attrs.lastAccessTime();
-                    } catch (UnixException x) {
-                        x.rethrowAsIOException(file);
-                    }
+                utimensat(AT_FDCWD, file, accessValue, modValue,
+                          followLinks ? 0 : AT_SYMLINK_NOFOLLOW);
+            } catch (UnixException x) {
+                // if utimensat fails with EINVAL and one/both of
+                // the times is negative then we adjust the value to the
+                // epoch and retry.
+                if (x.errno() == EINVAL &&
+                    (modValue < 0L || accessValue < 0L)) {
+                    retry = true;
+                } else {
+                    x.rethrowAsIOException(file);
                 }
-
-                // update times
-                TimeUnit timeUnit = (useFutimens || useUtimensat) ?
-                    TimeUnit.NANOSECONDS : TimeUnit.MICROSECONDS;
-                long modValue = lastModifiedTime.to(timeUnit);
-                long accessValue= lastAccessTime.to(timeUnit);
-
-                boolean retry = false;
+            }
+            if (retry) {
+                if (modValue < 0L) modValue = 0L;
+                if (accessValue < 0L) accessValue= 0L;
                 try {
-                    if (useFutimens) {
-                        futimens(fd, accessValue, modValue);
-                    } else if (useFutimes) {
-                        futimes(fd, accessValue, modValue);
-                    } else if (useLutimes) {
-                        lutimes(file, accessValue, modValue);
-                    } else if (useUtimensat) {
-                        utimensat(AT_FDCWD, file, accessValue, modValue,
-                                  followLinks ? 0 : AT_SYMLINK_NOFOLLOW);
-                    } else {
-                        utimes(file, accessValue, modValue);
-                    }
+                    utimensat(AT_FDCWD, file, accessValue, modValue,
+                              followLinks ? 0 : AT_SYMLINK_NOFOLLOW);
                 } catch (UnixException x) {
-                    // if futimes/utimes fails with EINVAL and one/both of the times is
-                    // negative then we adjust the value to the epoch and retry.
-                    if (x.errno() == EINVAL &&
-                        (modValue < 0L || accessValue < 0L)) {
-                        retry = true;
-                    } else {
-                        x.rethrowAsIOException(file);
-                    }
+                    x.rethrowAsIOException(file);
                 }
-                if (retry) {
-                    if (modValue < 0L) modValue = 0L;
-                    if (accessValue < 0L) accessValue= 0L;
-                    try {
-                        if (useFutimens) {
-                            futimens(fd, accessValue, modValue);
-                        } else if (useFutimes) {
-                            futimes(fd, accessValue, modValue);
-                        } else if (useLutimes) {
-                            lutimes(file, accessValue, modValue);
-                        } else if (useUtimensat) {
-                            utimensat(AT_FDCWD, file, accessValue, modValue,
-                                      followLinks ? 0 : AT_SYMLINK_NOFOLLOW);
-                        } else {
-                            utimes(file, accessValue, modValue);
-                        }
-                    } catch (UnixException x) {
-                        x.rethrowAsIOException(file);
-                    }
-                }
-            } finally {
-                close(fd, e -> null);
             }
         }
     }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -577,14 +577,14 @@ abstract class UnixFileSystem
             // copy time stamps last
             if (flags.copyBasicAttributes) {
                 try {
-                    if (dfd >= 0 && futimesSupported()) {
-                        futimes(dfd,
-                                attrs.lastAccessTime().to(TimeUnit.MICROSECONDS),
-                                attrs.lastModifiedTime().to(TimeUnit.MICROSECONDS));
+                    if (dfd >= 0) {
+                        futimens(dfd,
+                                 attrs.lastAccessTime().to(TimeUnit.NANOSECONDS),
+                                 attrs.lastModifiedTime().to(TimeUnit.NANOSECONDS));
                     } else {
-                        utimes(target,
-                               attrs.lastAccessTime().to(TimeUnit.MICROSECONDS),
-                               attrs.lastModifiedTime().to(TimeUnit.MICROSECONDS));
+                        utimensat(AT_FDCWD, target,
+                                  attrs.lastAccessTime().to(TimeUnit.NANOSECONDS),
+                                  attrs.lastModifiedTime().to(TimeUnit.NANOSECONDS), 0);
                     }
                 } catch (UnixException x) {
                     // unable to set times
@@ -727,15 +727,9 @@ abstract class UnixFileSystem
                 // copy time attributes
                 if (flags.copyBasicAttributes) {
                     try {
-                        if (futimesSupported()) {
-                            futimes(fo,
-                                    attrs.lastAccessTime().to(TimeUnit.MICROSECONDS),
-                                    attrs.lastModifiedTime().to(TimeUnit.MICROSECONDS));
-                        } else {
-                            utimes(target,
-                                   attrs.lastAccessTime().to(TimeUnit.MICROSECONDS),
-                                   attrs.lastModifiedTime().to(TimeUnit.MICROSECONDS));
-                        }
+                        futimens(fo,
+                                 attrs.lastAccessTime().to(TimeUnit.NANOSECONDS),
+                                 attrs.lastModifiedTime().to(TimeUnit.NANOSECONDS));
                     } catch (UnixException x) {
                         if (flags.failIfUnableToCopyBasic)
                             x.rethrowAsIOException(target);
@@ -814,9 +808,10 @@ abstract class UnixFileSystem
             }
             if (flags.copyBasicAttributes) {
                 try {
-                    utimes(target,
-                           attrs.lastAccessTime().to(TimeUnit.MICROSECONDS),
-                           attrs.lastModifiedTime().to(TimeUnit.MICROSECONDS));
+                    utimensat(AT_FDCWD, target,
+                              attrs.lastAccessTime().to(TimeUnit.NANOSECONDS),
+                              attrs.lastModifiedTime().to(TimeUnit.NANOSECONDS),
+                              0);
                 } catch (UnixException x) {
                     if (flags.failIfUnableToCopyBasic)
                         x.rethrowAsIOException(target);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixNativeDispatcher.java
@@ -348,47 +348,12 @@ class UnixNativeDispatcher {
     private static native void fchmod0(int fd, int mode) throws UnixException;
 
     /**
-     * utimes(const char* path, const struct timeval times[2])
-     */
-    static void utimes(UnixPath path, long times0, long times1)
-        throws UnixException
-    {
-        try (NativeBuffer buffer = copyToNativeBuffer(path)) {
-            utimes0(buffer.address(), times0, times1);
-        }
-    }
-    private static native void utimes0(long pathAddress, long times0, long times1)
-        throws UnixException;
-
-    /**
-     * futimes(int fildes, const struct timeval times[2])
-     */
-    static void futimes(int fd, long times0, long times1) throws UnixException {
-        futimes0(fd, times0, times1);
-    }
-    private static native void futimes0(int fd, long times0, long times1)
-        throws UnixException;
-
-    /**
      * futimens(int fildes, const struct timespec times[2])
      */
     static void futimens(int fd, long times0, long times1) throws UnixException {
         futimens0(fd, times0, times1);
     }
     private static native void futimens0(int fd, long times0, long times1)
-        throws UnixException;
-
-    /**
-     * lutimes(const char* path, const struct timeval times[2])
-     */
-    static void lutimes(UnixPath path, long times0, long times1)
-        throws UnixException
-    {
-        try (NativeBuffer buffer = copyToNativeBuffer(path)) {
-            lutimes0(buffer.address(), times0, times1);
-        }
-    }
-    private static native void lutimes0(long pathAddress, long times0, long times1)
         throws UnixException;
 
     /**
@@ -568,11 +533,7 @@ class UnixNativeDispatcher {
      * Capabilities
      */
     private static final int SUPPORTS_OPENAT        = 1 << 1;  // syscalls
-    private static final int SUPPORTS_FUTIMES       = 1 << 2;
-    private static final int SUPPORTS_FUTIMENS      = 1 << 3;
-    private static final int SUPPORTS_LUTIMES       = 1 << 4;
-    private static final int SUPPORTS_UTIMENSAT     = 1 << 5;
-    private static final int SUPPORTS_XATTR         = 1 << 6;
+    private static final int SUPPORTS_XATTR         = 1 << 3;
     private static final int SUPPORTS_BIRTHTIME     = 1 << 16; // other features
     private static final int capabilities;
 
@@ -581,34 +542,6 @@ class UnixNativeDispatcher {
      */
     static boolean openatSupported() {
         return (capabilities & SUPPORTS_OPENAT) != 0;
-    }
-
-    /**
-     * Supports futimes
-     */
-    static boolean futimesSupported() {
-        return (capabilities & SUPPORTS_FUTIMES) != 0;
-    }
-
-    /**
-     * Supports futimens
-     */
-    static boolean futimensSupported() {
-        return (capabilities & SUPPORTS_FUTIMENS) != 0;
-    }
-
-    /**
-     * Supports lutimes
-     */
-    static boolean lutimesSupported() {
-        return (capabilities & SUPPORTS_LUTIMES) != 0;
-    }
-
-    /**
-     * Supports utimensat
-     */
-    static boolean utimensatSupported() {
-        return (capabilities & SUPPORTS_UTIMENSAT) != 0;
     }
 
     /**

--- a/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -415,9 +415,9 @@ class UnixSecureDirectoryStream
                     }
                     // update times
                     try {
-                        futimes(fd,
-                                lastAccessTime.to(TimeUnit.MICROSECONDS),
-                                lastModifiedTime.to(TimeUnit.MICROSECONDS));
+                        futimens(fd,
+                                 lastAccessTime.to(TimeUnit.NANOSECONDS),
+                                 lastModifiedTime.to(TimeUnit.NANOSECONDS));
                     } catch (UnixException x) {
                         x.rethrowAsIOException(file);
                     }

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
@@ -24,8 +24,6 @@
 /* @test
  * @bug 8181493 8231174 8343417
  * @summary Verify that nanosecond precision is maintained for file timestamps
- * @requires (os.family == "aix") | (os.family == "linux") |
- *           (os.family == "mac") | (os.family == "windows")
  * @library ../.. /test/lib
  * @build jdk.test.lib.Platform
  * @modules java.base/sun.nio.fs:+open

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
@@ -51,18 +51,6 @@ import jtreg.SkippedException;
 public class SetTimesNanos {
 
     public static void main(String[] args) throws Exception {
-        if (!Platform.isWindows()) {
-            // Check whether futimens() system call is supported
-            Class unixNativeDispatcherClass =
-                Class.forName("sun.nio.fs.UnixNativeDispatcher");
-            Method futimensSupported =
-                unixNativeDispatcherClass.getDeclaredMethod("futimensSupported");
-            futimensSupported.setAccessible(true);
-            if (!(boolean)futimensSupported.invoke(null)) {
-                throw new SkippedException("futimens() not supported");
-            }
-        }
-
         Path dirPath = Path.of("test");
         Path dir = Files.createDirectory(dirPath);
         FileStore store = Files.getFileStore(dir);
@@ -80,10 +68,8 @@ public class SetTimesNanos {
         Path file = Files.createFile(dir.resolve("test.dat"));
         testNanos(file);
 
-        if (Platform.isLinux()) {
-            testNanosLink(false);
-            testNanosLink(true);
-        }
+        testNanosLink(false);
+        testNanosLink(true);
     }
 
     private static void testNanos(Path path) throws IOException {
@@ -130,7 +116,14 @@ public class SetTimesNanos {
             Files.createFile(target);
             Files.createSymbolicLink(symlink, target);
 
-            var newTime = FileTime.from(1730417633157646106L, NANOSECONDS);
+            long timeNanos = 1730417633157646106L;
+
+            // Windows file time resolution is 100ns so truncate
+            if (Platform.isWindows()) {
+                timeNanos = 100L*(timeNanos/100L);
+            }
+
+            var newTime = FileTime.from(timeNanos, NANOSECONDS);
             System.out.println("newTime: " + newTime.to(NANOSECONDS));
 
             for (Path p : List.of(target, symlink)) {

--- a/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
+++ b/test/jdk/java/nio/file/attribute/BasicFileAttributeView/SetTimesNanos.java
@@ -24,7 +24,8 @@
 /* @test
  * @bug 8181493 8231174 8343417
  * @summary Verify that nanosecond precision is maintained for file timestamps
- * @requires (os.family == "linux") | (os.family == "mac") | (os.family == "windows")
+ * @requires (os.family == "aix") | (os.family == "linux") |
+ *           (os.family == "mac") | (os.family == "windows")
  * @library ../.. /test/lib
  * @build jdk.test.lib.Platform
  * @modules java.base/sun.nio.fs:+open


### PR DESCRIPTION
Remove the syscalls `utimes`, `futimes`, and `lutimes` that set the file access and modification times using microsecond precision.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343785](https://bugs.openjdk.org/browse/JDK-8343785): (fs) Remove syscalls that set file times with microsecond precision (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21989/head:pull/21989` \
`$ git checkout pull/21989`

Update a local copy of the PR: \
`$ git checkout pull/21989` \
`$ git pull https://git.openjdk.org/jdk.git pull/21989/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21989`

View PR using the GUI difftool: \
`$ git pr show -t 21989`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21989.diff">https://git.openjdk.org/jdk/pull/21989.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21989#issuecomment-2465207714)
</details>
