### PR TITLE
8344534: Remove leftover import of java.security.AccessControlContext in JavaLangAccess

### DIFF
--- a/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaLangAccess.java
@@ -38,7 +38,6 @@ import java.lang.reflect.Method;
 import java.net.URI;
 import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
-import java.security.AccessControlContext;
 import java.security.ProtectionDomain;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Please review this trivial cleanup of an unused import of `AccessControlContext ` in `JavaLangAccess`. 

This was left over after #22035 removed `JavaLangAccess::newThreadWithAcc(Runnable, AccessControlContext)`.

Verification: `make images` succeeds.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344534](https://bugs.openjdk.org/browse/JDK-8344534): Remove leftover import of java.security.AccessControlContext in JavaLangAccess (**Enhancement** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22234/head:pull/22234` \
`$ git checkout pull/22234`

Update a local copy of the PR: \
`$ git checkout pull/22234` \
`$ git pull https://git.openjdk.org/jdk.git pull/22234/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22234`

View PR using the GUI difftool: \
`$ git pr show -t 22234`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22234.diff">https://git.openjdk.org/jdk/pull/22234.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22234#issuecomment-2485359452)
</details>
