### PR TITLE
8343889: Test runtime/cds/appcds/redefineClass/RedefineBasicTest.java failed

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/OldClassAndRedefineClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/OldClassAndRedefineClass.java
@@ -26,15 +26,15 @@
  * @test
  * @bug 8342303
  * @summary Test loading of shared old class when another class has been redefined.
- * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes /test/hotspot/jtreg/runtime/cds/appcds/jvmti
- * @requires vm.cds.write.archived.java.heap
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds /test/hotspot/jtreg/runtime/cds/appcds/test-classes
+ * @requires vm.cds
  * @requires vm.jvmti
+ * @run driver RedefineClassHelper
  * @build jdk.test.whitebox.WhiteBox
  *        OldClassAndRedefineClassApp
  * @compile ../../test-classes/OldSuper.jasm
  *          ../../test-classes/ChildOldSuper.java
  *          ../../test-classes/Hello.java
- * @run driver RedefineClassHelper
  * @run driver OldClassAndRedefineClass
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/RedefineBootClassTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/RedefineBootClassTest.java
@@ -29,12 +29,12 @@
  * @library /test/lib
  *          /test/hotspot/jtreg/runtime/cds/appcds
  *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- *          /test/hotspot/jtreg/runtime/cds/appcds/jvmti
+ * @requires vm.cds
  * @requires vm.jvmti
+ * @run driver RedefineClassHelper
  * @build RedefineBootClassTest
  *        RedefineBootClassApp
  *        BootSuper BootChild
- * @run driver RedefineClassHelper
  * @run driver RedefineBootClassTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/RedefineOldSuperTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses/RedefineOldSuperTest.java
@@ -29,13 +29,13 @@
  * @library /test/lib
  *          /test/hotspot/jtreg/runtime/cds/appcds
  *          /test/hotspot/jtreg/runtime/cds/appcds/test-classes
- *          /test/hotspot/jtreg/runtime/cds/appcds/jvmti
+ * @requires vm.cds
  * @requires vm.jvmti
  * @compile ../../test-classes/OldSuper.jasm
+ * @run driver RedefineClassHelper
  * @build RedefineOldSuperTest
  *        RedefineOldSuperApp
  *        NewChild
- * @run driver RedefineClassHelper
  * @run driver RedefineOldSuperTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineBasicTest.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineBasicTest.java
@@ -30,7 +30,7 @@
  * @requires vm.jvmti
  * @library /test/lib /test/hotspot/jtreg/serviceability/jvmti/RedefineClasses /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver RedefineClassHelper
- * @build jdk.test.whitebox.WhiteBox jdk.test.lib.compiler.InMemoryJavaCompiler  RedefineBasic
+ * @build jdk.test.whitebox.WhiteBox RedefineBasic
  * @run driver RedefineBasicTest
  */
 

--- a/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
@@ -30,7 +30,7 @@
  * @requires vm.jvmti
  * @library /test/lib /test/hotspot/jtreg/serviceability/jvmti/RedefineClasses /test/hotspot/jtreg/runtime/cds/appcds
  * @run driver RedefineClassHelper
- * @build jdk.test.whitebox.WhiteBox jdk.test.lib.compiler.InMemoryJavaCompiler
+ * @build jdk.test.whitebox.WhiteBox
  * @compile RedefineRunningMethods_SharedHelper.java
  * @run driver RedefineRunningMethods_Shared
  */

--- a/test/hotspot/jtreg/runtime/logging/RedefineClasses.java
+++ b/test/hotspot/jtreg/runtime/logging/RedefineClasses.java
@@ -30,7 +30,6 @@
  * @modules java.compiler
  *          java.instrument
  * @requires vm.jvmti
- * @build jdk.test.lib.compiler.InMemoryJavaCompiler
  * @run main RedefineClassHelper
  * @run main/othervm -Xmx256m -XX:MaxMetaspaceSize=64m -javaagent:redefineagent.jar -Xlog:all=trace:file=all.log RedefineClasses
  */


### PR DESCRIPTION
Fixing the tests under `test/hotspot/jtreg/runtime/cds/appcds/jvmti/redefineClasses` so that the `@run driver RedefineClassHelper` comes before any `@build` command so that subsequent tests can find classes under the` test.lib.helpers` package such as the `ClassFileInstaller` class.

Revert the changes, which was done via JDK-8342303, to the following tests as the changes are not needed with the current fix.
```
test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineBasicTest.java
test/hotspot/jtreg/runtime/cds/appcds/redefineClass/RedefineRunningMethods_Shared.java
test/hotspot/jtreg/runtime/logging/RedefineClasses.java
```

This change also adds `@requires vm.cds` to the tests so it also fixes JDK-8344046.

Testing:
- passed tiers 1, 4 tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8343889](https://bugs.openjdk.org/browse/JDK-8343889): Test runtime/cds/appcds/redefineClass/RedefineBasicTest.java failed (**Bug** - P4)
 * [JDK-8344046](https://bugs.openjdk.org/browse/JDK-8344046): Tests under cds/appcds/jvmti/redefineClasses should have @<!---->requires vm.cds (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22085/head:pull/22085` \
`$ git checkout pull/22085`

Update a local copy of the PR: \
`$ git checkout pull/22085` \
`$ git pull https://git.openjdk.org/jdk.git pull/22085/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22085`

View PR using the GUI difftool: \
`$ git pr show -t 22085`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22085.diff">https://git.openjdk.org/jdk/pull/22085.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22085#issuecomment-2474554012)
</details>
