### PR TITLE
8344014: Simplify TracePhase constructor

### DIFF
--- a/src/hotspot/share/opto/buildOopMap.cpp
+++ b/src/hotspot/share/opto/buildOopMap.cpp
@@ -601,7 +601,7 @@ static void do_liveness(PhaseRegAlloc* regalloc, PhaseCFG* cfg, Block_List* work
 
 // Collect GC mask info - where are all the OOPs?
 void PhaseOutput::BuildOopMaps() {
-  Compile::TracePhase tp("bldOopMaps", &timers[_t_buildOopMaps]);
+  Compile::TracePhase tp(_t_buildOopMaps);
   // Can't resource-mark because I need to leave all those OopMaps around,
   // or else I need to resource-mark some arena other than the default.
   // ResourceMark rm;              // Reclaim all OopFlows when done

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -2444,7 +2444,7 @@ void Compile::Optimize() {
 #endif
 
   {
-    TracePhase tp("macroExpand", _t_macroExpand);
+    TracePhase tp(_t_macroExpand);
     print_method(PHASE_BEFORE_MACRO_EXPANSION, 3);
     PhaseMacroExpand  mex(igvn);
     if (mex.expand_macro_nodes()) {

--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -746,7 +746,7 @@ Compile::Compile( ciEnv* ci_env, ciMethod* target, int osr_bci,
 
   print_inlining_init();
   { // Scope for timing the parser
-    TracePhase tp("parse", &timers[_t_parser]);
+    TracePhase tp(_t_parser);
 
     // Put top into the hash table ASAP.
     initial_gvn()->transform(top());
@@ -2031,7 +2031,7 @@ void Compile::inline_boxing_calls(PhaseIterGVN& igvn) {
 bool Compile::inline_incrementally_one() {
   assert(IncrementalInline, "incremental inlining should be on");
 
-  TracePhase tp("incrementalInline_inline", &timers[_t_incrInline_inline]);
+  TracePhase tp(_t_incrInline_inline);
 
   set_inlining_progress(false);
   set_do_cleanup(false);
@@ -2072,12 +2072,12 @@ bool Compile::inline_incrementally_one() {
 
 void Compile::inline_incrementally_cleanup(PhaseIterGVN& igvn) {
   {
-    TracePhase tp("incrementalInline_pru", &timers[_t_incrInline_pru]);
+    TracePhase tp(_t_incrInline_pru);
     ResourceMark rm;
     PhaseRemoveUseless pru(initial_gvn(), *igvn_worklist());
   }
   {
-    TracePhase tp("incrementalInline_igvn", &timers[_t_incrInline_igvn]);
+    TracePhase tp(_t_incrInline_igvn);
     igvn.reset_from_gvn(initial_gvn());
     igvn.optimize();
     if (failing()) return;
@@ -2087,7 +2087,7 @@ void Compile::inline_incrementally_cleanup(PhaseIterGVN& igvn) {
 
 // Perform incremental inlining until bound on number of live nodes is reached
 void Compile::inline_incrementally(PhaseIterGVN& igvn) {
-  TracePhase tp("incrementalInline", &timers[_t_incrInline]);
+  TracePhase tp(_t_incrInline);
 
   set_inlining_incrementally(true);
   uint low_live_nodes = 0;
@@ -2095,7 +2095,7 @@ void Compile::inline_incrementally(PhaseIterGVN& igvn) {
   while (_late_inlines.length() > 0) {
     if (live_nodes() > (uint)LiveNodeCountInliningCutoff) {
       if (low_live_nodes < (uint)LiveNodeCountInliningCutoff * 8 / 10) {
-        TracePhase tp("incrementalInline_ideal", &timers[_t_incrInline_ideal]);
+        TracePhase tp(_t_incrInline_ideal);
         // PhaseIdealLoop is expensive so we only try it once we are
         // out of live nodes and we only try it again if the previous
         // helped got the number of nodes down significantly
@@ -2179,7 +2179,7 @@ void Compile::process_late_inline_calls_no_inline(PhaseIterGVN& igvn) {
 bool Compile::optimize_loops(PhaseIterGVN& igvn, LoopOptsMode mode) {
   if (_loop_opts_cnt > 0) {
     while (major_progress() && (_loop_opts_cnt > 0)) {
-      TracePhase tp("idealLoop", &timers[_t_idealLoop]);
+      TracePhase tp(_t_idealLoop);
       PhaseIdealLoop::optimize(igvn, mode);
       _loop_opts_cnt--;
       if (failing())  return false;
@@ -2217,7 +2217,7 @@ void Compile::remove_root_to_sfpts_edges(PhaseIterGVN& igvn) {
 //------------------------------Optimize---------------------------------------
 // Given a graph, optimize it.
 void Compile::Optimize() {
-  TracePhase tp("optimizer", &timers[_t_optimizer]);
+  TracePhase tp(_t_optimizer);
 
 #ifndef PRODUCT
   if (env()->break_at_compile()) {
@@ -2247,7 +2247,7 @@ void Compile::Optimize() {
   _modified_nodes = new (comp_arena()) Unique_Node_List(comp_arena());
 #endif
   {
-    TracePhase tp("iterGVN", &timers[_t_iterGVN]);
+    TracePhase tp(_t_iterGVN);
     igvn.optimize();
   }
 
@@ -2296,7 +2296,7 @@ void Compile::Optimize() {
 
   assert(EnableVectorSupport || !has_vbox_nodes(), "sanity");
   if (EnableVectorSupport && has_vbox_nodes()) {
-    TracePhase tp("", &timers[_t_vector]);
+    TracePhase tp(_t_vector);
     PhaseVector pv(igvn);
     pv.optimize_vector_boxes();
     if (failing())  return;
@@ -2305,7 +2305,7 @@ void Compile::Optimize() {
   assert(!has_vbox_nodes(), "sanity");
 
   if (!failing() && RenumberLiveNodes && live_nodes() + NodeLimitFudgeFactor < unique()) {
-    Compile::TracePhase tp("", &timers[_t_renumberLive]);
+    Compile::TracePhase tp(_t_renumberLive);
     igvn_worklist()->ensure_empty(); // should be done with igvn
     {
       ResourceMark rm;
@@ -2326,7 +2326,7 @@ void Compile::Optimize() {
   if (do_escape_analysis() && ConnectionGraph::has_candidates(this)) {
     if (has_loops()) {
       // Cleanup graph (remove dead nodes).
-      TracePhase tp("idealLoop", &timers[_t_idealLoop]);
+      TracePhase tp(_t_idealLoop);
       PhaseIdealLoop::optimize(igvn, LoopOptsMaxUnroll);
       if (failing())  return;
     }
@@ -2346,7 +2346,7 @@ void Compile::Optimize() {
       if (failing()) return;
 
       if (congraph() != nullptr && macro_count() > 0) {
-        TracePhase tp("macroEliminate", &timers[_t_macroEliminate]);
+        TracePhase tp(_t_macroEliminate);
         PhaseMacroExpand mexp(igvn);
         mexp.eliminate_macro_nodes();
         if (failing()) return;
@@ -2375,7 +2375,7 @@ void Compile::Optimize() {
   // Set loop opts counter
   if((_loop_opts_cnt > 0) && (has_loops() || has_split_ifs())) {
     {
-      TracePhase tp("idealLoop", &timers[_t_idealLoop]);
+      TracePhase tp(_t_idealLoop);
       PhaseIdealLoop::optimize(igvn, LoopOptsDefault);
       _loop_opts_cnt--;
       if (major_progress()) print_method(PHASE_PHASEIDEALLOOP1, 2);
@@ -2383,7 +2383,7 @@ void Compile::Optimize() {
     }
     // Loop opts pass if partial peeling occurred in previous pass
     if(PartialPeelLoop && major_progress() && (_loop_opts_cnt > 0)) {
-      TracePhase tp("idealLoop", &timers[_t_idealLoop]);
+      TracePhase tp(_t_idealLoop);
       PhaseIdealLoop::optimize(igvn, LoopOptsSkipSplitIf);
       _loop_opts_cnt--;
       if (major_progress()) print_method(PHASE_PHASEIDEALLOOP2, 2);
@@ -2391,7 +2391,7 @@ void Compile::Optimize() {
     }
     // Loop opts pass for loop-unrolling before CCP
     if(major_progress() && (_loop_opts_cnt > 0)) {
-      TracePhase tp("idealLoop", &timers[_t_idealLoop]);
+      TracePhase tp(_t_idealLoop);
       PhaseIdealLoop::optimize(igvn, LoopOptsSkipSplitIf);
       _loop_opts_cnt--;
       if (major_progress()) print_method(PHASE_PHASEIDEALLOOP3, 2);
@@ -2408,7 +2408,7 @@ void Compile::Optimize() {
   PhaseCCP ccp( &igvn );
   assert( true, "Break here to ccp.dump_nodes_and_types(_root,999,1)");
   {
-    TracePhase tp("ccp", &timers[_t_ccp]);
+    TracePhase tp(_t_ccp);
     ccp.do_transform();
   }
   print_method(PHASE_CCP1, 2);
@@ -2417,7 +2417,7 @@ void Compile::Optimize() {
 
   // Iterative Global Value Numbering, including ideal transforms
   {
-    TracePhase tp("iterGVN2", &timers[_t_iterGVN2]);
+    TracePhase tp(_t_iterGVN2);
     igvn.reset_from_igvn(&ccp);
     igvn.optimize();
   }
@@ -2444,7 +2444,7 @@ void Compile::Optimize() {
 #endif
 
   {
-    TracePhase tp("macroExpand", &timers[_t_macroExpand]);
+    TracePhase tp("macroExpand", _t_macroExpand);
     print_method(PHASE_BEFORE_MACRO_EXPANSION, 3);
     PhaseMacroExpand  mex(igvn);
     if (mex.expand_macro_nodes()) {
@@ -2455,7 +2455,7 @@ void Compile::Optimize() {
   }
 
   {
-    TracePhase tp("barrierExpand", &timers[_t_barrierExpand]);
+    TracePhase tp(_t_barrierExpand);
     if (bs->expand_barriers(this, igvn)) {
       assert(failing(), "must bail out w/ explicit message");
       return;
@@ -2493,7 +2493,7 @@ void Compile::Optimize() {
 
  // A method with only infinite loops has no edges entering loops from root
  {
-   TracePhase tp("graphReshape", &timers[_t_graphReshaping]);
+   TracePhase tp(_t_graphReshaping);
    if (final_graph_reshaping()) {
      assert(failing(), "must bail out w/ explicit message");
      return;
@@ -2935,7 +2935,7 @@ void Compile::Code_Gen() {
   Matcher matcher;
   _matcher = &matcher;
   {
-    TracePhase tp("matcher", &timers[_t_matcher]);
+    TracePhase tp(_t_matcher);
     matcher.match();
     if (failing()) {
       return;
@@ -2960,7 +2960,7 @@ void Compile::Code_Gen() {
   }
   _cfg = &cfg;
   {
-    TracePhase tp("scheduler", &timers[_t_scheduler]);
+    TracePhase tp(_t_scheduler);
     bool success = cfg.do_global_code_motion();
     if (!success) {
       return;
@@ -2974,7 +2974,7 @@ void Compile::Code_Gen() {
   PhaseChaitin regalloc(unique(), cfg, matcher, false);
   _regalloc = &regalloc;
   {
-    TracePhase tp("regalloc", &timers[_t_registerAllocation]);
+    TracePhase tp(_t_registerAllocation);
     // Perform register allocation.  After Chaitin, use-def chains are
     // no longer accurate (at spill code) and so must be ignored.
     // Node->LRG->reg mappings are still accurate.
@@ -2993,7 +2993,7 @@ void Compile::Code_Gen() {
   // are not adding any new instructions.  If any basic block is empty, we
   // can now safely remove it.
   {
-    TracePhase tp("blockOrdering", &timers[_t_blockOrdering]);
+    TracePhase tp(_t_blockOrdering);
     cfg.remove_empty_blocks();
     if (do_freq_based_layout()) {
       PhaseBlockLayout layout(cfg);
@@ -3008,7 +3008,7 @@ void Compile::Code_Gen() {
 
   // Apply peephole optimizations
   if( OptoPeephole ) {
-    TracePhase tp("peephole", &timers[_t_peephole]);
+    TracePhase tp(_t_peephole);
     PhasePeephole peep( _regalloc, cfg);
     peep.do_transform();
     print_method(PHASE_PEEPHOLE, 3);
@@ -3016,14 +3016,14 @@ void Compile::Code_Gen() {
 
   // Do late expand if CPU requires this.
   if (Matcher::require_postalloc_expand) {
-    TracePhase tp("postalloc_expand", &timers[_t_postalloc_expand]);
+    TracePhase tp(_t_postalloc_expand);
     cfg.postalloc_expand(_regalloc);
     print_method(PHASE_POSTALLOC_EXPAND, 3);
   }
 
   // Convert Nodes to instruction bits in a buffer
   {
-    TracePhase tp("output", &timers[_t_output]);
+    TracePhase tp(_t_output);
     PhaseOutput output;
     output.Output();
     if (failing())  return;
@@ -4313,11 +4313,10 @@ void Compile::record_failure(const char* reason DEBUG_ONLY(COMMA bool allow_mult
   _root = nullptr;  // flush the graph, too
 }
 
-Compile::TracePhase::TracePhase(const char* name, elapsedTimer* accumulator)
-  : TraceTime(name, accumulator, CITime, CITimeVerbose),
+Compile::TracePhase::TracePhase(const char* name, PhaseTraceId id)
+  : TraceTime(name, &Phase::timers[id], CITime, CITimeVerbose),
     _compile(Compile::current()),
     _log(nullptr),
-    _phase_name(name),
     _dolog(CITimeVerbose)
 {
   assert(_compile != nullptr, "sanity check");
@@ -4325,11 +4324,14 @@ Compile::TracePhase::TracePhase(const char* name, elapsedTimer* accumulator)
     _log = _compile->log();
   }
   if (_log != nullptr) {
-    _log->begin_head("phase name='%s' nodes='%d' live='%d'", _phase_name, _compile->unique(), _compile->live_nodes());
+    _log->begin_head("phase name='%s' nodes='%d' live='%d'", phase_name(), _compile->unique(), _compile->live_nodes());
     _log->stamp();
     _log->end_head();
   }
 }
+
+Compile::TracePhase::TracePhase(PhaseTraceId id)
+  : TracePhase(Phase::get_phase_trace_id_text(id), id) {}
 
 Compile::TracePhase::~TracePhase() {
   if (_compile->failing_internal()) {
@@ -4338,7 +4340,7 @@ Compile::TracePhase::~TracePhase() {
 #ifdef ASSERT
   if (PrintIdealNodeCount) {
     tty->print_cr("phase name='%s' nodes='%d' live='%d' live_graph_walk='%d'",
-                  _phase_name, _compile->unique(), _compile->live_nodes(), _compile->count_live_nodes_by_graph_walk());
+                  phase_name(), _compile->unique(), _compile->live_nodes(), _compile->count_live_nodes_by_graph_walk());
   }
 
   if (VerifyIdealNodeCount) {
@@ -4347,7 +4349,7 @@ Compile::TracePhase::~TracePhase() {
 #endif
 
   if (_log != nullptr) {
-    _log->done("phase name='%s' nodes='%d' live='%d'", _phase_name, _compile->unique(), _compile->live_nodes());
+    _log->done("phase name='%s' nodes='%d' live='%d'", phase_name(), _compile->unique(), _compile->live_nodes());
   }
 }
 

--- a/src/hotspot/share/opto/compile.hpp
+++ b/src/hotspot/share/opto/compile.hpp
@@ -239,11 +239,12 @@ class Compile : public Phase {
    private:
     Compile*    _compile;
     CompileLog* _log;
-    const char* _phase_name;
     bool _dolog;
    public:
-    TracePhase(const char* name, elapsedTimer* accumulator);
+    TracePhase(PhaseTraceId phaseTraceId);
+    TracePhase(const char* name, PhaseTraceId phaseTraceId);
     ~TracePhase();
+    const char* phase_name() const { return title(); }
   };
 
   // Information per category of alias (memory slice)

--- a/src/hotspot/share/opto/escape.cpp
+++ b/src/hotspot/share/opto/escape.cpp
@@ -103,7 +103,7 @@ bool ConnectionGraph::has_candidates(Compile *C) {
 }
 
 void ConnectionGraph::do_analysis(Compile *C, PhaseIterGVN *igvn) {
-  Compile::TracePhase tp("escapeAnalysis", &Phase::timers[Phase::_t_escapeAnalysis]);
+  Compile::TracePhase tp(Phase::_t_escapeAnalysis);
   ResourceMark rm;
 
   // Add ConP and ConN null oop nodes before ConnectionGraph construction
@@ -148,7 +148,7 @@ bool ConnectionGraph::compute_escape() {
   GrowableArray<MergeMemNode*>   mergemem_worklist;
   DEBUG_ONLY( GrowableArray<Node*> addp_worklist; )
 
-  { Compile::TracePhase tp("connectionGraph", &Phase::timers[Phase::_t_connectionGraph]);
+  { Compile::TracePhase tp(Phase::_t_connectionGraph);
 
   // 1. Populate Connection Graph (CG) with PointsTo nodes.
   ideal_nodes.map(C->live_nodes(), nullptr);  // preallocate space

--- a/src/hotspot/share/opto/gcm.cpp
+++ b/src/hotspot/share/opto/gcm.cpp
@@ -1681,7 +1681,7 @@ void PhaseCFG::global_code_motion() {
   PhaseIFG ifg(&live_arena);
   if (OptoRegScheduling && block_size_threshold_ok) {
     regalloc.mark_ssa();
-    Compile::TracePhase tp("computeLive", &timers[_t_computeLive]);
+    Compile::TracePhase tp(_t_computeLive);
     rm_live.reset_to_mark();           // Reclaim working storage
     IndexSet::reset_memory(C, &live_arena);
     uint node_size = regalloc._lrg_map.max_lrg_id();

--- a/src/hotspot/share/opto/ifg.cpp
+++ b/src/hotspot/share/opto/ifg.cpp
@@ -313,7 +313,7 @@ void PhaseChaitin::interfere_with_live(uint lid, IndexSet* liveout) {
 // at this point can end up in bad places).  Copies I re-insert later I have
 // more opportunity to insert them in low-frequency locations.
 void PhaseChaitin::build_ifg_virtual( ) {
-  Compile::TracePhase tp("buildIFG_virt", &timers[_t_buildIFGvirtual]);
+  Compile::TracePhase tp(_t_buildIFGvirtual);
 
   // For all blocks (in any order) do...
   for (uint i = 0; i < _cfg.number_of_blocks(); i++) {
@@ -843,7 +843,7 @@ void PhaseChaitin::print_pressure_info(Pressure& pressure, const char *str) {
  *   low to high register pressure transition within the block (if any).
  */
 uint PhaseChaitin::build_ifg_physical( ResourceArea *a ) {
-  Compile::TracePhase tp("buildIFG", &timers[_t_buildIFGphysical]);
+  Compile::TracePhase tp(_t_buildIFGphysical);
 
   uint must_spill = 0;
   for (uint i = 0; i < _cfg.number_of_blocks(); i++) {

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1108,7 +1108,7 @@ void IdealLoopTree::policy_unroll_slp_analysis(CountedLoopNode *cl, PhaseIdealLo
   // Enable this functionality target by target as needed
   if (SuperWordLoopUnrollAnalysis) {
     if (!cl->was_slp_analyzed()) {
-      Compile::TracePhase tp("autoVectorize", &Phase::timers[Phase::_t_autoVectorize]);
+      Compile::TracePhase tp(Phase::_t_autoVectorize);
 
       VLoop vloop(this, true);
       if (vloop.check_preconditions()) {

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -4971,7 +4971,7 @@ void PhaseIdealLoop::build_and_optimize() {
 
   // Auto-vectorize main-loop
   if (C->do_superword() && C->has_loops() && !C->major_progress()) {
-    Compile::TracePhase tp("autoVectorize", &timers[_t_autoVectorize]);
+    Compile::TracePhase tp(_t_autoVectorize);
 
     // Shared data structures for all AutoVectorizations, to reduce allocations
     // of large arrays.

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -1196,7 +1196,7 @@ public:
   static void verify(PhaseIterGVN& igvn) {
 #ifdef ASSERT
     ResourceMark rm;
-    Compile::TracePhase tp("idealLoopVerify", &timers[_t_idealLoopVerify]);
+    Compile::TracePhase tp(_t_idealLoopVerify);
     PhaseIdealLoop v(igvn);
 #endif
   }

--- a/src/hotspot/share/opto/matcher.cpp
+++ b/src/hotspot/share/opto/matcher.cpp
@@ -434,7 +434,7 @@ void Matcher::match( ) {
   Fixup_Save_On_Entry( );
 
   { // Cleanup mach IR after selection phase is over.
-    Compile::TracePhase tp("postselect_cleanup", &timers[_t_postselect_cleanup]);
+    Compile::TracePhase tp(_t_postselect_cleanup);
     do_postselect_cleanup();
     if (C->failing())  return;
     assert(verify_after_postselect_cleanup(), "");

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -437,7 +437,7 @@ void PhaseOutput::compute_loop_first_inst_sizes() {
 // branch instructions. Replace eligible long branches with short branches.
 void PhaseOutput::shorten_branches(uint* blk_starts) {
 
-  Compile::TracePhase tp("shorten branches", &timers[_t_shortenBranches]);
+  Compile::TracePhase tp(_t_shortenBranches);
 
   // Compute size of each block, method size, and relocation information size
   uint nblocks  = C->cfg()->number_of_blocks();
@@ -1418,7 +1418,7 @@ void PhaseOutput::fill_buffer(C2_MacroAssembler* masm, uint* blk_starts) {
 
   // Compute the size of first NumberOfLoopInstrToAlign instructions at head
   // of a loop. It is used to determine the padding for loop alignment.
-  Compile::TracePhase tp("fill buffer", &timers[_t_fillBuffer]);
+  Compile::TracePhase tp(_t_fillBuffer);
 
   compute_loop_first_inst_sizes();
 
@@ -2162,7 +2162,7 @@ void PhaseOutput::ScheduleAndBundle() {
     return;
   }
 
-  Compile::TracePhase tp("isched", &timers[_t_instrSched]);
+  Compile::TracePhase tp(_t_instrSched);
 
   // Create a data structure for all the scheduling information
   Scheduling scheduling(Thread::current()->resource_area(), *C);
@@ -3428,7 +3428,7 @@ void PhaseOutput::install_code(ciMethod*         target,
       return;
     }
 #endif
-    Compile::TracePhase tp("install_code", &timers[_t_registerMethod]);
+    Compile::TracePhase tp(_t_registerMethod);
 
     if (C->is_osr_compilation()) {
       _code_offsets.set_value(CodeOffsets::Verified_Entry, 0);

--- a/src/hotspot/share/opto/phase.cpp
+++ b/src/hotspot/share/opto/phase.cpp
@@ -29,7 +29,6 @@
 #include "opto/matcher.hpp"
 #include "opto/node.hpp"
 #include "opto/phase.hpp"
-#include "utilities/globalDefinitions.hpp"
 
 int Phase::_total_bytes_compiled = 0;
 

--- a/src/hotspot/share/opto/phase.cpp
+++ b/src/hotspot/share/opto/phase.cpp
@@ -29,6 +29,7 @@
 #include "opto/matcher.hpp"
 #include "opto/node.hpp"
 #include "opto/phase.hpp"
+#include "utilities/globalDefinitions.hpp"
 
 int Phase::_total_bytes_compiled = 0;
 
@@ -38,6 +39,16 @@ elapsedTimer Phase::_t_stubCompilation;
 
 // The counters to use for LogCompilation
 elapsedTimer Phase::timers[max_phase_timers];
+
+const char* Phase::get_phase_trace_id_text(PhaseTraceId id) {
+  static const char* const texts[] = {
+  #define DEF_TEXT(name, text) text,
+      ALL_PHASE_TRACE_IDS(DEF_TEXT)
+  #undef DEF_TEXT
+      nullptr
+  };
+  return texts[(int)id];
+}
 
 //------------------------------Phase------------------------------------------
 Phase::Phase( PhaseNumber pnum ) : _pnum(pnum), C( pnum == Compiler ? nullptr : Compile::current()) {

--- a/src/hotspot/share/opto/phase.hpp
+++ b/src/hotspot/share/opto/phase.hpp
@@ -64,61 +64,61 @@ public:
     last_phase
   };
 
-#define ALL_PHASE_TRACE_IDS(f) \
-		f(   _t_parser,                  "parse") \
-		f(   _t_optimizer,               "optimizer") \
-		f(     _t_escapeAnalysis,        "escapeAnalysis") \
-		f(       _t_connectionGraph,     "connectionGraph") \
-		f(       _t_macroEliminate,      "macroEliminate") \
-		f(     _t_iterGVN,               "iterGVN") \
-		f(     _t_incrInline,            "incrementalInline") \
-		f(       _t_incrInline_ideal,    "incrementalInline_ideal") \
-		f(       _t_incrInline_igvn,     "incrementalInline_igvn") \
-		f(       _t_incrInline_pru,      "incrementalInline_pru") \
-		f(       _t_incrInline_inline,   "incrementalInline_inline") \
-		f(     _t_vector,                "") \
-		f(       _t_vector_elimination,  "vector_elimination") \
-		f(         _t_vector_igvn,       "incrementalInline_igvn") \
-		f(         _t_vector_pru,        "vector_pru") \
-		f(     _t_renumberLive,          "") \
-		f(     _t_idealLoop,             "idealLoop") \
-		f(       _t_autoVectorize,       "autoVectorize") \
-		f(     _t_idealLoopVerify,       "idealLoopVerify") \
-		f(     _t_ccp,                   "ccp") \
-		f(     _t_iterGVN2,              "iterGVN2") \
-		f(     _t_macroExpand,           "macroExpand") \
-		f(     _t_barrierExpand,         "barrierExpand") \
-		f(     _t_graphReshaping,        "XXXX") \
-		f(   _t_matcher,                 "XXXX") \
-		f(     _t_postselect_cleanup,    "XXXX") \
-		f(   _t_scheduler,               "XXXX") \
-		f(   _t_registerAllocation,      "XXXX") \
-		f(     _t_ctorChaitin,           "XXXX") \
-		f(     _t_buildIFGvirtual,       "XXXX") \
-		f(     _t_buildIFGphysical,      "XXXX") \
-		f(     _t_computeLive,           "XXXX") \
-		f(     _t_regAllocSplit,         "XXXX") \
-		f(     _t_postAllocCopyRemoval,  "XXXX") \
-		f(     _t_mergeMultidefs,        "XXXX") \
-		f(     _t_fixupSpills,           "XXXX") \
-		f(     _t_chaitinCompact,        "XXXX") \
-		f(     _t_chaitinCoalesce1,      "XXXX") \
-		f(     _t_chaitinCoalesce2,      "XXXX") \
-		f(     _t_chaitinCoalesce3,      "XXXX") \
-		f(     _t_chaitinCacheLRG,       "XXXX") \
-		f(     _t_chaitinSimplify,       "XXXX") \
-		f(     _t_chaitinSelect,         "XXXX") \
-		f(   _t_blockOrdering,           "XXXX") \
-		f(   _t_peephole,                "XXXX") \
-		f(   _t_postalloc_expand,        "XXXX") \
-		f(   _t_output,                  "XXXX") \
-		f(     _t_instrSched,            "XXXX") \
-		f(     _t_shortenBranches,       "XXXX") \
-		f(     _t_buildOopMaps,          "XXXX") \
-		f(     _t_fillBuffer,            "XXXX") \
-		f(     _t_registerMethod,        "XXXX") \
-		f(   _t_temporaryTimer1,         "XXXX") \
-		f(   _t_temporaryTimer2,         "XXXX")
+#define ALL_PHASE_TRACE_IDS(f)                                   \
+    f(   _t_parser,                  "parse")                    \
+    f(   _t_optimizer,               "optimizer")                \
+    f(     _t_escapeAnalysis,        "escapeAnalysis")           \
+    f(       _t_connectionGraph,     "connectionGraph")          \
+    f(       _t_macroEliminate,      "macroEliminate")           \
+    f(     _t_iterGVN,               "iterGVN")                  \
+    f(     _t_incrInline,            "incrementalInline")        \
+    f(       _t_incrInline_ideal,    "incrementalInline_ideal")  \
+    f(       _t_incrInline_igvn,     "incrementalInline_igvn")   \
+    f(       _t_incrInline_pru,      "incrementalInline_pru")    \
+    f(       _t_incrInline_inline,   "incrementalInline_inline") \
+    f(     _t_vector,                "")                         \
+    f(       _t_vector_elimination,  "vector_elimination")       \
+    f(         _t_vector_igvn,       "incrementalInline_igvn")   \
+    f(         _t_vector_pru,        "vector_pru")               \
+    f(     _t_renumberLive,          "")                         \
+    f(     _t_idealLoop,             "idealLoop")                \
+    f(       _t_autoVectorize,       "autoVectorize")            \
+    f(     _t_idealLoopVerify,       "idealLoopVerify")          \
+    f(     _t_ccp,                   "ccp")                      \
+    f(     _t_iterGVN2,              "iterGVN2")                 \
+    f(     _t_macroExpand,           "macroExpand")              \
+    f(     _t_barrierExpand,         "barrierExpand")            \
+    f(     _t_graphReshaping,        "graphReshape")             \
+    f(   _t_matcher,                 "matcher")                  \
+    f(     _t_postselect_cleanup,    "postselect_cleanup")       \
+    f(   _t_scheduler,               "scheduler")                \
+    f(   _t_registerAllocation,      "regalloc")                 \
+    f(     _t_ctorChaitin,           "ctorChaitin")              \
+    f(     _t_buildIFGvirtual,       "buildIFG_virt")            \
+    f(     _t_buildIFGphysical,      "buildIFG")                 \
+    f(     _t_computeLive,           "computeLive")              \
+    f(     _t_regAllocSplit,         "regAllocSplit")            \
+    f(     _t_postAllocCopyRemoval,  "postAllocCopyRemoval")     \
+    f(     _t_mergeMultidefs,        "mergeMultidefs")           \
+    f(     _t_fixupSpills,           "fixupSpills")              \
+    f(     _t_chaitinCompact,        "chaitinCompact")           \
+    f(     _t_chaitinCoalesce1,      "chaitinCoalesce1")         \
+    f(     _t_chaitinCoalesce2,      "chaitinCoalesce2")         \
+    f(     _t_chaitinCoalesce3,      "chaitinCoalesce3")         \
+    f(     _t_chaitinCacheLRG,       "chaitinCacheLRG")          \
+    f(     _t_chaitinSimplify,       "chaitinSimplify")          \
+    f(     _t_chaitinSelect,         "chaitinSelect")            \
+    f(   _t_blockOrdering,           "blockOrdering")            \
+    f(   _t_peephole,                "peephole")                 \
+    f(   _t_postalloc_expand,        "postalloc_expand")         \
+    f(   _t_output,                  "output")                   \
+    f(     _t_instrSched,            "isched")                   \
+    f(     _t_shortenBranches,       "shorten branches")         \
+    f(     _t_buildOopMaps,          "bldOopMaps")               \
+    f(     _t_fillBuffer,            "fill buffer")              \
+    f(     _t_registerMethod,        "install_code")             \
+    f(   _t_temporaryTimer1,         "tempTimer1")               \
+    f(   _t_temporaryTimer2,         "tempTimer2")
 
   enum PhaseTraceId {
 #define DEFID(name, text) name,

--- a/src/hotspot/share/opto/phase.hpp
+++ b/src/hotspot/share/opto/phase.hpp
@@ -64,63 +64,70 @@ public:
     last_phase
   };
 
+#define ALL_PHASE_TRACE_IDS(f) \
+		f(   _t_parser,                  "parse") \
+		f(   _t_optimizer,               "optimizer") \
+		f(     _t_escapeAnalysis,        "escapeAnalysis") \
+		f(       _t_connectionGraph,     "connectionGraph") \
+		f(       _t_macroEliminate,      "macroEliminate") \
+		f(     _t_iterGVN,               "iterGVN") \
+		f(     _t_incrInline,            "incrementalInline") \
+		f(       _t_incrInline_ideal,    "incrementalInline_ideal") \
+		f(       _t_incrInline_igvn,     "incrementalInline_igvn") \
+		f(       _t_incrInline_pru,      "incrementalInline_pru") \
+		f(       _t_incrInline_inline,   "incrementalInline_inline") \
+		f(     _t_vector,                "") \
+		f(       _t_vector_elimination,  "vector_elimination") \
+		f(         _t_vector_igvn,       "incrementalInline_igvn") \
+		f(         _t_vector_pru,        "vector_pru") \
+		f(     _t_renumberLive,          "") \
+		f(     _t_idealLoop,             "idealLoop") \
+		f(       _t_autoVectorize,       "autoVectorize") \
+		f(     _t_idealLoopVerify,       "idealLoopVerify") \
+		f(     _t_ccp,                   "ccp") \
+		f(     _t_iterGVN2,              "iterGVN2") \
+		f(     _t_macroExpand,           "macroExpand") \
+		f(     _t_barrierExpand,         "barrierExpand") \
+		f(     _t_graphReshaping,        "XXXX") \
+		f(   _t_matcher,                 "XXXX") \
+		f(     _t_postselect_cleanup,    "XXXX") \
+		f(   _t_scheduler,               "XXXX") \
+		f(   _t_registerAllocation,      "XXXX") \
+		f(     _t_ctorChaitin,           "XXXX") \
+		f(     _t_buildIFGvirtual,       "XXXX") \
+		f(     _t_buildIFGphysical,      "XXXX") \
+		f(     _t_computeLive,           "XXXX") \
+		f(     _t_regAllocSplit,         "XXXX") \
+		f(     _t_postAllocCopyRemoval,  "XXXX") \
+		f(     _t_mergeMultidefs,        "XXXX") \
+		f(     _t_fixupSpills,           "XXXX") \
+		f(     _t_chaitinCompact,        "XXXX") \
+		f(     _t_chaitinCoalesce1,      "XXXX") \
+		f(     _t_chaitinCoalesce2,      "XXXX") \
+		f(     _t_chaitinCoalesce3,      "XXXX") \
+		f(     _t_chaitinCacheLRG,       "XXXX") \
+		f(     _t_chaitinSimplify,       "XXXX") \
+		f(     _t_chaitinSelect,         "XXXX") \
+		f(   _t_blockOrdering,           "XXXX") \
+		f(   _t_peephole,                "XXXX") \
+		f(   _t_postalloc_expand,        "XXXX") \
+		f(   _t_output,                  "XXXX") \
+		f(     _t_instrSched,            "XXXX") \
+		f(     _t_shortenBranches,       "XXXX") \
+		f(     _t_buildOopMaps,          "XXXX") \
+		f(     _t_fillBuffer,            "XXXX") \
+		f(     _t_registerMethod,        "XXXX") \
+		f(   _t_temporaryTimer1,         "XXXX") \
+		f(   _t_temporaryTimer2,         "XXXX")
+
   enum PhaseTraceId {
-    _t_parser,
-    _t_optimizer,
-      _t_escapeAnalysis,
-        _t_connectionGraph,
-        _t_macroEliminate,
-      _t_iterGVN,
-      _t_incrInline,
-        _t_incrInline_ideal,
-        _t_incrInline_igvn,
-        _t_incrInline_pru,
-        _t_incrInline_inline,
-      _t_vector,
-        _t_vector_elimination,
-          _t_vector_igvn,
-          _t_vector_pru,
-      _t_renumberLive,
-      _t_idealLoop,
-        _t_autoVectorize,
-      _t_idealLoopVerify,
-      _t_ccp,
-      _t_iterGVN2,
-      _t_macroExpand,
-      _t_barrierExpand,
-      _t_graphReshaping,
-    _t_matcher,
-      _t_postselect_cleanup,
-    _t_scheduler,
-    _t_registerAllocation,
-      _t_ctorChaitin,
-      _t_buildIFGvirtual,
-      _t_buildIFGphysical,
-      _t_computeLive,
-      _t_regAllocSplit,
-      _t_postAllocCopyRemoval,
-      _t_mergeMultidefs,
-      _t_fixupSpills,
-      _t_chaitinCompact,
-      _t_chaitinCoalesce1,
-      _t_chaitinCoalesce2,
-      _t_chaitinCoalesce3,
-      _t_chaitinCacheLRG,
-      _t_chaitinSimplify,
-      _t_chaitinSelect,
-    _t_blockOrdering,
-    _t_peephole,
-    _t_postalloc_expand,
-    _t_output,
-      _t_instrSched,
-      _t_shortenBranches,
-      _t_buildOopMaps,
-      _t_fillBuffer,
-      _t_registerMethod,
-    _t_temporaryTimer1,
-    _t_temporaryTimer2,
+#define DEFID(name, text) name,
+    ALL_PHASE_TRACE_IDS(DEFID)
+#undef DEFID
     max_phase_timers
    };
+
+  static const char* get_phase_trace_id_text(PhaseTraceId id);
 
   static elapsedTimer timers[max_phase_timers];
 

--- a/src/hotspot/share/opto/postaloc.cpp
+++ b/src/hotspot/share/opto/postaloc.cpp
@@ -401,7 +401,7 @@ bool PhaseChaitin::eliminate_copy_of_constant(Node* val, Node* n,
 // all the uses that we've seen so far to use the merge. After that we keep replacing the new defs in the same lrg
 // as they get encountered with the merge node and keep adding these defs to the merge inputs.
 void PhaseChaitin::merge_multidefs() {
-  Compile::TracePhase tp("mergeMultidefs", &timers[_t_mergeMultidefs]);
+  Compile::TracePhase tp(_t_mergeMultidefs);
   ResourceMark rm;
   // Keep track of the defs seen in registers and collect their uses in the block.
   RegToDefUseMap reg2defuse(_max_reg, _max_reg, RegDefUse());
@@ -501,7 +501,7 @@ int PhaseChaitin::possibly_merge_multidef(Node *n, uint k, Block *block, RegToDe
 // When we see a use from a reg-reg Copy, we will attempt to use the copy's
 // source directly and make the copy go dead.
 void PhaseChaitin::post_allocate_copy_removal() {
-  Compile::TracePhase tp("postAllocCopyRemoval", &timers[_t_postAllocCopyRemoval]);
+  Compile::TracePhase tp(_t_postAllocCopyRemoval);
   ResourceMark rm;
 
   // Need a mapping from basic block Node_Lists.  We need a Node_List to

--- a/src/hotspot/share/opto/reg_split.cpp
+++ b/src/hotspot/share/opto/reg_split.cpp
@@ -495,7 +495,7 @@ bool PhaseChaitin::prompt_use( Block *b, uint lidx ) {
 //       Else, hoist LRG back up to register only (ie - split is also DEF)
 // We will compute a new maxlrg as we go
 uint PhaseChaitin::Split(uint maxlrg, ResourceArea* split_arena) {
-  Compile::TracePhase tp("regAllocSplit", &timers[_t_regAllocSplit]);
+  Compile::TracePhase tp(_t_regAllocSplit);
 
   // Free thread local resources used by this method on exit.
   ResourceMark rm(split_arena);

--- a/src/hotspot/share/opto/vector.cpp
+++ b/src/hotspot/share/opto/vector.cpp
@@ -42,7 +42,7 @@ static bool is_vector_shuffle(ciKlass* klass) {
 
 
 void PhaseVector::optimize_vector_boxes() {
-  Compile::TracePhase tp("vector_elimination", &timers[_t_vector_elimination]);
+  Compile::TracePhase tp(_t_vector_elimination);
 
   // Signal GraphKit it's post-parse phase.
   assert(C->inlining_incrementally() == false, "sanity");
@@ -66,13 +66,13 @@ void PhaseVector::optimize_vector_boxes() {
 void PhaseVector::do_cleanup() {
   if (C->failing())  return;
   {
-    Compile::TracePhase tp("vector_pru", &timers[_t_vector_pru]);
+    Compile::TracePhase tp(_t_vector_pru);
     ResourceMark rm;
     PhaseRemoveUseless pru(C->initial_gvn(), *C->igvn_worklist());
     if (C->failing())  return;
   }
   {
-    Compile::TracePhase tp("incrementalInline_igvn", &timers[_t_vector_igvn]);
+    Compile::TracePhase tp(_t_vector_igvn);
     _igvn.reset_from_gvn(C->initial_gvn());
     _igvn.optimize();
     if (C->failing())  return;

--- a/src/hotspot/share/runtime/timerTrace.hpp
+++ b/src/hotspot/share/runtime/timerTrace.hpp
@@ -67,6 +67,8 @@ class TraceTime: public StackObj {
             TraceTimerLogPrintFunc ttlpf);
 
   ~TraceTime();
+
+  const char* title() const { return _title; }
 };
 
 


### PR DESCRIPTION
As a prerequisite for [JDK-8344009](https://bugs.openjdk.org/browse/JDK-8344009), `TracePhase` constructor needs to know the PhaseTraceId. And while we are at it, it can be simplified: trace strings can be kept in via x-macro with the IDs, and it is sufficient to pass in the IDs, no need to pass the pointer to the counters since we use the same counters anyway.

Since this is a somewhat invasive but purely mechanical change, I separate this work from [JDK-8344009](https://bugs.openjdk.org/browse/JDK-8344009).

There are no functional changes. Trace texts have been faithfully taken over, even in the case where the original TracePhase constructor invocation got fed an empty string (`_t_vector` and `_t_renumberLive`) - whether this was intentional or not, this patch does not change it.

The patch preserves the possibility to override the phase name with an explicit argument to the constructor. This is used in one existing case ("computeLive (sbplr)"), again, to faithfully preserve the log format.

Test: I checked manually with +CITimeVerbose with and without patch and compared the output; output format is preserved.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8344014](https://bugs.openjdk.org/browse/JDK-8344014): Simplify TracePhase constructor (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22029/head:pull/22029` \
`$ git checkout pull/22029`

Update a local copy of the PR: \
`$ git checkout pull/22029` \
`$ git pull https://git.openjdk.org/jdk.git pull/22029/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22029`

View PR using the GUI difftool: \
`$ git pr show -t 22029`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22029.diff">https://git.openjdk.org/jdk/pull/22029.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22029#issuecomment-2470582263)
</details>
