### PR TITLE
8344189: Cleanup code in sun.net.www.protocol.mailto.MailToURLConnection and sun.net.smtp after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/sun/net/smtp/SmtpClient.java
+++ b/src/java.base/share/classes/sun/net/smtp/SmtpClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.net.smtp;
 import java.io.*;
 import java.net.*;
 import sun.net.TransferProtocolClient;
-import sun.security.action.GetPropertyAction;
 
 /**
  * This class implements the SMTP client.
@@ -167,7 +166,7 @@ public class SmtpClient extends TransferProtocolClient {
         }
         try {
             String s;
-            mailhost = GetPropertyAction.privilegedGetProperty("mail.host");
+            mailhost = System.getProperty("mail.host");
             if (mailhost != null) {
                 openServer(mailhost);
                 return;
@@ -193,7 +192,7 @@ public class SmtpClient extends TransferProtocolClient {
         setConnectTimeout(to);
         try {
             String s;
-            mailhost = GetPropertyAction.privilegedGetProperty("mail.host");
+            mailhost = System.getProperty("mail.host");
             if (mailhost != null) {
                 openServer(mailhost);
                 return;

--- a/src/java.base/share/classes/sun/net/www/protocol/mailto/MailToURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/mailto/MailToURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,7 @@ package sun.net.www.protocol.mailto;
 
 import java.net.URL;
 import java.net.InetAddress;
-import java.net.SocketPermission;
 import java.io.*;
-import java.security.Permission;
 
 import jdk.internal.util.StaticProperty;
 import sun.net.www.*;
@@ -48,7 +46,6 @@ public class MailToURLConnection extends URLConnection {
     OutputStream os = null;
 
     SmtpClient client;
-    Permission permission;
     private int connectTimeout = -1;
     private int readTimeout = -1;
 
@@ -67,12 +64,6 @@ public class MailToURLConnection extends URLConnection {
     String getFromAddress() {
         String str = System.getProperty("user.fromaddr");
         if (str == null) {
-            // Perform the property security check for user.name
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPropertyAccess("user.name");
-            }
             str = StaticProperty.userName();
             if (str != null) {
                 String host = System.getProperty("mail.host");
@@ -110,16 +101,6 @@ public class MailToURLConnection extends URLConnection {
 
         os = client.startMessage();
         return os;
-    }
-
-    @Override
-    public Permission getPermission() throws IOException {
-        if (permission == null) {
-            connect();
-            String host = client.getMailHost() + ":" + 25;
-            permission = new SocketPermission(host, "connect");
-        }
-        return permission;
     }
 
     @Override


### PR DESCRIPTION
Please review this JEP486 cleanup PR in the `s.n.w.p.mailto.MailToURLConnection` and `sun.net.smtp.SmtpClient` classes.

* The `MailToURLConnection::getPermission` override with the related `permission` field is removed
* The SM property access check in `MailToURLConnection::getFromAddress` is removed
* The `SmtpClient` use of `GetPropertyAction` is replaced with plain `System::getProperty`

As a side note I have been programming Java since 1998 and I was not aware that this very limited mechanism for sending email existed in the JDK. Unless it is in extensive use, perhaps we should consider deprecating it somehow.

