### PR TITLE
8344128: Regression: make help broken after JDK-8340818

### DIFF
--- a/make/Global.gmk
+++ b/make/Global.gmk
@@ -102,7 +102,7 @@ help:
 	$(info $(_)                        # method is 'auto', 'ignore' or 'fail' (default))
 	$(info $(_) TEST="test1 ..."       # Use the given test descriptor(s) for testing, e.g.)
 	$(info $(_)                        # make test TEST="jdk_lang gtest:all")
-	$(info $(_) TEST_DEPS="dependency1 ..." # Specify additional dependencies for running tests, e.g docs-jdk
+	$(info $(_) TEST_DEPS="dependency1 ..." # Specify additional dependencies for running tests, e.g docs-jdk)
 	$(info $(_) JTREG="OPT1=x;OPT2=y"  # Control the JTREG test harness, use 'make test-only JTREG=help' to list)
 	$(info $(_) GTEST="OPT1=x;OPT2=y"  # Control the GTEST test harness, use 'make test-only GTEST=help' to list)
 	$(info $(_) MICRO="OPT1=x;OPT2=y"  # Control the MICRO test harness, use 'make test-only MICRO=help' to list)


### PR DESCRIPTION
I was not successful in writing a test to check to return value of `make help`, but this patch should fix the current bug.

```
% make help >/dev/null; echo $?                                                                     
0
% make help

OpenJDK Makefile help
=====================

Common make targets
 make [default]         # Compile all modules and create a runnable "exploded"
                        # image (alias for jdk or exploded-image)
 make all               # Create all images: product, test, docs
                        # (alias for all-images)
 make images            # Create a complete jdk image
                        # (alias for product-images)
 make <name>-image      # Build just the image for any of: 
                        # jdk, test, docs, symbols, legacy-jre, static-libs
 make <phase>           # Build the specified phase and everything it depends on
                        # (gensrc, java, copy, libs, launchers, gendata)
 make *-only            # Applies to most targets and disables building the
                        # dependencies for that target. This is faster but may
                        # result in incorrect build results!
 make docs              # Create all docs
 make docs-jdk-api      # Create just JDK javadocs
 make bootcycle-images  # Build images twice, second time with newly built JDK
 make check             # Run basic testing (currently tier1)
 make test-<test>       # Run test, e.g. test-tier1
 make test TEST=<t>     # Run test(s) given by TEST specification
 make exploded-test TEST=<t> # Run test(s) on the exploded image instead of
                        # the full jdk image

Targets for troubleshooting
 make help              # Give some help on using make
 make doctor            # Diagnose build environment problems
 make reconfigure       # Rerun configure with the same arguments as last time

Targets for cleaning
 make clean             # Remove all files generated by make, but not those
                        # generated by configure
 make dist-clean        # Remove all files, including configuration
 make clean-<outputdir> # Remove the subdir in the output dir with the name
 make clean-<phase>     # Remove all build results related to a certain build
                        # phase (gensrc, java, libs, launchers)
 make clean-<module>    # Remove all build results related to a certain module
 make clean-<module>-<phase> # Remove all build results related to a certain
                        # module and phase

Targets for Hotspot
 make hotspot           # Build all of hotspot
 make hotspot-<variant> # Build just the specified jvm variant
 make hotspot-gensrc    # Only build the gensrc part of hotspot
 make hotspot-<variant>-<phase> # Build the specified phase for the variant

Targets for specific modules
 make <module>          # Build <module> and everything it depends on
 make <module>-<phase>  # Compile the specified phase for the specified module
                        # and everything it depends on
                        # (gensrc, java, copy, libs, launchers, gendata)

Make control variables
 CONF=<selector>        # Select which configuration(s) to build
 CONF=                  # Select all configurations (note, assignment is empty)
 CONF_NAME=<string>     # Select the configuration with the name <string>
 SPEC=<spec file>       # Build the configuration given by the spec file
 LOG=<loglevel>         # Change the log level from warn to <loglevel>
                        # Available log levels are:
                        # 'warn' (default), 'info', 'debug' and 'trace'
                        # To see executed command lines, use LOG=debug
 JOBS=<n>               # Run <n> parallel make jobs
                        # Note that -jN does not work as expected!
 TEST_JOBS=<n>          # Run <n> parallel test jobs
 CONF_CHECK=<method>    # What to do if spec file is out of date
                        # method is 'auto', 'ignore' or 'fail' (default)
 TEST="test1 ..."       # Use the given test descriptor(s) for testing, e.g.
                        # make test TEST="jdk_lang gtest:all"
 TEST_DEPS="dependency1 ..." # Specify additional dependencies for running tests, e.g docs-jdk
 JTREG="OPT1=x;OPT2=y"  # Control the JTREG test harness, use 'make test-only JTREG=help' to list
 GTEST="OPT1=x;OPT2=y"  # Control the GTEST test harness, use 'make test-only GTEST=help' to list
 MICRO="OPT1=x;OPT2=y"  # Control the MICRO test harness, use 'make test-only MICRO=help' to list
 TEST_OPTS="OPT1=x;..." # Generic control of all test harnesses
 TEST_VM_OPTS="ARG ..." # Same as setting TEST_OPTS to VM_OPTIONS="ARG ..."

Available configurations in [redacted]/build:
* macosx-aarch64
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344128](https://bugs.openjdk.org/browse/JDK-8344128): Regression: make help broken after JDK-8340818 (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22089/head:pull/22089` \
`$ git checkout pull/22089`

Update a local copy of the PR: \
`$ git checkout pull/22089` \
`$ git pull https://git.openjdk.org/jdk.git pull/22089/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22089`

View PR using the GUI difftool: \
`$ git pr show -t 22089`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22089.diff">https://git.openjdk.org/jdk/pull/22089.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22089#issuecomment-2475033637)
</details>
