### PR TITLE
8344185: Remove calls to SecurityManager in sun.net.ftp

### DIFF
--- a/src/java.base/share/classes/sun/net/ftp/FtpClient.java
+++ b/src/java.base/share/classes/sun/net/ftp/FtpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -234,8 +234,6 @@ public abstract class FtpClient implements java.io.Closeable {
      * @param dest the address of the destination server
      * @return this FtpClient
      * @throws IOException if connection failed.
-     * @throws SecurityException if there is a SecurityManager installed and it
-     * denied the authorization to connect to the destination.
      * @throws FtpProtocolException
      */
     public abstract FtpClient connect(SocketAddress dest) throws FtpProtocolException, IOException;
@@ -247,8 +245,6 @@ public abstract class FtpClient implements java.io.Closeable {
      * @param timeout the value, in milliseconds, to use as a connection timeout
      * @return this FtpClient
      * @throws IOException if connection failed.
-     * @throws SecurityException if there is a SecurityManager installed and it
-     * denied the authorization to connect to the destination.
      * @throws FtpProtocolException
      */
     public abstract FtpClient connect(SocketAddress dest, int timeout) throws FtpProtocolException, IOException;

--- a/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
+++ b/src/java.base/share/classes/sun/net/ftp/impl/FtpClient.java
@@ -44,9 +44,6 @@ import java.net.Proxy;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
 import java.text.DateFormat;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -133,31 +130,17 @@ public class FtpClient extends sun.net.ftp.FtpClient {
     private DateFormat df = DateFormat.getDateInstance(DateFormat.MEDIUM, java.util.Locale.US);
     private static final boolean acceptPasvAddressVal;
     static {
-        final int vals[] = {0, 0};
-        final String acceptPasvAddress[] = {null};
-        @SuppressWarnings("removal")
-        final String enc = AccessController.doPrivileged(
-                new PrivilegedAction<String>() {
-                    public String run() {
-                        acceptPasvAddress[0] = System.getProperty("jdk.net.ftp.trustPasvAddress", "false");
-                        vals[0] = Integer.getInteger("sun.net.client.defaultReadTimeout", 300_000).intValue();
-                        vals[1] = Integer.getInteger("sun.net.client.defaultConnectTimeout", 300_000).intValue();
-                        return System.getProperty("file.encoding", "ISO8859_1");
-                    }
-                });
-        if (vals[0] == 0) {
+        defaultSoTimeout = Integer.getInteger("sun.net.client.defaultReadTimeout", 300_000).intValue();
+        if (defaultSoTimeout == 0) {
             defaultSoTimeout = -1;
-        } else {
-            defaultSoTimeout = vals[0];
         }
 
-        if (vals[1] == 0) {
+        defaultConnectTimeout = Integer.getInteger("sun.net.client.defaultConnectTimeout", 300_000).intValue();
+        if (defaultConnectTimeout == 0) {
             defaultConnectTimeout = -1;
-        } else {
-            defaultConnectTimeout = vals[1];
         }
 
-        encoding = enc;
+        encoding = System.getProperty("file.encoding", "ISO8859_1");
         try {
             if (!isASCIISuperset(encoding)) {
                 encoding = "ISO8859_1";
@@ -171,7 +154,7 @@ public class FtpClient extends sun.net.ftp.FtpClient {
             patterns[i] = Pattern.compile(patStrings[i]);
         }
 
-        acceptPasvAddressVal = Boolean.parseBoolean(acceptPasvAddress[0]);
+        acceptPasvAddressVal = Boolean.getBoolean("jdk.net.ftp.trustPasvAddress");
     }
 
     /**
@@ -662,10 +645,7 @@ public class FtpClient extends sun.net.ftp.FtpClient {
         Socket s;
         if (proxy != null) {
             if (proxy.type() == Proxy.Type.SOCKS) {
-                PrivilegedAction<Socket> pa = () -> new Socket(proxy);
-                @SuppressWarnings("removal")
-                var tmp = AccessController.doPrivileged(pa);
-                s = tmp;
+                s = new Socket(proxy);
             } else {
                 s = new Socket(Proxy.NO_PROXY);
             }
@@ -673,9 +653,7 @@ public class FtpClient extends sun.net.ftp.FtpClient {
             s = new Socket();
         }
 
-        PrivilegedAction<InetAddress> pa = () -> server.getLocalAddress();
-        @SuppressWarnings("removal")
-        InetAddress serverAddress = AccessController.doPrivileged(pa);
+        InetAddress serverAddress = server.getLocalAddress();
 
         // Bind the socket to the same address as the control channel. This
         // is needed in case of multi-homed systems.
@@ -761,11 +739,8 @@ public class FtpClient extends sun.net.ftp.FtpClient {
     }
 
     private static InetAddress privilegedLocalHost() throws FtpProtocolException {
-        PrivilegedExceptionAction<InetAddress> action = InetAddress::getLocalHost;
         try {
-            @SuppressWarnings("removal")
-            var tmp = AccessController.doPrivileged(action);
-            return tmp;
+            return InetAddress.getLocalHost();
         } catch (Exception e) {
             var ftpEx = new FtpProtocolException(ERROR_MSG);
             ftpEx.initCause(e);
@@ -774,11 +749,8 @@ public class FtpClient extends sun.net.ftp.FtpClient {
     }
 
     private static InetAddress[] privilegedGetAllByName(String hostName) throws FtpProtocolException {
-        PrivilegedExceptionAction<InetAddress[]> pAction = () -> InetAddress.getAllByName(hostName);
         try {
-            @SuppressWarnings("removal")
-            var tmp =AccessController.doPrivileged(pAction);
-            return tmp;
+            return InetAddress.getAllByName(hostName);
         } catch (Exception e) {
             var ftpEx = new FtpProtocolException(ERROR_MSG);
             ftpEx.initCause(e);
@@ -1021,10 +993,7 @@ public class FtpClient extends sun.net.ftp.FtpClient {
         Socket s;
         if (proxy != null) {
             if (proxy.type() == Proxy.Type.SOCKS) {
-                PrivilegedAction<Socket> pa = () -> new Socket(proxy);
-                @SuppressWarnings("removal")
-                var tmp = AccessController.doPrivileged(pa);
-                s = tmp;
+                s = new Socket(proxy);
             } else {
                 s = new Socket(Proxy.NO_PROXY);
             }


### PR DESCRIPTION
Please review this PR which removes uses of `AccessController::doPrivileged` in `sun/net/ftp`.

Changes are mostly straightforward, one exception is the removal of the somewhat exotic unwrapping of temporary arrays in the static initializer of `impl/FtpClient`.

Testing: `test/jdk/sun/net/ftp` run green. GHA results pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344185](https://bugs.openjdk.org/browse/JDK-8344185): Remove calls to SecurityManager in sun.net.ftp (**Sub-task** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22105/head:pull/22105` \
`$ git checkout pull/22105`

Update a local copy of the PR: \
`$ git checkout pull/22105` \
`$ git pull https://git.openjdk.org/jdk.git pull/22105/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22105`

View PR using the GUI difftool: \
`$ git pr show -t 22105`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22105.diff">https://git.openjdk.org/jdk/pull/22105.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22105#issuecomment-2476459242)
</details>
