### PR TITLE
8344595: State transitions in internal VirtualThread comment needs to be updated

### DIFF
--- a/src/java.base/share/classes/java/lang/VirtualThread.java
+++ b/src/java.base/share/classes/java/lang/VirtualThread.java
@@ -108,14 +108,14 @@ final class VirtualThread extends BaseVirtualThread {
      * UNBLOCKED -> RUNNING        // continue execution after blocked on monitor enter
      *
      *   RUNNING -> WAITING        // transitional state during wait on monitor
-     *   WAITING -> WAITED         // waiting on monitor
-     *    WAITED -> BLOCKED        // notified, waiting to be unblocked by monitor owner
-     *    WAITED -> UNBLOCKED      // timed-out/interrupted
+     *   WAITING -> WAIT           // waiting on monitor
+     *      WAIT -> BLOCKED        // notified, waiting to be unblocked by monitor owner
+     *      WAIT -> UNBLOCKED      // timed-out/interrupted
      *
      *       RUNNING -> TIMED_WAITING   // transition state during timed-waiting on monitor
-     * TIMED_WAITING -> TIMED_WAITED    // timed-waiting on monitor
-     *  TIMED_WAITED -> BLOCKED         // notified, waiting to be unblocked by monitor owner
-     *  TIMED_WAITED -> UNBLOCKED       // timed-out/interrupted
+     * TIMED_WAITING -> TIMED_WAIT      // timed-waiting on monitor
+     *    TIMED_WAIT -> BLOCKED         // notified, waiting to be unblocked by monitor owner
+     *    TIMED_WAIT -> UNBLOCKED       // timed-out/interrupted
      *
      *  RUNNING -> YIELDING        // Thread.yield
      * YIELDING -> YIELDED         // cont.yield successful, may be scheduled to continue


### PR DESCRIPTION
See internal bug review 9077848

This is a very small unimportant mistake in the naming of the documentation that does not match the code.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344595](https://bugs.openjdk.org/browse/JDK-8344595): State transitions in internal VirtualThread comment needs to be updated (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22253/head:pull/22253` \
`$ git checkout pull/22253`

Update a local copy of the PR: \
`$ git checkout pull/22253` \
`$ git pull https://git.openjdk.org/jdk.git pull/22253/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22253`

View PR using the GUI difftool: \
`$ git pr show -t 22253`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22253.diff">https://git.openjdk.org/jdk/pull/22253.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22253#issuecomment-2487627136)
</details>
