### PR TITLE
8042211: javax/management/monitor/DerivedGaugeMonitorTest.java AByte: Count down not reached

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -559,8 +559,6 @@ sun/management/jdp/JdpOffTest.java                              8308807 aix-ppc6
 
 javax/management/MBeanServer/OldMBeanServerTest.java            8030957 aix-all
 
-javax/management/monitor/DerivedGaugeMonitorTest.java           8042211 generic-all
-
 javax/management/remote/mandatory/connection/BrokenConnectionTest.java 8262312 linux-all
 
 javax/management/remote/mandatory/notif/EmptyDomainNotificationTest.java 8343838 generic-all

--- a/test/jdk/javax/management/monitor/DerivedGaugeMonitorTest.java
+++ b/test/jdk/javax/management/monitor/DerivedGaugeMonitorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,6 +42,8 @@ import javax.management.monitor.CounterMonitor;
 import javax.management.monitor.GaugeMonitor;
 
 public class DerivedGaugeMonitorTest {
+
+    public static final int WAIT_TIME = 10000;
 
     public static interface Things {
         public long getALong();
@@ -239,7 +241,7 @@ public class DerivedGaugeMonitorTest {
             mon1.setGranularityPeriod(5);
             mon2.setGranularityPeriod(5);
 
-            my.cdl.await(1000, TimeUnit.MILLISECONDS);
+            my.cdl.await(WAIT_TIME, TimeUnit.MILLISECONDS);
             if (my.cdl.getCount() > 0)
                 throw new Exception(attr+": Count down not reached!");
 


### PR DESCRIPTION
Test timeout change to cope with -Xcomp runs.
More testing in progress, will finalize when tests are done.