### PR TITLE
8344349: Problemlist jdk/jfr/jvm/TestVirtualThreadExclusion.java before JDK-8344199 resolved

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -30,3 +30,4 @@
 java/lang/invoke/MethodHandles/CatchExceptionTest.java          8146623 generic-all
 java/lang/reflect/callerCache/ReflectionCallerCacheTest.java    8332028 generic-all
 com/sun/jdi/InterruptHangTest.java                              8043571 generic-all
+jdk/jfr/jvm/TestVirtualThreadExclusion.java                     8344199 generic-all


### PR DESCRIPTION
Hi all,
The test `jdk/jfr/jvm/TestVirtualThreadExclusion.java` fails after [JDK-8338383](https://bugs.openjdk.org/browse/JDK-8338383),  before [JDK-8344199](https://bugs.openjdk.org/browse/JDK-8344199) been resolved, should we problemlist this test to make less CI noisy.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344349](https://bugs.openjdk.org/browse/JDK-8344349): Problemlist jdk/jfr/jvm/TestVirtualThreadExclusion.java before JDK-8344199 resolved (**Sub-task** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22178/head:pull/22178` \
`$ git checkout pull/22178`

Update a local copy of the PR: \
`$ git checkout pull/22178` \
`$ git pull https://git.openjdk.org/jdk.git pull/22178/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22178`

View PR using the GUI difftool: \
`$ git pr show -t 22178`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22178.diff">https://git.openjdk.org/jdk/pull/22178.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22178#issuecomment-2480895608)
</details>
