### PR TITLE
8344018: Remove unlimited memory setting from TestScalarReplacementMaxLiveNodes

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestScalarReplacementMaxLiveNodes.java
+++ b/test/hotspot/jtreg/compiler/c2/TestScalarReplacementMaxLiveNodes.java
@@ -36,7 +36,6 @@
  *                   -XX:CompileCommand=inline,*String*::*
  *                   -XX:CompileCommand=dontinline,*StringBuilder*::ensureCapacityInternal
  *                   -XX:CompileCommand=dontinline,*String*::substring
- *                   -XX:CompileCommand=MemLimit,*.*,0
  *                   -XX:NodeCountInliningCutoff=220000
  *                   -XX:DesiredMethodLimit=100000
  *                   compiler.c2.TestScalarReplacementMaxLiveNodes


### PR DESCRIPTION
[JDK-8342612](https://bugs.openjdk.org/browse/JDK-8342612) increased the memory limit as a workaround for [JDK-8331295](https://bugs.openjdk.org/browse/JDK-8331295) which was found to be a separate issue ([JDK-8343038](https://bugs.openjdk.org/browse/JDK-8343038)). Let's remove the setting now that [JDK-8343038](https://bugs.openjdk.org/browse/JDK-8343038) got resolved by [JDK-8340824](https://bugs.openjdk.org/browse/JDK-8340824).

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344018](https://bugs.openjdk.org/browse/JDK-8344018): Remove unlimited memory setting from TestScalarReplacementMaxLiveNodes (**Enhancement** - P4)


### Reviewers
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22034/head:pull/22034` \
`$ git checkout pull/22034`

Update a local copy of the PR: \
`$ git checkout pull/22034` \
`$ git pull https://git.openjdk.org/jdk.git pull/22034/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22034`

View PR using the GUI difftool: \
`$ git pr show -t 22034`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22034.diff">https://git.openjdk.org/jdk/pull/22034.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22034#issuecomment-2470154693)
</details>
