### PR TITLE
8330606: Redefinition doesn't but should verify the new klass

### DIFF
--- a/src/hotspot/share/classfile/verifier.cpp
+++ b/src/hotspot/share/classfile/verifier.cpp
@@ -105,11 +105,13 @@ static verify_byte_codes_fn_t verify_byte_codes_fn() {
 
 // Methods in Verifier
 
+// This method determines whether we run the verifier and class file format checking code.
 bool Verifier::should_verify_for(oop class_loader) {
   return class_loader == nullptr ?
     BytecodeVerificationLocal : BytecodeVerificationRemote;
 }
 
+// This method determines whether we allow package access in access checks in reflection.
 bool Verifier::relax_access_for(oop loader) {
   bool trusted = java_lang_ClassLoader::is_trusted_loader(loader);
   bool need_verify =
@@ -277,14 +279,6 @@ bool Verifier::is_eligible_for_verification(InstanceKlass* klass, bool should_ve
   Symbol* name = klass->name();
 
   return (should_verify_class &&
-    // return if the class is a bootstrapping class
-    // or defineClass specified not to verify by default (flags override passed arg)
-    // We need to skip the following four for bootstraping
-    name != vmSymbols::java_lang_Object() &&
-    name != vmSymbols::java_lang_Class() &&
-    name != vmSymbols::java_lang_String() &&
-    name != vmSymbols::java_lang_Throwable() &&
-
     // Can not verify the bytecodes for shared classes because they have
     // already been rewritten to contain constant pool cache indices,
     // which the verifier can't understand.

--- a/src/hotspot/share/classfile/verifier.hpp
+++ b/src/hotspot/share/classfile/verifier.hpp
@@ -61,7 +61,6 @@ class Verifier : AllStatic {
   static void trace_class_resolution(Klass* resolve_class, InstanceKlass* verify_class);
 
  private:
-  static bool is_eligible_for_verification(InstanceKlass* klass, bool should_verify_class);
   static Symbol* inference_verify(
     InstanceKlass* klass, char* msg, size_t msg_len, TRAPS);
 };

--- a/src/hotspot/share/oops/method.cpp
+++ b/src/hotspot/share/oops/method.cpp
@@ -335,7 +335,8 @@ int Method::bci_from(address bcp) const {
 
 
 int Method::validate_bci(int bci) const {
-  return (bci == 0 || bci < code_size()) ? bci : -1;
+  // Called from the verifier, and should return -1 if not valid.
+  return ((is_native() && bci == 0) || (!is_native() && 0 <= bci && bci < code_size())) ? bci : -1;
 }
 
 // Return bci if it appears to be a valid bcp

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineVerifyError.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineVerifyError.java
@@ -55,6 +55,7 @@ import jdk.internal.org.objectweb.asm.TypePath;
 
 public class RedefineVerifyError implements Opcodes {
 
+    // This is a redefinition of java.lang.VerifyError with two broken init methods (no bytecodes)
     public static byte[] dump () throws Exception {
 
         ClassWriter classWriter = new ClassWriter(0);
@@ -71,45 +72,12 @@ public class RedefineVerifyError implements Opcodes {
         {
             methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
             methodVisitor.visitCode();
-            Label label0 = new Label();
-            methodVisitor.visitLabel(label0);
-            methodVisitor.visitLineNumber(43, label0);
-            methodVisitor.visitVarInsn(ALOAD, 0);
-            methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/LinkageError", "<init>", "()V", false);
-            Label label1 = new Label();
-            methodVisitor.visitLabel(label1);
-            methodVisitor.visitLineNumber(44, label1);
-            methodVisitor.visitInsn(RETURN);
-            Label label2 = new Label();
-            methodVisitor.visitLabel(label2);
-            methodVisitor.visitLocalVariable("this", "Ljava/lang/VerifyError;", null, label0, label2, 0);
-            methodVisitor.visitMaxs(1, 1);
             methodVisitor.visitEnd();
         }
 
-        {   // broken method
+        {
             methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "(Ljava/lang/String;)V", null, null);
             methodVisitor.visitCode();
-            Label label0 = new Label();
-            Label label1 = new Label();
-            Label label2 = new Label();
-            methodVisitor.visitTryCatchBlock(label0, label1, label2, "java/lang/Exception");
-            methodVisitor.visitLabel(label0);
-            methodVisitor.visitVarInsn(ALOAD, 0);
-            methodVisitor.visitVarInsn(ALOAD, 1);
-            methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/LinkageError", "<init>", "(Ljava/lang/String;)V", false);
-            methodVisitor.visitLabel(label1);
-            Label label3 = new Label();
-            methodVisitor.visitJumpInsn(GOTO, label3);
-            methodVisitor.visitLabel(label2);
-            methodVisitor.visitFrame(Opcodes.F_FULL, 2, new Object[] {"MyError", "java/lang/String"}, 1, new Object[] {"java/lang/Exception"});
-            methodVisitor.visitVarInsn(ASTORE, 2);
-            methodVisitor.visitLabel(label3);
-            // Missing stackmap frame makes rededefine classes throw VerifyError
-            // methodVisitor.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
-            methodVisitor.visitInsn(RETURN);
-            methodVisitor.visitMaxs(2, 3);
-            methodVisitor.visitEnd();
             classWriter.visitEnd();
         }
 
@@ -125,6 +93,7 @@ public class RedefineVerifyError implements Opcodes {
             RedefineClassHelper.redefineClass(verifyErrorMirror, dump());
             throw new RuntimeException("This should throw VerifyError");
         } catch (VerifyError e) {
+            // JVMTI recreates the VerifyError so the verification message is lost.
             System.out.println("Passed");
         }
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineVerifyError.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/RedefineClasses/RedefineVerifyError.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 6402717 8330606
+ * @summary Redefine VerifyError to get a VerifyError should not throw SOE
+ * @requires vm.jvmti
+ * @library /test/lib
+ * @modules java.base/jdk.internal.misc
+ *          java.base/jdk.internal.org.objectweb.asm
+ *          java.compiler
+ *          java.instrument
+ *          jdk.jartool/sun.tools.jar
+ * @run main RedefineClassHelper
+ * @run main/othervm/timeout=180
+ *         -javaagent:redefineagent.jar
+ *         -Xlog:class+init
+ *         RedefineVerifyError
+ */
+
+import jdk.internal.org.objectweb.asm.AnnotationVisitor;
+import jdk.internal.org.objectweb.asm.Attribute;
+import jdk.internal.org.objectweb.asm.ClassReader;
+import jdk.internal.org.objectweb.asm.ClassWriter;
+import jdk.internal.org.objectweb.asm.ConstantDynamic;
+import jdk.internal.org.objectweb.asm.FieldVisitor;
+import jdk.internal.org.objectweb.asm.Handle;
+import jdk.internal.org.objectweb.asm.Label;
+import jdk.internal.org.objectweb.asm.MethodVisitor;
+import jdk.internal.org.objectweb.asm.Opcodes;
+import jdk.internal.org.objectweb.asm.RecordComponentVisitor;
+import jdk.internal.org.objectweb.asm.Type;
+import jdk.internal.org.objectweb.asm.TypePath;
+
+public class RedefineVerifyError implements Opcodes {
+
+    public static byte[] dump () throws Exception {
+
+        ClassWriter classWriter = new ClassWriter(0);
+        FieldVisitor fieldVisitor;
+        RecordComponentVisitor recordComponentVisitor;
+        MethodVisitor methodVisitor;
+        AnnotationVisitor annotationVisitor0;
+
+        classWriter.visit(52, ACC_SUPER | ACC_PUBLIC, "java/lang/VerifyError", null, "java/lang/LinkageError", null);
+        {
+            fieldVisitor = classWriter.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, "serialVersionUID", "J", null, new Long(7001962396098498785L));
+            fieldVisitor.visitEnd();
+        }
+        {
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitLineNumber(43, label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/LinkageError", "<init>", "()V", false);
+            Label label1 = new Label();
+            methodVisitor.visitLabel(label1);
+            methodVisitor.visitLineNumber(44, label1);
+            methodVisitor.visitInsn(RETURN);
+            Label label2 = new Label();
+            methodVisitor.visitLabel(label2);
+            methodVisitor.visitLocalVariable("this", "Ljava/lang/VerifyError;", null, label0, label2, 0);
+            methodVisitor.visitMaxs(1, 1);
+            methodVisitor.visitEnd();
+        }
+
+        {   // broken method
+            methodVisitor = classWriter.visitMethod(ACC_PUBLIC, "<init>", "(Ljava/lang/String;)V", null, null);
+            methodVisitor.visitCode();
+            Label label0 = new Label();
+            Label label1 = new Label();
+            Label label2 = new Label();
+            methodVisitor.visitTryCatchBlock(label0, label1, label2, "java/lang/Exception");
+            methodVisitor.visitLabel(label0);
+            methodVisitor.visitVarInsn(ALOAD, 0);
+            methodVisitor.visitVarInsn(ALOAD, 1);
+            methodVisitor.visitMethodInsn(INVOKESPECIAL, "java/lang/LinkageError", "<init>", "(Ljava/lang/String;)V", false);
+            methodVisitor.visitLabel(label1);
+            Label label3 = new Label();
+            methodVisitor.visitJumpInsn(GOTO, label3);
+            methodVisitor.visitLabel(label2);
+            methodVisitor.visitFrame(Opcodes.F_FULL, 2, new Object[] {"MyError", "java/lang/String"}, 1, new Object[] {"java/lang/Exception"});
+            methodVisitor.visitVarInsn(ASTORE, 2);
+            methodVisitor.visitLabel(label3);
+            // methodVisitor.visitFrame(Opcodes.F_SAME, 0, null, 0, null);
+            methodVisitor.visitInsn(RETURN);
+            methodVisitor.visitMaxs(2, 3);
+            methodVisitor.visitEnd();
+            classWriter.visitEnd();
+        }
+
+        return classWriter.toByteArray();
+    }
+
+    public static void main(String[] args) throws Exception {
+
+        Class<?> verifyErrorMirror = java.lang.VerifyError.class;
+
+        try {
+            RedefineClassHelper.redefineClass(verifyErrorMirror, dump());
+            VerifyError err = new VerifyError("verify me now");
+            throw new RuntimeException("This should throw VerifyError");
+        } catch (VerifyError e) {
+            System.out.println("Passed");
+        }
+    }
+}


### PR DESCRIPTION
This change adds a couple of comments, removes some ancient bootstrapping code, and adds an old test that we call the verifier for redefining a class, even one in the bootclass path.

The fix for always verifying redefined classes was actually pushed with JDK-8341094, where the verifier code respected the parameter "should_verify_class".  By default this parameter follows the -Xverify setting.  For redefinition, this is passed as true.   The rest of the fix removes the special bootstrap loader cases that may have failed early on in the JDK development with -Xverify:all but now no longer do.  If someone tries to redefine these classes, they should also do the verification on the redefined bytecodes.

Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8330606](https://bugs.openjdk.org/browse/JDK-8330606): Redefinition doesn't but should verify the new klass (**Bug** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22116/head:pull/22116` \
`$ git checkout pull/22116`

Update a local copy of the PR: \
`$ git checkout pull/22116` \
`$ git pull https://git.openjdk.org/jdk.git pull/22116/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22116`

View PR using the GUI difftool: \
`$ git pr show -t 22116`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22116.diff">https://git.openjdk.org/jdk/pull/22116.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22116#issuecomment-2477228876)
</details>
