### PR TITLE
8343832: Enhance test summary with number of skipped tests

### DIFF
--- a/make/RunTests.gmk
+++ b/make/RunTests.gmk
@@ -1297,15 +1297,15 @@ run-test-report: post-run-test
 	  , \
 	    $(eval TEST_NAME := $(test)) \
 	  ) \
-	  $(if $(filter $($(TEST_ID)_PASSED), $($(TEST_ID)_TOTAL)), \
-	    $(PRINTF) >> $(TEST_SUMMARY) "%2s %-49s %5d %5d %5d %5d %5d %2s\n" \
-	        "  " "$(TEST_NAME)" $($(TEST_ID)_TOTAL) $($(TEST_ID)_PASSED) \
-	        $($(TEST_ID)_FAILED) $($(TEST_ID)_ERROR) $($(TEST_ID)_SKIPPED) "  " $(NEWLINE) \
-	  , \
+	  $(if $(filter-out 0, $($(TEST_ID)_FAILED) $($(TEST_ID)_ERROR)), \
 	    $(PRINTF) >> $(TEST_SUMMARY) "%2s %-49s %5d %5d %5d %5d %5d %2s\n" \
 	         ">>" "$(TEST_NAME)" $($(TEST_ID)_TOTAL) $($(TEST_ID)_PASSED) \
 	        $($(TEST_ID)_FAILED) $($(TEST_ID)_ERROR) $($(TEST_ID)_SKIPPED) "<<" $(NEWLINE) \
 	    $(eval TEST_FAILURE := true) \
+	  , \
+	    $(PRINTF) >> $(TEST_SUMMARY) "%2s %-49s %5d %5d %5d %5d %5d %2s\n" \
+	        "  " "$(TEST_NAME)" $($(TEST_ID)_TOTAL) $($(TEST_ID)_PASSED) \
+	        $($(TEST_ID)_FAILED) $($(TEST_ID)_ERROR) $($(TEST_ID)_SKIPPED) "  " $(NEWLINE) \
 	  ) \
 	)
 	$(ECHO) >> $(TEST_SUMMARY) ==============================


### PR DESCRIPTION
The output for Jtreg v7.5 was [enhanced](https://github.com/openjdk/jtreg/pull/217/files#diff-b6ab77bf651f1fd9a83c3ca0aab9cd24ae5c08cef41e6e257f7eaccc07c7c366R947) with [information about skipped tests](https://github.com/openjdk/jtreg/blob/master/src/share/doc/javatest/regtest/faq.md#what-do-all-those-numbers-in-the-test-results-line-mean).

Use the additional information in the "summary" block printed at the end of `make test` target.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8343832](https://bugs.openjdk.org/browse/JDK-8343832): Enhance test summary with number of skipped tests (**Enhancement** - P4) ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)
 * [Erik Joelsson](https://openjdk.org/census#erikj) (@erikj79 - **Reviewer**)

### Contributors
 * Magnus Ihse Bursie `<ihse@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22245/head:pull/22245` \
`$ git checkout pull/22245`

Update a local copy of the PR: \
`$ git checkout pull/22245` \
`$ git pull https://git.openjdk.org/jdk.git pull/22245/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22245`

View PR using the GUI difftool: \
`$ git pr show -t 22245`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22245.diff">https://git.openjdk.org/jdk/pull/22245.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22245#issuecomment-2503915873)
</details>
