### PR TITLE
8344393: RISC-V: Remove option UseRVVForBigIntegerShiftIntrinsics

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -117,8 +117,6 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseZvfh, false, DIAGNOSTIC, "Use Zvfh instructions")             \
   product(bool, UseZvkn, false, EXPERIMENTAL,                                    \
           "Use Zvkn group extension, Zvkned, Zvknhb, Zvkb, Zvkt")                \
-  product(bool, UseRVVForBigIntegerShiftIntrinsics, true,                        \
-          "Use RVV instructions for left/right shift of BigInteger")             \
   product(bool, UseCtxFencei, false, EXPERIMENTAL,                               \
           "Use PR_RISCV_CTX_SW_FENCEI_ON to avoid explicit icache flush")
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -6502,7 +6502,7 @@ static const int64_t right_3_bits = right_n_bits(3);
       StubRoutines::_poly1305_processBlocks = generate_poly1305_processBlocks();
     }
 
-    if (UseRVVForBigIntegerShiftIntrinsics) {
+    if (UseRVV) {
       StubRoutines::_bigIntegerLeftShiftWorker = generate_bigIntegerLeftShift();
       StubRoutines::_bigIntegerRightShiftWorker = generate_bigIntegerRightShift();
     }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -233,7 +233,6 @@ void VM_Version::c2_initialize() {
 
   if (!UseRVV) {
     FLAG_SET_DEFAULT(MaxVectorSize, 0);
-    FLAG_SET_DEFAULT(UseRVVForBigIntegerShiftIntrinsics, false);
   } else {
     if (!FLAG_IS_DEFAULT(MaxVectorSize) && MaxVectorSize != _initial_vector_length) {
       warning("Current system does not support RVV vector length for MaxVectorSize %d. Set MaxVectorSize to %d",


### PR DESCRIPTION
Seem that it's more reasonable to control BigInteger shift intrinsics with`UseRVV` option.
I witnessed performance benefit on BPI-F3 with the RISC-V vector extension. And it's still
possible to disable these two intrinsics with `-XX:DisableIntrinsic` option.

JMH on BPI-F3 for reference:
```
Without instrinsic:
BigIntegers.testLeftShift                        N/A  avgt   15      4083.865 ±   224.139  ns/op
BigIntegers.testRightShift                       N/A  avgt   15      1745.833 ±    44.855  ns/op

With instrinsic:
BigIntegers.testLeftShift                        N/A  avgt   15      2243.095 ±    24.821  ns/op
BigIntegers.testRightShift                       N/A  avgt   15      1558.770 ±    36.191  ns/op
```