### PR TITLE
8344214: Remove Security Manager dependencies from jdk.crypto.mscapi module

### DIFF
--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyStore.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/CKeyStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,15 +29,12 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.security.AccessController;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.KeyStoreSpi;
 import java.security.KeyStoreException;
-import java.security.PrivilegedAction;
 import java.security.UnrecoverableKeyException;
 import java.security.NoSuchAlgorithmException;
-import java.security.SecurityPermission;
 import java.security.cert.X509Certificate;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
@@ -242,9 +239,7 @@ abstract class CKeyStore extends KeyStoreSpi {
 
     CKeyStore(String storeName, int storeLocation) {
         // Get the compatibility mode
-        @SuppressWarnings("removal")
-        String prop = AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty(KEYSTORE_COMPATIBILITY_MODE_PROP));
+        String prop = System.getProperty(KEYSTORE_COMPATIBILITY_MODE_PROP);
 
         if ("false".equalsIgnoreCase(prop)) {
             keyStoreCompatibilityMode = false;
@@ -695,10 +690,6 @@ abstract class CKeyStore extends KeyStoreSpi {
      * the integrity of the keystore cannot be found
      * @exception CertificateException if any of the certificates in the
      * keystore could not be loaded
-     * @exception SecurityException if the security check for
-     *  <code>SecurityPermission("authProvider.<i>name</i>")</code> does not
-     *  pass, where <i>name</i> is the value returned by
-     *  this provider's <code>getName</code> method.
      */
     public void engineLoad(InputStream stream, char[] password)
             throws IOException, NoSuchAlgorithmException, CertificateException {
@@ -708,16 +699,6 @@ abstract class CKeyStore extends KeyStoreSpi {
 
         if (password != null && !keyStoreCompatibilityMode) {
             throw new IOException("Keystore password must be null");
-        }
-
-        /*
-         * Use the same security check as AuthProvider.login
-         */
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new SecurityPermission(
-                "authProvider.SunMSCAPI"));
         }
 
         // Clear all key entries

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
@@ -48,9 +48,14 @@ public final class SunMSCAPI extends Provider {
     private static final String INFO = "Sun's Microsoft Crypto API provider";
 
     static {
-        @SuppressWarnings("restricted")
+        loadLibrary();
+    }
+
+    @SuppressWarnings("restricted")
+    private static void loadLibrary() {
         System.loadLibrary("sunmscapi");
     }
+
     private static class ProviderServiceA extends ProviderService {
         ProviderServiceA(Provider p, String type, String algo, String cn,
                 HashMap<String, String> attrs) {

--- a/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
+++ b/src/jdk.crypto.mscapi/windows/classes/sun/security/mscapi/SunMSCAPI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package sun.security.mscapi;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.Provider;
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidParameterException;
@@ -50,13 +48,8 @@ public final class SunMSCAPI extends Provider {
     private static final String INFO = "Sun's Microsoft Crypto API provider";
 
     static {
-        @SuppressWarnings({"removal", "restricted"})
-        var dummy = AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-                System.loadLibrary("sunmscapi");
-                return null;
-            }
-        });
+        @SuppressWarnings("restricted")
+        System.loadLibrary("sunmscapi");
     }
     private static class ProviderServiceA extends ProviderService {
         ProviderServiceA(Provider p, String type, String algo, String cn,
@@ -148,119 +141,113 @@ public final class SunMSCAPI extends Provider {
         }
     }
 
-    @SuppressWarnings("removal")
     public SunMSCAPI() {
         super("SunMSCAPI", PROVIDER_VER, INFO);
 
         final Provider p = this;
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-                /*
-                 * Secure random
-                 */
-                HashMap<String, String> srattrs = new HashMap<>(1);
-                srattrs.put("ThreadSafe", "true");
-                putService(new ProviderService(p, "SecureRandom",
-                           "Windows-PRNG", "sun.security.mscapi.PRNG",
-                           null, srattrs));
+        /*
+         * Secure random
+         */
+        HashMap<String, String> srattrs = new HashMap<>(1);
+        srattrs.put("ThreadSafe", "true");
+        putService(new ProviderService(p, "SecureRandom",
+                   "Windows-PRNG", "sun.security.mscapi.PRNG",
+                   null, srattrs));
 
-                /*
-                 * Key store
-                 */
-                putService(new ProviderService(p, "KeyStore",
-                           "Windows-MY", "sun.security.mscapi.CKeyStore$MY"));
-                putService(new ProviderService(p, "KeyStore",
-                            "Windows-MY-CURRENTUSER", "sun.security.mscapi.CKeyStore$MY"));
-                putService(new ProviderService(p, "KeyStore",
-                           "Windows-ROOT", "sun.security.mscapi.CKeyStore$ROOT"));
-                putService(new ProviderService(p, "KeyStore",
-                            "Windows-ROOT-CURRENTUSER", "sun.security.mscapi.CKeyStore$ROOT"));
-                putService(new ProviderService(p, "KeyStore",
-                            "Windows-MY-LOCALMACHINE", "sun.security.mscapi.CKeyStore$MYLocalMachine"));
-                putService(new ProviderService(p, "KeyStore",
-                            "Windows-ROOT-LOCALMACHINE", "sun.security.mscapi.CKeyStore$ROOTLocalMachine"));
+        /*
+         * Key store
+         */
+        putService(new ProviderService(p, "KeyStore",
+                   "Windows-MY", "sun.security.mscapi.CKeyStore$MY"));
+        putService(new ProviderService(p, "KeyStore",
+                   "Windows-MY-CURRENTUSER", "sun.security.mscapi.CKeyStore$MY"));
+        putService(new ProviderService(p, "KeyStore",
+                   "Windows-ROOT", "sun.security.mscapi.CKeyStore$ROOT"));
+        putService(new ProviderService(p, "KeyStore",
+                   "Windows-ROOT-CURRENTUSER", "sun.security.mscapi.CKeyStore$ROOT"));
+        putService(new ProviderService(p, "KeyStore",
+                   "Windows-MY-LOCALMACHINE", "sun.security.mscapi.CKeyStore$MYLocalMachine"));
+        putService(new ProviderService(p, "KeyStore",
+                   "Windows-ROOT-LOCALMACHINE", "sun.security.mscapi.CKeyStore$ROOTLocalMachine"));
 
-                /*
-                 * Signature engines
-                 */
-                HashMap<String, String> attrs = new HashMap<>(1);
-                attrs.put("SupportedKeyClasses", "sun.security.mscapi.CKey");
+        /*
+         * Signature engines
+         */
+        HashMap<String, String> attrs = new HashMap<>(1);
+        attrs.put("SupportedKeyClasses", "sun.security.mscapi.CKey");
 
-                // NONEwithRSA must be supplied with a pre-computed message digest.
-                // Only the following digest algorithms are supported: MD5, SHA-1,
-                // SHA-256, SHA-384, SHA-512 and a special-purpose digest
-                // algorithm which is a concatenation of SHA-1 and MD5 digests.
-                putService(new ProviderService(p, "Signature",
-                           "NONEwithRSA", "sun.security.mscapi.CSignature$NONEwithRSA",
-                           null, attrs));
-                putService(new ProviderService(p, "Signature",
-                           "SHA1withRSA", "sun.security.mscapi.CSignature$SHA1withRSA",
-                           null, attrs));
-                putService(new ProviderServiceA(p, "Signature",
-                           "SHA256withRSA",
-                           "sun.security.mscapi.CSignature$SHA256withRSA",
-                           attrs));
-                putService(new ProviderServiceA(p, "Signature",
-                           "SHA384withRSA",
-                           "sun.security.mscapi.CSignature$SHA384withRSA",
-                           attrs));
-                putService(new ProviderServiceA(p, "Signature",
-                           "SHA512withRSA",
-                           "sun.security.mscapi.CSignature$SHA512withRSA",
-                           attrs));
-                putService(new ProviderServiceA(p, "Signature",
-                           "RSASSA-PSS", "sun.security.mscapi.CSignature$PSS",
-                           attrs));
-                putService(new ProviderService(p, "Signature",
-                           "MD5withRSA", "sun.security.mscapi.CSignature$MD5withRSA",
-                           null, attrs));
-                putService(new ProviderService(p, "Signature",
-                           "MD2withRSA", "sun.security.mscapi.CSignature$MD2withRSA",
-                           null, attrs));
-                putService(new ProviderServiceA(p, "Signature",
-                           "SHA1withECDSA",
-                           "sun.security.mscapi.CSignature$SHA1withECDSA",
-                           attrs));
-                putService(new ProviderServiceA(p, "Signature",
-                           "SHA224withECDSA",
-                           "sun.security.mscapi.CSignature$SHA224withECDSA",
-                           attrs));
-                putService(new ProviderServiceA(p, "Signature",
-                           "SHA256withECDSA",
-                           "sun.security.mscapi.CSignature$SHA256withECDSA",
-                           attrs));
-                putService(new ProviderServiceA(p, "Signature",
-                           "SHA384withECDSA",
-                           "sun.security.mscapi.CSignature$SHA384withECDSA",
-                           attrs));
-                putService(new ProviderServiceA(p, "Signature",
-                           "SHA512withECDSA",
-                           "sun.security.mscapi.CSignature$SHA512withECDSA",
-                           attrs));
-                /*
-                 * Key Pair Generator engines
-                 */
-                attrs.clear();
-                attrs.put("KeySize", "16384");
-                putService(new ProviderService(p, "KeyPairGenerator",
-                           "RSA", "sun.security.mscapi.CKeyPairGenerator$RSA",
-                           null, attrs));
+        // NONEwithRSA must be supplied with a pre-computed message digest.
+        // Only the following digest algorithms are supported: MD5, SHA-1,
+        // SHA-256, SHA-384, SHA-512 and a special-purpose digest
+        // algorithm which is a concatenation of SHA-1 and MD5 digests.
+        putService(new ProviderService(p, "Signature",
+                   "NONEwithRSA", "sun.security.mscapi.CSignature$NONEwithRSA",
+                   null, attrs));
+        putService(new ProviderService(p, "Signature",
+                   "SHA1withRSA", "sun.security.mscapi.CSignature$SHA1withRSA",
+                   null, attrs));
+        putService(new ProviderServiceA(p, "Signature",
+                   "SHA256withRSA",
+                   "sun.security.mscapi.CSignature$SHA256withRSA",
+                   attrs));
+        putService(new ProviderServiceA(p, "Signature",
+                   "SHA384withRSA",
+                   "sun.security.mscapi.CSignature$SHA384withRSA",
+                   attrs));
+        putService(new ProviderServiceA(p, "Signature",
+                   "SHA512withRSA",
+                   "sun.security.mscapi.CSignature$SHA512withRSA",
+                   attrs));
+        putService(new ProviderServiceA(p, "Signature",
+                   "RSASSA-PSS", "sun.security.mscapi.CSignature$PSS",
+                   attrs));
+        putService(new ProviderService(p, "Signature",
+                   "MD5withRSA", "sun.security.mscapi.CSignature$MD5withRSA",
+                   null, attrs));
+        putService(new ProviderService(p, "Signature",
+                   "MD2withRSA", "sun.security.mscapi.CSignature$MD2withRSA",
+                   null, attrs));
+        putService(new ProviderServiceA(p, "Signature",
+                   "SHA1withECDSA",
+                   "sun.security.mscapi.CSignature$SHA1withECDSA",
+                   attrs));
+        putService(new ProviderServiceA(p, "Signature",
+                   "SHA224withECDSA",
+                   "sun.security.mscapi.CSignature$SHA224withECDSA",
+                   attrs));
+        putService(new ProviderServiceA(p, "Signature",
+                   "SHA256withECDSA",
+                   "sun.security.mscapi.CSignature$SHA256withECDSA",
+                   attrs));
+        putService(new ProviderServiceA(p, "Signature",
+                   "SHA384withECDSA",
+                   "sun.security.mscapi.CSignature$SHA384withECDSA",
+                   attrs));
+        putService(new ProviderServiceA(p, "Signature",
+                   "SHA512withECDSA",
+                   "sun.security.mscapi.CSignature$SHA512withECDSA",
+                   attrs));
+        /*
+         * Key Pair Generator engines
+         */
+        attrs.clear();
+        attrs.put("KeySize", "16384");
+        putService(new ProviderService(p, "KeyPairGenerator",
+                   "RSA", "sun.security.mscapi.CKeyPairGenerator$RSA",
+                   null, attrs));
 
-                /*
-                 * Cipher engines
-                 */
-                attrs.clear();
-                attrs.put("SupportedModes", "ECB");
-                attrs.put("SupportedPaddings", "PKCS1PADDING");
-                attrs.put("SupportedKeyClasses", "sun.security.mscapi.CKey");
-                putService(new ProviderService(p, "Cipher",
-                           "RSA", "sun.security.mscapi.CRSACipher",
-                           null, attrs));
-                putService(new ProviderService(p, "Cipher",
-                           "RSA/ECB/PKCS1Padding", "sun.security.mscapi.CRSACipher",
-                           null, attrs));
-                return null;
-            }
-        });
+        /*
+         * Cipher engines
+         */
+        attrs.clear();
+        attrs.put("SupportedModes", "ECB");
+        attrs.put("SupportedPaddings", "PKCS1PADDING");
+        attrs.put("SupportedKeyClasses", "sun.security.mscapi.CKey");
+        putService(new ProviderService(p, "Cipher",
+                   "RSA", "sun.security.mscapi.CRSACipher",
+                   null, attrs));
+        putService(new ProviderService(p, "Cipher",
+                   "RSA/ECB/PKCS1Padding", "sun.security.mscapi.CRSACipher",
+                   null, attrs));
     }
 }


### PR DESCRIPTION
Now that JEP 486 is integrated, the jdk.crypto.mscapi module implementation dependencies on System.getSecurityManager and AccessController.doPrivileged can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344214](https://bugs.openjdk.org/browse/JDK-8344214): Remove Security Manager dependencies from jdk.crypto.mscapi module (**Enhancement** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22112/head:pull/22112` \
`$ git checkout pull/22112`

Update a local copy of the PR: \
`$ git checkout pull/22112` \
`$ git pull https://git.openjdk.org/jdk.git pull/22112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22112`

View PR using the GUI difftool: \
`$ git pr show -t 22112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22112.diff">https://git.openjdk.org/jdk/pull/22112.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22112#issuecomment-2477010909)
</details>
