### PR TITLE
8343598: Since Checker can mark some preview elements as new even if bytecode reference is identical

### DIFF
--- a/test/jdk/tools/sincechecker/SinceChecker.java
+++ b/test/jdk/tools/sincechecker/SinceChecker.java
@@ -515,11 +515,7 @@ public class SinceChecker {
                     .collect(Collectors.joining(",", "(", ")"));
             suffix = ": " + returnType + " " + te.getQualifiedName() + "." + methodName + descriptor;
         } else if (kind.isDeclaredType()) {
-            if (kind.isClass()) {
-                prefix = "class";
-            } else if (kind.isInterface()) {
-                prefix = "interface";
-            }
+            prefix = "class";
             suffix = ": " + ((TypeElement) element).getQualifiedName();
         } else if (kind == ElementKind.PACKAGE) {
             prefix = "package";
@@ -562,7 +558,7 @@ public class SinceChecker {
                 "field: com.sun.source.tree.CaseTree.CaseKind:STATEMENT",
                 "field: com.sun.source.tree.CaseTree.CaseKind:RULE",
                 "field: com.sun.source.tree.Tree.Kind:SWITCH_EXPRESSION",
-                "interface: com.sun.source.tree.SwitchExpressionTree",
+                "class: com.sun.source.tree.SwitchExpressionTree",
                 "method: com.sun.source.tree.ExpressionTree com.sun.source.tree.SwitchExpressionTree.getExpression()",
                 "method: java.util.List com.sun.source.tree.SwitchExpressionTree.getCases()",
                 "method: java.lang.Object com.sun.source.tree.TreeVisitor.visitSwitchExpression(com.sun.source.tree.SwitchExpressionTree,java.lang.Object)",
@@ -580,7 +576,7 @@ public class SinceChecker {
                 "field: com.sun.source.tree.CaseTree.CaseKind:STATEMENT",
                 "field: com.sun.source.tree.CaseTree.CaseKind:RULE",
                 "field: com.sun.source.tree.Tree.Kind:SWITCH_EXPRESSION",
-                "interface: com.sun.source.tree.SwitchExpressionTree",
+                "class: com.sun.source.tree.SwitchExpressionTree",
                 "method: com.sun.source.tree.ExpressionTree com.sun.source.tree.SwitchExpressionTree.getExpression()",
                 "method: java.util.List com.sun.source.tree.SwitchExpressionTree.getCases()",
                 "method: java.lang.Object com.sun.source.tree.TreeVisitor.visitSwitchExpression(com.sun.source.tree.SwitchExpressionTree,java.lang.Object)",
@@ -591,7 +587,7 @@ public class SinceChecker {
                 "method: java.lang.String java.lang.String.formatted(java.lang.Object[])",
                 "class: javax.swing.plaf.basic.motif.MotifLookAndFeel",
                 "field: com.sun.source.tree.Tree.Kind:YIELD",
-                "interface: com.sun.source.tree.YieldTree",
+                "class: com.sun.source.tree.YieldTree",
                 "method: com.sun.source.tree.ExpressionTree com.sun.source.tree.YieldTree.getValue()",
                 "method: java.lang.Object com.sun.source.tree.TreeVisitor.visitYield(com.sun.source.tree.YieldTree,java.lang.Object)",
                 "method: java.lang.Object com.sun.source.util.SimpleTreeVisitor.visitYield(com.sun.source.tree.YieldTree,java.lang.Object)",
@@ -625,10 +621,10 @@ public class SinceChecker {
                 "method: boolean java.lang.Class.isRecord()",
                 "method: java.lang.reflect.RecordComponent[] java.lang.Class.getRecordComponents()",
                 "class: java.lang.Record",
-                "interface: com.sun.source.tree.PatternTree",
+                "class: com.sun.source.tree.PatternTree",
                 "field: com.sun.source.tree.Tree.Kind:BINDING_PATTERN",
                 "method: com.sun.source.tree.PatternTree com.sun.source.tree.InstanceOfTree.getPattern()",
-                "interface: com.sun.source.tree.BindingPatternTree",
+                "class: com.sun.source.tree.BindingPatternTree",
                 "method: java.lang.Object com.sun.source.tree.TreeVisitor.visitBindingPattern(com.sun.source.tree.BindingPatternTree,java.lang.Object)"
         ));
 
@@ -664,10 +660,10 @@ public class SinceChecker {
                 "method: java.util.List com.sun.source.tree.ClassTree.getPermitsClause()",
                 "method: boolean java.lang.Class.isSealed()",
                 "method: java.lang.constant.ClassDesc[] java.lang.Class.permittedSubclasses()",
-                "interface: com.sun.source.tree.PatternTree",
+                "class: com.sun.source.tree.PatternTree",
                 "field: com.sun.source.tree.Tree.Kind:BINDING_PATTERN",
                 "method: com.sun.source.tree.PatternTree com.sun.source.tree.InstanceOfTree.getPattern()",
-                "interface: com.sun.source.tree.BindingPatternTree",
+                "class: com.sun.source.tree.BindingPatternTree",
                 "method: java.lang.Object com.sun.source.tree.TreeVisitor.visitBindingPattern(com.sun.source.tree.BindingPatternTree,java.lang.Object)"
         ));
 


### PR DESCRIPTION
Can I get a review for this test only change to the Since Checker?

I drop the distinction between classes and interfaces when generating ids and use a generic name "class" to describe both, as to not consider classes that get converted to interfaces (and vice versa) as new API (Something that may happen to APIs in preview).

TIA.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343598](https://bugs.openjdk.org/browse/JDK-8343598): Since Checker can mark some preview elements as new even if bytecode reference is identical (**Bug** - P4)


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22213/head:pull/22213` \
`$ git checkout pull/22213`

Update a local copy of the PR: \
`$ git checkout pull/22213` \
`$ git pull https://git.openjdk.org/jdk.git pull/22213/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22213`

View PR using the GUI difftool: \
`$ git pr show -t 22213`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22213.diff">https://git.openjdk.org/jdk/pull/22213.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22213#issuecomment-2483647319)
</details>
