### PR TITLE
8344034: Remove security manager dependency in Serialization

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputFilter.java
+++ b/src/java.base/share/classes/java/io/ObjectInputFilter.java
@@ -29,8 +29,6 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.util.StaticProperty;
 
 import java.lang.reflect.InvocationTargetException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.Security;
 import java.util.ArrayList;
 import java.util.List;
@@ -630,17 +628,13 @@ public interface ObjectInputFilter {
             configLog = System.getLogger("java.io.serialization");
 
             // Get the values of the system properties, if they are defined
-            @SuppressWarnings("removal")
             String factoryClassName = StaticProperty.jdkSerialFilterFactory() != null
                     ? StaticProperty.jdkSerialFilterFactory()
-                    : AccessController.doPrivileged((PrivilegedAction<String>) () ->
-                        Security.getProperty(SERIAL_FILTER_FACTORY_PROPNAME));
+                    : Security.getProperty(SERIAL_FILTER_FACTORY_PROPNAME);
 
-            @SuppressWarnings("removal")
             String filterString = StaticProperty.jdkSerialFilter() != null
                     ? StaticProperty.jdkSerialFilter()
-                    : AccessController.doPrivileged((PrivilegedAction<String>) () ->
-                        Security.getProperty(SERIAL_FILTER_PROPNAME));
+                    : Security.getProperty(SERIAL_FILTER_PROPNAME);
 
             // Initialize the static filter if the jdk.serialFilter is present
             String filterMessage = null;

--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -34,13 +34,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.Objects;
 
 import jdk.internal.access.JavaLangAccess;
@@ -49,8 +43,6 @@ import jdk.internal.event.DeserializationEvent;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.util.ByteArray;
 import sun.reflect.misc.ReflectUtil;
-import sun.security.action.GetBooleanAction;
-import sun.security.action.GetIntegerAction;
 
 /**
  * An ObjectInputStream deserializes primitive data and objects previously
@@ -278,8 +270,7 @@ public class ObjectInputStream
          * have been read.
          * See {@link #setObjectInputFilter(ObjectInputFilter)}
          */
-        static final boolean SET_FILTER_AFTER_READ = GetBooleanAction
-                .privilegedGetProperty("jdk.serialSetFilterAfterRead");
+        static final boolean SET_FILTER_AFTER_READ = Boolean.getBoolean("jdk.serialSetFilterAfterRead");
 
         /**
          * Property to control {@link GetField#get(String, Object)} conversion of
@@ -287,8 +278,7 @@ public class ObjectInputStream
          * {@link GetField#get(String, Object)} returns null otherwise
          * throwing {@link ClassNotFoundException}.
          */
-        private static final boolean GETFIELD_CNFE_RETURNS_NULL = GetBooleanAction
-                .privilegedGetProperty("jdk.serialGetFieldCnfeReturnsNull");
+        private static final boolean GETFIELD_CNFE_RETURNS_NULL = Boolean.getBoolean("jdk.serialGetFieldCnfeReturnsNull");
 
         /**
          * Property to override the implementation limit on the number
@@ -296,8 +286,8 @@ public class ObjectInputStream
          * The maximum number of interfaces allowed for a proxy is limited to 65535 by
          * {@link java.lang.reflect.Proxy#newProxyInstance(ClassLoader, Class[], InvocationHandler)}.
          */
-        static final int PROXY_INTERFACE_LIMIT = Math.clamp(GetIntegerAction
-                .privilegedGetProperty("jdk.serialProxyInterfaceLimit", 65535), 0, 65535);
+        static final int PROXY_INTERFACE_LIMIT =
+                Math.clamp(Integer.getInteger("jdk.serialProxyInterfaceLimit", 65535), 0, 65535);
     }
 
     /*
@@ -386,7 +376,6 @@ public class ObjectInputStream
      */
     @SuppressWarnings("this-escape")
     public ObjectInputStream(InputStream in) throws IOException {
-        verifySubclass();
         bin = new BlockDataInputStream(in);
         handles = new HandleTable(10);
         vlist = new ValidationList();
@@ -416,11 +405,6 @@ public class ObjectInputStream
      *      fails due to invalid serial filter or serial filter factory properties.
      */
     protected ObjectInputStream() throws IOException {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SUBCLASS_IMPLEMENTATION_PERMISSION);
-        }
         bin = null;
         handles = null;
         vlist = null;
@@ -907,13 +891,6 @@ public class ObjectInputStream
         if (enable == enableResolve) {
             return enable;
         }
-        if (enable) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(SUBSTITUTION_PERMISSION);
-            }
-        }
         enableResolve = enable;
         return !enableResolve;
     }
@@ -1309,11 +1286,6 @@ public class ObjectInputStream
      * @since 9
      */
     public final void setObjectInputFilter(ObjectInputFilter filter) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(ObjectStreamConstants.SERIAL_FILTER_PERMISSION);
-        }
         if (totalObjectRefs > 0 && !Caches.SET_FILTER_AFTER_READ) {
             throw new IllegalStateException(
                     "filter can not be set after an object has been read");
@@ -1572,57 +1544,29 @@ public class ObjectInputStream
     }
 
     /**
-     * Verifies that this (possibly subclass) instance can be constructed
-     * without violating security constraints: the subclass must not override
-     * security-sensitive non-final methods, or else the
-     * "enableSubclassImplementation" SerializablePermission is checked.
-     */
-    private void verifySubclass() {
-        Class<?> cl = getClass();
-        if (cl == ObjectInputStream.class) {
-            return;
-        }
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm == null) {
-            return;
-        }
-        boolean result = Caches.subclassAudits.get(cl);
-        if (!result) {
-            sm.checkPermission(SUBCLASS_IMPLEMENTATION_PERMISSION);
-        }
-    }
-
-    /**
      * Performs reflective checks on given subclass to verify that it doesn't
      * override security-sensitive non-final methods.  Returns TRUE if subclass
      * is "safe", FALSE otherwise.
      */
     @SuppressWarnings("removal")
     private static Boolean auditSubclass(Class<?> subcl) {
-        return AccessController.doPrivileged(
-            new PrivilegedAction<Boolean>() {
-                public Boolean run() {
-                    for (Class<?> cl = subcl;
-                         cl != ObjectInputStream.class;
-                         cl = cl.getSuperclass())
-                    {
-                        try {
-                            cl.getDeclaredMethod(
-                                "readUnshared", (Class[]) null);
-                            return Boolean.FALSE;
-                        } catch (NoSuchMethodException ex) {
-                        }
-                        try {
-                            cl.getDeclaredMethod("readFields", (Class[]) null);
-                            return Boolean.FALSE;
-                        } catch (NoSuchMethodException ex) {
-                        }
-                    }
-                    return Boolean.TRUE;
-                }
+        for (Class<?> cl = subcl;
+             cl != ObjectInputStream.class;
+             cl = cl.getSuperclass())
+        {
+            try {
+                cl.getDeclaredMethod(
+                    "readUnshared", (Class[]) null);
+                return Boolean.FALSE;
+            } catch (NoSuchMethodException ex) {
             }
-        );
+            try {
+                cl.getDeclaredMethod("readFields", (Class[]) null);
+                return Boolean.FALSE;
+            } catch (NoSuchMethodException ex) {
+            }
+        }
+        return Boolean.TRUE;
     }
 
     /**
@@ -2702,16 +2646,12 @@ public class ObjectInputStream
             final ObjectInputValidation obj;
             final int priority;
             Callback next;
-            @SuppressWarnings("removal")
-            final AccessControlContext acc;
 
-            Callback(ObjectInputValidation obj, int priority, Callback next,
-                @SuppressWarnings("removal") AccessControlContext acc)
+            Callback(ObjectInputValidation obj, int priority, Callback next)
             {
                 this.obj = obj;
                 this.priority = priority;
                 this.next = next;
-                this.acc = acc;
             }
         }
 
@@ -2740,12 +2680,10 @@ public class ObjectInputStream
                 prev = cur;
                 cur = cur.next;
             }
-            @SuppressWarnings("removal")
-            AccessControlContext acc = AccessController.getContext();
             if (prev != null) {
-                prev.next = new Callback(obj, priority, cur, acc);
+                prev.next = new Callback(obj, priority, cur);
             } else {
-                list = new Callback(obj, priority, list, acc);
+                list = new Callback(obj, priority, list);
             }
         }
 
@@ -2760,19 +2698,12 @@ public class ObjectInputStream
         void doCallbacks() throws InvalidObjectException {
             try {
                 while (list != null) {
-                    AccessController.doPrivileged(
-                        new PrivilegedExceptionAction<Void>()
-                    {
-                        public Void run() throws InvalidObjectException {
-                            list.obj.validateObject();
-                            return null;
-                        }
-                    }, list.acc);
+                    list.obj.validateObject();
                     list = list.next;
                 }
-            } catch (PrivilegedActionException ex) {
+            } catch (InvalidObjectException ex) {
                 list = null;
-                throw (InvalidObjectException) ex.getException();
+                throw ex;
             }
         }
 

--- a/src/java.base/share/classes/java/io/ObjectStreamClass.java
+++ b/src/java.base/share/classes/java/io/ObjectStreamClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,21 +32,12 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.RecordComponent;
-import java.lang.reflect.UndeclaredThrowableException;
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Proxy;
-import java.security.AccessControlContext;
-import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.PermissionCollection;
-import java.security.Permissions;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -59,12 +50,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import jdk.internal.event.SerializationMisdeclarationEvent;
 import jdk.internal.misc.Unsafe;
 import jdk.internal.reflect.CallerSensitive;
-import jdk.internal.reflect.Reflection;
 import jdk.internal.reflect.ReflectionFactory;
-import jdk.internal.access.SharedSecrets;
-import jdk.internal.access.JavaSecurityAccess;
 import jdk.internal.util.ByteArray;
-import sun.reflect.misc.ReflectUtil;
 
 /**
  * Serialization's descriptor for classes.  It contains the name and
@@ -97,12 +84,6 @@ public final class ObjectStreamClass implements Serializable {
     @java.io.Serial
     private static final ObjectStreamField[] serialPersistentFields =
         NO_FIELDS;
-
-    /** reflection factory for obtaining serialization constructors */
-    @SuppressWarnings("removal")
-    private static final ReflectionFactory reflFactory =
-        AccessController.doPrivileged(
-            new ReflectionFactory.GetReflectionFactoryAction());
 
     private static class Caches {
         /** cache mapping local classes -> descriptors */
@@ -206,8 +187,6 @@ public final class ObjectStreamClass implements Serializable {
     /** session-cache of record deserialization constructor
      * (in de-serialized OSC only), or null */
     private MethodHandle deserializationCtr;
-    /** protection domains that need to be checked when calling the constructor */
-    private ProtectionDomain[] domains;
 
     /** class-defined writeObject method, or null if none */
     private Method writeObjectMethod;
@@ -280,20 +259,13 @@ public final class ObjectStreamClass implements Serializable {
      *
      * @return  the SUID of the class described by this descriptor
      */
-    @SuppressWarnings("removal")
     public long getSerialVersionUID() {
         // REMIND: synchronize instead of relying on volatile?
         if (suid == null) {
             if (isRecord)
                 return 0L;
 
-            suid = AccessController.doPrivileged(
-                new PrivilegedAction<Long>() {
-                    public Long run() {
-                        return computeDefaultSUID(cl);
-                    }
-                }
-            );
+            suid = computeDefaultSUID(cl);
         }
         return suid.longValue();
     }
@@ -304,19 +276,12 @@ public final class ObjectStreamClass implements Serializable {
      *
      * @return  the {@code Class} instance that this descriptor represents
      */
-    @SuppressWarnings("removal")
     @CallerSensitive
     public Class<?> forClass() {
         if (cl == null) {
             return null;
         }
         requireInitialized();
-        if (System.getSecurityManager() != null) {
-            Class<?> caller = Reflection.getCallerClass();
-            if (ReflectUtil.needsPackageAccessCheck(caller.getClassLoader(), cl.getClassLoader())) {
-                ReflectUtil.checkPackageAccess(cl);
-            }
-        }
         return cl;
     }
 
@@ -384,53 +349,44 @@ public final class ObjectStreamClass implements Serializable {
         localDesc = this;
 
         if (serializable) {
-            AccessController.doPrivileged(new PrivilegedAction<>() {
-                public Void run() {
-                    if (isEnum) {
-                        suid = 0L;
-                        fields = NO_FIELDS;
-                        return null;
-                    }
-                    if (cl.isArray()) {
-                        fields = NO_FIELDS;
-                        return null;
-                    }
-
-                    suid = getDeclaredSUID(cl);
-                    try {
-                        fields = getSerialFields(cl);
-                        computeFieldOffsets();
-                    } catch (InvalidClassException e) {
-                        serializeEx = deserializeEx =
+            if (isEnum) {
+                suid = 0L;
+                fields = NO_FIELDS;
+            } else if (cl.isArray()) {
+                fields = NO_FIELDS;
+            } else {
+                suid = getDeclaredSUID(cl);
+                try {
+                    fields = getSerialFields(cl);
+                    computeFieldOffsets();
+                } catch (InvalidClassException e) {
+                    serializeEx = deserializeEx =
                             new ExceptionInfo(e.classname, e.getMessage());
-                        fields = NO_FIELDS;
-                    }
-
-                    if (isRecord) {
-                        canonicalCtr = canonicalRecordCtr(cl);
-                        deserializationCtrs = new DeserializationConstructorsCache();
-                    } else if (externalizable) {
-                        cons = getExternalizableConstructor(cl);
-                    } else {
-                        cons = getSerializableConstructor(cl);
-                        writeObjectMethod = getPrivateMethod(cl, "writeObject",
-                            new Class<?>[] { ObjectOutputStream.class },
-                            Void.TYPE);
-                        readObjectMethod = getPrivateMethod(cl, "readObject",
-                            new Class<?>[] { ObjectInputStream.class },
-                            Void.TYPE);
-                        readObjectNoDataMethod = getPrivateMethod(
-                            cl, "readObjectNoData", null, Void.TYPE);
-                        hasWriteObjectData = (writeObjectMethod != null);
-                    }
-                    domains = getProtectionDomains(cons, cl);
-                    writeReplaceMethod = getInheritableMethod(
-                        cl, "writeReplace", null, Object.class);
-                    readResolveMethod = getInheritableMethod(
-                        cl, "readResolve", null, Object.class);
-                    return null;
+                    fields = NO_FIELDS;
                 }
-            });
+
+                if (isRecord) {
+                    canonicalCtr = canonicalRecordCtr(cl);
+                    deserializationCtrs = new DeserializationConstructorsCache();
+                } else if (externalizable) {
+                    cons = getExternalizableConstructor(cl);
+                } else {
+                    cons = getSerializableConstructor(cl);
+                    writeObjectMethod = getPrivateMethod(cl, "writeObject",
+                            new Class<?>[]{ObjectOutputStream.class},
+                            Void.TYPE);
+                    readObjectMethod = getPrivateMethod(cl, "readObject",
+                            new Class<?>[]{ObjectInputStream.class},
+                            Void.TYPE);
+                    readObjectNoDataMethod = getPrivateMethod(
+                            cl, "readObjectNoData", null, Void.TYPE);
+                    hasWriteObjectData = (writeObjectMethod != null);
+                }
+                writeReplaceMethod = getInheritableMethod(
+                        cl, "writeReplace", null, Object.class);
+                readResolveMethod = getInheritableMethod(
+                        cl, "readResolve", null, Object.class);
+            }
         } else {
             suid = 0L;
             fields = NO_FIELDS;
@@ -475,66 +431,6 @@ public final class ObjectStreamClass implements Serializable {
     }
 
     /**
-     * Creates a PermissionDomain that grants no permission.
-     */
-    private ProtectionDomain noPermissionsDomain() {
-        PermissionCollection perms = new Permissions();
-        perms.setReadOnly();
-        return new ProtectionDomain(null, perms);
-    }
-
-    /**
-     * Aggregate the ProtectionDomains of all the classes that separate
-     * a concrete class {@code cl} from its ancestor's class declaring
-     * a constructor {@code cons}.
-     *
-     * If {@code cl} is defined by the boot loader, or the constructor
-     * {@code cons} is declared by {@code cl}, or if there is no security
-     * manager, then this method does nothing and {@code null} is returned.
-     *
-     * @param cons A constructor declared by {@code cl} or one of its
-     *             ancestors.
-     * @param cl A concrete class, which is either the class declaring
-     *           the constructor {@code cons}, or a serializable subclass
-     *           of that class.
-     * @return An array of ProtectionDomain representing the set of
-     *         ProtectionDomain that separate the concrete class {@code cl}
-     *         from its ancestor's declaring {@code cons}, or {@code null}.
-     */
-    @SuppressWarnings("removal")
-    private ProtectionDomain[] getProtectionDomains(Constructor<?> cons,
-                                                    Class<?> cl) {
-        ProtectionDomain[] domains = null;
-        if (cons != null && cl.getClassLoader() != null
-                && System.getSecurityManager() != null) {
-            Class<?> cls = cl;
-            Class<?> fnscl = cons.getDeclaringClass();
-            Set<ProtectionDomain> pds = null;
-            while (cls != fnscl) {
-                ProtectionDomain pd = cls.getProtectionDomain();
-                if (pd != null) {
-                    if (pds == null) pds = new HashSet<>();
-                    pds.add(pd);
-                }
-                cls = cls.getSuperclass();
-                if (cls == null) {
-                    // that's not supposed to happen
-                    // make a ProtectionDomain with no permission.
-                    // should we throw instead?
-                    if (pds == null) pds = new HashSet<>();
-                    else pds.clear();
-                    pds.add(noPermissionsDomain());
-                    break;
-                }
-            }
-            if (pds != null) {
-                domains = pds.toArray(new ProtectionDomain[0]);
-            }
-        }
-        return domains;
-    }
-
-    /**
      * Initializes class descriptor representing a proxy class.
      */
     void initProxy(Class<?> cl,
@@ -564,7 +460,6 @@ public final class ObjectStreamClass implements Serializable {
             writeReplaceMethod = localDesc.writeReplaceMethod;
             readResolveMethod = localDesc.readResolveMethod;
             deserializeEx = localDesc.deserializeEx;
-            domains = localDesc.domains;
             cons = localDesc.cons;
         }
         fieldRefl = getReflector(fields, localDesc);
@@ -656,7 +551,6 @@ public final class ObjectStreamClass implements Serializable {
             if (deserializeEx == null) {
                 deserializeEx = localDesc.deserializeEx;
             }
-            domains = localDesc.domains;
             assert cl.isRecord() ? localDesc.cons == null : true;
             cons = localDesc.cons;
         }
@@ -1021,35 +915,7 @@ public final class ObjectStreamClass implements Serializable {
         requireInitialized();
         if (cons != null) {
             try {
-                if (domains == null || domains.length == 0) {
-                    return cons.newInstance();
-                } else {
-                    JavaSecurityAccess jsa = SharedSecrets.getJavaSecurityAccess();
-                    PrivilegedAction<?> pea = () -> {
-                        try {
-                            return cons.newInstance();
-                        } catch (InstantiationException
-                                 | InvocationTargetException
-                                 | IllegalAccessException x) {
-                            throw new UndeclaredThrowableException(x);
-                        }
-                    }; // Can't use PrivilegedExceptionAction with jsa
-                    try {
-                        return jsa.doIntersectionPrivilege(pea,
-                                   AccessController.getContext(),
-                                   new AccessControlContext(domains));
-                    } catch (UndeclaredThrowableException x) {
-                        Throwable cause = x.getCause();
-                        if (cause instanceof InstantiationException ie)
-                            throw ie;
-                        if (cause instanceof InvocationTargetException ite)
-                            throw ite;
-                        if (cause instanceof IllegalAccessException iae)
-                            throw iae;
-                        // not supposed to happen
-                        throw x;
-                    }
-                }
+                return cons.newInstance();
             } catch (IllegalAccessException ex) {
                 // should not occur, as access checks have been suppressed
                 throw new InternalError(ex);
@@ -1454,7 +1320,7 @@ public final class ObjectStreamClass implements Serializable {
      * returned constructor (if any).
      */
     private static Constructor<?> getSerializableConstructor(Class<?> cl) {
-        return reflFactory.newConstructorForSerialization(cl);
+        return ReflectionFactory.getReflectionFactory().newConstructorForSerialization(cl);
     }
 
     /**
@@ -1465,19 +1331,16 @@ public final class ObjectStreamClass implements Serializable {
     @SuppressWarnings("removal")
     private static MethodHandle canonicalRecordCtr(Class<?> cls) {
         assert cls.isRecord() : "Expected record, got: " + cls;
-        PrivilegedAction<MethodHandle> pa = () -> {
-            Class<?>[] paramTypes = Arrays.stream(cls.getRecordComponents())
-                                          .map(RecordComponent::getType)
-                                          .toArray(Class<?>[]::new);
-            try {
-                Constructor<?> ctr = cls.getDeclaredConstructor(paramTypes);
-                ctr.setAccessible(true);
-                return MethodHandles.lookup().unreflectConstructor(ctr);
-            } catch (IllegalAccessException | NoSuchMethodException e) {
-                return null;
-            }
-        };
-        return AccessController.doPrivileged(pa);
+        Class<?>[] paramTypes = Arrays.stream(cls.getRecordComponents())
+                                      .map(RecordComponent::getType)
+                                      .toArray(Class<?>[]::new);
+        try {
+            Constructor<?> ctr = cls.getDeclaredConstructor(paramTypes);
+            ctr.setAccessible(true);
+            return MethodHandles.lookup().unreflectConstructor(ctr);
+        } catch (IllegalAccessException | NoSuchMethodException e) {
+            return null;
+        }
     }
 
     /**
@@ -2367,14 +2230,7 @@ public final class ObjectStreamClass implements Serializable {
             if (mh != null) return desc.deserializationCtr = mh;
 
             // retrieve record components
-            RecordComponent[] recordComponents;
-            try {
-                Class<?> cls = desc.forClass();
-                PrivilegedExceptionAction<RecordComponent[]> pa = cls::getRecordComponents;
-                recordComponents = AccessController.doPrivileged(pa);
-            } catch (PrivilegedActionException e) {
-                throw new InternalError(e.getCause());
-            }
+            RecordComponent[] recordComponents = desc.forClass().getRecordComponents();
 
             // retrieve the canonical constructor
             // (T1, T2, ..., Tn):TR


### PR DESCRIPTION
After [JDK-8338411](https://bugs.openjdk.org/browse/JDK-8338411), Serialization implementation dependencies on SecurityManager, doPrivildged, and AccessController are removed.
Some refactoring to cleanup the remaining code is expected.