### PR TITLE
8344080: Return type mismatch for jfr_unregister_stack_filter

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -163,7 +163,7 @@ void JNICALL jfr_emit_data_loss(JNIEnv* env, jclass jvm, jlong bytes);
 
 jlong JNICALL jfr_register_stack_filter(JNIEnv* env, jclass jvm, jobjectArray classes, jobjectArray methods);
 
-jlong JNICALL jfr_unregister_stack_filter(JNIEnv* env, jclass jvm, jlong id);
+void JNICALL jfr_unregister_stack_filter(JNIEnv* env, jclass jvm, jlong id);
 
 jlong JNICALL jfr_nanos_now(JNIEnv* env, jclass jvm);
 


### PR DESCRIPTION
Greetings,

Tiny adjustment to function declaration.

Test: jdk_jfr

Thanks
Markus
