### PR TITLE
JDK-8344104

### DIFF
--- a/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
+++ b/test/hotspot/jtreg/compiler/c2/TestMergeStores.java
@@ -340,8 +340,8 @@ public class TestMergeStores {
             set_random(aL);
             set_random(bL);
 
-            offset1 = Math.abs(RANDOM.nextInt()) % 100;
-            offset2 = Math.abs(RANDOM.nextInt()) % 100;
+            offset1 = Math.abs(RANDOM.nextInt() & 0x0fffffff) % 100;
+            offset2 = Math.abs(RANDOM.nextInt() & 0x0fffffff) % 100;
             vB1 = (byte)RANDOM.nextInt();
             vB2 = (byte)RANDOM.nextInt();
             vS1 = (short)RANDOM.nextInt();


### PR DESCRIPTION
Test-bug: `RANDOM.nextInt()` would occasionally return a `min_int`. And sadly this overflows: `Math.abs(min_int) == min_int`. Wen we calculate it `% 100`, it still gives us a negative value, and we end up out of bounds. Fixed with a mask.