### PR TITLE
8344265: RISC-V: Remove unused function get_previous_sp_entry

### DIFF
--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
@@ -34,16 +34,6 @@
 // Implementation of the platform-specific part of StubRoutines - for
 // a description of how to extend it, see the stubRoutines.hpp file.
 
-address StubRoutines::riscv::_get_previous_sp_entry = nullptr;
-
-address StubRoutines::riscv::_f2i_fixup = nullptr;
-address StubRoutines::riscv::_f2l_fixup = nullptr;
-address StubRoutines::riscv::_d2i_fixup = nullptr;
-address StubRoutines::riscv::_d2l_fixup = nullptr;
-address StubRoutines::riscv::_float_sign_mask = nullptr;
-address StubRoutines::riscv::_float_sign_flip = nullptr;
-address StubRoutines::riscv::_double_sign_mask = nullptr;
-address StubRoutines::riscv::_double_sign_flip = nullptr;
 address StubRoutines::riscv::_zero_blocks = nullptr;
 address StubRoutines::riscv::_compare_long_string_LL = nullptr;
 address StubRoutines::riscv::_compare_long_string_UU = nullptr;

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.cpp
@@ -42,7 +42,6 @@ address StubRoutines::riscv::_compare_long_string_UL = nullptr;
 address StubRoutines::riscv::_string_indexof_linear_ll = nullptr;
 address StubRoutines::riscv::_string_indexof_linear_uu = nullptr;
 address StubRoutines::riscv::_string_indexof_linear_ul = nullptr;
-address StubRoutines::riscv::_large_byte_array_inflate = nullptr;
 
 bool StubRoutines::riscv::_completed = false;
 

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
@@ -56,7 +56,6 @@ class riscv {
   static address _string_indexof_linear_ll;
   static address _string_indexof_linear_uu;
   static address _string_indexof_linear_ul;
-  static address _large_byte_array_inflate;
 
   static bool _completed;
 
@@ -92,10 +91,6 @@ class riscv {
 
   static address string_indexof_linear_uu() {
     return _string_indexof_linear_uu;
-  }
-
-  static address large_byte_array_inflate() {
-    return _large_byte_array_inflate;
   }
 
   static bool complete() {

--- a/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
+++ b/src/hotspot/cpu/riscv/stubRoutines_riscv.hpp
@@ -47,18 +47,6 @@ class riscv {
  friend class StubGenerator;
 
  private:
-  static address _get_previous_sp_entry;
-
-  static address _f2i_fixup;
-  static address _f2l_fixup;
-  static address _d2i_fixup;
-  static address _d2l_fixup;
-
-  static address _float_sign_mask;
-  static address _float_sign_flip;
-  static address _double_sign_mask;
-  static address _double_sign_flip;
-
   static address _zero_blocks;
 
   static address _compare_long_string_LL;
@@ -73,42 +61,6 @@ class riscv {
   static bool _completed;
 
  public:
-
-  static address get_previous_sp_entry() {
-    return _get_previous_sp_entry;
-  }
-
-  static address f2i_fixup() {
-    return _f2i_fixup;
-  }
-
-  static address f2l_fixup() {
-    return _f2l_fixup;
-  }
-
-  static address d2i_fixup() {
-    return _d2i_fixup;
-  }
-
-  static address d2l_fixup() {
-    return _d2l_fixup;
-  }
-
-  static address float_sign_mask() {
-    return _float_sign_mask;
-  }
-
-  static address float_sign_flip() {
-    return _float_sign_flip;
-  }
-
-  static address double_sign_mask() {
-    return _double_sign_mask;
-  }
-
-  static address double_sign_flip() {
-    return _double_sign_flip;
-  }
 
   static address zero_blocks() {
     return _zero_blocks;


### PR DESCRIPTION
Hi, I noticed that there are a several unused functions here that are currently only used in the x86 architecture, not used in RISC-V.

### Testing
 - [x] release & fastdebug cross-build  linux-riscv64 OK
 - [x] release & fastdebug build  on SOPHON SG2042
- [x] Run tier1 tests on SOPHON SG2042 (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344265](https://bugs.openjdk.org/browse/JDK-8344265): RISC-V: Remove unused function get_previous_sp_entry (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22130/head:pull/22130` \
`$ git checkout pull/22130`

Update a local copy of the PR: \
`$ git checkout pull/22130` \
`$ git pull https://git.openjdk.org/jdk.git pull/22130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22130`

View PR using the GUI difftool: \
`$ git pr show -t 22130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22130.diff">https://git.openjdk.org/jdk/pull/22130.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22130#issuecomment-2477778562)
</details>
