### PR TITLE
8343915: Memory leak at MethodHandles::verify_ref_kind of methodHandles_x86.cpp

### DIFF
--- a/src/hotspot/cpu/x86/methodHandles_x86.cpp
+++ b/src/hotspot/cpu/x86/methodHandles_x86.cpp
@@ -118,6 +118,7 @@ void MethodHandles::verify_ref_kind(MacroAssembler* _masm, int ref_kind, Registe
       // could do this for all ref_kinds, but would explode assembly code size
       trace_method_handle(_masm, buf);
     __ STOP(buf);
+    FreeHeap(buf);
   }
   BLOCK_COMMENT("} verify_ref_kind");
   __ bind(L);


### PR DESCRIPTION
When I build the jdk with additional configure options `--enable-asan --enable-ubsan --enable-lsan`, during the make process the make break as address sinitizer report memory leak at `MethodHandles::verify_ref_kind` of methodHandles_x86.cpp

Additional testing:

- [ ] linux-x64 build with fastdebug/release configure
- [ ] linux-x64 jtreg tests(include tier1/2/3) with release build
- [ ] linux-x64 jtreg tests(include tier1/2/3) with fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343915](https://bugs.openjdk.org/browse/JDK-8343915): Memory leak at MethodHandles::verify_ref_kind of methodHandles_x86.cpp (**Bug** - P3) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22004/head:pull/22004` \
`$ git checkout pull/22004`

Update a local copy of the PR: \
`$ git checkout pull/22004` \
`$ git pull https://git.openjdk.org/jdk.git pull/22004/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22004`

View PR using the GUI difftool: \
`$ git pr show -t 22004`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22004.diff">https://git.openjdk.org/jdk/pull/22004.diff</a>

</details>
