### PR TITLE
8344445: MethodCounters don't need a vptr

### DIFF
--- a/src/hotspot/share/oops/metadata.hpp
+++ b/src/hotspot/share/oops/metadata.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,11 +44,10 @@ class Metadata : public MetaspaceObj {
   virtual bool is_method()             const { return false; }
   virtual bool is_methodData()         const { return false; }
   virtual bool is_constantPool()       const { return false; }
-  virtual bool is_methodCounters()     const { return false; }
   virtual int  size()                  const = 0;
   virtual MetaspaceObj::Type type()    const = 0;
   virtual const char* internal_name()  const = 0;
-  virtual void metaspace_pointers_do(MetaspaceClosure* iter) {}
+  virtual void metaspace_pointers_do(MetaspaceClosure* iter) = 0;
 
   void print()       const;
   void print_value() const;

--- a/src/hotspot/share/oops/methodCounters.cpp
+++ b/src/hotspot/share/oops/methodCounters.cpp
@@ -50,12 +50,12 @@ MethodCounters::MethodCounters(const methodHandle& mh) :
 
 MethodCounters* MethodCounters::allocate_no_exception(const methodHandle& mh) {
   ClassLoaderData* loader_data = mh->method_holder()->class_loader_data();
-  return new(loader_data, method_counters_size(), MetaspaceObj::MethodCountersType) MethodCounters(mh);
+  return new(loader_data, size(), MetaspaceObj::MethodCountersType) MethodCounters(mh);
 }
 
 MethodCounters* MethodCounters::allocate_with_exception(const methodHandle& mh, TRAPS) {
   ClassLoaderData* loader_data = mh->method_holder()->class_loader_data();
-  return new(loader_data, method_counters_size(), MetaspaceObj::MethodCountersType, THREAD) MethodCounters(mh);
+  return new(loader_data, size(), MetaspaceObj::MethodCountersType, THREAD) MethodCounters(mh);
 }
 
 void MethodCounters::clear_counters() {

--- a/src/hotspot/share/oops/methodCounters.cpp
+++ b/src/hotspot/share/oops/methodCounters.cpp
@@ -70,7 +70,6 @@ void MethodCounters::clear_counters() {
 }
 
 void MethodCounters::print_value_on(outputStream* st) const {
-  assert(is_methodCounters(), "must be methodCounters");
   st->print("method counters");
   print_address_on(st);
 }

--- a/src/hotspot/share/oops/methodCounters.hpp
+++ b/src/hotspot/share/oops/methodCounters.hpp
@@ -30,7 +30,7 @@
 #include "interpreter/invocationCounter.hpp"
 #include "utilities/align.hpp"
 
-class MethodCounters : public Metadata {
+class MethodCounters : public MetaspaceObj {
  friend class VMStructs;
  friend class JVMCIVMStructs;
  private:
@@ -52,17 +52,18 @@ class MethodCounters : public Metadata {
 
   MethodCounters(const methodHandle& mh);
  public:
-  virtual bool is_methodCounters() const { return true; }
-
   static MethodCounters* allocate_no_exception(const methodHandle& mh);
   static MethodCounters* allocate_with_exception(const methodHandle& mh, TRAPS);
 
+  DEBUG_ONLY(bool on_stack() { return false; })
   void deallocate_contents(ClassLoaderData* loader_data) {}
+
+  void metaspace_pointers_do(MetaspaceClosure* it) { return; }
 
   static int method_counters_size() {
     return align_up((int)sizeof(MethodCounters), wordSize) / wordSize;
   }
-  virtual int size() const {
+  int size() const {
     return method_counters_size();
   }
   MetaspaceObj::Type type() const { return MethodCountersType; }
@@ -128,8 +129,7 @@ class MethodCounters : public Metadata {
     return byte_offset_of(MethodCounters, _backedge_mask);
   }
 
-  virtual const char* internal_name() const { return "{method counters}"; }
-  virtual void print_value_on(outputStream* st) const;
-
+  const char* internal_name() const { return "{method counters}"; }
+  void print_value_on(outputStream* st) const;
 };
 #endif // SHARE_OOPS_METHODCOUNTERS_HPP

--- a/src/hotspot/share/oops/methodCounters.hpp
+++ b/src/hotspot/share/oops/methodCounters.hpp
@@ -60,12 +60,10 @@ class MethodCounters : public MetaspaceObj {
 
   void metaspace_pointers_do(MetaspaceClosure* it) { return; }
 
-  static int method_counters_size() {
+  static int size() {
     return align_up((int)sizeof(MethodCounters), wordSize) / wordSize;
   }
-  int size() const {
-    return method_counters_size();
-  }
+
   MetaspaceObj::Type type() const { return MethodCountersType; }
   void clear_counters();
 


### PR DESCRIPTION
This is a somewhat trivial change to make MethodCounters inherit from MetaspaceObj so that they don't have any virtual functions (and vptrs).  They're just a bunch of ints.

Tested with tier1-4.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344445](https://bugs.openjdk.org/browse/JDK-8344445): MethodCounters don't need a vptr (**Enhancement** - P4)


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) Review applies to [fafb86ff](https://git.openjdk.org/jdk/pull/22220/files/fafb86ff47dd06d715e76107d8df2e489b3963df)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22220/head:pull/22220` \
`$ git checkout pull/22220`

Update a local copy of the PR: \
`$ git checkout pull/22220` \
`$ git pull https://git.openjdk.org/jdk.git pull/22220/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22220`

View PR using the GUI difftool: \
`$ git pr show -t 22220`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22220.diff">https://git.openjdk.org/jdk/pull/22220.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22220#issuecomment-2484088770)
</details>
