### PR TITLE
8316151: [macos14] ActionListenerCalledTwiceTest.java fails on macOS 14

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -707,7 +707,6 @@ javax/swing/JComboBox/TestComboBoxComponentRendering.java 8309734 linux-all
 
 # This test fails on macOS 14
 javax/swing/plaf/synth/7158712/bug7158712.java 8324782 macosx-all
-javax/swing/JMenuItem/ActionListenerCalledTwice/ActionListenerCalledTwiceTest.java 8316151 macosx-all
 
 ############################################################################
 


### PR DESCRIPTION
Test was failing due to apple bug in version < 14.5 and is passing in latest..Tested in CI systems and all passed for several iterations, so removing from PL..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8316151](https://bugs.openjdk.org/browse/JDK-8316151): [macos14] ActionListenerCalledTwiceTest.java fails on macOS 14 (**Bug** - P4)


### Reviewers
 * [Tejesh R](https://openjdk.org/census#tr) (@TejeshR13 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22182/head:pull/22182` \
`$ git checkout pull/22182`

Update a local copy of the PR: \
`$ git checkout pull/22182` \
`$ git pull https://git.openjdk.org/jdk.git pull/22182/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22182`

View PR using the GUI difftool: \
`$ git pr show -t 22182`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22182.diff">https://git.openjdk.org/jdk/pull/22182.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22182#issuecomment-2481164131)
</details>
