### PR TITLE
8344112: Remove code to support security manager execution mode from DatagramChannel implementation

### DIFF
--- a/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/DatagramChannelImpl.java
@@ -60,8 +60,6 @@ import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.spi.AbstractSelectableChannel;
 import java.nio.channels.spi.SelectorProvider;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -293,8 +291,7 @@ class DatagramChannelImpl
     public SocketAddress getLocalAddress() throws IOException {
         synchronized (stateLock) {
             ensureOpen();
-            // Perform security check before returning address
-            return Net.getRevealedLocalAddress(localAddress);
+            return localAddress;
         }
     }
 
@@ -573,24 +570,16 @@ class DatagramChannelImpl
                 SocketAddress remote = beginRead(blocking, false);
                 configureSocketNonBlockingIfVirtualThread();
                 boolean connected = (remote != null);
-                @SuppressWarnings("removal")
-                SecurityManager sm = System.getSecurityManager();
-                if (connected || (sm == null)) {
-                    // connected or no security manager
-                    int n = receive(dst, connected);
-                    if (blocking) {
-                        while (IOStatus.okayToRetry(n) && isOpen()) {
-                            park(Net.POLLIN);
-                            n = receive(dst, connected);
-                        }
+                int n = receive(dst, connected);
+                if (blocking) {
+                    while (IOStatus.okayToRetry(n) && isOpen()) {
+                        park(Net.POLLIN);
+                        n = receive(dst, connected);
                     }
-                    if (n > 0 || (n == 0 && isOpen())) {
-                        // sender address is in socket address buffer
-                        sender = sourceSocketAddress();
-                    }
-                } else {
-                    // security manager and unconnected
-                    sender = untrustedReceive(dst);
+                }
+                if (n > 0 || (n == 0 && isOpen())) {
+                    // sender address is in socket address buffer
+                    sender = sourceSocketAddress();
                 }
                 return sender;
             } finally {
@@ -598,49 +587,6 @@ class DatagramChannelImpl
             }
         } finally {
             readLock.unlock();
-        }
-    }
-
-    /**
-     * Receives a datagram into an untrusted buffer. When there is a security
-     * manager set, and the socket is not connected, datagrams have to be received
-     * into a buffer that is not accessible to the user. The datagram is copied
-     * into the user's buffer when the sender address is accepted by the security
-     * manager.
-     */
-    private SocketAddress untrustedReceive(ByteBuffer dst) throws IOException {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        assert readLock.isHeldByCurrentThread()
-                && sm != null && remoteAddress == null;
-
-        boolean blocking = isBlocking();
-        for (;;) {
-            int n;
-            ByteBuffer bb = Util.getTemporaryDirectBuffer(dst.remaining());
-            try {
-                n = receive(bb, false);
-                if (n >= 0) {
-                    // sender address is in socket address buffer
-                    InetSocketAddress isa = sourceSocketAddress();
-                    try {
-                        sm.checkAccept(isa.getAddress().getHostAddress(), isa.getPort());
-                        bb.flip();
-                        dst.put(bb);
-                        return isa;
-                    } catch (SecurityException se) {
-                        // ignore datagram
-                    }
-                }
-            } finally {
-                Util.releaseTemporaryDirectBuffer(bb);
-            }
-
-            if (blocking && IOStatus.okayToRetry(n) && isOpen()) {
-                park(Net.POLLIN);
-            } else {
-                return null;
-            }
         }
     }
 
@@ -675,58 +621,30 @@ class DatagramChannelImpl
                 bufLength = DatagramPackets.getBufLength(p);
             }
 
-            long startNanos = System.nanoTime();
-            long remainingNanos = nanos;
-            SocketAddress sender = null;
+            boolean completed = false;
             try {
                 SocketAddress remote = beginRead(true, false);
                 boolean connected = (remote != null);
-                do {
-                    ByteBuffer dst = tryBlockingReceive(connected, bufLength, remainingNanos);
-
+                ByteBuffer dst = tryBlockingReceive(connected, bufLength, nanos);
+                if (dst != null) {
                     // if datagram received then get sender and copy to DatagramPacket
-                    if (dst != null) {
-                        try {
-                            // sender address is in socket address buffer
-                            sender = sourceSocketAddress();
-
-                            // check sender when security manager set and not connected
-                            @SuppressWarnings("removal")
-                            SecurityManager sm = System.getSecurityManager();
-                            if (sm != null && !connected) {
-                                InetSocketAddress isa = (InetSocketAddress) sender;
-                                try {
-                                    sm.checkAccept(isa.getAddress().getHostAddress(), isa.getPort());
-                                } catch (SecurityException e) {
-                                    sender = null;
-                                }
-                            }
-
-                            if (sender != null) {
-                                // copy bytes to the DatagramPacket, and set length and sender
-                                synchronized (p) {
-                                    // re-read p.bufLength in case DatagramPacket changed
-                                    int len = Math.min(dst.limit(), DatagramPackets.getBufLength(p));
-                                    dst.get(p.getData(), p.getOffset(), len);
-                                    DatagramPackets.setLength(p, len);
-                                    p.setSocketAddress(sender);
-                                }
-                            } else {
-                                // need to retry, adjusting timeout if needed
-                                if (nanos > 0) {
-                                    remainingNanos = nanos - (System.nanoTime() - startNanos);
-                                    if (remainingNanos <= 0) {
-                                        throw new SocketTimeoutException("Receive timed out");
-                                    }
-                                }
-                            }
-                        } finally {
-                            Util.offerFirstTemporaryDirectBuffer(dst);
+                    try {
+                        SocketAddress sender = sourceSocketAddress();
+                        synchronized (p) {
+                            // copy bytes to the DatagramPacket, and set length and sender.
+                            // Need to re-read p.bufLength in case DatagramPacket changed
+                            int len = Math.min(dst.limit(), DatagramPackets.getBufLength(p));
+                            dst.get(p.getData(), p.getOffset(), len);
+                            DatagramPackets.setLength(p, len);
+                            p.setSocketAddress(sender);
                         }
+                    } finally {
+                        Util.offerFirstTemporaryDirectBuffer(dst);
                     }
-                } while (sender == null && isOpen());
+                    completed = true;
+                }
             } finally {
-                endRead(true, (sender != null));
+                endRead(true, completed);
             }
         } finally {
             readLock.unlock();
@@ -884,16 +802,7 @@ class DatagramChannelImpl
                     completed = (n > 0);
                 } else {
                     // not connected
-                    @SuppressWarnings("removal")
-                    SecurityManager sm = System.getSecurityManager();
                     InetAddress ia = isa.getAddress();
-                    if (sm != null) {
-                        if (ia.isMulticastAddress()) {
-                            sm.checkMulticast(ia);
-                        } else {
-                            sm.checkConnect(ia.getHostAddress(), isa.getPort());
-                        }
-                    }
                     if (ia.isLinkLocalAddress())
                         isa = IPAddressUtil.toScopedAddress(isa);
                     if (isa.getPort() == 0)
@@ -1344,10 +1253,6 @@ class DatagramChannelImpl
         } else {
             isa = Net.checkAddress(local, family);
         }
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkListen(isa.getPort());
 
         Net.bind(family, fd, isa.getAddress(), isa.getPort());
         localAddress = Net.localAddress(fd);
@@ -1373,17 +1278,6 @@ class DatagramChannelImpl
      */
     DatagramChannel connect(SocketAddress sa, boolean check) throws IOException {
         InetSocketAddress isa = Net.checkAddress(sa, family);
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            InetAddress ia = isa.getAddress();
-            if (ia.isMulticastAddress()) {
-                sm.checkMulticast(ia);
-            } else {
-                sm.checkConnect(ia.getHostAddress(), isa.getPort());
-                sm.checkAccept(ia.getHostAddress(), isa.getPort());
-            }
-        }
 
         readLock.lock();
         try {
@@ -1589,17 +1483,13 @@ class DatagramChannelImpl
     /**
      * Defines static methods to access AbstractSelectableChannel non-public members.
      */
-    @SuppressWarnings("removal")
     private static class AbstractSelectableChannels {
         private static final Method FOREACH;
         static {
             try {
-                PrivilegedExceptionAction<Method> pae = () -> {
-                    Method m = AbstractSelectableChannel.class.getDeclaredMethod("forEach", Consumer.class);
-                    m.setAccessible(true);
-                    return m;
-                };
-                FOREACH = AccessController.doPrivileged(pae);
+                Method m = AbstractSelectableChannel.class.getDeclaredMethod("forEach", Consumer.class);
+                m.setAccessible(true);
+                FOREACH = m;
             } catch (Exception e) {
                 throw new InternalError(e);
             }
@@ -1645,11 +1535,6 @@ class DatagramChannelImpl
             if (source.getClass() != group.getClass())
                 throw new IllegalArgumentException("Source address is different type to group");
         }
-
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkMulticast(group);
 
         synchronized (stateLock) {
             ensureOpen();
@@ -2051,10 +1936,7 @@ class DatagramChannelImpl
         private static final VarHandle BUF_LENGTH;
         static {
             try {
-                PrivilegedExceptionAction<MethodHandles.Lookup> pa = () ->
-                    MethodHandles.privateLookupIn(DatagramPacket.class, MethodHandles.lookup());
-                @SuppressWarnings("removal")
-                MethodHandles.Lookup l = AccessController.doPrivileged(pa);
+                MethodHandles.Lookup l = MethodHandles.privateLookupIn(DatagramPacket.class, MethodHandles.lookup());
                 LENGTH = l.findVarHandle(DatagramPacket.class, "length", int.class);
                 BUF_LENGTH = l.findVarHandle(DatagramPacket.class, "bufLength", int.class);
             } catch (Exception e) {


### PR DESCRIPTION
Remove code required for the now defunct SecurityManager execution mode from DatagramChannelImpl. Dropping this execution mode means that untrustedReceive can be removed. Additionally, blockingReceive (used to support the adaptor) no longer needs a loop to drop datagrams that the SecurityManager rejects.

Once this change is in then it allow reverting some changes introduced to avoid pinning in the adaptor's receive method, a consequence of have both JEP 486 and JEP 491 integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344112](https://bugs.openjdk.org/browse/JDK-8344112): Remove code to support security manager execution mode from DatagramChannel implementation (**Enhancement** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22072/head:pull/22072` \
`$ git checkout pull/22072`

Update a local copy of the PR: \
`$ git checkout pull/22072` \
`$ git pull https://git.openjdk.org/jdk.git pull/22072/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22072`

View PR using the GUI difftool: \
`$ git pr show -t 22072`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22072.diff">https://git.openjdk.org/jdk/pull/22072.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22072#issuecomment-2473788519)
</details>
