### PR TITLE
8344041: Re-enable external specs page

### DIFF
--- a/make/Docs.gmk
+++ b/make/Docs.gmk
@@ -107,15 +107,13 @@ JAVA_WARNINGS_ARE_ERRORS ?= -Werror
 JAVADOC_OPTIONS := -use -keywords -notimestamp \
     -encoding ISO-8859-1 -docencoding UTF-8 -breakiterator \
     -splitIndex --system none -javafx --expand-requires transitive \
-    --override-methods=summary \
-    --no-external-specs-page
+    --override-methods=summary
 
 # The reference options must stay stable to allow for comparisons across the
 # development cycle.
 REFERENCE_OPTIONS := -XDignore.symbol.file=true -use -keywords -notimestamp \
     -encoding ISO-8859-1 -breakiterator -splitIndex --system none \
-    -html5 -javafx --expand-requires transitive \
-    --no-external-specs-page
+    -html5 -javafx --expand-requires transitive
 
 # Should we add DRAFT stamps to the generated javadoc?
 ifeq ($(VERSION_IS_GA), true)

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDoclet.java
@@ -280,9 +280,7 @@ public class HtmlDoclet extends AbstractDoclet {
         }
 
         if (options.createIndex()) {
-            if (!options.noExternalSpecsPage()){
-                writerFactory.newExternalSpecsWriter().buildPage();
-            }
+            writerFactory.newExternalSpecsWriter().buildPage();
             writerFactory.newSearchTagsWriter().buildPage();
             writerFactory.newSystemPropertiesWriter().buildPage();
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlOptions.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,13 +143,6 @@ public class HtmlOptions extends BaseOptions {
      * false.
      */
     private boolean noDeprecatedList = false;
-
-    /**
-     * Argument for command-line option {@code --no-external-spec-page}.
-     * True if command-line option "--no-external-spec-page" is used. Default value is
-     * false.
-     */
-    private boolean noExternalSpecsPage = false;
 
     /**
      * Argument for command-line option {@code -nohelp}.
@@ -370,14 +363,6 @@ public class HtmlOptions extends BaseOptions {
                             messages.error("doclet.Option_conflict", "-nooverview", "-overview");
                             return false;
                         }
-                        return true;
-                    }
-                },
-
-                new Hidden(resources, "--no-external-specs-page") {
-                    @Override
-                    public boolean process(String opt, List<String> args) {
-                        noExternalSpecsPage = true;
                         return true;
                     }
                 },
@@ -747,15 +732,6 @@ public class HtmlOptions extends BaseOptions {
      */
     public boolean noDeprecatedList() {
         return noDeprecatedList;
-    }
-
-    /**
-     * Argument for command-line option {@code --no-external-specs-page}.
-     * True if command-line option "--no-external-specs-page" is used. Default value is
-     * false.
-     */
-    public boolean noExternalSpecsPage() {
-        return noExternalSpecsPage;
     }
 
     /**

--- a/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
+++ b/test/langtools/jdk/javadoc/doclet/testSpecTag/TestSpecTag.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 6251738 8226279 8297802 8296546 8305407
+ * @bug 6251738 8226279 8297802 8305407
  * @summary JDK-8226279 javadoc should support a new at-spec tag
  * @library /tools/lib ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool
@@ -509,20 +509,6 @@ public class TestSpecTag extends JavadocTester {
                            ^
                     """
                     .replace("#FILE#", src.resolve("p").resolve("C.java").toString()));
-    }
-
-    @Test
-    public void testSuppressSpecPage(Path base) throws IOException {
-        Path src = base.resolve("src");
-        tb.writeJavaFiles(src, "package p; /** @spec http://example.com label */ public class C { }");
-
-        javadoc("-d", base.resolve("out").toString(),
-                "--source-path", src.toString(),
-                "--no-external-specs-page",
-                "p");
-        checkExit(Exit.OK);
-
-        checkFiles(false, "external-specs.html");
     }
 
     @Test


### PR DESCRIPTION
Please review a change to enable the External Specifications page in API docs. The page was disabled because of missing `@spec` tags in OpenJDK sources. This is a straightforward undo of of #13127 / [JDK-8304689], which means the hidden ad-hoc `--no-external-specs-page` option is also removed.

[JDK-8304689]: https://bugs.openjdk.org/browse/JDK-8304689

[This is what the External Specifications page looks like.](https://cr.openjdk.org/~hannesw/8344041/api.00/external-specs.html)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8344041](https://bugs.openjdk.org/browse/JDK-8344041): Re-enable external specs page (**Enhancement** - P3)


### Reviewers
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)
 * [Nizar Benalla](https://openjdk.org/census#nbenalla) (@nizarbenalla - Committer)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22240/head:pull/22240` \
`$ git checkout pull/22240`

Update a local copy of the PR: \
`$ git checkout pull/22240` \
`$ git pull https://git.openjdk.org/jdk.git pull/22240/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22240`

View PR using the GUI difftool: \
`$ git pr show -t 22240`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22240.diff">https://git.openjdk.org/jdk/pull/22240.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22240#issuecomment-2486089963)
</details>
