### PR TITLE
8344250: Obsolete the DontYieldALot flag

### DIFF
--- a/src/hotspot/os/posix/os_posix.cpp
+++ b/src/hotspot/os/posix/os_posix.cpp
@@ -931,10 +931,6 @@ void os::_exit(int num) {
   ALLOW_C_FUNCTION(::_exit, ::_exit(num);)
 }
 
-bool os::dont_yield() {
-  return DontYieldALot;
-}
-
 void os::naked_yield() {
   sched_yield();
 }

--- a/src/hotspot/os/windows/os_windows.cpp
+++ b/src/hotspot/os/windows/os_windows.cpp
@@ -4856,12 +4856,6 @@ int os::loadavg(double loadavg[], int nelem) {
   return -1;
 }
 
-
-// DontYieldALot=false by default: dutifully perform all yields as requested by JVM_Yield()
-bool os::dont_yield() {
-  return DontYieldALot;
-}
-
 int os::open(const char *path, int oflag, int mode) {
   errno_t err;
   wchar_t* wide_path = wide_abs_unc_path(path, err);

--- a/src/hotspot/os_cpu/aix_ppc/globals_aix_ppc.hpp
+++ b/src/hotspot/os_cpu/aix_ppc/globals_aix_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,7 +29,6 @@
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
 
-define_pd_global(bool, DontYieldALot,            false);
 define_pd_global(intx, ThreadStackSize,          2048); // 0 => use system default
 define_pd_global(intx, VMThreadStackSize,        2048);
 

--- a/src/hotspot/os_cpu/bsd_aarch64/globals_bsd_aarch64.hpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/globals_bsd_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * Copyright (c) 2021, Azul Systems, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -31,7 +31,6 @@
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
 
-define_pd_global(bool, DontYieldALot,            false);
 define_pd_global(intx, ThreadStackSize,          2048); // 0 => use system default
 define_pd_global(intx, VMThreadStackSize,        2048);
 

--- a/src/hotspot/os_cpu/bsd_x86/globals_bsd_x86.hpp
+++ b/src/hotspot/os_cpu/bsd_x86/globals_bsd_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
 //
-define_pd_global(bool, DontYieldALot,            false);
 #ifdef AMD64
 define_pd_global(intx, CompilerThreadStackSize,  1024);
 define_pd_global(intx, ThreadStackSize,          1024); // 0 => use system default

--- a/src/hotspot/os_cpu/bsd_zero/globals_bsd_zero.hpp
+++ b/src/hotspot/os_cpu/bsd_zero/globals_bsd_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2010 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,7 +31,6 @@
 // runtime system.  See globals.hpp for details of what they do.
 //
 
-define_pd_global(bool,  DontYieldALot,           false);
 define_pd_global(intx,  ThreadStackSize,         1536);
 #ifdef _LP64
 define_pd_global(intx,  VMThreadStackSize,       1024);

--- a/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
+++ b/src/hotspot/os_cpu/linux_aarch64/globals_linux_aarch64.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -28,8 +28,6 @@
 
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
-
-define_pd_global(bool, DontYieldALot,            false);
 
 // Set default stack sizes < 2MB so as to prevent stacks from getting
 // large-page aligned and backed by THPs on systems where 2MB is the

--- a/src/hotspot/os_cpu/linux_arm/globals_linux_arm.hpp
+++ b/src/hotspot/os_cpu/linux_arm/globals_linux_arm.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
 //
-define_pd_global(bool, DontYieldALot,            false);
 define_pd_global(intx, CompilerThreadStackSize,  512);
 // System default ThreadStackSize appears to be 512 which is too big.
 define_pd_global(intx, ThreadStackSize,          320);

--- a/src/hotspot/os_cpu/linux_ppc/globals_linux_ppc.hpp
+++ b/src/hotspot/os_cpu/linux_ppc/globals_linux_ppc.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2012, 2015 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,7 +29,6 @@
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
 
-define_pd_global(bool, DontYieldALot,            false);
 define_pd_global(intx, ThreadStackSize,          2048); // 0 => use system default
 define_pd_global(intx, VMThreadStackSize,        2048);
 

--- a/src/hotspot/os_cpu/linux_riscv/globals_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/globals_linux_riscv.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -29,7 +29,6 @@
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
 
-define_pd_global(bool,  DontYieldALot,            false);
 define_pd_global(intx,  ThreadStackSize,          2048); // 0 => use system default
 define_pd_global(intx,  VMThreadStackSize,        2048);
 

--- a/src/hotspot/os_cpu/linux_s390/globals_linux_s390.hpp
+++ b/src/hotspot/os_cpu/linux_s390/globals_linux_s390.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2016 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,7 +31,6 @@
 // Sets the default values for platform dependent flags used by the
 // runtime system (see globals.hpp).
 
-define_pd_global(bool, DontYieldALot,            false);
 define_pd_global(intx, ThreadStackSize,          1024); // 0 => Use system default.
 define_pd_global(intx, VMThreadStackSize,        1024);
 // Some jck tests in lang/fp/fpl038 run out of compile thread stack.

--- a/src/hotspot/os_cpu/linux_x86/globals_linux_x86.hpp
+++ b/src/hotspot/os_cpu/linux_x86/globals_linux_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
 
-define_pd_global(bool, DontYieldALot,            false);
 #ifdef AMD64
 define_pd_global(intx, CompilerThreadStackSize,  1024);
 define_pd_global(intx, ThreadStackSize,          1024); // 0 => use system default

--- a/src/hotspot/os_cpu/linux_zero/globals_linux_zero.hpp
+++ b/src/hotspot/os_cpu/linux_zero/globals_linux_zero.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright 2007, 2008, 2010 Red Hat, Inc.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -31,7 +31,6 @@
 // runtime system.  See globals.hpp for details of what they do.
 //
 
-define_pd_global(bool,  DontYieldALot,           false);
 define_pd_global(intx,  ThreadStackSize,         1536);
 #ifdef _LP64
 define_pd_global(intx,  VMThreadStackSize,       1024);

--- a/src/hotspot/os_cpu/windows_aarch64/globals_windows_aarch64.hpp
+++ b/src/hotspot/os_cpu/windows_aarch64/globals_windows_aarch64.hpp
@@ -28,8 +28,6 @@
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
 
-define_pd_global(bool, DontYieldALot,            false);
-
 // Default stack size on Windows is determined by the executable (java.exe
 // has a default value of 320K/1MB [32bit/64bit]). Depending on Windows version, changing
 // ThreadStackSize to non-zero may have significant impact on memory usage.

--- a/src/hotspot/os_cpu/windows_x86/globals_windows_x86.hpp
+++ b/src/hotspot/os_cpu/windows_x86/globals_windows_x86.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@
 
 // Sets the default values for platform dependent flags used by the runtime system.
 // (see globals.hpp)
-
-define_pd_global(bool, DontYieldALot,            false);
 
 // Default stack size on Windows is determined by the executable (java.exe
 // has a default value of 320K/1MB [32bit/64bit]). Depending on Windows version, changing

--- a/src/hotspot/share/prims/jvm.cpp
+++ b/src/hotspot/share/prims/jvm.cpp
@@ -2951,7 +2951,6 @@ JVM_END
 
 
 JVM_LEAF(void, JVM_Yield(JNIEnv *env, jclass threadClass))
-  if (os::dont_yield()) return;
   HOTSPOT_THREAD_YIELD();
   os::naked_yield();
 JVM_END

--- a/src/hotspot/share/runtime/globals.hpp
+++ b/src/hotspot/share/runtime/globals.hpp
@@ -697,9 +697,6 @@ const int ObjectAlignmentInBytes = 8;
           "Allow parallel defineClass requests for class loaders "          \
           "registering as parallel capable")                                \
                                                                             \
-  product_pd(bool, DontYieldALot,                                           \
-             "(Deprecated) Throw away obvious excess yield calls")          \
-                                                                            \
   product(bool, DisablePrimordialThreadGuardPages, false, EXPERIMENTAL,     \
                "Disable the use of stack guard pages if the JVM is loaded " \
                "on the primordial process thread")                          \

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -1042,8 +1042,6 @@ class os: AllStatic {
   // debugging support (mostly used by debug.cpp but also fatal error handler)
   static bool find(address pc, outputStream* st = tty); // OS specific function to make sense out of an address
 
-  static bool dont_yield();                     // when true, JVM_Yield() is nop
-
   // Thread priority helpers (implemented in OS-specific part)
   static OSReturn set_native_priority(Thread* thread, int native_prio);
   static OSReturn get_native_priority(const Thread* const thread, int* priority_ptr);


### PR DESCRIPTION
Please review this simple fix to remove all code related to the deprecated `DontYieldALot` flag, which is obsoleted in JDK 24.

Testing
- GHA (in progress)
- tiers 1-3 (in progress)

Thanks

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344250](https://bugs.openjdk.org/browse/JDK-8344250): Obsolete the DontYieldALot flag (**Bug** - P2)


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22120/head:pull/22120` \
`$ git checkout pull/22120`

Update a local copy of the PR: \
`$ git checkout pull/22120` \
`$ git pull https://git.openjdk.org/jdk.git pull/22120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22120`

View PR using the GUI difftool: \
`$ git pr show -t 22120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22120.diff">https://git.openjdk.org/jdk/pull/22120.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22120#issuecomment-2477457627)
</details>
