### PR TITLE
8343416: CDS dump fails when unregistered class can also be loaded from system modules

### DIFF
--- a/src/hotspot/share/cds/unregisteredClasses.cpp
+++ b/src/hotspot/share/cds/unregisteredClasses.cpp
@@ -51,6 +51,7 @@ InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path, T
                              PerfClassTraceTime::CLASS_LOAD);
 
   Symbol* path_symbol = SymbolTable::new_symbol(path);
+  Symbol* findClass = SymbolTable::new_symbol("findClass");
   Handle url_classloader = get_url_classloader(path_symbol, CHECK_NULL);
   Handle ext_class_name = java_lang_String::externalize_classname(name, CHECK_NULL);
 
@@ -58,11 +59,10 @@ InstanceKlass* UnregisteredClasses::load_class(Symbol* name, const char* path, T
   JavaCallArguments args(2);
   args.set_receiver(url_classloader);
   args.push_oop(ext_class_name);
-  args.push_int(JNI_FALSE);
   JavaCalls::call_virtual(&result,
                           vmClasses::URLClassLoader_klass(),
-                          vmSymbols::loadClass_name(),
-                          vmSymbols::string_boolean_class_signature(),
+                          findClass,
+                          vmSymbols::string_class_signature(),
                           &args,
                           CHECK_NULL);
   assert(result.get_type() == T_OBJECT, "just checking");

--- a/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassFromSystemModule.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/customLoader/ClassFromSystemModule.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+ * @test
+ * @bug 8343416
+ * @summary Test dumping of class from a system module loaded by a custom loader.
+ * @requires vm.cds
+ * @requires vm.cds.custom.loaders
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @run driver ClassFromSystemModule
+ */
+
+import java.nio.file.*;
+
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class ClassFromSystemModule {
+    public static void main(String[] args) throws Exception {
+        Path jrtFs = Paths.get(System.getProperty("java.home"), "lib", "jrt-fs.jar");
+        System.out.println("jrtFs: " + jrtFs.toString());
+
+        String classlist[] = new String[] {
+            "java/nio/file/spi/FileSystemProvider id: 1000",
+            "jdk/internal/jrtfs/JrtFileSystemProvider id: 1001 super:1000 source: " + jrtFs.toString(),
+        };
+
+        OutputAnalyzer out = TestCommon.testDump(null, classlist, "-Xlog:cds,cds+class=debug");
+        out.shouldContain("boot  java.nio.file.spi.FileSystemProvider")
+           .shouldContain("unreg jdk.internal.jrtfs.JrtFileSystemProvider");
+    }
+}


### PR DESCRIPTION
For classes to be loaded by a custom class loader during dump time, we currently use the `URLClassLoader.loadClass` to load the class which will be delegated to the boot class loader if the class is from a system module jar (e.g. jrt-fs.jar). To avoid the delegation and load the class by a custom class loader, this fix uses the `URLClassLoader.findClass` instead.

Passed tiers 1 - 3 testing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343416](https://bugs.openjdk.org/browse/JDK-8343416): CDS dump fails when unregistered class can also be loaded from system modules (**Bug** - P3)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22049/head:pull/22049` \
`$ git checkout pull/22049`

Update a local copy of the PR: \
`$ git checkout pull/22049` \
`$ git pull https://git.openjdk.org/jdk.git pull/22049/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22049`

View PR using the GUI difftool: \
`$ git pr show -t 22049`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22049.diff">https://git.openjdk.org/jdk/pull/22049.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22049#issuecomment-2471707066)
</details>
