### PR TITLE
8343801: Change string printed by nsk_null_string for null strings

### DIFF
--- a/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_tools.hpp
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/native/nsk_tools.hpp
@@ -160,7 +160,7 @@ void nsk_printHexBytes(const char indent[], int columns,
 /*************************************************************/
 
 /**
- * Returns str or "<NULL>" if str is null; useful for printing strings.
+ * Returns str or "<null>" if str is null; useful for printing strings.
  */
 const char* nsk_null_string(const char* str);
 


### PR DESCRIPTION
Trivial change to test comment.  Ran vmTestbase/nsk/jvmti tests locally.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343801](https://bugs.openjdk.org/browse/JDK-8343801): Change string printed by nsk_null_string for null strings (**Enhancement** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22047/head:pull/22047` \
`$ git checkout pull/22047`

Update a local copy of the PR: \
`$ git checkout pull/22047` \
`$ git pull https://git.openjdk.org/jdk.git pull/22047/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22047`

View PR using the GUI difftool: \
`$ git pr show -t 22047`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22047.diff">https://git.openjdk.org/jdk/pull/22047.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22047#issuecomment-2471467909)
</details>
