### PR TITLE
8344179: SecurityManager cleanup in the ZIP and JAR areas

### DIFF
--- a/src/java.base/share/classes/java/util/jar/JarFile.java
+++ b/src/java.base/share/classes/java/util/jar/JarFile.java
@@ -28,7 +28,6 @@ package java.util.jar;
 import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.JavaUtilZipFileAccess;
 import jdk.internal.misc.ThreadTracker;
-import sun.security.action.GetPropertyAction;
 import sun.security.util.ManifestEntryVerifier;
 import sun.security.util.SignatureFileVerifier;
 
@@ -171,7 +170,7 @@ public class JarFile extends ZipFile {
         // multi-release jar file versions >= 9
         BASE_VERSION = Runtime.Version.parse(Integer.toString(8));
         BASE_VERSION_FEATURE = BASE_VERSION.feature();
-        String jarVersion = GetPropertyAction.privilegedGetProperty("jdk.util.jar.version");
+        String jarVersion = System.getProperty("jdk.util.jar.version");
         int runtimeVersion = Runtime.version().feature();
         if (jarVersion != null) {
             int jarVer = Integer.parseInt(jarVersion);
@@ -180,8 +179,8 @@ public class JarFile extends ZipFile {
                     : Math.max(jarVer, BASE_VERSION_FEATURE);
         }
         RUNTIME_VERSION = Runtime.Version.parse(Integer.toString(runtimeVersion));
-        String enableMultiRelease = GetPropertyAction
-                .privilegedGetProperty("jdk.util.jar.enableMultiRelease", "true");
+        String enableMultiRelease = System.
+                getProperty("jdk.util.jar.enableMultiRelease", "true");
         switch (enableMultiRelease) {
             case "false" -> {
                 MULTI_RELEASE_ENABLED = false;

--- a/src/java.base/share/classes/java/util/zip/ZipFile.java
+++ b/src/java.base/share/classes/java/util/zip/ZipFile.java
@@ -55,7 +55,6 @@ import jdk.internal.ref.CleanerFactory;
 import jdk.internal.vm.annotation.Stable;
 import sun.nio.cs.UTF_8;
 import sun.nio.fs.DefaultFileSystemProvider;
-import sun.security.action.GetPropertyAction;
 import sun.security.util.SignatureFileVerifier;
 
 import static java.util.zip.ZipConstants64.*;
@@ -193,14 +192,6 @@ public class ZipFile implements ZipConstants, Closeable {
         }
         String name = file.getPath();
         file = new File(name);
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkRead(name);
-            if ((mode & OPEN_DELETE) != 0) {
-                sm.checkDelete(name);
-            }
-        }
         Objects.requireNonNull(charset, "charset");
 
         this.filePath = name;
@@ -1059,8 +1050,7 @@ public class ZipFile implements ZipConstants, Closeable {
      */
     static boolean getDisableZip64ExtraFieldValidation() {
         boolean result;
-        String value = GetPropertyAction.privilegedGetProperty(
-                "jdk.util.zip.disableZip64ExtraFieldValidation");
+        String value = System.getProperty("jdk.util.zip.disableZip64ExtraFieldValidation");
         if (value == null) {
             result = false;
         } else {

--- a/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
+++ b/src/java.base/share/classes/java/util/zip/ZipOutputStream.java
@@ -35,7 +35,6 @@ import static java.util.zip.ZipConstants64.*;
 import static java.util.zip.ZipEntry.isCENHeaderValid;
 import static java.util.zip.ZipUtils.*;
 import sun.nio.cs.UTF_8;
-import sun.security.action.GetBooleanAction;
 
 /**
  * This class implements an output stream filter for writing files in the
@@ -58,7 +57,7 @@ public class ZipOutputStream extends DeflaterOutputStream implements ZipConstant
      * some in jdk7.
      */
     private static final boolean inhibitZip64 =
-        GetBooleanAction.privilegedGetProperty("jdk.util.zip.inhibitZip64");
+        Boolean.getBoolean("jdk.util.zip.inhibitZip64");
 
     private static class XEntry {
         final ZipEntry entry;


### PR DESCRIPTION
Please review this PR which cleans up `SecurityManager`-related code in `java.util.zip` and `java.util.jar`:

* `JarFile` is updated to use `System::getProperty` instead of `GetPropertyAction::privilegedGetProperty`
* `ZipFile` is updated to use `System::getProperty` instead of `GetPropertyAction::privilegedGetProperty`
*  `ZipFile` is updated to not call SM::checkRead, SM::checkDelete
* `ZipOutputStream` is updated to use `Boolean::getBoolean` instead of `GetBooleanAction::privilegedGetProperty`
