### PR TITLE
8344446: Remove security manager dependency from module jdk.sctp

### DIFF
--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -1082,7 +1082,7 @@ public class SctpChannelImpl extends SctpChannel
         loadSctpLibrary();
     }
 
-    @SuppressWarnings({"removal", "restricted"})
+    @SuppressWarnings({"restricted"})
     private static void loadSctpLibrary() {
         IOUtil.load();   /* loads nio & net native libraries */
         System.loadLibrary("sctp");

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -1082,7 +1082,7 @@ public class SctpChannelImpl extends SctpChannel
         loadSctpLibrary();
     }
 
-    @SuppressWarnings({"restricted"})
+    @SuppressWarnings("restricted")
     private static void loadSctpLibrary() {
         IOUtil.load();   /* loads nio & net native libraries */
         System.loadLibrary("sctp");

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,6 @@ import java.net.SocketException;
 import java.net.InetSocketAddress;
 import java.io.FileDescriptor;
 import java.io.IOException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Collections;
 import java.util.Set;
 import java.util.HashSet;
@@ -194,11 +192,6 @@ public class SctpChannelImpl extends SctpChannel
                         SctpNet.throwAlreadyBoundException();
                     InetSocketAddress isa = (local == null) ?
                         new InetSocketAddress(0) : Net.checkAddress(local);
-                    @SuppressWarnings("removal")
-                    SecurityManager sm = System.getSecurityManager();
-                    if (sm != null) {
-                        sm.checkListen(isa.getPort());
-                    }
                     Net.bind(fd, isa.getAddress(), isa.getPort());
                     InetSocketAddress boundIsa = Net.localAddress(fd);
                     port = boundIsa.getPort();
@@ -364,11 +357,6 @@ public class SctpChannelImpl extends SctpChannel
             synchronized (sendLock) {
                 ensureOpenAndUnconnected();
                 InetSocketAddress isa = Net.checkAddress(endpoint);
-                @SuppressWarnings("removal")
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null)
-                    sm.checkConnect(isa.getAddress().getHostAddress(),
-                                    isa.getPort());
                 synchronized (blockingLock()) {
                     int n = 0;
                     try {
@@ -1097,13 +1085,7 @@ public class SctpChannelImpl extends SctpChannel
     @SuppressWarnings({"removal", "restricted"})
     private static void loadSctpLibrary() {
         IOUtil.load();   /* loads nio & net native libraries */
-        AccessController.doPrivileged(
-            new PrivilegedAction<>() {
-                public Void run() {
-                    System.loadLibrary("sctp");
-                    return null;
-                }
-            });
+        System.loadLibrary("sctp");
         initIDs();
     }
 }

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpMultiChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -149,10 +149,6 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
                     InetSocketAddress isa = (local == null) ?
                         new InetSocketAddress(0) : Net.checkAddress(local);
 
-                    @SuppressWarnings("removal")
-                    SecurityManager sm = System.getSecurityManager();
-                    if (sm != null)
-                        sm.checkListen(isa.getPort());
                     Net.bind(fd, isa.getAddress(), isa.getPort());
 
                     InetSocketAddress boundIsa = Net.localAddress(fd);
@@ -508,21 +504,6 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
                                     resultContainer.getMessageInfo();
                             info.setAssociation(lookupAssociation(info.
                                     associationID()));
-                            @SuppressWarnings("removal")
-                            SecurityManager sm = System.getSecurityManager();
-                            if (sm != null) {
-                                InetSocketAddress isa  = (InetSocketAddress)info.address();
-                                if (!addressMap.containsKey(isa)) {
-                                    /* must be a new association */
-                                    try {
-                                        sm.checkAccept(isa.getAddress().getHostAddress(),
-                                                       isa.getPort());
-                                    } catch (SecurityException se) {
-                                        buffer.clear();
-                                        throw se;
-                                    }
-                                }
-                            }
 
                             assert info.association() != null;
                             return info;
@@ -805,12 +786,6 @@ public class SctpMultiChannelImpl extends SctpMultiChannel
                             checkStreamNumber(association, messageInfo.streamNumber());
                             assocId = association.associationID();
 
-                        } else { /* must be new association */
-                            @SuppressWarnings("removal")
-                            SecurityManager sm = System.getSecurityManager();
-                            if (sm != null)
-                                sm.checkConnect(addr.getAddress().getHostAddress(),
-                                                addr.getPort());
                         }
                     } else {
                         throw new AssertionError(

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
@@ -213,7 +213,6 @@ public class SctpServerChannelImpl extends SctpServerChannel
                 throw new ClosedChannelException();
             if (!isBound())
                 throw new NotYetBoundException();
-            SctpChannel sc = null;
 
             int n = 0;
             FileDescriptor newfd = new FileDescriptor();

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
@@ -240,10 +240,7 @@ public class SctpServerChannelImpl extends SctpServerChannel
                 return null;
 
             IOUtil.configureBlocking(newfd, true);
-            InetSocketAddress isa = isaa[0];
-            sc = new SctpChannelImpl(provider(), newfd);
-
-            return sc;
+            return new SctpChannelImpl(provider(), newfd);
         }
     }
 

--- a/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
+++ b/src/jdk.sctp/unix/classes/sun/nio/ch/sctp/SctpServerChannelImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -109,10 +109,6 @@ public class SctpServerChannelImpl extends SctpServerChannel
 
                 InetSocketAddress isa = (local == null) ?
                     new InetSocketAddress(0) : Net.checkAddress(local);
-                @SuppressWarnings("removal")
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null)
-                    sm.checkListen(isa.getPort());
                 Net.bind(fd, isa.getAddress(), isa.getPort());
 
                 InetSocketAddress boundIsa = Net.localAddress(fd);
@@ -246,12 +242,6 @@ public class SctpServerChannelImpl extends SctpServerChannel
             IOUtil.configureBlocking(newfd, true);
             InetSocketAddress isa = isaa[0];
             sc = new SctpChannelImpl(provider(), newfd);
-
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null)
-                sm.checkAccept(isa.getAddress().getHostAddress(),
-                               isa.getPort());
 
             return sc;
         }


### PR DESCRIPTION
Expunge the use of the `SecurityManager`, `AccessController`, and the like from the `jdk.sctp` module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344446](https://bugs.openjdk.org/browse/JDK-8344446): Remove security manager dependency from module jdk.sctp (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) Review applies to [5e8c8d7a](https://git.openjdk.org/jdk/pull/22225/files/5e8c8d7aee18318d2df7ac3ef375cc895e88e9de)
 * [Sean Mullan](https://openjdk.org/census#mullan) (@seanjmullan - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22225/head:pull/22225` \
`$ git checkout pull/22225`

Update a local copy of the PR: \
`$ git checkout pull/22225` \
`$ git pull https://git.openjdk.org/jdk.git pull/22225/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22225`

View PR using the GUI difftool: \
`$ git pr show -t 22225`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22225.diff">https://git.openjdk.org/jdk/pull/22225.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22225#issuecomment-2484512963)
</details>
