### PR TITLE
8344330: Remove AccessController.doPrivileged() from jdk.charsets module

### DIFF
--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/SJIS_0213.java
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/SJIS_0213.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,11 +31,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.util.Arrays;
 import sun.nio.cs.CharsetMapping;
-import sun.nio.cs.*;
 
 /*
  *  5 types of entry in SJIS_X_0213/Unicode mapping table
@@ -77,13 +73,8 @@ public class SJIS_0213 extends Charset {
     }
 
     private static class Holder {
-        @SuppressWarnings("removal")
-        static final CharsetMapping mapping = AccessController.doPrivileged(
-                new PrivilegedAction<CharsetMapping>() {
-                    public CharsetMapping run() {
-                        return CharsetMapping.get(SJIS_0213.class.getResourceAsStream("sjis0213.dat"));
-                    }
-                });
+        static final CharsetMapping mapping =
+            CharsetMapping.get(SJIS_0213.class.getResourceAsStream("sjis0213.dat"));
     }
 
     protected static class Decoder extends CharsetDecoder {

--- a/src/jdk.charsets/share/classes/sun/nio/cs/ext/SJIS_0213.java
+++ b/src/jdk.charsets/share/classes/sun/nio/cs/ext/SJIS_0213.java
@@ -31,7 +31,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CoderResult;
-import sun.nio.cs.CharsetMapping;
+import sun.nio.cs.*;
 
 /*
  *  5 types of entry in SJIS_X_0213/Unicode mapping table


### PR DESCRIPTION
Removing a `AccessController.doPrivileged()` call from jdk.charsets module after JEP486 integration.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344330](https://bugs.openjdk.org/browse/JDK-8344330): Remove AccessController.doPrivileged() from jdk.charsets module (**Enhancement** - P3)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Justin Lu](https://openjdk.org/census#jlu) (@justin-curtis-lu - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22162/head:pull/22162` \
`$ git checkout pull/22162`

Update a local copy of the PR: \
`$ git checkout pull/22162` \
`$ git pull https://git.openjdk.org/jdk.git pull/22162/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22162`

View PR using the GUI difftool: \
`$ git pr show -t 22162`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22162.diff">https://git.openjdk.org/jdk/pull/22162.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22162#issuecomment-2479778830)
</details>
