### PR TITLE
8343541: C1: Plain memory accesses are emitted with membars with +AlwaysAtomicAccesses

### DIFF
--- a/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
@@ -141,7 +141,7 @@ LIR_Opr BarrierSetC1::atomic_add_at(LIRAccess& access, LIRItem& value) {
 void BarrierSetC1::store_at_resolved(LIRAccess& access, LIR_Opr value) {
   DecoratorSet decorators = access.decorators();
   bool is_volatile = (decorators & MO_SEQ_CST) != 0;
-  bool is_atomic_access = is_volatile || AlwaysAtomicAccesses;
+  bool is_atomic = is_volatile || AlwaysAtomicAccesses;
   bool needs_patching = (decorators & C1_NEEDS_PATCHING) != 0;
   bool mask_boolean = (decorators & C1_MASK_BOOLEAN) != 0;
   LIRGenerator* gen = access.gen();
@@ -155,7 +155,7 @@ void BarrierSetC1::store_at_resolved(LIRAccess& access, LIR_Opr value) {
   }
 
   LIR_PatchCode patch_code = needs_patching ? lir_patch_normal : lir_patch_none;
-  if (is_atomic_access && !needs_patching) {
+  if (is_atomic && !needs_patching) {
     gen->volatile_field_store(value, access.resolved_addr()->as_address_ptr(), access.access_emit_info());
   } else {
     __ store(value, access.resolved_addr()->as_address_ptr(), access.access_emit_info(), patch_code);
@@ -170,7 +170,7 @@ void BarrierSetC1::load_at_resolved(LIRAccess& access, LIR_Opr result) {
   LIRGenerator *gen = access.gen();
   DecoratorSet decorators = access.decorators();
   bool is_volatile = (decorators & MO_SEQ_CST) != 0;
-  bool is_atomic_access = is_volatile || AlwaysAtomicAccesses;
+  bool is_atomic = is_volatile || AlwaysAtomicAccesses;
   bool needs_patching = (decorators & C1_NEEDS_PATCHING) != 0;
   bool mask_boolean = (decorators & C1_MASK_BOOLEAN) != 0;
   bool in_native = (decorators & IN_NATIVE) != 0;
@@ -182,7 +182,7 @@ void BarrierSetC1::load_at_resolved(LIRAccess& access, LIR_Opr result) {
   LIR_PatchCode patch_code = needs_patching ? lir_patch_normal : lir_patch_none;
   if (in_native) {
     __ move_wide(access.resolved_addr()->as_address_ptr(), result);
-  } else if (is_atomic_access && !needs_patching) {
+  } else if (is_atomic && !needs_patching) {
     gen->volatile_field_load(access.resolved_addr()->as_address_ptr(), result, access.access_emit_info());
   } else {
     __ load(access.resolved_addr()->as_address_ptr(), result, access.access_emit_info(), patch_code);

--- a/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
+++ b/src/hotspot/share/gc/shared/c1/barrierSetC1.cpp
@@ -140,7 +140,8 @@ LIR_Opr BarrierSetC1::atomic_add_at(LIRAccess& access, LIRItem& value) {
 
 void BarrierSetC1::store_at_resolved(LIRAccess& access, LIR_Opr value) {
   DecoratorSet decorators = access.decorators();
-  bool is_volatile = (((decorators & MO_SEQ_CST) != 0) || AlwaysAtomicAccesses);
+  bool is_volatile = (decorators & MO_SEQ_CST) != 0;
+  bool is_atomic_access = is_volatile || AlwaysAtomicAccesses;
   bool needs_patching = (decorators & C1_NEEDS_PATCHING) != 0;
   bool mask_boolean = (decorators & C1_MASK_BOOLEAN) != 0;
   LIRGenerator* gen = access.gen();
@@ -154,7 +155,7 @@ void BarrierSetC1::store_at_resolved(LIRAccess& access, LIR_Opr value) {
   }
 
   LIR_PatchCode patch_code = needs_patching ? lir_patch_normal : lir_patch_none;
-  if (is_volatile && !needs_patching) {
+  if (is_atomic_access && !needs_patching) {
     gen->volatile_field_store(value, access.resolved_addr()->as_address_ptr(), access.access_emit_info());
   } else {
     __ store(value, access.resolved_addr()->as_address_ptr(), access.access_emit_info(), patch_code);
@@ -168,7 +169,8 @@ void BarrierSetC1::store_at_resolved(LIRAccess& access, LIR_Opr value) {
 void BarrierSetC1::load_at_resolved(LIRAccess& access, LIR_Opr result) {
   LIRGenerator *gen = access.gen();
   DecoratorSet decorators = access.decorators();
-  bool is_volatile = (((decorators & MO_SEQ_CST) != 0) || AlwaysAtomicAccesses);
+  bool is_volatile = (decorators & MO_SEQ_CST) != 0;
+  bool is_atomic_access = is_volatile || AlwaysAtomicAccesses;
   bool needs_patching = (decorators & C1_NEEDS_PATCHING) != 0;
   bool mask_boolean = (decorators & C1_MASK_BOOLEAN) != 0;
   bool in_native = (decorators & IN_NATIVE) != 0;
@@ -180,7 +182,7 @@ void BarrierSetC1::load_at_resolved(LIRAccess& access, LIR_Opr result) {
   LIR_PatchCode patch_code = needs_patching ? lir_patch_normal : lir_patch_none;
   if (in_native) {
     __ move_wide(access.resolved_addr()->as_address_ptr(), result);
-  } else if (is_volatile && !needs_patching) {
+  } else if (is_atomic_access && !needs_patching) {
     gen->volatile_field_load(access.resolved_addr()->as_address_ptr(), result, access.access_emit_info());
   } else {
     __ load(access.resolved_addr()->as_address_ptr(), result, access.access_emit_info(), patch_code);


### PR DESCRIPTION
C1 and C2 has different implementations for `+AlwaysAtomicAccesses`, [C2 impl](https://github.com/openjdk/jdk/blob/4a7ce1d7c1bd4b751063b98cf8bedcd27055760b/src/hotspot/share/gc/shared/c2/barrierSetC2.cpp#L410) only guarantees atomicity hence no membars  are emitted for plain memory access, but C1 treats it same as volatile access hence it emits membars.  The change removes the unnecessary membars in C1 for `+AlwaysAtomicAccesses`. 

The test have been verified by very simple JMH benchmarks to measure the latency of reading/writing long/volatile long variable 10000 times, and run with VM option `-XX:TieredStopAtLevel=3 -XX:+UnlockExperimentalVMOptions -XX:+AlwaysAtomicAccesses`: 

Before the fix:
```
Benchmark                                   Mode  Cnt       Score      Error  Units
AlwaysAtomicAccesses.testReadLong           avgt    5   58711.131 ±  716.940  ns/op
AlwaysAtomicAccesses.testReadVolatileLong   avgt    5   59014.735 ±  675.354  ns/op
AlwaysAtomicAccesses.testWriteLong          avgt    5  115817.978 ±  302.089  ns/op
AlwaysAtomicAccesses.testWriteVolatileLong  avgt    5  116317.835 ± 1451.365  ns/op
```

After the fix:
```
Benchmark                                   Mode  Cnt       Score      Error  Units
AlwaysAtomicAccesses.testReadLong           avgt    5   49651.527 ±  159.948  ns/op
AlwaysAtomicAccesses.testReadVolatileLong   avgt    5   58668.844 ±  316.029  ns/op
AlwaysAtomicAccesses.testWriteLong          avgt    5   23008.361 ±   10.947  ns/op
AlwaysAtomicAccesses.testWriteVolatileLong  avgt    5  116440.017 ± 1240.832  ns/op
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8343541](https://bugs.openjdk.org/browse/JDK-8343541): C1: Plain memory accesses are emitted with membars with +AlwaysAtomicAccesses (**Enhancement** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22191/head:pull/22191` \
`$ git checkout pull/22191`

Update a local copy of the PR: \
`$ git checkout pull/22191` \
`$ git pull https://git.openjdk.org/jdk.git pull/22191/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22191`

View PR using the GUI difftool: \
`$ git pr show -t 22191`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22191.diff">https://git.openjdk.org/jdk/pull/22191.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22191#issuecomment-2482318384)
</details>
