### PR TITLE
8344387: RISC-V: C2: Improve encoding of LoadNKlass for compact headers

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -3124,13 +3124,3 @@ void C2_MacroAssembler::extract_fp_v(FloatRegister dst, VectorRegister src, Basi
     vfmv_f_s(dst, tmp);
   }
 }
-
-void C2_MacroAssembler::load_narrow_klass_compact_c2(Register dst, Address src) {
-  // The incoming address is pointing into obj-start + klass_offset_in_bytes. We need to extract
-  // obj-start, so that we can load from the object's mark-word instead. Usually the address
-  // comes as obj-start in obj and klass_offset_in_bytes in disp.
-  assert(UseCompactObjectHeaders, "must");
-  int offset = oopDesc::mark_offset_in_bytes() - oopDesc::klass_offset_in_bytes();
-  ld(dst, Address(src.base(), src.offset() + offset));
-  srli(dst, dst, markWord::klass_shift);
-}

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -281,6 +281,4 @@
   void extract_v(Register dst, VectorRegister src, BasicType bt, int idx, VectorRegister tmp);
   void extract_fp_v(FloatRegister dst, VectorRegister src, BasicType bt, int idx, VectorRegister tmp);
 
-  void load_narrow_klass_compact_c2(Register dst, Address src);
-
 #endif // CPU_RISCV_C2_MACROASSEMBLER_RISCV_HPP

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -4814,10 +4814,14 @@ instruct loadNKlassCompactHeaders(iRegNNoSp dst, memory mem)
   match(Set dst (LoadNKlass mem));
 
   ins_cost(LOAD_COST);
-  format %{ "load_narrow_klass_compact $dst, $mem\t# compressed class ptr, #@loadNKlassCompactHeaders" %}
+  format %{
+    "lwu  $dst, $mem\t# compressed klass ptr, shifted\n\t"
+    "srli $dst, $dst, markWord::klass_shift_at_offset"
+  %}
 
   ins_encode %{
-    __ load_narrow_klass_compact_c2(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
+    __ lwu(as_Register($dst$$reg), Address(as_Register($mem$$base), $mem$$disp));
+    __ srli(as_Register($dst$$reg), as_Register($dst$$reg), (unsigned) markWord::klass_shift_at_offset);
   %}
 
   ins_pipe(iload_reg_mem);


### PR DESCRIPTION
Hi,
Can you help to review this patch? This is a follow-up of 8340453 on riscv.
Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344387](https://bugs.openjdk.org/browse/JDK-8344387): RISC-V: C2: Improve encoding of LoadNKlass for compact headers (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Ludovic Henry](https://openjdk.org/census#luhenry) (@luhenry - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22203/head:pull/22203` \
`$ git checkout pull/22203`

Update a local copy of the PR: \
`$ git checkout pull/22203` \
`$ git pull https://git.openjdk.org/jdk.git pull/22203/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22203`

View PR using the GUI difftool: \
`$ git pr show -t 22203`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22203.diff">https://git.openjdk.org/jdk/pull/22203.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22203#issuecomment-2482793816)
</details>
