### PR TITLE
8344540: Remove superseded wildcard description from java manpage

### DIFF
--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3074,9 +3074,9 @@ The following items describe the syntax of `java` argument files:
 -   The argument file size must not exceed MAXINT (2,147,483,647) bytes.
 
 -   The launcher doesn't expand wildcards that are present within an argument
-    file. That means, an asterisk  `*` is passed on as-is to the starting VM.
+    file. That means an asterisk `*` is passed on as-is to the starting VM.
     For example `*.java` stays `*.java` and is not expanded to `Foo.java`,
-    `Bar.java`, etc. like on some command line shell.
+    `Bar.java ...`, as would happen with some command line shells.
 
 -   Use white space or new line characters to separate arguments included in
     the file.

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -280,7 +280,7 @@ first matching close quote are preserved by simply removing the pair of quotes.
 In case a matching quote is not found, the launcher will abort with an error
 message. `@`-files are supported as they are specified in the command line.
 Any wildcard literal `*` in the `JDK_JAVA_OPTIONS` environment variable
-content isn't expanded and is passed as-is to the java launcher. In order to
+content isn't expanded and is passed as-is to the starting VM. In order to
 mitigate potential misuse of `JDK_JAVA_OPTIONS` behavior, options that specify
 the main class (such as `-jar`) or cause the `java` launcher to exit without
 executing the main class (such as `-h`) are disallowed in the environment

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3074,9 +3074,9 @@ The following items describe the syntax of `java` argument files:
 -   The argument file size must not exceed MAXINT (2,147,483,647) bytes.
 
 -   The launcher doesn't expand wildcards that are present within an argument
-    file. That means an asterisk `*` is passed on as-is to the starting VM.
-    For example `*.java` stays `*.java` and is not expanded to `Foo.java`,
-    `Bar.java ...`, as would happen with some command line shells.
+    file. That means an asterisk (`*`) is passed on as-is to the starting VM.
+    For example `*.java` stays `*.java` and is not expanded to
+    `Foo.java Bar.java ...`, as would happen with some command line shells.
 
 -   Use white space or new line characters to separate arguments included in
     the file.

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -279,7 +279,8 @@ contain whitespace characters. All content between the open quote and the
 first matching close quote are preserved by simply removing the pair of quotes.
 In case a matching quote is not found, the launcher will abort with an error
 message. `@`-files are supported as they are specified in the command line.
-However, as in `@`-files, use of a wildcard is not supported. In order to
+Any wildcard literal `*` in the `JDK_JAVA_OPTIONS` environment variable
+content isn't expanded and is passed as-is to the java launcher. In order to
 mitigate potential misuse of `JDK_JAVA_OPTIONS` behavior, options that specify
 the main class (such as `-jar`) or cause the `java` launcher to exit without
 executing the main class (such as `-h`) are disallowed in the environment

--- a/src/java.base/share/man/java.md
+++ b/src/java.base/share/man/java.md
@@ -3118,8 +3118,6 @@ The following items describe the syntax of `java` argument files:
 -   An open quote stops at end-of-line unless `\` is the last character, which
     then joins the next line by removing all leading white space characters.
 
--   Wildcards (\*) aren't allowed in these lists (such as specifying `*.java`).
-
 -   Use of the at sign (`@`) to recursively interpret files isn't supported.
 
 ### Example of Open or Partial Quotes in an Argument File


### PR DESCRIPTION
Please review this follow-up PR to improve `java`'s manpage section about wildcards in argument files: the confusing sentence is now removed.

This is a cleanup of commit https://github.com/openjdk/jdk/commit/5cb0d438231383d491b2fcca455d09af7f2ee016

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344540](https://bugs.openjdk.org/browse/JDK-8344540): Remove superseded wildcard description from java manpage (**Enhancement** - P5)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22236/head:pull/22236` \
`$ git checkout pull/22236`

Update a local copy of the PR: \
`$ git checkout pull/22236` \
`$ git pull https://git.openjdk.org/jdk.git pull/22236/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22236`

View PR using the GUI difftool: \
`$ git pr show -t 22236`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22236.diff">https://git.openjdk.org/jdk/pull/22236.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22236#issuecomment-2485534860)
</details>
