### PR TITLE
8343123: Nimbus: javax/swing/JInternalFrame/bug6726866.java does not have green undecorated window

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2014, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
@@ -24,12 +24,20 @@
  */
 package javax.swing.plaf.nimbus;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.NoninvertibleTransformException;
 import java.awt.image.BufferedImage;
-import java.util.*;
-import javax.swing.*;
+import javax.swing.JDesktopPane;
+import javax.swing.JSlider;
+import javax.swing.JSplitPane;
+import javax.swing.JTabbedPane;
+import javax.swing.Painter;
+import javax.swing.SwingConstants;
+import javax.swing.UIManager;
 import javax.swing.plaf.UIResource;
 import javax.swing.plaf.synth.SynthContext;
 import javax.swing.plaf.synth.SynthPainter;

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
@@ -30,6 +30,7 @@ import java.awt.geom.NoninvertibleTransformException;
 import java.awt.image.BufferedImage;
 import java.util.*;
 import javax.swing.*;
+import javax.swing.plaf.UIResource;
 import javax.swing.plaf.synth.SynthContext;
 import javax.swing.plaf.synth.SynthPainter;
 import javax.swing.plaf.synth.SynthConstants;
@@ -531,7 +532,11 @@ class SynthPainterImpl extends SynthPainter {
     public void paintDesktopPaneBackground(SynthContext context,
                                            Graphics g, int x, int y,
                                            int w, int h) {
-        paintBackground(context, g, x, y, w, h, null);
+        if (context.getComponent() instanceof JDesktopPane pane) {
+            if (pane.getBackground() instanceof UIResource) {
+                paintBackground(context, g, x, y, w, h, null);
+            }
+        }
     }
 
     /**

--- a/test/jdk/javax/swing/JInternalFrame/bug6726866.java
+++ b/test/jdk/javax/swing/JInternalFrame/bug6726866.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6726866 8186617
+ * @bug 6726866 8186617 8343123
  * @summary Repainting artifacts when resizing or dragging JInternalFrames in
             non-opaque toplevel
  * @library /java/awt/regtesthelpers
@@ -34,7 +34,6 @@
 import java.awt.Color;
 import java.awt.Window;
 
-import javax.swing.JApplet;
 import javax.swing.JDesktopPane;
 import javax.swing.JFrame;
 import javax.swing.JInternalFrame;


### PR DESCRIPTION
Test fails in NimbusL&F as DesktopPane does not have green background as set by the user, which is because, the auto-generated [DesktopPanePainter class](https://github.com/openjdk/jdk/blob/eb40a88f4076360708402454a494907e8c0c845d/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java#L100-L102) which has pre-coded color values does not honour user-defined color.

Fix is to make sure user-defined DesktopPane background color is honoured and is painted and only auto-generated class for L&F derived colors.
CI is ok..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343123](https://bugs.openjdk.org/browse/JDK-8343123): Nimbus: javax/swing/JInternalFrame/bug6726866.java does not have green undecorated window (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)
 * [Damon Nguyen](https://openjdk.org/census#dnguyen) (@DamonGuy - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22057/head:pull/22057` \
`$ git checkout pull/22057`

Update a local copy of the PR: \
`$ git checkout pull/22057` \
`$ git pull https://git.openjdk.org/jdk.git pull/22057/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22057`

View PR using the GUI difftool: \
`$ git pr show -t 22057`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22057.diff">https://git.openjdk.org/jdk/pull/22057.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22057#issuecomment-2472252777)
</details>
