### PR TITLE
8344350: Add '.gdbinit' and '.lldbinit' to file '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ NashornProfile.txt
 /.settings/
 /compile_commands.json
 /.cache
+/.gdbinit
+/.lldbinit


### PR DESCRIPTION
Hi all,

Some developers want to run some initial scripts locally when the debugger (gdb or lldb) starts. So they often add a file named `.gdbinit` or `.lldbinit` in the project root path. It is good to ignore them.

Thanks for your review.

Best Regards,
-- Guoxiong

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344350](https://bugs.openjdk.org/browse/JDK-8344350): Add '.gdbinit' and '.lldbinit' to file '.gitignore' (**Enhancement** - P5)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22176/head:pull/22176` \
`$ git checkout pull/22176`

Update a local copy of the PR: \
`$ git checkout pull/22176` \
`$ git pull https://git.openjdk.org/jdk.git pull/22176/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22176`

View PR using the GUI difftool: \
`$ git pr show -t 22176`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22176.diff">https://git.openjdk.org/jdk/pull/22176.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22176#issuecomment-2480645332)
</details>
