### PR TITLE
8344271: Comparison build fails due to difference in doc summary

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/ModuleWriter.java
@@ -41,6 +41,7 @@ import javax.lang.model.util.ElementFilter;
 
 import com.sun.source.doctree.DeprecatedTree;
 import com.sun.source.doctree.DocTree;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import jdk.javadoc.doclet.DocletEnvironment.ModuleMode;
@@ -591,14 +592,10 @@ public class ModuleWriter extends HtmlDocletWriter {
                                      .anyMatch(rd -> rd.isTransitive() &&
                                                      javaBase.equals(rd.getDependency()));
                 if (hasRequiresTransitiveJavaBase) {
-                    Map<ModuleElement, SortedSet<PackageElement>> filteredIndirectPackages =
-                            indirectPackages.entrySet()
-                                            .stream()
-                                            .filter(e -> !e.getKey().equals(javaBase))
-                                            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
                     String aepText = resources.getText("doclet.Indirect_Exports_Summary");
                     var aepTable = getTable2(Text.of(aepText), indirectPackagesHeader);
-                    addIndirectPackages(aepTable, filteredIndirectPackages);
+                    addIndirectPackages(aepTable, indirectPackages,
+                                        m -> !m.equals(javaBase));
                     section.add(aepTable);
                     //add the preview box:
                     section.add(HtmlTree.BR());
@@ -614,30 +611,26 @@ public class ModuleWriter extends HtmlDocletWriter {
                     section.add(previewDiv);
 
                     //add the Indirect Exports
-                    filteredIndirectPackages =
-                            indirectPackages.entrySet()
-                                            .stream()
-                                            .filter(e -> e.getKey().equals(javaBase))
-                                            .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
                     String aepPreviewText = resources.getText("doclet.Indirect_Exports_Summary");
                     ContentBuilder tableCaption = new ContentBuilder(
                             Text.of(aepPreviewText),
                             HtmlTree.SUP(links.createLink(previewRequiresTransitiveId,
                                          contents.previewMark)));
                     var aepPreviewTable = getTable2(tableCaption, indirectPackagesHeader);
-                    addIndirectPackages(aepPreviewTable, filteredIndirectPackages);
+                    addIndirectPackages(aepPreviewTable, indirectPackages,
+                                        m -> m.equals(javaBase));
                     section.add(aepPreviewTable);
                 } else {
                     String aepText = resources.getText("doclet.Indirect_Exports_Summary");
                     var aepTable = getTable2(Text.of(aepText), indirectPackagesHeader);
-                    addIndirectPackages(aepTable, indirectPackages);
+                    addIndirectPackages(aepTable, indirectPackages, _ -> true);
                     section.add(aepTable);
                 }
             }
             if (display(indirectOpenPackages)) {
                 String aopText = resources.getText("doclet.Indirect_Opens_Summary");
                 var aopTable = getTable2(Text.of(aopText), indirectPackagesHeader);
-                addIndirectPackages(aopTable, indirectOpenPackages);
+                addIndirectPackages(aopTable, indirectOpenPackages, _ -> true);
                 section.add(aopTable);
             }
             summariesList.add(HtmlTree.LI(section));
@@ -768,9 +761,14 @@ public class ModuleWriter extends HtmlDocletWriter {
      * @param table the table to which the content rows will be added
      * @param ip indirect packages to be added
      */
-    public void addIndirectPackages(Table<?> table, Map<ModuleElement, SortedSet<PackageElement>> ip) {
+    public void addIndirectPackages(Table<?> table,
+                                    Map<ModuleElement, SortedSet<PackageElement>> ip,
+                                    Predicate<ModuleElement> acceptModule) {
         for (Map.Entry<ModuleElement, SortedSet<PackageElement>> entry : ip.entrySet()) {
             ModuleElement m = entry.getKey();
+            if (!acceptModule.test(m)) {
+                continue;
+            }
             SortedSet<PackageElement> pkgList = entry.getValue();
             Content moduleLinkContent = getModuleLink(m, Text.of(m.getQualifiedName()));
             Content list = new ContentBuilder();


### PR DESCRIPTION
A test ensuring the JDK build is reproducible is failing due to the recent https://github.com/openjdk/jdk/commit/81342acdae82262815e04e1ade7deb2d0f24094a . The reason is the unordered map used when filtering `java.base` out of the list of dependencies.

This patch is resolving that, by moving the filtering to `addIndirectPackages`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344271](https://bugs.openjdk.org/browse/JDK-8344271): Comparison build fails due to difference in doc summary (**Bug** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22189/head:pull/22189` \
`$ git checkout pull/22189`

Update a local copy of the PR: \
`$ git checkout pull/22189` \
`$ git pull https://git.openjdk.org/jdk.git pull/22189/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22189`

View PR using the GUI difftool: \
`$ git pr show -t 22189`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22189.diff">https://git.openjdk.org/jdk/pull/22189.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22189#issuecomment-2482084014)
</details>
