### PR TITLE
8344239: runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java fails on x64 with -Xmixed

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
@@ -39,7 +39,7 @@ import jdk.test.whitebox.WhiteBox;
 public class AddmodsOption {
 
     private static final WhiteBox WB = WhiteBox.getWhiteBox();
-    private static final boolean isJVMCISupported = (WB.getBooleanVMFlag("EnableJVMCI") != null);
+    private static final boolean isJVMCISupported = WB.getBooleanVMFlag("EnableJVMCI");
 
     public static void main(String[] args) throws Exception {
         final String moduleOption = "jdk.httpserver/sun.net.httpserver.simpleserver.Main";


### PR DESCRIPTION
A simple test fix to correct the setting of the `isJVMCISupported` boolean variable.

Ran the test successfully on linux-x64 with and without the `-Xmixed` VM option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344239](https://bugs.openjdk.org/browse/JDK-8344239): runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java fails on x64 with -Xmixed (**Bug** - P4)


### Reviewers
 * [Ioi Lam](https://openjdk.org/census#iklam) (@iklam - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22226/head:pull/22226` \
`$ git checkout pull/22226`

Update a local copy of the PR: \
`$ git checkout pull/22226` \
`$ git pull https://git.openjdk.org/jdk.git pull/22226/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22226`

View PR using the GUI difftool: \
`$ git pr show -t 22226`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22226.diff">https://git.openjdk.org/jdk/pull/22226.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22226#issuecomment-2484801150)
</details>
