### PR TITLE
8344149: Remove usage of Security Manager from java.rmi

### DIFF
--- a/src/java.rmi/share/classes/java/rmi/MarshalledObject.java
+++ b/src/java.rmi/share/classes/java/rmi/MarshalledObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,8 +35,6 @@ import java.io.ObjectOutputStream;
 import java.io.ObjectStreamConstants;
 import java.io.OutputStream;
 import java.io.Serializable;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import sun.rmi.server.MarshalInputStream;
 import sun.rmi.server.MarshalOutputStream;
@@ -317,7 +315,6 @@ public final class MarshalledObject<T> implements Serializable {
          * <code>null</code>, then all annotations will be
          * <code>null</code>.
          */
-        @SuppressWarnings("removal")
         MarshalledObjectInputStream(InputStream objIn, InputStream locIn,
                     ObjectInputFilter filter)
             throws IOException
@@ -325,13 +322,10 @@ public final class MarshalledObject<T> implements Serializable {
             super(objIn);
             this.locIn = (locIn == null ? null : new ObjectInputStream(locIn));
             if (filter != null) {
-                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    MarshalledObjectInputStream.this.setObjectInputFilter(filter);
-                    if (MarshalledObjectInputStream.this.locIn != null) {
-                        MarshalledObjectInputStream.this.locIn.setObjectInputFilter(filter);
-                    }
-                    return null;
-                });
+                MarshalledObjectInputStream.this.setObjectInputFilter(filter);
+                if (MarshalledObjectInputStream.this.locIn != null) {
+                    MarshalledObjectInputStream.this.locIn.setObjectInputFilter(filter);
+                }
             }
         }
 

--- a/src/java.rmi/share/classes/java/rmi/server/LogStream.java
+++ b/src/java.rmi/share/classes/java/rmi/server/LogStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -120,14 +120,6 @@ public class LogStream extends PrintStream {
      */
     @Deprecated
     public static synchronized void setDefaultStream(PrintStream newDefault) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-
-        if (sm != null) {
-            sm.checkPermission(
-                new java.util.logging.LoggingPermission("control", null));
-        }
-
         defaultStream = newDefault;
     }
 

--- a/src/java.rmi/share/classes/java/rmi/server/ObjID.java
+++ b/src/java.rmi/share/classes/java/rmi/server/ObjID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,6 @@ import java.io.IOException;
 import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.SecureRandom;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -242,9 +240,7 @@ public final class ObjID implements Serializable {
     }
 
     private static boolean useRandomIDs() {
-        @SuppressWarnings("removal")
-        String value = AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("java.rmi.server.randomIDs"));
+        String value = System.getProperty("java.rmi.server.randomIDs");
         return value == null ? true : Boolean.parseBoolean(value);
     }
 }

--- a/src/java.rmi/share/classes/java/rmi/server/RMIClassLoader.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RMIClassLoader.java
@@ -27,8 +27,6 @@ package java.rmi.server;
 
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 
@@ -112,12 +110,7 @@ public class RMIClassLoader {
         newDefaultProviderInstance();
 
     /** provider instance */
-    @SuppressWarnings("removal")
-    private static final RMIClassLoaderSpi provider =
-        AccessController.doPrivileged(
-            new PrivilegedAction<RMIClassLoaderSpi>() {
-                public RMIClassLoaderSpi run() { return initializeProvider(); }
-            });
+    private static final RMIClassLoaderSpi provider = initializeProvider();
 
     /*
      * Disallow anyone from creating one of these.
@@ -538,11 +531,6 @@ public class RMIClassLoader {
      * @since   1.4
      */
     public static RMIClassLoaderSpi getDefaultProviderInstance() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission("setFactory"));
-        }
         return defaultProvider;
     }
 

--- a/src/java.rmi/share/classes/java/rmi/server/RMISocketFactory.java
+++ b/src/java.rmi/share/classes/java/rmi/server/RMISocketFactory.java
@@ -131,11 +131,6 @@ public abstract class RMISocketFactory
         if (factory != null) {
             throw new SocketException("factory already defined");
         }
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkSetFactory();
-        }
         factory = fac;
     }
 
@@ -181,11 +176,6 @@ public abstract class RMISocketFactory
      */
     public static synchronized void setFailureHandler(RMIFailureHandler fh)
     {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkSetFactory();
-        }
         handler = fh;
     }
 

--- a/src/java.rmi/share/classes/sun/rmi/log/ReliableLog.java
+++ b/src/java.rmi/share/classes/sun/rmi/log/ReliableLog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,6 @@ package sun.rmi.log;
 
 import java.io.*;
 import java.lang.reflect.Constructor;
-import java.rmi.server.RMIClassLoader;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * This class is a simple implementation of a reliable Log.  The
@@ -132,15 +129,13 @@ public class ReliableLog {
      * if an exception occurs during invocation of the handler's
      * snapshot method or if other IOException occurs.
      */
-    @SuppressWarnings("removal")
     public ReliableLog(String dirPath,
                      LogHandler handler,
                      boolean pad)
         throws IOException
     {
         super();
-        this.Debug = AccessController.doPrivileged(
-            (PrivilegedAction<Boolean>) () -> Boolean.getBoolean("sun.rmi.log.debug"));
+        this.Debug = Boolean.getBoolean("sun.rmi.log.debug");
         dir = new File(dirPath);
         if (!(dir.exists() && dir.isDirectory())) {
             // create directory
@@ -331,19 +326,10 @@ public class ReliableLog {
     private static Constructor<? extends LogFile>
         getLogClassConstructor() {
 
-        @SuppressWarnings("removal")
-        String logClassName = AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("sun.rmi.log.class"));
+        String logClassName = System.getProperty("sun.rmi.log.class");
         if (logClassName != null) {
             try {
-                @SuppressWarnings("removal")
-                ClassLoader loader =
-                    AccessController.doPrivileged(
-                        new PrivilegedAction<ClassLoader>() {
-                            public ClassLoader run() {
-                               return ClassLoader.getSystemClassLoader();
-                            }
-                        });
+                ClassLoader loader = ClassLoader.getSystemClassLoader();
                 Class<? extends LogFile> cl =
                     loader.loadClass(logClassName).asSubclass(LogFile.class);
                 return cl.getConstructor(String.class, String.class);

--- a/src/java.rmi/share/classes/sun/rmi/registry/RegistryImpl.java
+++ b/src/java.rmi/share/classes/sun/rmi/registry/RegistryImpl.java
@@ -263,7 +263,6 @@ public class RegistryImpl extends java.rmi.server.RemoteServer
      * Check that the caller has access to perform indicated operation.
      * The client must be on same the same host as this server.
      */
-    @SuppressWarnings("removal")
     public static void checkAccess(String op) throws AccessException {
 
         try {
@@ -370,7 +369,6 @@ public class RegistryImpl extends java.rmi.server.RemoteServer
      *          {@link ObjectInputFilter.Status#REJECTED} if rejected,
      *          otherwise {@link ObjectInputFilter.Status#UNDECIDED}
      */
-    @SuppressWarnings("removal")
     private static ObjectInputFilter.Status registryFilter(ObjectInputFilter.FilterInfo filterInfo) {
         if (registryFilter != null) {
             ObjectInputFilter.Status status = registryFilter.checkInput(filterInfo);

--- a/src/java.rmi/share/classes/sun/rmi/runtime/NewThreadAction.java
+++ b/src/java.rmi/share/classes/sun/rmi/runtime/NewThreadAction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,13 +25,11 @@
 
 package sun.rmi.runtime;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import sun.security.util.SecurityConstants;
-
 /**
- * A PrivilegedAction for creating a new thread conveniently with an
- * AccessController.doPrivileged construct.
+ * A utility class for creating threads. The constructors take a
+ * variety of parameters to configure the thread. The run() method
+ * creates and sets up the thread and returns it, but does not
+ * start it.
  *
  * All constructors allow the choice of the Runnable for the new
  * thread to execute, the name of the new thread (which will be
@@ -48,34 +46,26 @@ import sun.security.util.SecurityConstants;
  *
  * @author      Peter Jones
  **/
-public final class NewThreadAction implements PrivilegedAction<Thread> {
+public final class NewThreadAction {
 
     /** cached reference to the system (root) thread group */
-    @SuppressWarnings("removal")
-    static final ThreadGroup systemThreadGroup =
-        AccessController.doPrivileged(new PrivilegedAction<ThreadGroup>() {
-            public ThreadGroup run() {
-                ThreadGroup group = Thread.currentThread().getThreadGroup();
-                ThreadGroup parent;
-                while ((parent = group.getParent()) != null) {
-                    group = parent;
-                }
-                return group;
-            }
-        });
+    static final ThreadGroup systemThreadGroup;
+    static {
+        ThreadGroup group = Thread.currentThread().getThreadGroup();
+        ThreadGroup parent;
+        while ((parent = group.getParent()) != null) {
+            group = parent;
+        }
+        systemThreadGroup = group;
+    }
+
 
     /**
      * special child of the system thread group for running tasks that
      * may execute user code, so that the security policy for threads in
      * the system thread group will not apply
      */
-    @SuppressWarnings("removal")
-    static final ThreadGroup userThreadGroup =
-        AccessController.doPrivileged(new PrivilegedAction<ThreadGroup>() {
-            public ThreadGroup run() {
-                return new ThreadGroup(systemThreadGroup, "RMI Runtime");
-            }
-        });
+    static final ThreadGroup userThreadGroup = new ThreadGroup(systemThreadGroup, "RMI Runtime");
 
     private final ThreadGroup group;
     private final Runnable runnable;
@@ -128,11 +118,6 @@ public final class NewThreadAction implements PrivilegedAction<Thread> {
     }
 
     public Thread run() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
-        }
         Thread t = new Thread(group, runnable, "RMI " + name);
         t.setContextClassLoader(ClassLoader.getSystemClassLoader());
         t.setDaemon(daemon);

--- a/src/java.rmi/share/classes/sun/rmi/runtime/NewThreadAction.java
+++ b/src/java.rmi/share/classes/sun/rmi/runtime/NewThreadAction.java
@@ -61,9 +61,10 @@ public final class NewThreadAction {
 
 
     /**
-     * special child of the system thread group for running tasks that
-     * may execute user code, so that the security policy for threads in
-     * the system thread group will not apply
+     * Special child of the system thread group for running tasks that
+     * may execute user code. The need for a separate thread group may
+     * be a vestige of it having had a different security policy from
+     * the system thread group, so this might no longer be necessary.
      */
     static final ThreadGroup userThreadGroup = new ThreadGroup(systemThreadGroup, "RMI Runtime");
 

--- a/src/java.rmi/share/classes/sun/rmi/server/MarshalInputStream.java
+++ b/src/java.rmi/share/classes/sun/rmi/server/MarshalInputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,7 +34,6 @@ import java.util.*;
 import java.security.AccessControlException;
 import java.security.Permission;
 import java.rmi.server.RMIClassLoader;
-import java.security.PrivilegedAction;
 
 /**
  * MarshalInputStream is an extension of ObjectInputStream.  When resolving
@@ -62,12 +61,9 @@ public class MarshalInputStream extends ObjectInputStream {
      * The value is only false when the property is present
      * and is equal to "false".
      */
-    @SuppressWarnings("removal")
     private static final boolean useCodebaseOnlyProperty =
-        ! java.security.AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty(
-                "java.rmi.server.useCodebaseOnly", "true"))
-            .equalsIgnoreCase("false");
+        ! System.getProperty("java.rmi.server.useCodebaseOnly", "true")
+                .equalsIgnoreCase("false");
 
     /** table to hold sun classes to which access is explicitly permitted */
     protected static Map<String, Class<?>> permittedSunClasses

--- a/src/java.rmi/share/classes/sun/rmi/server/MarshalOutputStream.java
+++ b/src/java.rmi/share/classes/sun/rmi/server/MarshalOutputStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,19 +58,12 @@ public class MarshalOutputStream extends ObjectOutputStream
     /**
      * Creates a marshal output stream with the given protocol version.
      */
-    @SuppressWarnings("removal")
     public MarshalOutputStream(OutputStream out, int protocolVersion)
         throws IOException
     {
         super(out);
         this.useProtocolVersion(protocolVersion);
-        java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<Void>() {
-                public Void run() {
-                enableReplaceObject(true);
-                return null;
-            }
-        });
+        enableReplaceObject(true);
     }
 
     /**

--- a/src/java.rmi/share/classes/sun/rmi/server/UnicastRef.java
+++ b/src/java.rmi/share/classes/sun/rmi/server/UnicastRef.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,6 @@ import java.rmi.server.Operation;
 import java.rmi.server.RemoteCall;
 import java.rmi.server.RemoteObject;
 import java.rmi.server.RemoteRef;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import jdk.internal.access.SharedSecrets;
 import sun.rmi.runtime.Log;
@@ -64,11 +62,9 @@ public class UnicastRef implements RemoteRef {
     /**
      * Client-side call log.
      */
-    @SuppressWarnings("removal")
     public static final Log clientCallLog =
         Log.getLog("sun.rmi.client.call", "RMI",
-                   AccessController.doPrivileged((PrivilegedAction<Boolean>) () ->
-                       Boolean.getBoolean("sun.rmi.client.logCalls")));
+                   Boolean.getBoolean("sun.rmi.client.logCalls"));
     private static final long serialVersionUID = 8258372400816541186L;
 
     @SuppressWarnings("serial") // Type of field is not Serializable

--- a/src/java.rmi/share/classes/sun/rmi/server/Util.java
+++ b/src/java.rmi/share/classes/sun/rmi/server/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,28 +35,20 @@ import java.lang.reflect.Method;
 import java.rmi.Remote;
 import java.rmi.RemoteException;
 import java.rmi.StubNotFoundException;
-import java.rmi.registry.Registry;
 import java.rmi.server.LogStream;
-import java.rmi.server.ObjID;
-import java.rmi.server.RMIClientSocketFactory;
 import java.rmi.server.RemoteObjectInvocationHandler;
 import java.rmi.server.RemoteRef;
 import java.rmi.server.RemoteStub;
 import java.rmi.server.Skeleton;
 import java.rmi.server.SkeletonNotFoundException;
-import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.DigestOutputStream;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
-import sun.rmi.registry.RegistryImpl;
 import sun.rmi.runtime.Log;
-import sun.rmi.transport.LiveRef;
-import sun.rmi.transport.tcp.TCPEndpoint;
 
 /**
  * A utility class with static methods for creating stubs/proxies and
@@ -66,20 +58,15 @@ import sun.rmi.transport.tcp.TCPEndpoint;
 public final class Util {
 
     /** "server" package log level */
-    @SuppressWarnings("removal")
-    static final int logLevel = LogStream.parseLevel(
-        AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("sun.rmi.server.logLevel")));
+    static final int logLevel = LogStream.parseLevel(System.getProperty("sun.rmi.server.logLevel"));
 
     /** server reference log */
     public static final Log serverRefLog =
         Log.getLog("sun.rmi.server.ref", "transport", Util.logLevel);
 
     /** cached value of property java.rmi.server.ignoreStubClasses */
-    @SuppressWarnings("removal")
     private static final boolean ignoreStubClasses =
-        AccessController.doPrivileged(
-            (PrivilegedAction<Boolean>) () -> Boolean.getBoolean("java.rmi.server.ignoreStubClasses"));
+        Boolean.getBoolean("java.rmi.server.ignoreStubClasses");
 
     /** cache of  impl classes that have no corresponding stub class */
     private static final Map<Class<?>, Void> withoutStubs =
@@ -120,7 +107,6 @@ public final class Util {
      * @throws StubNotFoundException if problem locating/creating stub or
      * creating the dynamic proxy instance
      **/
-    @SuppressWarnings("removal")
     public static Remote createProxy(Class<?> implClass,
                                      RemoteRef clientRef,
                                      boolean forceStubUse)
@@ -150,12 +136,7 @@ public final class Util {
         /* REMIND: private remote interfaces? */
 
         try {
-            return AccessController.doPrivileged(new PrivilegedAction<Remote>() {
-                public Remote run() {
-                    return (Remote) Proxy.newProxyInstance(loader,
-                                                           interfaces,
-                                                           handler);
-                }});
+            return (Remote) Proxy.newProxyInstance(loader, interfaces, handler);
         } catch (IllegalArgumentException e) {
             throw new StubNotFoundException("unable to create proxy", e);
         }

--- a/src/java.rmi/share/classes/sun/rmi/transport/DGCAckHandler.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/DGCAckHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package sun.rmi.transport;
 
 import java.rmi.server.UID;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -64,16 +62,12 @@ import sun.rmi.runtime.RuntimeUtil;
 public class DGCAckHandler {
 
     /** timeout for holding references without receiving an acknowledgment */
-    @SuppressWarnings("removal")
     private static final long dgcAckTimeout =           // default 5 minutes
-        AccessController.doPrivileged((PrivilegedAction<Long>) () ->
-            Long.getLong("sun.rmi.dgc.ackTimeout", 300000));
+        Long.getLong("sun.rmi.dgc.ackTimeout", 300000);
 
     /** thread pool for scheduling delayed tasks */
-    @SuppressWarnings("removal")
     private static final ScheduledExecutorService scheduler =
-        AccessController.doPrivileged(
-            new RuntimeUtil.GetInstanceAction()).getScheduler();
+        RuntimeUtil.getInstance().getScheduler();
 
     /** table mapping ack ID to handler */
     private static final Map<UID,DGCAckHandler> idTable =

--- a/src/java.rmi/share/classes/sun/rmi/transport/DGCClient.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/DGCClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,17 +27,13 @@ package sun.rmi.transport;
 import java.io.InvalidClassException;
 import java.lang.ref.PhantomReference;
 import java.lang.ref.ReferenceQueue;
-import java.net.SocketPermission;
 import java.rmi.UnmarshalException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.rmi.ConnectException;
 import java.rmi.RemoteException;
 import java.rmi.dgc.DGC;
 import java.rmi.dgc.Lease;
@@ -48,10 +44,6 @@ import sun.rmi.runtime.Log;
 import sun.rmi.runtime.NewThreadAction;
 import sun.rmi.server.UnicastRef;
 import sun.rmi.server.Util;
-
-import java.security.AccessControlContext;
-import java.security.Permissions;
-import java.security.ProtectionDomain;
 
 /**
  * DGCClient implements the client-side of the RMI distributed garbage
@@ -91,22 +83,16 @@ final class DGCClient {
     private static VMID vmid = new VMID();
 
     /** lease duration to request (usually ignored by server) */
-    @SuppressWarnings("removal")
     private static final long leaseValue =              // default 10 minutes
-        AccessController.doPrivileged((PrivilegedAction<Long>) () ->
-            Long.getLong("java.rmi.dgc.leaseValue", 600000));
+        Long.getLong("java.rmi.dgc.leaseValue", 600000);
 
     /** maximum interval between retries of failed clean calls */
-    @SuppressWarnings("removal")
     private static final long cleanInterval =           // default 3 minutes
-        AccessController.doPrivileged((PrivilegedAction<Long>) () ->
-            Long.getLong("sun.rmi.dgc.cleanInterval", 180000));
+        Long.getLong("sun.rmi.dgc.cleanInterval", 180000);
 
     /** maximum interval between complete garbage collections of local heap */
-    @SuppressWarnings("removal")
     private static final long gcInterval =              // default 1 hour
-        AccessController.doPrivileged((PrivilegedAction<Long>) () ->
-            Long.getLong("sun.rmi.dgc.client.gcInterval", 3600000));
+        Long.getLong("sun.rmi.dgc.client.gcInterval", 3600000);
 
     /** minimum retry count for dirty calls that fail */
     private static final int dirtyFailureRetries = 5;
@@ -119,21 +105,6 @@ final class DGCClient {
 
     /** ObjID for server-side DGC object */
     private static final ObjID dgcID = new ObjID(ObjID.DGC_ID);
-
-    /**
-     * An AccessControlContext with only socket permissions,
-     * suitable for an RMIClientSocketFactory.
-     */
-    @SuppressWarnings("removal")
-    private static final AccessControlContext SOCKET_ACC = createSocketAcc();
-
-    @SuppressWarnings("removal")
-    private static AccessControlContext createSocketAcc() {
-        Permissions perms = new Permissions();
-        perms.add(new SocketPermission("*", "connect,resolve"));
-        ProtectionDomain[] pd = { new ProtectionDomain(null, perms) };
-        return new AccessControlContext(pd);
-    }
 
     /*
      * Disallow anyone from creating one of these.
@@ -256,7 +227,6 @@ final class DGCClient {
             }
         }
 
-        @SuppressWarnings("removal")
         private EndpointEntry(final Endpoint endpoint) {
             this.endpoint = endpoint;
             try {
@@ -266,9 +236,9 @@ final class DGCClient {
             } catch (RemoteException e) {
                 throw new Error("internal error creating DGC stub");
             }
-            renewCleanThread =  AccessController.doPrivileged(
+            renewCleanThread =
                 new NewThreadAction(new RenewCleanThread(),
-                                    "RenewClean-" + endpoint, true));
+                                    "RenewClean-" + endpoint, true).run();
             renewCleanThread.start();
         }
 
@@ -496,20 +466,13 @@ final class DGCClient {
          *
          * This method must ONLY be called while synchronized on this entry.
          */
-        @SuppressWarnings("removal")
         private void setRenewTime(long newRenewTime) {
             assert Thread.holdsLock(this);
 
             if (newRenewTime < renewTime) {
                 renewTime = newRenewTime;
                 if (interruptible) {
-                    AccessController.doPrivileged(
-                        new PrivilegedAction<Void>() {
-                            public Void run() {
-                            renewCleanThread.interrupt();
-                            return null;
-                        }
-                    });
+                    renewCleanThread.interrupt();
                 }
             } else {
                 renewTime = newRenewTime;
@@ -522,7 +485,6 @@ final class DGCClient {
          */
         private class RenewCleanThread implements Runnable {
 
-            @SuppressWarnings("removal")
             public void run() {
                 do {
                     long timeToWait;
@@ -601,19 +563,13 @@ final class DGCClient {
                         }
                     }
 
-                    boolean needRenewal_ = needRenewal;
-                    Set<RefEntry> refsToDirty_ = refsToDirty;
-                    long sequenceNum_ = sequenceNum;
-                    AccessController.doPrivileged((PrivilegedAction<Void>)() -> {
-                        if (needRenewal_) {
-                            makeDirtyCall(refsToDirty_, sequenceNum_);
-                        }
+                    if (needRenewal) {
+                        makeDirtyCall(refsToDirty, sequenceNum);
+                    }
 
-                        if (!pendingCleans.isEmpty()) {
-                            makeCleanCalls();
-                        }
-                        return null;
-                    }, SOCKET_ACC);
+                    if (!pendingCleans.isEmpty()) {
+                        makeCleanCalls();
+                    }
                 } while (!removed || !pendingCleans.isEmpty());
             }
         }

--- a/src/java.rmi/share/classes/sun/rmi/transport/DGCImpl_Stub.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/DGCImpl_Stub.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,6 @@ import java.rmi.RemoteException;
 import java.rmi.dgc.Lease;
 import java.rmi.dgc.VMID;
 import java.rmi.server.UID;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 
 /**

--- a/src/java.rmi/share/classes/sun/rmi/transport/GC.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/GC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package sun.rmi.transport;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import jdk.internal.misc.InnocuousThread;
@@ -39,7 +37,7 @@ import jdk.internal.misc.InnocuousThread;
  * @since    1.2
  */
 
-@SuppressWarnings({"removal", "restricted"})
+@SuppressWarnings("restricted")
 class GC {
 
     private GC() { }            /* To prevent instantiation */
@@ -85,11 +83,7 @@ class GC {
     public static native long maxObjectInspectionAge();
 
     static {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-                System.loadLibrary("rmi");
-                return null;
-            }});
+        System.loadLibrary("rmi");
     }
 
     private static class Daemon implements Runnable {
@@ -134,18 +128,12 @@ class GC {
 
         /* Create a new daemon thread */
         public static void create() {
-            PrivilegedAction<Void> pa = new PrivilegedAction<Void>() {
-                public Void run() {
-                    Thread t = InnocuousThread.newSystemThread("RMI GC Daemon",
-                                                               new Daemon());
-                    assert t.getContextClassLoader() == null;
-                    t.setDaemon(true);
-                    t.setPriority(Thread.MIN_PRIORITY + 1);
-                    t.start();
-                    GC.daemon = t;
-                    return null;
-                }};
-            AccessController.doPrivileged(pa);
+            Thread t = InnocuousThread.newSystemThread("RMI GC Daemon", new Daemon());
+            assert t.getContextClassLoader() == null;
+            t.setDaemon(true);
+            t.setPriority(Thread.MIN_PRIORITY + 1);
+            t.start();
+            GC.daemon = t;
         }
 
     }

--- a/src/java.rmi/share/classes/sun/rmi/transport/ObjectTable.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/ObjectTable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,6 @@ import java.rmi.Remote;
 import java.rmi.dgc.VMID;
 import java.rmi.server.ExportException;
 import java.rmi.server.ObjID;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
 import sun.rmi.runtime.Log;
@@ -48,10 +46,8 @@ import sun.rmi.runtime.NewThreadAction;
 public final class ObjectTable {
 
     /** maximum interval between complete garbage collections of local heap */
-    @SuppressWarnings("removal")
     private static final long gcInterval =              // default 1 hour
-        AccessController.doPrivileged((PrivilegedAction<Long>) () ->
-            Long.getLong("sun.rmi.dgc.server.gcInterval", 3600000));
+        Long.getLong("sun.rmi.dgc.server.gcInterval", 3600000);
 
     /**
      * lock guarding objTable and implTable.
@@ -270,14 +266,12 @@ public final class ObjectTable {
      * thread operates, the reaper thread also serves as the non-daemon
      * VM keep-alive thread; a new reaper thread is created if necessary.
      */
-    @SuppressWarnings("removal")
     static void incrementKeepAliveCount() {
         synchronized (keepAliveLock) {
             keepAliveCount++;
 
             if (reaper == null) {
-                reaper = AccessController.doPrivileged(
-                    new NewThreadAction(new Reaper(), "Reaper", false));
+                reaper = new NewThreadAction(new Reaper(), "Reaper", false).run();
                 reaper.start();
             }
 
@@ -307,19 +301,13 @@ public final class ObjectTable {
      * reaper thread is terminated to cease keeping the VM alive (and
      * because there are no more non-permanent remote objects to reap).
      */
-    @SuppressWarnings("removal")
     static void decrementKeepAliveCount() {
         synchronized (keepAliveLock) {
             keepAliveCount--;
 
             if (keepAliveCount == 0) {
                 if (!(reaper != null)) { throw new AssertionError(); }
-                AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                    public Void run() {
-                        reaper.interrupt();
-                        return null;
-                    }
-                });
+                reaper.interrupt();
                 reaper = null;
 
                 /*

--- a/src/java.rmi/share/classes/sun/rmi/transport/StreamRemoteCall.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/StreamRemoteCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,8 +37,6 @@ import java.rmi.MarshalException;
 import java.rmi.UnmarshalException;
 import java.rmi.server.ObjID;
 import java.rmi.server.RemoteCall;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import sun.rmi.runtime.Log;
 import sun.rmi.server.UnicastRef;
@@ -139,17 +137,13 @@ public class StreamRemoteCall implements RemoteCall {
      * Get the InputStream the stub/skeleton should get results/arguments
      * from.
      */
-    @SuppressWarnings("removal")
     public ObjectInput getInputStream() throws IOException {
         if (in == null) {
             Transport.transportLog.log(Log.VERBOSE, "getting input stream");
 
             in = new ConnectionInputStream(conn.getInputStream());
             if (filter != null) {
-                AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                    in.setObjectInputFilter(filter);
-                    return null;
-                });
+                in.setObjectInputFilter(filter);
             }
         }
         return in;

--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPChannel.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPChannel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,18 +27,12 @@ package sun.rmi.transport.tcp;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.lang.ref.Reference;
-import java.lang.ref.SoftReference;
 import java.net.Socket;
 import java.rmi.ConnectIOException;
 import java.rmi.RemoteException;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.WeakHashMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -70,42 +64,21 @@ public class TCPChannel implements Channel {
     /** connection acceptor (should be in TCPTransport) */
     private ConnectionAcceptor acceptor;
 
-    /** most recently authorized AccessControlContext */
-    @SuppressWarnings("removal")
-    private AccessControlContext okContext;
-
-    /** cache of authorized AccessControlContexts */
-    @SuppressWarnings("removal")
-    private WeakHashMap<AccessControlContext,
-                        Reference<AccessControlContext>> authcache;
-
-    /** the SecurityManager which authorized okContext and authcache */
-    @SuppressWarnings("removal")
-    private SecurityManager cacheSecurityManager = null;
-
     /** client-side connection idle usage timeout */
-    @SuppressWarnings("removal")
     private static final long idleTimeout =             // default 15 seconds
-        AccessController.doPrivileged((PrivilegedAction<Long>) () ->
-            Long.getLong("sun.rmi.transport.connectionTimeout", 15000));
+        Long.getLong("sun.rmi.transport.connectionTimeout", 15000);
 
     /** client-side connection handshake read timeout */
-    @SuppressWarnings("removal")
     private static final int handshakeTimeout =         // default 1 minute
-        AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
-            Integer.getInteger("sun.rmi.transport.tcp.handshakeTimeout", 60000));
+        Integer.getInteger("sun.rmi.transport.tcp.handshakeTimeout", 60000);
 
     /** client-side connection response read timeout (after handshake) */
-    @SuppressWarnings("removal")
     private static final int responseTimeout =          // default infinity
-        AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
-            Integer.getInteger("sun.rmi.transport.tcp.responseTimeout", 0));
+        Integer.getInteger("sun.rmi.transport.tcp.responseTimeout", 0);
 
     /** thread pool for scheduling delayed tasks */
-    @SuppressWarnings("removal")
     private static final ScheduledExecutorService scheduler =
-        AccessController.doPrivileged(
-            new RuntimeUtil.GetInstanceAction()).getScheduler();
+        RuntimeUtil.getInstance().getScheduler();
 
     /**
      * Create channel for endpoint.
@@ -120,41 +93,6 @@ public class TCPChannel implements Channel {
      */
     public Endpoint getEndpoint() {
         return ep;
-    }
-
-    /**
-     * Checks if the current caller has sufficient privilege to make
-     * a connection to the remote endpoint.
-     * @exception SecurityException if caller is not allowed to use this
-     * Channel.
-     */
-    @SuppressWarnings("removal")
-    private void checkConnectPermission() throws SecurityException {
-        SecurityManager security = System.getSecurityManager();
-        if (security == null)
-            return;
-
-        if (security != cacheSecurityManager) {
-            // The security manager changed: flush the cache
-            okContext = null;
-            authcache = new WeakHashMap<AccessControlContext,
-                                        Reference<AccessControlContext>>();
-            cacheSecurityManager = security;
-        }
-
-        AccessControlContext ctx = AccessController.getContext();
-
-        // If ctx is the same context as last time, or if it
-        // appears in the cache, bypass the checkConnect.
-        if (okContext == null ||
-            !(okContext.equals(ctx) || authcache.containsKey(ctx)))
-        {
-            security.checkConnect(ep.getHost(), ep.getPort());
-            authcache.put(ctx, new SoftReference<AccessControlContext>(ctx));
-            // A WeakHashMap is transformed into a SoftHashSet by making
-            // each value softly refer to its own key (Peter's idea).
-        }
-        okContext = ctx;
     }
 
     /**
@@ -175,10 +113,6 @@ public class TCPChannel implements Channel {
                 int elementPos = freeList.size()-1;
 
                 if (elementPos >= 0) {
-                    // If there is a security manager, make sure
-                    // the caller is allowed to connect to the
-                    // requested endpoint.
-                    checkConnectPermission();
                     conn = freeList.get(elementPos);
                     freeList.remove(elementPos);
                 }
@@ -467,11 +401,10 @@ class ConnectionAcceptor implements Runnable {
      * Start a new thread to accept connections.
      */
     public void startNewAcceptor() {
-        @SuppressWarnings("removal")
-        Thread t = AccessController.doPrivileged(
+        Thread t =
             new NewThreadAction(ConnectionAcceptor.this,
                                 "TCPChannel Accept-" + ++ threadNum,
-                                true));
+                                true).run();
         t.start();
     }
 

--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPChannel.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPChannel.java
@@ -401,10 +401,9 @@ class ConnectionAcceptor implements Runnable {
      * Start a new thread to accept connections.
      */
     public void startNewAcceptor() {
-        Thread t =
-            new NewThreadAction(ConnectionAcceptor.this,
-                                "TCPChannel Accept-" + ++ threadNum,
-                                true).run();
+        Thread t = new NewThreadAction(ConnectionAcceptor.this,
+                                       "TCPChannel Accept-" + ++ threadNum,
+                                       true).run();
         t.start();
     }
 

--- a/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPEndpoint.java
+++ b/src/java.rmi/share/classes/sun/rmi/transport/tcp/TCPEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,6 @@ import java.rmi.RemoteException;
 import java.rmi.server.RMIClientSocketFactory;
 import java.rmi.server.RMIServerSocketFactory;
 import java.rmi.server.RMISocketFactory;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -79,27 +77,19 @@ public class TCPEndpoint implements Endpoint {
     /** true if real local host name is known yet */
     private static boolean localHostKnown;
 
-    // this should be a *private* method since it is privileged
-    @SuppressWarnings("removal")
     private static int getInt(String name, int def) {
-        return AccessController.doPrivileged(
-                (PrivilegedAction<Integer>) () -> Integer.getInteger(name, def));
+        return Integer.getInteger(name, def);
     }
 
-    // this should be a *private* method since it is privileged
-    @SuppressWarnings("removal")
     private static boolean getBoolean(String name) {
-        return AccessController.doPrivileged(
-                (PrivilegedAction<Boolean>) () -> Boolean.getBoolean(name));
+        return Boolean.getBoolean(name);
     }
 
     /**
      * Returns the value of the java.rmi.server.hostname property.
      */
-    @SuppressWarnings("removal")
     private static String getHostnameProperty() {
-        return AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> System.getProperty("java.rmi.server.hostname"));
+        return System.getProperty("java.rmi.server.hostname");
     }
 
     /**
@@ -762,9 +752,7 @@ public class TCPEndpoint implements Endpoint {
         private void getFQDN() {
 
             /* FQDN finder will run in RMI threadgroup. */
-            @SuppressWarnings("removal")
-            Thread t = AccessController.doPrivileged(
-                new NewThreadAction(FQDN.this, "FQDN Finder", true));
+            Thread t = new NewThreadAction(FQDN.this, "FQDN Finder", true).run();
             t.start();
         }
 


### PR DESCRIPTION
First cut at removal of Security Manager stuff from RMI.

This covers just about every SM-related case in RMI, except for a bit of package checking in MarshalInputStream. This will be handled separately. It's covered by [JDK-8344329](https://bugs.openjdk.org/browse/JDK-8344329).

Further simplifications could be done in RuntimeUtil and NewThreadAction. However, those changes started to become somewhat more intrusive than I'd like for this PR, which is focused on removing security-related stuff. EDIT: I've filed [JDK-8344461](https://bugs.openjdk.org/browse/JDK-8344461) to cover this additional cleanup work.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344149](https://bugs.openjdk.org/browse/JDK-8344149): Remove usage of Security Manager from java.rmi (**Enhancement** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) Review applies to [1e7e88a7](https://git.openjdk.org/jdk/pull/22129/files/1e7e88a7104f63d9096112011b5c5cfe7b9a679e)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - **Reviewer**) Review applies to [1e7e88a7](https://git.openjdk.org/jdk/pull/22129/files/1e7e88a7104f63d9096112011b5c5cfe7b9a679e)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22129/head:pull/22129` \
`$ git checkout pull/22129`

Update a local copy of the PR: \
`$ git checkout pull/22129` \
`$ git pull https://git.openjdk.org/jdk.git pull/22129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22129`

View PR using the GUI difftool: \
`$ git pr show -t 22129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22129.diff">https://git.openjdk.org/jdk/pull/22129.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22129#issuecomment-2483619129)
</details>
