### PR TITLE
Optimize int and long to string

### DIFF
--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -126,11 +126,11 @@ final class StringLatin1 {
             charPos -= 2;
             writeDigitPair(buf, charPos, -i);
         } else {
-            buf[--charPos] = (byte)('0' - i);
+            putChar(buf, --charPos, '0' - i);
         }
 
         if (negative) {
-            buf[--charPos] = (byte)'-';
+            putChar(buf, --charPos, '-');
         }
         return charPos;
     }
@@ -185,19 +185,19 @@ final class StringLatin1 {
             charPos -= 2;
             writeDigitPair(buf, charPos, -i2);
         } else {
-            buf[--charPos] = (byte)('0' - i2);
+            putChar(buf, --charPos, '0' - i2);
         }
 
         if (negative) {
-            buf[--charPos] = (byte)'-';
+            putChar(buf, --charPos, '-');
         }
         return charPos;
     }
 
     private static void writeDigitPair(byte[] buf, int charPos, int value) {
         short pair = DecimalDigits.digitPair(value);
-        buf[charPos] = (byte)(pair);
-        buf[charPos + 1] = (byte)(pair >> 8);
+        putChar(buf, charPos    , (byte)(pair));
+        putChar(buf, charPos + 1, (byte)(pair >> 8));
     }
 
     public static void getChars(byte[] value, int srcBegin, int srcEnd, char[] dst, int dstBegin) {
@@ -849,8 +849,8 @@ final class StringLatin1 {
     }
 
     public static void putChar(byte[] val, int index, int c) {
-        //assert (canEncode(c));
-        val[index] = (byte)(c);
+        assert index >= 0 && index < length(val) : "Trusted caller missed bounds check";
+        UNSAFE.putByte(val, Unsafe.ARRAY_BYTE_BASE_OFFSET + index, (byte) c);
     }
 
     public static char getChar(byte[] val, int index) {

--- a/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
+++ b/test/micro/org/openjdk/bench/java/lang/StringBuilders.java
@@ -54,6 +54,8 @@ public class StringBuilders {
     private StringBuilder sbLatin2;
     private StringBuilder sbUtf16;
     private StringBuilder sbUtf17;
+    private int[] intsArray;
+    private long[] longArray;
 
     @Setup
     public void setup() {
@@ -69,6 +71,13 @@ public class StringBuilders {
         sbLatin2 = new StringBuilder("Latin1 string");
         sbUtf16 = new StringBuilder("UTF-\uFF11\uFF16 string");
         sbUtf17 = new StringBuilder("UTF-\uFF11\uFF16 string");
+        int size = 16;
+        intsArray = new int[size];
+        longArray = new long[size];
+        for (int i = 0; i < longArray.length; i++) {
+            intsArray[i] = ((100 * i + i) << 24) + 4543 + i * 4;
+            longArray[i] = ((100L * i + i) << 32) + 4543 + i * 4L;
+        }
     }
 
     @Benchmark
@@ -224,6 +233,47 @@ public class StringBuilders {
         return result.toString();
     }
 
+    @Benchmark
+    public int appendWithIntLatin1() {
+        StringBuilder buf = sbLatin1;
+        buf.setLength(0);
+        for (long l : longArray) {
+            buf.append(l);
+        }
+        return buf.length();
+    }
+
+    @Benchmark
+    public int appendWithIntUtf16() {
+        StringBuilder buf = sbUtf16;
+        buf.setLength(0);
+        buf.setLength(0);
+        for (long l : longArray) {
+            buf.append(l);
+        }
+        return buf.length();
+    }
+
+    @Benchmark
+    public int appendWithLongLatin1() {
+        StringBuilder buf = sbLatin1;
+        buf.setLength(0);
+        for (long l : longArray) {
+            buf.append(l);
+        }
+        return buf.length();
+    }
+
+    @Benchmark
+    public int appendWithLongUtf16() {
+        StringBuilder buf = sbUtf16;
+        buf.setLength(0);
+        buf.setLength(0);
+        for (long l : longArray) {
+            buf.append(l);
+        }
+        return buf.length();
+    }
 
     @Benchmark
     public int appendWithBool8Latin1() {


### PR DESCRIPTION
StringUTF16#putChar is a trusted caller missed bounds check, which makes -COMPACT_STRINGS perform better than +COMPACT_STRINGS in the scenarios of Integer/Long.toString and StringBuilder#append(int/long). I think this is not the performance number we expect.

Below are the performance numbers running under AMD EPYC™ Genoa (x64)

* benchmark script
```sh
git remote add wenshao git@github.com:wenshao/jdk.git
git fetch wenshao

# master
git checkout 37387d8a27dacb52e2c9fe44852b42c899572619
make test TEST="micro:java.lang.StringBuilders.appendWithInt"
make test TEST="micro:java.lang.StringBuilders.appendWithLong"

# current
git checkout 661fccf05053bda7428bbb0c36a4d15144c94d62
make test TEST="micro:java.lang.StringBuilders.appendWithInt"
make test TEST="micro:java.lang.StringBuilders.appendWithLong"
```

* benchmark numbers
```diff
# master 37387d8a27dacb52e2c9fe44852b42c899572619
Benchmark                           Mode  Cnt    Score   Error  Units
StringBuilders.appendWithIntLatin1  avgt   15  225.953 ± 0.923  ns/op
StringBuilders.appendWithIntUtf16   avgt   15  212.090 ± 1.172  ns/op

Benchmark                            Mode  Cnt    Score   Error  Units
StringBuilders.appendWithLongLatin1  avgt   15  227.951 ± 3.702  ns/op
StringBuilders.appendWithLongUtf16   avgt   15  211.267 ± 1.914  ns/op

# current 661fccf05053bda7428bbb0c36a4d15144c94d62
Benchmark                           Mode  Cnt    Score   Error  Units
StringBuilders.appendWithIntLatin1  avgt   15  192.433 ± 0.956  ns/op +17%
StringBuilders.appendWithIntUtf16   avgt   15  210.805 ± 0.624  ns/op

Benchmark                            Mode  Cnt    Score   Error  Units
StringBuilders.appendWithLongLatin1  avgt   15  191.443 ± 1.533  ns/op +19%
StringBuilders.appendWithLongUtf16   avgt   15  210.444 ± 1.118  ns/op

```

In the master version, we can see that the performance of appendWithIntLatin1 is worse than that of appendWithIntUtf16.

In the current version, based on the unsafe implementation of putChar, the performance of appendWithIntLatin1 and appendWithLongLatin1 has increased by 17% and 19% respectively, which means that the performance of appendWithIntLatin1 exceeds that of appendWithIntUtf16.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22000/head:pull/22000` \
`$ git checkout pull/22000`

Update a local copy of the PR: \
`$ git checkout pull/22000` \
`$ git pull https://git.openjdk.org/jdk.git pull/22000/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22000`

View PR using the GUI difftool: \
`$ git pr show -t 22000`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22000.diff">https://git.openjdk.org/jdk/pull/22000.diff</a>

</details>
