### PR TITLE
8344389: 32-bit builds fail at CDS build time after JDK-8331497

### DIFF
--- a/src/hotspot/share/cds/archiveBuilder.cpp
+++ b/src/hotspot/share/cds/archiveBuilder.cpp
@@ -897,7 +897,7 @@ void ArchiveBuilder::make_klasses_shareable() {
           assert(HeapShared::is_archivable_hidden_klass(ik), "sanity");
         } else {
           // Legacy CDS support for lambda proxies
-          assert(HeapShared::is_lambda_proxy_klass(ik), "sanity");
+          CDS_JAVA_HEAP_ONLY(assert(HeapShared::is_lambda_proxy_klass(ik), "sanity");)
         }
       } else if (ik->is_shared_boot_class()) {
         type = "boot";


### PR DESCRIPTION
Trying to build 32-bit builds would fail during the build on this assert:

```
# Internal Error (/home/buildbot/worker/build-jdkX/build/src/hotspot/share/cds/archiveBuilder.cpp:900), pid=267008, tid=267017
# assert(HeapShared::is_lambda_proxy_klass(ik)) failed: sanity
#
# JRE version: OpenJDK Runtime Environment (24.0) (fastdebug build 24-internal-adhoc.buildbot.build)
# Java VM: OpenJDK Server VM (fastdebug 24-internal-adhoc.buildbot.build, interpreted mode, g1 gc, linux-arm)
# Problematic frame:
# V [libjvm.so+0x2a3db8] ArchiveBuilder::make_klasses_shareable()+0x15d0
```

That assert was added by [JDK-8331497](https://bugs.openjdk.org/browse/JDK-8331497). Unfortunately, with `!INCLUDE_CDS_JAVA_HEAP` for 32-bit builds, `HeapShared::is_lambda_proxy_klass` would be compiled as unconditional `false`, which is guaranteed to fail the assert.

I think the minimal fix to unbreak the builds is wrapping that asserts with appropriate macros.

Additional testing:
 - [x] Linux x86_32 fastdebug build now passes (needs [JDK-8344352](https://bugs.openjdk.org/browse/JDK-8344352) too)
 - [x] Linux arm32 fastdebug build now passes (needs [JDK-8344352](https://bugs.openjdk.org/browse/JDK-8344352) too)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344389](https://bugs.openjdk.org/browse/JDK-8344389): 32-bit builds fail at CDS build time after JDK-8331497 (**Bug** - P2)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22201/head:pull/22201` \
`$ git checkout pull/22201`

Update a local copy of the PR: \
`$ git checkout pull/22201` \
`$ git pull https://git.openjdk.org/jdk.git pull/22201/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22201`

View PR using the GUI difftool: \
`$ git pr show -t 22201`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22201.diff">https://git.openjdk.org/jdk/pull/22201.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22201#issuecomment-2482742362)
</details>
