### PR TITLE
8344259: Annotate Float16 with jdk.internal.ValueBased

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -146,6 +146,8 @@ module java.base {
         jdk.compiler;
     exports com.sun.security.ntlm to
         java.security.sasl;
+    exports jdk.internal to
+        jdk.incubator.vector;
     // Note: all modules in the exported list participate in preview  features
     // and therefore if they use preview features they do not need to be
     // compiled with "--enable-preview".

--- a/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
+++ b/src/jdk.incubator.vector/share/classes/jdk/incubator/vector/Float16.java
@@ -95,8 +95,7 @@ import static java.lang.Math.multiplyHigh;
 // Currently Float16 is a value-based class and in future it is
 // expected to be aligned with Value Classes and Object as described in
 // JEP-401 (https://openjdk.org/jeps/401).
-// @jdk.internal.MigratedValueClass
-// @jdk.internal.ValueBased
+@jdk.internal.ValueBased
 public final class Float16
     extends Number
     implements Comparable<Float16> {
@@ -323,7 +322,7 @@ public final class Float16
     * @param  f a {@code float}
     */
     public static Float16 valueOf(float f) {
-        return new Float16(Float.floatToFloat16(f));
+        return new Float16(floatToFloat16(f));
     }
 
    /**


### PR DESCRIPTION
Annotate `Float16` with `jdk.internal.ValueBased`. This requires we export the package `jdk.internal` in module `java.base` to module` jdk.incubator.vector`.

Doing so enables the compiler and runtime to report warnings about improper attempts to synchronize on instances of `Float16`, as described in [JEP 390](https://openjdk.org/jeps/390).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344259](https://bugs.openjdk.org/browse/JDK-8344259): Annotate Float16 with jdk.internal.ValueBased (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22128/head:pull/22128` \
`$ git checkout pull/22128`

Update a local copy of the PR: \
`$ git checkout pull/22128` \
`$ git pull https://git.openjdk.org/jdk.git pull/22128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22128`

View PR using the GUI difftool: \
`$ git pr show -t 22128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22128.diff">https://git.openjdk.org/jdk/pull/22128.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22128#issuecomment-2477694119)
</details>
