### PR TITLE
8341935: javac states that -proc:full is the default but the default as of 23 is -proc:none

### DIFF
--- a/src/jdk.compiler/share/man/javac.md
+++ b/src/jdk.compiler/share/man/javac.md
@@ -336,10 +336,15 @@ file system locations may be directories, JAR files or JMOD files.
 
 <a id="option-proc">`-proc:`\[`none`, `only`, `full`\]</a>
 :   Controls whether annotation processing and compilation are done.
-    `-proc:none` means that compilation takes place without annotation
-    processing. `-proc:only` means that only annotation processing is done,
-    without any subsequent compilation. and
-    `-proc:full` means annotation processing and compilation are done.
+
+    -   `-proc:none` means that compilation takes place without annotation
+    processing
+
+    -   `-proc:only` means that only annotation processing is done,
+    without any subsequent compilation.
+
+    -   `-proc:full` means annotation processing and compilation are done.
+
     If this option is not used, annotation processing and compilation
     are done if at least one other option is used to explicitly
     configure annotation processing.

--- a/src/jdk.compiler/share/man/javac.md
+++ b/src/jdk.compiler/share/man/javac.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -338,8 +338,11 @@ file system locations may be directories, JAR files or JMOD files.
 :   Controls whether annotation processing and compilation are done.
     `-proc:none` means that compilation takes place without annotation
     processing. `-proc:only` means that only annotation processing is done,
-    without any subsequent compilation. If this option is not used, or
-    `-proc:full` is specified, annotation processing and compilation are done.
+    without any subsequent compilation. and
+    `-proc:full` means annotation processing and compilation are done.
+    If this option is not used, annotation processing and compilation
+    are done if at least one other option is used to explicitly
+    configure annotation processing.
 
 <a id="option-processor">`-processor` *class1*\[`,`*class2*`,`*class3*...\]</a>
 :   Names of the annotation processors to run. This bypasses the default
@@ -1427,15 +1430,26 @@ The API for annotation processors is defined in the
 
 ### How Annotation Processing Works
 
-Unless annotation processing is disabled with the [`-proc:none`](#option-proc) option, the
-compiler searches for any annotation processors that are available. The search
-path can be specified with the [`-processorpath`](#option-processor-path) option. If no path is
-specified, then the user class path is used. Processors are located by means of
-service provider-configuration files named
-`META-INF/services/javax.annotation.processing.Processor` on the search path.
-Such files should contain the names of any annotation processors to be used,
-listed one per line. Alternatively, processors can be specified explicitly,
-using the [`-processor`](#option-processor) option.
+Annotation processing is requested by using an option to configure
+annotation processing, such as [`-processor`](#option-processor),
+[`--processor-path`](#option-processor-path),
+[`--processor-module-path`](#option-processor-module-path) or by
+explicitly enabling processing with the [`-proc:full`](#option-proc)
+or [`-proc:only`](#option-proc) options.  Annotation processing is
+disabled using the [`-proc:none`](#option-proc) option.
+
+If annotation processing is requested, the compiler searches for any
+annotation processors that are available.
+
+The search path can be specified with the
+[`-processorpath`](#option-processor-path) option. If no path is
+specified, then the user class path is used. Processors are located by
+means of service provider-configuration files named
+`META-INF/services/javax.annotation.processing.Processor` on the
+search path.  Such files should contain the names of any
+annotationation processors to be used, listed one per
+line. Alternatively, processors can be specified explicitly, using the
+[`-processor`](#option-processor) option.
 
 After scanning the source files and classes on the command line to determine
 what annotations are present, the compiler queries the processors to determine


### PR DESCRIPTION
Update javac man page is describe current behavior; includes updates discussed in CSR [JDK-8321319](https://bugs.openjdk.org/browse/JDK-8321319) that were not included in the man pages for JDK 23 GA.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8344477](https://bugs.openjdk.org/browse/JDK-8344477) to be approved

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8341935: javac states that -proc:full is the default but the default as of 23 is -proc:none`

### Issues
 * [JDK-8341935](https://bugs.openjdk.org/browse/JDK-8341935): javac states that -proc:full is the default but the default as of 23 is -proc:none (**Bug** - P3)
 * [JDK-8344477](https://bugs.openjdk.org/browse/JDK-8344477): javac states that -proc:full is the default but the default as of 23 is -proc:none (**CSR**)


### Reviewers
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22227/head:pull/22227` \
`$ git checkout pull/22227`

Update a local copy of the PR: \
`$ git checkout pull/22227` \
`$ git pull https://git.openjdk.org/jdk.git pull/22227/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22227`

View PR using the GUI difftool: \
`$ git pr show -t 22227`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22227.diff">https://git.openjdk.org/jdk/pull/22227.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22227#issuecomment-2484838699)
</details>
