### PR TITLE
8344562: Remove security manager dependency from module jdk.jdi

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineManagerImpl.java
+++ b/src/jdk.jdi/share/classes/com/sun/tools/jdi/VirtualMachineManagerImpl.java
@@ -59,13 +59,6 @@ public class VirtualMachineManagerImpl implements VirtualMachineManagerService {
     private static VirtualMachineManagerImpl vmm;
 
     public static VirtualMachineManager virtualMachineManager() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            JDIPermission vmmPermission =
-                new JDIPermission("virtualMachineManager");
-            sm.checkPermission(vmmPermission);
-        }
         synchronized (lock) {
             if (vmm == null) {
                 vmm = new VirtualMachineManagerImpl();


### PR DESCRIPTION
Trivial removal of the use of the `SecurityManager` from a single class.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344562](https://bugs.openjdk.org/browse/JDK-8344562): Remove security manager dependency from module jdk.jdi (**Bug** - P4)


### Reviewers
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22251/head:pull/22251` \
`$ git checkout pull/22251`

Update a local copy of the PR: \
`$ git checkout pull/22251` \
`$ git pull https://git.openjdk.org/jdk.git pull/22251/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22251`

View PR using the GUI difftool: \
`$ git pr show -t 22251`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22251.diff">https://git.openjdk.org/jdk/pull/22251.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22251#issuecomment-2486463202)
</details>
