### PR TITLE
8343978: Update the default value of CodeEntryAlignment for Ampere-1A and 1B

### DIFF
--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -159,7 +159,7 @@ void VM_Version::initialize() {
       FLAG_SET_DEFAULT(OnSpinWaitInstCount, 2);
     }
     if (FLAG_IS_DEFAULT(CodeEntryAlignment) &&
-	(_model == CPU_MODEL_AMPERE_1A || _model == CPU_MODEL_AMPERE_1B)) {
+        (_model == CPU_MODEL_AMPERE_1A || _model == CPU_MODEL_AMPERE_1B)) {
       FLAG_SET_DEFAULT(CodeEntryAlignment, 32);
     }
   }

--- a/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/vm_version_aarch64.cpp
@@ -158,6 +158,10 @@ void VM_Version::initialize() {
     if (FLAG_IS_DEFAULT(OnSpinWaitInstCount)) {
       FLAG_SET_DEFAULT(OnSpinWaitInstCount, 2);
     }
+    if (FLAG_IS_DEFAULT(CodeEntryAlignment) &&
+	(_model == CPU_MODEL_AMPERE_1A || _model == CPU_MODEL_AMPERE_1B)) {
+      FLAG_SET_DEFAULT(CodeEntryAlignment, 32);
+    }
   }
 
   // ThunderX


### PR DESCRIPTION
This PR updates the default value of CodeEntryAlignment for Ampere-1A and 1B from 64 to 32. The microbenchmark CodeCacheStress shows that frontend stall becomes ~21% smaller by the change, and IPC increases by ~2.8%. The benefits persist after CodeCacheSegmentSize changes from 64 back to 128.

Ran JTReg tier1 on Ampere-1A and no new issues were found.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343978](https://bugs.openjdk.org/browse/JDK-8343978): Update the default value of CodeEntryAlignment for Ampere-1A and 1B (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22134/head:pull/22134` \
`$ git checkout pull/22134`

Update a local copy of the PR: \
`$ git checkout pull/22134` \
`$ git pull https://git.openjdk.org/jdk.git pull/22134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22134`

View PR using the GUI difftool: \
`$ git pr show -t 22134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22134.diff">https://git.openjdk.org/jdk/pull/22134.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22134#issuecomment-2478105712)
</details>
