### PR TITLE
8344003: WB: Add option to skip clinit during class loading for testing

### DIFF
--- a/src/hotspot/share/classfile/classFileParser.hpp
+++ b/src/hotspot/share/classfile/classFileParser.hpp
@@ -193,6 +193,8 @@ class ClassFileParser {
   bool _has_final_method;
   bool _has_contended_fields;
 
+  bool _clinit_loading_disabled;        // WhiteBox testing feature
+
   // precomputed flags
   bool _has_finalizer;
   bool _has_empty_finalizer;
@@ -277,6 +279,12 @@ class ClassFileParser {
                      bool* const has_final_method,
                      bool* const declares_nonstatic_concrete_methods,
                      TRAPS);
+
+  bool wb_clinit_removal_check(const Method * const method,
+                               const int index,
+                               const int length,
+                               int & offset,
+                               TRAPS);
 
   const unsafe_u2* parse_exception_table(const ClassFileStream* const stream,
                                          u4 code_length,

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -150,6 +150,7 @@
 
 bool WhiteBox::_used = false;
 volatile bool WhiteBox::compilation_locked = false;
+volatile bool WhiteBox::clinit_loading_disabled = false;
 
 class VM_WhiteBoxOperation : public VM_Operation {
  public:
@@ -286,6 +287,16 @@ WB_ENTRY(void, WB_PrintHeapSizes(JNIEnv* env, jobject o)) {
                 MaxHeapSize,
                 SpaceAlignment,
                 HeapAlignment);
+}
+WB_END
+
+WB_ENTRY(void, WB_DisableClinitLoading(JNIEnv* env, jobject o)) {
+    NOT_PRODUCT(Atomic::store(&WhiteBox::clinit_loading_disabled, true));
+}
+WB_END
+
+WB_ENTRY(void, WB_EnableClinitLoading(JNIEnv* env, jobject o)) {
+    NOT_PRODUCT(Atomic::store(&WhiteBox::clinit_loading_disabled, false);)
 }
 WB_END
 
@@ -2711,6 +2722,8 @@ static JNINativeMethod methods[] = {
   {CC"getCompressedOopsMaxHeapSize", CC"()J",
       (void*)&WB_GetCompressedOopsMaxHeapSize},
   {CC"printHeapSizes",     CC"()V",                   (void*)&WB_PrintHeapSizes    },
+  {CC"disableClinitLoading",             CC"()V",     (void*)&WB_DisableClinitLoading},
+  {CC"enableClinitLoading",              CC"()V",     (void*)&WB_EnableClinitLoading},
   {CC"readFromNoaccessArea",CC"()V",                  (void*)&WB_ReadFromNoaccessArea},
   {CC"stressVirtualSpaceResize",CC"(JJJ)I",           (void*)&WB_StressVirtualSpaceResize},
 #if INCLUDE_CDS

--- a/src/hotspot/share/prims/whitebox.hpp
+++ b/src/hotspot/share/prims/whitebox.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,6 +54,7 @@ class WhiteBox : public AllStatic {
   static bool _used;
  public:
   static volatile bool compilation_locked;
+  static volatile bool clinit_loading_disabled;
   static bool used()     { return _used; }
   static void set_used() { _used = true; }
   static int offset_for_field(const char* field_name, oop object,

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -72,6 +72,17 @@ public class WhiteBox {
   // Arguments
   public native void printHeapSizes();
 
+  /**
+   * Disables clinit loading (does not affect core library classes)
+   */
+  public native void disableClinitLoading();
+
+  /**
+   * Restores clinit loading feature (the default Hotspot behaviour)
+   */
+  public native void enableClinitLoading();
+
+
   // Memory
   private native long getObjectAddress0(Object o);
   public           long getObjectAddress(Object o) {


### PR DESCRIPTION
This PR adds a White-Box controlled option to skip `clinit` methods during class loading.
Such a feature would allow for non-executing testing techniques of random and untrusted jars/classes in CI systems without being afraid of breaking or harming the running system.

The clinit skipping does not affect core libraries (i.e. those under `java`, `jdk` and `sun` packages), and will only be available in debug builds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344003](https://bugs.openjdk.org/browse/JDK-8344003): WB: Add option to skip clinit during class loading for testing (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22030/head:pull/22030` \
`$ git checkout pull/22030`

Update a local copy of the PR: \
`$ git checkout pull/22030` \
`$ git pull https://git.openjdk.org/jdk.git pull/22030/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22030`

View PR using the GUI difftool: \
`$ git pr show -t 22030`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22030.diff">https://git.openjdk.org/jdk/pull/22030.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22030#issuecomment-2469878070)
</details>
