### PR TITLE
Fix DecimalDigits unsafe offset overflow

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
+++ b/src/java.base/share/classes/jdk/internal/util/DecimalDigits.java
@@ -28,8 +28,6 @@ package jdk.internal.util;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.vm.annotation.Stable;
 
-import static jdk.internal.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
-
 /**
  * Digits class for decimal digits.
  *
@@ -37,6 +35,7 @@ import static jdk.internal.misc.Unsafe.ARRAY_BYTE_BASE_OFFSET;
  */
 public final class DecimalDigits {
     private static final Unsafe UNSAFE = Unsafe.getUnsafe();
+    private static final long ARRAY_BYTE_BASE_OFFSET = Unsafe.ARRAY_BYTE_BASE_OFFSET;
 
     /**
      * Each element of the array represents the packaging of two ascii characters based on little endian:<p>


### PR DESCRIPTION
8343925 Feedback PR #21593 test/jdk/java/util/BitSet/HugeToString.java crash， It has been verified that the problem is caused by unsafe offset overflow. The problem has been reproduced and fixed.

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22014/head:pull/22014` \
`$ git checkout pull/22014`

Update a local copy of the PR: \
`$ git checkout pull/22014` \
`$ git pull https://git.openjdk.org/jdk.git pull/22014/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22014`

View PR using the GUI difftool: \
`$ git pr show -t 22014`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22014.diff">https://git.openjdk.org/jdk/pull/22014.diff</a>

</details>
