### PR TITLE
8344253: Test java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java failed

### DIFF
--- a/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
+++ b/src/java.base/share/classes/java/util/concurrent/ConcurrentSkipListMap.java
@@ -3165,7 +3165,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                         current = n;
                         Index<K,V> r = q.down;
                         row = (s.right != null) ? s : s.down;
-                        est -= est >>> 2;
+                        est >>>= 1;
                         return new KeySpliterator<K,V>(cmp, r, e, sk, est);
                     }
                 }
@@ -3255,7 +3255,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                         current = n;
                         Index<K,V> r = q.down;
                         row = (s.right != null) ? s : s.down;
-                        est -= est >>> 2;
+                        est >>>= 1;
                         return new ValueSpliterator<K,V>(cmp, r, e, sk, est);
                     }
                 }
@@ -3341,7 +3341,7 @@ public class ConcurrentSkipListMap<K,V> extends AbstractMap<K,V>
                         current = n;
                         Index<K,V> r = q.down;
                         row = (s.right != null) ? s : s.down;
-                        est -= est >>> 2;
+                        est >>>= 1;
                         return new EntrySpliterator<K,V>(cmp, r, e, sk, est);
                     }
                 }


### PR DESCRIPTION
This change now halves each side of the split regardless, the old code would end up in a situation where it wouldn't decrement since unsigned shift right twice would lead to decrementing estimated size by 0.

It's worth noting the probabilistic nature of skip lists and that their spliterators are not SIZED and their estimatedSize() is therefor not to be relied upon for deterministic correctness.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344253](https://bugs.openjdk.org/browse/JDK-8344253): Test java/util/Spliterator/SpliteratorTraversingAndSplittingTest.java failed (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22210/head:pull/22210` \
`$ git checkout pull/22210`

Update a local copy of the PR: \
`$ git checkout pull/22210` \
`$ git pull https://git.openjdk.org/jdk.git pull/22210/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22210`

View PR using the GUI difftool: \
`$ git pr show -t 22210`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22210.diff">https://git.openjdk.org/jdk/pull/22210.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22210#issuecomment-2483443403)
</details>
