### PR TITLE
8344010: RISC-V: Zacas do not work with LW locking

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1175,16 +1175,6 @@ public:
   void atomic_xchgwu(Register prev, Register newv, Register addr);
   void atomic_xchgalwu(Register prev, Register newv, Register addr);
 
-  void atomic_cas(Register prev, Register newv, Register addr);
-  void atomic_casw(Register prev, Register newv, Register addr);
-  void atomic_casl(Register prev, Register newv, Register addr);
-  void atomic_caslw(Register prev, Register newv, Register addr);
-  void atomic_casal(Register prev, Register newv, Register addr);
-  void atomic_casalw(Register prev, Register newv, Register addr);
-  void atomic_caswu(Register prev, Register newv, Register addr);
-  void atomic_caslwu(Register prev, Register newv, Register addr);
-  void atomic_casalwu(Register prev, Register newv, Register addr);
-
   void atomic_cas(Register prev, Register newv, Register addr, enum operand_size size,
               Assembler::Aqrl acquire = Assembler::relaxed, Assembler::Aqrl release = Assembler::relaxed);
 


### PR DESCRIPTION
Hi all, please consider.

Light weight locking fails:
- We need to add cas acquire.
- Register _result_ may shadow _new_val_ (same register).
  (NOTE this second item can effect many other cases, unclear)

As the code becomes much cleaner by calling amocas_d/w directly I removed the aliases.
Which fixes the first issue with cas acquire.

By using t0 instead of _result_ we fix the other issue.

This is a short bugfix, there are so many dragons here that I do not want to address them while fixing the bug.
There are also several performance optimizations we can do here, specially for LR/SC case.
So I'll do a couple of more iterations of this code in seperate PR's.

Testing a bunch of local cherry-picked tests which failed.
I'll start tier1 over the weekend.

Thanks, Robbin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344010](https://bugs.openjdk.org/browse/JDK-8344010): RISC-V: Zacas do not work with LW locking (**Bug** - P3)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22149/head:pull/22149` \
`$ git checkout pull/22149`

Update a local copy of the PR: \
`$ git checkout pull/22149` \
`$ git pull https://git.openjdk.org/jdk.git pull/22149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22149`

View PR using the GUI difftool: \
`$ git pr show -t 22149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22149.diff">https://git.openjdk.org/jdk/pull/22149.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22149#issuecomment-2478771523)
</details>
