### PR TITLE
8344078: Remove security manager dependency in java.nio

### DIFF
--- a/src/java.base/aix/classes/sun/nio/ch/DefaultSelectorProvider.java
+++ b/src/java.base/aix/classes/sun/nio/ch/DefaultSelectorProvider.java
@@ -30,8 +30,7 @@ package sun.nio.ch;
  */
 
 public class DefaultSelectorProvider {
-    private static final SelectorProviderImpl INSTANCE =
-        new PollSelectorProvider();
+    private static final SelectorProviderImpl INSTANCE = new PollSelectorProvider();
 
     /**
      * Prevent instantiation.

--- a/src/java.base/aix/classes/sun/nio/ch/DefaultSelectorProvider.java
+++ b/src/java.base/aix/classes/sun/nio/ch/DefaultSelectorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,13 @@
 
 package sun.nio.ch;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * Creates this platform's default SelectorProvider
  */
 
-@SuppressWarnings("removal")
 public class DefaultSelectorProvider {
-    private static final SelectorProviderImpl INSTANCE;
-    static {
-        PrivilegedAction<SelectorProviderImpl> pa = PollSelectorProvider::new;
-        INSTANCE = AccessController.doPrivileged(pa);
-    }
+    private static final SelectorProviderImpl INSTANCE =
+        new PollSelectorProvider();
 
     /**
      * Prevent instantiation.

--- a/src/java.base/linux/classes/sun/nio/ch/DefaultSelectorProvider.java
+++ b/src/java.base/linux/classes/sun/nio/ch/DefaultSelectorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,13 @@
 
 package sun.nio.ch;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * Creates this platform's default SelectorProvider
  */
 
-@SuppressWarnings("removal")
 public class DefaultSelectorProvider {
-    private static final SelectorProviderImpl INSTANCE;
-    static {
-        PrivilegedAction<SelectorProviderImpl> pa = EPollSelectorProvider::new;
-        INSTANCE = AccessController.doPrivileged(pa);
-    }
+    private static final SelectorProviderImpl INSTANCE =
+        new EPollSelectorProvider();
 
     /**
      * Prevent instantiation.

--- a/src/java.base/linux/classes/sun/nio/ch/DefaultSelectorProvider.java
+++ b/src/java.base/linux/classes/sun/nio/ch/DefaultSelectorProvider.java
@@ -30,8 +30,7 @@ package sun.nio.ch;
  */
 
 public class DefaultSelectorProvider {
-    private static final SelectorProviderImpl INSTANCE =
-        new EPollSelectorProvider();
+    private static final SelectorProviderImpl INSTANCE = new EPollSelectorProvider();
 
     /**
      * Prevent instantiation.

--- a/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
+++ b/src/java.base/linux/classes/sun/nio/fs/LinuxDosFileAttributeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -115,8 +115,6 @@ class LinuxDosFileAttributeView
 
     @Override
     public DosFileAttributes readAttributes() throws IOException {
-        file.checkRead();
-
         int fd = -1;
         try {
              fd = file.openForAttributeAccess(followLinks);
@@ -249,8 +247,6 @@ class LinuxDosFileAttributeView
      * Updates the value of the user.DOSATTRIB extended attribute
      */
     private void updateDosAttribute(int flag, boolean enable) throws IOException {
-        file.checkWrite();
-
         int fd = -1;
         try {
             fd = file.openForAttributeAccess(followLinks);

--- a/src/java.base/macosx/classes/sun/nio/ch/DefaultSelectorProvider.java
+++ b/src/java.base/macosx/classes/sun/nio/ch/DefaultSelectorProvider.java
@@ -25,20 +25,12 @@
 
 package sun.nio.ch;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * Creates this platform's default SelectorProvider
  */
 
-@SuppressWarnings("removal")
 public class DefaultSelectorProvider {
-    private static final SelectorProviderImpl INSTANCE;
-    static {
-        PrivilegedAction<SelectorProviderImpl> pa = KQueueSelectorProvider::new;
-        INSTANCE = AccessController.doPrivileged(pa);
-    }
+    private static final SelectorProviderImpl INSTANCE = new KQueueSelectorProvider();
 
     /**
      * Prevent instantiation.

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileAttributeViews.java
@@ -50,9 +50,6 @@ class BsdFileAttributeViews {
             return;
         }
 
-        // permission check
-        path.checkWrite();
-
         // use a file descriptor if possible to avoid a race due to accessing
         // a path more than once as the file at that path could change.
         // if path is a symlink, then the open should fail with ELOOP and

--- a/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystem.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/BsdFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,13 +28,11 @@ package sun.nio.fs;
 import java.io.IOException;
 import java.nio.file.FileStore;
 import java.nio.file.WatchService;
-import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import sun.nio.ch.IOStatus;
-import sun.security.action.GetPropertyAction;
 
 import static sun.nio.fs.UnixConstants.*;
 import static sun.nio.fs.UnixNativeDispatcher.chown;

--- a/src/java.base/share/classes/java/nio/channels/spi/AsynchronousChannelProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AsynchronousChannelProvider.java
@@ -91,9 +91,7 @@ public abstract class AsynchronousChannelProvider {
                 ServiceLoader.load(AsynchronousChannelProvider.class,
                                    ClassLoader.getSystemClassLoader());
             Iterator<AsynchronousChannelProvider> i = sl.iterator();
-            for (;;) {
-                return (i.hasNext()) ? i.next() : null;
-            }
+            return sl.findFirst().orElse(null);
         }
     }
 

--- a/src/java.base/share/classes/java/nio/channels/spi/AsynchronousChannelProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AsynchronousChannelProvider.java
@@ -31,8 +31,6 @@ import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.ServiceConfigurationError;
 import java.util.concurrent.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * Service-provider class for asynchronous channels.
@@ -62,20 +60,15 @@ public abstract class AsynchronousChannelProvider {
     private static class ProviderHolder {
         static final AsynchronousChannelProvider provider = load();
 
-        @SuppressWarnings("removal")
         private static AsynchronousChannelProvider load() {
-            return AccessController
-                .doPrivileged(new PrivilegedAction<>() {
-                    public AsynchronousChannelProvider run() {
-                        AsynchronousChannelProvider p;
-                        p = loadProviderFromProperty();
-                        if (p != null)
-                            return p;
-                        p = loadProviderAsService();
-                        if (p != null)
-                            return p;
-                        return sun.nio.ch.DefaultAsynchronousChannelProvider.create();
-                    }});
+            AsynchronousChannelProvider p;
+            p = loadProviderFromProperty();
+            if (p != null)
+                return p;
+            p = loadProviderAsService();
+            if (p != null)
+                return p;
+            return sun.nio.ch.DefaultAsynchronousChannelProvider.create();
         }
 
         private static AsynchronousChannelProvider loadProviderFromProperty() {
@@ -87,7 +80,7 @@ public abstract class AsynchronousChannelProvider {
                 Object tmp = Class.forName(cn, true,
                                            ClassLoader.getSystemClassLoader()).newInstance();
                 return (AsynchronousChannelProvider)tmp;
-            } catch (ClassNotFoundException | SecurityException |
+            } catch (ClassNotFoundException |
                      InstantiationException | IllegalAccessException x) {
                 throw new ServiceConfigurationError(null, x);
             }
@@ -102,10 +95,6 @@ public abstract class AsynchronousChannelProvider {
                 try {
                     return (i.hasNext()) ? i.next() : null;
                 } catch (ServiceConfigurationError sce) {
-                    if (sce.getCause() instanceof SecurityException) {
-                        // Ignore the security exception, try the next provider
-                        continue;
-                    }
                     throw sce;
                 }
             }

--- a/src/java.base/share/classes/java/nio/channels/spi/AsynchronousChannelProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/AsynchronousChannelProvider.java
@@ -92,11 +92,7 @@ public abstract class AsynchronousChannelProvider {
                                    ClassLoader.getSystemClassLoader());
             Iterator<AsynchronousChannelProvider> i = sl.iterator();
             for (;;) {
-                try {
-                    return (i.hasNext()) ? i.next() : null;
-                } catch (ServiceConfigurationError sce) {
-                    throw sce;
-                }
+                return (i.hasNext()) ? i.next() : null;
             }
         }
     }

--- a/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
@@ -33,8 +33,6 @@ import java.nio.channels.DatagramChannel;
 import java.nio.channels.Pipe;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.ServiceLoader;
@@ -81,17 +79,13 @@ public abstract class SelectorProvider {
     private static class Holder {
         static final SelectorProvider INSTANCE = provider();
 
-        @SuppressWarnings("removal")
         static SelectorProvider provider() {
-            PrivilegedAction<SelectorProvider> pa = () -> {
-                SelectorProvider sp;
-                if ((sp = loadProviderFromProperty()) != null)
-                    return sp;
-                if ((sp = loadProviderAsService()) != null)
-                    return sp;
-                return sun.nio.ch.DefaultSelectorProvider.get();
-            };
-            return AccessController.doPrivileged(pa);
+            SelectorProvider sp;
+            if ((sp = loadProviderFromProperty()) != null)
+                return sp;
+            if ((sp = loadProviderAsService()) != null)
+                return sp;
+            return sun.nio.ch.DefaultSelectorProvider.get();
         }
 
         private static SelectorProvider loadProviderFromProperty() {
@@ -105,8 +99,7 @@ public abstract class SelectorProvider {
                     NoSuchMethodException |
                     IllegalAccessException |
                     InvocationTargetException |
-                    InstantiationException |
-                    SecurityException x) {
+                    InstantiationException x) {
                 throw new ServiceConfigurationError(null, x);
             }
         }
@@ -120,10 +113,6 @@ public abstract class SelectorProvider {
                 try {
                     return i.hasNext() ? i.next() : null;
                 } catch (ServiceConfigurationError sce) {
-                    if (sce.getCause() instanceof SecurityException) {
-                        // Ignore the security exception, try the next provider
-                        continue;
-                    }
                     throw sce;
                 }
             }

--- a/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
@@ -109,9 +109,7 @@ public abstract class SelectorProvider {
                 ServiceLoader.load(SelectorProvider.class,
                                    ClassLoader.getSystemClassLoader());
             Iterator<SelectorProvider> i = sl.iterator();
-            for (;;) {
-                return i.hasNext() ? i.next() : null;
-            }
+            return sl.findFirst().orElse(null);
         }
     }
 

--- a/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
+++ b/src/java.base/share/classes/java/nio/channels/spi/SelectorProvider.java
@@ -110,11 +110,7 @@ public abstract class SelectorProvider {
                                    ClassLoader.getSystemClassLoader());
             Iterator<SelectorProvider> i = sl.iterator();
             for (;;) {
-                try {
-                    return i.hasNext() ? i.next() : null;
-                } catch (ServiceConfigurationError sce) {
-                    throw sce;
-                }
+                return i.hasNext() ? i.next() : null;
             }
         }
     }

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -40,7 +40,6 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
-import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.SortedMap;
@@ -344,9 +343,7 @@ public abstract class Charset
         cache1 = new Object[] { charsetName, cs };
     }
 
-    // Creates an iterator that walks over the available providers, ignoring
-    // those whose lookup or instantiation causes a security exception to be
-    // thrown.  Should be invoked with full privileges.
+    // Creates an iterator that walks over the available providers
     //
     private static Iterator<CharsetProvider> providers() {
         return new Iterator<>() {
@@ -358,13 +355,9 @@ public abstract class Charset
 
                 private boolean getNext() {
                     while (next == null) {
-                        try {
-                            if (!i.hasNext())
-                                return false;
-                            next = i.next();
-                        } catch (ServiceConfigurationError sce) {
-                            throw sce;
-                        }
+                        if (!i.hasNext())
+                            return false;
+                        next = i.next();
                     }
                     return true;
                 }

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,6 @@ import sun.nio.cs.ThreadLocalCoders;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.spi.CharsetProvider;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
@@ -365,10 +363,6 @@ public abstract class Charset
                                 return false;
                             next = i.next();
                         } catch (ServiceConfigurationError sce) {
-                            if (sce.getCause() instanceof SecurityException) {
-                                // Ignore security exceptions
-                                continue;
-                            }
                             throw sce;
                         }
                     }
@@ -406,7 +400,6 @@ public abstract class Charset
         ThreadTrackHolder.TRACKER.end(key);
     }
 
-    @SuppressWarnings("removal")
     private static Charset lookupViaProviders(final String charsetName) {
 
         // The runtime startup sequence looks up standard charsets as a
@@ -426,20 +419,14 @@ public abstract class Charset
             return null;
         }
         try {
-            return AccessController.doPrivileged(
-                new PrivilegedAction<>() {
-                    public Charset run() {
-                        for (Iterator<CharsetProvider> i = providers();
-                             i.hasNext();) {
-                            CharsetProvider cp = i.next();
-                            Charset cs = cp.charsetForName(charsetName);
-                            if (cs != null)
-                                return cs;
-                        }
-                        return null;
-                    }
-                });
-
+            for (Iterator<CharsetProvider> i = providers();
+                 i.hasNext();) {
+                CharsetProvider cp = i.next();
+                Charset cs = cp.charsetForName(charsetName);
+                if (cs != null)
+                    return cs;
+            }
+            return null;
         } finally {
             endLookup(key);
         }
@@ -449,22 +436,18 @@ public abstract class Charset
     private static class ExtendedProviderHolder {
         static final CharsetProvider[] extendedProviders = extendedProviders();
         // returns ExtendedProvider, if installed
-        @SuppressWarnings("removal")
         private static CharsetProvider[] extendedProviders() {
-            return AccessController.doPrivileged(new PrivilegedAction<>() {
-                    public CharsetProvider[] run() {
-                        CharsetProvider[] cps = new CharsetProvider[1];
-                        int n = 0;
-                        ServiceLoader<CharsetProvider> sl =
-                            ServiceLoader.loadInstalled(CharsetProvider.class);
-                        for (CharsetProvider cp : sl) {
-                            if (n + 1 > cps.length) {
-                                cps = Arrays.copyOf(cps, cps.length << 1);
-                            }
-                            cps[n++] = cp;
-                        }
-                        return n == cps.length ? cps : Arrays.copyOf(cps, n);
-                    }});
+            CharsetProvider[] cps = new CharsetProvider[1];
+            int n = 0;
+            ServiceLoader<CharsetProvider> sl =
+                ServiceLoader.loadInstalled(CharsetProvider.class);
+            for (CharsetProvider cp : sl) {
+                if (n + 1 > cps.length) {
+                    cps = Arrays.copyOf(cps, cps.length << 1);
+                }
+                cps[n++] = cp;
+            }
+            return n == cps.length ? cps : Arrays.copyOf(cps, n);
         }
     }
 
@@ -628,26 +611,20 @@ public abstract class Charset
      * @return An immutable, case-insensitive map from canonical charset names
      *         to charset objects
      */
-    @SuppressWarnings("removal")
     public static SortedMap<String,Charset> availableCharsets() {
-        return AccessController.doPrivileged(
-            new PrivilegedAction<>() {
-                public SortedMap<String,Charset> run() {
-                    TreeMap<String,Charset> m =
-                        new TreeMap<>(
-                            String.CASE_INSENSITIVE_ORDER);
-                    put(standardProvider.charsets(), m);
-                    CharsetProvider[] ecps = ExtendedProviderHolder.extendedProviders;
-                    for (CharsetProvider ecp :ecps) {
-                        put(ecp.charsets(), m);
-                    }
-                    for (Iterator<CharsetProvider> i = providers(); i.hasNext();) {
-                        CharsetProvider cp = i.next();
-                        put(cp.charsets(), m);
-                    }
-                    return Collections.unmodifiableSortedMap(m);
-                }
-            });
+        TreeMap<String,Charset> m =
+            new TreeMap<>(
+                String.CASE_INSENSITIVE_ORDER);
+        put(standardProvider.charsets(), m);
+        CharsetProvider[] ecps = ExtendedProviderHolder.extendedProviders;
+        for (CharsetProvider ecp :ecps) {
+            put(ecp.charsets(), m);
+        }
+        for (Iterator<CharsetProvider> i = providers(); i.hasNext();) {
+            CharsetProvider cp = i.next();
+            put(cp.charsets(), m);
+        }
+        return Collections.unmodifiableSortedMap(m);
     }
 
     private @Stable static Charset defaultCharset;

--- a/src/java.base/share/classes/java/nio/charset/Charset.java
+++ b/src/java.base/share/classes/java/nio/charset/Charset.java
@@ -412,8 +412,7 @@ public abstract class Charset
             return null;
         }
         try {
-            for (Iterator<CharsetProvider> i = providers();
-                 i.hasNext();) {
+            for (Iterator<CharsetProvider> i = providers(); i.hasNext();) {
                 CharsetProvider cp = i.next();
                 Charset cs = cp.charsetForName(charsetName);
                 if (cs != null)

--- a/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
+++ b/src/java.base/share/classes/java/nio/file/CopyMoveHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -116,13 +116,9 @@ class CopyMoveHelper {
         // attributes of source file
         BasicFileAttributes sourceAttrs = null;
         if (sourcePosixView != null) {
-            try {
-                sourceAttrs = Files.readAttributes(source,
-                                                   PosixFileAttributes.class,
-                                                   linkOptions);
-            } catch (SecurityException ignored) {
-                // okay to continue if RuntimePermission("accessUserInformation") not granted
-            }
+            sourceAttrs = Files.readAttributes(source,
+                                               PosixFileAttributes.class,
+                                               linkOptions);
         }
         if (sourceAttrs == null)
             sourceAttrs = Files.readAttributes(source,
@@ -173,11 +169,7 @@ class CopyMoveHelper {
 
                 if (sourceAttrs instanceof PosixFileAttributes sourcePosixAttrs &&
                     targetView instanceof PosixFileAttributeView targetPosixView) {
-                    try {
-                        targetPosixView.setPermissions(sourcePosixAttrs.permissions());
-                    } catch (SecurityException ignored) {
-                        // okay to continue if RuntimePermission("accessUserInformation") not granted
-                    }
+                    targetPosixView.setPermissions(sourcePosixAttrs.permissions());
                 }
             } catch (Throwable x) {
                 // rollback

--- a/src/java.base/share/classes/java/nio/file/FileSystems.java
+++ b/src/java.base/share/classes/java/nio/file/FileSystems.java
@@ -25,12 +25,10 @@
 
 package java.nio.file;
 
-import java.nio.file.spi.FileSystemProvider;
-import java.net.URI;
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.lang.reflect.Constructor;
+import java.net.URI;
+import java.nio.file.spi.FileSystemProvider;
 import java.util.Collections;
 import java.util.Map;
 import java.util.ServiceConfigurationError;
@@ -96,13 +94,7 @@ public final class FileSystems {
         // returns default file system
         private static FileSystem defaultFileSystem() {
             // load default provider
-            @SuppressWarnings("removal")
-            FileSystemProvider provider = AccessController
-                .doPrivileged(new PrivilegedAction<>() {
-                    public FileSystemProvider run() {
-                        return getDefaultProvider();
-                    }
-                });
+            FileSystemProvider provider = getDefaultProvider();
 
             // return file system
             return provider.getFileSystem(URI.create("file:///"));

--- a/src/java.base/share/classes/java/nio/file/FileTreeIterator.java
+++ b/src/java.base/share/classes/java/nio/file/FileTreeIterator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -58,8 +58,6 @@ class FileTreeIterator implements Iterator<Event>, Closeable {
      *          if {@code maxDepth} is negative
      * @throws  IOException
      *          if an I/O errors occurs opening the starting file
-     * @throws  SecurityException
-     *          if the security manager denies access to the starting file
      * @throws  NullPointerException
      *          if {@code start} or {@code options} is {@code null} or
      *          the options array contains a {@code null} element

--- a/src/java.base/share/classes/java/nio/file/FileTreeWalker.java
+++ b/src/java.base/share/classes/java/nio/file/FileTreeWalker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -198,14 +198,12 @@ class FileTreeWalker implements Closeable {
      * the walk is following sym links is not. The {@code canUseCached}
      * argument determines whether this method can use cached attributes.
      */
-    @SuppressWarnings("removal")
     private BasicFileAttributes getAttributes(Path file, boolean canUseCached)
         throws IOException
     {
         // if attributes are cached then use them if possible
         if (canUseCached &&
-            (file instanceof BasicFileAttributesHolder) &&
-            (System.getSecurityManager() == null))
+            (file instanceof BasicFileAttributesHolder))
         {
             BasicFileAttributes cached = ((BasicFileAttributesHolder)file).get();
             if (cached != null && (!followLinks || !cached.isSymbolicLink())) {
@@ -250,7 +248,7 @@ class FileTreeWalker implements Closeable {
                         // cycle detected
                         return true;
                     }
-                } catch (IOException | SecurityException x) {
+                } catch (IOException e) {
                     // ignore
                 }
             }
@@ -262,25 +260,16 @@ class FileTreeWalker implements Closeable {
      * Visits the given file, returning the {@code Event} corresponding to that
      * visit.
      *
-     * The {@code ignoreSecurityException} parameter determines whether
-     * any SecurityException should be ignored or not. If a SecurityException
-     * is thrown, and is ignored, then this method returns {@code null} to
-     * mean that there is no event corresponding to a visit to the file.
-     *
      * The {@code canUseCached} parameter determines whether cached attributes
      * for the file can be used or not.
      */
-    private Event visit(Path entry, boolean ignoreSecurityException, boolean canUseCached) {
+    private Event visit(Path entry, boolean canUseCached) {
         // need the file attributes
         BasicFileAttributes attrs;
         try {
             attrs = getAttributes(entry, canUseCached);
         } catch (IOException ioe) {
             return new Event(EventType.ENTRY, entry, ioe);
-        } catch (SecurityException se) {
-            if (ignoreSecurityException)
-                return null;
-            throw se;
         }
 
         // at maximum depth or file is not a directory
@@ -301,10 +290,6 @@ class FileTreeWalker implements Closeable {
             stream = Files.newDirectoryStream(entry);
         } catch (IOException ioe) {
             return new Event(EventType.ENTRY, entry, ioe);
-        } catch (SecurityException se) {
-            if (ignoreSecurityException)
-                return null;
-            throw se;
         }
 
         // push a directory node to the stack and return an event
@@ -321,7 +306,6 @@ class FileTreeWalker implements Closeable {
             throw new IllegalStateException("Closed");
 
         Event ev = visit(file,
-                         false,   // ignoreSecurityException
                          false);  // canUseCached
         assert ev != null;
         return ev;
@@ -372,7 +356,6 @@ class FileTreeWalker implements Closeable {
 
             // visit the entry
             ev = visit(entry,
-                       true,   // ignoreSecurityException
                        true);  // canUseCached
 
         } while (ev == null);

--- a/src/java.base/share/classes/java/nio/file/FileTreeWalker.java
+++ b/src/java.base/share/classes/java/nio/file/FileTreeWalker.java
@@ -202,8 +202,8 @@ class FileTreeWalker implements Closeable {
         throws IOException
     {
         // if attributes are cached then use them if possible
-        if (canUseCached && (file instanceof BasicFileAttributesHolder)) {
-            BasicFileAttributes cached = ((BasicFileAttributesHolder)file).get();
+        if (canUseCached && (file instanceof BasicFileAttributesHolder bfah)) {
+            BasicFileAttributes cached = bfah.get();
             if (cached != null && (!followLinks || !cached.isSymbolicLink())) {
                 return cached;
             }

--- a/src/java.base/share/classes/java/nio/file/FileTreeWalker.java
+++ b/src/java.base/share/classes/java/nio/file/FileTreeWalker.java
@@ -202,9 +202,7 @@ class FileTreeWalker implements Closeable {
         throws IOException
     {
         // if attributes are cached then use them if possible
-        if (canUseCached &&
-            (file instanceof BasicFileAttributesHolder))
-        {
+        if (canUseCached && (file instanceof BasicFileAttributesHolder)) {
             BasicFileAttributes cached = ((BasicFileAttributesHolder)file).get();
             if (cached != null && (!followLinks || !cached.isSymbolicLink())) {
                 return cached;

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -58,8 +58,6 @@ import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.spi.FileSystemProvider;
 import java.nio.file.spi.FileTypeDetector;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -696,14 +694,8 @@ public final class Files {
         } catch (IOException x) {
             // parent may not exist or other reason
         }
-        SecurityException se = null;
-        Path absDir = dir;
-        try {
-            absDir = dir.toAbsolutePath();
-        } catch (SecurityException x) {
-            // don't have permission to get absolute path
-            se = x;
-        }
+        Path absDir = dir.toAbsolutePath();
+
         // find a descendant that exists
         Path parent = absDir.getParent();
         while (parent != null) {
@@ -717,12 +709,8 @@ public final class Files {
         }
         if (parent == null) {
             // unable to find existing parent
-            if (se == null) {
-                throw new FileSystemException(absDir.toString(), null,
-                    "Unable to determine if root directory exists");
-            } else {
-                throw se;
-            }
+            throw new FileSystemException(absDir.toString(), null,
+                "Unable to determine if root directory exists");
         }
 
         // create directories
@@ -1525,29 +1513,19 @@ public final class Files {
             loadInstalledDetectors();
 
         // creates the default file type detector
-        @SuppressWarnings("removal")
         private static FileTypeDetector createDefaultFileTypeDetector() {
-            return AccessController
-                .doPrivileged(new PrivilegedAction<>() {
-                    @Override public FileTypeDetector run() {
-                        return sun.nio.fs.DefaultFileTypeDetector.create();
-                }});
+            return sun.nio.fs.DefaultFileTypeDetector.create();
         }
 
         // loads all installed file type detectors
-        @SuppressWarnings("removal")
         private static List<FileTypeDetector> loadInstalledDetectors() {
-            return AccessController
-                .doPrivileged(new PrivilegedAction<>() {
-                    @Override public List<FileTypeDetector> run() {
-                        List<FileTypeDetector> list = new ArrayList<>();
-                        ServiceLoader<FileTypeDetector> loader = ServiceLoader
-                            .load(FileTypeDetector.class, ClassLoader.getSystemClassLoader());
-                        for (FileTypeDetector detector: loader) {
-                            list.add(detector);
-                        }
-                        return list;
-                }});
+            List<FileTypeDetector> list = new ArrayList<>();
+            ServiceLoader<FileTypeDetector> loader = ServiceLoader
+                .load(FileTypeDetector.class, ClassLoader.getSystemClassLoader());
+            for (FileTypeDetector detector: loader) {
+                list.add(detector);
+            }
+            return list;
         }
     }
 
@@ -2863,26 +2841,16 @@ public final class Files {
         }
 
         // attempt to delete an existing file
-        SecurityException se = null;
         if (replaceExisting) {
-            try {
-                deleteIfExists(target);
-            } catch (SecurityException x) {
-                se = x;
-            }
+            deleteIfExists(target);
         }
 
-        // attempt to create target file. If it fails with
-        // FileAlreadyExistsException then it may be because the security
-        // manager prevented us from deleting the file, in which case we just
-        // throw the SecurityException.
+        // attempt to create target file.
         OutputStream ostream;
         try {
             ostream = newOutputStream(target, StandardOpenOption.CREATE_NEW,
                                               StandardOpenOption.WRITE);
         } catch (FileAlreadyExistsException x) {
-            if (se != null)
-                throw se;
             // someone else won the race and created the file
             throw x;
         }

--- a/src/java.base/share/classes/java/nio/file/TempFileHelper.java
+++ b/src/java.base/share/classes/java/nio/file/TempFileHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -117,16 +117,12 @@ class TempFileHelper {
         }
 
         // loop generating random names until file or directory can be created
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
         for (;;) {
             Path f;
             try {
                 f = generatePath(prefix, suffix, dir);
             } catch (InvalidPathException e) {
                 // don't reveal temporary directory location
-                if (sm != null)
-                    throw new IllegalArgumentException("Invalid prefix or suffix");
                 throw e;
             }
             try {
@@ -135,11 +131,6 @@ class TempFileHelper {
                 } else {
                     return Files.createFile(f, attrs);
                 }
-            } catch (SecurityException e) {
-                // don't reveal temporary directory location
-                if (dir == tmpdir && sm != null)
-                    throw new SecurityException("Unable to create temporary file or directory");
-                throw e;
             } catch (FileAlreadyExistsException e) {
                 // ignore
             }

--- a/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
+++ b/src/java.base/share/classes/java/nio/file/spi/FileSystemProvider.java
@@ -45,7 +45,6 @@ import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
-import java.nio.file.LinkPermission;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.NotLinkException;
@@ -68,8 +67,6 @@ import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import sun.nio.ch.FileChannelImpl;
 
@@ -185,13 +182,7 @@ public abstract class FileSystemProvider {
                     }
                     loadingProviders = true;
 
-                    @SuppressWarnings("removal")
-                    List<FileSystemProvider> list = AccessController
-                        .doPrivileged(new PrivilegedAction<>() {
-                            @Override
-                            public List<FileSystemProvider> run() {
-                                return loadInstalledProviders();
-                        }});
+                    List<FileSystemProvider> list = loadInstalledProviders();
 
                     // insert the default provider at the start of the list
                     list.add(0, defaultProvider);

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousChannelGroupImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousChannelGroupImpl.java
@@ -34,10 +34,6 @@ import java.util.Queue;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.security.PrivilegedAction;
-import java.security.AccessController;
-import java.security.AccessControlContext;
-import sun.security.action.GetIntegerAction;
 
 /**
  * Base implementation of AsynchronousChannelGroup
@@ -48,9 +44,8 @@ abstract class AsynchronousChannelGroupImpl
 {
     // number of internal threads handling I/O events when using an unbounded
     // thread pool. Internal threads do not dispatch to completion handlers.
-    @SuppressWarnings("removal")
-    private static final int internalThreadCount = AccessController.doPrivileged(
-        new GetIntegerAction("sun.nio.ch.internalThreadPoolSize", 1));
+    private static final int internalThreadCount =
+        Integer.valueOf(System.getProperty("sun.nio.ch.internalThreadPoolSize", "1"));
 
     // associated thread pool
     private final ThreadPool pool;
@@ -115,17 +110,10 @@ abstract class AsynchronousChannelGroupImpl
         };
     }
 
-    @SuppressWarnings("removal")
     private void startInternalThread(final Runnable task) {
-        AccessController.doPrivileged(new PrivilegedAction<>() {
-            @Override
-            public Void run() {
-                // internal threads should not be visible to application so
-                // cannot use user-supplied thread factory
-                ThreadPool.defaultThreadFactory().newThread(task).start();
-                return null;
-            }
-         });
+        // internal threads should not be visible to application so
+        // cannot use user-supplied thread factory
+        ThreadPool.defaultThreadFactory().newThread(task).start();
     }
 
     protected final void startThreads(Runnable task) {
@@ -247,18 +235,9 @@ abstract class AsynchronousChannelGroupImpl
      */
     abstract void shutdownHandlerTasks();
 
-    @SuppressWarnings("removal")
     private void shutdownExecutors() {
-        AccessController.doPrivileged(
-            new PrivilegedAction<>() {
-                public Void run() {
-                    pool.executor().shutdown();
-                    timeoutExecutor.shutdown();
-                    return null;
-                }
-            },
-            null,
-            new RuntimePermission("modifyThread"));
+        pool.executor().shutdown();
+        timeoutExecutor.shutdown();
     }
 
     @Override
@@ -320,28 +299,6 @@ abstract class AsynchronousChannelGroupImpl
      */
     @Override
     public final void execute(Runnable task) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            // when a security manager is installed then the user's task
-            // must be run with the current calling context
-            @SuppressWarnings("removal")
-            final AccessControlContext acc = AccessController.getContext();
-            final Runnable delegate = task;
-            task = new Runnable() {
-                @SuppressWarnings("removal")
-                @Override
-                public void run() {
-                    AccessController.doPrivileged(new PrivilegedAction<>() {
-                        @Override
-                        public Void run() {
-                            delegate.run();
-                            return null;
-                        }
-                    }, acc);
-                }
-            };
-        }
         executeOnPooledThread(task);
     }
 }

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousChannelGroupImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousChannelGroupImpl.java
@@ -45,7 +45,7 @@ abstract class AsynchronousChannelGroupImpl
     // number of internal threads handling I/O events when using an unbounded
     // thread pool. Internal threads do not dispatch to completion handlers.
     private static final int internalThreadCount =
-        Integer.valueOf(System.getProperty("sun.nio.ch.internalThreadPoolSize", "1"));
+        Integer.getInteger("sun.nio.ch.internalThreadPoolSize", 1);
 
     // associated thread pool
     private final ThreadPool pool;

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -150,10 +150,6 @@ abstract class AsynchronousServerSocketChannelImpl
     {
         InetSocketAddress isa = (local == null) ? new InetSocketAddress(0) :
             Net.checkAddress(local);
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkListen(isa.getPort());
 
         try {
             begin();

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousServerSocketChannelImpl.java
@@ -171,7 +171,7 @@ abstract class AsynchronousServerSocketChannelImpl
     public final SocketAddress getLocalAddress() throws IOException {
         if (!isOpen())
             throw new ClosedChannelException();
-        return Net.getRevealedLocalAddress(localAddress);
+        return localAddress;
     }
 
     @Override
@@ -253,7 +253,7 @@ abstract class AsynchronousServerSocketChannelImpl
             if (localAddress == null) {
                 sb.append("unbound");
             } else {
-                sb.append(Net.getRevealedLocalAddressAsString(localAddress));
+                sb.append(localAddress.toString());
             }
         }
         sb.append(']');

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -428,11 +428,6 @@ abstract class AsynchronousSocketChannelImpl
                     throw new AlreadyBoundException();
                 InetSocketAddress isa = (local == null) ?
                     new InetSocketAddress(0) : Net.checkAddress(local);
-                @SuppressWarnings("removal")
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                    sm.checkListen(isa.getPort());
-                }
                 NetHooks.beforeTcpBind(fd, isa.getAddress(), isa.getPort());
                 Net.bind(fd, isa.getAddress(), isa.getPort());
                 localAddress = Net.localAddress(fd);

--- a/src/java.base/share/classes/sun/nio/ch/AsynchronousSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/AsynchronousSocketChannelImpl.java
@@ -442,7 +442,7 @@ abstract class AsynchronousSocketChannelImpl
     public final SocketAddress getLocalAddress() throws IOException {
         if (!isOpen())
             throw new ClosedChannelException();
-         return Net.getRevealedLocalAddress(localAddress);
+         return localAddress;
     }
 
     @Override
@@ -586,8 +586,7 @@ abstract class AsynchronousSocketChannelImpl
                 }
                 if (localAddress != null) {
                     sb.append(" local=");
-                    sb.append(
-                            Net.getRevealedLocalAddressAsString(localAddress));
+                    sb.append(localAddress.toString());
                 }
                 if (remoteAddress != null) {
                     sb.append(" remote=");

--- a/src/java.base/share/classes/sun/nio/ch/CompletedFuture.java
+++ b/src/java.base/share/classes/sun/nio/ch/CompletedFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2010, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -49,8 +49,8 @@ final class CompletedFuture<V> implements Future<V> {
     }
 
     static <V> CompletedFuture<V> withFailure(Throwable exc) {
-        // exception must be IOException or SecurityException
-        if (!(exc instanceof IOException) && !(exc instanceof SecurityException))
+        // exception must be IOException
+        if (!(exc instanceof IOException))
             exc = new IOException(exc);
         return new CompletedFuture<V>(null, exc);
     }

--- a/src/java.base/share/classes/sun/nio/ch/Invoker.java
+++ b/src/java.base/share/classes/sun/nio/ch/Invoker.java
@@ -40,7 +40,7 @@ class Invoker {
     // thread before it re-directs invocations to the thread pool. This helps
     // avoid stack overflow and lessens the risk of starvation.
     private static final int maxHandlerInvokeCount =
-        Integer.valueOf(System.getProperty("sun.nio.ch.maxCompletionHandlersOnStack", "16"));
+        Integer.getInteger("sun.nio.ch.maxCompletionHandlersOnStack", 16);
 
     // Per-thread object with reference to channel group and a counter for
     // the number of completion handlers invoked. This should be reset to 0

--- a/src/java.base/share/classes/sun/nio/ch/Invoker.java
+++ b/src/java.base/share/classes/sun/nio/ch/Invoker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package sun.nio.ch;
 
 import java.nio.channels.*;
 import java.util.concurrent.*;
-import java.security.AccessController;
-import sun.security.action.GetIntegerAction;
 import jdk.internal.misc.InnocuousThread;
 
 /**
@@ -41,9 +39,8 @@ class Invoker {
     // maximum number of completion handlers that may be invoked on the current
     // thread before it re-directs invocations to the thread pool. This helps
     // avoid stack overflow and lessens the risk of starvation.
-    @SuppressWarnings("removal")
-    private static final int maxHandlerInvokeCount = AccessController.doPrivileged(
-        new GetIntegerAction("sun.nio.ch.maxCompletionHandlersOnStack", 16));
+    private static final int maxHandlerInvokeCount =
+        Integer.valueOf(System.getProperty("sun.nio.ch.maxCompletionHandlersOnStack", "16"));
 
     // Per-thread object with reference to channel group and a counter for
     // the number of completion handlers invoked. This should be reset to 0
@@ -115,7 +112,6 @@ class Invoker {
      * Invoke handler without checking the thread identity or number of handlers
      * on the thread stack.
      */
-    @SuppressWarnings("removal")
     static <V,A> void invokeUnchecked(CompletionHandler<V,? super A> handler,
                                       A attachment,
                                       V value,
@@ -129,18 +125,6 @@ class Invoker {
 
         // clear interrupt
         Thread.interrupted();
-
-        // clear thread locals when in default thread pool
-        if (System.getSecurityManager() != null) {
-            Thread me = Thread.currentThread();
-            if (me instanceof InnocuousThread) {
-                GroupAndInvokeCount thisGroupAndInvokeCount = myGroupAndInvokeCount.get();
-                ((InnocuousThread)me).eraseThreadLocals();
-                if (thisGroupAndInvokeCount != null) {
-                    myGroupAndInvokeCount.set(thisGroupAndInvokeCount);
-                }
-            }
-        }
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,14 +45,11 @@ import java.nio.channels.NotYetBoundException;
 import java.nio.channels.NotYetConnectedException;
 import java.nio.channels.UnresolvedAddressException;
 import java.nio.channels.UnsupportedAddressTypeException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Enumeration;
 import java.util.Objects;
 
 import sun.net.ext.ExtendedSocketOptions;
 import sun.net.util.IPAddressUtil;
-import sun.security.action.GetPropertyAction;
 
 public class Net {
     private Net() { }
@@ -216,31 +213,16 @@ public class Net {
     }
 
     /**
-     * Returns the local address after performing a SecurityManager#checkConnect.
+     * Returns the local address
      */
     static InetSocketAddress getRevealedLocalAddress(SocketAddress sa) {
         InetSocketAddress isa = (InetSocketAddress) sa;
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (isa != null && sm != null) {
-            try {
-                sm.checkConnect(isa.getAddress().getHostAddress(), -1);
-            } catch (SecurityException e) {
-                // Return loopback address only if security check fails
-                isa = getLoopbackAddress(isa.getPort());
-            }
-        }
         return isa;
     }
 
-    @SuppressWarnings("removal")
     static String getRevealedLocalAddressAsString(SocketAddress sa) {
         InetSocketAddress isa = (InetSocketAddress) sa;
-        if (System.getSecurityManager() == null) {
-            return isa.toString();
-        } else {
-            return getLoopbackAddress(isa.getPort()).toString();
-        }
+        return isa.toString();
     }
 
     private static InetSocketAddress getLoopbackAddress(int port) {
@@ -302,20 +284,15 @@ public class Net {
      * Returns any IPv4 address of the given network interface, or
      * null if the interface does not have any IPv4 addresses.
      */
-    @SuppressWarnings("removal")
     static Inet4Address anyInet4Address(final NetworkInterface interf) {
-        return AccessController.doPrivileged(new PrivilegedAction<Inet4Address>() {
-            public Inet4Address run() {
-                Enumeration<InetAddress> addrs = interf.getInetAddresses();
-                while (addrs.hasMoreElements()) {
-                    InetAddress addr = addrs.nextElement();
-                    if (addr instanceof Inet4Address inet4Address) {
-                        return inet4Address;
-                    }
-                }
-                return null;
+        Enumeration<InetAddress> addrs = interf.getInetAddresses();
+        while (addrs.hasMoreElements()) {
+            InetAddress addr = addrs.nextElement();
+            if (addr instanceof Inet4Address inet4Address) {
+                return inet4Address;
             }
-        });
+        }
+        return null;
     }
 
     /**
@@ -500,8 +477,7 @@ public class Net {
     }
 
     private static boolean isFastTcpLoopbackRequested() {
-        String loopbackProp = GetPropertyAction
-                .privilegedGetProperty("jdk.net.useFastTcpLoopback", "false");
+        String loopbackProp = System.getProperty("jdk.net.useFastTcpLoopback", "false");
         return loopbackProp.isEmpty() || Boolean.parseBoolean(loopbackProp);
     }
 
@@ -827,8 +803,7 @@ public class Net {
     static {
         int availLevel = isExclusiveBindAvailable();
         if (availLevel >= 0) {
-            String exclBindProp = GetPropertyAction
-                    .privilegedGetProperty("sun.net.useExclusiveBind");
+            String exclBindProp = System.getProperty("sun.net.useExclusiveBind");
             if (exclBindProp != null) {
                 EXCLUSIVE_BIND = exclBindProp.isEmpty() || Boolean.parseBoolean(exclBindProp);
             } else {

--- a/src/java.base/share/classes/sun/nio/ch/Net.java
+++ b/src/java.base/share/classes/sun/nio/ch/Net.java
@@ -212,19 +212,6 @@ public class Net {
         translateException(x, false);
     }
 
-    /**
-     * Returns the local address
-     */
-    static InetSocketAddress getRevealedLocalAddress(SocketAddress sa) {
-        InetSocketAddress isa = (InetSocketAddress) sa;
-        return isa;
-    }
-
-    static String getRevealedLocalAddressAsString(SocketAddress sa) {
-        InetSocketAddress isa = (InetSocketAddress) sa;
-        return isa.toString();
-    }
-
     private static InetSocketAddress getLoopbackAddress(int port) {
         return new InetSocketAddress(InetAddress.getLoopbackAddress(), port);
     }

--- a/src/java.base/share/classes/sun/nio/ch/PendingFuture.java
+++ b/src/java.base/share/classes/sun/nio/ch/PendingFuture.java
@@ -145,7 +145,7 @@ final class PendingFuture<V,A> implements Future<V> {
      * Sets the result, or a no-op if the result or exception is already set.
      */
     void setFailure(Throwable x) {
-        if (!(x instanceof IOException) && !(x instanceof SecurityException))
+        if (!(x instanceof IOException))
             x = new IOException(x);
         synchronized (this) {
             if (haveResult)

--- a/src/java.base/share/classes/sun/nio/ch/Reflect.java
+++ b/src/java.base/share/classes/sun/nio/ch/Reflect.java
@@ -41,17 +41,13 @@ class Reflect {                                 // package-private
         }
     }
 
-    private static void setAccessible(final AccessibleObject ao) {
-        ao.setAccessible(true);
-    }
-
     static Constructor<?> lookupConstructor(String className,
                                             Class<?>[] paramTypes)
     {
         try {
             Class<?> cl = Class.forName(className);
             Constructor<?> c = cl.getDeclaredConstructor(paramTypes);
-            setAccessible(c);
+            c.setAccessible(true);
             return c;
         } catch (ClassNotFoundException | NoSuchMethodException x) {
             throw new ReflectionError(x);
@@ -75,7 +71,7 @@ class Reflect {                                 // package-private
         try {
             Class<?> cl = Class.forName(className);
             Method m = cl.getDeclaredMethod(methodName, paramTypes);
-            setAccessible(m);
+            m.setAccessible(true);
             return m;
         } catch (ClassNotFoundException | NoSuchMethodException x) {
             throw new ReflectionError(x);
@@ -108,7 +104,7 @@ class Reflect {                                 // package-private
         try {
             Class<?> cl = Class.forName(className);
             Field f = cl.getDeclaredField(fieldName);
-            setAccessible(f);
+            f.setAccessible(true);
             return f;
         } catch (ClassNotFoundException | NoSuchFieldException x) {
             throw new ReflectionError(x);

--- a/src/java.base/share/classes/sun/nio/ch/Reflect.java
+++ b/src/java.base/share/classes/sun/nio/ch/Reflect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package sun.nio.ch;
 
 import java.io.*;
 import java.lang.reflect.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 
 class Reflect {                                 // package-private
@@ -43,13 +41,8 @@ class Reflect {                                 // package-private
         }
     }
 
-    @SuppressWarnings("removal")
     private static void setAccessible(final AccessibleObject ao) {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                public Void run() {
-                    ao.setAccessible(true);
-                    return null;
-                }});
+        ao.setAccessible(true);
     }
 
     static Constructor<?> lookupConstructor(String className,

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketAdaptor.java
@@ -89,7 +89,7 @@ class ServerSocketAdaptor                        // package-private
         if (local == null) {
             return null;
         } else {
-            return Net.getRevealedLocalAddress(local).getAddress();
+            return ((InetSocketAddress)local).getAddress();
         }
     }
 

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,9 +37,6 @@ import java.net.StandardSocketOptions;
 import java.nio.channels.IllegalBlockingModeException;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Set;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -61,14 +58,8 @@ class ServerSocketAdaptor                        // package-private
     // Timeout "option" value for accepts
     private volatile int timeout;
 
-    @SuppressWarnings("removal")
     static ServerSocket create(ServerSocketChannelImpl ssc) {
-        PrivilegedExceptionAction<ServerSocket> pa = () -> new ServerSocketAdaptor(ssc);
-        try {
-            return AccessController.doPrivileged(pa);
-        } catch (PrivilegedActionException pae) {
-            throw new InternalError("Should not reach here", pae);
-        }
+        return new ServerSocketAdaptor(ssc);
     }
 
     private ServerSocketAdaptor(ServerSocketChannelImpl ssc) {

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
@@ -202,11 +202,7 @@ class ServerSocketChannelImpl
     public SocketAddress getLocalAddress() throws IOException {
         synchronized (stateLock) {
             ensureOpen();
-            if (isUnixSocket()) {
-                return UnixDomainSockets.getRevealedLocalAddress(localAddress);
-            } else {
-                return Net.getRevealedLocalAddress(localAddress);
-            }
+            return localAddress;
         }
     }
 
@@ -733,9 +729,7 @@ class ServerSocketChannelImpl
                 if (addr == null) {
                     sb.append("unbound");
                 } else if (isUnixSocket()) {
-                    sb.append(UnixDomainSockets.getRevealedLocalAddressAsString(addr));
-                } else {
-                    sb.append(Net.getRevealedLocalAddressAsString(addr));
+                    sb.append(addr.toString());
                 }
             }
         }

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
@@ -305,7 +305,6 @@ class ServerSocketChannelImpl
     }
 
     private SocketAddress unixBind(SocketAddress local, int backlog) throws IOException {
-        UnixDomainSockets.checkPermission();
         if (local == null) {
             // Attempt up to 10 times to find an unused name in temp directory.
             // If local address supplied then bind called only once
@@ -336,10 +335,6 @@ class ServerSocketChannelImpl
         } else {
             isa = Net.checkAddress(local, family);
         }
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkListen(isa.getPort());
         NetHooks.beforeTcpBind(fd, isa.getAddress(), isa.getPort());
         Net.bind(family, fd, isa.getAddress(), isa.getPort());
         Net.listen(fd, backlog < 1 ? 50 : backlog);
@@ -423,7 +418,6 @@ class ServerSocketChannelImpl
         throws IOException
     {
         if (isUnixSocket()) {
-            UnixDomainSockets.checkPermission();
             String[] pa = new String[1];
             int n = UnixDomainSockets.accept(fd, newfd, pa);
             if (n > 0)
@@ -495,16 +489,6 @@ class ServerSocketChannelImpl
         try {
             // newly accepted socket is initially in blocking mode
             IOUtil.configureBlocking(newfd, true);
-
-            // check permitted to accept connections from the remote address
-            if (isNetSocket()) {
-                @SuppressWarnings("removal")
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                    InetSocketAddress isa = (InetSocketAddress) sa;
-                    sm.checkAccept(isa.getAddress().getHostAddress(), isa.getPort());
-                }
-            }
             return new SocketChannelImpl(provider(), family, newfd, sa);
         } catch (Exception e) {
             nd.close(newfd);

--- a/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/ServerSocketChannelImpl.java
@@ -729,7 +729,7 @@ class ServerSocketChannelImpl
                 if (addr == null) {
                     sb.append("unbound");
                 } else if (isUnixSocket()) {
-                    sb.append(addr.toString());
+                    sb.append(addr);
                 }
             }
         }

--- a/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SimpleAsynchronousFileChannelImpl.java
@@ -30,8 +30,6 @@ import jdk.internal.event.FileForceEvent;
 import java.nio.channels.*;
 import java.util.concurrent.*;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.io.FileDescriptor;
 import java.io.IOException;
 

--- a/src/java.base/share/classes/sun/nio/ch/SocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketAdaptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,9 +36,6 @@ import java.net.SocketException;
 import java.net.SocketOption;
 import java.net.StandardSocketOptions;
 import java.nio.channels.SocketChannel;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Set;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -63,16 +60,10 @@ class SocketAdaptor
         this.sc = sc;
     }
 
-    @SuppressWarnings("removal")
     static Socket create(SocketChannelImpl sc) {
         try {
-            if (System.getSecurityManager() == null) {
-                return new SocketAdaptor(sc);
-            } else {
-                PrivilegedExceptionAction<Socket> pa = () -> new SocketAdaptor(sc);
-                return AccessController.doPrivileged(pa);
-            }
-        } catch (SocketException | PrivilegedActionException e) {
+            return new SocketAdaptor(sc);
+        } catch (SocketException e) {
             throw new InternalError(e);
         }
     }

--- a/src/java.base/share/classes/sun/nio/ch/SocketAdaptor.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketAdaptor.java
@@ -123,7 +123,7 @@ class SocketAdaptor
         if (sc.isOpen()) {
             InetSocketAddress local = localAddress();
             if (local != null) {
-                return Net.getRevealedLocalAddress(local).getAddress();
+                return local.getAddress();
             }
         }
         return new InetSocketAddress(0).getAddress();
@@ -156,7 +156,7 @@ class SocketAdaptor
 
     @Override
     public SocketAddress getLocalSocketAddress() {
-        return Net.getRevealedLocalAddress(sc.localAddress());
+        return sc.localAddress();
     }
 
     @Override

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -811,7 +811,6 @@ class SocketChannelImpl
     }
 
     private SocketAddress unixBind(SocketAddress local) throws IOException {
-        UnixDomainSockets.checkPermission();
         if (local == null) {
             return UnixDomainSockets.unnamed();
         } else {
@@ -832,11 +831,6 @@ class SocketChannelImpl
             isa = new InetSocketAddress(Net.anyLocalAddress(family), 0);
         } else {
             isa = Net.checkAddress(local, family);
-        }
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkListen(isa.getPort());
         }
         NetHooks.beforeTcpBind(fd, isa.getAddress(), isa.getPort());
         Net.bind(family, fd, isa.getAddress(), isa.getPort());
@@ -923,15 +917,9 @@ class SocketChannelImpl
      */
     private SocketAddress checkRemote(SocketAddress sa) {
         if (isUnixSocket()) {
-            UnixDomainSockets.checkPermission();
             return UnixDomainSockets.checkAddress(sa);
         } else {
             InetSocketAddress isa = Net.checkAddress(sa, family);
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkConnect(isa.getAddress().getHostAddress(), isa.getPort());
-            }
             InetAddress address = isa.getAddress();
             if (address.isAnyLocalAddress()) {
                 int port = isa.getPort();

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -243,11 +243,7 @@ class SocketChannelImpl
     public SocketAddress getLocalAddress() throws IOException {
         synchronized (stateLock) {
             ensureOpen();
-            if (isUnixSocket()) {
-                return UnixDomainSockets.getRevealedLocalAddress(localAddress);
-            } else {
-                return Net.getRevealedLocalAddress(localAddress);
-            }
+            return localAddress;
         }
     }
 
@@ -1605,11 +1601,7 @@ class SocketChannelImpl
                 SocketAddress addr = localAddress();
                 if (addr != null) {
                     sb.append(" local=");
-                    if (isUnixSocket()) {
-                        sb.append(UnixDomainSockets.getRevealedLocalAddressAsString(addr));
-                    } else {
-                        sb.append(Net.getRevealedLocalAddressAsString(addr));
-                    }
+                    sb.append(addr.toString());
                 }
                 if (remoteAddress() != null) {
                     sb.append(" remote=");

--- a/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
+++ b/src/java.base/share/classes/sun/nio/ch/SocketChannelImpl.java
@@ -1601,11 +1601,11 @@ class SocketChannelImpl
                 SocketAddress addr = localAddress();
                 if (addr != null) {
                     sb.append(" local=");
-                    sb.append(addr.toString());
+                    sb.append(addr);
                 }
                 if (remoteAddress() != null) {
                     sb.append(" remote=");
-                    sb.append(remoteAddress().toString());
+                    sb.append(remoteAddress());
                 }
             }
         }

--- a/src/java.base/share/classes/sun/nio/ch/ThreadPool.java
+++ b/src/java.base/share/classes/sun/nio/ch/ThreadPool.java
@@ -26,10 +26,6 @@
 package sun.nio.ch;
 
 import java.util.concurrent.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import sun.security.action.GetPropertyAction;
-import sun.security.action.GetIntegerAction;
 import jdk.internal.misc.InnocuousThread;
 
 /**
@@ -72,24 +68,12 @@ public class ThreadPool {
         return poolSize;
     }
 
-    @SuppressWarnings("removal")
     static ThreadFactory defaultThreadFactory() {
-        if (System.getSecurityManager() == null) {
-            return (Runnable r) -> {
-                Thread t = new Thread(r);
-                t.setDaemon(true);
-                return t;
-            };
-        } else {
-            return (Runnable r) -> {
-                PrivilegedAction<Thread> action = () -> {
-                    Thread t = InnocuousThread.newThread(r);
-                    t.setDaemon(true);
-                    return t;
-               };
-               return AccessController.doPrivileged(action);
-           };
-        }
+        return (Runnable r) -> {
+            Thread t = new Thread(r);
+            t.setDaemon(true);
+            return t;
+        };
     }
 
     private static class DefaultThreadPoolHolder {
@@ -148,9 +132,7 @@ public class ThreadPool {
     }
 
     private static int getDefaultThreadPoolInitialSize() {
-        @SuppressWarnings("removal")
-        String propValue = AccessController.doPrivileged(new
-            GetPropertyAction(DEFAULT_THREAD_POOL_INITIAL_SIZE));
+        String propValue = System.getProperty(DEFAULT_THREAD_POOL_INITIAL_SIZE);
         if (propValue != null) {
             try {
                 return Integer.parseInt(propValue);
@@ -163,9 +145,7 @@ public class ThreadPool {
     }
 
     private static ThreadFactory getDefaultThreadPoolThreadFactory() {
-        @SuppressWarnings("removal")
-        String propValue = AccessController.doPrivileged(new
-            GetPropertyAction(DEFAULT_THREAD_POOL_THREAD_FACTORY));
+        String propValue = System.getProperty(DEFAULT_THREAD_POOL_THREAD_FACTORY);
         if (propValue != null) {
             try {
                 @SuppressWarnings("deprecation")

--- a/src/java.base/share/classes/sun/nio/ch/UnixDomainSockets.java
+++ b/src/java.base/share/classes/sun/nio/ch/UnixDomainSockets.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,22 +59,8 @@ class UnixDomainSockets {
         return supported;
     }
 
-    static void checkPermission() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkPermission(accessUnixDomainSocket);
-    }
-
     static UnixDomainSocketAddress getRevealedLocalAddress(SocketAddress sa) {
         UnixDomainSocketAddress addr = (UnixDomainSocketAddress) sa;
-        try {
-            checkPermission();
-            // Security check passed
-        } catch (SecurityException e) {
-            // Return unnamed address only if security check fails
-            addr = unnamed();
-        }
         return addr;
     }
 
@@ -85,9 +71,8 @@ class UnixDomainSockets {
 
     private static native byte[] localAddress0(FileDescriptor fd) throws IOException;
 
-    @SuppressWarnings("removal")
     static String getRevealedLocalAddressAsString(SocketAddress sa) {
-        return (System.getSecurityManager() != null) ? sa.toString() : "";
+        return sa.toString();
     }
 
     static UnixDomainSocketAddress checkAddress(SocketAddress sa) {

--- a/src/java.base/share/classes/sun/nio/ch/UnixDomainSockets.java
+++ b/src/java.base/share/classes/sun/nio/ch/UnixDomainSockets.java
@@ -59,21 +59,12 @@ class UnixDomainSockets {
         return supported;
     }
 
-    static UnixDomainSocketAddress getRevealedLocalAddress(SocketAddress sa) {
-        UnixDomainSocketAddress addr = (UnixDomainSocketAddress) sa;
-        return addr;
-    }
-
     static UnixDomainSocketAddress localAddress(FileDescriptor fd) throws IOException {
         String path = new String(localAddress0(fd), UnixDomainSocketsUtil.getCharset());
         return UnixDomainSocketAddress.of(path);
     }
 
     private static native byte[] localAddress0(FileDescriptor fd) throws IOException;
-
-    static String getRevealedLocalAddressAsString(SocketAddress sa) {
-        return sa.toString();
-    }
 
     static UnixDomainSocketAddress checkAddress(SocketAddress sa) {
         if (sa == null)

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,15 +32,12 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.ByteBuffer;
 import java.nio.MappedByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
 import jdk.internal.misc.TerminatingThreadLocal;
 import jdk.internal.misc.Unsafe;
-import sun.security.action.GetPropertyAction;
 
 public class Util {
 
@@ -75,7 +72,7 @@ public class Util {
      * for potential future-proofing.
      */
     private static long getMaxCachedBufferSize() {
-        String s = GetPropertyAction.privilegedGetProperty("jdk.nio.maxCachedBufferSize");
+        String s = System.getProperty("jdk.nio.maxCachedBufferSize");
         if (s != null) {
             try {
                 long m = Long.parseLong(s);
@@ -406,28 +403,23 @@ public class Util {
 
     private static volatile Constructor<?> directByteBufferConstructor;
 
-    @SuppressWarnings("removal")
     private static void initDBBConstructor() {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                public Void run() {
-                    try {
-                        Class<?> cl = Class.forName("java.nio.DirectByteBuffer");
-                        Constructor<?> ctor = cl.getDeclaredConstructor(
-                            new Class<?>[] { int.class,
-                                             long.class,
-                                             FileDescriptor.class,
-                                             Runnable.class,
-                                             boolean.class, MemorySegment.class});
-                        ctor.setAccessible(true);
-                        directByteBufferConstructor = ctor;
-                    } catch (ClassNotFoundException   |
-                             NoSuchMethodException    |
-                             IllegalArgumentException |
-                             ClassCastException x) {
-                        throw new InternalError(x);
-                    }
-                    return null;
-                }});
+        try {
+            Class<?> cl = Class.forName("java.nio.DirectByteBuffer");
+            Constructor<?> ctor = cl.getDeclaredConstructor(
+                new Class<?>[] { int.class,
+                                 long.class,
+                                 FileDescriptor.class,
+                                 Runnable.class,
+                                 boolean.class, MemorySegment.class });
+            ctor.setAccessible(true);
+            directByteBufferConstructor = ctor;
+        } catch (ClassNotFoundException   |
+                 NoSuchMethodException    |
+                 IllegalArgumentException |
+                 ClassCastException x) {
+            throw new InternalError(x);
+        }
     }
 
     static MappedByteBuffer newMappedByteBuffer(int size, long addr,
@@ -457,26 +449,22 @@ public class Util {
 
     @SuppressWarnings("removal")
     private static void initDBBRConstructor() {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                public Void run() {
-                    try {
-                        Class<?> cl = Class.forName("java.nio.DirectByteBufferR");
-                        Constructor<?> ctor = cl.getDeclaredConstructor(
-                            new Class<?>[] { int.class,
-                                             long.class,
-                                             FileDescriptor.class,
-                                             Runnable.class,
-                                             boolean.class, MemorySegment.class });
-                        ctor.setAccessible(true);
-                        directByteBufferRConstructor = ctor;
-                    } catch (ClassNotFoundException |
-                             NoSuchMethodException |
-                             IllegalArgumentException |
-                             ClassCastException x) {
-                        throw new InternalError(x);
-                    }
-                    return null;
-                }});
+        try {
+            Class<?> cl = Class.forName("java.nio.DirectByteBufferR");
+            Constructor<?> ctor = cl.getDeclaredConstructor(
+                new Class<?>[] { int.class,
+                                 long.class,
+                                 FileDescriptor.class,
+                                 Runnable.class,
+                                 boolean.class, MemorySegment.class });
+            ctor.setAccessible(true);
+            directByteBufferRConstructor = ctor;
+        } catch (ClassNotFoundException |
+                 NoSuchMethodException |
+                 IllegalArgumentException |
+                 ClassCastException x) {
+            throw new InternalError(x);
+        }
     }
 
     static MappedByteBuffer newMappedByteBufferR(int size, long addr,

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -447,7 +447,6 @@ public class Util {
 
     private static volatile Constructor<?> directByteBufferRConstructor;
 
-    @SuppressWarnings("removal")
     private static void initDBBRConstructor() {
         try {
             Class<?> cl = Class.forName("java.nio.DirectByteBufferR");

--- a/src/java.base/share/classes/sun/nio/cs/CharsetMapping.java
+++ b/src/java.base/share/classes/sun/nio/cs/CharsetMapping.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.nio.cs;
 import java.io.InputStream;
 import java.io.IOException;
 import java.util.*;
-import java.security.*;
 
 public class CharsetMapping {
     public static final char UNMAPPABLE_DECODING = '\uFFFD';
@@ -129,13 +128,8 @@ public class CharsetMapping {
     }
 
     // init the CharsetMapping object from the .dat binary file
-    @SuppressWarnings("removal")
     public static CharsetMapping get(final InputStream is) {
-        return AccessController.doPrivileged(new PrivilegedAction<>() {
-            public CharsetMapping run() {
-                return new CharsetMapping().load(is);
-            }
-        });
+        return new CharsetMapping().load(is);
     }
 
     public static class Entry {

--- a/src/java.base/share/classes/sun/nio/fs/AbstractPoller.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractPoller.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,8 +26,6 @@
 package sun.nio.fs;
 
 import java.nio.file.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.io.IOException;
 import java.util.*;
 
@@ -54,22 +52,14 @@ abstract class AbstractPoller implements Runnable {
     /**
      * Starts the poller thread
      */
-    @SuppressWarnings("removal")
     public void start() {
-        final Runnable thisRunnable = this;
-        AccessController.doPrivileged(new PrivilegedAction<>() {
-            @Override
-            public Object run() {
-                Thread thr = new Thread(null,
-                                        thisRunnable,
-                                        "FileSystemWatchService",
-                                        0,
-                                        false);
-                thr.setDaemon(true);
-                thr.start();
-                return null;
-            }
-         });
+        Thread thr = new Thread(null,
+                                this,
+                                "FileSystemWatchService",
+                                0,
+                                false);
+        thr.setDaemon(true);
+        thr.start();
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/fs/AbstractUserDefinedFileAttributeView.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractUserDefinedFileAttributeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,9 +25,9 @@
 
 package sun.nio.fs;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.attribute.UserDefinedFileAttributeView;
-import java.io.IOException;
 import java.util.*;
 
 /**
@@ -38,22 +38,6 @@ abstract class AbstractUserDefinedFileAttributeView
     implements UserDefinedFileAttributeView, DynamicFileAttributeView
 {
     protected AbstractUserDefinedFileAttributeView() { }
-
-    protected void checkAccess(String file,
-                               boolean checkRead,
-                               boolean checkWrite)
-    {
-        assert checkRead || checkWrite;
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            if (checkRead)
-                sm.checkRead(file);
-            if (checkWrite)
-                sm.checkWrite(file);
-            sm.checkPermission(new RuntimePermission("accessUserDefinedAttributes"));
-        }
-    }
 
     @Override
     public final String name() {

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -128,15 +128,9 @@ class PollingWatchService
         if (!isOpen())
             throw new ClosedWatchServiceException();
 
-        return doPrivilegedRegister(path, eventSet);
-    }
+        // registers directory returning a new key if not already registered or
+        // existing key if already registered
 
-    // registers directory returning a new key if not already registered or
-    // existing key if already registered
-    private PollingWatchKey doPrivilegedRegister(Path path,
-                                                 Set<? extends WatchEvent.Kind<?>> events)
-        throws IOException
-    {
         // check file is a directory and get its file key if possible
         BasicFileAttributes attrs = Files.readAttributes(path, BasicFileAttributes.class);
         if (!attrs.isDirectory()) {
@@ -163,7 +157,7 @@ class PollingWatchService
                     watchKey.disable();
                 }
             }
-            watchKey.enable(events);
+            watchKey.enable(eventSet);
             return watchKey;
         }
 

--- a/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
+++ b/src/java.base/share/classes/sun/nio/fs/PollingWatchService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,10 +36,6 @@ import java.nio.file.WatchEvent;
 import java.nio.file.WatchKey;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
-import java.security.PrivilegedActionException;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -86,7 +82,6 @@ class PollingWatchService
     /**
      * Register the given file with this watch service
      */
-    @SuppressWarnings("removal")
     @Override
     WatchKey register(final Path path,
                       WatchEvent.Kind<?>[] events,
@@ -133,22 +128,7 @@ class PollingWatchService
         if (!isOpen())
             throw new ClosedWatchServiceException();
 
-        // registration is done in privileged block as it requires the
-        // attributes of the entries in the directory.
-        try {
-            return AccessController.doPrivileged(
-                new PrivilegedExceptionAction<PollingWatchKey>() {
-                    @Override
-                    public PollingWatchKey run() throws IOException {
-                        return doPrivilegedRegister(path, eventSet);
-                    }
-                });
-        } catch (PrivilegedActionException pae) {
-            Throwable cause = pae.getCause();
-            if (cause instanceof IOException ioe)
-                throw ioe;
-            throw new AssertionError(pae);
-        }
+        return doPrivilegedRegister(path, eventSet);
     }
 
     // registers directory returning a new key if not already registered or
@@ -189,7 +169,6 @@ class PollingWatchService
 
     }
 
-    @SuppressWarnings("removal")
     @Override
     void implClose() throws IOException {
         synchronized (map) {
@@ -200,13 +179,7 @@ class PollingWatchService
             }
             map.clear();
         }
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            @Override
-            public Void run() {
-                scheduledExecutor.shutdown();
-                return null;
-            }
-         });
+        scheduledExecutor.shutdown();
     }
 
     /**

--- a/src/java.base/unix/classes/sun/nio/ch/InheritedChannel.java
+++ b/src/java.base/unix/classes/sun/nio/ch/InheritedChannel.java
@@ -150,18 +150,6 @@ class InheritedChannel {
     }
 
     /*
-     * If there's a SecurityManager then check for the appropriate
-     * RuntimePermission.
-     */
-    private static void checkAccess() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission("inheritedChannel"));
-        }
-    }
-
-    /*
      * If standard inherited channel is connected to a socket then return a Channel
      * of the appropriate type based standard input.
      */
@@ -252,11 +240,6 @@ class InheritedChannel {
             haveChannel = true;
         }
 
-        // if there is a channel then do the security check before
-        // returning it.
-        if (channel != null) {
-            checkAccess();
-        }
         return channel;
     }
 

--- a/src/java.base/unix/classes/sun/nio/ch/UnixAsynchronousSocketChannelImpl.java
+++ b/src/java.base/unix/classes/sun/nio/ch/UnixAsynchronousSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,6 @@ import java.io.FileDescriptor;
 import sun.net.ConnectionResetException;
 import sun.net.NetHooks;
 import sun.net.util.SocketExceptions;
-import sun.security.action.GetPropertyAction;
 
 /**
  * Unix implementation of AsynchronousSocketChannel
@@ -49,7 +48,7 @@ class UnixAsynchronousSocketChannelImpl
 
     private static final boolean disableSynchronousRead;
     static {
-        String propValue = GetPropertyAction.privilegedGetProperty(
+        String propValue = System.getProperty(
             "sun.nio.ch.disableSynchronousRead", "false");
         disableSynchronousRead = propValue.isEmpty() ?
             true : Boolean.parseBoolean(propValue);
@@ -308,12 +307,6 @@ class UnixAsynchronousSocketChannelImpl
         }
 
         InetSocketAddress isa = Net.checkAddress(remote);
-
-        // permission check
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkConnect(isa.getAddress().getHostAddress(), isa.getPort());
 
         // check and set state
         boolean notifyBeforeTcpConnect;

--- a/src/java.base/unix/classes/sun/nio/ch/UnixDomainSocketsUtil.java
+++ b/src/java.base/unix/classes/sun/nio/ch/UnixDomainSocketsUtil.java
@@ -26,8 +26,6 @@
 package sun.nio.ch;
 
 import java.nio.charset.Charset;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import sun.net.NetProperties;
 import jdk.internal.util.StaticProperty;
 
@@ -51,16 +49,12 @@ class UnixDomainSocketsUtil {
      * 2. ${jdk.net.unixdomain.tmpdir} if set as net property
      * 3. ${java.io.tmpdir} system property
      */
-    @SuppressWarnings("removal")
     static String getTempDir() {
-        PrivilegedAction<String> action = () -> {
-            String s = NetProperties.get("jdk.net.unixdomain.tmpdir");
-            if (s != null && s.length() > 0) {
-                return s;
-            } else {
-                return StaticProperty.javaIoTmpDir();
-            }
-        };
-        return AccessController.doPrivileged(action);
+        String s = NetProperties.get("jdk.net.unixdomain.tmpdir");
+        if (s != null && s.length() > 0) {
+            return s;
+        } else {
+            return StaticProperty.javaIoTmpDir();
+        }
     }
 }

--- a/src/java.base/unix/classes/sun/nio/fs/MimeTypesFileTypeDetector.java
+++ b/src/java.base/unix/classes/sun/nio/fs/MimeTypesFileTypeDetector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -93,19 +91,13 @@ class MimeTypesFileTypeDetector extends AbstractFileTypeDetector {
         if (!loaded) {
             synchronized (this) {
                 if (!loaded) {
-                    @SuppressWarnings("removal")
-                    List<String> lines = AccessController.doPrivileged(
-                        new PrivilegedAction<>() {
-                            @Override
-                            public List<String> run() {
-                                try {
-                                    return Files.readAllLines(mimeTypesFile,
-                                                              Charset.defaultCharset());
-                                } catch (IOException ignore) {
-                                    return Collections.emptyList();
-                                }
-                            }
-                        });
+                    List<String> lines;
+                    try {
+                        lines = Files.readAllLines(mimeTypesFile,
+                                                   Charset.defaultCharset());
+                    } catch (IOException ignore) {
+                        lines = Collections.emptyList();
+                    }
 
                     mimeTypeMap = HashMap.newHashMap(lines.size());
                     String entry = "";

--- a/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
@@ -108,7 +108,6 @@ class UnixChannelFactory {
      */
     static FileChannel newFileChannel(int dfd,
                                       UnixPath path,
-                                      String pathForPermissionCheck,
                                       Set<? extends OpenOption> options,
                                       int mode)
         throws UnixException
@@ -130,7 +129,7 @@ class UnixChannelFactory {
         if (flags.append && flags.truncateExisting)
             throw new IllegalArgumentException("APPEND + TRUNCATE_EXISTING not allowed");
 
-        FileDescriptor fdObj = open(dfd, path, pathForPermissionCheck, flags, mode);
+        FileDescriptor fdObj = open(dfd, path, flags, mode);
         return FileChannelImpl.open(fdObj, path.toString(), flags.read, flags.write,
                 (flags.sync || flags.dsync), flags.direct, null);
     }
@@ -143,7 +142,7 @@ class UnixChannelFactory {
                                       int mode)
         throws UnixException
     {
-        return newFileChannel(-1, path, null, options, mode);
+        return newFileChannel(-1, path, options, mode);
     }
 
     /**
@@ -167,7 +166,7 @@ class UnixChannelFactory {
             throw new UnsupportedOperationException("APPEND not allowed");
 
         // for now use simple implementation
-        FileDescriptor fdObj = open(-1, path, null, flags, mode);
+        FileDescriptor fdObj = open(-1, path, flags, mode);
         return SimpleAsynchronousFileChannelImpl.open(fdObj, path.toString(), flags.read, flags.write, pool);
     }
 
@@ -177,7 +176,6 @@ class UnixChannelFactory {
      */
     protected static FileDescriptor open(int dfd,
                                          UnixPath path,
-                                         String pathForPermissionCheck,
                                          Flags flags,
                                          int mode)
         throws UnixException

--- a/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixChannelFactory.java
@@ -25,9 +25,9 @@
 
 package sun.nio.fs;
 
+import java.io.FileDescriptor;
 import java.nio.file.*;
 import java.nio.channels.*;
-import java.io.FileDescriptor;
 import java.util.Set;
 
 import jdk.internal.access.SharedSecrets;
@@ -235,20 +235,6 @@ class UnixChannelFactory {
             oflags |= O_SYNC;
         if (flags.direct)
             oflags |= O_DIRECT;
-
-        // permission check before we open the file
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            if (pathForPermissionCheck == null)
-                pathForPermissionCheck = path.getPathForPermissionCheck();
-            if (flags.read)
-                sm.checkRead(pathForPermissionCheck);
-            if (flags.write)
-                sm.checkWrite(pathForPermissionCheck);
-            if (flags.deleteOnClose)
-                sm.checkDelete(pathForPermissionCheck);
-        }
 
         int fd;
         try {

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileAttributeViews.java
@@ -25,11 +25,11 @@
 
 package sun.nio.fs;
 
+import java.io.IOException;
 import java.nio.file.*;
 import java.nio.file.attribute.*;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.io.IOException;
 
 import static sun.nio.fs.UnixConstants.*;
 import static sun.nio.fs.UnixNativeDispatcher.*;
@@ -47,7 +47,6 @@ class UnixFileAttributeViews {
 
         @Override
         public BasicFileAttributes readAttributes() throws IOException {
-            file.checkRead();
             try {
                  UnixFileAttributes attrs =
                      UnixFileAttributes.get(file, followLinks);
@@ -68,9 +67,6 @@ class UnixFileAttributeViews {
                 // no effect
                 return;
             }
-
-            // permission check
-            file.checkWrite();
 
             // use a file descriptor if possible to avoid a race due to
             // accessing a path more than once as the file at that path could
@@ -156,24 +152,6 @@ class UnixFileAttributeViews {
             super(file, followLinks);
         }
 
-        final void checkReadExtended() {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                file.checkRead();
-                sm.checkPermission(new RuntimePermission("accessUserInformation"));
-            }
-        }
-
-        final void checkWriteExtended() {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                file.checkWrite();
-                sm.checkPermission(new RuntimePermission("accessUserInformation"));
-            }
-        }
-
         @Override
         public String name() {
             return "posix";
@@ -228,7 +206,6 @@ class UnixFileAttributeViews {
 
         @Override
         public UnixFileAttributes readAttributes() throws IOException {
-            checkReadExtended();
             try {
                  return UnixFileAttributes.get(file, followLinks);
             } catch (UnixException x) {
@@ -239,8 +216,6 @@ class UnixFileAttributeViews {
 
         // chmod
         final void setMode(int mode) throws IOException {
-            checkWriteExtended();
-
             if (followLinks) {
                 try {
                     chmod(file, mode);
@@ -283,7 +258,6 @@ class UnixFileAttributeViews {
 
         // chown
         final void setOwners(int uid, int gid) throws IOException {
-            checkWriteExtended();
             try {
                 if (followLinks) {
                     chown(file, uid, gid);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -34,8 +34,6 @@ import java.nio.file.attribute.*;
 import java.nio.channels.*;
 import java.util.*;
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * Base implementation of FileStore for Unix/like implementations.
@@ -269,17 +267,11 @@ abstract class UnixFileStore
     /**
      * Returns status to indicate if file system supports a given feature
      */
-    @SuppressWarnings("removal")
     FeatureStatus checkIfFeaturePresent(String feature) {
         if (props == null) {
             synchronized (loadLock) {
                 if (props == null) {
-                    props = AccessController.doPrivileged(
-                        new PrivilegedAction<>() {
-                            @Override
-                            public Properties run() {
-                                return loadProperties();
-                            }});
+                    props = loadProperties();
                 }
             }
         }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -34,7 +34,6 @@ import java.nio.file.FileStore;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystemException;
 import java.nio.file.LinkOption;
-import java.nio.file.LinkPermission;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.StandardCopyOption;
@@ -54,7 +53,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import sun.nio.ch.DirectBuffer;
 import sun.nio.ch.IOStatus;
-import sun.security.action.GetPropertyAction;
 import static sun.nio.fs.UnixConstants.*;
 import static sun.nio.fs.UnixNativeDispatcher.*;
 
@@ -87,8 +85,7 @@ abstract class UnixFileSystem
         // if process-wide chdir is allowed or default directory is not the
         // process working directory then paths must be resolved against the
         // default directory.
-        String propValue = GetPropertyAction
-                .privilegedGetProperty("sun.nio.fs.chdirAllowed", "false");
+        String propValue = System.getProperty("sun.nio.fs.chdirAllowed", "false");
         boolean chdirAllowed = propValue.isEmpty() ? true : Boolean.parseBoolean(propValue);
         if (chdirAllowed) {
             this.needToResolveAgainstDefaultDirectory = true;
@@ -182,15 +179,7 @@ abstract class UnixFileSystem
         final List<Path> allowedList = List.of(rootDirectory);
         return new Iterable<>() {
             public Iterator<Path> iterator() {
-                try {
-                    @SuppressWarnings("removal")
-                    SecurityManager sm = System.getSecurityManager();
-                    if (sm != null)
-                        sm.checkRead(rootDirectory.toString());
-                    return allowedList.iterator();
-                } catch (SecurityException x) {
-                    return Collections.emptyIterator(); //disallowed
-                }
+                return allowedList.iterator();
             }
         };
     }
@@ -228,16 +217,6 @@ abstract class UnixFileSystem
                 if (entry.isIgnored())
                     continue;
 
-                // check permission to read mount point
-                @SuppressWarnings("removal")
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                    try {
-                        sm.checkRead(Util.toString(entry.dir()));
-                    } catch (SecurityException x) {
-                        continue;
-                    }
-                }
                 try {
                     return getFileStore(entry);
                 } catch (IOException ignore) {
@@ -275,15 +254,6 @@ abstract class UnixFileSystem
 
     @Override
     public final Iterable<FileStore> getFileStores() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            try {
-                sm.checkPermission(new RuntimePermission("getFileStoreAttributes"));
-            } catch (SecurityException se) {
-                return Collections.emptyList();
-            }
-        }
         return new Iterable<>() {
             public Iterator<FileStore> iterator() {
                 return new FileStoreIterator();
@@ -845,14 +815,6 @@ abstract class UnixFileSystem
     void move(UnixPath source, UnixPath target, CopyOption... options)
         throws IOException
     {
-        // permission check
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            source.checkWrite();
-            target.checkWrite();
-        }
-
         // translate options into flags
         Flags flags = Flags.fromMoveOptions(options);
 
@@ -988,14 +950,6 @@ abstract class UnixFileSystem
               final UnixPath target,
               CopyOption... options) throws IOException
     {
-        // permission checks
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            source.checkRead();
-            target.checkWrite();
-        }
-
         // translate options into flags
         final Flags flags = Flags.fromCopyOptions(options);
 
@@ -1007,11 +961,6 @@ abstract class UnixFileSystem
             sourceAttrs = UnixFileAttributes.get(source, flags.followLinks);
         } catch (UnixException x) {
             x.rethrowAsIOException(source);
-        }
-
-        // if source file is symbolic link then we must check LinkPermission
-        if (sm != null && sourceAttrs.isSymbolicLink()) {
-            sm.checkPermission(new LinkPermission("symbolic"));
         }
 
         // ensure source can be copied

--- a/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixFileSystem.java
@@ -176,12 +176,7 @@ abstract class UnixFileSystem
      */
     @Override
     public final Iterable<Path> getRootDirectories() {
-        final List<Path> allowedList = List.of(rootDirectory);
-        return new Iterable<>() {
-            public Iterator<Path> iterator() {
-                return allowedList.iterator();
-            }
-        };
+        return List.of(rootDirectory);
     }
 
     /**
@@ -254,11 +249,7 @@ abstract class UnixFileSystem
 
     @Override
     public final Iterable<FileStore> getFileStores() {
-        return new Iterable<>() {
-            public Iterator<FileStore> iterator() {
-                return new FileStoreIterator();
-            }
-        };
+        return FileStoreIterator::new;
     }
 
     @Override

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -833,27 +833,6 @@ class UnixPath implements Path {
         return open(this, flags, 0);
     }
 
-    void checkRead() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkRead(getPathForPermissionCheck());
-    }
-
-    void checkWrite() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkWrite(getPathForPermissionCheck());
-    }
-
-    void checkDelete() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkDelete(getPathForPermissionCheck());
-    }
-
     @Override
     public UnixPath toAbsolutePath() {
         if (isAbsolute()) {
@@ -861,19 +840,12 @@ class UnixPath implements Path {
         }
         // The path is relative so need to resolve against default directory,
         // taking care not to reveal the user.dir
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPropertyAccess("user.dir");
-        }
         return new UnixPath(getFileSystem(),
             resolve(getFileSystem().defaultDirectory(), path));
     }
 
     @Override
     public Path toRealPath(LinkOption... options) throws IOException {
-        checkRead();
-
         UnixPath absolute = toAbsolutePath();
 
         // if resolving links then use realpath
@@ -1022,7 +994,6 @@ class UnixPath implements Path {
             throw new NullPointerException();
         if (!(watcher instanceof AbstractWatchService))
             throw new ProviderMismatchException();
-        checkRead();
         return ((AbstractWatchService)watcher).register(this, events, modifiers);
     }
 }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixPath.java
@@ -838,8 +838,7 @@ class UnixPath implements Path {
         if (isAbsolute()) {
             return this;
         }
-        // The path is relative so need to resolve against default directory,
-        // taking care not to reveal the user.dir
+        // The path is relative so need to resolve against default directory
         return new UnixPath(getFileSystem(),
             resolve(getFileSystem().defaultDirectory(), path));
     }

--- a/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixSecureDirectoryStream.java
@@ -139,15 +139,12 @@ class UnixSecureDirectoryStream
         int mode = UnixFileModeAttribute
             .toUnixMode(UnixFileModeAttribute.ALL_READWRITE, attrs);
 
-        // path for permission check
-        String pathToCheck = ds.directory().resolve(file).getPathForPermissionCheck();
-
         ds.readLock().lock();
         try {
             if (!ds.isOpen())
                 throw new ClosedDirectoryStreamException();
             try {
-                return UnixChannelFactory.newFileChannel(dfd, file, pathToCheck, options, mode);
+                return UnixChannelFactory.newFileChannel(dfd, file, options, mode);
             } catch (UnixException x) {
                 x.rethrowAsIOException(file);
                 return null; // keep compiler happy

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUriUtils.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUriUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -121,7 +121,6 @@ class UnixUriUtils {
         // trailing slash if directory
         if (sb.charAt(sb.length()-1) != '/') {
             try {
-                up.checkRead();
                 UnixFileAttributes attrs = UnixFileAttributes.getIfExists(up);
                 if (attrs != null
                         && ((attrs.mode() & UnixConstants.S_IFMT) == UnixConstants.S_IFDIR))

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUriUtils.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUriUtils.java
@@ -125,7 +125,7 @@ class UnixUriUtils {
                 if (attrs != null
                         && ((attrs.mode() & UnixConstants.S_IFMT) == UnixConstants.S_IFDIR))
                     sb.append('/');
-            } catch (UnixException | SecurityException ignore) { }
+            } catch (UnixException ignore) { }
         }
 
         try {

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserDefinedFileAttributeView.java
@@ -25,9 +25,9 @@
 
 package sun.nio.fs;
 
+import java.io.IOException;
 import java.nio.file.*;
 import java.nio.ByteBuffer;
-import java.io.IOException;
 import java.util.*;
 
 import jdk.internal.access.JavaNioAccess;
@@ -114,12 +114,8 @@ abstract class UnixUserDefinedFileAttributeView
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public List<String> list() throws IOException  {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), true, false);
-
         int fd = -1;
         try {
             fd = file.openForAttributeAccess(followLinks);
@@ -141,12 +137,8 @@ abstract class UnixUserDefinedFileAttributeView
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public int size(String name) throws IOException  {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), true, false);
-
         int fd = -1;
         try {
             fd = file.openForAttributeAccess(followLinks);
@@ -165,12 +157,8 @@ abstract class UnixUserDefinedFileAttributeView
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public int read(String name, ByteBuffer dst) throws IOException {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), true, false);
-
         if (dst.isReadOnly())
             throw new IllegalArgumentException("Read-only buffer");
         int pos = dst.position();
@@ -230,12 +218,8 @@ abstract class UnixUserDefinedFileAttributeView
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public int write(String name, ByteBuffer src) throws IOException {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), false, true);
-
         int pos = src.position();
         int lim = src.limit();
         assert (pos <= lim);
@@ -293,12 +277,8 @@ abstract class UnixUserDefinedFileAttributeView
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void delete(String name) throws IOException {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), false, true);
-
         int fd = -1;
         try {
             fd = file.openForAttributeAccess(followLinks);

--- a/src/java.base/unix/classes/sun/nio/fs/UnixUserPrincipals.java
+++ b/src/java.base/unix/classes/sun/nio/fs/UnixUserPrincipals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -132,11 +132,6 @@ public class UnixUserPrincipals {
     private static int lookupName(String name, boolean isGroup)
         throws IOException
     {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission("lookupUserInformation"));
-        }
         int id;
         try {
             id = (isGroup) ? getgrnam(name) : getpwnam(name);

--- a/src/java.base/windows/classes/sun/nio/ch/DefaultSelectorProvider.java
+++ b/src/java.base/windows/classes/sun/nio/ch/DefaultSelectorProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,20 +25,13 @@
 
 package sun.nio.ch;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * Creates this platform's default SelectorProvider
  */
 
-@SuppressWarnings("removal")
 public class DefaultSelectorProvider {
-    private static final SelectorProviderImpl INSTANCE;
-    static {
-        PrivilegedAction<SelectorProviderImpl> pa = WEPollSelectorProvider::new;
-        INSTANCE = AccessController.doPrivileged(pa);
-    }
+    private static final SelectorProviderImpl INSTANCE =
+        new WEPollSelectorProvider();
 
     /**
      * Prevent instantiation.

--- a/src/java.base/windows/classes/sun/nio/ch/DefaultSelectorProvider.java
+++ b/src/java.base/windows/classes/sun/nio/ch/DefaultSelectorProvider.java
@@ -30,8 +30,7 @@ package sun.nio.ch;
  */
 
 public class DefaultSelectorProvider {
-    private static final SelectorProviderImpl INSTANCE =
-        new WEPollSelectorProvider();
+    private static final SelectorProviderImpl INSTANCE = new WEPollSelectorProvider();
 
     /**
      * Prevent instantiation.

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,9 +39,6 @@ import java.nio.channels.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.channels.spi.*;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
-import java.security.PrivilegedActionException;
 import java.security.SecureRandom;
 import java.util.Random;
 
@@ -65,7 +62,6 @@ class PipeImpl
     private final SinkChannelImpl sink;
 
     private static class Initializer
-        implements PrivilegedExceptionAction<Void>
     {
 
         private final SelectorProvider sp;
@@ -79,7 +75,6 @@ class PipeImpl
             this.preferUnixDomain = preferUnixDomain;
         }
 
-        @Override
         public Void run() throws IOException {
             LoopbackConnector connector = new LoopbackConnector();
             connector.run();
@@ -190,17 +185,12 @@ class PipeImpl
      *
      * @param buffering if false set TCP_NODELAY on TCP sockets
      */
-    @SuppressWarnings("removal")
     PipeImpl(SelectorProvider sp, boolean preferAfUnix, boolean buffering) throws IOException {
         Initializer initializer = new Initializer(sp, preferAfUnix);
-        try {
-            AccessController.doPrivileged(initializer);
-            SinkChannelImpl sink = initializer.sink;
-            if (sink.isNetSocket() && !buffering) {
-                sink.setOption(StandardSocketOptions.TCP_NODELAY, true);
-            }
-        } catch (PrivilegedActionException pae) {
-            throw (IOException) pae.getCause();
+        initializer.run();
+        SinkChannelImpl sink = initializer.sink;
+        if (sink.isNetSocket() && !buffering) {
+            sink.setOption(StandardSocketOptions.TCP_NODELAY, true);
         }
         this.source = initializer.source;
         this.sink = initializer.sink;

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -61,9 +61,7 @@ class PipeImpl
     private final SourceChannelImpl source;
     private final SinkChannelImpl sink;
 
-    private static class Initializer
-    {
-
+    private static class Initializer {
         private final SelectorProvider sp;
         private final boolean preferUnixDomain;
         private IOException ioe;
@@ -75,7 +73,7 @@ class PipeImpl
             this.preferUnixDomain = preferUnixDomain;
         }
 
-        public Void run() throws IOException {
+        public void init() throws IOException {
             LoopbackConnector connector = new LoopbackConnector();
             connector.run();
             if (ioe instanceof ClosedByInterruptException) {
@@ -96,8 +94,6 @@ class PipeImpl
 
             if (ioe != null)
                 throw new IOException("Unable to establish loopback connection", ioe);
-
-            return null;
         }
 
         private class LoopbackConnector implements Runnable {
@@ -187,7 +183,7 @@ class PipeImpl
      */
     PipeImpl(SelectorProvider sp, boolean preferAfUnix, boolean buffering) throws IOException {
         Initializer initializer = new Initializer(sp, preferAfUnix);
-        initializer.run();
+        initializer.init();
         SinkChannelImpl sink = initializer.sink;
         if (sink.isNetSocket() && !buffering) {
             sink.setOption(StandardSocketOptions.TCP_NODELAY, true);

--- a/src/java.base/windows/classes/sun/nio/ch/UnixDomainSocketsUtil.java
+++ b/src/java.base/windows/classes/sun/nio/ch/UnixDomainSocketsUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package sun.nio.ch;
 
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import sun.net.NetProperties;
 import jdk.internal.util.StaticProperty;
 
@@ -50,20 +48,16 @@ class UnixDomainSocketsUtil {
      * 3. %TEMP%
      * 4. ${java.io.tmpdir}
      */
-    @SuppressWarnings("removal")
     static String getTempDir() {
-        PrivilegedAction<String> action = () -> {
-            String s = NetProperties.get("jdk.net.unixdomain.tmpdir");
-            if (s != null) {
-                return s;
-            }
-            String temp = System.getenv("TEMP");
-            if (temp != null) {
-                return temp;
-            }
-            return StaticProperty.javaIoTmpDir();
-        };
-        return AccessController.doPrivileged(action);
+        String s = NetProperties.get("jdk.net.unixdomain.tmpdir");
+        if (s != null) {
+            return s;
+        }
+        String temp = System.getenv("TEMP");
+        if (temp != null) {
+            return temp;
+        }
+        return StaticProperty.javaIoTmpDir();
     }
 }
 

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousServerSocketChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousServerSocketChannelImpl.java
@@ -187,7 +187,7 @@ class WindowsAsynchronousServerSocketChannelImpl
                 closeChildChannel();
                 if (x instanceof ClosedChannelException)
                     x = new AsynchronousCloseException();
-                if (!(x instanceof IOException) && !(x instanceof SecurityException))
+                if (!(x instanceof IOException))
                     x = new IOException(x);
                 enableAccept();
                 result.setFailure(x);
@@ -239,7 +239,7 @@ class WindowsAsynchronousServerSocketChannelImpl
                 closeChildChannel();
                 if (x instanceof ClosedChannelException)
                     x = new AsynchronousCloseException();
-                if (!(x instanceof IOException) && !(x instanceof SecurityException))
+                if (!(x instanceof IOException))
                     x = new IOException(x);
                 result.setFailure(x);
             }

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousServerSocketChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousServerSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,9 +30,6 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.io.IOException;
-import java.security.AccessControlContext;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import jdk.internal.misc.Unsafe;
 
 /**
@@ -115,16 +112,12 @@ class WindowsAsynchronousServerSocketChannelImpl
      */
     private class AcceptTask implements Runnable, Iocp.ResultHandler {
         private final WindowsAsynchronousSocketChannelImpl channel;
-        @SuppressWarnings("removal")
-        private final AccessControlContext acc;
         private final PendingFuture<AsynchronousSocketChannel,Object> result;
 
         AcceptTask(WindowsAsynchronousSocketChannelImpl channel,
-                   @SuppressWarnings("removal") AccessControlContext acc,
                    PendingFuture<AsynchronousSocketChannel,Object> result)
         {
             this.channel = channel;
-            this.acc = acc;
             this.result = result;
         }
 
@@ -139,7 +132,6 @@ class WindowsAsynchronousServerSocketChannelImpl
         }
 
         // caller must have acquired read lock for the listener and child channel.
-        @SuppressWarnings("removal")
         void finishAccept() throws IOException {
             /**
              * Set local/remote addresses. This is currently very inefficient
@@ -151,18 +143,6 @@ class WindowsAsynchronousServerSocketChannelImpl
             InetSocketAddress local = Net.localAddress(channel.fd);
             final InetSocketAddress remote = Net.remoteAddress(channel.fd);
             channel.setConnected(local, remote);
-
-            // permission check (in context of initiating thread)
-            if (acc != null) {
-                AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                    public Void run() {
-                        SecurityManager sm = System.getSecurityManager();
-                        sm.checkAccept(remote.getAddress().getHostAddress(),
-                                       remote.getPort());
-                        return null;
-                    }
-                }, acc);
-            }
         }
 
         /**
@@ -328,16 +308,9 @@ class WindowsAsynchronousServerSocketChannelImpl
             return null;
         }
 
-        // need calling context when there is security manager as
-        // permission check may be done in a different thread without
-        // any application call frames on the stack
-        @SuppressWarnings("removal")
-        AccessControlContext acc = (System.getSecurityManager() == null) ?
-            null : AccessController.getContext();
-
         PendingFuture<AsynchronousSocketChannel,Object> result =
             new PendingFuture<AsynchronousSocketChannel,Object>(this, handler, attachment);
-        AcceptTask task = new AcceptTask(ch, acc, result);
+        AcceptTask task = new AcceptTask(ch, result);
         result.setContext(task);
 
         // check and set flag to prevent concurrent accepting

--- a/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousSocketChannelImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/WindowsAsynchronousSocketChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,9 +31,6 @@ import java.nio.BufferOverflowException;
 import java.net.*;
 import java.util.concurrent.*;
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import jdk.internal.misc.Unsafe;
 import sun.net.util.SocketExceptions;
 
@@ -308,20 +305,6 @@ class WindowsAsynchronousSocketChannelImpl
         }
     }
 
-    @SuppressWarnings("removal")
-    private void doPrivilegedBind(final SocketAddress sa) throws IOException {
-        try {
-            AccessController.doPrivileged(new PrivilegedExceptionAction<Void>() {
-                public Void run() throws IOException {
-                    bind(sa);
-                    return null;
-                }
-            });
-        } catch (PrivilegedActionException e) {
-            throw (IOException) e.getException();
-        }
-    }
-
     @Override
     <A> Future<Void> implConnect(SocketAddress remote,
                                  A attachment,
@@ -337,12 +320,6 @@ class WindowsAsynchronousSocketChannelImpl
 
         InetSocketAddress isa = Net.checkAddress(remote);
 
-        // permission check
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkConnect(isa.getAddress().getHostAddress(), isa.getPort());
-
         // check and update state
         // ConnectEx requires the socket to be bound to a local address
         IOException bindException = null;
@@ -354,11 +331,7 @@ class WindowsAsynchronousSocketChannelImpl
             if (localAddress == null) {
                 try {
                     SocketAddress any = new InetSocketAddress(0);
-                    if (sm == null) {
-                        bind(any);
-                    } else {
-                        doPrivilegedBind(any);
-                    }
+                    bind(any);
                 } catch (IOException x) {
                     bindException = x;
                 }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsAclFileAttributeView.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsAclFileAttributeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -61,22 +61,6 @@ class WindowsAclFileAttributeView
         this.followLinks = followLinks;
     }
 
-    // permission check
-    private void checkAccess(WindowsPath file,
-                             boolean checkRead,
-                             boolean checkWrite)
-    {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            if (checkRead)
-                sm.checkRead(file.getPathForPermissionCheck());
-            if (checkWrite)
-                sm.checkWrite(file.getPathForPermissionCheck());
-            sm.checkPermission(new RuntimePermission("accessUserInformation"));
-        }
-    }
-
     // invokes GetFileSecurity to get requested security information
     static NativeBuffer getFileSecurity(String path, int request)
         throws IOException
@@ -114,8 +98,6 @@ class WindowsAclFileAttributeView
     public UserPrincipal getOwner()
         throws IOException
     {
-        checkAccess(file, true, false);
-
         // GetFileSecurity does not follow links so when following links we
         // need the final target
         String path = WindowsLinkSupport.getFinalPath(file, followLinks);
@@ -135,8 +117,6 @@ class WindowsAclFileAttributeView
     public List<AclEntry> getAcl()
         throws IOException
     {
-        checkAccess(file, true, false);
-
         // GetFileSecurity does not follow links so when following links we
         // need the final target
         String path = WindowsLinkSupport.getFinalPath(file, followLinks);
@@ -157,9 +137,6 @@ class WindowsAclFileAttributeView
         if (!(obj instanceof WindowsUserPrincipals.User))
             throw new ProviderMismatchException();
         WindowsUserPrincipals.User owner = (WindowsUserPrincipals.User)obj;
-
-        // permission check
-        checkAccess(file, false, true);
 
         // SetFileSecurity does not follow links so when following links we
         // need the final target
@@ -199,8 +176,6 @@ class WindowsAclFileAttributeView
 
     @Override
     public void setAcl(List<AclEntry> acl) throws IOException {
-        checkAccess(file, false, true);
-
         // SetFileSecurity does not follow links so when following links we
         // need the final target
         String path = WindowsLinkSupport.getFinalPath(file, followLinks);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsChannelFactory.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsChannelFactory.java
@@ -291,20 +291,6 @@ class WindowsChannelFactory {
             dwFlagsAndAttributes |= FILE_FLAG_OPEN_REPARSE_POINT;
         }
 
-        // permission check
-        if (pathToCheck != null) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                if (flags.read)
-                    sm.checkRead(pathToCheck);
-                if (flags.write)
-                    sm.checkWrite(pathToCheck);
-                if (flags.deleteOnClose)
-                    sm.checkDelete(pathToCheck);
-            }
-        }
-
         // open file
         long handle = CreateFile(pathForWindows,
                                  dwDesiredAccess,

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsChannelFactory.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsChannelFactory.java
@@ -139,11 +139,8 @@ class WindowsChannelFactory {
      *
      * @param   pathForWindows
      *          The path of the file to open/create
-     * @param   pathToCheck
-     *          The path used for permission checks (if security manager)
      */
     static FileChannel newFileChannel(String pathForWindows,
-                                      String pathToCheck,
                                       Set<? extends OpenOption> options,
                                       long pSecurityDescriptor)
         throws WindowsException
@@ -165,7 +162,7 @@ class WindowsChannelFactory {
         if (flags.append && flags.truncateExisting)
             throw new IllegalArgumentException("APPEND + TRUNCATE_EXISTING not allowed");
 
-        FileDescriptor fdObj = open(pathForWindows, pathToCheck, flags, pSecurityDescriptor);
+        FileDescriptor fdObj = open(pathForWindows, flags, pSecurityDescriptor);
         return FileChannelImpl.open(fdObj, pathForWindows, flags.read, flags.write,
                 (flags.sync || flags.dsync), flags.direct, null);
     }
@@ -175,13 +172,10 @@ class WindowsChannelFactory {
      *
      * @param   pathForWindows
      *          The path of the file to open/create
-     * @param   pathToCheck
-     *          The path used for permission checks (if security manager)
      * @param   pool
      *          The thread pool that the channel is associated with
      */
     static AsynchronousFileChannel newAsynchronousFileChannel(String pathForWindows,
-                                                              String pathToCheck,
                                                               Set<? extends OpenOption> options,
                                                               long pSecurityDescriptor,
                                                               ThreadPool pool)
@@ -204,7 +198,7 @@ class WindowsChannelFactory {
         // open file for overlapped I/O
         FileDescriptor fdObj;
         try {
-            fdObj = open(pathForWindows, pathToCheck, flags, pSecurityDescriptor);
+            fdObj = open(pathForWindows, flags, pSecurityDescriptor);
         } catch (WindowsException x) {
             x.rethrowAsIOException(pathForWindows);
             return null;
@@ -226,7 +220,6 @@ class WindowsChannelFactory {
      * encapsulating the handle to the open file.
      */
     private static FileDescriptor open(String pathForWindows,
-                                       String pathToCheck,
                                        Flags flags,
                                        long pSecurityDescriptor)
         throws WindowsException

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributeViews.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributeViews.java
@@ -109,7 +109,7 @@ class WindowsFileAttributeViews {
                             // retry succeeded
                             x = null;
                         }
-                    } catch (SecurityException | WindowsException | IOException ignore) {
+                    } catch (WindowsException | IOException ignore) {
                         // ignore exceptions to let original exception be thrown
                     }
                 }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributeViews.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributeViews.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,7 +46,6 @@ class WindowsFileAttributeViews {
 
         @Override
         public WindowsFileAttributes readAttributes() throws IOException {
-            file.checkRead();
             try {
                 return WindowsFileAttributes.get(file, followLinks);
             } catch (WindowsException x) {
@@ -134,9 +133,6 @@ class WindowsFileAttributeViews {
                 return;
             }
 
-            // permission check
-            file.checkWrite();
-
             // update times
             long t1 = (createTime == null) ? -1L :
                 WindowsFileAttributes.toWindowsTime(createTime);
@@ -219,8 +215,6 @@ class WindowsFileAttributeViews {
         private void updateAttributes(int flag, boolean enable)
             throws IOException
         {
-            file.checkWrite();
-
             // GetFileAttributes & SetFileAttributes do not follow links so when
             // following links we need the final target
             String path = WindowsLinkSupport.getFinalPath(file, followLinks);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileCopy.java
@@ -84,15 +84,6 @@ class WindowsFileCopy {
             throw new UnsupportedOperationException("Unsupported copy option: " + option);
         }
 
-        // check permissions. If the source file is a symbolic link then
-        // later we must also check LinkPermission
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            source.checkRead();
-            target.checkWrite();
-        }
-
         // get attributes of source file
         // attempt to get attributes of target file
         // if both files are the same there is nothing to do
@@ -142,11 +133,6 @@ class WindowsFileCopy {
 
         } finally {
             CloseHandle(sourceHandle);
-        }
-
-        // if source file is a symbolic link then we must check for LinkPermission
-        if (sm != null && sourceAttrs.isSymbolicLink()) {
-            sm.checkPermission(new LinkPermission("symbolic"));
         }
 
         // if source is a Unix domain socket, we don't want to copy it for various
@@ -306,13 +292,6 @@ class WindowsFileCopy {
             }
             if (option == null) throw new NullPointerException();
             throw new UnsupportedOperationException("Unsupported option: " + option);
-        }
-
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            source.checkWrite();
-            target.checkWrite();
         }
 
         final String sourcePath = asWin32Path(source);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
@@ -101,7 +101,7 @@ class WindowsFileSystem
             throw new AssertionError(x.getMessage());
         }
 
-        // iterate over roots, ignoring those that the security manager denies
+        // iterate over roots
         ArrayList<Path> result = new ArrayList<>();
         for (int i = 0; i <= 25; i++) {  // 0->A, 1->B, 2->C...
             if ((drives & (1 << i)) != 0) {
@@ -171,11 +171,7 @@ class WindowsFileSystem
 
     @Override
     public Iterable<FileStore> getFileStores() {
-        return new Iterable<FileStore>() {
-            public Iterator<FileStore> iterator() {
-                return new FileStoreIterator();
-            }
-        };
+        return FileStoreIterator::new;
     }
 
     // supported views

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -103,21 +103,12 @@ class WindowsFileSystem
 
         // iterate over roots, ignoring those that the security manager denies
         ArrayList<Path> result = new ArrayList<>();
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
         for (int i = 0; i <= 25; i++) {  // 0->A, 1->B, 2->C...
             if ((drives & (1 << i)) != 0) {
                 StringBuilder sb = new StringBuilder(3);
                 sb.append((char)('A' + i));
                 sb.append(":\\");
                 String root = sb.toString();
-                if (sm != null) {
-                    try {
-                        sm.checkRead(root);
-                    } catch (SecurityException x) {
-                        continue;
-                    }
-                }
                 result.add(WindowsPath.createFromNormalizedPath(this, root));
             }
         }
@@ -141,12 +132,6 @@ class WindowsFileSystem
                 if (!roots.hasNext())
                     return null;
                 WindowsPath root = (WindowsPath)roots.next();
-                // ignore if security manager denies access
-                try {
-                    root.checkRead();
-                } catch (SecurityException x) {
-                    continue;
-                }
                 try {
                     FileStore fs = WindowsFileStore.create(root.toString(), true);
                     if (fs != null)
@@ -186,15 +171,6 @@ class WindowsFileSystem
 
     @Override
     public Iterable<FileStore> getFileStores() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            try {
-                sm.checkPermission(new RuntimePermission("getFileStoreAttributes"));
-            } catch (SecurityException se) {
-                return Collections.emptyList();
-            }
-        }
         return new Iterable<FileStore>() {
             public Iterator<FileStore> iterator() {
                 return new FileStoreIterator();

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -241,7 +241,6 @@ class WindowsFileSystemProvider
     @Override
     boolean implDelete(Path obj, boolean failIfNotExists) throws IOException {
         WindowsPath file = WindowsPath.toWindowsPath(obj);
-        file.checkDelete();
 
         WindowsFileAttributes attrs = null;
         try {
@@ -371,7 +370,6 @@ class WindowsFileSystemProvider
 
         // check file exists only
         if (!(r || w || x)) {
-            file.checkRead();
             try {
                 WindowsFileAttributes.get(file, true);
                 return;
@@ -389,18 +387,12 @@ class WindowsFileSystemProvider
 
         int mask = 0;
         if (r) {
-            file.checkRead();
             mask |= FILE_READ_DATA;
         }
         if (w) {
-            file.checkWrite();
             mask |= FILE_WRITE_DATA;
         }
         if (x) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null)
-                sm.checkExec(file.getPathForPermissionCheck());
             mask |= FILE_EXECUTE;
         }
 
@@ -439,10 +431,6 @@ class WindowsFileSystemProvider
         if (!(obj2 instanceof WindowsPath))
             return false;
         WindowsPath file2 = (WindowsPath)obj2;
-
-        // check security manager access to both files
-        file1.checkRead();
-        file2.checkRead();
 
         // open both files and see if they are the same
         long h1 = 0L;
@@ -483,7 +471,6 @@ class WindowsFileSystemProvider
     @Override
     public boolean isHidden(Path obj) throws IOException {
         WindowsPath file = WindowsPath.toWindowsPath(obj);
-        file.checkRead();
         WindowsFileAttributes attrs = null;
         try {
             attrs = WindowsFileAttributes.get(file, true);
@@ -496,12 +483,6 @@ class WindowsFileSystemProvider
     @Override
     public FileStore getFileStore(Path obj) throws IOException {
         WindowsPath file = WindowsPath.toWindowsPath(obj);
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission("getFileStoreAttributes"));
-            file.checkRead();
-        }
         return WindowsFileStore.create(file);
     }
 
@@ -511,7 +492,6 @@ class WindowsFileSystemProvider
         throws IOException
     {
         WindowsPath dir = WindowsPath.toWindowsPath(obj);
-        dir.checkWrite();
         WindowsSecurityDescriptor sd = WindowsSecurityDescriptor.fromAttribute(attrs);
         try {
             CreateDirectory(dir.getPathForWin32Calls(), sd.address());
@@ -535,7 +515,6 @@ class WindowsFileSystemProvider
         throws IOException
     {
         WindowsPath dir = WindowsPath.toWindowsPath(obj);
-        dir.checkRead();
         if (filter == null)
             throw new NullPointerException();
         return new WindowsDirectoryStream(dir, filter);
@@ -553,14 +532,6 @@ class WindowsFileSystemProvider
             WindowsSecurityDescriptor.fromAttribute(attrs);  // may throw NPE or UOE
             throw new UnsupportedOperationException("Initial file attributes" +
                 "not supported when creating symbolic link");
-        }
-
-        // permission check
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new LinkPermission("symbolic"));
-            link.checkWrite();
         }
 
         /**
@@ -611,15 +582,6 @@ class WindowsFileSystemProvider
         WindowsPath link = WindowsPath.toWindowsPath(obj1);
         WindowsPath existing = WindowsPath.toWindowsPath(obj2);
 
-        // permission check
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new LinkPermission("hard"));
-            link.checkWrite();
-            existing.checkWrite();
-        }
-
         // create hard link
         try {
             CreateHardLink(link.getPathForWin32Calls(),
@@ -633,15 +595,6 @@ class WindowsFileSystemProvider
     public Path readSymbolicLink(Path obj1) throws IOException {
         WindowsPath link = WindowsPath.toWindowsPath(obj1);
         WindowsFileSystem fs = link.getFileSystem();
-
-        // permission check
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            FilePermission perm = new FilePermission(link.getPathForPermissionCheck(),
-                SecurityConstants.FILE_READLINK_ACTION);
-            sm.checkPermission(perm);
-        }
 
         String target = WindowsLinkSupport.readLink(link);
         return WindowsPath.createFromNormalizedPath(fs, target);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileSystemProvider.java
@@ -112,7 +112,6 @@ class WindowsFileSystemProvider
         try {
             return WindowsChannelFactory
                 .newFileChannel(file.getPathForWin32Calls(),
-                                file.getPathForPermissionCheck(),
                                 options,
                                 sd.address());
         } catch (WindowsException x) {
@@ -142,7 +141,6 @@ class WindowsFileSystemProvider
         try {
             return WindowsChannelFactory
                 .newAsynchronousFileChannel(file.getPathForWin32Calls(),
-                                            file.getPathForPermissionCheck(),
                                             options,
                                             sd.address(),
                                             pool);
@@ -227,7 +225,6 @@ class WindowsFileSystemProvider
         try {
             return WindowsChannelFactory
                 .newFileChannel(file.getPathForWin32Calls(),
-                                file.getPathForPermissionCheck(),
                                 options,
                                 sd.address());
         } catch (WindowsException x) {
@@ -323,7 +320,6 @@ class WindowsFileSystemProvider
             Set<OpenOption> opts = Collections.emptySet();
             FileChannel fc = WindowsChannelFactory
                 .newFileChannel(file.getPathForWin32Calls(),
-                                file.getPathForPermissionCheck(),
                                 opts,
                                 0L);
             fc.close();

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsLinkSupport.java
@@ -28,8 +28,6 @@ package sun.nio.fs;
 import java.nio.file.*;
 import java.io.IOException;
 import java.io.IOError;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import jdk.internal.misc.Unsafe;
 
 import static sun.nio.fs.WindowsNativeDispatcher.*;
@@ -120,7 +118,6 @@ class WindowsLinkSupport {
      * Returns the final path of a given path as a String. This should be used
      * prior to calling Win32 system calls that do not follow links.
      */
-    @SuppressWarnings("removal")
     static String getFinalPath(WindowsPath input, boolean followLinks)
         throws IOException
     {
@@ -164,12 +161,7 @@ class WindowsLinkSupport {
             if (parent == null) {
                 // no parent so use parent of absolute path
                 final WindowsPath t = target;
-                target = AccessController
-                    .doPrivileged(new PrivilegedAction<WindowsPath>() {
-                        @Override
-                        public WindowsPath run() {
-                            return t.toAbsolutePath();
-                        }});
+                target = t.toAbsolutePath();
                 parent = target.getParent();
             }
             target = parent.resolve(link);

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -166,11 +166,6 @@ class WindowsPath implements Path {
         return path;
     }
 
-    // use this path for permission checks
-    String getPathForPermissionCheck() {
-        return path;
-    }
-
     // use this path for Win32 calls
     // This method will prefix long paths with \\?\ or \\?\UNC as required.
     String getPathForWin32Calls() throws WindowsException {

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsPath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -890,30 +890,6 @@ class WindowsPath implements Path {
         }
     }
 
-    void checkRead() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkRead(getPathForPermissionCheck());
-        }
-    }
-
-    void checkWrite() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkWrite(getPathForPermissionCheck());
-        }
-    }
-
-    void checkDelete() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkDelete(getPathForPermissionCheck());
-        }
-    }
-
     @Override
     public URI toUri() {
         return WindowsUriSupport.toUri(this);
@@ -924,13 +900,6 @@ class WindowsPath implements Path {
         if (isAbsolute())
             return this;
 
-        // permission check as per spec
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPropertyAccess("user.dir");
-        }
-
         try {
             return createFromNormalizedPath(getFileSystem(), getAbsolutePath());
         } catch (WindowsException x) {
@@ -940,7 +909,6 @@ class WindowsPath implements Path {
 
     @Override
     public WindowsPath toRealPath(LinkOption... options) throws IOException {
-        checkRead();
         String rp = WindowsLinkSupport.getRealPath(this, Util.followLinks(options));
         return createFromNormalizedPath(getFileSystem(), rp);
     }
@@ -955,31 +923,6 @@ class WindowsPath implements Path {
             throw new NullPointerException();
         if (!(watcher instanceof WindowsWatchService))
             throw new ProviderMismatchException();
-
-        // When a security manager is set then we need to make a defensive
-        // copy of the modifiers and check for the Windows specific FILE_TREE
-        // modifier. When the modifier is present then check that permission
-        // has been granted recursively.
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            boolean watchSubtree = false;
-            final int ml = modifiers.length;
-            if (ml > 0) {
-                modifiers = Arrays.copyOf(modifiers, ml);
-                int i=0;
-                while (i < ml) {
-                    if (ExtendedOptions.FILE_TREE.matches(modifiers[i++])) {
-                        watchSubtree = true;
-                        break;
-                    }
-                }
-            }
-            String s = getPathForPermissionCheck();
-            sm.checkRead(s);
-            if (watchSubtree)
-                sm.checkRead(s + "\\-");
-        }
 
         return ((WindowsWatchService)watcher).register(this, events, modifiers);
     }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsUriSupport.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsUriSupport.java
@@ -105,7 +105,7 @@ class WindowsUriSupport {
         if (!s.endsWith("\\")) {
             try {
                  addSlash = WindowsFileAttributes.get(path, true).isDirectory();
-            } catch (SecurityException | WindowsException x) {
+            } catch (WindowsException x) {
             }
         }
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsUriSupport.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsUriSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -104,7 +104,6 @@ class WindowsUriSupport {
         boolean addSlash = false;
         if (!s.endsWith("\\")) {
             try {
-                 path.checkRead();
                  addSlash = WindowsFileAttributes.get(path, true).isDirectory();
             } catch (SecurityException | WindowsException x) {
             }

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsUserDefinedFileAttributeView.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsUserDefinedFileAttributeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,19 +100,13 @@ class WindowsUserDefinedFileAttributeView
         return Collections.unmodifiableList(list);
     }
 
-    @SuppressWarnings("removal")
     @Override
     public List<String> list() throws IOException  {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), true, false);
         return listUsingStreamEnumeration();
     }
 
-    @SuppressWarnings("removal")
     @Override
     public int size(String name) throws IOException  {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), true, false);
 
         // wrap with channel
         FileChannel fc = null;
@@ -136,12 +130,8 @@ class WindowsUserDefinedFileAttributeView
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public int read(String name, ByteBuffer dst) throws IOException {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), true, false);
-
         // wrap with channel
         FileChannel fc = null;
         try {
@@ -172,12 +162,8 @@ class WindowsUserDefinedFileAttributeView
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public int write(String name, ByteBuffer src) throws IOException {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), false, true);
-
         /**
          * Creating a named stream will cause the unnamed stream to be created
          * if it doesn't already exist. To avoid this we open the unnamed stream
@@ -229,12 +215,8 @@ class WindowsUserDefinedFileAttributeView
         }
     }
 
-    @SuppressWarnings("removal")
     @Override
     public void delete(String name) throws IOException {
-        if (System.getSecurityManager() != null)
-            checkAccess(file.getPathForPermissionCheck(), false, true);
-
         String path = WindowsLinkSupport.getFinalPath(file, followLinks);
         String toDelete = join(path, name);
         try {

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsUserDefinedFileAttributeView.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsUserDefinedFileAttributeView.java
@@ -116,9 +116,9 @@ class WindowsUserDefinedFileAttributeView
             if (!followLinks)
                 opts.add(WindowsChannelFactory.OPEN_REPARSE_POINT);
             fc = WindowsChannelFactory
-                .newFileChannel(join(file, name), null, opts, 0L);
+                .newFileChannel(join(file, name), opts, 0L);
         } catch (WindowsException x) {
-            x.rethrowAsIOException(join(file.getPathForPermissionCheck(), name));
+            x.rethrowAsIOException(join(file.getPathForExceptionMessage(), name));
         }
         try {
             long size = fc.size();
@@ -140,9 +140,9 @@ class WindowsUserDefinedFileAttributeView
             if (!followLinks)
                 opts.add(WindowsChannelFactory.OPEN_REPARSE_POINT);
             fc = WindowsChannelFactory
-                .newFileChannel(join(file, name), null, opts, 0L);
+                .newFileChannel(join(file, name), opts, 0L);
         } catch (WindowsException x) {
-            x.rethrowAsIOException(join(file.getPathForPermissionCheck(), name));
+            x.rethrowAsIOException(join(file.getPathForExceptionMessage(), name));
         }
 
         // read to EOF (nothing we can do if I/O error occurs)
@@ -196,9 +196,9 @@ class WindowsUserDefinedFileAttributeView
             FileChannel named = null;
             try {
                 named = WindowsChannelFactory
-                    .newFileChannel(join(file, name), null, opts, 0L);
+                    .newFileChannel(join(file, name), opts, 0L);
             } catch (WindowsException x) {
-                x.rethrowAsIOException(join(file.getPathForPermissionCheck(), name));
+                x.rethrowAsIOException(join(file.getPathForExceptionMessage(), name));
             }
             // write value (nothing we can do if I/O error occurs)
             try {

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsUserPrincipals.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsUserPrincipals.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -131,12 +131,6 @@ class WindowsUserPrincipals {
     }
 
     static UserPrincipal lookup(String name) throws IOException {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission("lookupUserInformation"));
-        }
-
         // invoke LookupAccountName to get buffer size needed for SID
         int size;
         try {


### PR DESCRIPTION
Expunge the use of the `SecurityManager`, `AccessController`, and the like from the `java.nio` and `sun.nio` package hierarchies.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344078](https://bugs.openjdk.org/browse/JDK-8344078): Remove security manager dependency in java.nio (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22132/head:pull/22132` \
`$ git checkout pull/22132`

Update a local copy of the PR: \
`$ git checkout pull/22132` \
`$ git pull https://git.openjdk.org/jdk.git pull/22132/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22132`

View PR using the GUI difftool: \
`$ git pr show -t 22132`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22132.diff">https://git.openjdk.org/jdk/pull/22132.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22132#issuecomment-2478005209)
</details>
