### PR TITLE
8343855: HTTP/2 ConnectionWindowUpdateSender may miss some unprocessed DataFrames from closed streams

### DIFF
--- a/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
+++ b/src/java.net.http/share/classes/jdk/internal/net/http/Stream.java
@@ -281,8 +281,8 @@ class Stream<T> extends ExchangeImpl<T> {
             } catch (Throwable x) {
                 Log.logError("Subscriber::onError threw exception: {0}", t);
             } finally {
+                // cancelImpl will eventually call drainInputQueue();
                 cancelImpl(t);
-                drainInputQueue();
             }
         }
     }

--- a/test/jdk/java/net/httpclient/http2/ConnectionFlowControlTest.java
+++ b/test/jdk/java/net/httpclient/http2/ConnectionFlowControlTest.java
@@ -171,7 +171,11 @@ public class ConnectionFlowControlTest {
                         var response = responses.get(keys[i]);
                         String ckey = response.headers().firstValue("X-Connection-Key").get();
                         if (label == null) label = ckey;
-                        assertEquals(ckey, label, "Unexpected key for " + query);
+                        if (i < max - 1) {
+                            // the connection window might be exceeded at i == max - 2, which
+                            // means that the last request could go on a new connection.
+                            assertEquals(ckey, label, "Unexpected key for " + query);
+                        }
                         int wait = uri.startsWith("https://") ? 500 : 250;
                         try (InputStream is = response.body()) {
                             Thread.sleep(Utils.adjustTimeout(wait));

--- a/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
+++ b/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
@@ -40,7 +40,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
-import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.charset.StandardCharsets;
@@ -48,14 +47,12 @@ import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 
-import jdk.httpclient.test.lib.common.HttpServerAdapters;
-import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpHeadHandler;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpHeadOrGetHandler;
 import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestServer;
 import jdk.httpclient.test.lib.http2.BodyOutputStream;
 import jdk.httpclient.test.lib.http2.Http2Handler;
@@ -269,7 +266,7 @@ public class StreamFlowControlTest {
         var https2TestServer = new Http2TestServer("localhost", true, sslContext);
         https2TestServer.addHandler(new Http2TestHandler(), "/https2/");
         this.https2TestServer = HttpTestServer.of(https2TestServer);
-        this.https2TestServer.addHandler(new HttpHeadHandler(), "/https2/head/");
+        this.https2TestServer.addHandler(new HttpHeadOrGetHandler(), "/https2/head/");
         https2URI = "https://" + this.https2TestServer.serverAuthority() + "/https2/x";
         String h2Head = "https://" + this.https2TestServer.serverAuthority() + "/https2/head/z";
 
@@ -352,8 +349,10 @@ public class StreamFlowControlTest {
             } finally {
                 if (t instanceof FCHttp2TestExchange fct) {
                     fct.responseSent(query);
-                } else fail("Exchange is not %s but %s"
-                        .formatted(FCHttp2TestExchange.class.getName(), t.getClass().getName()));
+                } else {
+                    fail("Exchange is not %s but %s"
+                            .formatted(FCHttp2TestExchange.class.getName(), t.getClass().getName()));
+                }
             }
         }
     }

--- a/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
+++ b/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8342075
+ * @bug 8342075 8343855
  * @library /test/lib /test/jdk/java/net/httpclient/lib
  * @build jdk.httpclient.test.lib.http2.Http2TestServer jdk.test.lib.net.SimpleSSLContext
  * @run testng/othervm  -Djdk.internal.httpclient.debug=true

--- a/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
+++ b/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
@@ -282,7 +282,7 @@ public class StreamFlowControlTest {
         this.https2TestServer.start();
 
         // warmup to eliminate delay due to SSL class loading and initialization.
-        try (var client = HttpClient.newBuilder().sslContext(sslContext).build();) {
+        try (var client = HttpClient.newBuilder().sslContext(sslContext).build()) {
             var request = HttpRequest.newBuilder(URI.create(h2Head)).HEAD().build();
             var resp = client.send(request, BodyHandlers.discarding());
             assertEquals(resp.statusCode(), 200);

--- a/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
+++ b/test/jdk/java/net/httpclient/http2/StreamFlowControlTest.java
@@ -48,11 +48,14 @@ import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSession;
 
+import jdk.httpclient.test.lib.common.HttpServerAdapters;
+import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpHeadHandler;
 import jdk.httpclient.test.lib.common.HttpServerAdapters.HttpTestServer;
 import jdk.httpclient.test.lib.http2.BodyOutputStream;
 import jdk.httpclient.test.lib.http2.Http2Handler;
@@ -69,6 +72,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
@@ -90,6 +94,19 @@ public class StreamFlowControlTest {
                 { http2URI,  true },
                 { https2URI, true },
         };
+    }
+
+    static void sleep(long wait) throws InterruptedException {
+        if (wait <= 0) return;
+        long remaining = Utils.adjustTimeout(wait);
+        long start = System.nanoTime();
+        while (remaining > 0) {
+            Thread.sleep(remaining);
+            long end = System.nanoTime();
+            remaining = remaining - NANOSECONDS.toMillis(end - start);
+        }
+        System.out.printf("Waited %s ms%n",
+                NANOSECONDS.toMillis(System.nanoTime() - start));
     }
 
 
@@ -115,7 +132,7 @@ public class StreamFlowControlTest {
                 CompletableFuture<String> sent = new CompletableFuture<>();
                 responseSent.put(query, sent);
                 HttpRequest request = HttpRequest.newBuilder(uriWithQuery)
-                        .POST(BodyPublishers.ofString("Hello there!"))
+                        .GET()
                         .build();
                 System.out.println("\nSending request:" + uriWithQuery);
                 final HttpClient cc = client;
@@ -130,9 +147,9 @@ public class StreamFlowControlTest {
                     // we have to pull to get the exception, but slow enough
                     // so that DataFrames are buffered up to the point that
                     // the window is exceeded...
-                    int wait = uri.startsWith("https://") ? 500 : 350;
+                    long wait = uri.startsWith("https://") ? 800 : 350;
                     try (InputStream is = response.body()) {
-                        Thread.sleep(Utils.adjustTimeout(wait));
+                        sleep(wait);
                         is.readAllBytes();
                     }
                     // we could fail here if we haven't waited long enough
@@ -174,7 +191,7 @@ public class StreamFlowControlTest {
                 CompletableFuture<String> sent = new CompletableFuture<>();
                 responseSent.put(query, sent);
                 HttpRequest request = HttpRequest.newBuilder(uriWithQuery)
-                        .POST(BodyPublishers.ofString("Hello there!"))
+                        .GET()
                         .build();
                 System.out.println("\nSending request:" + uriWithQuery);
                 final HttpClient cc = client;
@@ -188,9 +205,9 @@ public class StreamFlowControlTest {
                         assertEquals(key, label, "Unexpected key for " + query);
                     }
                     sent.join();
-                    int wait = uri.startsWith("https://") ? 600 : 300;
+                    long wait = uri.startsWith("https://") ? 800 : 350;
                     try (InputStream is = response.body()) {
-                        Thread.sleep(Utils.adjustTimeout(wait));
+                        sleep(wait);
                         is.readAllBytes();
                     }
                     // we could fail here if we haven't waited long enough
@@ -252,7 +269,9 @@ public class StreamFlowControlTest {
         var https2TestServer = new Http2TestServer("localhost", true, sslContext);
         https2TestServer.addHandler(new Http2TestHandler(), "/https2/");
         this.https2TestServer = HttpTestServer.of(https2TestServer);
+        this.https2TestServer.addHandler(new HttpHeadHandler(), "/https2/head/");
         https2URI = "https://" + this.https2TestServer.serverAuthority() + "/https2/x";
+        String h2Head = "https://" + this.https2TestServer.serverAuthority() + "/https2/head/z";
 
         // Override the default exchange supplier with a custom one to enable
         // particular test scenarios
@@ -261,6 +280,13 @@ public class StreamFlowControlTest {
 
         this.http2TestServer.start();
         this.https2TestServer.start();
+
+        // warmup to eliminate delay due to SSL class loading and initialization.
+        try (var client = HttpClient.newBuilder().sslContext(sslContext).build();) {
+            var request = HttpRequest.newBuilder(URI.create(h2Head)).HEAD().build();
+            var resp = client.send(request, BodyHandlers.discarding());
+            assertEquals(resp.statusCode(), 200);
+        }
     }
 
     @AfterTest
@@ -279,11 +305,19 @@ public class StreamFlowControlTest {
                  OutputStream os = t.getResponseBody()) {
 
                 byte[] bytes = is.readAllBytes();
-                System.out.println("Server " + t.getLocalAddress() + " received:\n"
-                        + t.getRequestURI() + ": " + new String(bytes, StandardCharsets.UTF_8));
+                if (bytes.length != 0) {
+                    System.out.println("Server " + t.getLocalAddress() + " received:\n"
+                            + t.getRequestURI() + ": " + new String(bytes, StandardCharsets.UTF_8));
+                } else {
+                    System.out.println("No request body for " + t.getRequestMethod());
+                }
+
                 t.getResponseHeaders().setHeader("X-Connection-Key", t.getConnectionKey());
 
-                if (bytes.length == 0) bytes = "no request body!".getBytes(StandardCharsets.UTF_8);
+                if (bytes.length == 0) {
+                    bytes = "no request body!"
+                            .repeat(100).getBytes(StandardCharsets.UTF_8);
+                }
                 int window = Integer.getInteger("jdk.httpclient.windowsize", 2 * 16 * 1024);
                 final int maxChunkSize;
                 if (t instanceof FCHttp2TestExchange fct) {
@@ -307,13 +341,20 @@ public class StreamFlowControlTest {
                             // ignore and continue...
                         }
                     }
-                    ((BodyOutputStream) os).writeUncontrolled(resp, 0, resp.length);
+                    try {
+                        ((BodyOutputStream) os).writeUncontrolled(resp, 0, resp.length);
+                    } catch (IOException x) {
+                        if (t instanceof FCHttp2TestExchange fct) {
+                            fct.conn.updateConnectionWindow(resp.length);
+                        }
+                    }
                 }
+            } finally {
+                if (t instanceof FCHttp2TestExchange fct) {
+                    fct.responseSent(query);
+                } else fail("Exchange is not %s but %s"
+                        .formatted(FCHttp2TestExchange.class.getName(), t.getClass().getName()));
             }
-            if (t instanceof FCHttp2TestExchange fct) {
-                fct.responseSent(query);
-            } else fail("Exchange is not %s but %s"
-                    .formatted(FCHttp2TestExchange.class.getName(), t.getClass().getName()));
         }
     }
 

--- a/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
+++ b/test/jdk/java/net/httpclient/lib/jdk/httpclient/test/lib/http2/Http2TestServerConnection.java
@@ -1384,7 +1384,7 @@ public class Http2TestServerConnection {
         }
     }
 
-    void updateConnectionWindow(int amount) {
+    public void updateConnectionWindow(int amount) {
         System.out.printf("sendWindow (window=%s, amount=%s) is now: %s%n",
                 sendWindow, amount, sendWindow + amount);
         synchronized (this) {


### PR DESCRIPTION
[JDK-8342075](https://bugs.openjdk.org/browse/JDK-8342075) has introduced more flow controls checks, but also introduced a race condition where DataFrames for closed streams may fail to be discounted from the connection window.

The consequence is that WINDOW_UPDATE frames for the connection window may not be sent when they should, preventing the server from making progress and stalling the connection.

This can be shown by modifying the StreamFlowControlTest to send less but bigger frames (e.g. chunks of 1600 bytes instead of chunks of 12 bytes). With such a modification the test can be seen failing intermittently, when sameClient=true.

The race happens when frames that have been added to Stream::inputQ fail to be drained after the stream is closed (or continue to be added to the inputQ after the stream is closed).

The fix ensures that Stream::drainInputQueue() is called when the stream is closed, and that no further data farme will be added to the inputQ after the stream is marked closed.

The modified StreamFlowControlTest could be observed failing relatively frequently on linux-aarch64 without the fix.
With the fix the test no longer fails.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343855](https://bugs.openjdk.org/browse/JDK-8343855): HTTP/2 ConnectionWindowUpdateSender may miss some unprocessed DataFrames from closed streams (**Bug** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21991/head:pull/21991` \
`$ git checkout pull/21991`

Update a local copy of the PR: \
`$ git checkout pull/21991` \
`$ git pull https://git.openjdk.org/jdk.git pull/21991/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21991`

View PR using the GUI difftool: \
`$ git pr show -t 21991`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21991.diff">https://git.openjdk.org/jdk/pull/21991.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21991#issuecomment-2465423787)
</details>
