### PR TITLE
8336041: Doccheck: the jfr command doesn't show the correct command-line options

### DIFF
--- a/src/jdk.jfr/share/man/jfr.md
+++ b/src/jdk.jfr/share/man/jfr.md
@@ -207,7 +207,7 @@ Use `jfr configure` to configure a .jfc settings file.
 The syntax is:
 
  `jfr configure` \[--interactive\] \[--verbose\]
-               \[--input <files>\] [--output <file>\]
+               \[--input &lt;files&gt;\] [--output &lt;file&gt;\]
                \[option=value\]* \[event-setting=value\]*
 
 <a id="configure-option-interactive">`--interactive`</a>
@@ -244,9 +244,9 @@ names, categories and field layout within a flight recording file.
 
 The syntax is:
 
-`jfr metadata` \[--categories <filter>\]
-              \[--events <filter>\]
-              \[<file>\]
+`jfr metadata` \[--categories &lt;filter&gt;\]
+              \[--events &lt;filter&gt;\]
+              \[&lt;file&gt;\]
 
 <a id="metadata-option-categories">`--categories` <*filter*></a>
 : Select events matching a category name. The filter is a comma-separated
@@ -259,7 +259,7 @@ list of names, simple and/or qualified, and/or quoted glob patterns.
 <a id="metadata-option-file"><*file*></a>
 : Location of the recording file (.jfr)
 
-If the <file> parameter is omitted, metadata from the JDK where
+If the &lt;file&gt; parameter is omitted, metadata from the JDK where
 the 'jfr' tool is located will be used.
 
 #### `jfr summary` subcommand


### PR DESCRIPTION
After [JDK-8344056](https://bugs.openjdk.org/browse/JDK-8344056), we can now easily fix these typos that caused errors when rendering the HTML.

While I didn't find anything in the markdown spec mentioning escaping angle brackets, this [stackoverflow answer](https://meta.stackoverflow.com/questions/288707/how-do-you-show-words-surrounded-by-angle-brackets) says that we should use HTML entities for angle brackets. Otherwise the content inside `<>` is not shown. Doing so seems to fix the bug in the generated HTML.

The output of the man pages is also broken (you can verify on your local machines as this bug exists exists in older JDKs)

```
   jfr metadata subcommand
       Use jfr metadata to display information about events, such as event names, categories and field layout within a flight recording file.

       The syntax is:

       jfr metadata [--categories ] [--events ] []
```

Before:

<img width="750" alt="Screenshot 2024-11-19 at 17 13 58" src="https://github.com/user-attachments/assets/a94053a1-49f1-43c6-8116-fbc711c51920">

<img width="722" alt="Screenshot 2024-11-19 at 17 13 46" src="https://github.com/user-attachments/assets/2d6105d1-b55d-473f-8ba7-48c37d147659">

<img width="319" alt="Screenshot 2024-11-19 at 17 14 18" src="https://github.com/user-attachments/assets/c4ccc5e7-1f2f-4ce1-a1fc-e04368449209">

After:

<img width="850" alt="Screenshot 2024-11-19 at 17 25 22" src="https://github.com/user-attachments/assets/a4b3f6ac-ffc4-4b73-9ffa-562195081042">
<img width="781" alt="Screenshot 2024-11-19 at 17 25 48" src="https://github.com/user-attachments/assets/76edc5cb-1be2-4c5b-bdc7-32c3ac6c8412">
<img width="496" alt="Screenshot 2024-11-19 at 18 33 29" src="https://github.com/user-attachments/assets/647a68cc-5804-4e61-b4e2-de788e790a0b">

Here is the diff in the HTML after the change 

```
--- build/macosx-aarch64/images/docs/specs/man/jfr.html 2024-11-19 17:08:08
+++ build/macosx-aarch64/images/test/docs/specs/man/jfr.html    2024-11-19 17:04:30
@@ -225,8 +225,7 @@
 <p>Use <code>jfr configure</code> to configure a .jfc settings file.</p>
 <p>The syntax is:</p>
 <p><code>jfr configure</code> [--interactive] [--verbose] [--input
-&lt;files&gt;] [--output &lt;file&gt;] [option=value]*
-[event-setting=value]*</p>
+<files>] [--output <file>] [option=value]* [event-setting=value]*</p>
 <dl>
 <dt><a id="configure-option-interactive"><code>--interactive</code></a></dt>
 <dd>
@@ -272,8 +271,8 @@
 such as event names, categories and field layout within a flight
 recording file.</p>
 <p>The syntax is:</p>
-<p><code>jfr metadata</code> [--categories &lt;filter&gt;] [--events
-&lt;filter&gt;] [&lt;file&gt;]</p>
+<p><code>jfr metadata</code> [--categories <filter>] [--events <filter>]
+[<file>]</p>
 <dl>
 <dt><a id="metadata-option-categories"><code>--categories</code>
 &lt;<em>filter</em>&gt;</a></dt>
@@ -292,8 +291,8 @@
 Location of the recording file (.jfr)
 </dd>
 </dl>
-<p>If the &lt;file&gt; parameter is omitted, metadata from the JDK where
-the 'jfr' tool is located will be used.</p>
+<p>If the <file> parameter is omitted, metadata from the JDK where the
+'jfr' tool is located will be used.</p>
 <h4 id="jfr-summary-subcommand"><code>jfr summary</code> subcommand</h4>
 <p>Use <code>jfr summary</code> to print statistics for a recording. For
 example, a summary can illustrate the number of recorded events and how

```

Here is the diff between the two troff files

```
213,214c213,214
< \f[V]jfr configure\f[R] [--interactive] [--verbose] [--input ] [--output
< ] [option=value]* [event-setting=value]*
---
> \f[V]jfr configure\f[R] [--interactive] [--verbose] [--input <files>]
> [--output <file>] [option=value]* [event-setting=value]*
255c255,256
< \f[V]jfr metadata\f[R] [--categories ] [--events ] []
---
> \f[V]jfr metadata\f[R] [--categories <filter>] [--events <filter>]
> [<file>]
270c271
< If the parameter is omitted, metadata from the JDK where the
---
> If the <file> parameter is omitted, metadata from the JDK where the

```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336041](https://bugs.openjdk.org/browse/JDK-8336041): Doccheck: the jfr command doesn't show the correct command-line options (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22247/head:pull/22247` \
`$ git checkout pull/22247`

Update a local copy of the PR: \
`$ git checkout pull/22247` \
`$ git pull https://git.openjdk.org/jdk.git pull/22247/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22247`

View PR using the GUI difftool: \
`$ git pr show -t 22247`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22247.diff">https://git.openjdk.org/jdk/pull/22247.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22247#issuecomment-2486416033)
</details>
