### PR TITLE
8344379: [s390x] build failure due to missing change from JDK-8339466

### DIFF
--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -2919,7 +2919,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(SharedStubId id, address cal
     __ z_lg(Z_R14, Address(Z_thread, JavaThread::saved_exception_pc_offset()));
   }
 
-  bool save_vectors = (poll_type == POLL_AT_VECTOR_LOOP);
+  bool save_vectors = (id == SharedStubId::polling_page_vectors_safepoint_handler_id);
   // Save registers, fpu state, and flags
   map = RegisterSaver::save_live_registers(masm, RegisterSaver::all_registers, Z_R14, save_vectors);
 


### PR DESCRIPTION
Trivial change. Adds one missing part from [JDK-8327652](https://bugs.openjdk.org/browse/JDK-8327652) as that is causing build failure on s390x.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344379](https://bugs.openjdk.org/browse/JDK-8344379): [s390x] build failure due to missing change from JDK-8339466 (**Bug** - P2)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22190/head:pull/22190` \
`$ git checkout pull/22190`

Update a local copy of the PR: \
`$ git checkout pull/22190` \
`$ git pull https://git.openjdk.org/jdk.git pull/22190/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22190`

View PR using the GUI difftool: \
`$ git pr show -t 22190`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22190.diff">https://git.openjdk.org/jdk/pull/22190.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22190#issuecomment-2482134409)
</details>
