### PR TITLE
8337660: C2: basic blocks with only BoxLock nodes are wrongly treated as empty

### DIFF
--- a/src/hotspot/share/opto/block.cpp
+++ b/src/hotspot/share/opto/block.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -181,10 +181,11 @@ int Block::is_Empty() const {
     return success_result;
   }
 
-  // Ideal nodes are allowable in empty blocks: skip them  Only MachNodes
-  // turn directly into code, because only MachNodes have non-trivial
-  // emit() functions.
-  while ((end_idx > 0) && !get_node(end_idx)->is_Mach()) {
+  // Ideal nodes (except BoxLock) are allowable in empty blocks: skip them. Only
+  // Mach and BoxLock nodes turn directly into code via emit().
+  while ((end_idx > 0) &&
+         !get_node(end_idx)->is_Mach() &&
+         !get_node(end_idx)->is_BoxLock()) {
     end_idx--;
   }
 

--- a/test/hotspot/jtreg/compiler/locks/TestSynchronizeWithEmptyBlock.java
+++ b/test/hotspot/jtreg/compiler/locks/TestSynchronizeWithEmptyBlock.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8337660
+ * @summary Test that C2 does not remove blocks with BoxLock nodes that are
+ *          otherwise empty.
+ * @run main/othervm -Xbatch -XX:LockingMode=1
+ *                   -XX:CompileOnly=compiler.locks.TestSynchronizeWithEmptyBlock::*
+ *                   compiler.locks.TestSynchronizeWithEmptyBlock
+ * @run main/othervm -Xbatch
+ *                   -XX:CompileOnly=compiler.locks.TestSynchronizeWithEmptyBlock::*
+ *                   compiler.locks.TestSynchronizeWithEmptyBlock
+ */
+
+package compiler.locks;
+
+public class TestSynchronizeWithEmptyBlock {
+
+    static int c;
+    static final Object obj = new Object();
+
+    static void test1() {
+        synchronized (TestSynchronizeWithEmptyBlock.class) {
+            int i = 0;
+            while (i < 1000) {
+                i++;
+                if (i < 5);
+            }
+        }
+        synchronized (TestSynchronizeWithEmptyBlock.class) {
+            int i = 0;
+            do {
+                i++;
+                if (i < 4) {
+                    boolean p = true;
+                    int j = 0;
+                    do {
+                        j++;
+                        if (p) {
+                            c++;
+                        }
+                    } while (j < 100);
+                }
+            } while (i < 1000);
+        }
+    }
+
+    static void test2() {
+        synchronized (obj) {
+            for (long i = 0; i < 1_000_000_000_000L; i+=6_500_000_000L) {}
+        }
+        synchronized (obj) {
+            for (long i = 0; i < 1_000_000_000_000L; i+=6_500_000_000L) {}
+        }
+    }
+
+    public static void main(String[] args) {
+        for (int i = 0; i < 10_000; i++) {
+            test1();
+        }
+        for (int i = 0; i < 10_000; i++) {
+            test2();
+        }
+    }
+}


### PR DESCRIPTION
This changeset takes into account the presence of `BoxLock` nodes in a basic block when determining whether the block is empty and [can be removed](https://github.com/openjdk/jdk/blob/5729227651969f542f040e5d0bfbf9b0b99b5698/src/hotspot/share/opto/compile.cpp#L2997). Special treatment of `BoxLock` nodes is required because these are not Mach nodes, yet they [are preserved in C2's back-end](https://github.com/openjdk/jdk/blob/f0b251d76078e8d5b47e967b0449c4cbdcb5a005/src/hotspot/share/opto/matcher.cpp#L2278) and result in [actual machine code being generated](https://github.com/openjdk/jdk/blob/f0b251d76078e8d5b47e967b0449c4cbdcb5a005/src/hotspot/cpu/x86/x86_64.ad#L1544). The proposed change avoids wrongly removing basic blocks consisting only of `BoxLock` and other non-Mach nodes, and crashing when the register that should have been defined by the wrongly removed `BoxLock` node is used (see complete failure analysis in the [JBS description](https://bugs.openjdk.org/browse/JDK-8337660)).

#### Testing

- tier1-5 (windows-x64, linux-x64, linux-aarch64, macosx-x64, macosx-aarch64; release and debug mode)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337660](https://bugs.openjdk.org/browse/JDK-8337660): C2: basic blocks with only BoxLock nodes are wrongly treated as empty (**Bug** - P2)


### Reviewers
 * [Quan Anh Mai](https://openjdk.org/census#qamai) (@merykitty - Committer)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Contributors
 * Emanuel Peter `<epeter@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22038/head:pull/22038` \
`$ git checkout pull/22038`

Update a local copy of the PR: \
`$ git checkout pull/22038` \
`$ git pull https://git.openjdk.org/jdk.git pull/22038/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22038`

View PR using the GUI difftool: \
`$ git pr show -t 22038`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22038.diff">https://git.openjdk.org/jdk/pull/22038.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22038#issuecomment-2470551607)
</details>
