### PR TITLE
8344093: Implementation of JEP XXX: Deprecate the 32-bit x86 Port for Removal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ on:
       platforms:
         description: 'Platform(s) to execute on (comma separated, e.g. "linux-x64, macos, aarch64")'
         required: true
-        default: 'linux-x64, linux-x86-hs, linux-x64-variants, linux-cross-compile, alpine-linux-x64, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
+        default: 'linux-x64, linux-x64-variants, linux-cross-compile, alpine-linux-x64, macos-x64, macos-aarch64, windows-x64, windows-aarch64, docs'
       configure-arguments:
         description: 'Additional configure arguments'
         required: false
@@ -62,7 +62,6 @@ jobs:
       EXCLUDED_PLATFORMS: 'alpine-linux-x64'
     outputs:
       linux-x64: ${{ steps.include.outputs.linux-x64 }}
-      linux-x86-hs: ${{ steps.include.outputs.linux-x86-hs }}
       linux-x64-variants: ${{ steps.include.outputs.linux-x64-variants }}
       linux-cross-compile: ${{ steps.include.outputs.linux-cross-compile }}
       alpine-linux-x64: ${{ steps.include.outputs.alpine-linux-x64 }}
@@ -145,7 +144,6 @@ jobs:
           }
 
           echo "linux-x64=$(check_platform linux-x64 linux x64)" >> $GITHUB_OUTPUT
-          echo "linux-x86-hs=$(check_platform linux-x86-hs linux x86)" >> $GITHUB_OUTPUT
           echo "linux-x64-variants=$(check_platform linux-x64-variants variants)" >> $GITHUB_OUTPUT
           echo "linux-cross-compile=$(check_platform linux-cross-compile cross-compile)" >> $GITHUB_OUTPUT
           echo "alpine-linux-x64=$(check_platform alpine-linux-x64 alpine-linux x64)" >> $GITHUB_OUTPUT
@@ -169,24 +167,6 @@ jobs:
       configure-arguments: ${{ github.event.inputs.configure-arguments }}
       make-arguments: ${{ github.event.inputs.make-arguments }}
     if: needs.prepare.outputs.linux-x64 == 'true'
-
-  build-linux-x86-hs:
-    name: linux-x86-hs
-    needs: prepare
-    uses: ./.github/workflows/build-linux.yml
-    with:
-      platform: linux-x86
-      make-target: 'hotspot'
-      gcc-major-version: '10'
-      gcc-package-suffix: '-multilib'
-      apt-architecture: 'i386'
-      # Some multilib libraries do not have proper inter-dependencies, so we have to
-      # install their dependencies manually.
-      apt-extra-packages: 'libfreetype-dev:i386 libtiff-dev:i386 libcupsimage2-dev:i386 libffi-dev:i386'
-      extra-conf-options: '--with-target-bits=32 --enable-fallback-linker --enable-libffi-bundling'
-      configure-arguments: ${{ github.event.inputs.configure-arguments }}
-      make-arguments: ${{ github.event.inputs.make-arguments }}
-    if: needs.prepare.outputs.linux-x86-hs == 'true'
 
   build-linux-x64-hs-nopch:
     name: linux-x64-hs-nopch

--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -666,14 +666,14 @@ AC_DEFUN([PLATFORM_CHECK_DEPRECATION],
 [
   AC_ARG_ENABLE(deprecated-ports, [AS_HELP_STRING([--enable-deprecated-ports@<:@=yes/no@:>@],
       [Suppress the error when configuring for a deprecated port @<:@no@:>@])])
-  # if test "x$OPENJDK_TARGET_CPU" = xx86; then
-  #   if test "x$enable_deprecated_ports" = "xyes"; then
-  #     AC_MSG_WARN([The x86 port is deprecated and may be removed in a future release.])
-  #   else
-  #     AC_MSG_ERROR(m4_normalize([The 32-bit x86 port is deprecated and may be removed in a future release.
-  #       Use --enable-deprecated-ports=yes to suppress this error.]))
-  #   fi
-  # fi
+  if test "x$OPENJDK_TARGET_CPU" = xx86; then
+    if test "x$enable_deprecated_ports" = "xyes"; then
+      AC_MSG_WARN([The x86 port is deprecated and may be removed in a future release.])
+    else
+      AC_MSG_ERROR(m4_normalize([The 32-bit x86 port is deprecated and may be removed in a future release.
+        Use --enable-deprecated-ports=yes to suppress this error.]))
+    fi
+  fi
 ])
 
 AC_DEFUN_ONCE([PLATFORM_SETUP_OPENJDK_BUILD_OS_VERSION],


### PR DESCRIPTION
WIP, as the JEP is still not targeted. We can review code meanwhile.

Additional testing:
 - [x] Linux x86-32 build configure fails by default
 - [x] Linux x86-32 build configures well with `--enable-deprecated-ports=yes`
 - [ ] GHA