### PR TITLE
8316804: Gracefully handle the case where --release is not specified last

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
@@ -230,16 +230,15 @@ class GNUStyleOptions {
             },
             new Option(true, OptionType.OTHER, "--release") {
                 void process(Main jartool, String opt, String arg) throws BadArgs {
-                    int v = 0; // Main.BASE_VERSION
                     try {
-                        v = Integer.valueOf(arg);
+                        int value = Integer.valueOf(arg);
+                        if (value < 9) {
+                            throw new BadArgs("error.release.value.toosmall", arg).showUsage(true);
+                        }
+                        jartool.releaseValue = value;
                     } catch (NumberFormatException x) {
                         throw new BadArgs("error.release.value.notnumber", arg);
                     }
-                    if (v < 9) {
-                        throw new BadArgs("error.release.value.toosmall", arg).showUsage(true);
-                    }
-                    jartool.releaseValue = v;
                 }
                 boolean isHidden() { return true; }
             },

--- a/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/GNUStyleOptions.java
@@ -228,6 +228,21 @@ class GNUStyleOptions {
                 }
                 boolean isHidden() { return true; }
             },
+            new Option(true, OptionType.OTHER, "--release") {
+                void process(Main jartool, String opt, String arg) throws BadArgs {
+                    int v = 0; // Main.BASE_VERSION
+                    try {
+                        v = Integer.valueOf(arg);
+                    } catch (NumberFormatException x) {
+                        throw new BadArgs("error.release.value.notnumber", arg);
+                    }
+                    if (v < 9) {
+                        throw new BadArgs("error.release.value.toosmall", arg).showUsage(true);
+                    }
+                    jartool.releaseValue = v;
+                }
+                boolean isHidden() { return true; }
+            },
 
             // Other options
             new Option(true, true, OptionType.OTHER, "--help", "-h", "-?") {
@@ -326,11 +341,17 @@ class GNUStyleOptions {
 
         // process options
         for (; count < args.length; count++) {
-            if (args[count].charAt(0) != '-' || args[count].equals("-C") ||
-                args[count].equals("--release"))
-                break;
-
             String name = args[count];
+            if (name.charAt(0) != '-' || name.equals("-C"))
+                break;
+            if (name.equals("--release")) {
+                // JDK-8316804: stay here when in `--describe-module`
+                // or in `--validate` operation mode in order to process
+                // the `--release` option before parsing file arguments
+                if (!(jartool.dflag || jartool.validate))
+                    break;
+            }
+
             if (name.equals("-XDsuppress-tool-removal-message")) {
                 jartool.suppressDeprecateMsg = true;
                 continue;

--- a/test/jdk/tools/jar/ReleaseBeforeFiles.java
+++ b/test/jdk/tools/jar/ReleaseBeforeFiles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,7 +121,9 @@ public class ReleaseBeforeFiles {
         touch("testfile");
         jar("--create --file=test.jar testfile");
         jar("--describe-module --release 9 --file test.jar");
+        jar("--describe-module --file test.jar --release 9");
         jar("--validate        --release 9 --file test.jar");
+        jar("--validate        --file test.jar --release 9");
         rm("test.jar testfile");
     }
 

--- a/test/jdk/tools/jar/ReleaseBeforeFiles.java
+++ b/test/jdk/tools/jar/ReleaseBeforeFiles.java
@@ -172,6 +172,6 @@ public class ReleaseBeforeFiles {
         var args = cmdline.split(" +");
         var code = tool.run(System.out, System.err, args);
         if (code == 0) return;
-        throw new RuntimeException("jat failed with non-zero error code: " + code);
+        throw new RuntimeException("jar failed with non-zero error code: " + code);
     }
 }


### PR DESCRIPTION
Please review this change for the `jar` tool to gracefully handle the case where `--release` is not specified as the last arguments.

Prior to this commit, operation modes `-d --describe-module` and `--validate` expected to read the optional `--release` option as a file argument: `jar -d -f a.jar --release 9`
By adding a hidden GNU-style `--release` option, processing the optional arguments before in those two operation modes, the position is now no longer required to trail behind the `-f --file` option: `jar -d --release 9 -f a.jar`

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jdk/tools/jar                             26    26     0     0
==============================
TEST SUCCESS
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316804](https://bugs.openjdk.org/browse/JDK-8316804): Gracefully handle the case where --release is not specified last (**Enhancement** - P4)


### Reviewers
 * [Henry Jen](https://openjdk.org/census#henryjen) (@slowhog - Committer) 🔄 Re-review required (review applies to [4f56a934](https://git.openjdk.org/jdk/pull/22079/files/4f56a934288ea51eb69e8e575f4d9eb57214bb2a))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22079/head:pull/22079` \
`$ git checkout pull/22079`

Update a local copy of the PR: \
`$ git checkout pull/22079` \
`$ git pull https://git.openjdk.org/jdk.git pull/22079/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22079`

View PR using the GUI difftool: \
`$ git pr show -t 22079`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22079.diff">https://git.openjdk.org/jdk/pull/22079.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22079#issuecomment-2473955946)
</details>
