### PR TITLE
8344289: SM cleanup in jdk.internal.util

### DIFF
--- a/src/java.base/share/classes/jdk/internal/util/ClassFileDumper.java
+++ b/src/java.base/share/classes/jdk/internal/util/ClassFileDumper.java
@@ -29,8 +29,6 @@ import jdk.internal.misc.VM;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.HexFormat;
 import java.util.Objects;
 import java.util.Set;
@@ -79,10 +77,6 @@ public final class ClassFileDumper {
     private final AtomicInteger counter = new AtomicInteger();
 
     private ClassFileDumper(String key, String path) {
-        /*
-         * GetPropertyAction.privilegedGetProperty cannot be used here, Using VM.getSavedProperty to avoid a bootstrap
-         * circularity issue in the java/lang/String/concat/WithSecurityManager.java test
-         */
         String value = VM.getSavedProperty(key);
         this.key = key;
         boolean enabled = value != null && value.isEmpty() ? true : Boolean.parseBoolean(value);
@@ -134,22 +128,18 @@ public final class ClassFileDumper {
 
     @SuppressWarnings("removal")
     private void write(Path path, byte[] bytes) {
-        AccessController.doPrivileged(new PrivilegedAction<>() {
-            @Override public Void run() {
-                try {
-                    Files.createDirectories(path.getParent());
-                    Files.write(path, bytes);
-                } catch (Exception ex) {
-                    if (VM.isModuleSystemInited()) {
-                        // log only when lambda is ready to use
-                        System.getLogger(ClassFileDumper.class.getName())
-                              .log(System.Logger.Level.WARNING, "Exception writing to " +
-                                        path + " " + ex.getMessage());
-                    }
-                    // simply don't care if this operation failed
-                }
-                return null;
-            }});
+        try {
+            Files.createDirectories(path.getParent());
+            Files.write(path, bytes);
+        } catch (Exception ex) {
+            if (VM.isModuleSystemInited()) {
+                // log only when lambda is ready to use
+                System.getLogger(ClassFileDumper.class.getName())
+                        .log(System.Logger.Level.WARNING, "Exception writing to " +
+                                path + " " + ex.getMessage());
+            }
+            // simply don't care if this operation failed
+        }
     }
 
     /*
@@ -157,25 +147,20 @@ public final class ClassFileDumper {
      */
     @SuppressWarnings("removal")
     private static Path validateDumpDir(String dir) {
-        return AccessController.doPrivileged(new PrivilegedAction<>() {
-            @Override
-            public Path run() {
-                Path path = Path.of(dir);
-                if (Files.notExists(path)) {
-                    try {
-                        Files.createDirectories(path);
-                    } catch (IOException ex) {
-                        throw new IllegalArgumentException("Fail to create " + path, ex);
-                    }
-                }
-                if (!Files.isDirectory(path)) {
-                    throw new IllegalArgumentException("Path " + path + " is not a directory");
-                } else if (!Files.isWritable(path)) {
-                    throw new IllegalArgumentException("Directory " + path + " is not writable");
-                }
-                return path;
+        Path path = Path.of(dir);
+        if (Files.notExists(path)) {
+            try {
+                Files.createDirectories(path);
+            } catch (IOException ex) {
+                throw new IllegalArgumentException("Fail to create " + path, ex);
             }
-        });
+        }
+        if (!Files.isDirectory(path)) {
+            throw new IllegalArgumentException("Path " + path + " is not a directory");
+        } else if (!Files.isWritable(path)) {
+            throw new IllegalArgumentException("Directory " + path + " is not writable");
+        }
+        return path;
     }
 
     private static final HexFormat HEX = HexFormat.of().withUpperCase();

--- a/src/java.base/share/classes/jdk/internal/util/ClassFileDumper.java
+++ b/src/java.base/share/classes/jdk/internal/util/ClassFileDumper.java
@@ -126,7 +126,6 @@ public final class ClassFileDumper {
         write(pathname(name + ".failed-" + counter.incrementAndGet()), bytes);
     }
 
-    @SuppressWarnings("removal")
     private void write(Path path, byte[] bytes) {
         try {
             Files.createDirectories(path.getParent());
@@ -145,7 +144,6 @@ public final class ClassFileDumper {
     /*
      * Validate if the given dir is a writeable directory if exists.
      */
-    @SuppressWarnings("removal")
     private static Path validateDumpDir(String dir) {
         Path path = Path.of(dir);
         if (Files.notExists(path)) {

--- a/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
+++ b/src/java.base/share/classes/jdk/internal/util/StaticProperty.java
@@ -32,14 +32,11 @@ import java.util.Properties;
  * Read-only access to System property values initialized during Phase 1
  * are cached.  Setting, clearing, or modifying the value using
  * {@link System#setProperty} or {@link System#getProperties()} is ignored.
- * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
- * in these access methods. The caller of these methods should take care to ensure
- * that the returned property is not made accessible to untrusted code.</strong>
  */
 public final class StaticProperty {
 
     // The class static initialization is triggered to initialize these final
-    // fields during init Phase 1 and before a security manager is set.
+    // fields during init Phase 1.
     private static final String JAVA_HOME;
     private static final String USER_HOME;
     private static final String USER_DIR;
@@ -143,10 +140,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code java.home} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String javaHome() {
         return JAVA_HOME;
@@ -154,10 +147,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code user.home} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String userHome() {
         return USER_HOME;
@@ -165,10 +154,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code user.dir} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String userDir() {
         return USER_DIR;
@@ -176,10 +161,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code user.name} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String userName() {
         return USER_NAME;
@@ -187,10 +168,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code java.library.path} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String javaLibraryPath() {
         return JAVA_LIBRARY_PATH;
@@ -198,10 +175,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code java.io.tmpdir} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String javaIoTmpDir() {
         return JAVA_IO_TMPDIR;
@@ -209,10 +182,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code sun.boot.library.path} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String sunBootLibraryPath() {
         return SUN_BOOT_LIBRARY_PATH;
@@ -221,10 +190,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code jdk.serialFilter} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String jdkSerialFilter() {
         return JDK_SERIAL_FILTER;
@@ -233,10 +198,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code jdk.serialFilterFactory} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String jdkSerialFilterFactory() {
         return JDK_SERIAL_FILTER_FACTORY;
@@ -244,10 +205,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code native.encoding} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String nativeEncoding() {
         return NATIVE_ENCODING;
@@ -255,10 +212,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code file.encoding} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String fileEncoding() {
         return FILE_ENCODING;
@@ -266,9 +219,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code java.properties.date} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method.</strong>
      */
     public static String javaPropertiesDate() {
         return JAVA_PROPERTIES_DATE;
@@ -276,10 +226,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code sun.jnu.encoding} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String jnuEncoding() {
         return SUN_JNU_ENCODING;
@@ -287,10 +233,6 @@ public final class StaticProperty {
 
     /**
      * {@return the {@code java.locale.useOldISOCodes} system property}
-     *
-     * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-     * in this method. The caller of this method should take care to ensure
-     * that the returned property is not made accessible to untrusted code.</strong>
      */
     public static String javaLocaleUseOldISOCodes() {
         return JAVA_LOCALE_USE_OLD_ISO_CODES;
@@ -298,8 +240,6 @@ public final class StaticProperty {
 
      /**
       * {@return the {@code os.name} system property}
-      * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-      * in this method. This property is not considered security sensitive.</strong>
       */
      public static String osName() {
          return OS_NAME;
@@ -307,8 +247,6 @@ public final class StaticProperty {
 
      /**
       * {@return the {@code os.arch} system property}
-      * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-      * in this method. This property is not considered security sensitive.</strong>
       */
      public static String osArch() {
          return OS_ARCH;
@@ -316,8 +254,6 @@ public final class StaticProperty {
 
      /**
       * {@return the {@code os.version} system property}
-      * <strong>{@link SecurityManager#checkPropertyAccess} is NOT checked
-      * in this method. This property is not considered security sensitive.</strong>
       */
      public static String osVersion() {
          return OS_VERSION;

--- a/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
+++ b/src/java.base/share/classes/jdk/internal/util/random/RandomSupport.java
@@ -725,11 +725,7 @@ public class RandomSupport {
 
     // The following decides which of two strategies initialSeed() will use.
     private static boolean secureRandomSeedRequested() {
-        @SuppressWarnings("removal")
-        String pp = java.security.AccessController.doPrivileged(
-                new sun.security.action.GetPropertyAction(
-                        "java.util.secureRandomSeed"));
-        return (pp != null && pp.equalsIgnoreCase("true"));
+        return Boolean.getBoolean("java.util.secureRandomSeed");
     }
 
     private static final boolean useSecureRandomSeed = secureRandomSeedRequested();


### PR DESCRIPTION
Please review this PR to clean up `RandomSupport`, `ClassFileDumper` and `StaticProperty` in the `jdk.internal.util` namespace:

* `RandomSupport` is updated to replace an `AccessController::doPrivileged` call with `Boolean::getBoolean`. (Existing code uses `String::equalsIgnoreCase`, equivalent to `Boolean::getBoolean`)
* `ClassFileDumper` constructor is updated to remove a comment referencing `GetPropertyAction`. (I left the `VM::getSavedProperty` call as-is, please advise if this should be replaced with `System::getProperty)
* `ClassFileDumper::write` is updated to unwrap a `AccessController::doPrivileged` call
* `StaticProperty` is updated to remove `SecurityManager::checkPropertyAccess` references in the documentation

Verification: GHA results pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8344289](https://bugs.openjdk.org/browse/JDK-8344289): SM cleanup in jdk.internal.util (**Enhancement** - P4)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22141/head:pull/22141` \
`$ git checkout pull/22141`

Update a local copy of the PR: \
`$ git checkout pull/22141` \
`$ git pull https://git.openjdk.org/jdk.git pull/22141/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22141`

View PR using the GUI difftool: \
`$ git pr show -t 22141`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22141.diff">https://git.openjdk.org/jdk/pull/22141.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22141#issuecomment-2478381126)
</details>
