### PR TITLE
8336087: Doccheck: the jpackage command page doesn't show the correct command-line options

### DIFF
--- a/src/jdk.jpackage/share/man/jpackage.md
+++ b/src/jdk.jpackage/share/man/jpackage.md
@@ -438,7 +438,7 @@ The `jpackage` tool will take as input a Java application and a Java run-time im
 
 <a id="option-linux-app-category">`--linux-app-category` *category-value*</a>
 
-:   Group value of the RPM /<name/>.spec file or
+:   Group value of the RPM \<name\>.spec file or
     Section value of DEB control file
 
 <a id="option-linux-shortcut">`--linux-shortcut`</a>


### PR DESCRIPTION
Simple typo fix.

Old view: https://github.com/openjdk/jdk/blob/dfddbcaab886b9baa731cd748bb7f547e1903b64/src/jdk.jpackage/share/man/jpackage.md

New view: https://github.com/alexeysemenyukoracle/jdk/blob/JDK-8336087/src/jdk.jpackage/share/man/jpackage.md

Navigate to "Group value of the RPM" text to see the diff

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336087](https://bugs.openjdk.org/browse/JDK-8336087): Doccheck: the jpackage command page doesn't show the correct command-line options (**Bug** - P3)


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22206/head:pull/22206` \
`$ git checkout pull/22206`

Update a local copy of the PR: \
`$ git checkout pull/22206` \
`$ git pull https://git.openjdk.org/jdk.git pull/22206/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22206`

View PR using the GUI difftool: \
`$ git pr show -t 22206`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22206.diff">https://git.openjdk.org/jdk/pull/22206.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22206#issuecomment-2483049124)
</details>
