### PR TITLE
8344169: RISC-V: Use more meaningful frame::metadata_words where possible

### DIFF
--- a/src/hotspot/cpu/riscv/continuationEntry_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationEntry_riscv.inline.hpp
@@ -40,11 +40,11 @@ inline frame ContinuationEntry::to_frame() const {
 }
 
 inline intptr_t* ContinuationEntry::entry_fp() const {
-  return (intptr_t*)((address)this + size()) + 2;
+  return (intptr_t*)((address)this + size()) + frame::metadata_words;
 }
 
 inline void ContinuationEntry::update_register_map(RegisterMap* map) const {
-  intptr_t** fp = (intptr_t**)(bottom_sender_sp() - 2);
+  intptr_t** fp = (intptr_t**)(bottom_sender_sp() - frame::metadata_words);
   frame::update_map_with_saved_link(map, fp);
 }
 

--- a/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/continuationHelper_riscv.inline.hpp
@@ -37,7 +37,7 @@ static inline intptr_t** link_address(const frame& f) {
   assert(FKind::is_instance(f), "");
   return FKind::interpreted
             ? (intptr_t**)(f.fp() + frame::link_offset)
-            : (intptr_t**)(f.unextended_sp() + f.cb()->frame_size() - 2);
+            : (intptr_t**)(f.unextended_sp() + f.cb()->frame_size() - frame::metadata_words);
 }
 
 static inline void patch_return_pc_with_preempt_stub(frame& f) {
@@ -81,7 +81,7 @@ inline void ContinuationHelper::update_register_map_with_callee(const frame& f, 
 }
 
 inline void ContinuationHelper::push_pd(const frame& f) {
-  *(intptr_t**)(f.sp() - 2) = f.fp();
+  *(intptr_t**)(f.sp() - frame::metadata_words) = f.fp();
 }
 
 inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, ContinuationEntry* entry) {
@@ -89,7 +89,7 @@ inline void ContinuationHelper::set_anchor_to_entry_pd(JavaFrameAnchor* anchor, 
 }
 
 inline void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t* sp) {
-  intptr_t* fp = *(intptr_t**)(sp - 2);
+  intptr_t* fp = *(intptr_t**)(sp - frame::metadata_words);
   anchor->set_last_Java_fp(fp);
 }
 
@@ -97,7 +97,7 @@ inline void ContinuationHelper::set_anchor_pd(JavaFrameAnchor* anchor, intptr_t*
 inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
   intptr_t* sp = f.sp();
   address pc = *(address*)(sp - frame::sender_sp_ret_address_offset());
-  intptr_t* fp = *(intptr_t**)(sp - 2);
+  intptr_t* fp = *(intptr_t**)(sp - frame::metadata_words);
   assert(f.raw_pc() == pc, "f.ra_pc: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.raw_pc()), p2i(pc));
   assert(f.fp() == fp, "f.fp: " INTPTR_FORMAT " actual: " INTPTR_FORMAT, p2i(f.fp()), p2i(fp));
   return f.raw_pc() == pc && f.fp() == fp;
@@ -105,7 +105,7 @@ inline bool ContinuationHelper::Frame::assert_frame_laid_out(frame f) {
 #endif
 
 inline intptr_t** ContinuationHelper::Frame::callee_link_address(const frame& f) {
-  return (intptr_t**)(f.sp() - 2);
+  return (intptr_t**)(f.sp() - frame::metadata_words);
 }
 
 inline address* ContinuationHelper::Frame::return_pc_address(const frame& f) {

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -154,7 +154,7 @@ bool frame::safe_for_sender(JavaThread *thread) {
 
       sender_unextended_sp = sender_sp;
       sender_pc = (address) *(sender_sp - 1);
-      saved_fp = (intptr_t*) *(sender_sp - 2);
+      saved_fp = (intptr_t*) *(sender_sp - frame::metadata_words);
     }
 
     if (Continuation::is_return_barrier_entry(sender_pc)) {
@@ -635,7 +635,7 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
       fp_loc = fp();
     } else {
       ret_pc_loc = real_fp() - 1;
-      fp_loc = real_fp() - 2;
+      fp_loc = real_fp() - frame::metadata_words;
     }
     address ret_pc = *(address*)ret_pc_loc;
     values.describe(frame_no, ret_pc_loc,

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -147,7 +147,10 @@ inline frame::frame(intptr_t* ptr_sp, intptr_t* unextended_sp, intptr_t* ptr_fp,
   setup(pc);
 }
 
-inline frame::frame(intptr_t* ptr_sp) : frame(ptr_sp, ptr_sp, *(intptr_t**)(ptr_sp - 2), *(address*)(ptr_sp - 1)) {}
+inline frame::frame(intptr_t* ptr_sp)
+  : frame(ptr_sp, ptr_sp,
+          *(intptr_t**)(ptr_sp - frame::metadata_words),
+          *(address*)(ptr_sp - 1)) {}
 
 inline frame::frame(intptr_t* ptr_sp, intptr_t* ptr_fp) {
   intptr_t a = intptr_t(ptr_sp);

--- a/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/smallRegisterMap_riscv.inline.hpp
@@ -51,13 +51,13 @@ public:
   RegisterMap* copy_to_RegisterMap(RegisterMap* map, intptr_t* sp) const {
     map->clear();
     map->set_include_argument_oops(this->include_argument_oops());
-    frame::update_map_with_saved_link(map, (intptr_t**)sp - 2);
+    frame::update_map_with_saved_link(map, (intptr_t**)sp - frame::metadata_words);
     return map;
   }
 
   inline address location(VMReg reg, intptr_t* sp) const {
     assert_is_fp(reg);
-    return (address)(sp - 2);
+    return (address)(sp - frame::metadata_words);
   }
 
   inline void set_location(VMReg reg, address loc) { assert_is_fp(reg); }

--- a/src/hotspot/cpu/riscv/stackChunkFrameStream_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/stackChunkFrameStream_riscv.inline.hpp
@@ -36,7 +36,7 @@ inline bool StackChunkFrameStream<frame_kind>::is_in_frame(void* p0) const {
   intptr_t* p = (intptr_t*)p0;
   int argsize = is_compiled() ? (_cb->as_nmethod()->num_stack_arg_slots() * VMRegImpl::stack_slot_size) >> LogBytesPerWord : 0;
   int frame_size = _cb->frame_size() + argsize;
-  return p == sp() - 2 || ((p - unextended_sp()) >= 0 && (p - unextended_sp()) < frame_size);
+  return p == sp() - frame::metadata_words || ((p - unextended_sp()) >= 0 && (p - unextended_sp()) < frame_size);
 }
 #endif
 
@@ -57,7 +57,7 @@ inline address StackChunkFrameStream<frame_kind>::get_pc() const {
 
 template <ChunkFrames frame_kind>
 inline intptr_t* StackChunkFrameStream<frame_kind>::fp() const {
-  intptr_t* fp_addr = _sp - 2;
+  intptr_t* fp_addr = _sp - frame::metadata_words;
   return (frame_kind == ChunkFrames::Mixed && is_interpreted())
     ? fp_addr + *fp_addr // derelativize
     : *(intptr_t**)fp_addr;
@@ -123,7 +123,8 @@ template<>
 template<>
 inline void StackChunkFrameStream<ChunkFrames::Mixed>::update_reg_map_pd(RegisterMap* map) {
   if (map->update_map()) {
-    frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)2 : (intptr_t**)(_sp - 2));
+    frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)(intptr_t)frame::metadata_words
+                                                          : (intptr_t**)(_sp - frame::metadata_words));
   }
 }
 
@@ -131,7 +132,8 @@ template<>
 template<>
 inline void StackChunkFrameStream<ChunkFrames::CompiledOnly>::update_reg_map_pd(RegisterMap* map) {
   if (map->update_map()) {
-    frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)2 : (intptr_t**)(_sp - 2));
+    frame::update_map_with_saved_link(map, map->in_cont() ? (intptr_t**)(intptr_t)frame::metadata_words
+                                                          : (intptr_t**)(_sp - frame::metadata_words));
   }
 }
 


### PR DESCRIPTION
Hello, please review this RISC-V specific change which improves code readability.

Some background to help understand. We have following frame enumerations in file frame_riscv.hpp:
```
enum {
  link_offset           = -2,
  return_addr_offset    = -1,
  sender_sp_offset      =  0
};
```
The values are compatible with the platform ABI and are different from other platforms like x64 and aarch64. Especially, `sender_sp_offset` is 0 for RISC-V compared to 2 for x64 and aarch64. As a result, there exists some differences in places where code calculates fp through offseting pointer sp by value `sender_sp_offset`. For RISC-V, we need to use constant number 2 instead of `sender_sp_offset` as the pointer offset. But the code will be more readable if we use `frame::metadata_words` which has the same value. This change would not affect correctness or functionality in theory.

Testing on linux-riscv64:
- [x] hotspot:tier1 (release)
- [x] hotspot_loom & jdk_loom (release & fastdebug)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344169](https://bugs.openjdk.org/browse/JDK-8344169): RISC-V: Use more meaningful frame::metadata_words where possible (**Enhancement** - P4)


### Reviewers
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22096/head:pull/22096` \
`$ git checkout pull/22096`

Update a local copy of the PR: \
`$ git checkout pull/22096` \
`$ git pull https://git.openjdk.org/jdk.git pull/22096/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22096`

View PR using the GUI difftool: \
`$ git pr show -t 22096`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22096.diff">https://git.openjdk.org/jdk/pull/22096.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22096#issuecomment-2475640032)
</details>
