### PR TITLE
8343929: Remove PreservedMarksSet::createTask() after JDK-8305895

### DIFF
--- a/src/hotspot/share/gc/shared/preservedMarks.cpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.cpp
@@ -143,10 +143,6 @@ void PreservedMarksSet::restore(WorkerThreads* workers) {
   assert_empty();
 }
 
-WorkerTask* PreservedMarksSet::create_task() {
-  return new RestorePreservedMarksTask(this);
-}
-
 void PreservedMarksSet::reclaim() {
   assert_empty();
 

--- a/src/hotspot/share/gc/shared/preservedMarks.hpp
+++ b/src/hotspot/share/gc/shared/preservedMarks.hpp
@@ -114,8 +114,6 @@ public:
   // is null, perform the work serially in the current thread.
   void restore(WorkerThreads* workers);
 
-  WorkerTask* create_task();
-
   // Reclaim stack array.
   void reclaim();
 


### PR DESCRIPTION
Hi all,

  please review this trivial cleanup after pushing the Compact Object Header JEP (JDK-8305895).

The method mentioned is unused.

Testing: gha, local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343929](https://bugs.openjdk.org/browse/JDK-8343929): Remove PreservedMarksSet::createTask() after JDK-8305895 (**Enhancement** - P4)


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22006/head:pull/22006` \
`$ git checkout pull/22006`

Update a local copy of the PR: \
`$ git checkout pull/22006` \
`$ git pull https://git.openjdk.org/jdk.git pull/22006/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22006`

View PR using the GUI difftool: \
`$ git pr show -t 22006`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22006.diff">https://git.openjdk.org/jdk/pull/22006.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22006#issuecomment-2467736279)
</details>
