### PR TITLE
8320743: AEAD ciphers throw undocumented exceptions on overflow

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/ChaCha20Cipher.java
@@ -245,7 +245,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
                 params.init((new DerValue(
                         DerValue.tag_OctetString, nonceData).toByteArray()));
             } catch (NoSuchAlgorithmException | IOException exc) {
-                throw new RuntimeException(exc);
+                throw new ProviderException(exc);
             }
         }
 
@@ -353,7 +353,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
                 break;
             default:
                 // Should never happen
-                throw new RuntimeException("ChaCha20 in unsupported mode");
+                throw new ProviderException("ChaCha20 in unsupported mode");
         }
         init(opmode, key, newNonce);
     }
@@ -426,7 +426,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
                 }
                 break;
             default:
-                throw new RuntimeException("Invalid mode: " + mode);
+                throw new ProviderException("Invalid mode: " + mode);
         }
 
         // Continue with initialization
@@ -730,7 +730,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
         try {
             engine.doFinal(in, inOfs, inLen, output, 0);
         } catch (ShortBufferException | KeyException exc) {
-            throw new RuntimeException(exc);
+            throw new ProviderException(exc);
         } finally {
             // Reset the cipher's state to post-init values.
             resetStartState();
@@ -767,7 +767,7 @@ abstract class ChaCha20Cipher extends CipherSpi {
         try {
             bytesUpdated = engine.doFinal(in, inOfs, inLen, out, outOfs);
         } catch (KeyException ke) {
-            throw new RuntimeException(ke);
+            throw new ProviderException(ke);
         } finally {
             // Reset the cipher's state to post-init values.
             resetStartState();

--- a/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/GaloisCounterMode.java
@@ -241,7 +241,7 @@ abstract class GaloisCounterMode extends CipherSpi {
             params.init(spec);
             return params;
         } catch (NoSuchAlgorithmException | InvalidParameterSpecException e) {
-            throw new RuntimeException(e);
+            throw new ProviderException(e);
         }
     }
 
@@ -781,7 +781,7 @@ abstract class GaloisCounterMode extends CipherSpi {
         int mergeBlock(byte[] buffer, int bufOfs, int bufLen, byte[] in,
             int inOfs, int inLen, byte[] block) {
             if (bufLen > blockSize) {
-                throw new RuntimeException("mergeBlock called on an ibuffer " +
+                throw new ProviderException("mergeBlock called on an ibuffer " +
                     "too big:  " + bufLen + " bytes");
             }
 


### PR DESCRIPTION
JDK-8320743: The particular issues mentioned in the bug report seem to be behaving as desired at this point, but we will prefer ProviderException over RuntimeException in these classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8320743](https://bugs.openjdk.org/browse/JDK-8320743): AEAD ciphers throw undocumented exceptions on overflow (**Bug** - P4)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22084/head:pull/22084` \
`$ git checkout pull/22084`

Update a local copy of the PR: \
`$ git checkout pull/22084` \
`$ git pull https://git.openjdk.org/jdk.git pull/22084/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22084`

View PR using the GUI difftool: \
`$ git pr show -t 22084`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22084.diff">https://git.openjdk.org/jdk/pull/22084.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22084#issuecomment-2477585482)
</details>
