### PR TITLE
8343884: [s390x]  Disallow OptoScheduling

### DIFF
--- a/src/hotspot/cpu/s390/vm_version_s390.cpp
+++ b/src/hotspot/cpu/s390/vm_version_s390.cpp
@@ -304,6 +304,12 @@ void VM_Version::initialize() {
   if (FLAG_IS_DEFAULT(UseUnalignedAccesses)) {
     FLAG_SET_DEFAULT(UseUnalignedAccesses, true);
   }
+
+  // The OptoScheduling information is not maintained in s390.ad.
+  if (OptoScheduling) {
+    warning("OptoScheduling is not supported on this CPU.");
+    FLAG_SET_DEFAULT(OptoScheduling, false);
+  }
 }
 
 


### PR DESCRIPTION
```
amit@a3560042:~/jdk$ ./build/linux-s390x-server-fastdebug/jdk/bin/java -XX:+OptoScheduling --version 
OpenJDK 64-Bit Server VM warning: OptoScheduling is not supported on this CPU.
openjdk 24-internal 2025-03-18
OpenJDK Runtime Environment (fastdebug build 24-internal-adhoc.amit.jdk)
OpenJDK 64-Bit Server VM (fastdebug build 24-internal-adhoc.amit.jdk, mixed mode)
amit@a3560042:~/jdk$
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343884](https://bugs.openjdk.org/browse/JDK-8343884): [s390x]  Disallow OptoScheduling (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22059/head:pull/22059` \
`$ git checkout pull/22059`

Update a local copy of the PR: \
`$ git checkout pull/22059` \
`$ git pull https://git.openjdk.org/jdk.git pull/22059/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22059`

View PR using the GUI difftool: \
`$ git pr show -t 22059`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22059.diff">https://git.openjdk.org/jdk/pull/22059.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22059#issuecomment-2472562806)
</details>
