### PR TITLE
8354791: Use Hashtable.putIfAbsent in CSS constructor

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -734,7 +734,7 @@ public class CSS implements Serializable {
         valueConvertor.put(CSS.Attribute.BACKGROUND_ATTACHMENT,
                            valueMapper);
         Object generic = new CssValue();
-        for (Attribute key : Attribute.allAttributes) {
+        for (CSS.Attribute key : CSS.Attribute.allAttributes) {
             valueConvertor.putIfAbsent(key, generic);
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/CSS.java
@@ -734,12 +734,8 @@ public class CSS implements Serializable {
         valueConvertor.put(CSS.Attribute.BACKGROUND_ATTACHMENT,
                            valueMapper);
         Object generic = new CssValue();
-        int n = CSS.Attribute.allAttributes.length;
-        for (int i = 0; i < n; i++) {
-            CSS.Attribute key = CSS.Attribute.allAttributes[i];
-            if (valueConvertor.get(key) == null) {
-                valueConvertor.put(key, generic);
-            }
+        for (Attribute key : Attribute.allAttributes) {
+            valueConvertor.putIfAbsent(key, generic);
         }
     }
 


### PR DESCRIPTION
We can use Hashtable.putIfAbsent instead of pair `get`/`put` methods.
It's faster and cleaner.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8354791](https://bugs.openjdk.org/browse/JDK-8354791): Use Hashtable.putIfAbsent in CSS constructor (**Enhancement** - P5)


### Reviewers
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**) Review applies to [64cf26d9](https://git.openjdk.org/jdk/pull/22032/files/64cf26d985c53196b1bef493593b82c9a09030c2)
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22032/head:pull/22032` \
`$ git checkout pull/22032`

Update a local copy of the PR: \
`$ git checkout pull/22032` \
`$ git pull https://git.openjdk.org/jdk.git pull/22032/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22032`

View PR using the GUI difftool: \
`$ git pr show -t 22032`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22032.diff">https://git.openjdk.org/jdk/pull/22032.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22032#issuecomment-2808795557)
</details>
