### PR TITLE
8344205: [PPC]: failing assertion: sharedRuntime_ppc.cpp:1652: cookie not found

### DIFF
--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -1602,7 +1602,6 @@ static void fill_continuation_entry(MacroAssembler* masm, Register reg_cont_obj,
 #ifdef ASSERT
   __ load_const_optimized(tmp2, ContinuationEntry::cookie_value());
   __ stw(tmp2, in_bytes(ContinuationEntry::cookie_offset()), R1_SP);
-  __ std(tmp2, _abi0(cr), R1_SP);
 #endif //ASSERT
 
   __ li(zero, 0);
@@ -1646,10 +1645,6 @@ static void continuation_enter_cleanup(MacroAssembler* masm) {
   __ ld_ptr(tmp1, JavaThread::cont_entry_offset(), R16_thread);
   __ cmpd(CCR0, R1_SP, tmp1);
   __ asm_assert_eq(FILE_AND_LINE ": incorrect R1_SP");
-  __ load_const_optimized(tmp1, ContinuationEntry::cookie_value());
-  __ ld(tmp2, _abi0(cr), R1_SP);
-  __ cmpd(CCR0, tmp1, tmp2);
-  __ asm_assert_eq(FILE_AND_LINE ": cookie not found");
 #endif
 
   __ ld_ptr(tmp1, ContinuationEntry::parent_cont_fastpath_offset(), R1_SP);


### PR DESCRIPTION
This PR removes the bad assertion that fails when leaving a continuation because the cookie value is not found in `frame::common_abi::cr`.
This is because after the cookie is stored there when entering the continuation it is overridden by the runtime call to thaw frames. This is compliant with the abi.
Strangely the assertion only ever failed on aix.

Testing: compiler/codecache/stress/UnexpectedDeoptimizationTest.java always failed since the bad assertion was introduced recently. It succeeds after removal.

The fix passed our CI testing:
Tier 1-4 of hotspot and jdk. All of Langtools and jaxp. Renaissance Suite and SAP specific tests.
Testing was done on the main platforms and also on Linux/PPC64le and AIX.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344205](https://bugs.openjdk.org/browse/JDK-8344205): [PPC]: failing assertion: sharedRuntime_ppc.cpp:1652: cookie not found (**Bug** - P4)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22109/head:pull/22109` \
`$ git checkout pull/22109`

Update a local copy of the PR: \
`$ git checkout pull/22109` \
`$ git pull https://git.openjdk.org/jdk.git pull/22109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22109`

View PR using the GUI difftool: \
`$ git pr show -t 22109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22109.diff">https://git.openjdk.org/jdk/pull/22109.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22109#issuecomment-2478165862)
</details>
