### PR TITLE
8343877: Test AsyncClose.java intermittent fails - Socket.getInputStream().read() wasn't preempted

### DIFF
--- a/test/jdk/java/net/Socket/asyncClose/Socket_getInputStream_read.java
+++ b/test/jdk/java/net/Socket/asyncClose/Socket_getInputStream_read.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -60,7 +60,7 @@ public class Socket_getInputStream_read extends AsyncCloseTest implements Runnab
             }
             latch.countDown();
             int n = in.read();
-            failed("Socket.getInputStream().read() returned unexpectedly!!");
+            failed("Socket.getInputStream().read() returned unexpectedly, n=" + n);
         } catch (SocketException se) {
             if (latch.getCount() != 1) {
                 closed();
@@ -79,13 +79,14 @@ public class Socket_getInputStream_read extends AsyncCloseTest implements Runnab
             InetAddress lh = InetAddress.getLocalHost();
             ServerSocket ss = new ServerSocket(0, 0, lh);
             s.connect( new InetSocketAddress(lh, ss.getLocalPort()) );
-            Socket s2 = ss.accept();
-            Thread thr = new Thread(this);
-            thr.start();
-            latch.await();
-            Thread.sleep(5000); //sleep, so Socket.getInputStream().read() can block
-            s.close();
-            thr.join();
+            try (Socket s2 = ss.accept()) {
+                Thread thr = new Thread(this);
+                thr.start();
+                latch.await();
+                Thread.sleep(5000); //sleep, so Socket.getInputStream().read() can block
+                s.close();
+                thr.join();
+            }
 
             if (isClosed()) {
                 return passed();

--- a/test/jdk/java/net/Socket/asyncClose/Socket_getInputStream_read.java
+++ b/test/jdk/java/net/Socket/asyncClose/Socket_getInputStream_read.java
@@ -77,21 +77,22 @@ public class Socket_getInputStream_read extends AsyncCloseTest implements Runnab
     public AsyncCloseTest go() {
         try {
             InetAddress lh = InetAddress.getLocalHost();
-            ServerSocket ss = new ServerSocket(0, 0, lh);
-            s.connect( new InetSocketAddress(lh, ss.getLocalPort()) );
-            try (Socket s2 = ss.accept()) {
-                Thread thr = new Thread(this);
-                thr.start();
-                latch.await();
-                Thread.sleep(5000); //sleep, so Socket.getInputStream().read() can block
-                s.close();
-                thr.join();
-            }
+            try (ServerSocket ss = new ServerSocket(0, 0, lh)) {
+                s.connect(new InetSocketAddress(lh, ss.getLocalPort()));
+                try (Socket s2 = ss.accept()) {
+                    Thread thr = new Thread(this);
+                    thr.start();
+                    latch.await();
+                    Thread.sleep(5000); //sleep, so Socket.getInputStream().read() can block
+                    s.close();
+                    thr.join();
+                }
 
-            if (isClosed()) {
-                return passed();
-            } else {
-                return failed("Socket.getInputStream().read() wasn't preempted");
+                if (isClosed()) {
+                    return passed();
+                } else {
+                    return failed("Socket.getInputStream().read() wasn't preempted");
+                }
             }
         } catch (Exception x) {
             failed(x.getMessage());

--- a/test/jdk/java/net/Socket/asyncClose/Socket_getOutputStream_write.java
+++ b/test/jdk/java/net/Socket/asyncClose/Socket_getOutputStream_write.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -68,13 +68,14 @@ public class Socket_getOutputStream_write extends AsyncCloseTest implements Runn
             InetAddress lh = InetAddress.getLocalHost();
             ServerSocket ss = new ServerSocket(0, 0, lh);
             s.connect( new InetSocketAddress(lh, ss.getLocalPort()) );
-            Socket s2 = ss.accept();
-            Thread thr = new Thread(this);
-            thr.start();
-            latch.await();
-            Thread.sleep(1000);
-            s.close();
-            thr.join();
+            try (Socket s2 = ss.accept()) {
+                Thread thr = new Thread(this);
+                thr.start();
+                latch.await();
+                Thread.sleep(1000);
+                s.close();
+                thr.join();
+            }
 
             if (isClosed()) {
                 return passed();

--- a/test/jdk/java/net/Socket/asyncClose/Socket_getOutputStream_write.java
+++ b/test/jdk/java/net/Socket/asyncClose/Socket_getOutputStream_write.java
@@ -66,21 +66,22 @@ public class Socket_getOutputStream_write extends AsyncCloseTest implements Runn
     public AsyncCloseTest go() {
         try {
             InetAddress lh = InetAddress.getLocalHost();
-            ServerSocket ss = new ServerSocket(0, 0, lh);
-            s.connect( new InetSocketAddress(lh, ss.getLocalPort()) );
-            try (Socket s2 = ss.accept()) {
-                Thread thr = new Thread(this);
-                thr.start();
-                latch.await();
-                Thread.sleep(1000);
-                s.close();
-                thr.join();
-            }
+            try (ServerSocket ss = new ServerSocket(0, 0, lh)) {
+                s.connect(new InetSocketAddress(lh, ss.getLocalPort()));
+                try (Socket s2 = ss.accept()) {
+                    Thread thr = new Thread(this);
+                    thr.start();
+                    latch.await();
+                    Thread.sleep(1000);
+                    s.close();
+                    thr.join();
+                }
 
-            if (isClosed()) {
-                return passed();
-            } else {
-                return failed("Socket.getOutputStream().write() wasn't preempted");
+                if (isClosed()) {
+                    return passed();
+                } else {
+                    return failed("Socket.getOutputStream().write() wasn't preempted");
+                }
             }
         } catch (Exception x) {
             failed(x.getMessage());


### PR DESCRIPTION
Can I please get a review of this test-only fix which addresses the intermittent failure in AsyncClose test as noted in https://bugs.openjdk.org/browse/JDK-8343877?

The `FileDescriptor` of the `Socket` instance that gets returned from a call to `ServerSocket.accept()` gets enrolled with the `java.lang.ref.Cleaner` so that the underlying file descriptor of the newly accepted socket gets closed.

The `Socket_getInputStream_read` and even the `Socket_getOutputStream_write` tests don't hold on to the `Socket` instance returned by the `accept()` call until the concurrent `Thread` that reads (or writes) on the client side of the socket. This is an oversight in the test and this can lead to a case where the GC upon noticing that the returned `Socket` instance isn't referenced may garbage collect that instance and thus the `Cleaner` may end up closing the underlying file descriptor. When that happens, the expectations of the test don't hold and thus the test fails as noted in the linked issue.

The commit in this PR updates these 2 tests to use a try-with-resources for the returned `Socket` instance and that way enforce reachability of the `Socket` instance until the end of the try block. This should prevent the GC from garbage collecting the instance and at the same time `close()` the returned `Socket` in a deterministic manner.

No explicit `java.lang.ref.Reference.reachabilityFence()` should be required here given what the JLS specifies about try-with-resources and reachability in section 14.20.3 https://docs.oracle.com/javase/specs/jls/se23/html/jls-14.html#jls-14.20.3.

These tests continue to pass after this change with a test repeat of 50. tier2 too passes without any failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343877](https://bugs.openjdk.org/browse/JDK-8343877): Test AsyncClose.java intermittent fails - Socket.getInputStream().read() wasn't preempted (**Bug** - P3)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer) Review applies to [186fd9ad](https://git.openjdk.org/jdk/pull/22093/files/186fd9add66ce477678645ea787e2a27f9e07176)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [186fd9ad](https://git.openjdk.org/jdk/pull/22093/files/186fd9add66ce477678645ea787e2a27f9e07176)
 * [Mark Sheppard](https://openjdk.org/census#msheppar) (@msheppar - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22093/head:pull/22093` \
`$ git checkout pull/22093`

Update a local copy of the PR: \
`$ git checkout pull/22093` \
`$ git pull https://git.openjdk.org/jdk.git pull/22093/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22093`

View PR using the GUI difftool: \
`$ git pr show -t 22093`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22093.diff">https://git.openjdk.org/jdk/pull/22093.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22093#issuecomment-2475421767)
</details>
