### PR TITLE
8343883: Cannot resolve user specified toolchain-path for lld after JDK-8338304

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -74,11 +74,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       # Clang needs the lld linker to work correctly
       BASIC_LDFLAGS="-fuse-ld=lld -Wl,--exclude-libs,ALL"
       if test "x$CXX_IS_USER_SUPPLIED" = xfalse && test "x$CC_IS_USER_SUPPLIED" = xfalse; then
-        if test "x$TOOLCHAIN_PATH" != x; then
-          UTIL_REQUIRE_PROGS(LLD, lld, $TOOLCHAIN_PATH)
-        else
-          UTIL_REQUIRE_PROGS(LLD, lld)
-        fi
+        UTIL_REQUIRE_PROGS(LLD, lld, $TOOLCHAIN_PATH:$PATH)
       fi
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then

--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -74,7 +74,11 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
       # Clang needs the lld linker to work correctly
       BASIC_LDFLAGS="-fuse-ld=lld -Wl,--exclude-libs,ALL"
       if test "x$CXX_IS_USER_SUPPLIED" = xfalse && test "x$CC_IS_USER_SUPPLIED" = xfalse; then
-        UTIL_REQUIRE_PROGS(LLD, lld)
+        if test "x$TOOLCHAIN_PATH" != x; then
+          UTIL_REQUIRE_PROGS(LLD, lld, $TOOLCHAIN_PATH)
+        else
+          UTIL_REQUIRE_PROGS(LLD, lld)
+        fi
       fi
     fi
     if test "x$OPENJDK_TARGET_OS" = xaix; then


### PR DESCRIPTION
Hi all,
After [JDK-8338304](https://bugs.openjdk.org/browse/JDK-8338304), below configure command will generate failure `error: Could not find required tool for LLD`. The lld linker located in path which config with option `--with-toolchain-path`, but the check `UTIL_REQUIRE_PROGS(LLD, lld)` introduced by [JDK-8338304](https://bugs.openjdk.org/browse/JDK-8338304) was unable to find the lld. This PR add the condition to deal with user specidied `--with-toolchain-path` to find the correct lld fullpath. The change has beeen verified locally, trivial fix, the risk is low.

```shell
bash configure --with-jobs=128 --with-debug-level=release --enable-unlimited-crypto --with-jvm-variants=server --with-version-opt=f4008968 --with-zlib=system --with-toolchain-type=clang --with-toolchain-path=/home/yansendao/software/acc/x86_64/bin
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343883](https://bugs.openjdk.org/browse/JDK-8343883): Cannot resolve user specified toolchain-path for lld after JDK-8338304 (**Bug** - P4)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer) Review applies to [6f513a3a](https://git.openjdk.org/jdk/pull/21999/files/6f513a3a8f5ba704ff9c4675c65ba846192c0a1d)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/21999/head:pull/21999` \
`$ git checkout pull/21999`

Update a local copy of the PR: \
`$ git checkout pull/21999` \
`$ git pull https://git.openjdk.org/jdk.git pull/21999/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 21999`

View PR using the GUI difftool: \
`$ git pr show -t 21999`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/21999.diff">https://git.openjdk.org/jdk/pull/21999.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/21999#issuecomment-2466577377)
</details>
