### PR TITLE
8344338: javax/swing/JTextArea/bug4265784.java fails on Ubuntu 24.04.1

### DIFF
--- a/test/jdk/javax/swing/JTextArea/bug4265784.java
+++ b/test/jdk/javax/swing/JTextArea/bug4265784.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,7 +50,7 @@ public class bug4265784 {
         try {
             SwingUtilities.invokeAndWait(() -> {
                 frame = new JFrame("bug4265784");
-                ta = new JTextArea();
+                ta = new JTextArea("some text", 50, 50);
                 frame.getContentPane().add(ta);
                 frame.pack();
                 frame.setLocationRelativeTo(null);


### PR DESCRIPTION
Test is seen to be passing locally but failing in OCI system...Although exact cause of failure is not known, making the JTexrArea bigger solves the issue thereby frame is not zero-sized and the test change is as present in the original issue JDK-4267291..
Several iterations of test passed in all platforms..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344338](https://bugs.openjdk.org/browse/JDK-8344338): javax/swing/JTextArea/bug4265784.java fails on Ubuntu 24.04.1 (**Bug** - P4)


### Reviewers
 * [Alisen Chung](https://openjdk.org/census#achung) (@alisenchung - Committer)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22230/head:pull/22230` \
`$ git checkout pull/22230`

Update a local copy of the PR: \
`$ git checkout pull/22230` \
`$ git pull https://git.openjdk.org/jdk.git pull/22230/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22230`

View PR using the GUI difftool: \
`$ git pr show -t 22230`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22230.diff">https://git.openjdk.org/jdk/pull/22230.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22230#issuecomment-2485025000)
</details>
