### PR TITLE
8344120: Remove Security Manager dependencies from jdk.crypto.cryptoki module

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -31,8 +31,6 @@ import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
-import java.security.*;
-
 import sun.security.util.PropertyExpander;
 
 import sun.security.pkcs11.wrapper.*;
@@ -62,27 +60,16 @@ final class Config {
     private static final String osArch;
 
     static {
-        @SuppressWarnings("removal")
-        List<String> props = AccessController.doPrivileged(
-            new PrivilegedAction<>() {
-                @Override
-                public List<String> run() {
-                    return List.of(
-                        System.getProperty(
-                            "sun.security.pkcs11.allowSingleThreadedModules",
-                            "true"),
-                        System.getProperty("os.name"),
-                        System.getProperty("os.arch"));
-                }
-            }
-        );
-        if ("false".equalsIgnoreCase(props.get(0))) {
+        String allowSingleThreadedModules =
+            System.getProperty(
+                "sun.security.pkcs11.allowSingleThreadedModules", "true");
+        if ("false".equalsIgnoreCase(allowSingleThreadedModules)) {
             staticAllowSingleThreadedModules = false;
         } else {
             staticAllowSingleThreadedModules = true;
         }
-        osName = props.get(1);
-        osArch = props.get(2);
+        osName = System.getProperty("os.name");
+        osArch = System.getProperty("os.arch");
     }
 
     private static final boolean DEBUG = false;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/Config.java
@@ -56,8 +56,6 @@ final class Config {
     // will accept single threaded modules regardless of the setting in their
     // config files.
     private static final boolean staticAllowSingleThreadedModules;
-    private static final String osName;
-    private static final String osArch;
 
     static {
         String allowSingleThreadedModules =
@@ -68,8 +66,6 @@ final class Config {
         } else {
             staticAllowSingleThreadedModules = true;
         }
-        osName = System.getProperty("os.name");
-        osArch = System.getProperty("os.arch");
     }
 
     private static final boolean DEBUG = false;

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -108,12 +108,9 @@ abstract class P11Key implements Key, Length {
      *
      */
     static {
-        PrivilegedAction<String> getKeyExtractionProp =
-                () -> System.getProperty(
-                        "sun.security.pkcs11.disableKeyExtraction", "false");
-        @SuppressWarnings("removal")
         String disableKeyExtraction =
-                AccessController.doPrivileged(getKeyExtractionProp);
+                System.getProperty(
+                        "sun.security.pkcs11.disableKeyExtraction", "false");
         DISABLE_NATIVE_KEYS_EXTRACTION =
                 "true".equalsIgnoreCase(disableKeyExtraction);
     }

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyAgreement.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyAgreement.java
@@ -71,11 +71,8 @@ final class P11KeyAgreement extends KeyAgreementSpi {
 
     private static class AllowKDF {
 
-        private static final boolean VALUE = getValue();
-
-        private static boolean getValue() {
-            return Boolean.getBoolean("jdk.crypto.KeyAgreement.legacyKDF");
-        }
+        private static final boolean VALUE =
+            Boolean.getBoolean("jdk.crypto.KeyAgreement.legacyKDF");
     }
 
     P11KeyAgreement(Token token, String algorithm, long mechanism) {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyAgreement.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11KeyAgreement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,11 +73,8 @@ final class P11KeyAgreement extends KeyAgreementSpi {
 
         private static final boolean VALUE = getValue();
 
-        @SuppressWarnings("removal")
         private static boolean getValue() {
-            return AccessController.doPrivileged(
-                (PrivilegedAction<Boolean>)
-                () -> Boolean.getBoolean("jdk.crypto.KeyAgreement.legacyKDF"));
+            return Boolean.getBoolean("jdk.crypto.KeyAgreement.legacyKDF");
         }
     }
 

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -130,7 +130,7 @@ public final class P11Util {
         return p;
     }
 
-    @SuppressWarnings("removal")
+    @SuppressWarnings("deprecation")
     private static Provider getProvider(Provider p, String providerName,
             String className) {
         if (p != null) {
@@ -140,22 +140,8 @@ public final class P11Util {
         if (p == null) {
             try {
                 final Class<?> c = Class.forName(className);
-                p = AccessController.doPrivileged(
-                    new PrivilegedAction<Provider>() {
-                        public Provider run() {
-                            try {
-                                @SuppressWarnings("deprecation")
-                                Object o = c.newInstance();
-                                return (Provider) o;
-                            } catch (Exception e) {
-                                throw new ProviderException(
-                                        "Could not find provider " +
-                                                providerName, e);
-                            }
-                        }
-                    }, null, new RuntimePermission(
-                            "accessClassInPackage." + c.getPackageName()));
-            } catch (ClassNotFoundException e) {
+                p = (Provider) c.newInstance();
+            } catch (Exception e) {
                 // Unexpected, as className is not a user but a
                 // P11Util-internal value.
                 throw new ProviderException("Could not find provider " +

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/SunPKCS11.java
@@ -117,19 +117,13 @@ public final class SunPKCS11 extends AuthProvider {
         poller = null;
     }
 
-    @SuppressWarnings("removal")
     @Override
     public Provider configure(String configArg) throws InvalidParameterException {
         final String newConfigName = checkNull(configArg);
         try {
-            return AccessController.doPrivileged(new PrivilegedExceptionAction<>() {
-                @Override
-                public SunPKCS11 run() throws Exception {
-                    return new SunPKCS11(new Config(newConfigName));
-                }
-            });
-        } catch (PrivilegedActionException pae) {
-            throw new InvalidParameterException("Error configuring SunPKCS11 provider", pae.getException());
+            return new SunPKCS11(new Config(newConfigName));
+        } catch (IOException ioe) {
+            throw new InvalidParameterException("Error configuring SunPKCS11 provider", ioe);
         }
     }
 
@@ -1117,7 +1111,6 @@ public final class SunPKCS11 extends AuthProvider {
     }
 
     // create the poller thread, if not already active
-    @SuppressWarnings("removal")
     private void createPoller() {
         if (poller != null) {
             return;
@@ -1197,7 +1190,6 @@ public final class SunPKCS11 extends AuthProvider {
     }
 
     // create the cleaner thread, if not already active
-    @SuppressWarnings("removal")
     private void createCleaner() {
         cleaner = new NativeResourceCleaner();
         Thread t = InnocuousThread.newSystemThread(
@@ -1210,7 +1202,6 @@ public final class SunPKCS11 extends AuthProvider {
     }
 
     // destroy the token. Called if we detect that it has been removed
-    @SuppressWarnings("removal")
     synchronized void uninitToken(Token token) {
         if (this.token != token) {
             // mismatch, our token must already be destroyed
@@ -1219,12 +1210,7 @@ public final class SunPKCS11 extends AuthProvider {
         destroyPoller();
         this.token = null;
         // unregister all algorithms
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
-            public Object run() {
-                clear();
-                return null;
-            }
-        });
+        clear();
         // keep polling for token insertion unless configured not to
         if (removable && !config.getDestroyTokenAfterLogout()) {
             createPoller();
@@ -1386,36 +1372,29 @@ public final class SunPKCS11 extends AuthProvider {
         }
 
         // register algorithms in provider
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-            public Object run() {
-                for (Map.Entry<Descriptor,Integer> entry
-                        : supportedAlgs.entrySet()) {
-                    Descriptor d = entry.getKey();
-                    int mechanism = entry.getValue().intValue();
-                    Service s = d.service(token, mechanism);
-                    putService(s);
-                }
-                if (((token.tokenInfo.flags & CKF_RNG) != 0)
-                        && config.isEnabled(PCKM_SECURERANDOM)
-                        && !token.sessionManager.lowMaxSessions()) {
-                    // do not register SecureRandom if the token does
-                    // not support many sessions. if we did, we might
-                    // run out of sessions in the middle of a
-                    // nextBytes() call where we cannot fail over.
-                    putService(new P11Service(token, SR, "PKCS11",
-                        "sun.security.pkcs11.P11SecureRandom", null,
-                        PCKM_SECURERANDOM));
-                }
-                if (config.isEnabled(PCKM_KEYSTORE)) {
-                    putService(new P11Service(token, KS, "PKCS11",
-                        "sun.security.pkcs11.P11KeyStore",
-                        List.of("PKCS11-" + config.getName()),
-                        PCKM_KEYSTORE));
-                }
-                return null;
-            }
-        });
+        for (Map.Entry<Descriptor,Integer> entry : supportedAlgs.entrySet()) {
+            Descriptor d = entry.getKey();
+            int mechanism = entry.getValue().intValue();
+            Service s = d.service(token, mechanism);
+            putService(s);
+        }
+        if (((token.tokenInfo.flags & CKF_RNG) != 0)
+                && config.isEnabled(PCKM_SECURERANDOM)
+                && !token.sessionManager.lowMaxSessions()) {
+            // do not register SecureRandom if the token does
+            // not support many sessions. if we did, we might
+            // run out of sessions in the middle of a
+            // nextBytes() call where we cannot fail over.
+            putService(new P11Service(token, SR, "PKCS11",
+                "sun.security.pkcs11.P11SecureRandom", null,
+                PCKM_SECURERANDOM));
+        }
+        if (config.isEnabled(PCKM_KEYSTORE)) {
+            putService(new P11Service(token, KS, "PKCS11",
+                "sun.security.pkcs11.P11KeyStore",
+                List.of("PKCS11-" + config.getName()),
+                PCKM_KEYSTORE));
+        }
 
         this.token = token;
         if (cleaner == null) {
@@ -1621,27 +1600,12 @@ public final class SunPKCS11 extends AuthProvider {
      * @throws IllegalStateException if the provider requires configuration
      * and Provider.configure has not been called
      * @throws LoginException if the login operation fails
-     * @throws SecurityException if the does not pass a security check for
-     *  <code>SecurityPermission("authProvider.<i>name</i>")</code>,
-     *  where <i>name</i> is the value returned by
-     *  this provider's <code>getName</code> method
      */
     public void login(Subject subject, CallbackHandler handler)
         throws LoginException {
 
         if (!isConfigured()) {
             throw new IllegalStateException("Configuration is required");
-        }
-
-        // security check
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            if (debug != null) {
-                debug.println("checking login permission");
-            }
-            sm.checkPermission(new SecurityPermission
-                        ("authProvider." + this.getName()));
         }
 
         if (!hasValidToken()) {
@@ -1753,22 +1717,10 @@ public final class SunPKCS11 extends AuthProvider {
      * @throws IllegalStateException if the provider requires configuration
      * and Provider.configure has not been called
      * @throws LoginException if the logout operation fails
-     * @throws SecurityException if the does not pass a security check for
-     *  <code>SecurityPermission("authProvider.<i>name</i>")</code>,
-     *  where <i>name</i> is the value returned by
-     *  this provider's <code>getName</code> method
      */
     public void logout() throws LoginException {
         if (!isConfigured()) {
             throw new IllegalStateException("Configuration is required");
-        }
-
-        // security check
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission
-                (new SecurityPermission("authProvider." + this.getName()));
         }
 
         if (!hasValidToken()) {
@@ -1844,24 +1796,11 @@ public final class SunPKCS11 extends AuthProvider {
      *
      * @throws IllegalStateException if the provider requires configuration
      * and Provider.configure has not been called
-     * @throws SecurityException if the caller does not pass a
-     *  security check for
-     *  <code>SecurityPermission("authProvider.<i>name</i>")</code>,
-     *  where <i>name</i> is the value returned by
-     *  this provider's <code>getName</code> method
      */
     public void setCallbackHandler(CallbackHandler handler) {
 
         if (!isConfigured()) {
             throw new IllegalStateException("Configuration is required");
-        }
-
-        // security check
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission
-                (new SecurityPermission("authProvider." + this.getName()));
         }
 
         synchronized (LOCK_HANDLER) {
@@ -1887,60 +1826,51 @@ public final class SunPKCS11 extends AuthProvider {
                 return pHandler;
             }
 
-            try {
+            if (debug != null) {
+                debug.println("getting default callback handler");
+            }
+
+            String defaultHandler = Security.getProperty
+                    ("auth.login.defaultCallbackHandler");
+
+            if (defaultHandler == null || defaultHandler.length() == 0) {
+
+                // ok
                 if (debug != null) {
-                    debug.println("getting default callback handler");
+                    debug.println("no default handler set");
                 }
+                return null;
+            }
 
-                @SuppressWarnings("removal")
-                CallbackHandler myHandler = AccessController.doPrivileged
-                    (new PrivilegedExceptionAction<CallbackHandler>() {
-                    public CallbackHandler run() throws Exception {
-
-                        String defaultHandler =
-                                java.security.Security.getProperty
-                                ("auth.login.defaultCallbackHandler");
-
-                        if (defaultHandler == null ||
-                            defaultHandler.length() == 0) {
-
-                            // ok
-                            if (debug != null) {
-                                debug.println("no default handler set");
-                            }
-                            return null;
-                        }
-
-                        Class<?> c = Class.forName
-                                   (defaultHandler,
-                                   true,
-                                   Thread.currentThread().getContextClassLoader());
-                        if (!javax.security.auth.callback.CallbackHandler.class.isAssignableFrom(c)) {
-                            // not the right subtype
-                            if (debug != null) {
-                                debug.println("default handler " + defaultHandler +
-                                              " is not a CallbackHandler");
-                            }
-                            return null;
-                        }
-                        @SuppressWarnings("deprecation")
-                        Object result = c.newInstance();
-                        return (CallbackHandler)result;
+            try {
+                Class<?> c = Class.forName
+                           (defaultHandler,
+                           true,
+                           Thread.currentThread().getContextClassLoader());
+                if (!CallbackHandler.class.isAssignableFrom(c)) {
+                    // not the right subtype
+                    if (debug != null) {
+                        debug.println("default handler " + defaultHandler +
+                                      " is not a CallbackHandler");
                     }
-                });
+                    return null;
+                }
+                @SuppressWarnings("deprecation")
+                Object result = c.newInstance();
+                CallbackHandler myHandler = (CallbackHandler)result;
                 // save it
                 pHandler = myHandler;
                 return myHandler;
 
-            } catch (PrivilegedActionException pae) {
+            } catch (ReflectiveOperationException roe) {
                 // ok
                 if (debug != null) {
                     debug.println("Unable to load default callback handler");
-                    pae.printStackTrace();
+                    roe.printStackTrace();
                 }
             }
+            return null;
         }
-        return null;
     }
 
     private Object writeReplace() throws ObjectStreamException {

--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/wrapper/PKCS11.java
@@ -51,9 +51,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 import sun.security.util.Debug;
 
 import sun.security.pkcs11.P11Util;
@@ -80,16 +77,12 @@ public class PKCS11 {
     private static final String PKCS11_WRAPPER = "j2pkcs11";
 
     static {
-        // cannot use LoadLibraryAction because that would make the native
-        // library available to the bootclassloader, but we run in the
-        // extension classloader.
-        @SuppressWarnings({"removal", "restricted"})
-        var dummy = AccessController.doPrivileged(new PrivilegedAction<Object>() {
-            public Object run() {
-                System.loadLibrary(PKCS11_WRAPPER);
-                return null;
-            }
-        });
+        loadAndInitializeLibrary();
+    }
+
+    @SuppressWarnings("restricted")
+    private static void loadAndInitializeLibrary() {
+        System.loadLibrary(PKCS11_WRAPPER);
         boolean enableDebug = Debug.getInstance("sunpkcs11") != null;
         initializeLibrary(enableDebug);
     }


### PR DESCRIPTION
Now that JEP 486 has been integrated, the `jdk.crypto.cryptoki` implementation dependencies on `System.getSecurityManager` and `AccessController.doPrivileged` can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344120](https://bugs.openjdk.org/browse/JDK-8344120): Remove Security Manager dependencies from jdk.crypto.cryptoki module (**Enhancement** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**) Review applies to [f3259bdc](https://git.openjdk.org/jdk/pull/22077/files/f3259bdc2fdd312a7f1e9d86a67c06153b4996a6)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22077/head:pull/22077` \
`$ git checkout pull/22077`

Update a local copy of the PR: \
`$ git checkout pull/22077` \
`$ git pull https://git.openjdk.org/jdk.git pull/22077/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22077`

View PR using the GUI difftool: \
`$ git pr show -t 22077`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22077.diff">https://git.openjdk.org/jdk/pull/22077.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22077#issuecomment-2473839939)
</details>
