### PR TITLE
8344371: RISC-V: compiler/intrinsics/chacha/TestChaCha20.java fails after JDK-8343555

### DIFF
--- a/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/chacha/TestChaCha20.java
@@ -104,7 +104,7 @@ public class TestChaCha20 {
             // Riscv64 intrinsics require the vector instructions
             if (containsFuzzy(cpuFeatures, "rvv")) {
                 System.out.println("Setting up vector worker");
-                configs.add(List.of("-XX:+UseRVV"));
+                configs.add(List.of());
             }
         } else {
             // We only have ChaCha20 intrinsics on x64, aarch64 and riscv64


### PR DESCRIPTION
Hello, please review this small fix.

From the error message, the cause of the failure is that 'UseRVV' was made diagnostic in [JDK-8343555.](https://bugs.openjdk.org/browse/JDK-8343555). But the test was not updated to refect this. Instead of adding one extra `-XX:+UnlockDiagnosticVMOptions option` option, this simply removed the use of `-XX:+UseRVV` from the test. The reason is that we have `-XX:+UseRVV` auto detected and enabled, so we will have RVV extension if we satisfy the test requirement:
```
(os.arch == "riscv64" & vm.cpu.features ~= ".*rvv.*")
```

Same test pass with this fix on linux-riscv64 with RVV extension.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8344371](https://bugs.openjdk.org/browse/JDK-8344371)

### Issue
 * [JDK-8344371](https://bugs.openjdk.org/browse/JDK-8344371): RISC-V: compiler/intrinsics/chacha/TestChaCha20.java fails after JDK-834355 (**Bug** - P4) ⚠️ Title mismatch between PR and JBS.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22187/head:pull/22187` \
`$ git checkout pull/22187`

Update a local copy of the PR: \
`$ git checkout pull/22187` \
`$ git pull https://git.openjdk.org/jdk.git pull/22187/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22187`

View PR using the GUI difftool: \
`$ git pr show -t 22187`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22187.diff">https://git.openjdk.org/jdk/pull/22187.diff</a>

</details>
