### PR TITLE
8344074: RISC-V: C1: More accurate _exception_handler_size and _deopt_handler_size

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.hpp
@@ -70,12 +70,11 @@ private:
     _call_stub_size = 11 * MacroAssembler::instruction_size +
                       1 * MacroAssembler::instruction_size + wordSize,
     // See emit_exception_handler for detail
-    // verify_not_null_oop + far_call + should_not_reach_here + invalidate_registers(DEBUG_ONLY)
-    _exception_handler_size = DEBUG_ONLY(584) NOT_DEBUG(548), // or smaller
+    _exception_handler_size = DEBUG_ONLY(256) NOT_DEBUG(32), // or smaller
     // See emit_deopt_handler for detail
-    // auipc (1) + far_jump (6 or 2)
+    // auipc (1) + far_jump (2)
     _deopt_handler_size = 1 * MacroAssembler::instruction_size +
-                          6 * MacroAssembler::instruction_size // or smaller
+                          2 * MacroAssembler::instruction_size
   };
 
   void check_conflict(ciKlass* exact_klass, intptr_t current_klass, Register tmp,


### PR DESCRIPTION
Hi, please review this small change.

I find that the reserved size for these two handlers are not accurate and are larger than needed. For `_exception_handler_size`, the used size is only 20 bytes for release build and 126 bytes for debug build (with -XX:+VerifyOops). Considering that the exception handler is not trivial, I reserved a little bit more than needed for release build (32 bytes). For `_deopt_handler_size`, `far_jump` will always emit two instructions.

Testing on linux-riscv64:
- [x] tier1 (release)
- [x] hotspot:tier1 (fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344074](https://bugs.openjdk.org/browse/JDK-8344074): RISC-V: C1: More accurate _exception_handler_size and _deopt_handler_size (**Enhancement** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22053/head:pull/22053` \
`$ git checkout pull/22053`

Update a local copy of the PR: \
`$ git checkout pull/22053` \
`$ git pull https://git.openjdk.org/jdk.git pull/22053/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22053`

View PR using the GUI difftool: \
`$ git pr show -t 22053`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22053.diff">https://git.openjdk.org/jdk/pull/22053.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22053#issuecomment-2472137687)
</details>
