### PR TITLE
8342836: Automatically determine that a test in the docs test root is requested

### DIFF
--- a/make/Main.gmk
+++ b/make/Main.gmk
@@ -1344,6 +1344,9 @@ test-hotspot-jtreg-native: test-hotspot_native_sanity
 test-hotspot-gtest: exploded-test-gtest
 test-jdk-jtreg-native: test-jdk_native_sanity
 
+# Set dependencies for doc tests
+$(eval $(call AddTestDependency, docs_all, docs-jdk))
+
 ALL_TARGETS += $(RUN_TEST_TARGETS) run-test exploded-run-test check \
     test-hotspot-jtreg test-hotspot-jtreg-native test-hotspot-gtest \
     test-jdk-jtreg-native

--- a/make/MainSupport.gmk
+++ b/make/MainSupport.gmk
@@ -137,6 +137,15 @@ define CleanModule
   $(call Clean-include, $1)
 endef
 
+define AddTestDependency
+  test-$(strip $1): $2
+
+  exploded-test-$(strip $1): $2
+
+  ifneq ($(filter $(TEST), $1), )
+    TEST_DEPS += $2
+  endif
+endef
 
 ################################################################################
 


### PR DESCRIPTION
Please review this patch to automatically set `TEST_DEPS` to `docs-jdk` when testing the documentation.

This comes as a followup to https://github.com/openjdk/jdk/commit/07f550b85a3910edd28d8761e2adfb8d6a1352f6 , as review comments suggested better aways of adding dependencies and to not require users to use a verbose `make test TEST=docs_all TEST_DEPS=docs-jdk`.

I have verified that `make test-docs_all` does indeed build the docs, `make test TEST=docs_all` does not but the former is clear and short enough to be used.

TIA.