### PR TITLE
8344331: SM cleanup in java.scripting

### DIFF
--- a/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
+++ b/src/java.scripting/share/classes/javax/script/ScriptEngineManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package javax.script;
 import java.util.*;
-import java.security.*;
 import java.util.ServiceLoader;
 import java.util.ServiceConfigurationError;
 import java.util.function.Function;
@@ -87,9 +86,7 @@ public class ScriptEngineManager  {
     private void initEngines(final ClassLoader loader) {
         Iterator<ScriptEngineFactory> itr;
         try {
-            @SuppressWarnings("removal")
-            var sl = AccessController.doPrivileged(
-                (PrivilegedAction<ServiceLoader<ScriptEngineFactory>>)() -> getServiceLoader(loader));
+            var sl = getServiceLoader(loader);
             itr = sl.iterator();
         } catch (ServiceConfigurationError err) {
             reportException("Can't find ScriptEngineFactory providers: ", err);


### PR DESCRIPTION
Please review this PR which removes the lone `AccessController.doPrivileged` call from the _java.scripting_ module after JEP486 integration.