### PR TITLE
8344247: Move objectWaiter field to VirtualThread instance

### DIFF
--- a/src/hotspot/share/classfile/javaClasses.hpp
+++ b/src/hotspot/share/classfile/javaClasses.hpp
@@ -37,6 +37,8 @@
 class JvmtiThreadState;
 class RecordComponent;
 class SerializeClosure;
+class ObjectWaiter;
+class ObjectMonitor;
 
 #define CHECK_INIT(offset)  assert(offset != 0, "should be initialized"); return offset;
 
@@ -520,6 +522,8 @@ class java_lang_ThreadGroup : AllStatic {
 
 
 // Interface to java.lang.VirtualThread objects
+#define VTHREAD_INJECTED_FIELDS(macro)                                           \
+  macro(java_lang_VirtualThread,   objectWaiter,  intptr_signature,       false)
 
 class java_lang_VirtualThread : AllStatic {
  private:
@@ -532,6 +536,7 @@ class java_lang_VirtualThread : AllStatic {
   static int _notified_offset;
   static int _recheckInterval_offset;
   static int _timeout_offset;
+  static int _objectWaiter_offset;
   JFR_ONLY(static int _jfr_epoch_offset;)
  public:
   enum {
@@ -583,6 +588,11 @@ class java_lang_VirtualThread : AllStatic {
   static void set_notified(oop vthread, jboolean value);
   static bool is_preempted(oop vthread);
   static JavaThreadStatus map_state_to_thread_status(int state);
+
+  static inline ObjectWaiter* objectWaiter(oop vthread);
+  static inline void set_objectWaiter(oop vthread, ObjectWaiter* waiter);
+  static ObjectMonitor* current_pending_monitor(oop vthread);
+  static ObjectMonitor* current_waiting_monitor(oop vthread);
 };
 
 

--- a/src/hotspot/share/classfile/javaClasses.inline.hpp
+++ b/src/hotspot/share/classfile/javaClasses.inline.hpp
@@ -220,6 +220,14 @@ inline oop java_lang_VirtualThread::vthread_scope() {
   return base->obj_field(static_vthread_scope_offset);
 }
 
+inline ObjectWaiter* java_lang_VirtualThread::objectWaiter(oop vthread) {
+  return (ObjectWaiter*)vthread->address_field(_objectWaiter_offset);
+}
+
+inline void java_lang_VirtualThread::set_objectWaiter(oop vthread, ObjectWaiter* value) {
+  vthread->address_field_put(_objectWaiter_offset, (address)value);
+}
+
 #if INCLUDE_JFR
 inline u2 java_lang_Thread::jfr_epoch(oop ref) {
   return ref->short_field(_jfr_epoch_offset);

--- a/src/hotspot/share/classfile/javaClassesImpl.hpp
+++ b/src/hotspot/share/classfile/javaClassesImpl.hpp
@@ -40,6 +40,7 @@
   STACKFRAMEINFO_INJECTED_FIELDS(macro)     \
   MODULE_INJECTED_FIELDS(macro)             \
   THREAD_INJECTED_FIELDS(macro)             \
+  VTHREAD_INJECTED_FIELDS(macro)            \
   INTERNALERROR_INJECTED_FIELDS(macro)      \
   STACKCHUNK_INJECTED_FIELDS(macro)
 

--- a/src/hotspot/share/oops/stackChunkOop.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.hpp
@@ -98,12 +98,6 @@ public:
   inline uint8_t lockstack_size() const;
   inline void set_lockstack_size(uint8_t value);
 
-  inline ObjectWaiter* object_waiter() const;
-  inline void set_object_waiter(ObjectWaiter* obj_waiter);
-
-  inline ObjectMonitor* current_pending_monitor() const;
-  inline ObjectMonitor* current_waiting_monitor() const;
-
   inline oop cont() const;
   template<typename P>
   inline oop cont() const;

--- a/src/hotspot/share/oops/stackChunkOop.inline.hpp
+++ b/src/hotspot/share/oops/stackChunkOop.inline.hpp
@@ -92,9 +92,6 @@ inline void stackChunkOopDesc::set_max_thawing_size(int value)  {
 inline uint8_t stackChunkOopDesc::lockstack_size() const         { return jdk_internal_vm_StackChunk::lockStackSize(as_oop()); }
 inline void stackChunkOopDesc::set_lockstack_size(uint8_t value) { jdk_internal_vm_StackChunk::set_lockStackSize(this, value); }
 
-inline ObjectWaiter* stackChunkOopDesc::object_waiter() const       { return (ObjectWaiter*)jdk_internal_vm_StackChunk::objectWaiter(as_oop()); }
-inline void stackChunkOopDesc::set_object_waiter(ObjectWaiter* obj) { jdk_internal_vm_StackChunk::set_objectWaiter(this, (address)obj); }
-
 inline oop stackChunkOopDesc::cont() const                { return jdk_internal_vm_StackChunk::cont(as_oop()); }
 inline void stackChunkOopDesc::set_cont(oop value)        { jdk_internal_vm_StackChunk::set_cont(this, value); }
 template<typename P>
@@ -169,22 +166,6 @@ inline bool stackChunkOopDesc::preempted() const { return is_flag(FLAG_PREEMPTED
 inline void stackChunkOopDesc::set_preempted(bool value) {
   assert(preempted() != value, "");
   set_flag(FLAG_PREEMPTED, value);
-}
-
-inline ObjectMonitor* stackChunkOopDesc::current_pending_monitor() const {
-  ObjectWaiter* waiter = object_waiter();
-  if (waiter != nullptr && waiter->at_monitorenter()) {
-    return waiter->monitor();
-  }
-  return nullptr;
-}
-
-inline ObjectMonitor* stackChunkOopDesc::current_waiting_monitor() const {
-  ObjectWaiter* waiter = object_waiter();
-  if (waiter != nullptr && waiter->is_wait()) {
-    return waiter->monitor();
-  }
-  return nullptr;
 }
 
 inline bool stackChunkOopDesc::has_lockstack() const         { return is_flag(FLAG_HAS_LOCKSTACK); }

--- a/src/hotspot/share/runtime/continuationJavaClasses.cpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.cpp
@@ -88,7 +88,6 @@ int jdk_internal_vm_StackChunk::_bottom_offset;
 int jdk_internal_vm_StackChunk::_flags_offset;
 int jdk_internal_vm_StackChunk::_maxThawingSize_offset;
 int jdk_internal_vm_StackChunk::_lockStackSize_offset;
-int jdk_internal_vm_StackChunk::_objectWaiter_offset;
 int jdk_internal_vm_StackChunk::_cont_offset;
 
 #define STACKCHUNK_FIELDS_DO(macro) \

--- a/src/hotspot/share/runtime/continuationJavaClasses.hpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.hpp
@@ -76,7 +76,6 @@ class jdk_internal_vm_Continuation: AllStatic {
   macro(jdk_internal_vm_StackChunk, pc,              intptr_signature,       false) \
   macro(jdk_internal_vm_StackChunk, maxThawingSize,  int_signature,          false) \
   macro(jdk_internal_vm_StackChunk, lockStackSize,   byte_signature,         false) \
-  macro(jdk_internal_vm_StackChunk, objectWaiter,    intptr_signature,       false) \
 
 class jdk_internal_vm_StackChunk: AllStatic {
   friend class JavaClasses;
@@ -89,7 +88,6 @@ class jdk_internal_vm_StackChunk: AllStatic {
   static int _flags_offset;
   static int _maxThawingSize_offset;
   static int _lockStackSize_offset;
-  static int _objectWaiter_offset;
   static int _cont_offset;
 
 
@@ -130,9 +128,6 @@ class jdk_internal_vm_StackChunk: AllStatic {
 
   static inline uint8_t lockStackSize(oop chunk);
   static inline void set_lockStackSize(oop chunk, uint8_t value);
-
-  static inline address objectWaiter(oop chunk);
-  static inline void set_objectWaiter(oop chunk, address mon);
 
   // cont oop's processing is essential for the chunk's GC protocol
   static inline oop cont(oop chunk);

--- a/src/hotspot/share/runtime/continuationJavaClasses.inline.hpp
+++ b/src/hotspot/share/runtime/continuationJavaClasses.inline.hpp
@@ -194,12 +194,4 @@ inline void jdk_internal_vm_StackChunk::set_lockStackSize(oop chunk, uint8_t val
   Atomic::store(chunk->field_addr<uint8_t>(_lockStackSize_offset), value);
 }
 
-inline address jdk_internal_vm_StackChunk::objectWaiter(oop chunk) {
-  return chunk->address_field(_objectWaiter_offset);
-}
-
-inline void jdk_internal_vm_StackChunk::set_objectWaiter(oop chunk, address value) {
-  chunk->address_field_put(_objectWaiter_offset, value);
-}
-
 #endif // SHARE_RUNTIME_CONTINUATIONJAVACLASSES_INLINE_HPP


### PR DESCRIPTION
Small follow-up change after JDK-8338383. This moves the objectWaiter field from the stackChunk to the VirtualThread instance. Only the top stackChunk uses this field so we could save some memory by just saving it in the virtual thread instance instead. Also, related methods stackChunkOopDesc::current_pending_monitor/current_waiting_monitor are now moved to the java_lang_VirtualThread class too where they naturally belong, since these are the equivalent of the JavaThread methods but for an unmounted vthread.
Tested by running mach5 tiers1-3.

Thanks,
Patricio