### PR TITLE
8268611: jar --validate should check targeted classes in MR-JAR files

### DIFF
--- a/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
@@ -131,8 +131,12 @@ final class FingerPrint {
         return attrs.name;
     }
 
+    public int classMajorVersion() {
+        return attrs.majorVersion; // ..., 53, 54, ...
+    }
+
     public int classReleaseVersion() {
-        return attrs.majorVersion - 44; // 53 -> 9, 54 -> 10, ...
+        return attrs.majorVersion - 44; // ..., 53 -> 9, 54 -> 10, ...
     }
 
     public int mrversion() {

--- a/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/FingerPrint.java
@@ -131,6 +131,10 @@ final class FingerPrint {
         return attrs.name;
     }
 
+    public int classReleaseVersion() {
+        return attrs.majorVersion - 44; // 53 -> 9, 54 -> 10, ...
+    }
+
     public int mrversion() {
         return mrversion;
     }

--- a/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Main.java
@@ -210,18 +210,8 @@ public class Main {
         }
     }
 
-    static String formatMsg(String key, String arg) {
+    static String formatMsg(String key, String... args) {
         String msg = getMsg(key);
-        String[] args = new String[1];
-        args[0] = arg;
-        return MessageFormat.format(msg, (Object[]) args);
-    }
-
-    static String formatMsg2(String key, String arg, String arg1) {
-        String msg = getMsg(key);
-        String[] args = new String[2];
-        args[0] = arg;
-        args[1] = arg1;
         return MessageFormat.format(msg, (Object[]) args);
     }
 
@@ -459,7 +449,7 @@ public class Main {
         try (ZipFile zf = new ZipFile(file)) {
             return Validator.validate(this, zf);
         } catch (IOException e) {
-            error(formatMsg2("error.validator.jarfile.exception", fname, e.getMessage()));
+            error(formatMsg("error.validator.jarfile.exception", fname, e.getMessage()));
             return true;
         }
     }
@@ -840,7 +830,7 @@ public class Main {
                     // the entry starts with VERSIONS_DIR and version != BASE_VERSION,
                     // which means the "[dirs|files]" in --release v [dirs|files]
                     // includes VERSIONS_DIR-ed entries --> warning and skip (?)
-                    error(formatMsg2("error.release.unexpected.versioned.entry",
+                    error(formatMsg("error.release.unexpected.versioned.entry",
                                      name, String.valueOf(version)));
                     ok = false;
                     return;
@@ -1264,8 +1254,7 @@ public class Main {
         if (vflag) {
             size = e.getSize();
             long csize = e.getCompressedSize();
-            out.print(formatMsg2("out.size", String.valueOf(size),
-                        String.valueOf(csize)));
+            out.print(formatMsg("out.size", String.valueOf(size), String.valueOf(csize)));
             if (e.getMethod() == ZipEntry.DEFLATED) {
                 long ratio = 0;
                 if (size != 0) {

--- a/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
@@ -51,7 +51,6 @@ import static sun.tools.jar.Main.VERSIONS_DIR_LENGTH;
 import static sun.tools.jar.Main.MODULE_INFO;
 import static sun.tools.jar.Main.getMsg;
 import static sun.tools.jar.Main.formatMsg;
-import static sun.tools.jar.Main.formatMsg2;
 import static sun.tools.jar.Main.toBinaryName;
 
 final class Validator {
@@ -166,8 +165,12 @@ final class Validator {
         fps.values().forEach( fp -> {
             // all versioned entries must be compatible with their release target number
             if (fp.mrversion() < fp.classReleaseVersion()) {
-                errorAndInvalid(formatMsg2("error.release.value.toohigh.versioned.entry",
-                        fp.entryName(), String.valueOf(fp.classReleaseVersion())));
+                String actual = fp.classMajorVersion() + " (Java " + fp.classReleaseVersion() + ")";
+                errorAndInvalid(formatMsg("error.release.value.toohigh.versioned.entry",
+                        fp.entryName(), // META-INF/versions/9/com/foo/Bar.class has class file version
+                        actual, // 69 (Java 25), but class file version
+                        String.valueOf(fp.mrversion() + 44), // 53 or less is required to target release
+                        String.valueOf(fp.mrversion()))); // 9 of the Java Platform
                 return;
             }
             // validate the versioned module-info
@@ -315,7 +318,7 @@ final class Validator {
         if (fp.className().equals(className(fp.basename()))) {
             return true;
         }
-        error(formatMsg2("error.validator.names.mismatch",
+        error(formatMsg("error.validator.names.mismatch",
                          fp.entryName(), fp.className().replace("/", ".")));
         return isValid = false;
     }

--- a/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -164,7 +164,12 @@ final class Validator {
     public void validateVersioned(Map<String, FingerPrint> fps) {
 
         fps.values().forEach( fp -> {
-
+            // all versioned entries must be compatible with their release target number
+            if (fp.mrversion() < fp.classReleaseVersion()) {
+                errorAndInvalid(formatMsg2("error.release.unexpected.versioned.entry",
+                        fp.entryName(), String.valueOf(fp.classReleaseVersion())));
+                return;
+            }
             // validate the versioned module-info
             if (MODULE_INFO.equals(fp.basename())) {
                 checkModuleDescriptor(fp.entryName());

--- a/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
@@ -167,7 +167,7 @@ final class Validator {
             if (fp.mrversion() < fp.classReleaseVersion()) {
                 errorAndInvalid(formatMsg("error.release.value.toohigh.versioned.entry",
                         fp.entryName(), // META-INF/versions/9/com/foo/Bar.class has class file version
-                        fp.classMajorVersion(), // 69, but class file version
+                        String.valueOf(fp.classMajorVersion()), // 69, but class file version
                         String.valueOf(fp.mrversion() + 44), // 53 or less is required to target release
                         String.valueOf(fp.mrversion()))); // 9 of the Java Platform
                 return;

--- a/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
@@ -165,10 +165,9 @@ final class Validator {
         fps.values().forEach( fp -> {
             // all versioned entries must be compatible with their release target number
             if (fp.mrversion() < fp.classReleaseVersion()) {
-                String actual = fp.classMajorVersion() + " (Java " + fp.classReleaseVersion() + ")";
                 errorAndInvalid(formatMsg("error.release.value.toohigh.versioned.entry",
                         fp.entryName(), // META-INF/versions/9/com/foo/Bar.class has class file version
-                        actual, // 69 (Java 25), but class file version
+                        fp.classMajorVersion(), // 69, but class file version
                         String.valueOf(fp.mrversion() + 44), // 53 or less is required to target release
                         String.valueOf(fp.mrversion()))); // 9 of the Java Platform
                 return;

--- a/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/Validator.java
@@ -166,7 +166,7 @@ final class Validator {
         fps.values().forEach( fp -> {
             // all versioned entries must be compatible with their release target number
             if (fp.mrversion() < fp.classReleaseVersion()) {
-                errorAndInvalid(formatMsg2("error.release.unexpected.versioned.entry",
+                errorAndInvalid(formatMsg2("error.release.value.toohigh.versioned.entry",
                         fp.entryName(), String.valueOf(fp.classReleaseVersion())));
                 return;
             }

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -91,7 +91,7 @@ error.release.value.toosmall=\
 error.release.unexpected.versioned.entry=\
         unexpected versioned entry {0} for release {1}
 error.release.value.toohigh.versioned.entry=\
-        classfile release value of {0} too high: {1}
+        {0} has class file version {1}, but class file version {2} or less is required to target release {3} of the Java Platform
 error.date.notvalid=\
         date {0} is not a valid ISO-8601 extended offset date-time with optional time-zone
 error.date.out.of.range=\

--- a/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
+++ b/src/jdk.jartool/share/classes/sun/tools/jar/resources/jar.properties
@@ -90,6 +90,8 @@ error.release.value.toosmall=\
         release {0} not valid, must be >= 9
 error.release.unexpected.versioned.entry=\
         unexpected versioned entry {0} for release {1}
+error.release.value.toohigh.versioned.entry=\
+        classfile release value of {0} too high: {1}
 error.date.notvalid=\
         date {0} is not a valid ISO-8601 extended offset date-time with optional time-zone
 error.date.out.of.range=\

--- a/test/jdk/sun/security/tools/jarsigner/multiRelease/MVJarSigningTest.java
+++ b/test/jdk/sun/security/tools/jarsigner/multiRelease/MVJarSigningTest.java
@@ -125,15 +125,15 @@ public class MVJarSigningTest {
     private static void compile (String jarContent_path) throws Throwable {
         Path classes = Paths.get(USR_DIR, "classes", "base");
         Path source = Paths.get(TEST_SRC, jarContent_path, "base", "version");
-        CompilerUtils.compile(source, classes);
+        CompilerUtils.compile(source, classes, "--release", "8");
 
         classes = Paths.get(USR_DIR, "classes", "v9");
         source = Paths.get(TEST_SRC, jarContent_path , "v9", "version");
-        CompilerUtils.compile(source, classes);
+        CompilerUtils.compile(source, classes, "--release", "9");
 
         classes = Paths.get(USR_DIR, "classes", "v10");
         source = Paths.get(TEST_SRC, jarContent_path, "v10", "version");
-        CompilerUtils.compile(source, classes);
+        CompilerUtils.compile(source, classes, "--release", "10");
     }
 
     private static OutputAnalyzer jar(String...args) throws Throwable {

--- a/test/jdk/tools/jar/multiRelease/ApiValidatorTest.java
+++ b/test/jdk/tools/jar/multiRelease/ApiValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -82,8 +82,8 @@ public class ApiValidatorTest extends MRTestBase {
         String base = classTemplate.replace(METHOD_SIG, sigBase);
         String v10 = classTemplate.replace(METHOD_SIG, sigV10);
 
-        compileTemplate(classes.resolve("base"), base);
-        compileTemplate(classes.resolve("v10"), v10);
+        compileTemplate(8, classes.resolve("base"), base);
+        compileTemplate(10, classes.resolve("v10"), v10);
 
         String jarfile = root.resolve("test.jar").toString();
         OutputAnalyzer result = jar("cf", jarfile,
@@ -135,8 +135,8 @@ public class ApiValidatorTest extends MRTestBase {
         String base = classTemplate.replace(API, "");
         String v10 = classTemplate.replace(API, publicAPI);
 
-        compileTemplate(classes.resolve("base"), base);
-        compileTemplate(classes.resolve("v10"), v10);
+        compileTemplate(8, classes.resolve("base"), base);
+        compileTemplate(10, classes.resolve("v10"), v10);
 
         String failureMessage = "contains a class with different api from earlier version";
 
@@ -176,8 +176,8 @@ public class ApiValidatorTest extends MRTestBase {
         String base = classTemplate.replace(API, "");
         String v10 = classTemplate.replace(API, privateAPI);
 
-        compileTemplate(classes.resolve("base"), base);
-        compileTemplate(classes.resolve("v10"), v10);
+        compileTemplate(8, classes.resolve("base"), base);
+        compileTemplate(10, classes.resolve("v10"), v10);
 
         String jarfile = root.resolve("test.jar").toString();
         jar("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
@@ -208,12 +208,12 @@ public class ApiValidatorTest extends MRTestBase {
         };
     }
 
-    private void compileTemplate(Path classes, String template) throws Throwable {
+    private void compileTemplate(int release, Path classes, String template) throws Throwable {
         Path classSourceFile = Files.createDirectories(
                 classes.getParent().resolve("src").resolve(classes.getFileName()))
                 .resolve("C.java");
         Files.write(classSourceFile, template.getBytes());
-        javac(classes, classSourceFile);
+        javac(release, classes, classSourceFile);
     }
 
      /* Modular multi-release checks */
@@ -452,7 +452,7 @@ public class ApiValidatorTest extends MRTestBase {
             sourceFiles[i + 1] = sourceFile;
         }
 
-        javac(classes, sourceFiles);
+        javac(9, classes, sourceFiles);
     }
 
     @SafeVarargs

--- a/test/jdk/tools/jar/multiRelease/Basic.java
+++ b/test/jdk/tools/jar/multiRelease/Basic.java
@@ -213,7 +213,7 @@ public class Basic extends MRTestBase {
         jarTool("uf", jarfile, "-C", classes.resolve("v9").toString(), "version",
                 "--release", "9", "-C", classes.resolve("v10").toString(), ".")
                 .shouldNotHaveExitValue(SUCCESS)
-                .shouldContain("unexpected versioned entry");
+                .shouldContain("classfile release value of META-INF/versions/9/version/Version.class too high: 10");
 
         FileUtils.deleteFileIfExistsWithRetry(Paths.get(jarfile));
         FileUtils.deleteFileTreeWithRetry(Paths.get(usr, "classes"));

--- a/test/jdk/tools/jar/multiRelease/Basic.java
+++ b/test/jdk/tools/jar/multiRelease/Basic.java
@@ -213,7 +213,10 @@ public class Basic extends MRTestBase {
         jarTool("uf", jarfile, "-C", classes.resolve("v9").toString(), "version",
                 "--release", "9", "-C", classes.resolve("v10").toString(), ".")
                 .shouldNotHaveExitValue(SUCCESS)
-                .shouldContain("classfile release value of META-INF/versions/9/version/Version.class too high: 10");
+                .shouldContain("META-INF/versions/9/version/Version.class")
+                .shouldContain(" has class file version 54 (Java 10),")
+                .shouldContain(" but class file version 53 or less is required")
+                .shouldContain(" to target release 9 of the Java Platform");
 
         FileUtils.deleteFileIfExistsWithRetry(Paths.get(jarfile));
         FileUtils.deleteFileTreeWithRetry(Paths.get(usr, "classes"));

--- a/test/jdk/tools/jar/multiRelease/Basic.java
+++ b/test/jdk/tools/jar/multiRelease/Basic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,7 +23,7 @@
 
 /*
  * @test
- # @bug 8186087 8196748 8212807
+ # @bug 8186087 8196748 8212807 8268611
  * @library /test/lib
  * @modules java.base/jdk.internal.misc
  *          jdk.compiler
@@ -126,9 +126,9 @@ public class Basic extends MRTestBase {
         Path classes = Paths.get("classes");
 
         // valid
-        for (String release : List.of("10000", "09", "00010", "10")) {
+        for (String release : List.of("09", "00010", "10")) {
             jarTool("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
-                    "--release", release, "-C", classes.resolve("v10").toString(), ".")
+                    "--release", release, "-C", classes.resolve("v9").toString(), ".")
                     .shouldHaveExitValue(SUCCESS)
                     .shouldBeEmptyIgnoreVMWarnings();
         }
@@ -207,26 +207,13 @@ public class Basic extends MRTestBase {
 
         compare(jarfile, names);
 
+        // 8268611: The following creates an invalid JAR, which gets deleted.
         // write the v9 version/Version.class entry in base and the v10
         // version/Version.class entry in versions/9 section
         jarTool("uf", jarfile, "-C", classes.resolve("v9").toString(), "version",
                 "--release", "9", "-C", classes.resolve("v10").toString(), ".")
-                .shouldHaveExitValue(SUCCESS);
-
-        checkMultiRelease(jarfile, true);
-
-        names = Map.of(
-                "version/Main.class",
-                new String[]{"base", "version", "Main.class"},
-
-                "version/Version.class",
-                new String[]{"v9", "version", "Version.class"},
-
-                "META-INF/versions/9/version/Version.class",
-                new String[]{"v10", "version", "Version.class"}
-        );
-
-        compare(jarfile, names);
+                .shouldNotHaveExitValue(SUCCESS)
+                .shouldContain("unexpected versioned entry");
 
         FileUtils.deleteFileIfExistsWithRetry(Paths.get(jarfile));
         FileUtils.deleteFileTreeWithRetry(Paths.get(usr, "classes"));
@@ -247,7 +234,7 @@ public class Basic extends MRTestBase {
 
         // replace the v9 class
         Path source = Paths.get(src, "data", "test04", "v9", "version");
-        javac(classes.resolve("v9"), source.resolve("Version.java"));
+        javac(9, classes.resolve("v9"), source.resolve("Version.java"));
 
         jarTool("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "9", "-C", classes.resolve("v9").toString(), ".")
@@ -269,7 +256,7 @@ public class Basic extends MRTestBase {
 
         // add the new v9 class
         Path source = Paths.get(src, "data", "test05", "v9", "version");
-        javac(classes.resolve("v9"), source.resolve("Extra.java"));
+        javac(9, classes.resolve("v9"), source.resolve("Extra.java"));
 
         jarTool("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "9", "-C", classes.resolve("v9").toString(), ".")
@@ -291,7 +278,7 @@ public class Basic extends MRTestBase {
 
         // add the new v9 class
         Path source = Paths.get(src, "data", "test06", "v9", "version");
-        javac(classes.resolve("v9"), source.resolve("Extra.java"));
+        javac(9, classes.resolve("v9"), source.resolve("Extra.java"));
 
         jarTool("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "9", "-C", classes.resolve("v9").toString(), ".")
@@ -313,7 +300,7 @@ public class Basic extends MRTestBase {
 
         // add the new v9 class
         Path source = Paths.get(src, "data", "test01", "base", "version");
-        javac(classes.resolve("v9"), source.resolve("Version.java"));
+        javac(9, classes.resolve("v9"), source.resolve("Version.java"));
 
         jarTool("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "9", "-C", classes.resolve("v9").toString(), ".")
@@ -382,11 +369,11 @@ public class Basic extends MRTestBase {
 
         // add a base class with a nested class
         Path source = Paths.get(src, "data", "test10", "base", "version");
-        javac(classes.resolve("base"), source.resolve("Nested.java"));
+        javac(8, classes.resolve("base"), source.resolve("Nested.java"));
 
         // add a versioned class with a nested class
         source = Paths.get(src, "data", "test10", "v9", "version");
-        javac(classes.resolve("v9"), source.resolve("Nested.java"));
+        javac(9, classes.resolve("v9"), source.resolve("Nested.java"));
 
         jarTool("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "9", "-C", classes.resolve("v9").toString(), ".")
@@ -407,14 +394,14 @@ public class Basic extends MRTestBase {
 
         // add a base class with a nested class
         Path source = Paths.get(src, "data", "test10", "base", "version");
-        javac(classes.resolve("base"), source.resolve("Nested.java"));
+        javac(8, classes.resolve("base"), source.resolve("Nested.java"));
 
         // remove the top level class, thus isolating the nested class
         Files.delete(classes.resolve("base").resolve("version").resolve("Nested.class"));
 
         // add a versioned class with a nested class
         source = Paths.get(src, "data", "test10", "v9", "version");
-        javac(classes.resolve("v9"), source.resolve("Nested.java"));
+        javac(9, classes.resolve("v9"), source.resolve("Nested.java"));
 
         List<String> output = jarTool("cf", jarfile,
                 "-C", classes.resolve("base").toString(), ".",
@@ -460,11 +447,11 @@ public class Basic extends MRTestBase {
 
         // add a base class with a nested class
         Path source = Paths.get(src, "data", "test10", "base", "version");
-        javac(classes.resolve("base"), source.resolve("Nested.java"));
+        javac(8, classes.resolve("base"), source.resolve("Nested.java"));
 
         // add a versioned class with a nested class
         source = Paths.get(src, "data", "test10", "v9", "version");
-        javac(classes.resolve("v9"), source.resolve("Nested.java"));
+        javac(9, classes.resolve("v9"), source.resolve("Nested.java"));
 
         // remove the top level class, thus isolating the nested class
         Files.delete(classes.resolve("v9").resolve("version").resolve("Nested.class"));
@@ -489,11 +476,11 @@ public class Basic extends MRTestBase {
 
         // add a base class with a nested and nested-nested class
         Path source = Paths.get(src, "data", "test13", "base", "version");
-        javac(classes.resolve("base"), source.resolve("Nested.java"));
+        javac(8, classes.resolve("base"), source.resolve("Nested.java"));
 
         // add a versioned class with a nested and nested-nested class
         source = Paths.get(src, "data", "test13", "v10", "version");
-        javac(classes.resolve("v10"), source.resolve("Nested.java"));
+        javac(10, classes.resolve("v10"), source.resolve("Nested.java"));
 
         jarTool("cf", jarfile, "-C", classes.resolve("base").toString(), ".",
                 "--release", "10", "-C", classes.resolve("v10").toString(), ".")
@@ -535,7 +522,7 @@ public class Basic extends MRTestBase {
 
         jar("ufm", jarfile, manifest.toString(),
                 "-C", classes.resolve("base").toString(), ".",
-                "--release", "9", "-C", classes.resolve("v10").toString(), ".")
+                "--release", "9", "-C", classes.resolve("v9").toString(), ".")
                 .shouldHaveExitValue(SUCCESS)
                 .shouldContain("WARNING: Duplicate name in Manifest: Multi-release.");
 

--- a/test/jdk/tools/jar/multiRelease/Basic.java
+++ b/test/jdk/tools/jar/multiRelease/Basic.java
@@ -214,7 +214,7 @@ public class Basic extends MRTestBase {
                 "--release", "9", "-C", classes.resolve("v10").toString(), ".")
                 .shouldNotHaveExitValue(SUCCESS)
                 .shouldContain("META-INF/versions/9/version/Version.class")
-                .shouldContain(" has class file version 54 (Java 10),")
+                .shouldContain(" has class file version 54,")
                 .shouldContain(" but class file version 53 or less is required")
                 .shouldContain(" to target release 9 of the Java Platform");
 

--- a/test/jdk/tools/jar/multiRelease/Basic1.java
+++ b/test/jdk/tools/jar/multiRelease/Basic1.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,22 +52,22 @@ public class Basic1 extends MRTestBase {
         Path base = classes.resolve("base");
         Files.createDirectories(base);
         Path source = Paths.get(src, "data", test, "base", "version");
-        javac(base, source.resolve("Main.java"), source.resolve("Version.java"));
+        javac(8, base, source.resolve("Main.java"), source.resolve("Version.java"));
 
         Path v9 = classes.resolve("v9");
         Files.createDirectories(v9);
         source = Paths.get(src, "data", test, "v9", "version");
-        javac(v9, source.resolve("Version.java"));
+        javac(9, v9, source.resolve("Version.java"));
 
         Path v10 = classes.resolve("v10");
         Files.createDirectories(v10);
         source = Paths.get(src, "data", test, "v10", "version");
-        javac(v10, source.resolve("Version.java"));
+        javac(10, v10, source.resolve("Version.java"));
 
         Path v10_1 = classes.resolve("v10_1").resolve("META-INF").resolve("versions").resolve("v10");
         Files.createDirectories(v10_1);
         source = Paths.get(src, "data", test, "v10", "version");
-        javac(v10_1, source.resolve("Version.java"));
+        javac(10, v10_1, source.resolve("Version.java"));
     }
 
     @Test

--- a/test/jdk/tools/jar/multiRelease/MRTestBase.java
+++ b/test/jdk/tools/jar/multiRelease/MRTestBase.java
@@ -102,11 +102,6 @@ public class MRTestBase {
     }
 
     void javac(int release, Path dest, Path... sourceFiles) throws Throwable {
-        javac(release, dest, List.of(), sourceFiles);
-    }
-
-    void javac(int release, Path dest, List<String> extraParameters, Path... sourceFiles) throws Throwable {
-
         List<String> commands = new ArrayList<>();
         String opts = System.getProperty("test.compiler.opts");
         if (!opts.isEmpty()) {
@@ -116,10 +111,7 @@ public class MRTestBase {
         commands.add(String.valueOf(release));
         commands.add("-d");
         commands.add(dest.toString());
-        Stream.of(sourceFiles)
-                .map(Object::toString)
-                .forEach(x -> commands.add(x));
-        commands.addAll(extraParameters);
+        Stream.of(sourceFiles).map(Object::toString).forEach(commands::add);
 
         StringWriter sw = new StringWriter();
         try (PrintWriter pw = new PrintWriter(sw)) {

--- a/test/jdk/tools/jar/multiRelease/MRTestBase.java
+++ b/test/jdk/tools/jar/multiRelease/MRTestBase.java
@@ -62,17 +62,17 @@ public class MRTestBase {
         Path classes = Paths.get(usr, "classes", "base");
         Files.createDirectories(classes);
         Path source = Paths.get(src, "data", test, "base", "version");
-        javac(classes, source.resolve("Main.java"), source.resolve("Version.java"));
+        javac(8, classes, source.resolve("Main.java"), source.resolve("Version.java"));
 
         classes = Paths.get(usr, "classes", "v9");
         Files.createDirectories(classes);
         source = Paths.get(src, "data", test, "v9", "version");
-        javac(classes, source.resolve("Version.java"));
+        javac(9, classes, source.resolve("Version.java"));
 
         classes = Paths.get(usr, "classes", "v10");
         Files.createDirectories(classes);
         source = Paths.get(src, "data", test, "v10", "version");
-        javac(classes, source.resolve("Version.java"));
+        javac(10, classes, source.resolve("Version.java"));
     }
 
     protected void checkMultiRelease(String jarFile,
@@ -101,17 +101,19 @@ public class MRTestBase {
         }
     }
 
-    void javac(Path dest, Path... sourceFiles) throws Throwable {
-        javac(dest, List.of(), sourceFiles);
+    void javac(int release, Path dest, Path... sourceFiles) throws Throwable {
+        javac(release, dest, List.of(), sourceFiles);
     }
 
-    void javac(Path dest, List<String> extraParameters, Path... sourceFiles) throws Throwable {
+    void javac(int release, Path dest, List<String> extraParameters, Path... sourceFiles) throws Throwable {
 
         List<String> commands = new ArrayList<>();
         String opts = System.getProperty("test.compiler.opts");
         if (!opts.isEmpty()) {
             commands.addAll(Arrays.asList(opts.split(" +")));
         }
+        commands.add("--release");
+        commands.add(String.valueOf(release));
         commands.add("-d");
         commands.add(dest.toString());
         Stream.of(sourceFiles)

--- a/test/jdk/tools/jar/multiRelease/VersionValidatorTest.java
+++ b/test/jdk/tools/jar/multiRelease/VersionValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -88,7 +88,7 @@ public class VersionValidatorTest extends MRTestBase {
 
         Path classesDir = root.resolve("classes").resolve(majorVersion);
 
-        javac(classesDir, List.of("--release", majorVersion), sourceFile);
+        javac(Integer.parseInt(majorVersion), classesDir, sourceFile);
         if (enablePreview) {
             rewriteMinorVersionForEnablePreviewClass(classesDir.resolve("Lib.class"));
         }

--- a/test/langtools/tools/jdeps/missingDeps/MissingDepsTest.java
+++ b/test/langtools/tools/jdeps/missingDeps/MissingDepsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class MissingDepsTest {
     private static final Path CLASSES_DIR = Paths.get("classes");
 
     private static final ToolProvider JAR_TOOL = ToolProvider.findFirst("jar").orElseThrow();
-    private static final String VERSION = "13";
+    private static final String VERSION = String.valueOf(Runtime.version().feature());
 
     private static final Set<String> modules = Set.of("m1", "m2");
 
@@ -122,7 +122,7 @@ public class MissingDepsTest {
             JdepsRunner jdepsRunner = new JdepsRunner(options.toArray(new String[0]));
             int rc = jdepsRunner.run(DEBUG);
             assertTrue(rc != 0);
-            String regex = "\\s+13/p.internal.X\\s+->\\s+q.T\\s+not found";
+            String regex = "\\s+" + VERSION + "/p.internal.X\\s+->\\s+q.T\\s+not found";
             assertTrue(Arrays.stream(jdepsRunner.output()).anyMatch(l -> l.matches(regex)));
         }
 

--- a/test/langtools/tools/jdeps/multiVersion/MultiVersionError.java
+++ b/test/langtools/tools/jdeps/multiVersion/MultiVersionError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class MultiVersionError {
     public void compileAll() throws Exception {
         CompilerUtils.cleanDir(MODS_DIR);
         modules.forEach(mn ->
-                assertTrue(CompilerUtils.compileModule(SRC_DIR, MODS_DIR, mn)));
+                assertTrue(CompilerUtils.compileModule(SRC_DIR, MODS_DIR, mn, "--release", "9")));
 
         // create a modular multi-release m1.jar
         Path m1 = MODS_DIR.resolve("m1");


### PR DESCRIPTION
Please review this change ensuring all targeted classes in a MR-JAR file should target the same or a lower classfile version. The [JAR File Specification](https://docs.oracle.com/javase/9/docs/specs/jar/jar.html#Multi-release) of JavaSE 9 reads:

> A class file under a versioned directory, of version N say, in a multi-release JAR must have a class file version less than or equal to the class file version associated with Nth major version of a Java platform release.

For example, having compiled source files with `javac` 25 without using the `--release` option (or with `--release 25`) and trying to archive them via a `jar --create --file a.jar --release 9 ... --release 10 ...` command now fails with:
```
META-INF/versions/9/com/foo/Bar.class has class file version 69.0, but class file version 53.0 or less is required to target release 9 of the Java Platform
invalid multi-release jar file a.jar deleted
```

This pull request contains fixes to existing tests which produced invalid MR-JAR files. Most of those fixes are achieved by adding an appropriate `--release N` option to the associated `javac` call. One of those fixes rewrites the classfile version bytes between the `javac` and `jar` calls.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8268611: jar --validate should check targeted classes in MR-JAR files`

### Issue
 * [JDK-8268611](https://bugs.openjdk.org/browse/JDK-8268611): jar --validate should check targeted classes in MR-JAR files (**Enhancement** - P4)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22103/head:pull/22103` \
`$ git checkout pull/22103`

Update a local copy of the PR: \
`$ git checkout pull/22103` \
`$ git pull https://git.openjdk.org/jdk.git pull/22103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22103`

View PR using the GUI difftool: \
`$ git pr show -t 22103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22103.diff">https://git.openjdk.org/jdk/pull/22103.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22103#issuecomment-2538060972)
</details>
