### PR TITLE
8344364: Remove unused SecurityManager-related imports from java.lang.instrument.ClassFileTransformer

### DIFF
--- a/src/java.instrument/share/classes/java/lang/instrument/ClassFileTransformer.java
+++ b/src/java.instrument/share/classes/java/lang/instrument/ClassFileTransformer.java
@@ -25,8 +25,6 @@
 
 package java.lang.instrument;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.ProtectionDomain;
 
 /*


### PR DESCRIPTION
Please review this trivial cleanup which removes unused imports of `java.security.AccessController` and `java.security.PrivilegedAction` from `java.lang.instrument.ClassFileTransformer`.

History: These imports came with the new transform method introduced by the module system implementation in JDK-8142968 and were left unused when JDK-8159147 instead added a ClassLoader parameter to the new transform method.

Verification: `make images` succeeds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344364](https://bugs.openjdk.org/browse/JDK-8344364): Remove unused SecurityManager-related imports from java.lang.instrument.ClassFileTransformer (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22184/head:pull/22184` \
`$ git checkout pull/22184`

Update a local copy of the PR: \
`$ git checkout pull/22184` \
`$ git pull https://git.openjdk.org/jdk.git pull/22184/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22184`

View PR using the GUI difftool: \
`$ git pr show -t 22184`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22184.diff">https://git.openjdk.org/jdk/pull/22184.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22184#issuecomment-2481418960)
</details>
