### PR TITLE
8335367: [s390] Add support for load immediate on condition instructions.

### DIFF
--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -992,8 +992,8 @@ class Assembler : public AbstractAssembler {
 #define BASR_ZOPC   (unsigned  int)(13 << 8)
 #define BCT_ZOPC    (unsigned  int)(70 << 24)
 #define BCTR_ZOPC   (unsigned  int)(6 << 8)
-#define BCTG_ZOPC   (unsigned  long)(227L << 40 | 70)
-#define BCTGR_ZOPC  (unsigned int)(0xb946 << 16)
+#define BCTG_ZOPC   (unsigned long)(227L << 40 | 70)
+#define BCTGR_ZOPC  (unsigned  int)(0xb946 << 16)
 // Absolute
 #define BC_ZOPC     (unsigned  int)(71 << 24)
 #define BAL_ZOPC    (unsigned  int)(69 << 24)
@@ -2071,7 +2071,7 @@ class Assembler : public AbstractAssembler {
   inline void z_llill(Register r1, int64_t i2);                 // r1 = i2_imm16    ; uint64 <- uint16
 
   // load halfword immediate on condition
-  inline void z_lochi(Register r1, int64_t i2, branch_condition m3);   // load immediate r1[32-63] = i2_simm16   ; int32 <- int16
+  inline void z_lochi( Register r1, int64_t i2, branch_condition m3);  // load immediate r1[32-63] = i2_simm16   ; int32 <- int16
   inline void z_lochhi(Register r1, int64_t i2, branch_condition m3);  // load immediate r1[ 0-31] = i2_simm16   ; int32 <- int16
   inline void z_locghi(Register r1, int64_t i2, branch_condition m3);  // load immediate r1[ 0-63] = i2_simm16   ; int64 <- int16
 

--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -2071,9 +2071,9 @@ class Assembler : public AbstractAssembler {
   inline void z_llill(Register r1, int64_t i2);                 // r1 = i2_imm16    ; uint64 <- uint16
 
   // load halfword immediate on condition
-  inline void z_lochi(Register r1, int64_t i2, branch_condition m3);   // load immediate r1[32-64] = i2_imm16   ; int32 <- int16
-  inline void z_lochhi(Register r1, int64_t i2, branch_condition m3);  // load immediate r1[ 0-31] = i2_imm16   ; int32 <- int16
-  inline void z_locghi(Register r1, int64_t i2, branch_condition m3);  // load immediate r1[ 0-63] = i2_imm16   ; int64 <- int16
+  inline void z_lochi(Register r1, int64_t i2, branch_condition m3);   // load immediate r1[32-63] = i2_simm16   ; int32 <- int16
+  inline void z_lochhi(Register r1, int64_t i2, branch_condition m3);  // load immediate r1[ 0-31] = i2_simm16   ; int32 <- int16
+  inline void z_locghi(Register r1, int64_t i2, branch_condition m3);  // load immediate r1[ 0-63] = i2_simm16   ; int64 <- int16
 
   // insert immediate
   inline void z_ic(  Register r1, int64_t d2, Register x2, Register b2); // insert character

--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -993,7 +993,7 @@ class Assembler : public AbstractAssembler {
 #define BCT_ZOPC    (unsigned  int)(70 << 24)
 #define BCTR_ZOPC   (unsigned  int)(6 << 8)
 #define BCTG_ZOPC   (unsigned  long)(227L << 40 | 70)
-#define BCTGR_ZOPC  (unsigned long)(0xb946 << 16)
+#define BCTGR_ZOPC  (unsigned int)(0xb946 << 16)
 // Absolute
 #define BC_ZOPC     (unsigned  int)(71 << 24)
 #define BAL_ZOPC    (unsigned  int)(69 << 24)

--- a/src/hotspot/cpu/s390/assembler_s390.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.hpp
@@ -637,6 +637,11 @@ class Assembler : public AbstractAssembler {
 #define LCDBR_ZOPC  (unsigned  int)(179 << 24 | 19 << 16)
 #define LCXBR_ZOPC  (unsigned  int)(179 << 24 | 67 << 16)
 
+ // Load Halfword Immediate on Condition
+ #define LOCHI_ZOPC   (unsigned long)(0xECL << 40 | 0x42L)
+ #define LOCHHI_ZOPC  (unsigned long)(0xECL << 40 | 0x4EL)
+ #define LOCGHI_ZOPC  (unsigned long)(0xECL << 40 | 0x46L)
+
 // Add
 // RR, signed
 #define AR_ZOPC     (unsigned  int)(26 << 8)
@@ -987,7 +992,7 @@ class Assembler : public AbstractAssembler {
 #define BASR_ZOPC   (unsigned  int)(13 << 8)
 #define BCT_ZOPC    (unsigned  int)(70 << 24)
 #define BCTR_ZOPC   (unsigned  int)(6 << 8)
-#define BCTG_ZOPC   (unsigned  int)(227L << 40 | 70)
+#define BCTG_ZOPC   (unsigned  long)(227L << 40 | 70)
 #define BCTGR_ZOPC  (unsigned long)(0xb946 << 16)
 // Absolute
 #define BC_ZOPC     (unsigned  int)(71 << 24)
@@ -2064,6 +2069,11 @@ class Assembler : public AbstractAssembler {
   inline void z_llihl(Register r1, int64_t i2);                 // r1 = i2_imm16    ; uint64 <- (uint16<<32)
   inline void z_llilh(Register r1, int64_t i2);                 // r1 = i2_imm16    ; uint64 <- (uint16<<16)
   inline void z_llill(Register r1, int64_t i2);                 // r1 = i2_imm16    ; uint64 <- uint16
+
+  // load halfword immediate on condition
+  inline void z_lochi(Register r1, int64_t i2, branch_condition m3);   // load immediate r1[32-64] = i2_imm16   ; int32 <- int16
+  inline void z_lochhi(Register r1, int64_t i2, branch_condition m3);  // load immediate r1[ 0-31] = i2_imm16   ; int32 <- int16
+  inline void z_locghi(Register r1, int64_t i2, branch_condition m3);  // load immediate r1[ 0-63] = i2_imm16   ; int64 <- int16
 
   // insert immediate
   inline void z_ic(  Register r1, int64_t d2, Register x2, Register b2); // insert character

--- a/src/hotspot/cpu/s390/assembler_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/assembler_s390.inline.hpp
@@ -245,6 +245,11 @@ inline void Assembler::z_stcm (Register r1, int64_t m3, int64_t d2, Register b2)
 inline void Assembler::z_stcmy(Register r1, int64_t m3, int64_t d2, Register b2) { emit_48( STCMY_ZOPC | regt(r1, 8, 48) | uimm4(m3, 12, 48) | rsymask_48(d2, b2)); }
 inline void Assembler::z_stcmh(Register r1, int64_t m3, int64_t d2, Register b2) { emit_48( STCMH_ZOPC | regt(r1, 8, 48) | uimm4(m3, 12, 48) | rsymask_48(d2, b2)); }
 
+// load halfword immediate on condition
+inline void Assembler::z_lochi(Register r1, int64_t i2, branch_condition m3) { emit_48( LOCHI_ZOPC | reg(r1, 8, 48) | simm16(i2, 16, 48) | uimm4(m3, 12, 48)); }
+inline void Assembler::z_lochhi(Register r1, int64_t i2, branch_condition m3) { emit_48( LOCHHI_ZOPC | reg(r1, 8, 48) | simm16(i2, 16, 48) | uimm4(m3, 12, 48)); }
+inline void Assembler::z_locghi(Register r1, int64_t i2, branch_condition m3) { emit_48( LOCGHI_ZOPC | reg(r1, 8, 48) | simm16(i2, 16, 48) | uimm4(m3, 12, 48)); }
+
 // memory-immediate instructions (8-bit immediate)
 inline void Assembler::z_cli( int64_t d1, Register b1, int64_t i2) { emit_32( CLI_ZOPC  | rsmask_32( d1, b1) | uimm8(i2, 8, 32)); }
 inline void Assembler::z_mvi( int64_t d1, Register b1, int64_t i2) { emit_32( MVI_ZOPC  | rsmask_32( d1, b1) | imm8(i2, 8, 32)); }

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3287,7 +3287,7 @@ void MacroAssembler::lookup_secondary_supers_table(Register r_sub_klass,
   z_bru(L_done); // pass whatever result we got from a slow path
 
   bind(L_failure);
-  // TODO: use load immediate on condition and z_bru above will not be required
+
   z_lghi(r_result, 1);
 
   bind(L_done);


### PR DESCRIPTION
Add support for load immediate on condition instructions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8335367: [s390] Add support for load immediate on condition instructions.`

### Issue
 * [JDK-8335367](https://bugs.openjdk.org/browse/JDK-8335367): [s390] Add support for load immediate on condition instructions. (**Enhancement** - P4)


### Reviewers
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer) Review applies to [31709a7d](https://git.openjdk.org/jdk/pull/22058/files/31709a7d2162b51ccdda35f9921a33d9de4eb859)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22058/head:pull/22058` \
`$ git checkout pull/22058`

Update a local copy of the PR: \
`$ git checkout pull/22058` \
`$ git pull https://git.openjdk.org/jdk.git pull/22058/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22058`

View PR using the GUI difftool: \
`$ git pr show -t 22058`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22058.diff">https://git.openjdk.org/jdk/pull/22058.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22058#issuecomment-2472552333)
</details>
