### PR TITLE
8344071: Mark some jdk/jfr/event/oldobject test flagless until they fixed to support all GC

### DIFF
--- a/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestClassLoaderLeak.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,6 +40,8 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
+ * @requires vm.flagless
+ * @comment Marked as flagless until JDK-8322597 is fixed
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k -Xmx64m jdk.jfr.event.oldobject.TestClassLoaderLeak

--- a/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
+++ b/test/jdk/jdk/jfr/event/oldobject/TestObjectDescription.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,7 +41,9 @@ import jdk.test.lib.jfr.Events;
  * @test
  * @key jfr
  * @requires vm.hasJFR
- * @requires vm.gc != "Z" & vm.gc != "Shenandoah"
+ * @requires vm.gc != "Shenandoah"
+ * @requires vm.flagless
+ * @comment Marked as flagless until JDK-8344015 is fixed
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal.test
  * @run main/othervm -XX:TLABSize=2k jdk.jfr.event.oldobject.TestObjectDescription


### PR DESCRIPTION
Tests
jdk/jfr/event/oldobject/TestObjectDescription.java
jdk/jfr/event/oldobject/TestClassLoaderLeak.java
fail with different GCs to get expected events.

They pass with G1 GC so I don't want to problemlist them.
However, they should test all GCs that support these events.

Removed ZGC, because I expect that is Generational and should be also supported.

The flagless should be removed when the main bugs are fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344071](https://bugs.openjdk.org/browse/JDK-8344071): Mark some jdk/jfr/event/oldobject test flagless until they fixed to support all GC (**Bug** - P4)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22050/head:pull/22050` \
`$ git checkout pull/22050`

Update a local copy of the PR: \
`$ git checkout pull/22050` \
`$ git pull https://git.openjdk.org/jdk.git pull/22050/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22050`

View PR using the GUI difftool: \
`$ git pr show -t 22050`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22050.diff">https://git.openjdk.org/jdk/pull/22050.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22050#issuecomment-2471731897)
</details>
