### PR TITLE
8344327: SM cleanup in jdk.unsupported ReflectionFactory

### DIFF
--- a/src/jdk.unsupported/share/classes/sun/reflect/ReflectionFactory.java
+++ b/src/jdk.unsupported/share/classes/sun/reflect/ReflectionFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,43 +29,23 @@ import java.io.OptionalDataException;
 import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.security.AccessController;
-import java.security.Permission;
-import java.security.PrivilegedAction;
 
 /**
  * ReflectionFactory supports custom serialization.
  * Its methods support the creation of uninitialized objects, invoking serialization
  * private methods for readObject, writeObject, readResolve, and writeReplace.
- * <p>
- * ReflectionFactory access is restricted, if a security manager is active,
- * unless the permission {@code RuntimePermission("reflectionFactoryAccess")}
- * is granted.
  */
 public class ReflectionFactory {
 
     private static final ReflectionFactory soleInstance = new ReflectionFactory();
-    @SuppressWarnings("removal")
-    private static final jdk.internal.reflect.ReflectionFactory delegate = AccessController.doPrivileged(
-            new PrivilegedAction<jdk.internal.reflect.ReflectionFactory>() {
-                public jdk.internal.reflect.ReflectionFactory run() {
-                    return jdk.internal.reflect.ReflectionFactory.getReflectionFactory();
-                }
-            });
+    private static final jdk.internal.reflect.ReflectionFactory delegate =
+            jdk.internal.reflect.ReflectionFactory.getReflectionFactory();
 
     private ReflectionFactory() {}
-
-    private static final Permission REFLECTION_FACTORY_ACCESS_PERM
-            = new RuntimePermission("reflectionFactoryAccess");
 
     /**
      * Provides the caller with the capability to instantiate reflective
      * objects.
-     *
-     * <p> First, if there is a security manager, its {@code checkPermission}
-     * method is called with a {@link java.lang.RuntimePermission} with target
-     * {@code "reflectionFactoryAccess"}.  This may result in a security
-     * exception.
      *
      * <p> The returned {@code ReflectionFactory} object should be carefully
      * guarded by the caller, since it can be used to read and write private
@@ -73,16 +53,8 @@ public class ReflectionFactory {
      * It must never be passed to untrusted code.
      *
      * @return the ReflectionFactory
-     * @throws SecurityException if a security manager exists and its
-     *         {@code checkPermission} method doesn't allow access to
-     *         the RuntimePermission "reflectionFactoryAccess".
      */
     public static ReflectionFactory getReflectionFactory() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(REFLECTION_FACTORY_ACCESS_PERM);
-        }
         return soleInstance;
     }
 


### PR DESCRIPTION
This cleanup of the use of SecurityManager is in the jdk.unsupported module.
Removed the permission check to call getReflectionFactory().

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8344423](https://bugs.openjdk.org/browse/JDK-8344423) to be approved

### Issues
 * [JDK-8344327](https://bugs.openjdk.org/browse/JDK-8344327): SM cleanup in jdk.unsupported ReflectionFactory (**Bug** - P4)
 * [JDK-8344423](https://bugs.openjdk.org/browse/JDK-8344423): SM cleanup in jdk.unsupported ReflectionFactory (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22158/head:pull/22158` \
`$ git checkout pull/22158`

Update a local copy of the PR: \
`$ git checkout pull/22158` \
`$ git pull https://git.openjdk.org/jdk.git pull/22158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22158`

View PR using the GUI difftool: \
`$ git pr show -t 22158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22158.diff">https://git.openjdk.org/jdk/pull/22158.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22158#issuecomment-2479692248)
</details>
