### PR TITLE
8343946: JFR: Wildcard should only work with COUNT for 'jfr view'

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/QueryResolver.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/QueryResolver.java
@@ -144,7 +144,7 @@ final class QueryResolver {
             field.aggregator = expression.aggregator();
             FieldBuilder.configureAggregator(field);
             expression.alias().ifPresent(alias -> fieldAliases.put(alias, field));
-            if (field.name.equals("*") && field.aggregator != Aggregator.COUNT) {
+            if (expression.name().equals("*") && field.aggregator != Aggregator.COUNT) {
                 throw new QuerySyntaxException("Wildcard ('*') can only be used with aggregator function COUNT");
             }
         }
@@ -259,7 +259,7 @@ final class QueryResolver {
         List<Field> fields = new ArrayList<>();
 
         if (name.equals("*")) {
-            // Used with COUNT(*) and UNIQUE(*)
+            // Used with COUNT(*)
             // All events should have a start time
             name = "startTime";
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/query/view.ini
@@ -178,7 +178,7 @@ table = "COLUMN 'StackTrace', 'Count', 'Avg.', 'Max.'
 [application.contention-by-address]
 label = "Contention by Monitor Address"
 table = "COLUMN 'Monitor Address', 'Class', 'Threads', 'Max Duration'
-         SELECT address, FIRST(monitorClass), UNIQUE(*), MAX(duration) AS M
+         SELECT address, FIRST(monitorClass), UNIQUE(eventThread), MAX(duration) AS M
          FROM JavaMonitorEnter
          GROUP BY monitorClass ORDER BY M"
 


### PR DESCRIPTION
Could I have a review of a PR that fixes a query validation bug for 'jfr view'?

When '*' is used as a field name with an aggregator function, the implementation defaults to using the 'startTime' field, resulting in the field expression COUNT(startTime). Unfortunately, this behavior allows the aggregate function to bypass validation. This issue can be fixed by checking against the actual text rather than the field name.

The lack of validation led to incorrect numbers being used for the 'Threads' column in the contention-by-address view.

Testing: jdk/jdk/jfr and manual inspection.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343946](https://bugs.openjdk.org/browse/JDK-8343946): JFR: Wildcard should only work with COUNT for 'jfr view' (**Bug** - P3)


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22018/head:pull/22018` \
`$ git checkout pull/22018`

Update a local copy of the PR: \
`$ git checkout pull/22018` \
`$ git pull https://git.openjdk.org/jdk.git pull/22018/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22018`

View PR using the GUI difftool: \
`$ git pr show -t 22018`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22018.diff">https://git.openjdk.org/jdk/pull/22018.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22018#issuecomment-2468821060)
</details>
