### PR TITLE
8278856: javac documentation does not mention use of Manifest class-path attribute

### DIFF
--- a/src/jdk.compiler/share/man/javac.md
+++ b/src/jdk.compiler/share/man/javac.md
@@ -1285,6 +1285,12 @@ although some module-related path options allow a package hierarchy to be
 specified on a per-module basis. All other path options are used to specify
 package hierarchies.
 
+When a JAR file in the user class path has a `Class-Path` manifest attribute,
+and the specified JAR file(s) exist, they are automatically inserted into the
+user class path after the JAR file. This rule also applies recursively to any
+new JAR files found. Consult the [JAR File Specification](../jar/jar.html#class-path-attribute)
+for details.
+
 ### Package Hierarchy
 
 In a package hierarchy, directories and subdirectories are used


### PR DESCRIPTION
Please review this improvement to `javac`'s manpage, section **Directory Hierarchies**.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8278856: javac documentation does not mention use of Manifest class-path attribute`

### Issue
 * [JDK-8278856](https://bugs.openjdk.org/browse/JDK-8278856): javac documentation does not mention use of Manifest class-path attribute (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22243/head:pull/22243` \
`$ git checkout pull/22243`

Update a local copy of the PR: \
`$ git checkout pull/22243` \
`$ git pull https://git.openjdk.org/jdk.git pull/22243/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22243`

View PR using the GUI difftool: \
`$ git pr show -t 22243`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22243.diff">https://git.openjdk.org/jdk/pull/22243.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22243#issuecomment-2486150292)
</details>
