### PR TITLE
8344134: Use static property in SystemLookup

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SystemLookup.java
@@ -35,6 +35,7 @@ import java.util.function.Function;
 import jdk.internal.loader.NativeLibrary;
 import jdk.internal.loader.RawNativeLibraries;
 import jdk.internal.util.OperatingSystem;
+import jdk.internal.util.StaticProperty;
 
 import static java.lang.foreign.ValueLayout.ADDRESS;
 
@@ -125,7 +126,7 @@ public final class SystemLookup implements SymbolLookup {
      * Returns the path of the given library name from JDK
      */
     private static Path jdkLibraryPath(String name) {
-        Path javahome = Path.of(System.getProperty("java.home"));
+        Path javahome = Path.of(StaticProperty.javaHome());
         String lib = OperatingSystem.isWindows() ? "bin" : "lib";
         String libname = System.mapLibraryName(name);
         return javahome.resolve(lib).resolve(libname);


### PR DESCRIPTION
This PR proposes to use a static property already resolved instead of calling `System.getProperty()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344134](https://bugs.openjdk.org/browse/JDK-8344134): Use static property in SystemLookup (**Enhancement** - P5)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22205/head:pull/22205` \
`$ git checkout pull/22205`

Update a local copy of the PR: \
`$ git checkout pull/22205` \
`$ git pull https://git.openjdk.org/jdk.git pull/22205/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22205`

View PR using the GUI difftool: \
`$ git pr show -t 22205`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22205.diff">https://git.openjdk.org/jdk/pull/22205.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22205#issuecomment-2482944017)
</details>
