### PR TITLE
8344315: Clean up sun.net.www.protocol.jrt.JavaRuntimeURLConnection after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/jrt/JavaRuntimeURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/jrt/JavaRuntimeURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,15 +30,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.AccessController;
-import java.security.Permission;
-import java.security.PrivilegedAction;
 
 import jdk.internal.jimage.ImageLocation;
 import jdk.internal.jimage.ImageReader;
 import jdk.internal.jimage.ImageReaderFactory;
 
-import jdk.internal.loader.URLClassPath;
 import jdk.internal.loader.Resource;
 import sun.net.www.ParseUtil;
 import sun.net.www.URLConnection;
@@ -47,15 +43,10 @@ import sun.net.www.URLConnection;
  * URLConnection implementation that can be used to connect to resources
  * contained in the runtime image.
  */
-@SuppressWarnings("removal")
 public class JavaRuntimeURLConnection extends URLConnection {
 
     // ImageReader to access resources in jimage
-    private static final ImageReader reader;
-    static {
-        PrivilegedAction<ImageReader> pa = ImageReaderFactory::getImageReader;
-        reader = AccessController.doPrivileged(pa);
-    }
+    private static final ImageReader reader = ImageReaderFactory.getImageReader();
 
     // the module and resource name in the URL
     private final String module;
@@ -92,7 +83,7 @@ public class JavaRuntimeURLConnection extends URLConnection {
         if (reader != null) {
             URL url = toJrtURL(module, name);
             ImageLocation location = reader.findLocation(module, name);
-            if (location != null && URLClassPath.checkURL(url) != null) {
+            if (location != null) {
                 return new Resource() {
                     @Override
                     public String getName() {
@@ -156,11 +147,6 @@ public class JavaRuntimeURLConnection extends URLConnection {
     public int getContentLength() {
         long len = getContentLengthLong();
         return len > Integer.MAX_VALUE ? -1 : (int)len;
-    }
-
-    @Override
-    public Permission getPermission() {
-        return new RuntimePermission("accessSystemModules");
     }
 
     /**


### PR DESCRIPTION
Can I please get a review of this change which removes references to `AccessController.doPriveleged()` and also removes a security check?

Specifically:

- The `AccessController.doPriveleged()` has been removed from the implementation.
- The overridden `getPermission()` method has been removed from this internal implementation class.
- The call to `URLClassPath.checkURL()` which used to invoke a SecurityManager check in the presence of a SecurityManager has been removed.

No new test has been introduced and tier1 and tier2 testing is currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344315](https://bugs.openjdk.org/browse/JDK-8344315): Clean up sun.net.www.protocol.jrt.JavaRuntimeURLConnection after JEP 486 integration (**Sub-task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22151/head:pull/22151` \
`$ git checkout pull/22151`

Update a local copy of the PR: \
`$ git checkout pull/22151` \
`$ git pull https://git.openjdk.org/jdk.git pull/22151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22151`

View PR using the GUI difftool: \
`$ git pr show -t 22151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22151.diff">https://git.openjdk.org/jdk/pull/22151.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22151#issuecomment-2479308163)
</details>
