### PR TITLE
8343741: SA jstack --mixed should print information about VM locks

### DIFF
--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -189,7 +189,8 @@ WB_END
 
 WB_ENTRY(jint, WB_TakeLockAndHangInSafepoint(JNIEnv* env, jobject wb))
   JavaThread* self = JavaThread::current();
-  MutexLocker mu(Compile_lock);
+  // VMStatistic_lock is used to minimize interference with VM locking
+  MutexLocker mu(VMStatistic_lock);
   VM_HangInSafepoint force_safepoint_stuck_op;
   VMThread::execute(&force_safepoint_stuck_op);
   ShouldNotReachHere();

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -187,6 +187,15 @@ WB_ENTRY(jstring, WB_PrintString(JNIEnv* env, jobject wb, jstring str, jint max_
   return (jstring) JNIHandles::make_local(THREAD, result);
 WB_END
 
+WB_ENTRY(jint, WB_LockAndStuckInSafepoint(JNIEnv* env, jobject wb))
+  JavaThread* self = JavaThread::current();
+  MutexLocker mu(Compile_lock);
+  VM_ForceSafepointStuck force_safepoint_stuck_op;
+  VMThread::execute(&force_safepoint_stuck_op);
+  ShouldNotReachHere();
+  return 0;
+WB_END
+
 class WBIsKlassAliveClosure : public LockedClassesDo {
     Symbol* _name;
     int _count;
@@ -2994,6 +3003,7 @@ static JNINativeMethod methods[] = {
   {CC"cleanMetaspaces", CC"()V",                      (void*)&WB_CleanMetaspaces},
   {CC"rss", CC"()J",                                  (void*)&WB_Rss},
   {CC"printString", CC"(Ljava/lang/String;I)Ljava/lang/String;", (void*)&WB_PrintString},
+  {CC"lockAndStuckInSafepoint", CC"()V", (void*)&WB_LockAndStuckInSafepoint},
   {CC"wordSize", CC"()J",                             (void*)&WB_WordSize},
   {CC"rootChunkWordSize", CC"()J",                    (void*)&WB_RootChunkWordSize}
 };

--- a/src/hotspot/share/prims/whitebox.cpp
+++ b/src/hotspot/share/prims/whitebox.cpp
@@ -187,10 +187,10 @@ WB_ENTRY(jstring, WB_PrintString(JNIEnv* env, jobject wb, jstring str, jint max_
   return (jstring) JNIHandles::make_local(THREAD, result);
 WB_END
 
-WB_ENTRY(jint, WB_LockAndStuckInSafepoint(JNIEnv* env, jobject wb))
+WB_ENTRY(jint, WB_TakeLockAndHangInSafepoint(JNIEnv* env, jobject wb))
   JavaThread* self = JavaThread::current();
   MutexLocker mu(Compile_lock);
-  VM_ForceSafepointStuck force_safepoint_stuck_op;
+  VM_HangInSafepoint force_safepoint_stuck_op;
   VMThread::execute(&force_safepoint_stuck_op);
   ShouldNotReachHere();
   return 0;
@@ -3003,7 +3003,7 @@ static JNINativeMethod methods[] = {
   {CC"cleanMetaspaces", CC"()V",                      (void*)&WB_CleanMetaspaces},
   {CC"rss", CC"()J",                                  (void*)&WB_Rss},
   {CC"printString", CC"(Ljava/lang/String;I)Ljava/lang/String;", (void*)&WB_PrintString},
-  {CC"lockAndStuckInSafepoint", CC"()V", (void*)&WB_LockAndStuckInSafepoint},
+  {CC"lockAndStuckInSafepoint", CC"()V", (void*)&WB_TakeLockAndHangInSafepoint},
   {CC"wordSize", CC"()J",                             (void*)&WB_WordSize},
   {CC"rootChunkWordSize", CC"()J",                    (void*)&WB_RootChunkWordSize}
 };

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -590,7 +590,6 @@ void Mutex::print_lock_ranks(outputStream* st) {
 #endif // ASSERT
 }
 
-
 RecursiveMutex::RecursiveMutex() : _sem(1), _owner(nullptr), _recursions(0) {}
 
 void RecursiveMutex::lock(Thread* current) {

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -533,6 +533,7 @@ void Mutex::set_owner_implementation(Thread *new_owner) {
   }
 }
 #endif // ASSERT
+
 // Print all mutexes/monitors that are currently owned by a thread; called
 // by fatal error handler.
 void Mutex::print_owned_locks_on_error(outputStream* st) {

--- a/src/hotspot/share/runtime/mutex.cpp
+++ b/src/hotspot/share/runtime/mutex.cpp
@@ -267,6 +267,16 @@ bool Monitor::wait(uint64_t timeout) {
   return wait_status != 0;          // return true IFF timeout
 }
 
+static const int MAX_NUM_MUTEX = 1204;
+static Mutex* _internal_mutex_arr[MAX_NUM_MUTEX];
+Mutex** Mutex::_mutex_array = _internal_mutex_arr;
+int Mutex::_num_mutex = 0;
+
+void Mutex::add_mutex(Mutex* var) {
+  assert(Mutex::_num_mutex < MAX_NUM_MUTEX, "increase MAX_NUM_MUTEX");
+  Mutex::_mutex_array[_num_mutex++] = var;
+}
+
 Mutex::~Mutex() {
   assert_owner(nullptr);
   os::free(const_cast<char*>(_name));
@@ -523,6 +533,61 @@ void Mutex::set_owner_implementation(Thread *new_owner) {
   }
 }
 #endif // ASSERT
+// Print all mutexes/monitors that are currently owned by a thread; called
+// by fatal error handler.
+void Mutex::print_owned_locks_on_error(outputStream* st) {
+  st->print("VM Mutex/Monitor currently owned by a thread: ");
+  bool none = true;
+  for (int i = 0; i < _num_mutex; i++) {
+    // see if it has an owner
+    if (_mutex_array[i]->owner() != nullptr) {
+      if (none) {
+        // print format used by Mutex::print_on_error()
+        st->print_cr(" ([mutex/lock_event])");
+        none = false;
+      }
+      _mutex_array[i]->print_on_error(st);
+      st->cr();
+    }
+  }
+  if (none) st->print_cr("None");
+}
+
+void Mutex::print_lock_ranks(outputStream* st) {
+  st->print_cr("VM Mutex/Monitor ranks: ");
+
+#ifdef ASSERT
+  // Be extra defensive and figure out the bounds on
+  // ranks right here. This also saves a bit of time
+  // in the #ranks*#mutexes loop below.
+  int min_rank = INT_MAX;
+  int max_rank = INT_MIN;
+  for (int i = 0; i < _num_mutex; i++) {
+    Mutex* m = _mutex_array[i];
+    int r = (int) m->rank();
+    if (min_rank > r) min_rank = r;
+    if (max_rank < r) max_rank = r;
+  }
+
+  // Print the listings rank by rank
+  for (int r = min_rank; r <= max_rank; r++) {
+    bool first = true;
+    for (int i = 0; i < _num_mutex; i++) {
+      Mutex* m = _mutex_array[i];
+      if (r != (int) m->rank()) continue;
+
+      if (first) {
+        st->cr();
+        st->print_cr("Rank \"%s\":", m->rank_name());
+        first = false;
+      }
+      st->print_cr("  %s", m->name());
+    }
+  }
+#else
+  st->print_cr("  Only known in debug builds.");
+#endif // ASSERT
+}
 
 
 RecursiveMutex::RecursiveMutex() : _sem(1), _owner(nullptr), _recursions(0) {}

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -135,7 +135,6 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   void assert_owner            (Thread* expected)                     NOT_DEBUG_RETURN;
 
  public:
-  static void  add_mutex(Mutex* var);
   static const bool _allow_vm_block_flag        = true;
 
   // Locks can be acquired with or without a safepoint check. NonJavaThreads do not follow
@@ -199,16 +198,18 @@ class Mutex : public CHeapObj<mtSynchronizer> {
 
   const char *name() const                  { return _name; }
 
+  static void  add_mutex(Mutex* var);
+
   void print_on_error(outputStream* st) const;
+  #ifndef PRODUCT
+    void print_on(outputStream* st) const;
+    void print() const;
+  #endif
 
   // Print all mutexes/monitors that are currently owned by a thread; called
   // by fatal error handler.
   static void print_owned_locks_on_error(outputStream* st);
   static void print_lock_ranks(outputStream* st);
-  #ifndef PRODUCT
-    void print_on(outputStream* st) const;
-    void print() const;
-  #endif
 };
 
 class Monitor : public Mutex {

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -51,7 +51,7 @@
 
 class Mutex : public CHeapObj<mtSynchronizer> {
 
- friend class VMStructs;
+  friend class VMStructs;
  public:
   // Special low level locks are given names and ranges avoid overlap.
   enum class Rank {

--- a/src/hotspot/share/runtime/mutex.hpp
+++ b/src/hotspot/share/runtime/mutex.hpp
@@ -51,6 +51,7 @@
 
 class Mutex : public CHeapObj<mtSynchronizer> {
 
+ friend class VMStructs;
  public:
   // Special low level locks are given names and ranges avoid overlap.
   enum class Rank {
@@ -103,6 +104,9 @@ class Mutex : public CHeapObj<mtSynchronizer> {
 #ifndef PRODUCT
   bool    _allow_vm_block;
 #endif
+  static Mutex** _mutex_array;
+  static int _num_mutex;
+
 #ifdef ASSERT
   Rank    _rank;                 // rank (to avoid/detect potential deadlocks)
   Mutex*  _next;                 // Used by a Thread to link up owned locks
@@ -131,6 +135,7 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   void assert_owner            (Thread* expected)                     NOT_DEBUG_RETURN;
 
  public:
+  static void  add_mutex(Mutex* var);
   static const bool _allow_vm_block_flag        = true;
 
   // Locks can be acquired with or without a safepoint check. NonJavaThreads do not follow
@@ -195,6 +200,11 @@ class Mutex : public CHeapObj<mtSynchronizer> {
   const char *name() const                  { return _name; }
 
   void print_on_error(outputStream* st) const;
+
+  // Print all mutexes/monitors that are currently owned by a thread; called
+  // by fatal error handler.
+  static void print_owned_locks_on_error(outputStream* st);
+  static void print_lock_ranks(outputStream* st);
   #ifndef PRODUCT
     void print_on(outputStream* st) const;
     void print() const;

--- a/src/hotspot/share/runtime/mutexLocker.hpp
+++ b/src/hotspot/share/runtime/mutexLocker.hpp
@@ -171,11 +171,6 @@ extern Mutex*   tty_lock;                          // lock to synchronize output
 // order.  If their implementations change such that these assumptions
 // are violated, a whole lot of code will break.
 
-// Print all mutexes/monitors that are currently owned by a thread; called
-// by fatal error handler.
-void print_owned_locks_on_error(outputStream* st);
-void print_lock_ranks(outputStream* st);
-
 // for debugging: check that we're already owning this lock (or are at a safepoint / handshake)
 #ifdef ASSERT
 void assert_locked_or_safepoint(const Mutex* lock);

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -66,7 +66,9 @@ class VM_ForceSafepointStuck: public VM_Operation {
 public:
   VMOp_Type type() const { return VMOp_ForceSafepoint; }
   void doit() {
-    while(true) {}
+    while(true) {
+      os::naked_short_sleep(10);
+    }
   }
 };
 

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -62,7 +62,7 @@ class VM_ForceSafepoint: public VM_EmptyOperation {
 
 // used by whitebox API to emulate VM issues
 // when VM can't operate and doesn't respond to jcmd
-class VM_ForceSafepointStuck: public VM_Operation {
+class VM_HangInSafepoint: public VM_Operation {
 public:
   VMOp_Type type() const { return VMOp_ForceSafepoint; }
   void doit() {

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -61,7 +61,7 @@ class VM_ForceSafepoint: public VM_EmptyOperation {
 };
 
 // used by whitebox API to emulate VM issues
-// when VM can't operate and doesn't respond to jcm
+// when VM can't operate and doesn't respond to jcmd
 class VM_ForceSafepointStuck: public VM_Operation {
 public:
   VMOp_Type type() const { return VMOp_ForceSafepoint; }

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -60,6 +60,16 @@ class VM_ForceSafepoint: public VM_EmptyOperation {
   VMOp_Type type() const { return VMOp_ForceSafepoint; }
 };
 
+// used by whitebox API to emulate VM issues
+// when VM can't operate and doesn't respond to jcm
+class VM_ForceSafepointStuck: public VM_Operation {
+public:
+  VMOp_Type type() const { return VMOp_ForceSafepoint; }
+  void doit() {
+    while(true) {}
+  }
+};
+
 class VM_ClearICs: public VM_Operation {
  private:
   bool _preserve_static_stubs;

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1023,7 +1023,7 @@
   nonstatic_field(InvocationCounter,           _counter,                                      unsigned int)                          \
                                                                                                                                      \
   nonstatic_field(UpcallStub::FrameData,       jfa,                                           JavaFrameAnchor)                       \
-
+                                                                                                                                     \
   nonstatic_field(Mutex,                       _name,                                         const char*)                           \
   static_field(Mutex,                          _mutex_array,                                  Mutex**)                               \
   static_field(Mutex,                          _num_mutex,                                    int)                                   \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1023,6 +1023,7 @@
   nonstatic_field(InvocationCounter,           _counter,                                      unsigned int)                          \
                                                                                                                                      \
   nonstatic_field(UpcallStub::FrameData,       jfa,                                           JavaFrameAnchor)                       \
+
   nonstatic_field(Mutex,                       _name,                                         const char*)                           \
   static_field(Mutex,                          _mutex_array,                                  Mutex**)                               \
   static_field(Mutex,                          _num_mutex,                                    int)                                   \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -659,7 +659,6 @@
   volatile_nonstatic_field(JavaThread,         _is_method_handle_return,                      int)                                   \
   nonstatic_field(JavaThread,                  _saved_exception_pc,                           address)                               \
   volatile_nonstatic_field(JavaThread,         _thread_state,                                 JavaThreadState)                       \
-  nonstatic_field(JavaThread,                  _osthread,                                     OSThread*)                             \
   nonstatic_field(JavaThread,                  _stack_base,                                   address)                               \
   nonstatic_field(JavaThread,                  _stack_size,                                   size_t)                                \
   nonstatic_field(JavaThread,                  _vframe_array_head,                            vframeArray*)                          \
@@ -667,6 +666,7 @@
   nonstatic_field(JavaThread,                  _active_handles,                               JNIHandleBlock*)                       \
   nonstatic_field(JavaThread,                  _lock_id,                                      int64_t)                               \
   volatile_nonstatic_field(JavaThread,         _terminated,                                   JavaThread::TerminatedTypes)           \
+  nonstatic_field(Thread,                      _osthread,                                     OSThread*)                             \
   nonstatic_field(Thread,                      _resource_area,                                ResourceArea*)                         \
   nonstatic_field(CompilerThread,              _env,                                          ciEnv*)                                \
                                                                                                                                      \

--- a/src/hotspot/share/runtime/vmStructs.cpp
+++ b/src/hotspot/share/runtime/vmStructs.cpp
@@ -1022,7 +1022,11 @@
   nonstatic_field(elapsedTimer,                _active,                                       bool)                                  \
   nonstatic_field(InvocationCounter,           _counter,                                      unsigned int)                          \
                                                                                                                                      \
-  nonstatic_field(UpcallStub::FrameData,       jfa,                                           JavaFrameAnchor)
+  nonstatic_field(UpcallStub::FrameData,       jfa,                                           JavaFrameAnchor)                       \
+  nonstatic_field(Mutex,                       _name,                                         const char*)                           \
+  static_field(Mutex,                          _mutex_array,                                  Mutex**)                               \
+  static_field(Mutex,                          _num_mutex,                                    int)                                   \
+  volatile_nonstatic_field(Mutex,              _owner,                                        Thread*)
 
 //--------------------------------------------------------------------------------
 // VM_TYPES
@@ -1937,6 +1941,7 @@
   declare_toplevel_type(JNIid)                                            \
   declare_toplevel_type(JNIid*)                                           \
   declare_toplevel_type(jmethodID*)                                       \
+  declare_toplevel_type(Mutex)                                            \
   declare_toplevel_type(Mutex*)                                           \
   declare_toplevel_type(nmethod*)                                         \
   COMPILER2_PRESENT(declare_unsigned_integer_type(node_idx_t))            \

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -1223,7 +1223,7 @@ void VMError::report(outputStream* st, bool _verbose) {
 
   STEP_IF("printing owned locks on error", _verbose)
     // mutexes/monitors that currently have an owner
-    print_owned_locks_on_error(st);
+    Mutex::print_owned_locks_on_error(st);
     st->cr();
 
   STEP_IF("printing number of OutOfMemoryError and StackOverflow exceptions",

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Mutex.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Mutex.java
@@ -35,7 +35,7 @@ public class Mutex extends VMObject {
   private static long          nameFieldOffset;
   private static long          ownerFieldOffset;
 
-  private static AddressField mutex_array;
+  private static AddressField  mutex_array;
   private static int           maxNum;
 
   private static final long addrSize = VM.getVM().getAddressSize();
@@ -49,7 +49,7 @@ public class Mutex extends VMObject {
   }
 
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
-    Type type  = db.lookupType("Mutex");
+    Type type = db.lookupType("Mutex");
 
     sun.jvm.hotspot.types.Field f = type.getField("_name");
     nameFieldOffset = f.getOffset();
@@ -57,7 +57,7 @@ public class Mutex extends VMObject {
     f = type.getField("_owner");
     ownerFieldOffset = f.getOffset();
     mutex_array = type.getAddressField("_mutex_array");
-    maxNum =  type.getCIntegerField("_num_mutex").getJInt();
+    maxNum = type.getCIntegerField("_num_mutex").getJInt();
 
   }
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Mutex.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Mutex.java
@@ -51,14 +51,13 @@ public class Mutex extends VMObject {
   private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
     Type type = db.lookupType("Mutex");
 
-    sun.jvm.hotspot.types.Field f = type.getField("_name");
-    nameFieldOffset = f.getOffset();
+    sun.jvm.hotspot.types.Field nameField = type.getField("_name");
+    nameFieldOffset = nameField.getOffset();
+    sun.jvm.hotspot.types.Field ownerField = type.getField("_owner");
+    ownerFieldOffset = ownerField.getOffset();
 
-    f = type.getField("_owner");
-    ownerFieldOffset = f.getOffset();
     mutex_array = type.getAddressField("_mutex_array");
     maxNum = type.getCIntegerField("_num_mutex").getJInt();
-
   }
 
   public Mutex(Address addr) {
@@ -72,6 +71,5 @@ public class Mutex extends VMObject {
   public static Address at(int i) { return mutex_array.getValue().getAddressAt(i * addrSize); }
 
   public static int maxNum() { return maxNum; }
-
 
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Mutex.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Mutex.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.runtime;
+
+import sun.jvm.hotspot.debugger.Address;
+import sun.jvm.hotspot.types.AddressField;
+import sun.jvm.hotspot.types.Type;
+import sun.jvm.hotspot.types.TypeDataBase;
+import sun.jvm.hotspot.types.WrongTypeException;
+import sun.jvm.hotspot.utilities.*;
+
+public class Mutex extends VMObject {
+  private static long          nameFieldOffset;
+  private static long          ownerFieldOffset;
+
+  private static AddressField mutex_array;
+  private static int           maxNum;
+
+  private static final long addrSize = VM.getVM().getAddressSize();
+
+  static {
+    VM.registerVMInitializedObserver(new Observer() {
+        public void update(Observable o, Object data) {
+          initialize(VM.getVM().getTypeDataBase());
+        }
+      });
+  }
+
+  private static synchronized void initialize(TypeDataBase db) throws WrongTypeException {
+    Type type  = db.lookupType("Mutex");
+
+    sun.jvm.hotspot.types.Field f = type.getField("_name");
+    nameFieldOffset = f.getOffset();
+
+    f = type.getField("_owner");
+    ownerFieldOffset = f.getOffset();
+    mutex_array = type.getAddressField("_mutex_array");
+    maxNum =  type.getCIntegerField("_num_mutex").getJInt();
+
+  }
+
+  public Mutex(Address addr) {
+    super(addr);
+  }
+
+  public String name() { return CStringUtilities.getString(addr.getAddressAt(nameFieldOffset)); }
+
+  public Address owner() { return addr.getAddressAt(ownerFieldOffset); }
+
+  public static Address at(int i) { return mutex_array.getValue().getAddressAt(i * addrSize); }
+
+  public static int maxNum() { return maxNum; }
+
+
+}

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Thread.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/Thread.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -37,6 +37,7 @@ public class Thread extends VMObject {
 
   private static AddressField currentPendingMonitorField;
   private static AddressField currentWaitingMonitorField;
+  private static AddressField osThreadField;
 
   private static JLongField allocatedBytesField;
 
@@ -53,6 +54,8 @@ public class Thread extends VMObject {
     Type typeJavaThread = db.lookupType("JavaThread");
 
     suspendFlagsField = typeJavaThread.getCIntegerField("_suspend_flags");
+    osThreadField = typeThread.getAddressField("_osthread");
+
 
     tlabFieldOffset    = typeThread.getField("_tlab").getOffset();
     currentPendingMonitorField = typeJavaThread.getAddressField("_current_pending_monitor");
@@ -121,6 +124,10 @@ public class Thread extends VMObject {
     // underlying thread, which is only present for Java threads; see
     // JavaThread.java.
     return false;
+  }
+
+  public OSThread osThread() {
+    return new OSThread(osThreadField.getValue(addr));
   }
 
   /** Assistance for ObjectMonitor implementation */

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMLocksPrinter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMLocksPrinter.java
@@ -47,14 +47,14 @@ public class VMLocksPrinter {
     }
 
     private String ownerThreadName(Address addr) {
-        for (int i = 0; i < threads.getNumberOfThreads(); i++) {
-            JavaThread thread = threads.getJavaThreadAt(i);
-            if (thread.getAddress().equals(addr)) {
-                return thread.getThreadName();
-            }
+        try {
+            JavaThread thread = VM.getVM().getThreads().createJavaThreadWrapper(addr);
+            return thread.getThreadName();
+        } catch (Exception e) {
+            return "Unknown thread";
         }
-        return "Unknown thread";
     }
+
     public void printVMLocks() {
          int maxNum = Mutex.maxNum();
          for (int i = 0; i < maxNum; i++) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMLocksPrinter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMLocksPrinter.java
@@ -53,15 +53,17 @@ public class VMLocksPrinter {
                 return thread.getThreadName();
             }
         }
-        return "Unknnown thread (Might be non-Java Thread)";
+        return "Unknown thread";
     }
     public void printVMLocks() {
          int maxNum = Mutex.maxNum();
          for (int i = 0; i < maxNum; i++) {
          Mutex mutex = new Mutex(Mutex.at(i));
             if (mutex.owner() != null) {
+                sun.jvm.hotspot.runtime.Thread t = new sun.jvm.hotspot.runtime.Thread(mutex.owner());
+                int nativeThreadId = t.osThread().threadId();
                 tty.println("Internal VM Mutex " + mutex.name() + " is owned by " + ownerThreadName(mutex.owner())
-                        + " with address: " + mutex.owner());
+                        + ", nid=" + nativeThreadId + ", address=" + mutex.owner());
                }
          }
     }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMLocksPrinter.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/VMLocksPrinter.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+package sun.jvm.hotspot.runtime;
+
+import sun.jvm.hotspot.debugger.Address;
+import sun.jvm.hotspot.memory.SystemDictionary;
+import sun.jvm.hotspot.oops.DefaultHeapVisitor;
+import sun.jvm.hotspot.oops.Klass;
+import sun.jvm.hotspot.oops.ObjectHeap;
+import sun.jvm.hotspot.oops.Oop;
+import sun.jvm.hotspot.oops.OopUtilities;
+
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class VMLocksPrinter {
+    private PrintStream tty;
+    private Threads threads = VM.getVM().getThreads();
+
+    public VMLocksPrinter(PrintStream tty) {
+        this.tty = tty;
+    }
+
+    private String ownerThreadName(Address addr) {
+        for (int i = 0; i < threads.getNumberOfThreads(); i++) {
+            JavaThread thread = threads.getJavaThreadAt(i);
+            if (thread.getAddress().equals(addr)) {
+                return thread.getThreadName();
+            }
+        }
+        return "Unknnown thread (Might be non-Java Thread)";
+    }
+    public void printVMLocks() {
+         int maxNum = Mutex.maxNum();
+         for (int i = 0; i < maxNum; i++) {
+         Mutex mutex = new Mutex(Mutex.at(i));
+            if (mutex.owner() != null) {
+                tty.println("Internal VM Mutex " + mutex.name() + " is owned by " + ownerThreadName(mutex.owner())
+                        + " with address: " + mutex.owner());
+               }
+         }
+    }
+}

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -81,8 +81,12 @@ public class PStack extends Tool {
             out.println("can't print deadlock information: " + exp);
          }
 
-         VMLocksPrinter vmLocksPrinter = new VMLocksPrinter(out);
-         vmLocksPrinter.printVMLocks();
+         try {
+             VMLocksPrinter vmLocksPrinter = new VMLocksPrinter(out);
+             vmLocksPrinter.printVMLocks();
+         } catch (Exception e) {
+             out.println("can't print VM locks information: " + e);
+         }
 
          List<ThreadProxy> l = cdbg.getThreadList();
          if (l.isEmpty() && PlatformInfo.getOS().equals("darwin")) {

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/tools/PStack.java
@@ -81,6 +81,9 @@ public class PStack extends Tool {
             out.println("can't print deadlock information: " + exp);
          }
 
+         VMLocksPrinter vmLocksPrinter = new VMLocksPrinter(out);
+         vmLocksPrinter.printVMLocks();
+
          List<ThreadProxy> l = cdbg.getThreadList();
          if (l.isEmpty() && PlatformInfo.getOS().equals("darwin")) {
            // If the list is empty, we assume we attached to a process, and on OSX we can only

--- a/test/hotspot/jtreg/ProblemList-zgc.txt
+++ b/test/hotspot/jtreg/ProblemList-zgc.txt
@@ -92,6 +92,7 @@ serviceability/sa/TestIntConstant.java                        8307393   generic-
 serviceability/sa/TestJhsdbJstackLineNumbers.java             8307393   generic-all
 serviceability/sa/TestJhsdbJstackLock.java                    8307393   generic-all
 serviceability/sa/TestJhsdbJstackMixed.java                   8307393   generic-all
+serviceability/sa/TestJhsdbJstackPrintVMLocks.java            8307393   generic-all
 serviceability/sa/TestJhsdbJstackUpcall.java                  8307393   generic-all
 serviceability/sa/TestJmapCore.java                           8307393   generic-all
 serviceability/sa/TestJmapCoreMetaspace.java                  8307393   generic-all

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbField.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -55,7 +55,7 @@ public class ClhsdbField {
                 "field InstanceKlass _methods Array<Method*>*",
                 "field InstanceKlass _constants ConstantPool*",
                 "field Klass _name Symbol*",
-                "field JavaThread _osthread OSThread*",
+                "field Thread _osthread OSThread*",
                 "field TenuredGeneration _the_space ContiguousSpace*",
                 "field VirtualSpace _low_boundary char*",
                 "field MethodCounters _backedge_counter InvocationCounter",

--- a/test/hotspot/jtreg/serviceability/sa/ClhsdbVmStructsDump.java
+++ b/test/hotspot/jtreg/serviceability/sa/ClhsdbVmStructsDump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,7 +56,7 @@ public class ClhsdbVmStructsDump {
                 "field InstanceKlass _constants ConstantPool*",
                 "field Klass _name Symbol*",
                 "type ClassLoaderData* null",
-                "field JavaThread _osthread OSThread*",
+                "field Thread _osthread OSThread*",
                 "type TenuredGeneration Generation",
                 "type Universe null",
                 "type ConstantPoolCache MetaspaceObj"));

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLockInVM.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLockInVM.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.whitebox.WhiteBox;
+import jdk.test.lib.apps.LingeredApp;
+
+public class LingeredAppWithLockInVM extends LingeredApp {
+
+    private static class LockerThread implements Runnable {
+        public void run() {
+            WhiteBox wb = WhiteBox.getWhiteBox();
+            wb.lockAndStuckInSafepoint();
+        }
+    }
+
+
+    public static void main(String args[]) {
+        if (args.length != 1) {
+            System.err.println("Lock file name is not specified");
+            System.exit(7);
+        }
+
+        Thread t = new Thread(new LockerThread());
+        t.setName("LockerThread");
+        t.start();
+
+        LingeredApp.main(args);
+    }
+ }

--- a/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLockInVM.java
+++ b/test/hotspot/jtreg/serviceability/sa/LingeredAppWithLockInVM.java
@@ -28,6 +28,12 @@ public class LingeredAppWithLockInVM extends LingeredApp {
 
     private static class LockerThread implements Runnable {
         public void run() {
+            while (!isReady()) {
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException e) {
+                }
+            }
             WhiteBox wb = WhiteBox.getWhiteBox();
             wb.lockAndStuckInSafepoint();
         }

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
@@ -29,9 +29,8 @@ import jtreg.SkippedException;
 
 /**
  * @test
- * @summary Test verifies that jstack --mixed print information about VM locks
+ * @summary Test verifies that jstack --mixed prints information about VM locks
  * @requires vm.hasSA
- * @requires vm.flagless
  * @library /test/lib
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
@@ -47,8 +46,7 @@ public class TestJhsdbJstackPrintVMLocks {
         LingeredApp theApp = null;
         try {
             theApp = new LingeredAppWithLockInVM();
-            String classPath = System.getProperty("test.class.path");
-            LingeredApp.startAppExactJvmOpts(theApp,
+            LingeredApp.startApp(theApp,
                     "-XX:+UnlockDiagnosticVMOptions",
                     "-XX:+WhiteBoxAPI",
                     "-Xbootclasspath/a:.");
@@ -73,7 +71,7 @@ public class TestJhsdbJstackPrintVMLocks {
                 System.out.println(out.getStdout());
                 System.err.println(out.getStderr());
 
-                if (out.contains("Mutex Compile_lock is owned by LockerThread")) {
+                if (out.contains("Mutex VMStatistic_lock is owned by LockerThread")) {
                     System.out.println("Test PASSED");
                     return;
                 }

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
@@ -39,7 +39,7 @@ import jtreg.SkippedException;
 
 public class TestJhsdbJstackPrintVMLocks {
 
-    final static int MAX_ATTEMPTS = 3;
+    final static int MAX_ATTEMPTS = 5;
     public static void main(String[] args) throws Exception {
         SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
 
@@ -75,7 +75,7 @@ public class TestJhsdbJstackPrintVMLocks {
                     System.out.println("Test PASSED");
                     return;
                 }
-                Thread.sleep(2000);
+                Thread.sleep(attempt * 2000);
             }
             throw new RuntimeException("Not able to find lock");
         } finally {

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.test.lib.JDKToolLauncher;
+import jdk.test.lib.SA.SATestUtils;
+import jdk.test.lib.apps.LingeredApp;
+import jdk.test.lib.process.OutputAnalyzer;
+import jtreg.SkippedException;
+
+/**
+ * @test
+ * @summary Test verifies that jstack --mixed print information about VM locks
+ * @requires vm.hasSA
+ * @requires vm.flagless
+ * @library /test/lib
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run driver TestJhsdbJstackPrintVMLocks
+ */
+
+public class TestJhsdbJstackPrintVMLocks {
+
+    public static void main(String[] args) throws Exception {
+        SATestUtils.skipIfCannotAttach(); // throws SkippedException if attach not expected to work.
+
+        LingeredApp theApp = null;
+        try {
+            theApp = new LingeredAppWithLockInVM();
+            String classPath = System.getProperty("test.class.path");
+            LingeredApp.startAppExactJvmOpts(theApp,
+                    "-XX:+UnlockDiagnosticVMOptions",
+                    "-XX:+WhiteBoxAPI",
+                    "-Xbootclasspath/a:.");
+
+            System.out.println("Started LingeredApp with pid " + theApp.getPid());
+            theApp.waitAppReadyOrCrashed();
+
+            JDKToolLauncher launcher = JDKToolLauncher
+                    .createUsingTestJDK("jhsdb");
+            launcher.addToolArg("jstack");
+            launcher.addToolArg("--mixed");
+            launcher.addToolArg("--pid");
+            launcher.addToolArg(Long.toString(theApp.getPid()));
+
+            ProcessBuilder pb = SATestUtils.createProcessBuilder(launcher);
+            Process jhsdb = pb.start();
+            OutputAnalyzer out = new OutputAnalyzer(jhsdb);
+
+            jhsdb.waitFor();
+
+            System.out.println(out.getStdout());
+            System.err.println(out.getStderr());
+
+            out.shouldContain("Mutex Compile_lock is owned by LockerThread");
+        } finally {
+            theApp.getProcess().destroyForcibly();
+        }
+        System.out.println("Test PASSED");
+    }
+}

--- a/test/lib/jdk/test/lib/apps/LingeredApp.java
+++ b/test/lib/jdk/test/lib/apps/LingeredApp.java
@@ -589,6 +589,12 @@ public class LingeredApp {
 
     static class SteadyStateLock {};
 
+    private static volatile boolean isReady = false;
+
+    protected static boolean isReady() {
+        return isReady;
+    }
+
     /**
      * This part is the application itself. First arg is optional "forceCrash".
      * Following arg is the lock file name.
@@ -627,6 +633,7 @@ public class LingeredApp {
                 while (Files.exists(path)) {
                     // Touch the lock to indicate our readiness
                     setLastModified(theLockFileName, epoch());
+                    isReady = true;
                     Thread.sleep(spinDelay);
                 }
             }

--- a/test/lib/jdk/test/whitebox/WhiteBox.java
+++ b/test/lib/jdk/test/whitebox/WhiteBox.java
@@ -99,6 +99,8 @@ public class WhiteBox {
   // printed by the VM.
   public native String printString(String str, int maxLength);
 
+  public native void lockAndStuckInSafepoint();
+
   public int countAliveClasses(String name) {
     // Make sure class name is in the correct format
     return countAliveClasses0(name.replace('.', '/'));


### PR DESCRIPTION
Hi
Could you please review the the fix that add locks information into SA jhsdb stack --mixed output.

Here is the motivation for this rfe and explanation why I add it into SA now.

The information about current owners of Hotspot Mutex is often very useful for dealock investigations.

The jcmd usually doesn't work because VM can't reach or exit safepoints. So it doesn't respond to jcmd.

The SA 'jstack --mixed' provides information about stacktraces on Java and non-Java Threads. So having information about locks along with stack traces might significantly help to identify issues.

The gdb allows to provide stacktraces, but the debug symbols are required to get info about locks. These symbols are often absent during execution.
Also the debugger solution is OS specifc.

The significant part of fix is refacotorrng of mutex_array to be vmStructs compatible.

The adding support of non-JavaThreads into SA might be implemented later to obtain more info about their names.
The example of output:

[2024-11-06T21:32:48.897414435Z] Gathering output for process 1620563
Attaching to process ID 1620533, please wait...
Debugger attached successfully.
Server compiler detected.
JVM version is 24-internal-adhoc.lmesnik.open
Deadlock Detection:

No deadlocks found.

Internal VM Mutex Threads_lock is owned by Unknnown thread (Might be non-Java Thread) with address: 0x00007f8cf825b190
Internal VM Mutex Compile_lock is owned by LockerThread with address: 0x00007f8cf8309a00
----------------- 1620559 -----------------
"C1 CompilerThread4" https://github.com/openjdk/jdk/pull/28 daemon prio=9 tid=0x00007f8c300566a0 nid=1620559 runnable [0x0000000000000000]
java.lang.Thread.State: RUNNABLE
JavaThread state: _thread_blocked
0x00007f8cff11e88d syscall + 0x1d
0x00007f8cfe6c99de LinuxWaitBarrier::wait(int) + 0x8e
0x00007f8cfe2be409 SafepointMechanism::process(JavaThread*, bool, bool) + 0x79
0x00007f8cfd53ea91 ThreadInVMfromNative::ThreadInVMfromNative(JavaThread*) + 0xc1
0x00007f8cfd534a00 ciEnv::cache_jvmti_state() + 0x30
0x00007f8cfd679614 CompileBroker::invoke_compiler_on_method(CompileTask*) + 0x204
0x00007f8cfd67adc8 CompileBroker::compiler_thread_loop() + 0x5c8
0x00007f8cfdb4426c JavaThread::thread_main_inner() + 0xcc
0x00007f8cfe5a0bbe Thread::call_run() + 0xbe
0x00007f8cfe16813b thread_native_entry(Thread*) + 0x12b
.....
----------------- 1620554 -----------------
"LockerThread" https://github.com/openjdk/jdk/pull/31 prio=5 tid=0x00007f8cf8309a00 nid=1620554 waiting on condition [0x00007f8cc1dfe000]
java.lang.Thread.State: RUNNABLE
JavaThread state: _thread_blocked
0x00007f8cff091117 __GI___futex_abstimed_wait_cancelable64 + 0xe7
0x00007f8cff093a41 __GI___pthread_cond_wait + 0x211

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343741](https://bugs.openjdk.org/browse/JDK-8343741): SA jstack --mixed should print information about VM locks (**Enhancement** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22171/head:pull/22171` \
`$ git checkout pull/22171`

Update a local copy of the PR: \
`$ git checkout pull/22171` \
`$ git pull https://git.openjdk.org/jdk.git pull/22171/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22171`

View PR using the GUI difftool: \
`$ git pr show -t 22171`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22171.diff">https://git.openjdk.org/jdk/pull/22171.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22171#issuecomment-2480139801)
</details>
