### PR TITLE
8343984: Fix Unsafe address overflow

### DIFF
--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -830,11 +830,11 @@ final class StringLatin1 {
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4) {
         assert index >= 0 && index + 3 < length(val) : "Trusted caller missed bounds check";
         // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
-        long address  = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
-        UNSAFE.putByte(val, address    , (byte)(c1));
-        UNSAFE.putByte(val, address + 1, (byte)(c2));
-        UNSAFE.putByte(val, address + 2, (byte)(c3));
-        UNSAFE.putByte(val, address + 3, (byte)(c4));
+        long offset  = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        UNSAFE.putByte(val, offset    , (byte)(c1));
+        UNSAFE.putByte(val, offset + 1, (byte)(c2));
+        UNSAFE.putByte(val, offset + 2, (byte)(c3));
+        UNSAFE.putByte(val, offset + 3, (byte)(c4));
     }
 
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4, int c5) {

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -830,7 +830,7 @@ final class StringLatin1 {
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4) {
         assert index >= 0 && index + 3 < length(val) : "Trusted caller missed bounds check";
         // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
-        long offset  = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        long offset = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
         UNSAFE.putByte(val, offset    , (byte)(c1));
         UNSAFE.putByte(val, offset + 1, (byte)(c2));
         UNSAFE.putByte(val, offset + 2, (byte)(c3));

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -830,7 +830,7 @@ final class StringLatin1 {
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4) {
         assert index >= 0 && index + 3 < length(val) : "Trusted caller missed bounds check";
         // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
-        long address  = Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        long address  = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
         UNSAFE.putByte(val, address    , (byte)(c1));
         UNSAFE.putByte(val, address + 1, (byte)(c2));
         UNSAFE.putByte(val, address + 2, (byte)(c3));
@@ -840,7 +840,7 @@ final class StringLatin1 {
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4, int c5) {
         assert index >= 0 && index + 4 < length(val) : "Trusted caller missed bounds check";
         // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
-        long address  = Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        long address  = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
         UNSAFE.putByte(val, address    , (byte)(c1));
         UNSAFE.putByte(val, address + 1, (byte)(c2));
         UNSAFE.putByte(val, address + 2, (byte)(c3));

--- a/src/java.base/share/classes/java/lang/StringLatin1.java
+++ b/src/java.base/share/classes/java/lang/StringLatin1.java
@@ -840,12 +840,12 @@ final class StringLatin1 {
     static void putCharsAt(byte[] val, int index, int c1, int c2, int c3, int c4, int c5) {
         assert index >= 0 && index + 4 < length(val) : "Trusted caller missed bounds check";
         // Don't use the putChar method, Its instrinsic will cause C2 unable to combining values into larger stores.
-        long address  = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
-        UNSAFE.putByte(val, address    , (byte)(c1));
-        UNSAFE.putByte(val, address + 1, (byte)(c2));
-        UNSAFE.putByte(val, address + 2, (byte)(c3));
-        UNSAFE.putByte(val, address + 3, (byte)(c4));
-        UNSAFE.putByte(val, address + 4, (byte)(c5));
+        long offset  = (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        UNSAFE.putByte(val, offset    , (byte)(c1));
+        UNSAFE.putByte(val, offset + 1, (byte)(c2));
+        UNSAFE.putByte(val, offset + 2, (byte)(c3));
+        UNSAFE.putByte(val, offset + 3, (byte)(c4));
+        UNSAFE.putByte(val, offset + 4, (byte)(c5));
     }
 
     public static void putChar(byte[] val, int index, int c) {

--- a/src/java.base/share/classes/java/util/zip/ZipUtils.java
+++ b/src/java.base/share/classes/java/util/zip/ZipUtils.java
@@ -174,7 +174,7 @@ class ZipUtils {
         Preconditions.checkIndex(off, b.length, Preconditions.AIOOBE_FORMATTER);
         Preconditions.checkIndex(off + 1, b.length, Preconditions.AIOOBE_FORMATTER);
         return Short.toUnsignedInt(
-                UNSAFE.getShortUnaligned(b, off + Unsafe.ARRAY_BYTE_BASE_OFFSET, false));
+                UNSAFE.getShortUnaligned(b, off + (long) Unsafe.ARRAY_BYTE_BASE_OFFSET, false));
     }
 
     /**
@@ -185,7 +185,7 @@ class ZipUtils {
         Preconditions.checkIndex(off, b.length, Preconditions.AIOOBE_FORMATTER);
         Preconditions.checkIndex(off + 3, b.length, Preconditions.AIOOBE_FORMATTER);
         return Integer.toUnsignedLong(
-                UNSAFE.getIntUnaligned(b, off + Unsafe.ARRAY_BYTE_BASE_OFFSET, false));
+                UNSAFE.getIntUnaligned(b, off + (long) Unsafe.ARRAY_BYTE_BASE_OFFSET, false));
     }
 
     /**
@@ -195,7 +195,7 @@ class ZipUtils {
     public static final long get64S(byte[] b, int off) {
         Preconditions.checkIndex(off, b.length, Preconditions.AIOOBE_FORMATTER);
         Preconditions.checkIndex(off + 7, b.length, Preconditions.AIOOBE_FORMATTER);
-        return UNSAFE.getLongUnaligned(b, off + Unsafe.ARRAY_BYTE_BASE_OFFSET, false);
+        return UNSAFE.getLongUnaligned(b, off + (long) Unsafe.ARRAY_BYTE_BASE_OFFSET, false);
     }
 
     /**
@@ -206,7 +206,7 @@ class ZipUtils {
     public static final int get32S(byte[] b, int off) {
         Preconditions.checkIndex(off, b.length, Preconditions.AIOOBE_FORMATTER);
         Preconditions.checkIndex(off + 3, b.length, Preconditions.AIOOBE_FORMATTER);
-        return UNSAFE.getIntUnaligned(b, off + Unsafe.ARRAY_BYTE_BASE_OFFSET, false);
+        return UNSAFE.getIntUnaligned(b, off + (long) Unsafe.ARRAY_BYTE_BASE_OFFSET, false);
     }
 
     /*

--- a/src/java.base/share/classes/sun/nio/cs/StringUTF16.java
+++ b/src/java.base/share/classes/sun/nio/cs/StringUTF16.java
@@ -32,7 +32,7 @@ class StringUTF16 {
 
     public static char getChar(byte[] val, int index) {
         return unsafe.getChar(val,
-                (long) ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * index * 2L);
+                              ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * index * 2L);
     }
 
     private static final jdk.internal.misc.Unsafe unsafe = jdk.internal.misc.Unsafe.getUnsafe();

--- a/src/java.base/share/classes/sun/nio/cs/StringUTF16.java
+++ b/src/java.base/share/classes/sun/nio/cs/StringUTF16.java
@@ -32,7 +32,7 @@ class StringUTF16 {
 
     public static char getChar(byte[] val, int index) {
         return unsafe.getChar(val,
-                              ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * index * 2L);
+                (long) ARRAY_BYTE_BASE_OFFSET + ARRAY_BYTE_INDEX_SCALE * index * 2L);
     }
 
     private static final jdk.internal.misc.Unsafe unsafe = jdk.internal.misc.Unsafe.getUnsafe();

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -194,7 +194,7 @@ abstract class UnixUserDefinedFileAttributeView
                 int n = read(name, address, rem);
 
                 // copy from buffer into backing array
-                int off = dst.arrayOffset() + pos + Unsafe.ARRAY_BYTE_BASE_OFFSET;
+                long off = dst.arrayOffset() + pos + (long) Unsafe.ARRAY_BYTE_BASE_OFFSET;
                 unsafe.copyMemory(null, address, dst.array(), off, n);
                 dst.position(pos + n);
 
@@ -257,7 +257,7 @@ abstract class UnixUserDefinedFileAttributeView
 
                 if (src.hasArray()) {
                     // copy from backing array into buffer
-                    int off = src.arrayOffset() + pos + Unsafe.ARRAY_BYTE_BASE_OFFSET;
+                    long off = src.arrayOffset() + pos + (long) Unsafe.ARRAY_BYTE_BASE_OFFSET;
                     unsafe.copyMemory(src.array(), off, null, address, rem);
                 } else {
                     // backing array not accessible so transfer via temporary array

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/utilities/HeapHprofBinWriter.java
@@ -1005,56 +1005,56 @@ public class HeapHprofBinWriter extends AbstractHeapGraphWriter {
 
     private void writeBooleanArray(TypeArray array, int length) throws IOException {
         for (int index = 0; index < length; index++) {
-             long offset = BOOLEAN_BASE_OFFSET + index * BOOLEAN_SIZE;
+             long offset = (long) BOOLEAN_BASE_OFFSET + index * BOOLEAN_SIZE;
              out.writeBoolean(array.getHandle().getJBooleanAt(offset));
         }
     }
 
     private void writeByteArray(TypeArray array, int length) throws IOException {
         for (int index = 0; index < length; index++) {
-             long offset = BYTE_BASE_OFFSET + index * BYTE_SIZE;
+             long offset = (long) BYTE_BASE_OFFSET + index * BYTE_SIZE;
              out.writeByte(array.getHandle().getJByteAt(offset));
         }
     }
 
     private void writeShortArray(TypeArray array, int length) throws IOException {
         for (int index = 0; index < length; index++) {
-             long offset = SHORT_BASE_OFFSET + index * SHORT_SIZE;
+             long offset = (long) SHORT_BASE_OFFSET + index * SHORT_SIZE;
              out.writeShort(array.getHandle().getJShortAt(offset));
         }
     }
 
     private void writeIntArray(TypeArray array, int length) throws IOException {
         for (int index = 0; index < length; index++) {
-             long offset = INT_BASE_OFFSET + index * INT_SIZE;
+             long offset = (long) INT_BASE_OFFSET + index * INT_SIZE;
              out.writeInt(array.getHandle().getJIntAt(offset));
         }
     }
 
     private void writeLongArray(TypeArray array, int length) throws IOException {
         for (int index = 0; index < length; index++) {
-             long offset = LONG_BASE_OFFSET + index * LONG_SIZE;
+             long offset = (long) LONG_BASE_OFFSET + index * LONG_SIZE;
              out.writeLong(array.getHandle().getJLongAt(offset));
         }
     }
 
     private void writeCharArray(TypeArray array, int length) throws IOException {
         for (int index = 0; index < length; index++) {
-             long offset = CHAR_BASE_OFFSET + index * CHAR_SIZE;
+             long offset = (long) CHAR_BASE_OFFSET + index * CHAR_SIZE;
              out.writeChar(array.getHandle().getJCharAt(offset));
         }
     }
 
     private void writeFloatArray(TypeArray array, int length) throws IOException {
         for (int index = 0; index < length; index++) {
-             long offset = FLOAT_BASE_OFFSET + index * FLOAT_SIZE;
+             long offset = (long) FLOAT_BASE_OFFSET + index * FLOAT_SIZE;
              out.writeFloat(array.getHandle().getJFloatAt(offset));
         }
     }
 
     private void writeDoubleArray(TypeArray array, int length) throws IOException {
         for (int index = 0; index < length; index++) {
-             long offset = DOUBLE_BASE_OFFSET + index * DOUBLE_SIZE;
+             long offset = (long) DOUBLE_BASE_OFFSET + index * DOUBLE_SIZE;
              out.writeDouble(array.getHandle().getJDoubleAt(offset));
         }
     }

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -4101,7 +4101,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ByteVector.java
@@ -4101,7 +4101,7 @@ public abstract class ByteVector extends AbstractVector<Byte> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -3621,7 +3621,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/DoubleVector.java
@@ -3621,7 +3621,7 @@ public abstract class DoubleVector extends AbstractVector<Double> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -3571,7 +3571,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/FloatVector.java
@@ -3571,7 +3571,7 @@ public abstract class FloatVector extends AbstractVector<Float> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -3739,7 +3739,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/IntVector.java
@@ -3739,7 +3739,7 @@ public abstract class IntVector extends AbstractVector<Integer> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -3674,7 +3674,7 @@ public abstract class LongVector extends AbstractVector<Long> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/LongVector.java
@@ -3674,7 +3674,7 @@ public abstract class LongVector extends AbstractVector<Long> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -4092,7 +4092,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/ShortVector.java
@@ -4092,7 +4092,7 @@ public abstract class ShortVector extends AbstractVector<Short> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/X-Vector.java.template
@@ -5310,7 +5310,7 @@ public abstract class $abstractvectortype$ extends AbstractVector<$Boxtype$> {
 
     @ForceInline
     static long byteArrayAddress(byte[] a, int index) {
-        return Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
+        return (long) Unsafe.ARRAY_BYTE_BASE_OFFSET + index;
     }
 
     // ================================================


### PR DESCRIPTION
In the JDK code, there are some places that may cause Unsafe offset overflow. The probability of occurrence is low, but if it occurs, it will cause JVM crash.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343984](https://bugs.openjdk.org/browse/JDK-8343984): Fix Unsafe address overflow (**Bug** - P4)


### Reviewers
 * [Per Minborg](https://openjdk.org/census#pminborg) (@minborg - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22027/head:pull/22027` \
`$ git checkout pull/22027`

Update a local copy of the PR: \
`$ git checkout pull/22027` \
`$ git pull https://git.openjdk.org/jdk.git pull/22027/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22027`

View PR using the GUI difftool: \
`$ git pr show -t 22027`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22027.diff">https://git.openjdk.org/jdk/pull/22027.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22027#issuecomment-2469823629)
</details>
