### PR TITLE
8344337: SecurityManager cleanup in java.prefs module

### DIFF
--- a/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferences.java
+++ b/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferences.java
@@ -28,8 +28,6 @@ package java.util.prefs;
 import java.util.Objects;
 
 class MacOSXPreferences extends AbstractPreferences {
-    // fixme need security checks?
-
     // CF preferences file name for Java nodes with short names
     // This value is also in MacOSXPreferencesFile.c
     private static final String defaultAppName = "com.apple.java.util.prefs";

--- a/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferences.java
+++ b/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferencesFile.java
+++ b/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferencesFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferencesFile.java
+++ b/src/java.prefs/macosx/classes/java/util/prefs/MacOSXPreferencesFile.java
@@ -82,15 +82,9 @@ class MacOSXPreferencesFile {
         loadPrefsLib();
     }
 
-    @SuppressWarnings({"removal", "restricted"})
+    @SuppressWarnings("restricted")
     private static void loadPrefsLib() {
-        java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<Void>() {
-                public Void run() {
-                    System.loadLibrary("prefs");
-                    return null;
-                }
-            });
+        System.loadLibrary("prefs");
     }
 
     private static class FlushTask extends TimerTask {

--- a/src/java.prefs/share/classes/java/util/prefs/AbstractPreferences.java
+++ b/src/java.prefs/share/classes/java/util/prefs/AbstractPreferences.java
@@ -27,8 +27,6 @@ package java.util.prefs;
 
 import java.util.*;
 import java.io.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * This class provides a skeletal implementation of the {@link Preferences}
@@ -1060,12 +1058,7 @@ public abstract class AbstractPreferences extends Preferences {
      */
     @SuppressWarnings("removal")
     public boolean isUserNode() {
-        return AccessController.doPrivileged(
-            new PrivilegedAction<Boolean>() {
-                public Boolean run() {
-                    return root == Preferences.userRoot();
-            }
-            }).booleanValue();
+        return root == Preferences.userRoot();
     }
 
     public void addPreferenceChangeListener(PreferenceChangeListener pcl) {

--- a/src/java.prefs/share/classes/java/util/prefs/AbstractPreferences.java
+++ b/src/java.prefs/share/classes/java/util/prefs/AbstractPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -1056,7 +1056,6 @@ public abstract class AbstractPreferences extends Preferences {
      *         preference tree, {@code false} if it's in the system
      *         preference tree.
      */
-    @SuppressWarnings("removal")
     public boolean isUserNode() {
         return root == Preferences.userRoot();
     }

--- a/src/java.prefs/share/classes/java/util/prefs/Preferences.java
+++ b/src/java.prefs/share/classes/java/util/prefs/Preferences.java
@@ -217,7 +217,6 @@ public abstract class Preferences {
 
     private static final PreferencesFactory factory = factory();
 
-    @SuppressWarnings("removal")
     private static PreferencesFactory factory() {
         // 1. Try user-specified system property
         String factoryName = System.getProperty("java.util.prefs.PreferencesFactory");
@@ -245,10 +244,6 @@ public abstract class Preferences {
                 }
             }
         }
-        return factory1();
-    }
-
-    private static PreferencesFactory factory1() {
         // 2. Try service provider interface
         Iterator<PreferencesFactory> itr = ServiceLoader
             .load(PreferencesFactory.class, ClassLoader.getSystemClassLoader())

--- a/src/java.prefs/share/classes/java/util/prefs/Preferences.java
+++ b/src/java.prefs/share/classes/java/util/prefs/Preferences.java
@@ -30,19 +30,9 @@ import jdk.internal.util.OperatingSystem;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.security.AccessController;
-import java.security.Permission;
-import java.security.PrivilegedAction;
 import java.util.Iterator;
 import java.util.ServiceLoader;
 import java.util.ServiceConfigurationError;
-
-// These imports needed only as a workaround for a JavaDoc bug
-import java.lang.RuntimePermission;
-import java.lang.Integer;
-import java.lang.Long;
-import java.lang.Float;
-import java.lang.Double;
 
 /**
  * A node in a hierarchical collection of preference data.  This class
@@ -230,16 +220,8 @@ public abstract class Preferences {
     @SuppressWarnings("removal")
     private static PreferencesFactory factory() {
         // 1. Try user-specified system property
-        String factoryName = AccessController.doPrivileged(
-            new PrivilegedAction<String>() {
-                public String run() {
-                    return System.getProperty(
-                        "java.util.prefs.PreferencesFactory");}});
+        String factoryName = System.getProperty("java.util.prefs.PreferencesFactory");
         if (factoryName != null) {
-            // FIXME: This code should be run in a doPrivileged and
-            // not use the context classloader, to avoid being
-            // dependent on the invoking thread.
-            // Checking AllPermission also seems wrong.
             try {
                 @SuppressWarnings("deprecation")
                 Object result =Class.forName(factoryName, false,
@@ -250,10 +232,6 @@ public abstract class Preferences {
                 try {
                     // workaround for javaws, plugin,
                     // load factory class using non-system classloader
-                    SecurityManager sm = System.getSecurityManager();
-                    if (sm != null) {
-                        sm.checkPermission(new java.security.AllPermission());
-                    }
                     @SuppressWarnings("deprecation")
                     Object result = Class.forName(factoryName, false,
                                                   Thread.currentThread()
@@ -267,11 +245,7 @@ public abstract class Preferences {
                 }
             }
         }
-
-        return AccessController.doPrivileged(
-            new PrivilegedAction<PreferencesFactory>() {
-                public PreferencesFactory run() {
-                    return factory1();}});
+        return factory1();
     }
 
     private static PreferencesFactory factory1() {
@@ -428,23 +402,11 @@ public abstract class Preferences {
     }
 
     /**
-     * This permission object represents the permission required to get
-     * access to the user or system root (which in turn allows for all
-     * other operations).
-     */
-    private static Permission prefsPerm = new RuntimePermission("preferences");
-
-    /**
      * Returns the root preference node for the calling user.
      *
      * @return the root preference node for the calling user.
      */
     public static Preferences userRoot() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            security.checkPermission(prefsPerm);
-
         return factory.userRoot();
     }
 
@@ -454,11 +416,6 @@ public abstract class Preferences {
      * @return the root preference node for the system.
      */
     public static Preferences systemRoot() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null)
-            security.checkPermission(prefsPerm);
-
         return factory.systemRoot();
     }
 

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -27,9 +27,9 @@ package java.util.prefs;
 
 import java.util.*;
 import java.io.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedExceptionAction;
+//import java.security.AccessController;
+//import java.security.PrivilegedAction;
+//import java.security.PrivilegedExceptionAction;
 import java.security.PrivilegedActionException;
 import sun.util.logging.PlatformLogger;
 
@@ -53,13 +53,13 @@ class FileSystemPreferences extends AbstractPreferences {
         loadPrefsLib();
     }
 
-    @SuppressWarnings({"removal", "restricted"})
+    @SuppressWarnings("restricted")
     private static void loadPrefsLib() {
-        PrivilegedAction<Void> load = () -> {
+//        PrivilegedAction<Void> load = () -> {
             System.loadLibrary("prefs");
-            return null;
-        };
-        AccessController.doPrivileged(load);
+//            return null;
+//        };
+//        AccessController.doPrivileged(load);
     }
 
     /**
@@ -67,8 +67,7 @@ class FileSystemPreferences extends AbstractPreferences {
      */
     @SuppressWarnings("removal")
     private static final int SYNC_INTERVAL = Math.max(1,
-        AccessController.doPrivileged((PrivilegedAction<Integer>) () ->
-             Integer.getInteger("java.util.prefs.syncInterval", 30)));
+            Integer.getInteger("java.util.prefs.syncInterval", 30));
 
     /**
      * Returns logger for error messages. Backing store exceptions are logged at
@@ -117,10 +116,10 @@ class FileSystemPreferences extends AbstractPreferences {
         return root;
     }
 
-    @SuppressWarnings("removal")
+//    @SuppressWarnings("removal")
     private static void setupUserRoot() {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
+//        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+//            public Void run() {
                 userRootDir =
                       new File(System.getProperty("java.util.prefs.userRoot",
                       System.getProperty("user.home")), ".java/.userPrefs");
@@ -160,9 +159,9 @@ class FileSystemPreferences extends AbstractPreferences {
                     getLogger().warning(e.toString());
                 }
                 userRootModTime = userRootModFile.lastModified();
-                return null;
-            }
-        });
+//                return null;
+//            }
+//        });
     }
 
 
@@ -185,10 +184,10 @@ class FileSystemPreferences extends AbstractPreferences {
         return root;
     }
 
-    @SuppressWarnings("removal")
+//    @SuppressWarnings("removal")
     private static void setupSystemRoot() {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
+//        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+//            public Void run() {
                 String systemPrefsDirName =
                   System.getProperty("java.util.prefs.systemRoot","/etc/.java");
                 systemRootDir =
@@ -234,9 +233,9 @@ class FileSystemPreferences extends AbstractPreferences {
                 } catch (IOException e) { getLogger().warning(e.toString());
                 }
                 systemRootModTime = systemRootModFile.lastModified();
-                return null;
-            }
-        });
+//                return null;
+//            }
+//        });
     }
 
 
@@ -456,7 +455,7 @@ class FileSystemPreferences extends AbstractPreferences {
         addShutdownHook();
     }
 
-    @SuppressWarnings("removal")
+//    @SuppressWarnings("removal")
     private static void addShutdownHook() {
         // Add periodic timer task to periodically sync cached prefs
         syncTimer.schedule(new TimerTask() {
@@ -466,8 +465,8 @@ class FileSystemPreferences extends AbstractPreferences {
         }, SYNC_INTERVAL*1000, SYNC_INTERVAL*1000);
 
         // Add shutdown hook to flush cached prefs on normal termination
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
+//        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+//            public Void run() {
                 Runtime.getRuntime().addShutdownHook(
                     new Thread(null, null, "Sync Timer Thread", 0, false) {
                     public void run() {
@@ -475,9 +474,9 @@ class FileSystemPreferences extends AbstractPreferences {
                         syncWorld();
                     }
                 });
-                return null;
-            }
-        });
+//                return null;
+//            }
+//        });
     }
 
     private static void syncWorld() {
@@ -526,19 +525,19 @@ class FileSystemPreferences extends AbstractPreferences {
      * parent node and name.  This constructor, called from childSpi,
      * is used to make every node except for the two //roots.
      */
-    @SuppressWarnings("removal")
+//    @SuppressWarnings("removal")
     private FileSystemPreferences(FileSystemPreferences parent, String name) {
         super(parent, name);
         isUserNode = parent.isUserNode;
         dir  = new File(parent.dir, dirName(name));
         prefsFile = new File(dir, "prefs.xml");
         tmpFile  = new File(dir, "prefs.tmp");
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
+//        AccessController.doPrivileged(new PrivilegedAction<Void>() {
+//            public Void run() {
                 newNode = !dir.exists();
-                return null;
-            }
-        });
+//                return null;
+//            }
+//        });
         if (newNode) {
             // These 2 things guarantee node will get written at next flush/sync
             prefsCache = new TreeMap<>();
@@ -596,12 +595,12 @@ class FileSystemPreferences extends AbstractPreferences {
      * fails, a BackingStoreException is thrown and both prefsCache and
      * lastSyncTime are unaffected by the call.
      */
-    @SuppressWarnings("removal")
+//    @SuppressWarnings("removal")
     private void loadCache() throws BackingStoreException {
-        try {
-            AccessController.doPrivileged(
-                new PrivilegedExceptionAction<Void>() {
-                public Void run() throws BackingStoreException {
+//        try {
+//            AccessController.doPrivileged(
+//                new PrivilegedExceptionAction<Void>() {
+//                public Void run() throws BackingStoreException {
                     Map<String, String> m = new TreeMap<>();
                     long newLastSyncTime = 0;
                     try {
@@ -627,12 +626,12 @@ class FileSystemPreferences extends AbstractPreferences {
                     // Attempt succeeded; update state
                     prefsCache = m;
                     lastSyncTime = newLastSyncTime;
-                    return null;
-                }
-            });
-        } catch (PrivilegedActionException e) {
-            throw (BackingStoreException) e.getException();
-        }
+//                    return null;
+//                }
+//            });
+//        } catch (PrivilegedActionException e) { // get rid of?
+//            throw (BackingStoreException) e.getException();
+//        }
     }
 
     /**
@@ -644,32 +643,21 @@ class FileSystemPreferences extends AbstractPreferences {
      * and lastSyncTime will be unaffected by this call.  This call will
      * NEVER leave prefsFile in a corrupt state.
      */
-    @SuppressWarnings("removal")
     private void writeBackCache() throws BackingStoreException {
         try {
-            AccessController.doPrivileged(
-                new PrivilegedExceptionAction<Void>() {
-                public Void run() throws BackingStoreException {
-                    try {
-                        if (!dir.exists() && !dir.mkdirs())
-                            throw new BackingStoreException(dir +
-                                                             " create failed.");
-                        try (FileOutputStream fos = new FileOutputStream(tmpFile)) {
-                            XmlSupport.exportMap(fos, prefsCache);
-                        }
-                        if (!tmpFile.renameTo(prefsFile))
-                            throw new BackingStoreException("Can't rename " +
-                            tmpFile + " to " + prefsFile);
-                    } catch(Exception e) {
-                        if (e instanceof BackingStoreException)
-                            throw (BackingStoreException)e;
-                        throw new BackingStoreException(e);
-                    }
-                    return null;
-                }
-            });
-        } catch (PrivilegedActionException e) {
-            throw (BackingStoreException) e.getException();
+            if (!dir.exists() && !dir.mkdirs())
+                throw new BackingStoreException(dir +
+                                                 " create failed.");
+            try (FileOutputStream fos = new FileOutputStream(tmpFile)) {
+                XmlSupport.exportMap(fos, prefsCache);
+            }
+            if (!tmpFile.renameTo(prefsFile))
+                throw new BackingStoreException("Can't rename " +
+                tmpFile + " to " + prefsFile);
+        } catch(BackingStoreException e) {
+            throw e;
+        } catch(Exception e) {
+            throw new BackingStoreException(e);
         }
     }
 
@@ -678,21 +666,15 @@ class FileSystemPreferences extends AbstractPreferences {
         return prefsCache.keySet().toArray(new String[prefsCache.size()]);
     }
 
-    @SuppressWarnings("removal")
     protected String[] childrenNamesSpi() {
-        return AccessController.doPrivileged(
-            new PrivilegedAction<String[]>() {
-                public String[] run() {
-                    List<String> result = new ArrayList<>();
-                    File[] dirContents = dir.listFiles();
-                    if (dirContents != null) {
-                        for (int i = 0; i < dirContents.length; i++)
-                            if (dirContents[i].isDirectory())
-                                result.add(nodeName(dirContents[i].getName()));
-                    }
-                    return result.toArray(EMPTY_STRING_ARRAY);
-               }
-            });
+        List<String> result = new ArrayList<>();
+        File[] dirContents = dir.listFiles();
+        if (dirContents != null) {
+            for (int i = 0; i < dirContents.length; i++)
+                if (dirContents[i].isDirectory())
+                    result.add(nodeName(dirContents[i].getName()));
+        }
+        return result.toArray(EMPTY_STRING_ARRAY);
     }
 
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
@@ -717,42 +699,30 @@ class FileSystemPreferences extends AbstractPreferences {
     /**
      * Called with file lock held (in addition to node locks).
      */
-    @SuppressWarnings("removal")
     protected void removeNodeSpi() throws BackingStoreException {
-        try {
-            AccessController.doPrivileged(
-                new PrivilegedExceptionAction<Void>() {
-                public Void run() throws BackingStoreException {
-                    if (changeLog.contains(nodeCreate)) {
-                        changeLog.remove(nodeCreate);
-                        nodeCreate = null;
-                        return null;
-                    }
-                    if (!dir.exists())
-                        return null;
-                    prefsFile.delete();
-                    tmpFile.delete();
-                    // dir should be empty now.  If it's not, empty it
-                    File[] junk = dir.listFiles();
-                    if (junk.length != 0) {
-                        getLogger().warning(
-                           "Found extraneous files when removing node: "
-                            + Arrays.asList(junk));
-                        for (int i=0; i<junk.length; i++)
-                            junk[i].delete();
-                    }
-                    if (!dir.delete())
-                        throw new BackingStoreException("Couldn't delete dir: "
-                                                                         + dir);
-                    return null;
-                }
-            });
-        } catch (PrivilegedActionException e) {
-            throw (BackingStoreException) e.getException();
+        if (changeLog.contains(nodeCreate)) {
+            changeLog.remove(nodeCreate);
+            nodeCreate = null;
+            return;
         }
+        if (!dir.exists())
+            return;
+        prefsFile.delete();
+        tmpFile.delete();
+        // dir should be empty now.  If it's not, empty it
+        File[] junk = dir.listFiles();
+        if (junk.length != 0) {
+            getLogger().warning(
+               "Found extraneous files when removing node: "
+                + Arrays.asList(junk));
+            for (int i=0; i<junk.length; i++)
+                junk[i].delete();
+        }
+        if (!dir.delete())
+            throw new BackingStoreException("Couldn't delete dir: "
+                                                             + dir);
     }
 
-    @SuppressWarnings("removal")
     public synchronized void sync() throws BackingStoreException {
         boolean userNode = isUserNode();
         boolean shared;
@@ -765,56 +735,35 @@ class FileSystemPreferences extends AbstractPreferences {
             shared = !isSystemRootWritable;
         }
         synchronized (isUserNode()? userLockFile:systemLockFile) {
-           if (!lockFile(shared))
-               throw(new BackingStoreException("Couldn't get file lock."));
-           final Long newModTime =
-                AccessController.doPrivileged(
-                    new PrivilegedAction<Long>() {
-               public Long run() {
-                   long nmt;
-                   if (isUserNode()) {
-                       nmt = userRootModFile.lastModified();
-                       isUserRootModified = userRootModTime == nmt;
-                   } else {
-                       nmt = systemRootModFile.lastModified();
-                       isSystemRootModified = systemRootModTime == nmt;
-                   }
-                   return nmt;
-               }
-           });
+           if (!lockFile(shared)) {
+               throw (new BackingStoreException("Couldn't get file lock."));
+           }
+           long nmt;
+           if (isUserNode()) {
+               nmt = userRootModFile.lastModified();
+               isUserRootModified = userRootModTime == nmt;
+           } else {
+               nmt = systemRootModFile.lastModified();
+               isSystemRootModified = systemRootModTime == nmt;
+           }
+           final long newModTime = nmt;
            try {
                super.sync();
-               AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                   public Void run() {
-                   if (isUserNode()) {
-                       userRootModTime = newModTime.longValue() + 1000;
-                       userRootModFile.setLastModified(userRootModTime);
-                   } else {
-                       systemRootModTime = newModTime.longValue() + 1000;
-                       systemRootModFile.setLastModified(systemRootModTime);
-                   }
-                   return null;
-                   }
-               });
+               if (isUserNode()) {
+                   userRootModTime = newModTime + 1000;
+                   userRootModFile.setLastModified(userRootModTime);
+               } else {
+                   systemRootModTime = newModTime + 1000;
+                   systemRootModFile.setLastModified(systemRootModTime);
+               }
            } finally {
                 unlockFile();
            }
         }
     }
 
-    @SuppressWarnings("removal")
     protected void syncSpi() throws BackingStoreException {
-        try {
-            AccessController.doPrivileged(
-                new PrivilegedExceptionAction<Void>() {
-                public Void run() throws BackingStoreException {
-                    syncSpiPrivileged();
-                    return null;
-                }
-            });
-        } catch (PrivilegedActionException e) {
-            throw (BackingStoreException) e.getException();
-        }
+        syncSpiPrivileged();
     }
     private void syncSpiPrivileged() throws BackingStoreException {
         if (isRemoved())

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -27,9 +27,6 @@ package java.util.prefs;
 
 import java.util.*;
 import java.io.*;
-//import java.security.AccessController;
-//import java.security.PrivilegedAction;
-//import java.security.PrivilegedExceptionAction;
 import java.security.PrivilegedActionException;
 import sun.util.logging.PlatformLogger;
 
@@ -55,11 +52,7 @@ class FileSystemPreferences extends AbstractPreferences {
 
     @SuppressWarnings("restricted")
     private static void loadPrefsLib() {
-//        PrivilegedAction<Void> load = () -> {
-            System.loadLibrary("prefs");
-//            return null;
-//        };
-//        AccessController.doPrivileged(load);
+        System.loadLibrary("prefs");
     }
 
     /**
@@ -116,52 +109,46 @@ class FileSystemPreferences extends AbstractPreferences {
         return root;
     }
 
-//    @SuppressWarnings("removal")
     private static void setupUserRoot() {
-//        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-//            public Void run() {
-                userRootDir =
-                      new File(System.getProperty("java.util.prefs.userRoot",
-                      System.getProperty("user.home")), ".java/.userPrefs");
-                // Attempt to create root dir if it does not yet exist.
-                if (!userRootDir.exists()) {
-                    if (userRootDir.mkdirs()) {
-                        try {
-                            chmod(userRootDir.getCanonicalPath(), USER_RWX);
-                        } catch (IOException e) {
-                            getLogger().warning("Could not change permissions" +
-                                " on userRoot directory. ");
-                        }
-                        getLogger().info("Created user preferences directory.");
-                    }
-                    else
-                        getLogger().warning("Couldn't create user preferences" +
-                        " directory. User preferences are unusable.");
-                }
-                isUserRootWritable = userRootDir.canWrite();
-                String USER_NAME = System.getProperty("user.name");
-                userLockFile = new File (userRootDir,".user.lock." + USER_NAME);
-                userRootModFile = new File (userRootDir,
-                                               ".userRootModFile." + USER_NAME);
-                if (!userRootModFile.exists())
+        userRootDir =
+              new File(System.getProperty("java.util.prefs.userRoot",
+              System.getProperty("user.home")), ".java/.userPrefs");
+        // Attempt to create root dir if it does not yet exist.
+        if (!userRootDir.exists()) {
+            if (userRootDir.mkdirs()) {
                 try {
-                    // create if does not exist.
-                    userRootModFile.createNewFile();
-                    // Only user can read/write userRootModFile.
-                    int result = chmod(userRootModFile.getCanonicalPath(),
-                                                               USER_READ_WRITE);
-                    if (result !=0)
-                        getLogger().warning("Problem creating userRoot " +
-                            "mod file. Chmod failed on " +
-                             userRootModFile.getCanonicalPath() +
-                             " Unix error code " + result);
+                    chmod(userRootDir.getCanonicalPath(), USER_RWX);
                 } catch (IOException e) {
-                    getLogger().warning(e.toString());
+                    getLogger().warning("Could not change permissions" +
+                        " on userRoot directory. ");
                 }
-                userRootModTime = userRootModFile.lastModified();
-//                return null;
-//            }
-//        });
+                getLogger().info("Created user preferences directory.");
+            }
+            else
+                getLogger().warning("Couldn't create user preferences" +
+                " directory. User preferences are unusable.");
+        }
+        isUserRootWritable = userRootDir.canWrite();
+        String USER_NAME = System.getProperty("user.name");
+        userLockFile = new File (userRootDir,".user.lock." + USER_NAME);
+        userRootModFile = new File (userRootDir,
+                                       ".userRootModFile." + USER_NAME);
+        if (!userRootModFile.exists())
+        try {
+            // create if does not exist.
+            userRootModFile.createNewFile();
+            // Only user can read/write userRootModFile.
+            int result = chmod(userRootModFile.getCanonicalPath(),
+                                                       USER_READ_WRITE);
+            if (result !=0)
+                getLogger().warning("Problem creating userRoot " +
+                    "mod file. Chmod failed on " +
+                     userRootModFile.getCanonicalPath() +
+                     " Unix error code " + result);
+        } catch (IOException e) {
+            getLogger().warning(e.toString());
+        }
+        userRootModTime = userRootModFile.lastModified();
     }
 
 
@@ -184,58 +171,52 @@ class FileSystemPreferences extends AbstractPreferences {
         return root;
     }
 
-//    @SuppressWarnings("removal")
     private static void setupSystemRoot() {
-//        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-//            public Void run() {
-                String systemPrefsDirName =
-                  System.getProperty("java.util.prefs.systemRoot","/etc/.java");
-                systemRootDir =
-                     new File(systemPrefsDirName, ".systemPrefs");
-                // Attempt to create root dir if it does not yet exist.
-                if (!systemRootDir.exists()) {
-                    // system root does not exist in /etc/.java
-                    // Switching  to java.home
-                    systemRootDir =
-                                  new File(System.getProperty("java.home"),
-                                                            ".systemPrefs");
-                    if (!systemRootDir.exists()) {
-                        if (systemRootDir.mkdirs()) {
-                            getLogger().info(
-                                "Created system preferences directory "
-                                + "in java.home.");
-                            try {
-                                chmod(systemRootDir.getCanonicalPath(),
-                                                          USER_RWX_ALL_RX);
-                            } catch (IOException e) {
-                            }
-                        } else {
-                            getLogger().warning("Could not create "
-                                + "system preferences directory. System "
-                                + "preferences are unusable.");
-                        }
+        String systemPrefsDirName =
+          System.getProperty("java.util.prefs.systemRoot","/etc/.java");
+        systemRootDir =
+             new File(systemPrefsDirName, ".systemPrefs");
+        // Attempt to create root dir if it does not yet exist.
+        if (!systemRootDir.exists()) {
+            // system root does not exist in /etc/.java
+            // Switching  to java.home
+            systemRootDir =
+                          new File(System.getProperty("java.home"),
+                                                    ".systemPrefs");
+            if (!systemRootDir.exists()) {
+                if (systemRootDir.mkdirs()) {
+                    getLogger().info(
+                        "Created system preferences directory "
+                        + "in java.home.");
+                    try {
+                        chmod(systemRootDir.getCanonicalPath(),
+                                                  USER_RWX_ALL_RX);
+                    } catch (IOException e) {
                     }
+                } else {
+                    getLogger().warning("Could not create "
+                        + "system preferences directory. System "
+                        + "preferences are unusable.");
                 }
-                isSystemRootWritable = systemRootDir.canWrite();
-                systemLockFile = new File(systemRootDir, ".system.lock");
-                systemRootModFile =
-                               new File (systemRootDir,".systemRootModFile");
-                if (!systemRootModFile.exists() && isSystemRootWritable)
-                try {
-                    // create if does not exist.
-                    systemRootModFile.createNewFile();
-                    int result = chmod(systemRootModFile.getCanonicalPath(),
-                                                          USER_RW_ALL_READ);
-                    if (result !=0)
-                        getLogger().warning("Chmod failed on " +
-                               systemRootModFile.getCanonicalPath() +
-                              " Unix error code " + result);
-                } catch (IOException e) { getLogger().warning(e.toString());
-                }
-                systemRootModTime = systemRootModFile.lastModified();
-//                return null;
-//            }
-//        });
+            }
+        }
+        isSystemRootWritable = systemRootDir.canWrite();
+        systemLockFile = new File(systemRootDir, ".system.lock");
+        systemRootModFile =
+                       new File (systemRootDir,".systemRootModFile");
+        if (!systemRootModFile.exists() && isSystemRootWritable)
+        try {
+            // create if does not exist.
+            systemRootModFile.createNewFile();
+            int result = chmod(systemRootModFile.getCanonicalPath(),
+                                                  USER_RW_ALL_READ);
+            if (result !=0)
+                getLogger().warning("Chmod failed on " +
+                       systemRootModFile.getCanonicalPath() +
+                      " Unix error code " + result);
+        } catch (IOException e) { getLogger().warning(e.toString());
+        }
+        systemRootModTime = systemRootModFile.lastModified();
     }
 
 
@@ -455,7 +436,6 @@ class FileSystemPreferences extends AbstractPreferences {
         addShutdownHook();
     }
 
-//    @SuppressWarnings("removal")
     private static void addShutdownHook() {
         // Add periodic timer task to periodically sync cached prefs
         syncTimer.schedule(new TimerTask() {
@@ -465,18 +445,13 @@ class FileSystemPreferences extends AbstractPreferences {
         }, SYNC_INTERVAL*1000, SYNC_INTERVAL*1000);
 
         // Add shutdown hook to flush cached prefs on normal termination
-//        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-//            public Void run() {
-                Runtime.getRuntime().addShutdownHook(
-                    new Thread(null, null, "Sync Timer Thread", 0, false) {
-                    public void run() {
-                        syncTimer.cancel();
-                        syncWorld();
-                    }
-                });
-//                return null;
-//            }
-//        });
+        Runtime.getRuntime().addShutdownHook(
+            new Thread(null, null, "Sync Timer Thread", 0, false) {
+            public void run() {
+                syncTimer.cancel();
+                syncWorld();
+            }
+        });
     }
 
     private static void syncWorld() {
@@ -525,19 +500,13 @@ class FileSystemPreferences extends AbstractPreferences {
      * parent node and name.  This constructor, called from childSpi,
      * is used to make every node except for the two //roots.
      */
-//    @SuppressWarnings("removal")
     private FileSystemPreferences(FileSystemPreferences parent, String name) {
         super(parent, name);
         isUserNode = parent.isUserNode;
         dir  = new File(parent.dir, dirName(name));
         prefsFile = new File(dir, "prefs.xml");
         tmpFile  = new File(dir, "prefs.tmp");
-//        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-//            public Void run() {
-                newNode = !dir.exists();
-//                return null;
-//            }
-//        });
+        newNode = !dir.exists();
         if (newNode) {
             // These 2 things guarantee node will get written at next flush/sync
             prefsCache = new TreeMap<>();
@@ -597,41 +566,31 @@ class FileSystemPreferences extends AbstractPreferences {
      */
 //    @SuppressWarnings("removal")
     private void loadCache() throws BackingStoreException {
-//        try {
-//            AccessController.doPrivileged(
-//                new PrivilegedExceptionAction<Void>() {
-//                public Void run() throws BackingStoreException {
-                    Map<String, String> m = new TreeMap<>();
-                    long newLastSyncTime = 0;
-                    try {
-                        newLastSyncTime = prefsFile.lastModified();
-                        try (FileInputStream fis = new FileInputStream(prefsFile)) {
-                            XmlSupport.importMap(fis, m);
-                        }
-                    } catch(Exception e) {
-                        if (e instanceof InvalidPreferencesFormatException) {
-                            getLogger().warning("Invalid preferences format in "
-                                                        +  prefsFile.getPath());
-                            prefsFile.renameTo( new File(
-                                                    prefsFile.getParentFile(),
-                                                  "IncorrectFormatPrefs.xml"));
-                            m = new TreeMap<>();
-                        } else if (e instanceof FileNotFoundException) {
-                        getLogger().warning("Prefs file removed in background "
-                                           + prefsFile.getPath());
-                        } else {
-                            throw new BackingStoreException(e);
-                        }
-                    }
-                    // Attempt succeeded; update state
-                    prefsCache = m;
-                    lastSyncTime = newLastSyncTime;
-//                    return null;
-//                }
-//            });
-//        } catch (PrivilegedActionException e) { // get rid of?
-//            throw (BackingStoreException) e.getException();
-//        }
+        Map<String, String> m = new TreeMap<>();
+        long newLastSyncTime = 0;
+        try {
+            newLastSyncTime = prefsFile.lastModified();
+            try (FileInputStream fis = new FileInputStream(prefsFile)) {
+                XmlSupport.importMap(fis, m);
+            }
+        } catch(Exception e) {
+            if (e instanceof InvalidPreferencesFormatException) {
+                getLogger().warning("Invalid preferences format in "
+                                            +  prefsFile.getPath());
+                prefsFile.renameTo( new File(
+                                        prefsFile.getParentFile(),
+                                      "IncorrectFormatPrefs.xml"));
+                m = new TreeMap<>();
+            } else if (e instanceof FileNotFoundException) {
+            getLogger().warning("Prefs file removed in background "
+                               + prefsFile.getPath());
+            } else {
+                throw new BackingStoreException(e);
+            }
+        }
+        // Attempt succeeded; update state
+        prefsCache = m;
+        lastSyncTime = newLastSyncTime;
     }
 
     /**
@@ -763,9 +722,6 @@ class FileSystemPreferences extends AbstractPreferences {
     }
 
     protected void syncSpi() throws BackingStoreException {
-        syncSpiPrivileged();
-    }
-    private void syncSpiPrivileged() throws BackingStoreException {
         if (isRemoved())
             throw new IllegalStateException("Node has been removed");
         if (prefsCache == null)

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -133,20 +133,21 @@ class FileSystemPreferences extends AbstractPreferences {
         userLockFile = new File (userRootDir,".user.lock." + USER_NAME);
         userRootModFile = new File (userRootDir,
                                        ".userRootModFile." + USER_NAME);
-        if (!userRootModFile.exists())
-        try {
-            // create if does not exist.
-            userRootModFile.createNewFile();
-            // Only user can read/write userRootModFile.
-            int result = chmod(userRootModFile.getCanonicalPath(),
-                                                       USER_READ_WRITE);
-            if (result !=0)
-                getLogger().warning("Problem creating userRoot " +
-                    "mod file. Chmod failed on " +
-                     userRootModFile.getCanonicalPath() +
-                     " Unix error code " + result);
-        } catch (IOException e) {
-            getLogger().warning(e.toString());
+        if (!userRootModFile.exists()) {
+            try {
+                // create if does not exist.
+                userRootModFile.createNewFile();
+                // Only user can read/write userRootModFile.
+                int result = chmod(userRootModFile.getCanonicalPath(),
+                        USER_READ_WRITE);
+                if (result != 0)
+                    getLogger().warning("Problem creating userRoot " +
+                            "mod file. Chmod failed on " +
+                            userRootModFile.getCanonicalPath() +
+                            " Unix error code " + result);
+            } catch (IOException e) {
+                getLogger().warning(e.toString());
+            }
         }
         userRootModTime = userRootModFile.lastModified();
     }

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -214,7 +214,8 @@ class FileSystemPreferences extends AbstractPreferences {
                 getLogger().warning("Chmod failed on " +
                        systemRootModFile.getCanonicalPath() +
                       " Unix error code " + result);
-        } catch (IOException e) { getLogger().warning(e.toString());
+        } catch (IOException e) {
+            getLogger().warning(e.toString());
         }
         systemRootModTime = systemRootModFile.lastModified();
     }
@@ -564,7 +565,6 @@ class FileSystemPreferences extends AbstractPreferences {
      * fails, a BackingStoreException is thrown and both prefsCache and
      * lastSyncTime are unaffected by the call.
      */
-//    @SuppressWarnings("removal")
     private void loadCache() throws BackingStoreException {
         Map<String, String> m = new TreeMap<>();
         long newLastSyncTime = 0;

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -112,7 +112,7 @@ class FileSystemPreferences extends AbstractPreferences {
     private static void setupUserRoot() {
         userRootDir =
               new File(System.getProperty("java.util.prefs.userRoot",
-              System.getProperty("user.home")), ".java/.userPrefs");
+                      System.getProperty("user.home")), ".java/.userPrefs");
         // Attempt to create root dir if it does not yet exist.
         if (!userRootDir.exists()) {
             if (userRootDir.mkdirs()) {
@@ -130,7 +130,7 @@ class FileSystemPreferences extends AbstractPreferences {
         }
         isUserRootWritable = userRootDir.canWrite();
         String USER_NAME = System.getProperty("user.name");
-        userLockFile = new File (userRootDir,".user.lock." + USER_NAME);
+        userLockFile = new File(userRootDir,".user.lock." + USER_NAME);
         userRootModFile = new File (userRootDir,
                                        ".userRootModFile." + USER_NAME);
         if (!userRootModFile.exists()) {
@@ -174,7 +174,7 @@ class FileSystemPreferences extends AbstractPreferences {
 
     private static void setupSystemRoot() {
         String systemPrefsDirName =
-          System.getProperty("java.util.prefs.systemRoot","/etc/.java");
+          System.getProperty("java.util.prefs.systemRoot", "/etc/.java");
         systemRootDir =
              new File(systemPrefsDirName, ".systemPrefs");
         // Attempt to create root dir if it does not yet exist.
@@ -203,20 +203,21 @@ class FileSystemPreferences extends AbstractPreferences {
         }
         isSystemRootWritable = systemRootDir.canWrite();
         systemLockFile = new File(systemRootDir, ".system.lock");
-        systemRootModFile =
-                       new File (systemRootDir,".systemRootModFile");
-        if (!systemRootModFile.exists() && isSystemRootWritable)
-        try {
-            // create if does not exist.
-            systemRootModFile.createNewFile();
-            int result = chmod(systemRootModFile.getCanonicalPath(),
-                                                  USER_RW_ALL_READ);
-            if (result !=0)
-                getLogger().warning("Chmod failed on " +
-                       systemRootModFile.getCanonicalPath() +
-                      " Unix error code " + result);
-        } catch (IOException e) {
-            getLogger().warning(e.toString());
+        systemRootModFile = new File (systemRootDir, ".systemRootModFile");
+        if (!systemRootModFile.exists() && isSystemRootWritable) {
+            try {
+                // create if does not exist.
+                systemRootModFile.createNewFile();
+                int result = chmod(systemRootModFile.getCanonicalPath(),
+                        USER_RW_ALL_READ);
+                if (result != 0) {
+                    getLogger().warning("Chmod failed on " +
+                            systemRootModFile.getCanonicalPath() +
+                            " Unix error code " + result);
+                }
+            } catch (IOException e) {
+                getLogger().warning(e.toString());
+            }
         }
         systemRootModTime = systemRootModFile.lastModified();
     }
@@ -577,7 +578,7 @@ class FileSystemPreferences extends AbstractPreferences {
         } catch(Exception e) {
             if (e instanceof InvalidPreferencesFormatException) {
                 getLogger().warning("Invalid preferences format in "
-                                            +  prefsFile.getPath());
+                                            + prefsFile.getPath());
                 prefsFile.renameTo( new File(
                                         prefsFile.getParentFile(),
                                       "IncorrectFormatPrefs.xml"));

--- a/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
+++ b/src/java.prefs/unix/classes/java/util/prefs/FileSystemPreferences.java
@@ -123,10 +123,10 @@ class FileSystemPreferences extends AbstractPreferences {
                         " on userRoot directory. ");
                 }
                 getLogger().info("Created user preferences directory.");
-            }
-            else
+            } else {
                 getLogger().warning("Couldn't create user preferences" +
-                " directory. User preferences are unusable.");
+                        " directory. User preferences are unusable.");
+            }
         }
         isUserRootWritable = userRootDir.canWrite();
         String USER_NAME = System.getProperty("user.name");
@@ -583,8 +583,8 @@ class FileSystemPreferences extends AbstractPreferences {
                                       "IncorrectFormatPrefs.xml"));
                 m = new TreeMap<>();
             } else if (e instanceof FileNotFoundException) {
-            getLogger().warning("Prefs file removed in background "
-                               + prefsFile.getPath());
+                getLogger().warning("Prefs file removed in background "
+                        + prefsFile.getPath());
             } else {
                 throw new BackingStoreException(e);
             }

--- a/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
+++ b/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
@@ -27,8 +27,8 @@ package java.util.prefs;
 
 import java.util.StringTokenizer;
 import java.io.ByteArrayOutputStream;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
+//import java.security.AccessController;
+//import java.security.PrivilegedAction;
 
 import sun.util.logging.PlatformLogger;
 
@@ -50,13 +50,9 @@ class WindowsPreferences extends AbstractPreferences {
         loadPrefsLib();
     }
 
-    @SuppressWarnings({"removal", "restricted"})
+    @SuppressWarnings("restricted")
     private static void loadPrefsLib() {
-        PrivilegedAction<Void> load = () -> {
-            System.loadLibrary("prefs");
-            return null;
-        };
-        AccessController.doPrivileged(load);
+        System.loadLibrary("prefs");
     }
 
     /**

--- a/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
+++ b/src/java.prefs/windows/classes/java/util/prefs/WindowsPreferences.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package java.util.prefs;
 
 import java.util.StringTokenizer;
 import java.io.ByteArrayOutputStream;
-//import java.security.AccessController;
-//import java.security.PrivilegedAction;
 
 import sun.util.logging.PlatformLogger;
 


### PR DESCRIPTION
Remove usages of SecurityManager, doPrivildged, and AccessController from the java.prefs module.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344337](https://bugs.openjdk.org/browse/JDK-8344337): SecurityManager cleanup in java.prefs module (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22252/head:pull/22252` \
`$ git checkout pull/22252`

Update a local copy of the PR: \
`$ git checkout pull/22252` \
`$ git pull https://git.openjdk.org/jdk.git pull/22252/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22252`

View PR using the GUI difftool: \
`$ git pr show -t 22252`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22252.diff">https://git.openjdk.org/jdk/pull/22252.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22252#issuecomment-2486507273)
</details>
