### PR TITLE
8344065: Remove SecurityManager uses from the java.datatransfer module

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -313,7 +313,6 @@ module java.base {
         java.desktop;
     exports sun.reflect.misc to
         java.desktop,
-        java.datatransfer,
         java.management,
         java.management.rmi,
         java.rmi,

--- a/src/java.datatransfer/share/classes/java/awt/datatransfer/DataFlavor.java
+++ b/src/java.datatransfer/share/classes/java/awt/datatransfer/DataFlavor.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.Objects;
 
 import sun.datatransfer.DataFlavorUtil;
-import sun.reflect.misc.ReflectUtil;
 
 /**
  * A {@code DataFlavor} provides meta information about data. {@code DataFlavor}
@@ -131,32 +130,22 @@ public class DataFlavor implements Externalizable, Cloneable {
                                                    ClassLoader fallback)
         throws ClassNotFoundException
     {
-        ReflectUtil.checkPackageAccess(className);
+        ClassLoader loader = ClassLoader.getSystemClassLoader();
         try {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(new RuntimePermission("getClassLoader"));
-            }
-            ClassLoader loader = ClassLoader.getSystemClassLoader();
-            try {
-                // bootstrap class loader and system class loader if present
-                return Class.forName(className, true, loader);
-            }
-            catch (ClassNotFoundException exception) {
-                // thread context class loader if and only if present
-                loader = Thread.currentThread().getContextClassLoader();
-                if (loader != null) {
-                    try {
-                        return Class.forName(className, true, loader);
-                    }
-                    catch (ClassNotFoundException e) {
-                        // fallback to user's class loader
-                    }
+            // bootstrap class loader and system class loader if present
+            return Class.forName(className, true, loader);
+        }
+        catch (ClassNotFoundException exception) {
+            // thread context class loader if and only if present
+            loader = Thread.currentThread().getContextClassLoader();
+            if (loader != null) {
+                try {
+                    return Class.forName(className, true, loader);
+                }
+                catch (ClassNotFoundException e) {
+                    // fallback to user's class loader
                 }
             }
-        } catch (SecurityException exception) {
-            // ignore secured class loaders
         }
         return Class.forName(className, true, fallback);
     }

--- a/src/java.datatransfer/share/classes/java/awt/datatransfer/SystemFlavorMap.java
+++ b/src/java.datatransfer/share/classes/java/awt/datatransfer/SystemFlavorMap.java
@@ -30,8 +30,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.lang.ref.SoftReference;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -202,12 +200,8 @@ public final class SystemFlavorMap implements FlavorMap, FlavorTable {
         }
         isMapInitialized = true;
 
-        @SuppressWarnings("removal")
-        InputStream is = AccessController.doPrivileged(
-            (PrivilegedAction<InputStream>) () -> {
-                return SystemFlavorMap.class.getResourceAsStream(
+        InputStream is = SystemFlavorMap.class.getResourceAsStream(
                         "/sun/datatransfer/resources/flavormap.properties");
-            });
         if (is == null) {
             throw new InternalError("Default flavor mapping not found");
         }


### PR DESCRIPTION
remove uses of SM APIs from the java.datatransfer module. Also cleans up the now un-needed export from java.base

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344065](https://bugs.openjdk.org/browse/JDK-8344065): Remove SecurityManager uses from the java.datatransfer module (**Bug** - P4)


### Reviewers
 * [Sergey Bylokhov](https://openjdk.org/census#serb) (@mrserb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22127/head:pull/22127` \
`$ git checkout pull/22127`

Update a local copy of the PR: \
`$ git checkout pull/22127` \
`$ git pull https://git.openjdk.org/jdk.git pull/22127/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22127`

View PR using the GUI difftool: \
`$ git pr show -t 22127`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22127.diff">https://git.openjdk.org/jdk/pull/22127.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22127#issuecomment-2477653383)
</details>
