### PR TITLE
8343894: ProblemList javax/management/remote/mandatory/notif/EmptyDomainNotificationTest.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -563,6 +563,8 @@ javax/management/monitor/DerivedGaugeMonitorTest.java           8042211 generic-
 
 javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8262312 linux-all
 
+javax/management/remote/mandatory/notif/EmptyDomainNotificationTest.java 8343838 generic-all
+
 ############################################################################
 
 # jdk_net


### PR DESCRIPTION
This is causing hundreds of failures in our CI and [JDK-8343838](https://bugs.openjdk.org/browse/JDK-8343838) may not be fixed for a number of hours yet.

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343894](https://bugs.openjdk.org/browse/JDK-8343894): ProblemList javax/management/remote/mandatory/notif/EmptyDomainNotificationTest.java (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22001/head:pull/22001` \
`$ git checkout pull/22001`

Update a local copy of the PR: \
`$ git checkout pull/22001` \
`$ git pull https://git.openjdk.org/jdk.git pull/22001/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22001`

View PR using the GUI difftool: \
`$ git pr show -t 22001`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22001.diff">https://git.openjdk.org/jdk/pull/22001.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22001#issuecomment-2467061834)
</details>
