### PR TITLE
8318668: java/lang/management/MemoryMXBean/CollectionUsageThreshold.java fails with Xcomp

### DIFF
--- a/test/jdk/java/lang/management/MemoryMXBean/CollectionUsageThreshold.java
+++ b/test/jdk/java/lang/management/MemoryMXBean/CollectionUsageThreshold.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,7 @@
  * @library /test/lib
  * @modules jdk.management
  * @build CollectionUsageThreshold MemoryUtil RunUtil
- * @requires vm.opt.ExplicitGCInvokesConcurrent == "false" | vm.opt.ExplicitGCInvokesConcurrent == "null"
+ * @requires (vm.opt.ExplicitGCInvokesConcurrent == "false" | vm.opt.ExplicitGCInvokesConcurrent == "null") & vm.compMode != "Xcomp"
  * @build jdk.test.whitebox.WhiteBox
  * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
  * @run main/othervm/timeout=300 -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI -Xbootclasspath/a:. CollectionUsageThreshold


### PR DESCRIPTION
Trivial change to exclude the test from running with Xcomp flag.

The test fails because the number of GCs as reported by the MXBean doesn't match the expected number. This is due to the additional GC happening due to CodeCache crossing its threshold.
We could increase the code cache or restrict the specific compiler that fills the cache. But this will not completely eliminate the possibility as cache size could be overridden or the same failure can happen for a different compiler.

So, it is better to restrict the Xcomp flag as a whole.

Testing:
Only local testing done as it is trivial change. One run with Xcomp and another without any flags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8318668](https://bugs.openjdk.org/browse/JDK-8318668): java/lang/management/MemoryMXBean/CollectionUsageThreshold.java fails with Xcomp (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22180/head:pull/22180` \
`$ git checkout pull/22180`

Update a local copy of the PR: \
`$ git checkout pull/22180` \
`$ git pull https://git.openjdk.org/jdk.git pull/22180/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22180`

View PR using the GUI difftool: \
`$ git pr show -t 22180`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22180.diff">https://git.openjdk.org/jdk/pull/22180.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22180#issuecomment-2480922883)
</details>
