### PR TITLE
8344298: Test tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java fails on platforms without sa

### DIFF
--- a/test/jdk/tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java
+++ b/test/jdk/tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java
@@ -25,6 +25,7 @@
  * @test
  * @bug 8343781
  * @summary Test for `@since` in jdk.hotspot.agent module
+ * @requires vm.hasSA
  * @library /test/lib /test/jdk/tools/sincechecker
  * @run main SinceChecker jdk.hotspot.agent
  */


### PR DESCRIPTION
E.g. on AIx we run into this test failure :
error: module not found: jdk.hotspot.agent
Unable to retrieve `@since` for Module: module: jdk.hotspot.agent
java.lang.Exception: The `@since` checker found 1 problems
at SinceChecker.checkModule(SinceChecker.java:284)
at SinceChecker.main(SinceChecker.java:145)
at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
at java.base/java.lang.reflect.Method.invoke(Method.java:565)
at com.sun.javatest.regtest.agent.MainActionHelper$AgentVMRunnable.run(MainActionHelper.java:333)
at java.base/java.lang.Thread.run(Thread.java:1447)

So we should probably limit the execution of this test to jdk with sa support.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344298](https://bugs.openjdk.org/browse/JDK-8344298): Test tools/sincechecker/modules/jdk.hotspot.agent/JdkHotspotAgentCheckSince.java fails on platforms without sa (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22146/head:pull/22146` \
`$ git checkout pull/22146`

Update a local copy of the PR: \
`$ git checkout pull/22146` \
`$ git pull https://git.openjdk.org/jdk.git pull/22146/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22146`

View PR using the GUI difftool: \
`$ git pr show -t 22146`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22146.diff">https://git.openjdk.org/jdk/pull/22146.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22146#issuecomment-2480891940)
</details>
