### PR TITLE
8344310: Remove Security Manager dependencies from javax.crypto and com.sun.crypto packages

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/DHKeyAgreement.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/DHKeyAgreement.java
@@ -56,14 +56,8 @@ extends KeyAgreementSpi {
 
     private static class AllowKDF {
 
-        private static final boolean VALUE = getValue();
-
-        @SuppressWarnings("removal")
-        private static boolean getValue() {
-            return AccessController.doPrivileged(
-                (PrivilegedAction<Boolean>)
-                () -> Boolean.getBoolean("jdk.crypto.KeyAgreement.legacyKDF"));
-        }
+        private static final boolean VALUE =
+            Boolean.getBoolean("jdk.crypto.KeyAgreement.legacyKDF");
     }
 
     /**

--- a/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/JceKeyStore.java
@@ -30,14 +30,12 @@ import sun.security.util.IOUtils;
 
 import java.io.*;
 import java.util.*;
-import java.security.AccessController;
 import java.security.DigestInputStream;
 import java.security.DigestOutputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.Key;
 import java.security.PrivateKey;
-import java.security.PrivilegedAction;
 import java.security.KeyStoreSpi;
 import java.security.KeyStoreException;
 import java.security.UnrecoverableKeyException;
@@ -835,15 +833,9 @@ public final class JceKeyStore extends KeyStoreSpi {
                         // read the sealed key
                         try {
                             ois = new ObjectInputStream(dis);
-                            final ObjectInputStream ois2 = ois;
                             // Set a deserialization checker
-                            @SuppressWarnings("removal")
-                            var dummy = AccessController.doPrivileged(
-                                (PrivilegedAction<Void>)() -> {
-                                    ois2.setObjectInputFilter(
-                                        new DeserializationChecker(fullLength));
-                                    return null;
-                            });
+                            ois.setObjectInputFilter(
+                                new DeserializationChecker(fullLength));
                             entry.sealedKey = (SealedObject)ois.readObject();
                             entry.maxLength = fullLength;
                             // NOTE: don't close ois here since we are still

--- a/src/java.base/share/classes/com/sun/crypto/provider/SealedObjectForKeyProtector.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SealedObjectForKeyProtector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -73,18 +73,13 @@ final class SealedObjectForKeyProtector extends SealedObject {
         return params;
     }
 
-    @SuppressWarnings("removal")
     final Key getKey(Cipher c, int maxLength)
             throws IOException, ClassNotFoundException, IllegalBlockSizeException,
             BadPaddingException {
 
         try (ObjectInputStream ois = SharedSecrets.getJavaxCryptoSealedObjectAccess()
                 .getExtObjectInputStream(this, c)) {
-            AccessController.doPrivileged(
-                    (PrivilegedAction<Void>) () -> {
-                        ois.setObjectInputFilter(new DeserializationChecker(maxLength));
-                        return null;
-                    });
+                ois.setObjectInputFilter(new DeserializationChecker(maxLength));
             try {
                 @SuppressWarnings("unchecked")
                 Key t = (Key) ois.readObject();
@@ -113,16 +108,8 @@ final class SealedObjectForKeyProtector extends SealedObject {
         private static final ObjectInputFilter OWN_FILTER;
 
         static {
-            @SuppressWarnings("removal")
-            String prop = AccessController.doPrivileged(
-                    (PrivilegedAction<String>) () -> {
-                        String tmp = System.getProperty(KEY_SERIAL_FILTER);
-                        if (tmp != null) {
-                            return tmp;
-                        } else {
-                            return Security.getProperty(KEY_SERIAL_FILTER);
-                        }
-                    });
+            String prop = System.getProperty(
+                 KEY_SERIAL_FILTER, Security.getProperty(KEY_SERIAL_FILTER));
             OWN_FILTER = prop == null
                     ? null
                     : ObjectInputFilter.Config.createFilter(prop);

--- a/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/SunJCE.java
@@ -25,10 +25,8 @@
 
 package com.sun.crypto.provider;
 
-import java.security.AccessController;
 import java.security.Provider;
 import java.security.SecureRandom;
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.List;
 import static sun.security.util.SecurityConstants.PROVIDER_VER;
@@ -121,24 +119,12 @@ public final class SunJCE extends Provider {
                    attrs));
     }
 
-    @SuppressWarnings("removal")
     public SunJCE() {
         /* We are the "SunJCE" provider */
         super("SunJCE", PROVIDER_VER, info);
 
-        // if there is no security manager installed, put directly into
-        // the provider
-        if (System.getSecurityManager() == null) {
-            putEntries();
-        } else {
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    putEntries();
-                    return null;
-                }
-            });
-        }
+        putEntries();
+
         if (instance == null) {
             instance = this;
         }

--- a/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
+++ b/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
@@ -109,15 +109,7 @@ final class JceSecurity {
 
     static {
         try {
-            AccessController.doPrivileged(
-                new PrivilegedExceptionAction<> () {
-                    @Override
-                    public Void run() throws Exception {
-                        setupJurisdictionPolicies();
-                        return null;
-                    }
-                }
-            );
+            setupJurisdictionPolicies();
 
             isRestricted = defaultPolicy.implies(
                 CryptoAllPermission.INSTANCE) ? false : true;
@@ -285,20 +277,14 @@ final class JceSecurity {
         synchronized (codeBaseCacheRef) {
             URL url = codeBaseCacheRef.get(clazz);
             if (url == null) {
-                url = AccessController.doPrivileged(
-                    new PrivilegedAction<>() {
-                        @Override
-                        public URL run() {
-                            ProtectionDomain pd = clazz.getProtectionDomain();
-                            if (pd != null) {
-                                CodeSource cs = pd.getCodeSource();
-                                if (cs != null) {
-                                    return cs.getLocation();
-                                }
-                            }
-                            return NULL_URL;
-                        }
-                    });
+                url = NULL_URL;
+                ProtectionDomain pd = clazz.getProtectionDomain();
+                if (pd != null) {
+                    CodeSource cs = pd.getCodeSource();
+                    if (cs != null) {
+                        url = cs.getLocation();
+                    }
+                }
                 codeBaseCacheRef.put(clazz, url);
             }
             return (url == NULL_URL) ? null : url;

--- a/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
+++ b/src/java.base/share/classes/javax/crypto/JceSecurity.java.template
@@ -76,7 +76,6 @@ import sun.security.util.Debug;
  * @since 1.4
  */
 
-@SuppressWarnings("removal")
 final class JceSecurity {
 
     private static final Debug debug = Debug.getInstance("jca");

--- a/src/java.base/share/classes/javax/crypto/JceSecurityManager.java
+++ b/src/java.base/share/classes/javax/crypto/JceSecurityManager.java
@@ -65,18 +65,10 @@ final class JceSecurityManager {
         exemptPolicy = JceSecurity.getExemptPolicy();
         allPerm = CryptoAllPermission.INSTANCE;
 
-        PrivilegedAction<JceSecurityManager> paSM = JceSecurityManager::new;
-        @SuppressWarnings("removal")
-        JceSecurityManager dummySecurityManager =
-                AccessController.doPrivileged(paSM);
-        INSTANCE = dummySecurityManager;
+        INSTANCE = new JceSecurityManager();
 
-        PrivilegedAction<StackWalker> paWalker =
-                () -> StackWalker.getInstance(Set.of(Option.DROP_METHOD_INFO, Option.RETAIN_CLASS_REFERENCE));
-        @SuppressWarnings("removal")
-        StackWalker dummyWalker = AccessController.doPrivileged(paWalker);
-
-        WALKER = dummyWalker;
+        WALKER = StackWalker.getInstance(
+                Set.of(Option.DROP_METHOD_INFO, Option.RETAIN_CLASS_REFERENCE));
     }
 
     private JceSecurityManager() {

--- a/src/java.base/share/classes/javax/crypto/ProviderVerifier.java
+++ b/src/java.base/share/classes/javax/crypto/ProviderVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -100,20 +100,12 @@ final class ProviderVerifier {
 
             // Get a link to the Jarfile to search.
             try {
-                @SuppressWarnings("removal")
-                var tmp = AccessController.doPrivileged(
-                        (PrivilegedExceptionAction<JarFile>) () -> {
-                            JarURLConnection conn =
-                                (JarURLConnection) url.openConnection();
-                            // You could do some caching here as
-                            // an optimization.
-                            conn.setUseCaches(false);
-                            return conn.getJarFile();
-                        });
-                jf = tmp;
-            } catch (java.security.PrivilegedActionException pae) {
-                throw new SecurityException("Cannot load " + url,
-                    pae.getCause());
+                JarURLConnection conn = (JarURLConnection) url.openConnection();
+                // You could do some caching here as an optimization.
+                conn.setUseCaches(false);
+                jf = conn.getJarFile();
+            } catch (IOException ioe) {
+                throw new SecurityException("Cannot load " + url, ioe);
             }
 
             if (jf != null) {


### PR DESCRIPTION
Now that JEP 486 is integrated, javax.crypto and com.sun.crypto implementation dependencies on System.getSecurityManager and AccessController.doPrivileged can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344310](https://bugs.openjdk.org/browse/JDK-8344310): Remove Security Manager dependencies from javax.crypto and com.sun.crypto packages (**Enhancement** - P3)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22164/head:pull/22164` \
`$ git checkout pull/22164`

Update a local copy of the PR: \
`$ git checkout pull/22164` \
`$ git pull https://git.openjdk.org/jdk.git pull/22164/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22164`

View PR using the GUI difftool: \
`$ git pr show -t 22164`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22164.diff">https://git.openjdk.org/jdk/pull/22164.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22164#issuecomment-2479908280)
</details>
