### PR TITLE
8344471: Remove SecurityManager related code from java.compiler module

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/ToolProvider.java
+++ b/src/java.compiler/share/classes/javax/tools/ToolProvider.java
@@ -116,25 +116,13 @@ public class ToolProvider {
         try {
             ServiceLoader<T> sl = ServiceLoader.load(clazz, ClassLoader.getSystemClassLoader());
             for (T tool : sl) {
-                if (matches(tool, moduleName))
+                if (Objects.equals(tool.getClass().getModule().getName(), moduleName)) {
                     return tool;
+                }
             }
         } catch (ServiceConfigurationError e) {
             throw new Error(e);
         }
         return null;
-    }
-
-    /**
-     * Determine if this is the desired tool instance.
-     * @param <T>               the interface of the tool
-     * @param tool              the instance of the tool
-     * @param moduleName        the name of the module containing the desired implementation
-     * @return true if and only if the tool matches the specified criteria
-     */
-    private static <T> boolean matches(T tool, String moduleName) {
-        Module toolModule = tool.getClass().getModule();
-        String toolModuleName = toolModule.getName();
-        return Objects.equals(toolModuleName, moduleName);
     }
 }

--- a/src/java.compiler/share/classes/javax/tools/ToolProvider.java
+++ b/src/java.compiler/share/classes/javax/tools/ToolProvider.java
@@ -25,8 +25,6 @@
 
 package javax.tools;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
@@ -134,13 +132,9 @@ public class ToolProvider {
      * @param moduleName        the name of the module containing the desired implementation
      * @return true if and only if the tool matches the specified criteria
      */
-    @SuppressWarnings("removal")
     private static <T> boolean matches(T tool, String moduleName) {
-        PrivilegedAction<Boolean> pa = () -> {
-            Module toolModule = tool.getClass().getModule();
-            String toolModuleName = toolModule.getName();
-            return Objects.equals(toolModuleName, moduleName);
-        };
-        return AccessController.doPrivileged(pa);
+        Module toolModule = tool.getClass().getModule();
+        String toolModuleName = toolModule.getName();
+        return Objects.equals(toolModuleName, moduleName);
     }
 }


### PR DESCRIPTION
Can I please get a review of this change which cleans up the SecurityManager related usages from the `java.compiler` module? 

No new tests have been introduced and existing tests in tier1, tier2 and tier3 continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344471](https://bugs.openjdk.org/browse/JDK-8344471): Remove SecurityManager related code from java.compiler module (**Bug** - P4)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Jan Lahoda](https://openjdk.org/census#jlahoda) (@lahodaj - **Reviewer**)
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22229/head:pull/22229` \
`$ git checkout pull/22229`

Update a local copy of the PR: \
`$ git checkout pull/22229` \
`$ git pull https://git.openjdk.org/jdk.git pull/22229/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22229`

View PR using the GUI difftool: \
`$ git pr show -t 22229`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22229.diff">https://git.openjdk.org/jdk/pull/22229.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22229#issuecomment-2484977564)
</details>
