### PR TITLE
8344025: Remove unused ISO2022.Encoder.maximumDesignatorLength

### DIFF
--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/ISO2022.java
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/ISO2022.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -21,9 +21,6 @@
  * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
  * or visit www.oracle.com if you need additional information or have any
  * questions.
- */
-
-/*
  */
 
 package sun.nio.cs.ext;
@@ -66,8 +63,6 @@ abstract class ISO2022
         public static final byte SS2 = (byte)0x8e;
         public static final byte PLANE2 = (byte)0xA2;
         public static final byte PLANE3 = (byte)0xA3;
-
-        protected final byte maximumDesignatorLength = 4;
 
         protected byte[] SODesig,
                          SS2Desig = null,


### PR DESCRIPTION
The field `sun.nio.cs.ext.ISO2022.Encoder#maximumDesignatorLength` appears to be unused.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344025](https://bugs.openjdk.org/browse/JDK-8344025): Remove unused ISO2022.Encoder.maximumDesignatorLength (**Enhancement** - P5)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22031/head:pull/22031` \
`$ git checkout pull/22031`

Update a local copy of the PR: \
`$ git checkout pull/22031` \
`$ git pull https://git.openjdk.org/jdk.git pull/22031/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22031`

View PR using the GUI difftool: \
`$ git pr show -t 22031`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22031.diff">https://git.openjdk.org/jdk/pull/22031.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22031#issuecomment-2470310428)
</details>
