### PR TITLE
8340334: Update jcmd VM.events max parameter to be INT

### DIFF
--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -884,27 +884,23 @@ void CodeHeapAnalyticsDCmd::execute(DCmdSource source, TRAPS) {
 EventLogDCmd::EventLogDCmd(outputStream* output, bool heap) :
   DCmdWithParser(output, heap),
   _log("log", "Name of log to be printed. If omitted, all logs are printed.", "STRING", false, nullptr),
-  _max("max", "Maximum number of events to be printed (newest first). If omitted, all events are printed.", "STRING", false, nullptr)
+  _max("max", "Maximum number of events to be printed (newest first). If omitted or zero, all events are printed.", "INT", false, "0")
 {
   _dcmdparser.add_dcmd_option(&_log);
   _dcmdparser.add_dcmd_option(&_max);
 }
 
 void EventLogDCmd::execute(DCmdSource source, TRAPS) {
-  const char* max_value = _max.value();
-  int max = -1;
-  if (max_value != nullptr) {
-    char* endptr = nullptr;
-    if (!parse_integer(max_value, &max)) {
-      output()->print_cr("Invalid max option: \"%s\".", max_value);
-      return;
-    }
+  int max_value = (int)_max.value();
+  if (max_value < 0) {
+    output()->print_cr("Invalid max option: \"%d\".", max_value);
+    return;
   }
   const char* log_name = _log.value();
   if (log_name != nullptr) {
-    Events::print_one(output(), log_name, max);
+    Events::print_one(output(), log_name, max_value);
   } else {
-    Events::print_all(output(), max);
+    Events::print_all(output(), max_value);
   }
 }
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -891,16 +891,16 @@ EventLogDCmd::EventLogDCmd(outputStream* output, bool heap) :
 }
 
 void EventLogDCmd::execute(DCmdSource source, TRAPS) {
-  int max_value = (int)_max.value();
-  if (max_value < 0) {
-    output()->print_cr("Invalid max option: \"%d\".", max_value);
+  int max = (int)_max.value();
+  if (max < 0) {
+    output()->print_cr("Invalid max option: \"%d\".", max);
     return;
   }
   const char* log_name = _log.value();
   if (log_name != nullptr) {
-    Events::print_one(output(), log_name, max_value);
+    Events::print_one(output(), log_name, max);
   } else {
-    Events::print_all(output(), max_value);
+    Events::print_all(output(), max);
   }
 }
 

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -889,7 +889,7 @@ public:
 class EventLogDCmd : public DCmdWithParser {
 protected:
   DCmdArgument<char*> _log;
-  DCmdArgument<char*> _max;
+  DCmdArgument<jlong> _max;
 public:
   static int num_arguments() { return 2; }
   EventLogDCmd(outputStream* output, bool heap);

--- a/src/jdk.jcmd/share/man/jcmd.md
+++ b/src/jdk.jcmd/share/man/jcmd.md
@@ -836,7 +836,7 @@ The following commands are available:
     -   `log`: (Optional) Name of log to be printed.
         If omitted, all logs are printed. (STRING, no default value)
     -   `max`: (Optional) Maximum number of events to be printed (newest first).
-        If omitted, all events are printed. (STRING, no default value)
+        If omitted or zero, all events are printed. (INT, 0)
 
 `VM.flags` \[*options*\]
 :   Print the VM flag options and their current values.


### PR DESCRIPTION
The  jcmd VM.events max parameter type is changed to INT.
Also,I noted the max <= 0 is ignored, so I updated documentation and set "0" as a default value.
The jcmd exists if parameter is negative now.

The `max` is `int` while really it is the unsigned int. However I don't think it makes sense to change it to `size_t` or `unsigned int` in all places where 'max' is used.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340334](https://bugs.openjdk.org/browse/JDK-8340334): Update jcmd VM.events max parameter to be INT (**Enhancement** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**) Review applies to [3e80f1b5](https://git.openjdk.org/jdk/pull/22224/files/3e80f1b5be48f1d43ea13ff040cf3b770654cde8)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22224/head:pull/22224` \
`$ git checkout pull/22224`

Update a local copy of the PR: \
`$ git checkout pull/22224` \
`$ git pull https://git.openjdk.org/jdk.git pull/22224/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22224`

View PR using the GUI difftool: \
`$ git pr show -t 22224`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22224.diff">https://git.openjdk.org/jdk/pull/22224.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22224#issuecomment-2484473495)
</details>
