### PR TITLE
8344533: CTW: Add option to remove clinits before loading

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/PathHandler.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/PathHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,9 @@
 package sun.hotspot.tools.ctw;
 
 import java.io.Closeable;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassTransform;
+import java.lang.classfile.MethodModel;
 import java.net.URI;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
@@ -92,7 +95,22 @@ public class PathHandler implements Closeable {
         private final Function<String, byte[]> findByteCode;
 
         private PathEntryClassLoader(Function<String, byte[]> findByteCode) {
-            this.findByteCode = findByteCode;
+            boolean allowClinits = "true".equals(
+                    System.getProperty("sun.hotspot.tools.ctwrunner.allow_clinits", "true"));
+
+            this.findByteCode = allowClinits ? findByteCode
+                : findByteCode.andThen(PathEntryClassLoader::sterilizeClinits);
+        }
+
+        /**
+         * Removes 'clinit' methods to prevent code execution
+         */
+        private static byte[] sterilizeClinits(byte[] src) {
+            ClassFile classFile = ClassFile.of();
+            return classFile.transformClass(classFile.parse(src),
+                    ClassTransform.dropping(
+                        element -> element instanceof MethodModel mm
+                                   && mm.methodName().stringValue().equals("<clinit>")));
         }
 
         @Override


### PR DESCRIPTION
This PR adds an option-controlled (off by default) removal of <clinit> methods before loading them with CTW ClassLoader.
The main purpose is to prevent `static { ... }` blocks execution (along with static fields initialization).
Testing: manual CTW runs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344533](https://bugs.openjdk.org/browse/JDK-8344533): CTW: Add option to remove clinits before loading (**Enhancement** - P4)


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22235/head:pull/22235` \
`$ git checkout pull/22235`

Update a local copy of the PR: \
`$ git checkout pull/22235` \
`$ git pull https://git.openjdk.org/jdk.git pull/22235/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22235`

View PR using the GUI difftool: \
`$ git pr show -t 22235`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22235.diff">https://git.openjdk.org/jdk/pull/22235.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22235#issuecomment-2485364266)
</details>
