### PR TITLE
8344124: JDK-8341411 Broke the build

### DIFF
--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -3679,7 +3679,7 @@ bool LibraryCallKit::inline_native_setCurrentThread() {
   // Change the lock_id of the JavaThread
   Node* tid = load_field_from_object(arr, "tid", "J");
   Node* thread_id_offset = basic_plus_adr(thread, in_bytes(JavaThread::lock_id_offset()));
-  Node* tid_memory = store_to_memory(control(), thread_id_offset, tid, T_LONG, Compile::AliasIdxRaw, MemNode::unordered, true);
+  Node* tid_memory = store_to_memory(control(), thread_id_offset, tid, T_LONG, MemNode::unordered, true);
 
   JFR_ONLY(extend_setCurrentThread(thread, arr);)
   return true;


### PR DESCRIPTION
Fixes the broken build due to a coincidence where another PR was merged calling a method whose arguments were changed in JDK-8341411.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344124](https://bugs.openjdk.org/browse/JDK-8344124): JDK-8341411 Broke the build (**Bug** - P1)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22073/head:pull/22073` \
`$ git checkout pull/22073`

Update a local copy of the PR: \
`$ git checkout pull/22073` \
`$ git pull https://git.openjdk.org/jdk.git pull/22073/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22073`

View PR using the GUI difftool: \
`$ git pr show -t 22073`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22073.diff">https://git.openjdk.org/jdk/pull/22073.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22073#issuecomment-2473793735)
</details>
