### PR TITLE
8342811: java/net/httpclient/PlainProxyConnectionTest.java failed: Unexpected connection count: 5

### DIFF
--- a/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
+++ b/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
+++ b/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
@@ -60,13 +60,6 @@ import static java.net.Proxy.NO_PROXY;
  *          diagnosis of intermittent failures reported in 8342811.
  * @library /test/lib
  *          /test/jdk/java/net/httpclient/lib
- * @modules java.base/sun.net.www.http
- *          java.base/sun.net.www
- *          java.base/sun.net
- *          java.net.http/jdk.internal.net.http.common
- *          java.net.http/jdk.internal.net.http.frame
- *          java.net.http/jdk.internal.net.http.hpack
- *          jdk.httpserver
  * @run main/othervm -Djdk.tracePinnedThreads=full
  *      -Djdk.httpclient.HttpClient.log=headers,requests,trace
  *      -Djdk.internal.httpclient.debug=true

--- a/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
+++ b/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
@@ -64,7 +64,6 @@ import static java.net.Proxy.NO_PROXY;
  *      -Djdk.httpclient.HttpClient.log=headers,requests,trace
  *      -Djdk.internal.httpclient.debug=true
  *      PlainProxyConnectionTest
- * @author danielfuchs
  */
 public class PlainProxyConnectionTest {
 

--- a/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
+++ b/test/jdk/java/net/httpclient/PlainProxyConnectionTest.java
@@ -53,11 +53,11 @@ import static java.net.Proxy.NO_PROXY;
 
 /**
  * @test
- * @bug 8230526 8342811
+ * @bug 8230526
  * @summary Verifies that PlainProxyConnections are cached and reused properly. We do this by
  *          verifying that the remote address of the HTTP exchange (on the fake proxy server)
  *          is always the same InetSocketAddress. Logging verbosity is increased to aid in
- *          diagnosis of intermittent failures reported in 8342811.
+ *          diagnosis of intermittent failures.
  * @library /test/lib
  *          /test/jdk/java/net/httpclient/lib
  * @run main/othervm -Djdk.tracePinnedThreads=full
@@ -67,7 +67,7 @@ import static java.net.Proxy.NO_PROXY;
  */
 public class PlainProxyConnectionTest {
 
-    // Increase logging verbosity to troubleshoot intermittent failures reported in 8342811
+    // Increase logging verbosity to troubleshoot intermittent failures
     static {
         HttpServerAdapters.enableServerLogging();
     }


### PR DESCRIPTION
This PR introduces the following changes addressing intermittent `PlainProxyConnectionTest` failures reported in [JDK-8342811](https://bugs.openjdk.org/browse/JDK-8342811):

* Increase logging verbosity to aid in troubleshooting (if the failure happens to pop up again)
* Add salt to the used HTTP server path to decrease the chances of parallel running tests from interfering

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342811](https://bugs.openjdk.org/browse/JDK-8342811): java/net/httpclient/PlainProxyConnectionTest.java failed: Unexpected connection count: 5 (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22003/head:pull/22003` \
`$ git checkout pull/22003`

Update a local copy of the PR: \
`$ git checkout pull/22003` \
`$ git pull https://git.openjdk.org/jdk.git pull/22003/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22003`

View PR using the GUI difftool: \
`$ git pr show -t 22003`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22003.diff">https://git.openjdk.org/jdk/pull/22003.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22003#issuecomment-2476437491)
</details>
