### PR TITLE
8344352: 32-bit builds crash after JDK-8305895

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3678,7 +3678,6 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   if (UseCompactObjectHeaders && !UseCompressedClassPointers) {
     FLAG_SET_DEFAULT(UseCompressedClassPointers, true);
   }
-  ObjLayout::initialize();
 #endif
 
   return JNI_OK;

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -497,6 +497,9 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   // Timing (must come after argument parsing)
   TraceTime timer("Create VM", TRACETIME_LOG(Info, startuptime));
 
+  // Initialize object layout after parsing the args
+  ObjLayout::initialize();
+
   // Initialize the os module after parsing the args
   jint os_init_2_result = os::init_2();
   if (os_init_2_result != JNI_OK) return os_init_2_result;


### PR DESCRIPTION
The underlying reason is that newly added `ObjLayout::initialize` is set up in `LP64` block, so 32-bit platforms miss it. I moved the initialization closer to VM init sequence, as it _is_ the essential part of VM init, not just argument parsing. This is the same thing I did in my POC patch in [JDK-8343648](https://bugs.openjdk.org/browse/JDK-8343648).

Additional testing:
 - [x] Linux x86_32 fastdebug cross-build (now able to run simple things)
 - [x] Linux arm32 fastdebug cross-build (now able to run simple things)

Both builds are still broken at build-time CDS creation steps due to CDS bug ([JDK-8344389](https://bugs.openjdk.org/browse/JDK-8344389)), but they do not fail with ObjLayout bug anymore.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344352](https://bugs.openjdk.org/browse/JDK-8344352): 32-bit builds crash after JDK-8305895 (**Bug** - P4)


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22196/head:pull/22196` \
`$ git checkout pull/22196`

Update a local copy of the PR: \
`$ git checkout pull/22196` \
`$ git pull https://git.openjdk.org/jdk.git pull/22196/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22196`

View PR using the GUI difftool: \
`$ git pr show -t 22196`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22196.diff">https://git.openjdk.org/jdk/pull/22196.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22196#issuecomment-2482592763)
</details>
