### PR TITLE
8344036: Tests tools/jlink/runtimeImage fail on AIX after JDK-8311302

### DIFF
--- a/test/jdk/tools/jlink/runtimeImage/AddOptionsTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/AddOptionsTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g AddOptionsTest
+ * @run main/othervm -Xmx1400m AddOptionsTest
  */
 public class AddOptionsTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/AddOptionsTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/AddOptionsTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g AddOptionsTest
+ * @run main/othervm -Xmx2g AddOptionsTest
  */
 public class AddOptionsTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/BasicJlinkMissingJavaBase.java
+++ b/test/jdk/tools/jlink/runtimeImage/BasicJlinkMissingJavaBase.java
@@ -41,7 +41,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g BasicJlinkMissingJavaBase
+ * @run main/othervm -Xmx1400m BasicJlinkMissingJavaBase
  */
 public class BasicJlinkMissingJavaBase extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/BasicJlinkMissingJavaBase.java
+++ b/test/jdk/tools/jlink/runtimeImage/BasicJlinkMissingJavaBase.java
@@ -41,7 +41,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g BasicJlinkMissingJavaBase
+ * @run main/othervm -Xmx2g BasicJlinkMissingJavaBase
  */
 public class BasicJlinkMissingJavaBase extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/BasicJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/BasicJlinkTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g BasicJlinkTest false
+ * @run main/othervm -Xmx2g BasicJlinkTest false
  */
 public class BasicJlinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/BasicJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/BasicJlinkTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g BasicJlinkTest false
+ * @run main/othervm -Xmx1400m BasicJlinkTest false
  */
 public class BasicJlinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/CustomModuleJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/CustomModuleJlinkTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g CustomModuleJlinkTest
+ * @run main/othervm -Xmx2g CustomModuleJlinkTest
  */
 public class CustomModuleJlinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/CustomModuleJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/CustomModuleJlinkTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g CustomModuleJlinkTest
+ * @run main/othervm -Xmx1400m CustomModuleJlinkTest
  */
 public class CustomModuleJlinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/GenerateJLIClassesTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/GenerateJLIClassesTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g GenerateJLIClassesTest
+ * @run main/othervm -Xmx2g GenerateJLIClassesTest
  */
 public class GenerateJLIClassesTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/GenerateJLIClassesTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/GenerateJLIClassesTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g GenerateJLIClassesTest
+ * @run main/othervm -Xmx1400m GenerateJLIClassesTest
  */
 public class GenerateJLIClassesTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/JavaSEReproducibleTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/JavaSEReproducibleTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g JavaSEReproducibleTest
+ * @run main/othervm -Xmx1400m JavaSEReproducibleTest
  */
 public class JavaSEReproducibleTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/JavaSEReproducibleTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/JavaSEReproducibleTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g JavaSEReproducibleTest
+ * @run main/othervm -Xmx2g JavaSEReproducibleTest
  */
 public class JavaSEReproducibleTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/KeepPackagedModulesFailTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/KeepPackagedModulesFailTest.java
@@ -41,7 +41,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g KeepPackagedModulesFailTest
+ * @run main/othervm -Xmx2g KeepPackagedModulesFailTest
  */
 public class KeepPackagedModulesFailTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/KeepPackagedModulesFailTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/KeepPackagedModulesFailTest.java
@@ -41,7 +41,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g KeepPackagedModulesFailTest
+ * @run main/othervm -Xmx1400m KeepPackagedModulesFailTest
  */
 public class KeepPackagedModulesFailTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesExitTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesExitTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g ModifiedFilesExitTest
+ * @run main/othervm -Xmx2g ModifiedFilesExitTest
  */
 public class ModifiedFilesExitTest extends ModifiedFilesTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesExitTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesExitTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g ModifiedFilesExitTest
+ * @run main/othervm -Xmx1400m ModifiedFilesExitTest
  */
 public class ModifiedFilesExitTest extends ModifiedFilesTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWarningTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWarningTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g ModifiedFilesWarningTest
+ * @run main/othervm -Xmx1400m ModifiedFilesWarningTest
  */
 public class ModifiedFilesWarningTest extends ModifiedFilesTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWarningTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/ModifiedFilesWarningTest.java
@@ -39,7 +39,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g ModifiedFilesWarningTest
+ * @run main/othervm -Xmx2g ModifiedFilesWarningTest
  */
 public class ModifiedFilesWarningTest extends ModifiedFilesTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/MultiHopTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/MultiHopTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g MultiHopTest
+ * @run main/othervm -Xmx2g MultiHopTest
  */
 public class MultiHopTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/MultiHopTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/MultiHopTest.java
@@ -40,7 +40,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g MultiHopTest
+ * @run main/othervm -Xmx1400m MultiHopTest
  */
 public class MultiHopTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
@@ -49,7 +49,7 @@ import tests.JImageGenerator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm/timeout=1200 -Xmx2g PackagedModulesVsRuntimeImageLinkTest
+ * @run main/othervm/timeout=1200 -Xmx1400m PackagedModulesVsRuntimeImageLinkTest
  */
 public class PackagedModulesVsRuntimeImageLinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/PackagedModulesVsRuntimeImageLinkTest.java
@@ -49,7 +49,7 @@ import tests.JImageGenerator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g PackagedModulesVsRuntimeImageLinkTest
+ * @run main/othervm/timeout=1200 -Xmx2g PackagedModulesVsRuntimeImageLinkTest
  */
 public class PackagedModulesVsRuntimeImageLinkTest extends AbstractLinkableRuntimeTest {
 
@@ -76,6 +76,7 @@ public class PackagedModulesVsRuntimeImageLinkTest extends AbstractLinkableRunti
                 .output(helper.createNewImageDir("java-se-jmodfull"))
                 .addMods("java.se").call().assertSuccess();
 
+        System.out.println("Now comparing jmod-less and jmod-full) images");
         compareRecursively(javaSEruntimeLink, javaSEJmodFull);
     }
 

--- a/test/jdk/tools/jlink/runtimeImage/PatchedJDKModuleJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/PatchedJDKModuleJlinkTest.java
@@ -42,7 +42,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g PatchedJDKModuleJlinkTest
+ * @run main/othervm -Xmx2g PatchedJDKModuleJlinkTest
  */
 public class PatchedJDKModuleJlinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/PatchedJDKModuleJlinkTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/PatchedJDKModuleJlinkTest.java
@@ -42,7 +42,7 @@ import tests.Helper;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g PatchedJDKModuleJlinkTest
+ * @run main/othervm -Xmx1400m PatchedJDKModuleJlinkTest
  */
 public class PatchedJDKModuleJlinkTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/SystemModulesTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/SystemModulesTest.java
@@ -41,7 +41,7 @@ import tests.JImageValidator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g SystemModulesTest
+ * @run main/othervm -Xmx2g SystemModulesTest
  */
 public class SystemModulesTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/SystemModulesTest.java
+++ b/test/jdk/tools/jlink/runtimeImage/SystemModulesTest.java
@@ -41,7 +41,7 @@ import tests.JImageValidator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g SystemModulesTest
+ * @run main/othervm -Xmx1400m SystemModulesTest
  */
 public class SystemModulesTest extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/SystemModulesTest2.java
+++ b/test/jdk/tools/jlink/runtimeImage/SystemModulesTest2.java
@@ -42,7 +42,7 @@ import tests.JImageValidator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx1g SystemModulesTest2
+ * @run main/othervm -Xmx2g SystemModulesTest2
  */
 public class SystemModulesTest2 extends AbstractLinkableRuntimeTest {
 

--- a/test/jdk/tools/jlink/runtimeImage/SystemModulesTest2.java
+++ b/test/jdk/tools/jlink/runtimeImage/SystemModulesTest2.java
@@ -42,7 +42,7 @@ import tests.JImageValidator;
  *          jdk.jlink/jdk.tools.jimage
  * @build tests.* jdk.test.lib.process.OutputAnalyzer
  *        jdk.test.lib.process.ProcessTools
- * @run main/othervm -Xmx2g SystemModulesTest2
+ * @run main/othervm -Xmx1400m SystemModulesTest2
  */
 public class SystemModulesTest2 extends AbstractLinkableRuntimeTest {
 


### PR DESCRIPTION
On AIX we run into errors below, for example in test tools/jlink/runtimeImage/AddOptionsTest.java , this happened with fastdebug binaries, opt worked :

jlink options: --output java-base-with-opts-jlink-tmp --add-modules jdk.jlink,java.base --generate-linkable-runtime --keep-packaged-modules=java-base-with-opts-jlink-tmp/jmods
Error: Java heap space
java.lang.OutOfMemoryError: Java heap space
at java.base/java.io.InputStream.readNBytes(InputStream.java:447)
at java.base/java.io.InputStream.readAllBytes(InputStream.java:348)
at jdk.jlink/jdk.tools.jlink.plugin.ResourcePoolEntry.contentBytes(ResourcePoolEntry.java:127)
at jdk.jlink/jdk.tools.jlink.internal.runtimelink.ResourcePoolReader.getResourceBytes(ResourcePoolReader.java:54)
at jdk.jlink/jdk.tools.jlink.internal.runtimelink.JimageDiffGenerator.generateDiff(JimageDiffGenerator.java:89)
at jdk.jlink/jdk.tools.jlink.internal.ImageFileCreator.addResourceDiffFiles(ImageFileCreator.java:357)
at jdk.jlink/jdk.tools.jlink.internal.ImageFileCreator.generateJImage(ImageFileCreator.java:264)
at jdk.jlink/jdk.tools.jlink.internal.ImageFileCreator.writeImage(ImageFileCreator.java:202)
at jdk.jlink/jdk.tools.jlink.internal.ImageFileCreator.create(ImageFileCreator.java:131)
at jdk.jlink/jdk.tools.jlink.internal.JlinkTask$ImageHelper.retrieve(JlinkTask.java:1041)
at jdk.jlink/jdk.tools.jlink.internal.ImagePluginStack.operate(ImagePluginStack.java:194)
at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.createImage(JlinkTask.java:501)
at jdk.jlink/jdk.tools.jlink.internal.JlinkTask.run(JlinkTask.java:294)
at jdk.jlink/jdk.tools.jlink.internal.Main.run(Main.java:56)
at jdk.jlink/jdk.tools.jlink.internal.Main$JlinkToolProvider.run(Main.java:73)
at tests.JImageGenerator$JLinkTask.call(JImageGenerator.java:713)
at AbstractLinkableRuntimeTest.createRuntimeLinkImage(AbstractLinkableRuntimeTest.java:273)
at AbstractLinkableRuntimeTest.createJavaImageRuntimeLink(AbstractLinkableRuntimeTest.java:126)
at AbstractLinkableRuntimeTest.createJavaImageRuntimeLink(AbstractLinkableRuntimeTest.java:121)
at AddOptionsTest.runTest(AddOptionsTest.java:64)
at AbstractLinkableRuntimeTest.run(AbstractLinkableRuntimeTest.java:62)
at AddOptionsTest.main(AddOptionsTest.java:49)
at java.base/java.lang.invoke.LambdaForm$DMH/0x0a0001009070c3e0.invokeStatic(LambdaForm$DMH)
at java.base/java.lang.invoke.LambdaForm$MH/0x0a00010090710c10.invoke(LambdaForm$MH)
at java.base/java.lang.invoke.LambdaForm$MH/0x0a00010090711408.invokeExact_MT(LambdaForm$MH)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(DirectMethodHandleAccessor.java:155)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:567)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.runWith(Thread.java:1589)
at java.base/java.lang.Thread.run(Thread.java:1576)

java.lang.AssertionError: Unexpected failure: 4
at tests.Result.assertSuccess(Result.java:80)

The tests need more memory and one also needs a higher timeout value to succeed .

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344036](https://bugs.openjdk.org/browse/JDK-8344036): Tests tools/jlink/runtimeImage fail on AIX after JDK-8311302 (**Bug** - P4)


### Reviewers
 * [Severin Gehwolf](https://openjdk.org/census#sgehwolf) (@jerboaa - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22140/head:pull/22140` \
`$ git checkout pull/22140`

Update a local copy of the PR: \
`$ git checkout pull/22140` \
`$ git pull https://git.openjdk.org/jdk.git pull/22140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22140`

View PR using the GUI difftool: \
`$ git pr show -t 22140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22140.diff">https://git.openjdk.org/jdk/pull/22140.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22140#issuecomment-2478332290)
</details>
