### PR TITLE
8344336: Remove class System.CallersHolder, leftover from JEP468

### DIFF
--- a/src/java.base/share/classes/java/lang/System.java
+++ b/src/java.base/share/classes/java/lang/System.java
@@ -287,13 +287,6 @@ public final class System {
     private static native void setOut0(PrintStream out);
     private static native void setErr0(PrintStream err);
 
-    private static class CallersHolder {
-        // Remember callers of setSecurityManager() here so that warning
-        // is only printed once for each different caller
-        static final Map<Class<?>, Boolean> callers
-            = Collections.synchronizedMap(new WeakHashMap<>());
-    }
-
     static URL codeSource(Class<?> clazz) {
         PrivilegedAction<ProtectionDomain> pa = clazz::getProtectionDomain;
         @SuppressWarnings("removal")


### PR DESCRIPTION
Please review this trivial cleanup PR which removes the nested static private class `System.CallersHolder`.

This class was used pre JEP486 to track callers of `System::setSecurityManager` such that warnings were printed only once per caller.

This seems like a leftover from JEP-486 which would be nice to clean up.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344336](https://bugs.openjdk.org/browse/JDK-8344336): Remove class System.CallersHolder, leftover from JEP468 (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22167/head:pull/22167` \
`$ git checkout pull/22167`

Update a local copy of the PR: \
`$ git checkout pull/22167` \
`$ git pull https://git.openjdk.org/jdk.git pull/22167/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22167`

View PR using the GUI difftool: \
`$ git pr show -t 22167`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22167.diff">https://git.openjdk.org/jdk/pull/22167.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22167#issuecomment-2479976897)
</details>
