### PR TITLE
8344262: Win32AttachOperationRequest objects are created by using global new

### DIFF
--- a/src/hotspot/os/windows/attachListener_windows.cpp
+++ b/src/hotspot/os/windows/attachListener_windows.cpp
@@ -161,7 +161,7 @@ public:
 
 
 // Win32AttachOperationRequest is an element of AttachOperation request list.
-class Win32AttachOperationRequest {
+class Win32AttachOperationRequest: public CHeapObj<mtServiceability> {
 private:
   AttachAPIVersion _ver;
   char _name[AttachOperation::name_length_max + 1];


### PR DESCRIPTION
The issue was introduced by [JDK-8339289](https://bugs.openjdk.org/browse/JDK-8339289).
The fix makes `Win32AttachOperationRequest` successor of `CHeapObj<mtServiceability>`, so `Win32AttachOperationRequest` inherits its `new` operator

testing: tier1..tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344262](https://bugs.openjdk.org/browse/JDK-8344262): Win32AttachOperationRequest objects are created by using global new (**Bug** - P3)


### Reviewers
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22166/head:pull/22166` \
`$ git checkout pull/22166`

Update a local copy of the PR: \
`$ git checkout pull/22166` \
`$ git pull https://git.openjdk.org/jdk.git pull/22166/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22166`

View PR using the GUI difftool: \
`$ git pr show -t 22166`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22166.diff">https://git.openjdk.org/jdk/pull/22166.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22166#issuecomment-2479929404)
</details>
