### PR TITLE
8344190: Cleanup code in sun.net.www.protocol.http and sun.net.www.protocol.https after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationHeader.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationHeader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import java.util.HashMap;
 import java.util.Set;
 
 import sun.net.www.*;
-import sun.security.action.GetPropertyAction;
 
 /**
  * This class is used to parse the information in WWW-Authenticate: and Proxy-Authenticate:
@@ -98,7 +97,7 @@ public class AuthenticationHeader {
     }
 
     static {
-        String pref = GetPropertyAction.privilegedGetProperty("http.auth.preference");
+        String pref = System.getProperty("http.auth.preference");
 
         // http.auth.preference can be set to SPNEGO or Kerberos.
         // In fact they means "Negotiate with SPNEGO" and "Negotiate with

--- a/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/AuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1995, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package sun.net.www.protocol.http;
 
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.net.PasswordAuthentication;
 import java.net.URL;
 import java.util.HashMap;
@@ -67,10 +65,7 @@ public abstract class AuthenticationInfo extends AuthCacheValue implements Clone
      * repeatedly, via the Authenticator. Default is false, which means that this
      * behavior is switched off.
      */
-    @SuppressWarnings("removal")
-    static final boolean serializeAuth = java.security.AccessController.doPrivileged(
-            new sun.security.action.GetBooleanAction(
-                "http.auth.serializeRequests")).booleanValue();
+    static final boolean serializeAuth = Boolean.getBoolean("http.auth.serializeRequests");
 
     /* AuthCacheValue: */
 

--- a/src/java.base/share/classes/sun/net/www/protocol/http/BasicAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/BasicAuthentication.java
@@ -46,7 +46,7 @@ import sun.nio.cs.UTF_8;
  */
 
 
-class BasicAuthentication extends AuthenticationInfo {
+final class BasicAuthentication extends AuthenticationInfo {
 
     /** The authentication string for this host, port, and realm.  This is
         a simple BASE64 encoding of "login:password".    */

--- a/src/java.base/share/classes/sun/net/www/protocol/http/BasicAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/BasicAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,11 +32,8 @@ import java.net.PasswordAuthentication;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-import java.io.IOException;
-import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Objects;
 import sun.net.www.HeaderParser;
 import sun.nio.cs.ISO_8859_1;
 import sun.nio.cs.UTF_8;
@@ -50,9 +47,6 @@ import sun.nio.cs.UTF_8;
 
 
 class BasicAuthentication extends AuthenticationInfo {
-
-    @java.io.Serial
-    private static final long serialVersionUID = 100L;
 
     /** The authentication string for this host, port, and realm.  This is
         a simple BASE64 encoding of "login:password".    */

--- a/src/java.base/share/classes/sun/net/www/protocol/http/DigestAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/DigestAuthentication.java
@@ -61,7 +61,7 @@ import static sun.net.www.protocol.http.HttpURLConnection.HTTP_CONNECT;
  * @author Bill Foote
  */
 
-class DigestAuthentication extends AuthenticationInfo {
+final class DigestAuthentication extends AuthenticationInfo {
 
     private String authMethod;
 

--- a/src/java.base/share/classes/sun/net/www/protocol/http/DigestAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/DigestAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,17 +35,13 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivilegedAction;
 import java.security.Security;
 import java.text.Normalizer;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -66,9 +62,6 @@ import static sun.net.www.protocol.http.HttpURLConnection.HTTP_CONNECT;
  */
 
 class DigestAuthentication extends AuthenticationInfo {
-
-    @java.io.Serial
-    private static final long serialVersionUID = 100L;
 
     private String authMethod;
 
@@ -110,26 +103,15 @@ class DigestAuthentication extends AuthenticationInfo {
         HttpURLConnection.getHttpLogger();
 
     static {
-        @SuppressWarnings("removal")
-        Boolean b = AccessController.doPrivileged(
-            (PrivilegedAction<Boolean>) () -> NetProperties.getBoolean(compatPropName)
-        );
+        Boolean b = NetProperties.getBoolean(compatPropName);
         delimCompatFlag = (b == null) ? false : b.booleanValue();
 
-        @SuppressWarnings("removal")
-        String secprops = AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> Security.getProperty(secPropName)
-        );
-
+        String secprops = Security.getProperty(secPropName);
         Set<String> algs = new HashSet<>();
-
         // add the default insecure algorithms to set
         processPropValue(secprops, algs, (set, elem) -> set.add(elem));
 
-        @SuppressWarnings("removal")
-        String netprops = AccessController.doPrivileged(
-            (PrivilegedAction<String>) () -> NetProperties.get(enabledAlgPropName)
-        );
+        String netprops = NetProperties.get(enabledAlgPropName);
         // remove any algorithms from disabled set that were opted-in by user
         processPropValue(netprops, algs, (set, elem) -> set.remove(elem));
         disabledDigests = Set.copyOf(algs);

--- a/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
@@ -44,7 +44,7 @@ import static sun.net.www.protocol.http.AuthScheme.KERBEROS;
  * @since 1.6
  */
 
-class NegotiateAuthentication extends AuthenticationInfo {
+final class NegotiateAuthentication extends AuthenticationInfo {
 
     private final HttpCallerInfo hci;
 

--- a/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/http/NegotiateAuthentication.java
@@ -36,7 +36,6 @@ import java.util.concurrent.locks.ReentrantLock;
 import sun.net.www.HeaderParser;
 import static sun.net.www.protocol.http.AuthScheme.NEGOTIATE;
 import static sun.net.www.protocol.http.AuthScheme.KERBEROS;
-import sun.security.action.GetPropertyAction;
 
 /**
  * NegotiateAuthentication:
@@ -46,9 +45,6 @@ import sun.security.action.GetPropertyAction;
  */
 
 class NegotiateAuthentication extends AuthenticationInfo {
-
-    @java.io.Serial
-    private static final long serialVersionUID = 100L;
 
     private final HttpCallerInfo hci;
 
@@ -60,14 +56,6 @@ class NegotiateAuthentication extends AuthenticationInfo {
     static HashMap <String, Boolean> supported = null;
     static ThreadLocal <HashMap <String, Negotiator>> cache = null;
     private static final ReentrantLock negotiateLock = new ReentrantLock();
-
-    /* Whether cache is enabled for Negotiate/Kerberos */
-    private static final boolean cacheSPNEGO;
-    static {
-        String spnegoCacheProp =
-            GetPropertyAction.privilegedGetProperty("jdk.spnego.cache", "true");
-        cacheSPNEGO = Boolean.parseBoolean(spnegoCacheProp);
-    }
 
     // The HTTP Negotiate Helper
     private Negotiator negotiator = null;

--- a/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
@@ -35,7 +35,6 @@ import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.util.Base64;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Properties;
 
 import sun.net.www.HeaderParser;

--- a/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
@@ -69,7 +69,7 @@ import sun.security.action.GetPropertyAction;
  *    through a proxy, rather between client and proxy, or between client and server (with no proxy)
  */
 
-public class NTLMAuthentication extends AuthenticationInfo {
+public final class NTLMAuthentication extends AuthenticationInfo {
 
     private static final NTLMAuthenticationCallback NTLMAuthCallback =
         NTLMAuthenticationCallback.getNTLMAuthenticationCallback();

--- a/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
@@ -71,7 +71,6 @@ import sun.security.action.GetPropertyAction;
  */
 
 public class NTLMAuthentication extends AuthenticationInfo {
-    private static final long serialVersionUID = 170L;
 
     private static final NTLMAuthenticationCallback NTLMAuthCallback =
         NTLMAuthenticationCallback.getNTLMAuthenticationCallback();

--- a/src/java.base/windows/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
+++ b/src/java.base/windows/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
@@ -43,7 +43,7 @@ import sun.net.www.protocol.http.HttpURLConnection;
  * @author Michael McMahon
  */
 
-public class NTLMAuthentication extends AuthenticationInfo {
+public final class NTLMAuthentication extends AuthenticationInfo {
 
     private static final NTLMAuthenticationCallback NTLMAuthCallback =
             NTLMAuthenticationCallback.getNTLMAuthenticationCallback();

--- a/src/java.base/windows/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
+++ b/src/java.base/windows/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,14 +31,11 @@ import java.net.PasswordAuthentication;
 import java.net.UnknownHostException;
 import java.net.URL;
 import java.util.Locale;
-import java.util.Objects;
-import java.util.Properties;
 import sun.net.NetProperties;
 import sun.net.www.HeaderParser;
 import sun.net.www.protocol.http.AuthenticationInfo;
 import sun.net.www.protocol.http.AuthScheme;
 import sun.net.www.protocol.http.HttpURLConnection;
-import sun.security.action.GetPropertyAction;
 
 /**
  * NTLMAuthentication:
@@ -48,12 +45,9 @@ import sun.security.action.GetPropertyAction;
 
 public class NTLMAuthentication extends AuthenticationInfo {
 
-    private static final long serialVersionUID = 100L;
-
     private static final NTLMAuthenticationCallback NTLMAuthCallback =
-        NTLMAuthenticationCallback.getNTLMAuthenticationCallback();
+            NTLMAuthenticationCallback.getNTLMAuthenticationCallback();
 
-    private String hostname;
     /* Domain to use if not specified by user */
     private static final String defaultDomain;
     /* Whether cache is enabled for NTLM */
@@ -68,45 +62,16 @@ public class NTLMAuthentication extends AuthenticationInfo {
     private static final TransparentAuth authMode;
 
     static {
-        Properties props = GetPropertyAction.privilegedGetProperties();
-        defaultDomain = props.getProperty("http.auth.ntlm.domain", "domain");
-        String ntlmCacheProp = props.getProperty("jdk.ntlm.cache", "true");
+        defaultDomain = System.getProperty("http.auth.ntlm.domain", "domain");
+        String ntlmCacheProp = System.getProperty("jdk.ntlm.cache", "true");
         ntlmCache = Boolean.parseBoolean(ntlmCacheProp);
-        @SuppressWarnings("removal")
-        String modeProp = java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<String>() {
-                public String run() {
-                    return NetProperties.get("jdk.http.ntlm.transparentAuth");
-                }
-            });
-
+        String modeProp = NetProperties.get("jdk.http.ntlm.transparentAuth");
         if ("trustedHosts".equalsIgnoreCase(modeProp))
             authMode = TransparentAuth.TRUSTED_HOSTS;
         else if ("allHosts".equalsIgnoreCase(modeProp))
             authMode = TransparentAuth.ALL_HOSTS;
         else
             authMode = TransparentAuth.DISABLED;
-    }
-
-    @SuppressWarnings("removal")
-    private void init0() {
-
-        hostname = java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<String>() {
-            public String run() {
-                String localhost;
-                try {
-                    localhost = InetAddress.getLocalHost().getHostName().toUpperCase(Locale.ROOT);
-                } catch (UnknownHostException e) {
-                     localhost = "localhost";
-                }
-                return localhost;
-            }
-        });
-        int x = hostname.indexOf ('.');
-        if (x != -1) {
-            hostname = hostname.substring (0, x);
-        }
     }
 
     String username;
@@ -147,7 +112,6 @@ public class NTLMAuthentication extends AuthenticationInfo {
             ntdomain = null;
             password = null;
         }
-        init0();
     }
 
    /**


### PR DESCRIPTION
Can I please get a review of this code which cleans up usages of SecurityManager and related APIs? This addresses https://bugs.openjdk.org/browse/JDK-8344190.

No new tests have been added and testing of tier1, tier2, tier3 is in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344190](https://bugs.openjdk.org/browse/JDK-8344190): Cleanup code in sun.net.www.protocol.http and sun.net.www.protocol.https after JEP 486 integration (**Sub-task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22232/head:pull/22232` \
`$ git checkout pull/22232`

Update a local copy of the PR: \
`$ git checkout pull/22232` \
`$ git pull https://git.openjdk.org/jdk.git pull/22232/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22232`

View PR using the GUI difftool: \
`$ git pr show -t 22232`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22232.diff">https://git.openjdk.org/jdk/pull/22232.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22232#issuecomment-2485228492)
</details>
