### PR TITLE
8343934: Problemlist java/util/BitSet/HugeToString.java

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -745,6 +745,7 @@ com/sun/jdi/InvokeHangTest.java                                 8218463 linux-al
 
 # jdk_util
 java/util/zip/CloseInflaterDeflaterTest.java  8339216 linux-s390x
+java/util/BitSet/HugeToString.java            8343925 linux-all
 
 ############################################################################
 


### PR DESCRIPTION
Hi all,
Before the root cause of [JDK-8343925](https://bugs.openjdk.org/browse/JDK-8343925) has been fixed, should we Problemlist the known failure test `java/util/BitSet/HugeToString.java`, to make less CI noisy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343934](https://bugs.openjdk.org/browse/JDK-8343934): Problemlist java/util/BitSet/HugeToString.java (**Sub-task** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22013/head:pull/22013` \
`$ git checkout pull/22013`

Update a local copy of the PR: \
`$ git checkout pull/22013` \
`$ git pull https://git.openjdk.org/jdk.git pull/22013/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22013`

View PR using the GUI difftool: \
`$ git pr show -t 22013`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22013.diff">https://git.openjdk.org/jdk/pull/22013.diff</a>

</details>
