### PR TITLE
8344218: Remove calls to SecurityManager and and doPrivileged in java.net.NetworkInterface after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/java/net/NetworkInterface.java
+++ b/src/java.base/share/classes/java/net/NetworkInterface.java
@@ -118,16 +118,15 @@ public final class NetworkInterface {
     }
 
     /**
-     * Get an Enumeration with all, or a subset, of the InetAddresses bound to
-     * this network interface.
+     * Get an Enumeration of the InetAddresses bound to this network interface.
      *
      * @implNote
-     * The returned enumeration contains all, or a subset, of the InetAddresses that were
-     * bound to the interface at the time the {@linkplain #getNetworkInterfaces()
+     * The returned enumeration contains the InetAddresses that were bound to
+     * the interface at the time the {@linkplain #getNetworkInterfaces()
      * interface configuration was read}
      *
-     * @return an Enumeration object with all, or a subset, of the InetAddresses
-     * bound to this network interface
+     * @return an Enumeration object with the InetAddresses bound to this
+     * network interface
      * @see #inetAddresses()
      */
     public Enumeration<InetAddress> getInetAddresses() {
@@ -135,16 +134,14 @@ public final class NetworkInterface {
     }
 
     /**
-     * Get a Stream of all, or a subset, of the InetAddresses bound to this
-     * network interface.
+     * Get a Stream of the InetAddresses bound to this network interface.
      *
      * @implNote
-     * The stream contains all, or a subset, of the InetAddresses that were
-     * bound to the interface at the time the {@linkplain #getNetworkInterfaces()
+     * The stream contains the InetAddresses that were bound to the
+     * interface at the time the {@linkplain #getNetworkInterfaces()
      * interface configuration was read}
      *
-     * @return a Stream object with all, or a subset, of the InetAddresses
-     * bound to this network interface
+     * @return a Stream object with the InetAddresses bound to this network interface
      * @since 9
      */
     public Stream<InetAddress> inetAddresses() {
@@ -177,11 +174,11 @@ public final class NetworkInterface {
     }
 
     /**
-     * Get a List of all, or a subset, of the {@code InterfaceAddresses}
-     * of this network interface.
+     * Get a List of the {@code InterfaceAddresses} of this network interface.
      *
-     * @return a {@code List} object with all, or a subset, of the
-     *         InterfaceAddress of this network interface
+     * @return a {@code List} object with the InterfaceAddress of this
+     * network interface
+     *
      * @since 1.6
      */
     public java.util.List<InterfaceAddress> getInterfaceAddresses() {

--- a/src/java.base/share/classes/java/net/NetworkInterface.java
+++ b/src/java.base/share/classes/java/net/NetworkInterface.java
@@ -544,10 +544,10 @@ public final class NetworkInterface {
 
     /**
      * Returns the hardware address (usually MAC) of the interface if it
-     * has one and if it can be accessed given the current privileges.
+     * has one.
      *
      * @return  a byte array containing the address, or {@code null} if
-     *          the address doesn't exist or is not accessible
+     *          the address doesn't exist
      *
      * @throws          SocketException if an I/O error occurs.
      * @since 1.6

--- a/src/java.base/share/classes/java/net/NetworkInterface.java
+++ b/src/java.base/share/classes/java/net/NetworkInterface.java
@@ -507,10 +507,10 @@ public final class NetworkInterface {
 
     /**
      * Returns the hardware address (usually MAC) of the interface if it
-     * has one.
+     * has one and if it can be accessed given the current privileges.
      *
      * @return  a byte array containing the address, or {@code null} if
-     *          the address doesn't exist
+     *          the address doesn't exist or is not accessible
      *
      * @throws          SocketException if an I/O error occurs.
      * @since 1.6

--- a/src/java.base/share/classes/java/net/NetworkInterface.java
+++ b/src/java.base/share/classes/java/net/NetworkInterface.java
@@ -27,6 +27,7 @@ package java.net;
 
 import java.util.Arrays;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Spliterator;
@@ -79,9 +80,9 @@ public final class NetworkInterface {
     private String name;
     private String displayName;
     private int index;
-    private InetAddress addrs[];
-    private InterfaceAddress bindings[];
-    private NetworkInterface childs[];
+    private InetAddress[] addrs;
+    private InterfaceAddress[] bindings;
+    private NetworkInterface[] childs;
     private NetworkInterface parent = null;
     private boolean virtual = false;
     private static final NetworkInterface defaultInterface;
@@ -130,7 +131,7 @@ public final class NetworkInterface {
      * @see #inetAddresses()
      */
     public Enumeration<InetAddress> getInetAddresses() {
-        return enumerationFromArray(getCheckedInetAddresses());
+        return enumerationFromArray(addrs);
     }
 
     /**
@@ -145,32 +146,7 @@ public final class NetworkInterface {
      * @since 9
      */
     public Stream<InetAddress> inetAddresses() {
-        return streamFromArray(getCheckedInetAddresses());
-    }
-
-    private InetAddress[] getCheckedInetAddresses() {
-        InetAddress[] local_addrs = new InetAddress[addrs.length];
-        boolean trusted = true;
-
-        @SuppressWarnings("removal")
-        SecurityManager sec = System.getSecurityManager();
-        if (sec != null) {
-            try {
-                sec.checkPermission(new NetPermission("getNetworkInformation"));
-            } catch (SecurityException e) {
-                trusted = false;
-            }
-        }
-        int i = 0;
-        for (int j = 0; j < addrs.length; j++) {
-            try {
-                if (!trusted) {
-                    sec.checkConnect(addrs[j].getHostAddress(), -1);
-                }
-                local_addrs[i++] = addrs[j];
-            } catch (SecurityException e) { }
-        }
-        return Arrays.copyOf(local_addrs, i);
+        return streamFromArray(addrs);
     }
 
     /**
@@ -181,21 +157,8 @@ public final class NetworkInterface {
      *
      * @since 1.6
      */
-    public java.util.List<InterfaceAddress> getInterfaceAddresses() {
-        java.util.List<InterfaceAddress> lst = new java.util.ArrayList<>(1);
-        if (bindings != null) {
-            @SuppressWarnings("removal")
-            SecurityManager sec = System.getSecurityManager();
-            for (int j=0; j<bindings.length; j++) {
-                try {
-                    if (sec != null) {
-                        sec.checkConnect(bindings[j].getAddress().getHostAddress(), -1);
-                    }
-                    lst.add(bindings[j]);
-                } catch (SecurityException e) { }
-            }
-        }
-        return lst;
+    public List<InterfaceAddress> getInterfaceAddresses() {
+        return bindings == null ? List.of() : List.of(bindings);
     }
 
     /**
@@ -553,18 +516,6 @@ public final class NetworkInterface {
      * @since 1.6
      */
     public byte[] getHardwareAddress() throws SocketException {
-        @SuppressWarnings("removal")
-        SecurityManager sec = System.getSecurityManager();
-        if (sec != null) {
-            try {
-                sec.checkPermission(new NetPermission("getNetworkInformation"));
-            } catch (SecurityException e) {
-                if (!getInetAddresses().hasMoreElements()) {
-                    // don't have connect permission to any local address
-                    return null;
-                }
-            }
-        }
         if (isLoopback0(name, index)) {
             return null;
         }


### PR DESCRIPTION
Please review this PR which cleans up SecurityManager related code from `java.net.NetworkInterface` after JEP-486.

The specification of three methods in NetworkInterface is updated to reflect that these methods no longer use `SecurityManager` to filter their results such that a subset may be returned. A CSR draft has been proposed to fix this leftover from JEP-486.

The actual SecurityManager cleanup:

* The `getCheckedInetAddresses` method is removed.
* `getInetAddresses` is updated to return `enumerationFromArray(addrs)` (with no filtering)
* `inetAddresses` is update to return `streamFromArray(addrs)` (with no filtering)
* `getInterfaceAddresses` is updated to return the list of InterfaceAddresses (with no filtering)
* `getHardwareAddress` is updated to return the result with no permission checking
* Three c-style array declarations hurt my eyes and were updated (sorry!)

GHA and tier2 results pending.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8344351](https://bugs.openjdk.org/browse/JDK-8344351) to be approved

### Issues
 * [JDK-8344218](https://bugs.openjdk.org/browse/JDK-8344218): Remove calls to SecurityManager and and doPrivileged in java.net.NetworkInterface after JEP 486 integration (**Sub-task** - P4)
 * [JDK-8344351](https://bugs.openjdk.org/browse/JDK-8344351): Adjust specifications of java.net.NetworkInterface methods getInetAddresses, inetAddresses and getInterfaceAddresses post JEP-468 (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22177/head:pull/22177` \
`$ git checkout pull/22177`

Update a local copy of the PR: \
`$ git checkout pull/22177` \
`$ git pull https://git.openjdk.org/jdk.git pull/22177/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22177`

View PR using the GUI difftool: \
`$ git pr show -t 22177`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22177.diff">https://git.openjdk.org/jdk/pull/22177.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22177#issuecomment-2480823149)
</details>
