### PR TITLE
8344231: SecurityManager cleanup in java.lang.module and jdk.internal.module

### DIFF
--- a/src/java.base/share/classes/java/lang/module/ModuleFinder.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleFinder.java
@@ -26,9 +26,6 @@
 package java.lang.module;
 
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.Permission;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -130,16 +127,8 @@ public interface ModuleFinder {
      *
      * @return A {@code ModuleFinder} that locates the system modules
      */
-    @SuppressWarnings("removal")
     static ModuleFinder ofSystem() {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission("accessSystemModules"));
-            PrivilegedAction<ModuleFinder> pa = SystemModuleFinders::ofSystem;
-            return AccessController.doPrivileged(pa);
-        } else {
-            return SystemModuleFinders.ofSystem();
-        }
+        return SystemModuleFinders.ofSystem();
     }
 
     /**

--- a/src/java.base/share/classes/jdk/internal/module/ModuleReferences.java
+++ b/src/java.base/share/classes/jdk/internal/module/ModuleReferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -370,14 +370,6 @@ class ModuleReferences {
 
         ExplodedModuleReader(Path dir) {
             this.dir = dir;
-
-            // when running with a security manager then check that the caller
-            // has access to the directory.
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                boolean unused = Files.isDirectory(dir);
-            }
         }
 
         /**

--- a/src/java.base/share/classes/jdk/internal/module/Modules.java
+++ b/src/java.base/share/classes/jdk/internal/module/Modules.java
@@ -154,7 +154,6 @@ public class Modules {
         ModuleLayer layer = m.getLayer();
 
         ClassLoader loader = m.getClassLoader();
-
         ClassLoader platformClassLoader = ClassLoaders.platformClassLoader();
         if (layer == null || loader == null || loader == platformClassLoader) {
             // update ClassLoader catalog

--- a/src/java.base/share/classes/jdk/internal/module/Modules.java
+++ b/src/java.base/share/classes/jdk/internal/module/Modules.java
@@ -32,8 +32,6 @@ import java.lang.module.ModuleFinder;
 import java.lang.module.ModuleReference;
 import java.lang.module.ResolvedModule;
 import java.net.URI;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -155,9 +153,7 @@ public class Modules {
     public static void addProvides(Module m, Class<?> service, Class<?> impl) {
         ModuleLayer layer = m.getLayer();
 
-        PrivilegedAction<ClassLoader> pa = m::getClassLoader;
-        @SuppressWarnings("removal")
-        ClassLoader loader = AccessController.doPrivileged(pa);
+        ClassLoader loader = m.getClassLoader();
 
         ClassLoader platformClassLoader = ClassLoaders.platformClassLoader();
         if (layer == null || loader == null || loader == platformClassLoader) {

--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -361,7 +361,7 @@ public final class SystemModuleFinders {
     }
 
     /**
-     * Holder class for the ImageReader
+     * Holder class for the ImageReader.
      */
     private static class SystemImage {
         static final ImageReader READER = ImageReaderFactory.getImageReader();

--- a/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
+++ b/src/java.base/share/classes/jdk/internal/module/SystemModuleFinders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,6 @@ import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayDeque;
 import java.util.Collections;
 import java.util.Deque;
@@ -208,21 +206,7 @@ public final class SystemModuleFinders {
         Path dir = Path.of(home, "modules");
         if (!Files.isDirectory(dir))
             throw new InternalError("Unable to detect the run-time image");
-        ModuleFinder f = ModulePath.of(ModuleBootstrap.patcher(), dir);
-        return new ModuleFinder() {
-            @SuppressWarnings("removal")
-            @Override
-            public Optional<ModuleReference> find(String name) {
-                PrivilegedAction<Optional<ModuleReference>> pa = () -> f.find(name);
-                return AccessController.doPrivileged(pa);
-            }
-            @SuppressWarnings("removal")
-            @Override
-            public Set<ModuleReference> findAll() {
-                PrivilegedAction<Set<ModuleReference>> pa = f::findAll;
-                return AccessController.doPrivileged(pa);
-            }
-        };
+        return ModulePath.of(ModuleBootstrap.patcher(), dir);
     }
 
     /**
@@ -314,7 +298,7 @@ public final class SystemModuleFinders {
         Supplier<ModuleReader> readerSupplier = new Supplier<>() {
             @Override
             public ModuleReader get() {
-                return new SystemModuleReader(mn, uri);
+                return new SystemModuleReader(mn);
             }
         };
 
@@ -378,8 +362,6 @@ public final class SystemModuleFinders {
 
     /**
      * Holder class for the ImageReader
-     *
-     * @apiNote This class must be loaded before a security manager is set.
      */
     private static class SystemImage {
         static final ImageReader READER = ImageReaderFactory.getImageReader();
@@ -396,25 +378,7 @@ public final class SystemModuleFinders {
         private final String module;
         private volatile boolean closed;
 
-        /**
-         * If there is a security manager set then check permission to
-         * connect to the run-time image.
-         */
-        private static void checkPermissionToConnect(URI uri) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                try {
-                    URLConnection uc = uri.toURL().openConnection();
-                    sm.checkPermission(uc.getPermission());
-                } catch (IOException ioe) {
-                    throw new UncheckedIOException(ioe);
-                }
-            }
-        }
-
-        SystemModuleReader(String module, URI uri) {
-            checkPermissionToConnect(uri);
+        SystemModuleReader(String module) {
             this.module = module;
         }
 


### PR DESCRIPTION
Please review this PR which removes code depending on SecurityManager from the `java.lang.module` and `jdk.internal.module` packages:

* `ModuleFinder::ofSystem` is updated to not check the `"accessSystemModules"` RuntimePermission
* The `ModuleReferences.ExplodedModuleReader` constructor is updated to remove the check that the caller has access to the directory.
* `Modules::addProvides` is updated to not use `AccessController::doPrivileged` when getting the module class loader
* `SystemModuleFinder::ofSystem` is updated to not returned a wrapped result calling `AccessController::doPrivileged`
* `SystemModuleFinders.SystemImage` is updated to remove a class level comment referring to the SM
* `SystemModuleFinders.SystemModuleReader::checkPermissionToConnect` is removed. The URI constructor parameter in `SystemModuleReader` becomes unused and is removed.


Testing: I have run `test/jdk/java/lang/module`, `test/jdk/java/lang/ModuleTests`,  and `test/jdk/java/lang/ModuleLayer` successfully. GHA results pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344231](https://bugs.openjdk.org/browse/JDK-8344231): SecurityManager cleanup in java.lang.module and jdk.internal.module (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22113/head:pull/22113` \
`$ git checkout pull/22113`

Update a local copy of the PR: \
`$ git checkout pull/22113` \
`$ git pull https://git.openjdk.org/jdk.git pull/22113/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22113`

View PR using the GUI difftool: \
`$ git pr show -t 22113`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22113.diff">https://git.openjdk.org/jdk/pull/22113.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22113#issuecomment-2477355910)
</details>
