### PR TITLE
8344356: Aarch64: implement -XX:+VerifyActivationFrameSize

### DIFF
--- a/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/interp_masm_aarch64.cpp
@@ -393,7 +393,13 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
                                               bool verifyoop,
                                               bool generate_poll) {
   if (VerifyActivationFrameSize) {
-    Unimplemented();
+    Label L;
+    sub(Rtemp, FP, SP);
+    int min_frame_size = (frame::link_offset - frame::interpreter_frame_initial_sp_offset) * wordSize;
+    cmp(Rtemp, min_frame_size);
+    b(L, ge);
+    stop("broken stack frame");
+    bind(L);
   }
   if (verifyoop) {
     interp_verify_oop(r0, state);

--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -30,3 +30,4 @@
 java/lang/invoke/MethodHandles/CatchExceptionTest.java          8146623 generic-all
 java/lang/reflect/callerCache/ReflectionCallerCacheTest.java    8332028 generic-all
 com/sun/jdi/InterruptHangTest.java                              8043571 generic-all
+jdk/jfr/jvm/TestVirtualThreadExclusion.java                     8344199 generic-all


### PR DESCRIPTION
Hi all,
Currently on aarch64 platform the debug VM option `-XX:+VerifyActivationFrameSize` is Unimplemented. I want to implement `-XX:+VerifyActivationFrameSize` to make JVM easier to diagnose. Only effect debug build and with option `-XX:+VerifyActivationFrameSize`, the change has been verified locally, the risk is low.

Additional testing

- [ ] jtreg tests(include tier1/2/3 etc.) on linux-aarch64 release build
- [ ] jtreg tests(include tier1/2/3 etc.) on linux-aarch64 fastdebug build