### PR TITLE
8342047: Create Template Assertion Predicates with Halt nodes only instead of uncommon traps

### DIFF
--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -287,41 +287,36 @@ IfProjNode* PhaseIdealLoop::clone_parse_predicate_to_unswitched_loop(ParsePredic
 // It also rewires the control edges of data nodes with dependencies in the loop from the old predicates to the new
 // cloned predicates.
 void PhaseIdealLoop::clone_assertion_predicates_to_unswitched_loop(IdealLoopTree* loop, const Node_List& old_new,
-                                                                   Deoptimization::DeoptReason reason,
                                                                    ParsePredicateSuccessProj* old_parse_predicate_proj,
-                                                                   ParsePredicateSuccessProj* fast_loop_parse_predicate_proj,
-                                                                   ParsePredicateSuccessProj* slow_loop_parse_predicate_proj) {
-  assert(fast_loop_parse_predicate_proj->in(0)->is_ParsePredicate() &&
-         slow_loop_parse_predicate_proj->in(0)->is_ParsePredicate(), "sanity check");
-  // Only need to clone range check predicates as those can be changed and duplicated by inserting pre/main/post loops
-  // and doing loop unrolling. Push the original predicates on a list to later process them in reverse order to keep the
+                                                                   ParsePredicateNode* true_path_loop_parse_predicate,
+                                                                   ParsePredicateNode* false_path_loop_parse_predicate) {
+  // Push the original Template Assertion Predicates on a list to later process them in reverse order to keep the
   // original predicate order.
   Unique_Node_List list;
-  get_assertion_predicates(old_parse_predicate_proj, list);
+  get_template_assertion_predicates(old_parse_predicate_proj, list);
 
   Node_List to_process;
-  // Process in reverse order such that 'create_new_if_for_predicate' can be used in
-  // 'clone_assertion_predicate_for_unswitched_loops' and the original order is maintained.
   for (int i = list.size() - 1; i >= 0; i--) {
-    Node* predicate = list.at(i);
-    assert(predicate->in(0)->is_If(), "must be If node");
-    IfNode* iff = predicate->in(0)->as_If();
-    assert(predicate->is_Proj() && predicate->as_Proj()->is_IfProj(), "predicate must be a projection of an if node");
-    IfProjNode* predicate_proj = predicate->as_IfProj();
+    IfTrueNode* template_assertion_predicate_success_proj = list.at(i)->as_IfTrue();
+    assert(template_assertion_predicate_success_proj->in(0)->is_If(), "must be If node");
 
-    IfProjNode* fast_proj = clone_assertion_predicate_for_unswitched_loops(iff, predicate_proj, reason, fast_loop_parse_predicate_proj);
-    assert(assertion_predicate_has_loop_opaque_node(fast_proj->in(0)->as_If()), "must find Assertion Predicate for fast loop");
-    IfProjNode* slow_proj = clone_assertion_predicate_for_unswitched_loops(iff, predicate_proj, reason, slow_loop_parse_predicate_proj);
-    assert(assertion_predicate_has_loop_opaque_node(slow_proj->in(0)->as_If()), "must find Assertion Predicate for slow loop");
+    IfTrueNode* true_path_loop_proj =
+        clone_assertion_predicate_for_unswitched_loops(template_assertion_predicate_success_proj,
+                                                       true_path_loop_parse_predicate);
+    IfTrueNode* false_path_loop_proj =
+        clone_assertion_predicate_for_unswitched_loops(template_assertion_predicate_success_proj,
+                                                       false_path_loop_parse_predicate);
 
     // Update control dependent data nodes.
-    for (DUIterator j = predicate->outs(); predicate->has_out(j); j++) {
-      Node* fast_node = predicate->out(j);
+    for (DUIterator j = template_assertion_predicate_success_proj->outs();
+         template_assertion_predicate_success_proj->has_out(j);
+         j++) {
+      Node* fast_node = template_assertion_predicate_success_proj->out(j);
       if (loop->is_member(get_loop(ctrl_or_self(fast_node)))) {
-        assert(fast_node->in(0) == predicate, "only control edge");
+        assert(fast_node->in(0) == template_assertion_predicate_success_proj, "only control edge");
         Node* slow_node = old_new[fast_node->_idx];
-        assert(slow_node->in(0) == predicate, "only control edge");
-        _igvn.replace_input_of(fast_node, 0, fast_proj);
+        assert(slow_node->in(0) == template_assertion_predicate_success_proj, "only control edge");
+        _igvn.replace_input_of(fast_node, 0, true_path_loop_proj);
         to_process.push(slow_node);
         --j;
       }
@@ -329,7 +324,7 @@ void PhaseIdealLoop::clone_assertion_predicates_to_unswitched_loop(IdealLoopTree
     // Have to delay updates to the slow loop so uses of predicate are not modified while we iterate on them.
     while (to_process.size() > 0) {
       Node* slow_node = to_process.pop();
-      _igvn.replace_input_of(slow_node, 0, slow_proj);
+      _igvn.replace_input_of(slow_node, 0, false_path_loop_proj);
     }
   }
 }
@@ -337,8 +332,8 @@ void PhaseIdealLoop::clone_assertion_predicates_to_unswitched_loop(IdealLoopTree
 // Put all Assertion Predicate projections on a list, starting at 'predicate' and going up in the tree. If 'get_opaque'
 // is set, then the OpaqueTemplateAssertionPredicateNode nodes of the Assertion Predicates are put on the list instead
 // of the projections.
-void PhaseIdealLoop::get_assertion_predicates(ParsePredicateSuccessProj* parse_predicate_proj, Unique_Node_List& list,
-                                              const bool get_opaque) {
+void PhaseIdealLoop::get_template_assertion_predicates(ParsePredicateSuccessProj* parse_predicate_proj, Unique_Node_List& list,
+                                                       const bool get_opaque) {
   Deoptimization::DeoptReason deopt_reason = parse_predicate_proj->in(0)->as_ParsePredicate()->deopt_reason();
   PredicateBlockIterator predicate_iterator(parse_predicate_proj, deopt_reason);
   TemplateAssertionPredicateCollector template_assertion_predicate_collector(list, get_opaque);
@@ -348,39 +343,38 @@ void PhaseIdealLoop::get_assertion_predicates(ParsePredicateSuccessProj* parse_p
 // Clone an Assertion Predicate for an unswitched loop. OpaqueLoopInit and OpaqueLoopStride nodes are cloned and uncommon
 // traps are kept for the predicate (a Halt node is used later when creating pre/main/post loops and copying this cloned
 // predicate again).
-IfProjNode* PhaseIdealLoop::clone_assertion_predicate_for_unswitched_loops(IfNode* template_assertion_predicate,
-                                                                           IfProjNode* predicate,
-                                                                           Deoptimization::DeoptReason reason,
-                                                                           ParsePredicateSuccessProj* parse_predicate_proj) {
-  TemplateAssertionExpression template_assertion_expression(template_assertion_predicate->in(1)->as_OpaqueTemplateAssertionPredicate());
-  OpaqueTemplateAssertionPredicateNode* cloned_opaque_node = template_assertion_expression.clone(parse_predicate_proj->in(0)->in(0), this);
-  IfProjNode* if_proj = create_new_if_for_predicate(parse_predicate_proj, nullptr, reason,
-                                                    template_assertion_predicate->Opcode(), false);
-  _igvn.replace_input_of(if_proj->in(0), 1, cloned_opaque_node);
-  _igvn.replace_input_of(parse_predicate_proj->in(0), 0, if_proj);
-  set_idom(parse_predicate_proj->in(0), if_proj, dom_depth(if_proj));
-  return if_proj;
+IfTrueNode*
+PhaseIdealLoop::clone_assertion_predicate_for_unswitched_loops(IfTrueNode* template_assertion_predicate_success_proj,
+                                                               ParsePredicateNode* unswitched_loop_parse_predicate) {
+  TemplateAssertionPredicate template_assertion_predicate(template_assertion_predicate_success_proj);
+  IfTrueNode* template_success_proj = template_assertion_predicate.clone(unswitched_loop_parse_predicate->in(0), this);
+  assert(assertion_predicate_has_loop_opaque_node(template_success_proj->in(0)->as_If()),
+         "must find Assertion Predicate for fast loop");
+  _igvn.replace_input_of(unswitched_loop_parse_predicate, 0, template_success_proj);
+  set_idom(unswitched_loop_parse_predicate, template_success_proj, dom_depth(template_success_proj));
+  return template_success_proj;
 }
 
 // Clone the old Parse Predicates and Assertion Predicates before the unswitch If to the unswitched loops after the
 // unswitch If.
 void PhaseIdealLoop::clone_parse_and_assertion_predicates_to_unswitched_loop(IdealLoopTree* loop, Node_List& old_new,
-                                                                             IfProjNode*& iffast_pred, IfProjNode*& ifslow_pred) {
+                                                                             IfProjNode*& true_path_loop_entry,
+                                                                             IfProjNode*& false_path_loop_entry) {
   LoopNode* head = loop->_head->as_Loop();
   Node* entry = head->skip_strip_mined()->in(LoopNode::EntryControl);
 
   const Predicates predicates(entry);
   clone_loop_predication_predicates_to_unswitched_loop(loop, old_new, predicates.loop_predicate_block(),
-                                                       Deoptimization::Reason_predicate, iffast_pred, ifslow_pred);
+                                                       Deoptimization::Reason_predicate, true_path_loop_entry, false_path_loop_entry);
   clone_loop_predication_predicates_to_unswitched_loop(loop, old_new, predicates.profiled_loop_predicate_block(),
-                                                       Deoptimization::Reason_profile_predicate, iffast_pred, ifslow_pred);
+                                                       Deoptimization::Reason_profile_predicate, true_path_loop_entry, false_path_loop_entry);
 
   const PredicateBlock* loop_limit_check_predicate_block = predicates.loop_limit_check_predicate_block();
   if (loop_limit_check_predicate_block->has_parse_predicate() && !head->is_CountedLoop()) {
     // Don't clone the Loop Limit Check Parse Predicate if we already have a counted loop (a Loop Limit Check Predicate
     // is only created when converting a LoopNode to a CountedLoopNode).
     clone_parse_predicate_to_unswitched_loops(loop_limit_check_predicate_block, Deoptimization::Reason_loop_limit_check,
-                                              iffast_pred, ifslow_pred);
+                                              true_path_loop_entry, false_path_loop_entry);
   }
 }
 
@@ -388,16 +382,17 @@ void PhaseIdealLoop::clone_parse_and_assertion_predicates_to_unswitched_loop(Ide
 void PhaseIdealLoop::clone_loop_predication_predicates_to_unswitched_loop(IdealLoopTree* loop, const Node_List& old_new,
                                                                           const PredicateBlock* predicate_block,
                                                                           Deoptimization::DeoptReason reason,
-                                                                          IfProjNode*& iffast_pred,
-                                                                          IfProjNode*& ifslow_pred) {
+                                                                          IfProjNode*& true_path_loop_entry,
+                                                                          IfProjNode*& false_path_loop_entry) {
   if (predicate_block->has_parse_predicate()) {
     // We currently only clone Assertion Predicates if there are Parse Predicates. This is not entirely correct and will
     // be changed with the complete fix for Assertion Predicates.
-    clone_parse_predicate_to_unswitched_loops(predicate_block, reason, iffast_pred, ifslow_pred);
-    assert(iffast_pred->in(0)->is_ParsePredicate() && ifslow_pred->in(0)->is_ParsePredicate(),
+    clone_parse_predicate_to_unswitched_loops(predicate_block, reason, true_path_loop_entry, false_path_loop_entry);
+    assert(true_path_loop_entry->in(0)->is_ParsePredicate() && false_path_loop_entry->in(0)->is_ParsePredicate(),
            "must be success projections of the cloned Parse Predicates");
-    clone_assertion_predicates_to_unswitched_loop(loop, old_new, reason, predicate_block->parse_predicate_success_proj(),
-                                                  iffast_pred->as_IfTrue(), ifslow_pred->as_IfTrue());
+    clone_assertion_predicates_to_unswitched_loop(loop, old_new, predicate_block->parse_predicate_success_proj(),
+                                                  true_path_loop_entry->in(0)->as_ParsePredicate(),
+                                                  false_path_loop_entry->in(0)->as_ParsePredicate());
   }
 }
 
@@ -1250,9 +1245,9 @@ bool PhaseIdealLoop::loop_predication_impl_helper(IdealLoopTree* loop, IfProjNod
     // Fall through into rest of the cleanup code which will move any dependent nodes to the skeleton predicates of the
     // upper bound test. We always need to create skeleton predicates in order to properly remove dead loops when later
     // splitting the predicated loop into (unreachable) sub-loops (i.e. done by unrolling, peeling, pre/main/post etc.).
-    IfTrueNode* template_assertion_predicate_proj =
-        create_template_assertion_predicate(if_opcode, cl, parse_predicate_proj, upper_bound_proj, scale, offset, range,
-                                            deopt_reason);
+    IfTrueNode* template_assertion_predicate_proj = create_template_assertion_predicate(cl, parse_predicate,
+                                                                                        upper_bound_proj, scale, offset,
+                                                                                        range);
 
     // Eliminate the old range check in the loop body.
     // When a range check is eliminated, data dependent nodes (Load and range check CastII nodes) are now dependent on 2
@@ -1288,15 +1283,16 @@ void PhaseIdealLoop::eliminate_hoisted_range_check(IfTrueNode* hoisted_check_pro
 // Each newly created Hoisted Check Predicate is accompanied by two Template Assertion Predicates. Later, we initialize
 // them by making a copy of them when splitting a loop into sub loops. The Assertion Predicates ensure that dead sub
 // loops are removed properly.
-IfTrueNode* PhaseIdealLoop::create_template_assertion_predicate(const int if_opcode, CountedLoopNode* loop_head,
-                                                                ParsePredicateSuccessProj* parse_predicate_proj,
+IfTrueNode* PhaseIdealLoop::create_template_assertion_predicate(CountedLoopNode* loop_head,
+                                                                ParsePredicateNode* parse_predicate,
                                                                 IfProjNode* new_control, const int scale, Node* offset,
-                                                                Node* range, Deoptimization::DeoptReason deopt_reason) {
+                                                                Node* range) {
 
   TemplateAssertionPredicateCreator template_assertion_predicate_creator(loop_head, scale, offset, range, this);
-  return template_assertion_predicate_creator.create_with_uncommon_trap(new_control, parse_predicate_proj, deopt_reason,
-                                                                        if_opcode);
-
+  IfTrueNode* template_success_proj = template_assertion_predicate_creator.create(new_control);
+  _igvn.replace_input_of(parse_predicate, 0, template_success_proj);
+  set_idom(parse_predicate, template_success_proj, dom_depth(template_success_proj));
+  return template_success_proj;
 }
 
 // Insert Hoisted Check Predicates for null checks and range checks and additional Template Assertion Predicates for

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -329,7 +329,7 @@ void PhaseIdealLoop::clone_assertion_predicates_to_unswitched_loop(IdealLoopTree
   }
 }
 
-// Put all Assertion Predicate projections on a list, starting at 'predicate' and going up in the tree. If 'get_opaque'
+// Put all Template Assertion Predicate projections on a list, starting at 'predicate' and going up in the tree. If 'get_opaque'
 // is set, then the OpaqueTemplateAssertionPredicateNode nodes of the Assertion Predicates are put on the list instead
 // of the projections.
 void PhaseIdealLoop::get_template_assertion_predicates(ParsePredicateSuccessProj* parse_predicate_proj, Unique_Node_List& list,

--- a/src/hotspot/share/opto/loopPredicate.cpp
+++ b/src/hotspot/share/opto/loopPredicate.cpp
@@ -283,9 +283,9 @@ IfProjNode* PhaseIdealLoop::clone_parse_predicate_to_unswitched_loop(ParsePredic
   return new_predicate_proj;
 }
 
-// Clones Assertion Predicates to both unswitched loops starting at 'old_predicate_proj' by following its control inputs.
-// It also rewires the control edges of data nodes with dependencies in the loop from the old predicates to the new
-// cloned predicates.
+// Clones Template Assertion Predicates to both unswitched loops starting at 'old_predicate_proj' by following its
+// control inputs. It also rewires the control edges of data nodes with dependencies in the loop from the old predicates
+// to the new  cloned predicates.
 void PhaseIdealLoop::clone_assertion_predicates_to_unswitched_loop(IdealLoopTree* loop, const Node_List& old_new,
                                                                    ParsePredicateSuccessProj* old_parse_predicate_proj,
                                                                    ParsePredicateNode* true_path_loop_parse_predicate,
@@ -311,17 +311,17 @@ void PhaseIdealLoop::clone_assertion_predicates_to_unswitched_loop(IdealLoopTree
     for (DUIterator j = template_assertion_predicate_success_proj->outs();
          template_assertion_predicate_success_proj->has_out(j);
          j++) {
-      Node* fast_node = template_assertion_predicate_success_proj->out(j);
-      if (loop->is_member(get_loop(ctrl_or_self(fast_node)))) {
-        assert(fast_node->in(0) == template_assertion_predicate_success_proj, "only control edge");
-        Node* slow_node = old_new[fast_node->_idx];
-        assert(slow_node->in(0) == template_assertion_predicate_success_proj, "only control edge");
-        _igvn.replace_input_of(fast_node, 0, true_path_loop_proj);
-        to_process.push(slow_node);
+      Node* true_path_loop_node = template_assertion_predicate_success_proj->out(j);
+      if (loop->is_member(get_loop(ctrl_or_self(true_path_loop_node)))) {
+        assert(true_path_loop_node->in(0) == template_assertion_predicate_success_proj, "only control edge");
+        Node* false_path_loop_node = old_new[true_path_loop_node->_idx];
+        assert(false_path_loop_node->in(0) == template_assertion_predicate_success_proj, "only control edge");
+        _igvn.replace_input_of(true_path_loop_node, 0, true_path_loop_proj);
+        to_process.push(false_path_loop_node);
         --j;
       }
     }
-    // Have to delay updates to the slow loop so uses of predicate are not modified while we iterate on them.
+    // Have to delay updates to the false path loop so uses of predicate are not modified while we iterate on them.
     while (to_process.size() > 0) {
       Node* slow_node = to_process.pop();
       _igvn.replace_input_of(slow_node, 0, false_path_loop_proj);

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -2768,7 +2768,7 @@ void PhaseIdealLoop::do_range_check(IdealLoopTree *loop, Node_List &old_new) {
           // unrolling or splitting this main-loop further.
           TemplateAssertionPredicateCreator template_assertion_predicate_creator(cl, scale_con , int_offset, int_limit,
                                                                                  this);
-          loop_entry = template_assertion_predicate_creator.create_with_halt(loop_entry);
+          loop_entry = template_assertion_predicate_creator.create(loop_entry);
           assert(assertion_predicate_has_loop_opaque_node(loop_entry->in(0)->as_If()), "unexpected");
 
           // Initialized Assertion Predicate for the value of the initial main-loop.

--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -2834,7 +2834,7 @@ Node* CountedLoopNode::skip_assertion_predicates_with_halt() {
     ctrl = skip_strip_mined()->in(LoopNode::EntryControl);
   }
   if (is_main_loop() || is_post_loop()) {
-    AssertionPredicatesWithHalt assertion_predicates(ctrl);
+    AssertionPredicates assertion_predicates(ctrl);
     return assertion_predicates.entry();
   }
   return ctrl;
@@ -4470,7 +4470,7 @@ void PhaseIdealLoop::collect_useful_template_assertion_predicates_for_loop(Ideal
     const PredicateBlock* profiled_loop_predicate_block = predicates.profiled_loop_predicate_block();
     if (profiled_loop_predicate_block->has_parse_predicate()) {
       ParsePredicateSuccessProj* parse_predicate_proj = profiled_loop_predicate_block->parse_predicate_success_proj();
-      get_assertion_predicates(parse_predicate_proj, useful_predicates, true);
+      get_template_assertion_predicates(parse_predicate_proj, useful_predicates, true);
     }
   }
 
@@ -4478,7 +4478,7 @@ void PhaseIdealLoop::collect_useful_template_assertion_predicates_for_loop(Ideal
     const PredicateBlock* loop_predicate_block = predicates.loop_predicate_block();
     if (loop_predicate_block->has_parse_predicate()) {
       ParsePredicateSuccessProj* parse_predicate_proj = loop_predicate_block->parse_predicate_success_proj();
-      get_assertion_predicates(parse_predicate_proj, useful_predicates, true);
+      get_template_assertion_predicates(parse_predicate_proj, useful_predicates, true);
     }
   }
 }

--- a/src/hotspot/share/opto/loopnode.hpp
+++ b/src/hotspot/share/opto/loopnode.hpp
@@ -947,7 +947,7 @@ private:
   DEBUG_ONLY(static bool assertion_predicate_has_loop_opaque_node(IfNode* iff);)
  private:
   DEBUG_ONLY(static void count_opaque_loop_nodes(Node* n, uint& init, uint& stride);)
-  static void get_assertion_predicates(ParsePredicateSuccessProj* parse_predicate_proj, Unique_Node_List& list, bool get_opaque = false);
+  static void get_template_assertion_predicates(ParsePredicateSuccessProj* parse_predicate_proj, Unique_Node_List& list, bool get_opaque = false);
   void update_main_loop_assertion_predicates(CountedLoopNode* main_loop_head);
   void initialize_assertion_predicates_for_peeled_loop(CountedLoopNode* peeled_loop_head,
                                                        CountedLoopNode* remaining_loop_head,
@@ -1389,10 +1389,8 @@ public:
   void loop_predication_follow_branches(Node *c, IdealLoopTree *loop, float loop_trip_cnt,
                                         PathFrequency& pf, Node_Stack& stack, VectorSet& seen,
                                         Node_List& if_proj_list);
-  IfTrueNode* create_template_assertion_predicate(int if_opcode, CountedLoopNode* loop_head,
-                                                  ParsePredicateSuccessProj* parse_predicate_proj,
-                                                  IfProjNode* new_control, int scale, Node* offset,
-                                                  Node* range, Deoptimization::DeoptReason deopt_reason);
+  IfTrueNode* create_template_assertion_predicate(CountedLoopNode* loop_head, ParsePredicateNode* parse_predicate,
+                                                  IfProjNode* new_control, int scale, Node* offset, Node* range);
   void eliminate_hoisted_range_check(IfTrueNode* hoisted_check_proj, IfTrueNode* template_assertion_predicate_proj);
 
   // Helper function to collect predicate for eliminating the useless ones
@@ -1661,23 +1659,24 @@ private:
  public:
   // Clone Parse Predicates to slow and fast loop when unswitching a loop
   void clone_parse_and_assertion_predicates_to_unswitched_loop(IdealLoopTree* loop, Node_List& old_new,
-                                                               IfProjNode*& iffast_pred, IfProjNode*& ifslow_pred);
+                                                               IfProjNode*& true_path_loop_entry,
+                                                               IfProjNode*& false_path_loop_entry);
  private:
   void clone_loop_predication_predicates_to_unswitched_loop(IdealLoopTree* loop, const Node_List& old_new,
                                                             const PredicateBlock* predicate_block,
-                                                            Deoptimization::DeoptReason reason, IfProjNode*& iffast_pred,
-                                                            IfProjNode*& ifslow_pred);
+                                                            Deoptimization::DeoptReason reason,
+                                                            IfProjNode*& true_path_loop_entry,
+                                                            IfProjNode*& false_path_loop_entry);
   void clone_parse_predicate_to_unswitched_loops(const PredicateBlock* predicate_block, Deoptimization::DeoptReason reason,
                                                  IfProjNode*& iffast_pred, IfProjNode*& ifslow_pred);
   IfProjNode* clone_parse_predicate_to_unswitched_loop(ParsePredicateSuccessProj* parse_predicate_proj, Node* new_entry,
                                                        Deoptimization::DeoptReason reason, bool slow_loop);
   void clone_assertion_predicates_to_unswitched_loop(IdealLoopTree* loop, const Node_List& old_new,
-                                                     Deoptimization::DeoptReason reason, ParsePredicateSuccessProj* old_parse_predicate_proj,
-                                                     ParsePredicateSuccessProj* fast_loop_parse_predicate_proj,
-                                                     ParsePredicateSuccessProj* slow_loop_parse_predicate_proj);
-  IfProjNode* clone_assertion_predicate_for_unswitched_loops(IfNode* template_assertion_predicate, IfProjNode* predicate,
-                                                             Deoptimization::DeoptReason reason,
-                                                             ParsePredicateSuccessProj* parse_predicate_proj);
+                                                     ParsePredicateSuccessProj* old_parse_predicate_proj,
+                                                     ParsePredicateNode* true_path_loop_parse_predicate,
+                                                     ParsePredicateNode* false_path_loop_parse_predicate);
+  IfTrueNode* clone_assertion_predicate_for_unswitched_loops(IfTrueNode* template_assertion_predicate_success_proj,
+                                                             ParsePredicateNode* unswitched_loop_parse_predicate);
   static void check_cloned_parse_predicate_for_unswitching(const Node* new_entry, bool is_fast_loop) PRODUCT_RETURN;
 
   bool _created_loop_node;


### PR DESCRIPTION
This patch replaces the creation of Template Assertion Predicates with uncommon traps with Halt nodes.

### Goal of Assertion Predicates
#### Initialized Assertion Predicates
These predicates ensure that control is properly folded when data is dying. They are **always true by design** and thus can never fail at runtime. We therefore put a halt node on the failing path.

#### Template Assertion Predicates
Only serve as templates to create Initialized Assertion Predicates from. They are never executed and are always removed after loop opts are over. Conceptionally, it does not matter whether the failing path uses an UCT or a halt node (or something else completely - I plan to have a separate "no-op" `TemplateAssertionPredicateNode` at some point which only falls through to the next node and does not have a failing path at all).

### Why Did we Use UCTs for Template Assertion Predicates?
When the concept of Assertion Predicates was first introduced, it only covered a few edge cases. It was quite straight forward to reuse existing Loop Predication code which creates new predicates from a Parse Predicate by copying it and merging the UCTs on the failing paths with a region node. This was done with `PhaseIdealLoop::create_new_if_for_predicate()`.

### Why Do we Need to Use Halt Nodes for Template Assertion Predicates?
#### Missing UCTs for Predicates above Loops
Over time, we found more cases where we need to create Initialized Assertion Predicates from templates - including locations where we do not have Parse Predicates (and thus no safepoints). For example, when peeling one iteration off a loop with Parse Predicates, they will be kept at the peeled iteration and the remaining loop does not have any Parse Predicates anymore.

#### Missing UCTs to Create Template Assertion Predicates
Whenever we split a loop with Template Assertion Predicates, we also need to ensure that they are copied to all split loop versions. Since they rely on using UCTs, we also need to make sure that an UCT/safepoint is available to be used. However, this is not always the case (for example, after peeling an iteration off as described in the last section). As a result, we cannot easily establish new Template Assertion Predicates anywhere. One could think about faking an UCT or doing other special logic. But this seems rather fragile and could introduce quite some complexity - especially since we conceptionally don't even need to use UCTs at all for Template Assertion Predicates.

There is already some special logic for a main loop, where we create Template Assertion Predicates with a Halt node because there is no UCT available for the main loop. But this logic and implementation it is not easily reusable and we would need to keep supporting both formats with UCTs and halt nodes.

### Solution: Assertion Predicates with Halt Nodes only
As a simple solution to the problems described above, I propose to get rid of UCTs completely. This not only enables us to fix the remaining unresolved bugs where Assertion Predicates are missing but also simplifies the logic and the IR itself.

I've added some comments in the PR to better explain the refactoring steps.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8342047](https://bugs.openjdk.org/browse/JDK-8342047): Create Template Assertion Predicates with Halt nodes only instead of uncommon traps (**Sub-task** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22040/head:pull/22040` \
`$ git checkout pull/22040`

Update a local copy of the PR: \
`$ git checkout pull/22040` \
`$ git pull https://git.openjdk.org/jdk.git pull/22040/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22040`

View PR using the GUI difftool: \
`$ git pr show -t 22040`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22040.diff">https://git.openjdk.org/jdk/pull/22040.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22040#issuecomment-2470854362)
</details>
