### PR TITLE
8344383: Include ZipArchive and JarArchive directly

### DIFF
--- a/make/ZipSecurity.gmk
+++ b/make/ZipSecurity.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@ default: all
 
 include $(SPEC)
 include MakeBase.gmk
-include JavaCompilation.gmk
+include ZipArchive.gmk
 
 ################################################################################
 #

--- a/make/ZipSource.gmk
+++ b/make/ZipSource.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2014, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,8 @@ default: all
 
 include $(SPEC)
 include MakeBase.gmk
-include JavaCompilation.gmk
 include Modules.gmk
+include ZipArchive.gmk
 
 SRC_ZIP_WORK_DIR := $(SUPPORT_OUTPUTDIR)/src
 $(if $(filter $(TOPDIR)/%, $(SUPPORT_OUTPUTDIR)), $(eval SRC_ZIP_BASE := $(TOPDIR)), $(eval SRC_ZIP_BASE := $(SUPPORT_OUTPUTDIR)))

--- a/make/test/BuildMicrobenchmark.gmk
+++ b/make/test/BuildMicrobenchmark.gmk
@@ -30,6 +30,7 @@ include $(SPEC)
 include MakeBase.gmk
 
 include CopyFiles.gmk
+include JarArchive.gmk
 include JavaCompilation.gmk
 include TestFilesCompilation.gmk
 


### PR DESCRIPTION
Some makefiles include JavaCompilation.gmk when they really want to include ZipArchive.gmk. (Currently, JavaCompilation.gmk includes ZipArchive.gmk indirectly to keep backwards compatibility from when these were implemented in the same file.)

Also, all files that calls SetupJarArchive should include JarArchive.gmk directly.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344383](https://bugs.openjdk.org/browse/JDK-8344383): Include ZipArchive and JarArchive directly (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22194/head:pull/22194` \
`$ git checkout pull/22194`

Update a local copy of the PR: \
`$ git checkout pull/22194` \
`$ git pull https://git.openjdk.org/jdk.git pull/22194/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22194`

View PR using the GUI difftool: \
`$ git pr show -t 22194`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22194.diff">https://git.openjdk.org/jdk/pull/22194.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22194#issuecomment-2482531572)
</details>
