### PR TITLE
8178966: Don't swallow early bootstrap exceptions in Boolean.getBoolean, Integer.getInteger and Long.getLong

### DIFF
--- a/src/java.base/share/classes/java/lang/Boolean.java
+++ b/src/java.base/share/classes/java/lang/Boolean.java
@@ -275,12 +275,7 @@ public final class Boolean implements java.io.Serializable,
      * @see     java.lang.System#getProperty(java.lang.String, java.lang.String)
      */
     public static boolean getBoolean(String name) {
-        boolean result = false;
-        try {
-            result = parseBoolean(System.getProperty(name));
-        } catch (IllegalArgumentException | NullPointerException e) {
-        }
-        return result;
+        return name != null && !name.isEmpty() && parseBoolean(System.getProperty(name));
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/Integer.java
+++ b/src/java.base/share/classes/java/lang/Integer.java
@@ -1275,11 +1275,7 @@ public final class Integer extends Number
      * @see     System#getProperty(java.lang.String, java.lang.String)
      */
     public static Integer getInteger(String nm, Integer val) {
-        String v = null;
-        try {
-            v = System.getProperty(nm);
-        } catch (IllegalArgumentException | NullPointerException e) {
-        }
+        String v = nm != null && !nm.isEmpty() ? System.getProperty(nm) : null;
         if (v != null) {
             try {
                 return Integer.decode(v);

--- a/src/java.base/share/classes/java/lang/Long.java
+++ b/src/java.base/share/classes/java/lang/Long.java
@@ -1370,11 +1370,7 @@ public final class Long extends Number
      * @see     System#getProperty(java.lang.String, java.lang.String)
      */
     public static Long getLong(String nm, Long val) {
-        String v = null;
-        try {
-            v = System.getProperty(nm);
-        } catch (IllegalArgumentException | NullPointerException e) {
-        }
+        String v = nm != null && !nm.isEmpty() ? System.getProperty(nm) : null;
         if (v != null) {
             try {
                 return Long.decode(v);


### PR DESCRIPTION
Please review this PR which removes exceptional control flow in `Boolean::getBoolean`, `Integer::getInteger` and `Long::getLong`.

These methods are catching `IllegalArgumentException` and `NullPointerException`, thrown by `System::getProperty` via `System::checkKey`. This PR replaces the exceptional control flow with explicit checks that the system property name is non-null and non-empty before calling into `System::getProperty`.

As JDK-8178966 points out, there is a possibility that System.getProperty could throw one of NPE and IAE for other reasons than the name being null or empty. This risk is reduced now that custom security managers cannot interfere. Adding to that, if such exceptions are thrown today, they are masked by these methods catching and swallowing them by returning false or default values. It's better to expose such  bugs if they exist.

GHA results pending. Local tier2 ran successfully.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8178966](https://bugs.openjdk.org/browse/JDK-8178966): Don't swallow early bootstrap exceptions in Boolean.getBoolean, Integer.getInteger and Long.getLong (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Contributors
 * Peter Levart `<plevart@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22183/head:pull/22183` \
`$ git checkout pull/22183`

Update a local copy of the PR: \
`$ git checkout pull/22183` \
`$ git pull https://git.openjdk.org/jdk.git pull/22183/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22183`

View PR using the GUI difftool: \
`$ git pr show -t 22183`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22183.diff">https://git.openjdk.org/jdk/pull/22183.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22183#issuecomment-2481540243)
</details>
