### PR TITLE
8343848: Fix typo of property name in TestOAEPPadding after 8341927

### DIFF
--- a/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPPadding.java
+++ b/test/jdk/com/sun/crypto/provider/Cipher/RSA/TestOAEPPadding.java
@@ -57,7 +57,7 @@ public class TestOAEPPadding {
                         System.getProperty("test.provider.name", "SunJCE"));
         System.out.println("Testing provider " + cp.getName() + "...");
         Provider kfp = Security.getProvider(
-                        System.getProperty("test.providername", "SunRsaSign"));
+                        System.getProperty("test.provider.name", "SunRsaSign"));
         String kpgAlgorithm = "RSA";
         KeyPairGenerator kpg = KeyPairGenerator.getInstance(kpgAlgorithm, kfp);
         kpg.initialize(SecurityUtils.getTestKeySize(kpgAlgorithm));


### PR DESCRIPTION
Trivial fix of typo.

Thanks to @RealLucy for spotting this!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343848](https://bugs.openjdk.org/browse/JDK-8343848): Fix typo of property name in TestOAEPPadding after 8341927 (**Bug** - P5)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21990/head:pull/21990` \
`$ git checkout pull/21990`

Update a local copy of the PR: \
`$ git checkout pull/21990` \
`$ git pull https://git.openjdk.org/jdk.git pull/21990/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21990`

View PR using the GUI difftool: \
`$ git pr show -t 21990`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21990.diff">https://git.openjdk.org/jdk/pull/21990.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21990#issuecomment-2465223594)
</details>
