### PR TITLE
8338565: Test crashed: assert(is_path_empty()) failed: invariant

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrEmergencyDump.cpp
@@ -109,8 +109,6 @@ static void close_emergency_dump_file() {
 }
 
 static const char* create_emergency_dump_path() {
-  assert(is_path_empty(), "invariant");
-
   const size_t path_len = get_dump_directory();
   if (path_len == 0) {
     return nullptr;


### PR DESCRIPTION
Greetings,

This adjustment removes an assert which is unnecessarily strong.

Its ok to reuse the _path_buffer, because every use is a full overwrite, i.e. a clobber.

Tests: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8338565](https://bugs.openjdk.org/browse/JDK-8338565): Test crashed: assert(is_path_empty()) failed: invariant (**Bug** - P4)


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22021/head:pull/22021` \
`$ git checkout pull/22021`

Update a local copy of the PR: \
`$ git checkout pull/22021` \
`$ git pull https://git.openjdk.org/jdk.git pull/22021/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22021`

View PR using the GUI difftool: \
`$ git pr show -t 22021`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22021.diff">https://git.openjdk.org/jdk/pull/22021.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22021#issuecomment-2468885646)
</details>
