### PR TITLE
8335468: [XWayland] JavaFX hangs when calling java.awt.Robot.getPixelColor

### DIFF
--- a/src/java.desktop/unix/native/libawt_xawt/awt/fp_pipewire.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/fp_pipewire.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,7 +58,6 @@ void (*fp_pw_stream_destroy)(struct pw_stream *stream);
 
 
 void (*fp_pw_init)(int *argc, char **argv[]);
-void (*fp_pw_deinit)(void);
 
 struct pw_core *
 (*fp_pw_context_connect_fd)(struct pw_context *context,

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -285,6 +285,9 @@ GtkApi* gtk3_load(JNIEnv *env, const char* lib_name)
 
         fp_g_main_context_iteration =
             dl_symbol("g_main_context_iteration");
+        fp_g_main_context_default = dl_symbol("g_main_context_default");
+        fp_g_main_context_is_owner = dl_symbol("g_main_context_is_owner");
+
 
         fp_g_value_init = dl_symbol("g_value_init");
         fp_g_type_is_a = dl_symbol("g_type_is_a");
@@ -556,6 +559,7 @@ GtkApi* gtk3_load(JNIEnv *env, const char* lib_name)
         fp_g_signal_connect_data = dl_symbol("g_signal_connect_data");
         fp_gtk_widget_show = dl_symbol("gtk_widget_show");
         fp_gtk_main = dl_symbol("gtk_main");
+        fp_gtk_main_level = dl_symbol("gtk_main_level");
 
         fp_g_path_get_dirname = dl_symbol("g_path_get_dirname");
 
@@ -3125,6 +3129,8 @@ static void gtk3_init(GtkApi* gtk) {
     gtk->g_uuid_string_is_valid = fp_g_uuid_string_is_valid;
 
     gtk->g_main_context_iteration = fp_g_main_context_iteration;
+    gtk->g_main_context_default = fp_g_main_context_default;
+    gtk->g_main_context_is_owner = fp_g_main_context_is_owner;
     gtk->g_error_free = fp_g_error_free;
     gtk->g_unix_fd_list_get = fp_g_unix_fd_list_get;
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk3_interface.h
@@ -392,6 +392,9 @@ static void         (*fp_g_object_set)(gpointer object,
                                        ...);
 
 static gboolean (*fp_g_main_context_iteration)(GMainContext *context, gboolean may_block);
+static GMainContext *(*fp_g_main_context_default)();
+static gboolean (*fp_g_main_context_is_owner)(GMainContext* context);
+
 static gboolean (*fp_g_str_has_prefix)(const gchar *str, const gchar *prefix);
 static gchar** (*fp_g_strsplit)(const gchar *string, const gchar *delimiter,
            gint max_tokens);

--- a/src/java.desktop/unix/native/libawt_xawt/awt/gtk_interface.h
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/gtk_interface.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -792,6 +792,8 @@ typedef struct GtkApi {
 
     gboolean (*g_main_context_iteration)(GMainContext *context,
                                          gboolean may_block);
+    GMainContext *(*g_main_context_default)();
+    gboolean (*g_main_context_is_owner)(GMainContext* context);
 
     void (*g_error_free)(GError *error);
 

--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -49,6 +49,7 @@ static GString *activeSessionToken;
 
 struct ScreenSpace screenSpace = {0};
 static struct PwLoopData pw = {0};
+volatile bool isGtkMainThread = FALSE;
 
 jclass tokenStorageClass = NULL;
 jmethodID storeTokenMethodID = NULL;
@@ -945,9 +946,10 @@ JNIEXPORT jint JNICALL Java_sun_awt_screencast_ScreencastHelper_getRGBPixelsImpl
                          ? (*env)->GetStringUTFChars(env, jtoken, NULL)
                          : NULL;
 
+    isGtkMainThread = gtk->g_main_context_is_owner(gtk->g_main_context_default());
     DEBUG_SCREENCAST(
-            "taking screenshot at \n\tx: %5i y %5i w %5i h %5i with token |%s|\n",
-            jx, jy, jwidth, jheight, token
+            "taking screenshot at \n\tx: %5i y %5i w %5i h %5i\n\twith token |%s| isGtkMainThread %d\n",
+            jx, jy, jwidth, jheight, token, isGtkMainThread
     );
 
     int attemptResult = makeScreencast(

--- a/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
+++ b/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c
@@ -133,10 +133,6 @@ static void doCleanup() {
         screenSpace.screenCount = 0;
     }
 
-    if (!sessionClosed) {
-        fp_pw_deinit();
-    }
-
     gtk->g_string_set_size(activeSessionToken, 0);
     sessionClosed = TRUE;
 }
@@ -583,6 +579,13 @@ static gboolean doLoop(GdkRectangle requestedArea) {
         pw.loop = fp_pw_thread_loop_new("AWT Pipewire Thread", NULL);
 
         if (!pw.loop) {
+            // in case someone called the pw_deinit before
+            DEBUG_SCREENCAST("pw_init\n", NULL);
+            fp_pw_init(NULL, NULL);
+            pw.loop = fp_pw_thread_loop_new("AWT Pipewire Thread", NULL);
+        }
+
+        if (!pw.loop) {
             DEBUG_SCREENCAST("!!! Could not create a loop\n", NULL);
             doCleanup();
             return FALSE;
@@ -712,7 +715,6 @@ static gboolean loadSymbols() {
     LOAD_SYMBOL(fp_pw_stream_disconnect, "pw_stream_disconnect");
     LOAD_SYMBOL(fp_pw_stream_destroy, "pw_stream_destroy");
     LOAD_SYMBOL(fp_pw_init, "pw_init");
-    LOAD_SYMBOL(fp_pw_deinit, "pw_deinit");
     LOAD_SYMBOL(fp_pw_context_connect_fd, "pw_context_connect_fd");
     LOAD_SYMBOL(fp_pw_core_disconnect, "pw_core_disconnect");
     LOAD_SYMBOL(fp_pw_context_new, "pw_context_new");


### PR DESCRIPTION
This is a linux only issue and this PR contains two parts(they are available as two separate commits):

a. [8335468](https://bugs.openjdk.org/browse/JDK-8335468): [XWayland] JavaFX hangs when calling java.awt.Robot.getPixelColor
b. [8335469](https://bugs.openjdk.org/browse/JDK-8335469): [XWayland] crash when an AWT ScreenCast session overlaps with an FX ScreenCast session

`b.` is not reproducible without `a.` being fixed.

More about both cases:

------
<a href="#a-part" id="a-part">`a.`</a>

Previously we used a blocking [`g_main_context_iteration`](https://docs.gtk.org/glib/method.MainContext.iteration.html) call, this prevents normal execution if there is a GTK main loop running in the process.

Now we are handling 3 cases:
1. If there is no GTK main loop running
_Example: just a JDK only application._
In this case we call `g_main_context_iteration(NULL, TRUE)` as before (when [`gtk_main_level() == 0`](https://docs.gtk.org/gtk3/func.main_level.html)).

2. If there is a GTK main loop running, but we are not requesting pixels on its thread
_Example: application showing a `JFXPanel`, but are requesting pixels from a main thread._
Now we are not trying to block thread: `g_main_context_iteration(NULL, FALSE)` (when `gtk_main_level() > 0`) .

3. If there is a GTK main loop running, and we are requesting pixels on its thread
_Example: a JavaFX application trying to get pixels on the FX application thread, e.g. from a button callback._
Now we go nested with [`gtk_main()`](https://docs.gtk.org/gtk3/func.main.html)

[jdk commit](https://github.com/openjdk/jdk/pull/22131/commits/f439eb9739cf53ed6196a98062032b3045dd1cbe)

------

<a href="#b-part" id="b-part">`b.`</a>

After fixing `a.` [the crash](https://bugs.openjdk.org/browse/JDK-8335469) appears:

Internally the ScreenCast session keeps open for 2s (both JDK and JFX, and their implementations are almost identical).
This is to reduce overhead in case of frequent consecutive screen captures.

When we perform a [cleanup](https://github.com/openjdk/jdk/blob/db56266ad164b4ecae59451dc0a832097dbfbd8e/src/java.desktop/unix/native/libawt_xawt/awt/screencast_pipewire.c#L91) to close the session, we internally call [`pw_deinit`](https://docs.pipewire.org/group__pw__pipewire.html#gafa6045cd7391b467af4575c6752d6c4e).

It becomes a problem if these sessions overlap in time, so that the second session cleanup crashes when it tries to call pipewire functions without initializing the pipewire system by  [`pw_init`](https://docs.pipewire.org/group__pw__pipewire.html#ga06c879b2d800579f4724109054368d99) (please note that `This function can be called multiple times.`).

So the solution is not to call `pw_deinit` because we don't really need it, and it needs to be applied to both the JDK and JavaFX.

[jdk commit](https://github.com/openjdk/jdk/pull/22131/commits/19956fda202269e92ec70670bc88c8d3c7accf73) / [jfx commit](https://github.com/openjdk/jfx/pull/1639/commits/dba8a8871a38831d0a0da697a2be41f0c240c8f0)
[FX review counterpart](https://github.com/openjdk/jfx/pull/1639)

------

Testing in different scenarios looks good.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8335468](https://bugs.openjdk.org/browse/JDK-8335468): [XWayland] JavaFX hangs when calling java.awt.Robot.getPixelColor (**Bug** - P3)


### Reviewers
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22131/head:pull/22131` \
`$ git checkout pull/22131`

Update a local copy of the PR: \
`$ git checkout pull/22131` \
`$ git pull https://git.openjdk.org/jdk.git pull/22131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22131`

View PR using the GUI difftool: \
`$ git pr show -t 22131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22131.diff">https://git.openjdk.org/jdk/pull/22131.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22131#issuecomment-2477814055)
</details>
