### PR TITLE
8331295: C2: Do not clone address computations that are indirect memory input to at least one load/store

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -2632,6 +2632,23 @@ bool Matcher::pd_clone_node(Node* n, Node* m, Matcher::MStack& mstack) {
 // to be subsumed into complex addressing expressions or compute them
 // into registers?
 bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack, VectorSet& address_visited) {
+
+  // Loads and stores with indirect memory input (e.g., volatile loads and
+  // stores) do not subsume the input into complex addressing expressions. If
+  // the addressing expression is input to at least one such load or store, do
+  // not clone the addressing expression. Query needs_acquiring_load and
+  // needs_releasing_store as a proxy for indirect memory input, as it is not
+  // possible to directly query for indirect memory input at this stage.
+  for (DUIterator_Fast imax, i = m->fast_outs(imax); i < imax; i++) {
+    Node* n = m->fast_out(i);
+    if (n->is_Load() && needs_acquiring_load(n)) {
+      return false;
+    }
+    if (n->is_Store() && needs_releasing_store(n)) {
+      return false;
+    }
+  }
+
   if (clone_base_plus_offset_address(m, mstack, address_visited)) {
     return true;
   }

--- a/test/hotspot/jtreg/compiler/c2/TestFindNode.java
+++ b/test/hotspot/jtreg/compiler/c2/TestFindNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
  * @requires vm.debug == true & vm.flavor == "server"
  * @summary Test which uses some special flags in order to test Node::find() in debug builds which could result in an endless loop or a stack overflow crash.
  *
- * @run main/othervm -Xbatch -XX:CompileCommand=option,*::*,bool,Vectorize,true -XX:CompileCommand=memlimit,compiler.c2.TestFindNode::*,0
+ * @run main/othervm -Xbatch -XX:CompileCommand=option,*::*,bool,Vectorize,true
  *                   -XX:+PrintOpto -XX:+TraceLoopOpts compiler.c2.TestFindNode
  */
 package compiler.c2;

--- a/test/hotspot/jtreg/compiler/codegen/TestMatcherClone.java
+++ b/test/hotspot/jtreg/compiler/codegen/TestMatcherClone.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8331295
+ * @requires os.simpleArch == "aarch64"
+ * @summary Check that the matcher does not needlessly clone an addressing
+ *          expression that will in any case not be subsumed into complex
+ *          loads and stores.
+ * @library /test/lib /
+ * @run driver compiler.codegen.TestMatcherClone
+ */
+
+package compiler.codegen;
+
+import compiler.lib.ir_framework.*;
+
+public class TestMatcherClone {
+    static volatile int[] iArr;
+    static volatile int x;
+    static int[] iArr2 = new int[100];
+    static int[] iArr3 = new int[100];
+
+    public static void main(String[] args) {
+        TestFramework.run();
+    }
+
+    @Test(compLevel = CompLevel.C2)
+    @IR(counts = {IRNode.ADD_P_OF, "reg_imm", "<200"},
+        phase = CompilePhase.MATCHING)
+    public void test() {
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+        iArr = new int[] {x % 2};
+
+        for (int i = 0; i < 50; i++) {
+            iArr2[i] = iArr3[i];
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/loopopts/TestDeepGraphVerifyIterativeGVN.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestDeepGraphVerifyIterativeGVN.java
@@ -28,7 +28,6 @@
  * @summary Test which causes a stack overflow segmentation fault with -XX:VerifyIterativeGVN=1 due to a too deep recursion in Node::verify_recur().
  *
  * @run main/othervm/timeout=600 -Xcomp -XX:VerifyIterativeGVN=1 -XX:CompileCommand=compileonly,compiler.loopopts.TestDeepGraphVerifyIterativeGVN::*
- *                               -XX:CompileCommand=memlimit,compiler.loopopts.TestDeepGraphVerifyIterativeGVN::*,0
  *                               compiler.loopopts.TestDeepGraphVerifyIterativeGVN
  */
 


### PR DESCRIPTION
### Issue Summary

On aarch64, the C2 instruction matcher often clones addressing expressions, expecting them to be subsumed (during later stages of matching) into complex load/store instructions. However, volatile aarch64 load and store instructions have indirect memory inputs and therefore cannot subsume the addressing computation. In one case that we investigated, the result is a very large number of cloned identical instructions for address computations that, in combination with how the instruction scheduler currently hoists instructions, create major difficulties for the register allocator.

### Changeset

- Add a guard that ensures the instruction matcher does not clone addressing expressions that have at least one successor load/store that cannot subsume the addressing computation. One could argue that, in cases where there is at least one such successor, other successors may be able to subsume the computation and we should therefore still clone the expression. The benefit of subsuming in such a case is unclear, however, as we in any case need to generate at least one separate instruction for the addressing computation.
- Remove temporary `-XX:CompileCommand=memlimit,...,0` for tests that previously failed.
- Add a new IR framework regression test.

### Testing

- [GitHub Actions](https://github.com/dlunde/jdk/actions/runs/11859255022)
- `tier1` to `tier4` (and additional Oracle-internal testing) on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64.
- Performance benchmarks: DaCapo, SPECjbb, and SPECjvm on Windows x64, Linux x64, Linux aarch64, macOS x64, and macOS aarch64. No clear regressions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8331295](https://bugs.openjdk.org/browse/JDK-8331295): C2: Do not clone address computations that are indirect memory input to at least one load/store (**Bug** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)

### Contributors
 * Roberto Castañeda Lozano `<rcastanedalo@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22157/head:pull/22157` \
`$ git checkout pull/22157`

Update a local copy of the PR: \
`$ git checkout pull/22157` \
`$ git pull https://git.openjdk.org/jdk.git pull/22157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22157`

View PR using the GUI difftool: \
`$ git pr show -t 22157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22157.diff">https://git.openjdk.org/jdk/pull/22157.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22157#issuecomment-2479689308)
</details>
