### PR TITLE
8344181: Remove SecurityManager and related calls from jdk.management and jdk.management.agent

### DIFF
--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
@@ -36,7 +36,6 @@ import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 import java.nio.BufferUnderflowException;
-import java.security.PrivilegedAction;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;

--- a/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
+++ b/src/jdk.management.agent/share/classes/jdk/internal/agent/Agent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.UnknownHostException;
 import java.nio.BufferUnderflowException;
-import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.text.MessageFormat;
 import java.util.HashMap;

--- a/src/jdk.management.agent/unix/classes/jdk/internal/agent/FileSystemImpl.java
+++ b/src/jdk.management.agent/unix/classes/jdk/internal/agent/FileSystemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -53,12 +53,6 @@ public class FileSystemImpl extends FileSystem {
     // Initialization
 
     static {
-        java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<Void>() {
-                public Void run() {
-                    System.loadLibrary("management_agent");
-                    return null;
-                }
-            });
+        System.loadLibrary("management_agent");
     }
 }

--- a/src/jdk.management.agent/windows/classes/jdk/internal/agent/FileSystemImpl.java
+++ b/src/jdk.management.agent/windows/classes/jdk/internal/agent/FileSystemImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -64,13 +64,7 @@ public class FileSystemImpl extends FileSystem {
     // Initialization
 
     static {
-        java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<Void>() {
-                public Void run() {
-                    System.loadLibrary("management_agent");
-                    return null;
-                }
-            });
+        System.loadLibrary("management_agent");
         init0();
     }
 }

--- a/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandImpl.java
@@ -149,13 +149,6 @@ public class DiagnosticCommandImpl extends NotificationEmitterSupport
         }
 
         public String execute(String[] args) {
-            if (permission != null) {
-                @SuppressWarnings("removal")
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                    sm.checkPermission(permission);
-                }
-            }
             if(args == null) {
                 return executeDiagnosticCommand(cmd);
             } else {

--- a/src/jdk.management/share/classes/com/sun/management/internal/Flag.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/Flag.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package com.sun.management.internal;
 import java.util.*;
 import com.sun.management.VMOption;
 import com.sun.management.VMOption.Origin;
-import java.security.AccessController;
 
 /**
  * Flag class is a helper class for constructing a VMOption.
@@ -117,13 +116,7 @@ class Flag {
     static synchronized native void setStringValue(String name, String value);
 
     static {
-        AccessController.doPrivileged(
-            new java.security.PrivilegedAction<Void>() {
-                public Void run() {
-                    System.loadLibrary("management");
-                    return null;
-                }
-            });
+        System.loadLibrary("management");
         initialize();
     }
     private static native void initialize();

--- a/src/jdk.management/share/classes/com/sun/management/internal/GarbageCollectionNotifInfoCompositeData.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/GarbageCollectionNotifInfoCompositeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,8 +33,6 @@ import javax.management.openmbean.CompositeDataSupport;
 import javax.management.openmbean.OpenDataException;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.SimpleType;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.lang.reflect.Field;
 import java.util.HashMap;
 import sun.management.LazyCompositeData;
@@ -65,19 +63,17 @@ public class GarbageCollectionNotifInfoCompositeData extends LazyCompositeData {
     }
 
     private CompositeType getCompositeTypeByBuilder() {
-        @SuppressWarnings("removal")
-        final GcInfoBuilder builder = AccessController.doPrivileged (new PrivilegedAction<GcInfoBuilder>() {
-                public GcInfoBuilder run() {
-                    try {
-                        Class<?> cl = Class.forName("com.sun.management.GcInfo");
-                        Field f = cl.getDeclaredField("builder");
-                        f.setAccessible(true);
-                        return (GcInfoBuilder)f.get(gcNotifInfo.getGcInfo());
-                    } catch(ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
-                        return null;
-                    }
-                }
-            });
+
+        GcInfoBuilder builder = null;
+        try {
+            Class<?> cl = Class.forName("com.sun.management.GcInfo");
+            Field f = cl.getDeclaredField("builder");
+            f.setAccessible(true);
+            builder = (GcInfoBuilder) f.get(gcNotifInfo.getGcInfo());
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+            // ignore
+        }
+
         CompositeType gict = null;
         synchronized(compositeTypeByBuilder) {
             gict = compositeTypeByBuilder.get(builder);

--- a/src/jdk.management/share/classes/com/sun/management/internal/GcInfoCompositeData.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/GcInfoCompositeData.java
@@ -74,7 +74,7 @@ public class GcInfoCompositeData extends LazyCompositeData {
             Class<?> cl = Class.forName("com.sun.management.GcInfo");
             Field f = cl.getDeclaredField("builder");
             f.setAccessible(true);
-            builder =  (GcInfoBuilder)f.get(info);
+            builder = (GcInfoBuilder)f.get(info);
         } catch(ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
             // ignore
         }

--- a/src/jdk.management/share/classes/com/sun/management/internal/GcInfoCompositeData.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/GcInfoCompositeData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,8 +38,6 @@ import javax.management.openmbean.SimpleType;
 import javax.management.openmbean.OpenType;
 import javax.management.openmbean.OpenDataException;
 import com.sun.management.GcInfo;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import sun.management.LazyCompositeData;
 import static sun.management.LazyCompositeData.getLong;
 import sun.management.MappedMXBeanType;
@@ -71,32 +69,24 @@ public class GcInfoCompositeData extends LazyCompositeData {
     }
 
     public static CompositeData toCompositeData(final GcInfo info) {
-        @SuppressWarnings("removal")
-        final GcInfoBuilder builder = AccessController.doPrivileged (new PrivilegedAction<GcInfoBuilder>() {
-                        public GcInfoBuilder run() {
-                            try {
-                                Class<?> cl = Class.forName("com.sun.management.GcInfo");
-                                Field f = cl.getDeclaredField("builder");
-                                f.setAccessible(true);
-                                return (GcInfoBuilder)f.get(info);
-                            } catch(ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
-                                return null;
-                            }
-                        }
-                    });
-        @SuppressWarnings("removal")
-        final Object[] extAttr = AccessController.doPrivileged (new PrivilegedAction<Object[]>() {
-                        public Object[] run() {
-                            try {
-                                Class<?> cl = Class.forName("com.sun.management.GcInfo");
-                                Field f = cl.getDeclaredField("extAttributes");
-                                f.setAccessible(true);
-                                return (Object[])f.get(info);
-                            } catch(ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
-                                return null;
-                            }
-                        }
-                    });
+        GcInfoBuilder builder = null;
+        try {
+            Class<?> cl = Class.forName("com.sun.management.GcInfo");
+            Field f = cl.getDeclaredField("builder");
+            f.setAccessible(true);
+            builder =  (GcInfoBuilder)f.get(info);
+        } catch(ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+            // ignore
+        }
+        Object[] extAttr = null;
+        try {
+            Class<?> cl = Class.forName("com.sun.management.GcInfo");
+            Field f = cl.getDeclaredField("extAttributes");
+            f.setAccessible(true);
+            extAttr = (Object[])f.get(info);
+        } catch(ClassNotFoundException | NoSuchFieldException | IllegalAccessException e) {
+            // ignore
+        }
         GcInfoCompositeData gcicd =
             new GcInfoCompositeData(info,builder,extAttr);
         return gcicd.getCompositeData();

--- a/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
@@ -147,7 +147,6 @@ public class HotSpotDiagnostic implements HotSpotDiagnosticMXBean {
     }
 
     @Override
-    @SuppressWarnings("removal")
     public void dumpThreads(String outputFile, ThreadDumpFormat format) throws IOException {
         Path file = Path.of(outputFile);
         if (!file.isAbsolute())

--- a/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
@@ -49,7 +49,7 @@ public class HotSpotDiagnostic implements HotSpotDiagnosticMXBean {
     public void dumpHeap(String outputFile, boolean live) throws IOException {
 
         String propertyName = "jdk.management.heapdump.allowAnyFileSuffix";
-        boolean allowAnyFileSuffix = Boolean.parseBoolean(System.getProperty(propertyName, "false"));
+        boolean allowAnyFileSuffix = Boolean.getBoolean(propertyName);
         if (!allowAnyFileSuffix && !outputFile.endsWith(".hprof")) {
             throw new IllegalArgumentException("heapdump file must have .hprof extension");
         }

--- a/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/HotSpotDiagnostic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.List;
 import javax.management.ObjectName;
@@ -53,18 +49,9 @@ public class HotSpotDiagnostic implements HotSpotDiagnosticMXBean {
     public void dumpHeap(String outputFile, boolean live) throws IOException {
 
         String propertyName = "jdk.management.heapdump.allowAnyFileSuffix";
-        PrivilegedAction<Boolean> pa = () -> Boolean.parseBoolean(System.getProperty(propertyName, "false"));
-        @SuppressWarnings("removal")
-        boolean allowAnyFileSuffix = AccessController.doPrivileged(pa);
+        boolean allowAnyFileSuffix = Boolean.parseBoolean(System.getProperty(propertyName, "false"));
         if (!allowAnyFileSuffix && !outputFile.endsWith(".hprof")) {
             throw new IllegalArgumentException("heapdump file must have .hprof extension");
-        }
-
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkWrite(outputFile);
-            Util.checkControlAccess();
         }
 
         dumpHeap0(outputFile, live);
@@ -107,7 +94,6 @@ public class HotSpotDiagnostic implements HotSpotDiagnosticMXBean {
             throw new NullPointerException("value cannot be null");
         }
 
-        Util.checkControlAccess();
         Flag flag = Flag.getFlag(name);
         if (flag == null) {
             throw new IllegalArgumentException("VM option \"" +
@@ -167,27 +153,8 @@ public class HotSpotDiagnostic implements HotSpotDiagnosticMXBean {
         if (!file.isAbsolute())
             throw new IllegalArgumentException("'outputFile' not absolute path");
 
-        // need ManagementPermission("control")
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            Util.checkControlAccess();
-
         try (OutputStream out = Files.newOutputStream(file, StandardOpenOption.CREATE_NEW)) {
-            PrivilegedExceptionAction<Void> pa = () -> {
                 dumpThreads(out, format);
-                return null;
-            };
-            try {
-                AccessController.doPrivileged(pa);
-            } catch (PrivilegedActionException pae) {
-                Throwable cause = pae.getCause();
-                if (cause instanceof IOException ioe)
-                    throw ioe;
-                if (cause instanceof RuntimeException e)
-                    throw e;
-                throw new RuntimeException(cause);
-            }
         }
     }
 

--- a/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
@@ -30,7 +30,6 @@ import com.sun.management.ThreadMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryManagerMXBean;
 import java.lang.management.OperatingSystemMXBean;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/PlatformMBeanProviderImpl.java
@@ -30,7 +30,6 @@ import com.sun.management.ThreadMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryManagerMXBean;
 import java.lang.management.OperatingSystemMXBean;
-import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -55,10 +54,7 @@ public final class PlatformMBeanProviderImpl extends PlatformMBeanProvider {
     private static OperatingSystemMXBean osMBean = null;
 
     static {
-       AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-           System.loadLibrary("management_ext");
-           return null;
-       });
+       System.loadLibrary("management_ext");
     }
 
     public PlatformMBeanProviderImpl() {

--- a/src/jdk.management/share/classes/com/sun/management/internal/VirtualThreadSchedulerImpls.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/VirtualThreadSchedulerImpls.java
@@ -175,3 +175,4 @@ public class VirtualThreadSchedulerImpls {
         }
     }
 }
+

--- a/src/jdk.management/share/classes/com/sun/management/internal/VirtualThreadSchedulerImpls.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/VirtualThreadSchedulerImpls.java
@@ -55,13 +55,6 @@ public class VirtualThreadSchedulerImpls {
     private abstract static class BaseVirtualThreadSchedulerImpl
             implements VirtualThreadSchedulerMXBean {
 
-        abstract void implSetParallelism(int size);
-
-        @Override
-        public final void setParallelism(int size) {
-            implSetParallelism(size);
-        }
-
         @Override
         public final ObjectName getObjectName() {
             return Util.newObjectName("jdk.management:type=VirtualThreadScheduler");
@@ -113,7 +106,7 @@ public class VirtualThreadSchedulerImpls {
         }
 
         @Override
-        void implSetParallelism(int size) {
+        public void setParallelism(int size) {
             if (Scheduler.instance() instanceof ForkJoinPool pool) {
                 pool.setParallelism(size);
                 if (pool.getPoolSize() < size) {
@@ -162,7 +155,7 @@ public class VirtualThreadSchedulerImpls {
         }
 
         @Override
-        void implSetParallelism(int size) {
+        public void setParallelism(int size) {
             throw new UnsupportedOperationException();
         }
 

--- a/src/jdk.management/share/classes/com/sun/management/internal/VirtualThreadSchedulerImpls.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/VirtualThreadSchedulerImpls.java
@@ -59,7 +59,6 @@ public class VirtualThreadSchedulerImpls {
 
         @Override
         public final void setParallelism(int size) {
-            Util.checkControlAccess();
             implSetParallelism(size);
         }
 

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
@@ -38,7 +38,7 @@ import jdk.test.lib.SA.SATestUtils;
  * @requires vm.hasSA
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @requires os.family=="windows" | os.family == "linux" | os.family == "mac"
- * 
+ * @requires vm.flagless
  * @library /test/lib
  * @run driver TestJhsdbJstackLineNumbers
  */

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackLineNumbers.java
@@ -38,7 +38,7 @@ import jdk.test.lib.SA.SATestUtils;
  * @requires vm.hasSA
  * @requires os.arch=="amd64" | os.arch=="x86_64"
  * @requires os.family=="windows" | os.family == "linux" | os.family == "mac"
- * @requires vm.flagless
+ * 
  * @library /test/lib
  * @run driver TestJhsdbJstackLineNumbers
  */


### PR DESCRIPTION
Remove redundant SecurityManager, AccessController references
(following on from JDK-8338411: Implement JEP 486: Permanently Disable the Security Manager).

src/jdk.management/share/classes/com/sun/management/internal/GarbageCollectionNotifInfoCompositeData.java
There is an existing theoretical path where GcInfoBuilder stays null, should never happen, "com.sun.management.GcInfo" exists...

src/jdk.management/share/classes/com/sun/management/internal/GcInfoCompositeData.java
Similarly there is an existing assumption that Class.forName("com.sun.management.GcInfo") succeeds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344181](https://bugs.openjdk.org/browse/JDK-8344181): Remove SecurityManager and related calls from jdk.management and jdk.management.agent (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) Review applies to [84d59ac3](https://git.openjdk.org/jdk/pull/22155/files/84d59ac39365167792e9d66fe81e57150af837f0)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22155/head:pull/22155` \
`$ git checkout pull/22155`

Update a local copy of the PR: \
`$ git checkout pull/22155` \
`$ git pull https://git.openjdk.org/jdk.git pull/22155/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22155`

View PR using the GUI difftool: \
`$ git pr show -t 22155`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22155.diff">https://git.openjdk.org/jdk/pull/22155.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22155#issuecomment-2482729073)
</details>
