### PR TITLE
8344318: Enhance configure help for enabling/disabling single JVM features

### DIFF
--- a/make/autoconf/help.m4
+++ b/make/autoconf/help.m4
@@ -240,6 +240,7 @@ AC_DEFUN_ONCE([HELP_PRINT_ADDITIONAL_HELP_AND_EXIT],
 
     # Print available JVM features
     $PRINTF "The following JVM features are valid as arguments to --with-jvm-features.\n"
+    $PRINTF "The flag --enable-jvm-feature-<name>=no can be used to disable a single JVM feature.\n"
     $PRINTF "Which are available to use depends on the environment and JVM variant.\n"
     m4_foreach(FEATURE, m4_split(jvm_features_valid), [
       # Create an m4 variable containing the description for FEATURE.


### PR DESCRIPTION
The current help of OpenJDK configure could be enhanced a bit regarding enabling/disabling JVM features.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344318](https://bugs.openjdk.org/browse/JDK-8344318): Enhance configure help for enabling/disabling single JVM features (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22231/head:pull/22231` \
`$ git checkout pull/22231`

Update a local copy of the PR: \
`$ git checkout pull/22231` \
`$ git pull https://git.openjdk.org/jdk.git pull/22231/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22231`

View PR using the GUI difftool: \
`$ git pr show -t 22231`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22231.diff">https://git.openjdk.org/jdk/pull/22231.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22231#issuecomment-2485159710)
</details>
