### PR TITLE
8343902: javax/swing/plaf/nimbus/8041642/bug8041642.java fails in ubuntu22.04

### DIFF
--- a/test/jdk/javax/swing/plaf/nimbus/8041642/bug8041642.java
+++ b/test/jdk/javax/swing/plaf/nimbus/8041642/bug8041642.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,11 +26,16 @@
  * @key headful
  * @bug 8041642 8079450 8140237
  * @summary Incorrect paint of JProgressBar in Nimbus LF
- * @author Semyon Sadetsky
  */
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.BorderLayout;
+import java.awt.Color;
+import java.awt.Point;
+import java.awt.Robot;
+import javax.swing.JFrame;
+import javax.swing.JProgressBar;
+import javax.swing.SwingUtilities;
+import javax.swing.UIManager;
 
 public class bug8041642 {
 
@@ -50,7 +55,8 @@ public class bug8041642 {
                 }
             });
             final Robot robot = new Robot();
-            robot.delay(300);
+            robot.waitForIdle();
+            robot.delay(1000);
             SwingUtilities.invokeAndWait(new Runnable() {
                 @Override
                 public void run() {
@@ -58,7 +64,7 @@ public class bug8041642 {
                 }
             });
             Color color = robot.getPixelColor(point.x + 1, point.y + 7);
-            System.out.println(color);
+            System.out.println("point " + point + " color " + color);
             if (color.getGreen() < 150 || color.getBlue() > 30 ||
                     color.getRed() > 200) {
                 throw new RuntimeException("Bar padding color should be green");

--- a/test/jdk/javax/swing/plaf/nimbus/8041642/bug8041642.java
+++ b/test/jdk/javax/swing/plaf/nimbus/8041642/bug8041642.java
@@ -28,10 +28,15 @@
  * @summary Incorrect paint of JProgressBar in Nimbus LF
  */
 
+import java.io.File;
 import java.awt.BorderLayout;
 import java.awt.Color;
+import java.awt.Graphics;
 import java.awt.Point;
+import java.awt.Rectangle;
 import java.awt.Robot;
+import java.awt.image.BufferedImage;
+import javax.imageio.ImageIO;
 import javax.swing.JFrame;
 import javax.swing.JProgressBar;
 import javax.swing.SwingUtilities;
@@ -67,6 +72,12 @@ public class bug8041642 {
             System.out.println("point " + point + " color " + color);
             if (color.getGreen() < 150 || color.getBlue() > 30 ||
                     color.getRed() > 200) {
+                Rectangle bounds = frame.getBounds();
+                BufferedImage img = new BufferedImage(bounds.width, bounds.height, BufferedImage.TYPE_INT_ARGB);
+                Graphics g = img.getGraphics();
+                frame.paint(g);
+                g.dispose();
+                ImageIO.write(img, "png", new File("bug8041642.png"));
                 throw new RuntimeException("Bar padding color should be green");
             }
 


### PR DESCRIPTION
test/jdk/javax/swing/plaf/nimbus/8041642/bug8041642.java fails in ubuntu 22.04 OCI with

----------System.out:(1/30)----------
java.awt.Color[r=49,g=0,b=33]
----------System.err:(11/647)----------
java.lang.RuntimeException: Bar padding color should be green
at bug8041642.main(bug8041642.java:64)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:573)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1576) 

and the color obtained seems to suggest that the frame is not visible when the test condition was checked, since the color seems to be dark brown which seems to be the desktop barkground in ubuntu, I have updated the test to have more delay of 1sec which is what we used for headful test after creating GUI and subsequent run works fine in my testing...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343902](https://bugs.openjdk.org/browse/JDK-8343902): javax/swing/plaf/nimbus/8041642/bug8041642.java fails in ubuntu22.04 (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22002/head:pull/22002` \
`$ git checkout pull/22002`

Update a local copy of the PR: \
`$ git checkout pull/22002` \
`$ git pull https://git.openjdk.org/jdk.git pull/22002/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22002`

View PR using the GUI difftool: \
`$ git pr show -t 22002`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22002.diff">https://git.openjdk.org/jdk/pull/22002.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22002#issuecomment-2467333684)
</details>
