### PR TITLE
8343170: java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java does not show the default cursor

### DIFF
--- a/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
+++ b/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
@@ -81,7 +81,7 @@ public class JPanelCursorTest {
         j.setRightComponent(panel);
         j.setContinuousLayout(true);
         j.setSize(200, 200);
-        
+
         frame.getContentPane().add("North", j);
         pane.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
         frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));

--- a/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
+++ b/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
@@ -44,12 +44,12 @@ import javax.swing.border.BevelBorder;
 
 public class JPanelCursorTest {
     public static void main(String[] args) throws Exception {
-        String INSTRUCTIONS = """
+        final String INSTRUCTIONS = """
                 This test checks for setCursor in a JPanel when added to a
                 JFrame's contentPane.
 
                 1. Verify that the cursor in the left side of the test window
-                    is a move cursor (or default cursor in MacOS).
+                    is a wait cursor.
                 2. Verify that the cursor changes to the crosshair cursor when
                     pointing over the button.
                 3. Verify that the cursor changes to the hand cursor when in
@@ -68,7 +68,7 @@ public class JPanelCursorTest {
     }
 
     public static JFrame createUI() {
-        JFrame frame = new JFrame();
+        JFrame frame = new JFrame("Cursor Test Frame");
 
         JSplitPane j = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
         ExtJComponent pane = new ExtJComponent();
@@ -80,8 +80,7 @@ public class JPanelCursorTest {
         j.setContinuousLayout(true);
 
         frame.getContentPane().add("Center", j);
-        pane.setCursor(Cursor.getPredefinedCursor(Cursor.MOVE_CURSOR));
-        frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        pane.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
         frame.pack();
         return frame;
     }
@@ -96,7 +95,7 @@ class ExtJComponent extends JComponent {
         setBorder(new BevelBorder(BevelBorder.RAISED));
     }
     public void paintComponent(Graphics g) {
-        g.drawString("Move", 20, 30);
+        g.drawString("Wait", 20, 30);
     }
     public Dimension getPreferredSize() {
         return new Dimension(100, 100);

--- a/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
+++ b/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
@@ -49,11 +49,13 @@ public class JPanelCursorTest {
                 JFrame's contentPane.
 
                 1. Verify that the cursor in the left side of the test window
-                    is a wait cursor.
+                    is a text cursor.
                 2. Verify that the cursor changes to the crosshair cursor when
                     pointing over the button.
                 3. Verify that the cursor changes to the hand cursor when in
                     the right side of the splitpane (and not on the button).
+                4. Verify that the cursor changes to the wait cursor when in
+                    the empty bottom section of the test window.
 
                 If true, then pass the test. Otherwise, fail this test.
                 """;
@@ -78,10 +80,12 @@ public class JPanelCursorTest {
         j.setLeftComponent(pane);
         j.setRightComponent(panel);
         j.setContinuousLayout(true);
-
-        frame.getContentPane().add("Center", j);
-        pane.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
-        frame.pack();
+        j.setSize(200, 200);
+        
+        frame.getContentPane().add("North", j);
+        pane.setCursor(Cursor.getPredefinedCursor(Cursor.TEXT_CURSOR));
+        frame.setCursor(Cursor.getPredefinedCursor(Cursor.WAIT_CURSOR));
+        frame.setSize(300, 200);
         return frame;
     }
 }
@@ -95,7 +99,7 @@ class ExtJComponent extends JComponent {
         setBorder(new BevelBorder(BevelBorder.RAISED));
     }
     public void paintComponent(Graphics g) {
-        g.drawString("Wait", 20, 30);
+        g.drawString("Text", 20, 30);
     }
     public Dimension getPreferredSize() {
         return new Dimension(100, 100);
@@ -103,7 +107,7 @@ class ExtJComponent extends JComponent {
 }
 
 class CursorBugPanel extends JPanel {
-    public CursorBugPanel () {
+    public CursorBugPanel() {
         // BUG: fails to set cursor for panel
         setCursor(Cursor.getPredefinedCursor(Cursor.HAND_CURSOR));
 

--- a/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
+++ b/test/jdk/java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java
@@ -49,7 +49,7 @@ public class JPanelCursorTest {
                 JFrame's contentPane.
 
                 1. Verify that the cursor in the left side of the test window
-                    is a default cursor.
+                    is a move cursor (or default cursor in MacOS).
                 2. Verify that the cursor changes to the crosshair cursor when
                     pointing over the button.
                 3. Verify that the cursor changes to the hand cursor when in
@@ -61,7 +61,7 @@ public class JPanelCursorTest {
         PassFailJFrame.builder()
                 .title("Test Instructions")
                 .instructions(INSTRUCTIONS)
-                .columns(35)
+                .columns(37)
                 .testUI(JPanelCursorTest::createUI)
                 .build()
                 .awaitAndCheck();
@@ -96,7 +96,7 @@ class ExtJComponent extends JComponent {
         setBorder(new BevelBorder(BevelBorder.RAISED));
     }
     public void paintComponent(Graphics g) {
-        g.drawString("Default", 20, 30);
+        g.drawString("Move", 20, 30);
     }
     public Dimension getPreferredSize() {
         return new Dimension(100, 100);


### PR DESCRIPTION
Change test instructions and drawString to say "Text" instead of "Default" for cursor type. Added instructions to test `setCursor` for the frame as well. Also increased the column count to fit the instructions in linux, as it was mentioned that the instructions didn't fit there.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343170](https://bugs.openjdk.org/browse/JDK-8343170): java/awt/Cursor/JPanelCursorTest/JPanelCursorTest.java does not show the default cursor (**Bug** - P4)


### Reviewers
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer) Review applies to [77a7ccfb](https://git.openjdk.org/jdk/pull/22055/files/77a7ccfbd83415f1b6ffe1eb6bc8c8109ce7667d)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22055/head:pull/22055` \
`$ git checkout pull/22055`

Update a local copy of the PR: \
`$ git checkout pull/22055` \
`$ git pull https://git.openjdk.org/jdk.git pull/22055/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22055`

View PR using the GUI difftool: \
`$ git pr show -t 22055`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22055.diff">https://git.openjdk.org/jdk/pull/22055.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22055#issuecomment-2472101672)
</details>
