### PR TITLE
8344550: Compilation error of jpackage test JPackageStringBundle.java source

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageStringBundle.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/JPackageStringBundle.java
@@ -26,6 +26,7 @@ package jdk.jpackage.test;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.text.MessageFormat;
+import static jdk.jpackage.internal.util.function.ExceptionBox.rethrowUnchecked;
 
 public enum JPackageStringBundle {
 
@@ -39,7 +40,7 @@ public enum JPackageStringBundle {
             i18nClass_getString = i18nClass.getDeclaredMethod("getString", String.class);
             i18nClass_getString.setAccessible(true);
         } catch (ClassNotFoundException|NoSuchMethodException ex) {
-            throw Functional.rethrowUnchecked(ex);
+            throw rethrowUnchecked(ex);
         }
     }
 
@@ -50,7 +51,7 @@ public enum JPackageStringBundle {
         try {
             return (String)i18nClass_getString.invoke(i18nClass, key);
         } catch (IllegalAccessException|InvocationTargetException ex) {
-            throw Functional.rethrowUnchecked(ex);
+            throw rethrowUnchecked(ex);
         }
     }
 


### PR DESCRIPTION
Bad merge fix

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344550](https://bugs.openjdk.org/browse/JDK-8344550): Compilation error of jpackage test JPackageStringBundle.java source (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22241/head:pull/22241` \
`$ git checkout pull/22241`

Update a local copy of the PR: \
`$ git checkout pull/22241` \
`$ git pull https://git.openjdk.org/jdk.git pull/22241/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22241`

View PR using the GUI difftool: \
`$ git pr show -t 22241`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22241.diff">https://git.openjdk.org/jdk/pull/22241.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22241#issuecomment-2486105487)
</details>
