### PR TITLE
8344199: Incorrect excluded field value set by getEventWriter intrinsic

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -30,4 +30,3 @@
 java/lang/invoke/MethodHandles/CatchExceptionTest.java          8146623 generic-all
 java/lang/reflect/callerCache/ReflectionCallerCacheTest.java    8332028 generic-all
 com/sun/jdi/InterruptHangTest.java                              8043571 generic-all
-jdk/jfr/jvm/TestVirtualThreadExclusion.java                     8344199 generic-all


### PR DESCRIPTION
The C2 intrinsic for `jdk.jfr.internal.JVM::getEventWriter` sets a boolean `excluded` field by masking the most significant bit of the unsigned 2-byte `thread_epoch_raw` field value. A shift is needed to get a proper boolean value.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344199](https://bugs.openjdk.org/browse/JDK-8344199): Incorrect excluded field value set by getEventWriter intrinsic (**Bug** - P3)


### Reviewers
 * [SendaoYan](https://openjdk.org/census#syan) (@sendaoYan - Committer)
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)

### Contributors
 * Patricio Chilano Mateo `<pchilanomate@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22195/head:pull/22195` \
`$ git checkout pull/22195`

Update a local copy of the PR: \
`$ git checkout pull/22195` \
`$ git pull https://git.openjdk.org/jdk.git pull/22195/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22195`

View PR using the GUI difftool: \
`$ git pr show -t 22195`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22195.diff">https://git.openjdk.org/jdk/pull/22195.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22195#issuecomment-2482554533)
</details>
