### PR TITLE
8343964: RISC-V: Improve PrintOptoAssembly output for loadNKlassCompactHeaders node

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -4790,7 +4790,7 @@ instruct loadN(iRegNNoSp dst, memory mem)
   match(Set dst (LoadN mem));
 
   ins_cost(LOAD_COST);
-  format %{ "lwu  $dst, $mem\t# loadN, compressed ptr, #@loadN" %}
+  format %{ "lwu  $dst, $mem\t# compressed ptr, #@loadN" %}
 
   ins_encode %{
     __ lwu(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
@@ -4821,7 +4821,7 @@ instruct loadNKlass(iRegNNoSp dst, memory mem)
   match(Set dst (LoadNKlass mem));
 
   ins_cost(LOAD_COST);
-  format %{ "lwu  $dst, $mem\t# loadNKlass, compressed class ptr, #@loadNKlass" %}
+  format %{ "lwu  $dst, $mem\t# compressed class ptr, #@loadNKlass" %}
 
   ins_encode %{
     __ lwu(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
@@ -4836,7 +4836,7 @@ instruct loadNKlassCompactHeaders(iRegNNoSp dst, memory mem)
   match(Set dst (LoadNKlass mem));
 
   ins_cost(LOAD_COST);
-  format %{ "lwu  $dst, $mem\t# loadNKlass, compressed class ptr, #@loadNKlass" %}
+  format %{ "load_narrow_klass_compact $dst, $mem\t# compressed class ptr, #@loadNKlassCompactHeaders" %}
 
   ins_encode %{
     __ load_narrow_klass_compact_c2(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));


### PR DESCRIPTION
Hi, please review this small change.

Currently, we print a simple `lwu` for this node, which is not accurate becasue we do a `ld` and logic shift right the loaded 64-bit value for this node. This simply changed it into `load_narrow_klass_compact` like other CPU platforms. After this change, we have:

```
070     B2: #   out( B8 B3 ) <- in( B1 )  Freq: 0.9
070 +   load_narrow_klass_compact R28, [R12, #4]        # compressed class ptr, #@loadNKlassCompactHeaders
```

(Tagging: @Hamlin-Li)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343964](https://bugs.openjdk.org/browse/JDK-8343964): RISC-V: Improve PrintOptoAssembly output for loadNKlassCompactHeaders node (**Enhancement** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22025/head:pull/22025` \
`$ git checkout pull/22025`

Update a local copy of the PR: \
`$ git checkout pull/22025` \
`$ git pull https://git.openjdk.org/jdk.git pull/22025/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22025`

View PR using the GUI difftool: \
`$ git pr show -t 22025`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22025.diff">https://git.openjdk.org/jdk/pull/22025.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22025#issuecomment-2469529754)
</details>
