### PR TITLE
8343953: Test jdk/jfr/threading/TestDeepVirtualStackTrace.java fails with Parallel/Serial GC

### DIFF
--- a/test/jdk/jdk/jfr/threading/TestDeepVirtualStackTrace.java
+++ b/test/jdk/jdk/jfr/threading/TestDeepVirtualStackTrace.java
@@ -80,6 +80,8 @@ public class TestDeepVirtualStackTrace {
 
     private static void deepsleep(int depth) {
         if (depth == 0) {
+            // The TLAB max size is not limited explicitly
+            // So the test limit max size of young generation to allocate outside TLAB
             allocated = new Object[10_000_000];
             System.out.println("Emitted ObjectAllocationOutsideTLAB event");
             return;

--- a/test/jdk/jdk/jfr/threading/TestDeepVirtualStackTrace.java
+++ b/test/jdk/jdk/jfr/threading/TestDeepVirtualStackTrace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,7 +42,7 @@ import jdk.test.lib.jfr.Events;
  * @requires vm.hasJFR & vm.continuations
  * @library /test/lib /test/jdk
  * @modules jdk.jfr/jdk.jfr.internal
- * @run main/othervm -XX:FlightRecorderOptions:stackdepth=2048
+ * @run main/othervm -XX:MaxNewSize=40M -XX:FlightRecorderOptions:stackdepth=2048
  *      jdk.jfr.threading.TestDeepVirtualStackTrace
  */
 public class TestDeepVirtualStackTrace {


### PR DESCRIPTION
Test fails because it doesn't always trigger jdk.ObjectAllocationOutsideTLAB event.

Test tries to trigger jdk.ObjectAllocationOutsideTLAB by allocating 
new Object[10_000_000];
array.

However, the TLAB is not limited for Parallel/Serial/Z GCs. So VM might just increase TLAB and allocate the array in new TLAB. The fix limit young generation size to ensure that TLAB of expected size can't be created and
 jdk.ObjectAllocationOutsideTLAB  event is always generated.
Verified by running 100 times with Parallel/Serial/ZGC on different platforms.

Using  jdk.ObjectAllocationOutsideTLAB is not  the signifcant for the test. The better fix would be trigger some other event with 100% guarantee assuming that this event is not triggered outside of virtual thread. But not sure I which event is the good candidate.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343953](https://bugs.openjdk.org/browse/JDK-8343953): Test jdk/jfr/threading/TestDeepVirtualStackTrace.java fails with Parallel/Serial GC (**Bug** - P3)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22052/head:pull/22052` \
`$ git checkout pull/22052`

Update a local copy of the PR: \
`$ git checkout pull/22052` \
`$ git pull https://git.openjdk.org/jdk.git pull/22052/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22052`

View PR using the GUI difftool: \
`$ git pr show -t 22052`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22052.diff">https://git.openjdk.org/jdk/pull/22052.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22052#issuecomment-2472030927)
</details>
