### PR TITLE
8344314: Revert removal of jdk.internal.java.PreviewFeature.CLASSFILE_API

### DIFF
--- a/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
+++ b/src/java.base/share/classes/jdk/internal/javac/PreviewFeature.java
@@ -74,6 +74,7 @@ public @interface PreviewFeature {
         SCOPED_VALUES,
         @JEP(number=480, title="Structured Concurrency", status="Third Preview")
         STRUCTURED_CONCURRENCY,
+        CLASSFILE_API,
         STREAM_GATHERERS,
         @JEP(number=494, title="Module Import Declarations", status="Second Preview")
         MODULE_IMPORTS,


### PR DESCRIPTION
jdk.internal.java.PreviewFeature.CLASSFILE_API has been accidentally removed with JDK-8334714, however it should remain until used in bootstrap build.

Please review.

Thank you,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344314](https://bugs.openjdk.org/browse/JDK-8344314): Revert removal of jdk.internal.java.PreviewFeature.CLASSFILE_API (**Bug** - P2)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22150/head:pull/22150` \
`$ git checkout pull/22150`

Update a local copy of the PR: \
`$ git checkout pull/22150` \
`$ git pull https://git.openjdk.org/jdk.git pull/22150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22150`

View PR using the GUI difftool: \
`$ git pr show -t 22150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22150.diff">https://git.openjdk.org/jdk/pull/22150.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22150#issuecomment-2479276453)
</details>
