### PR TITLE
8344147: Remove Security Manager dependencies from java.security.sasl module

### DIFF
--- a/src/java.security.sasl/share/classes/com/sun/security/sasl/Provider.java
+++ b/src/java.security.sasl/share/classes/com/sun/security/sasl/Provider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
  */
 package com.sun.security.sasl;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidParameterException;
 import java.security.ProviderException;
@@ -98,34 +96,28 @@ public final class Provider extends java.security.Provider {
         }
     }
 
-    @SuppressWarnings("removal")
     public Provider() {
         super("SunSASL", PROVIDER_VER, info);
 
         final Provider p = this;
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-                // Client mechanisms
-                putService(new ProviderService(p, "SaslClientFactory",
-                           "DIGEST-MD5", "com.sun.security.sasl.digest.FactoryImpl"));
-                putService(new ProviderService(p, "SaslClientFactory",
-                           "NTLM", "com.sun.security.sasl.ntlm.FactoryImpl"));
-                putService(new ProviderService(p, "SaslClientFactory",
-                           "EXTERNAL", "com.sun.security.sasl.ClientFactoryImpl"));
-                putService(new ProviderService(p, "SaslClientFactory",
-                           "PLAIN", "com.sun.security.sasl.ClientFactoryImpl"));
-                putService(new ProviderService(p, "SaslClientFactory",
-                           "CRAM-MD5", "com.sun.security.sasl.ClientFactoryImpl"));
+        // Client mechanisms
+        putService(new ProviderService(p, "SaslClientFactory",
+                   "DIGEST-MD5", "com.sun.security.sasl.digest.FactoryImpl"));
+        putService(new ProviderService(p, "SaslClientFactory",
+                   "NTLM", "com.sun.security.sasl.ntlm.FactoryImpl"));
+        putService(new ProviderService(p, "SaslClientFactory",
+                   "EXTERNAL", "com.sun.security.sasl.ClientFactoryImpl"));
+        putService(new ProviderService(p, "SaslClientFactory",
+                   "PLAIN", "com.sun.security.sasl.ClientFactoryImpl"));
+        putService(new ProviderService(p, "SaslClientFactory",
+                   "CRAM-MD5", "com.sun.security.sasl.ClientFactoryImpl"));
 
-                // Server mechanisms
-                putService(new ProviderService(p, "SaslServerFactory",
-                           "CRAM-MD5", "com.sun.security.sasl.ServerFactoryImpl"));
-                putService(new ProviderService(p, "SaslServerFactory",
-                           "DIGEST-MD5", "com.sun.security.sasl.digest.FactoryImpl"));
-                putService(new ProviderService(p, "SaslServerFactory",
-                           "NTLM", "com.sun.security.sasl.ntlm.FactoryImpl"));
-                return null;
-            }
-        });
+        // Server mechanisms
+        putService(new ProviderService(p, "SaslServerFactory",
+                   "CRAM-MD5", "com.sun.security.sasl.ServerFactoryImpl"));
+        putService(new ProviderService(p, "SaslServerFactory",
+                   "DIGEST-MD5", "com.sun.security.sasl.digest.FactoryImpl"));
+        putService(new ProviderService(p, "SaslServerFactory",
+                   "NTLM", "com.sun.security.sasl.ntlm.FactoryImpl"));
     }
 }

--- a/src/java.security.sasl/share/classes/javax/security/sasl/Sasl.java
+++ b/src/java.security.sasl/share/classes/javax/security/sasl/Sasl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package javax.security.sasl;
 
 import javax.security.auth.callback.CallbackHandler;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Iterator;
@@ -74,10 +72,7 @@ public class Sasl {
     private static List<String> disabledMechanisms = new ArrayList<>();
 
     static {
-        @SuppressWarnings("removal")
-        String prop = AccessController.doPrivileged(
-                (PrivilegedAction<String>)
-                () -> Security.getProperty("jdk.sasl.disabledMechanisms"));
+        String prop = Security.getProperty("jdk.sasl.disabledMechanisms");
 
         if (prop != null) {
             for (String s : prop.split("\\s*,\\s*")) {
@@ -452,9 +447,7 @@ public class Sasl {
              * that was used to load the provider.
              * In order to get the class loader of a class, the
              * caller's class loader must be the same as or an ancestor of
-             * the class loader being returned. Otherwise, the caller must
-             * have "getClassLoader" permission, or a SecurityException
-             * will be thrown.
+             * the class loader being returned.
              */
             return service.newInstance(null);
         } catch (InvalidParameterException | NoSuchAlgorithmException e) {


### PR DESCRIPTION
Now that JEP 486 has been integrated, java.security.sasl implementation dependencies on AccessController.doPrivileged can be removed. 