### PR TITLE
8344176: Remove SecurityManager-dependant URL checking from URLClassPath

### DIFF
--- a/src/java.base/share/classes/java/net/URLClassLoader.java
+++ b/src/java.base/share/classes/java/net/URLClassLoader.java
@@ -379,7 +379,7 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
                 new PrivilegedExceptionAction<>() {
                     public Class<?> run() throws ClassNotFoundException {
                         String path = name.replace('.', '/').concat(".class");
-                        Resource res = ucp.getResource(path, false);
+                        Resource res = ucp.getResource(path);
                         if (res != null) {
                             try {
                                 return defineClass(name, res);
@@ -582,11 +582,11 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
         URL url = AccessController.doPrivileged(
             new PrivilegedAction<>() {
                 public URL run() {
-                    return ucp.findResource(name, true);
+                    return ucp.findResource(name);
                 }
             }, acc);
 
-        return url != null ? URLClassPath.checkURL(url) : null;
+        return url;
     }
 
     /**
@@ -601,45 +601,7 @@ public class URLClassLoader extends SecureClassLoader implements Closeable {
     public Enumeration<URL> findResources(final String name)
         throws IOException
     {
-        final Enumeration<URL> e = ucp.findResources(name, true);
-
-        return new Enumeration<>() {
-            private URL url = null;
-
-            private boolean next() {
-                if (url != null) {
-                    return true;
-                }
-                do {
-                    @SuppressWarnings("removal")
-                    URL u = AccessController.doPrivileged(
-                        new PrivilegedAction<>() {
-                            public URL run() {
-                                if (!e.hasMoreElements())
-                                    return null;
-                                return e.nextElement();
-                            }
-                        }, acc);
-                    if (u == null)
-                        break;
-                    url = URLClassPath.checkURL(u);
-                } while (url == null);
-                return url != null;
-            }
-
-            public URL nextElement() {
-                if (!next()) {
-                    throw new NoSuchElementException();
-                }
-                URL u = url;
-                url = null;
-                return u;
-            }
-
-            public boolean hasMoreElements() {
-                return next();
-            }
-        };
+        return ucp.findResources(name);
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/loader/Loader.java
+++ b/src/java.base/share/classes/jdk/internal/loader/Loader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -352,22 +352,6 @@ public final class Loader extends SecureClassLoader {
                 });
         } catch (PrivilegedActionException pae) {
             throw (IOException) pae.getCause();
-        }
-
-        // check access with permissions restricted by ACC
-        if (url != null && System.getSecurityManager() != null) {
-            try {
-                URL urlToCheck = url;
-                url = AccessController.doPrivileged(
-                    new PrivilegedExceptionAction<URL>() {
-                        @Override
-                        public URL run() throws IOException {
-                            return URLClassPath.checkURL(urlToCheck);
-                        }
-                    }, acc);
-            } catch (PrivilegedActionException pae) {
-                url = null;
-            }
         }
 
         return url;

--- a/src/java.base/share/classes/sun/net/www/protocol/jrt/JavaRuntimeURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jrt/JavaRuntimeURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import jdk.internal.jimage.ImageLocation;
 import jdk.internal.jimage.ImageReader;
 import jdk.internal.jimage.ImageReaderFactory;
 
-import jdk.internal.loader.URLClassPath;
 import jdk.internal.loader.Resource;
 import sun.net.www.ParseUtil;
 import sun.net.www.URLConnection;
@@ -92,7 +91,7 @@ public class JavaRuntimeURLConnection extends URLConnection {
         if (reader != null) {
             URL url = toJrtURL(module, name);
             ImageLocation location = reader.findLocation(module, name);
-            if (location != null && URLClassPath.checkURL(url) != null) {
+            if (location != null && url != null) {
                 return new Resource() {
                     @Override
                     public String getName() {


### PR DESCRIPTION
Please review this PR which removes the methods `URLClassPath::check` and its null-returning variant `URLClassPath::checkURL`. These do nothing now that SM is always null.

This PR is deliberately targeted to only remove URL checking. This narrow focus makes this PR easier to review and also removes some noise when removing more general SM-depending code in coming PR. (Happy to take feedback on this scope decision)

Direct and indirect call sites are updated as follows:

* `URLClassPath` methods `getResource`, `findResource`, `getResources` and `findResources` are updated to not take a `boolean check` parameter and to not perform URL checking. 
* `java.net.URLClassLoader` is updated to call non-checking methods in `URLClassPath`
* `URLClassLoader:findResources` currently returns a custom `Enumeration` which performs lazy checking. This is now changed to simply return the result of `URLClassPath::findResources`.
* `jdk.internal.loader.BuiltinClassLoader` is updated to call the non-checking methods in `URLClassPath` and to not call `URLClassPath.checkURL`. The `findResources` method is updated to not return a custom `Enumeration` which performs  lazy URL checking.
* `jdk.internal.loader.Loader` is updated to not call `checkURL`.
* `sun.net.www.protocol.jrt.JavaRuntimeURLConnection` is updated to not call `checkURL`

Verification: This is a cleanup PR. No tests are added or updated. GHA results pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344176](https://bugs.openjdk.org/browse/JDK-8344176): Remove SecurityManager-dependant URL checking from URLClassPath (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22098/head:pull/22098` \
`$ git checkout pull/22098`

Update a local copy of the PR: \
`$ git checkout pull/22098` \
`$ git pull https://git.openjdk.org/jdk.git pull/22098/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22098`

View PR using the GUI difftool: \
`$ git pr show -t 22098`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22098.diff">https://git.openjdk.org/jdk/pull/22098.diff</a>

</details>
