### PR TITLE
8344215: Remove calls to SecurityManager and doPrivileged in java.net.Socket and java.net.ServerSocket after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/java/net/Socket.java
+++ b/src/java.base/share/classes/java/net/Socket.java
@@ -28,7 +28,6 @@ package java.net;
 import jdk.internal.event.SocketReadEvent;
 import jdk.internal.event.SocketWriteEvent;
 import jdk.internal.invoke.MhUtil;
-import sun.security.util.SecurityConstants;
 
 import java.io.InputStream;
 import java.io.InterruptedIOException;
@@ -158,15 +157,6 @@ public class Socket implements java.io.Closeable {
     }
 
     /**
-     * Creates an unconnected socket with the given {@code SocketImpl}.
-     */
-    private Socket(Void unused, SocketImpl impl) {
-        if (impl != null) {
-            this.impl = impl;
-        }
-    }
-
-    /**
      * Creates an unconnected Socket.
      * <p>
      * If the application has specified a {@linkplain SocketImplFactory client
@@ -212,22 +202,10 @@ public class Socket implements java.io.Closeable {
                                           : sun.net.ApplicationProxy.create(proxy);
         Proxy.Type type = p.type();
         if (type == Proxy.Type.SOCKS || type == Proxy.Type.HTTP) {
-            @SuppressWarnings("removal")
-            SecurityManager security = System.getSecurityManager();
             InetSocketAddress epoint = (InetSocketAddress) p.address();
             if (epoint.getAddress() != null) {
                 checkAddress (epoint.getAddress(), "Socket");
             }
-            if (security != null) {
-                if (epoint.isUnresolved())
-                    epoint = new InetSocketAddress(epoint.getHostName(), epoint.getPort());
-                if (epoint.isUnresolved())
-                    security.checkConnect(epoint.getHostName(), epoint.getPort());
-                else
-                    security.checkConnect(epoint.getAddress().getHostAddress(),
-                                  epoint.getPort());
-            }
-
             // create a SOCKS or HTTP SocketImpl that delegates to a platform SocketImpl
             SocketImpl delegate = SocketImpl.createPlatformSocketImpl(false);
             impl = (type == Proxy.Type.SOCKS) ? new SocksSocketImpl(p, delegate)
@@ -259,18 +237,9 @@ public class Socket implements java.io.Closeable {
      * @since   1.1
      */
     protected Socket(SocketImpl impl) throws SocketException {
-        this(checkPermission(impl), impl);
-    }
-
-    private static Void checkPermission(SocketImpl impl) {
         if (impl != null) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(SecurityConstants.SET_SOCKETIMPL_PERMISSION);
-            }
+            this.impl = impl;
         }
-        return null;
     }
 
     /**
@@ -497,7 +466,7 @@ public class Socket implements java.io.Closeable {
             if (localAddr != null)
                 bind(localAddr);
             connect(address);
-        } catch (IOException | IllegalArgumentException | SecurityException e) {
+        } catch (IOException | IllegalArgumentException e) {
             try {
                 close();
             } catch (IOException ce) {
@@ -684,15 +653,6 @@ public class Socket implements java.io.Closeable {
         int port = epoint.getPort();
         checkAddress(addr, "connect");
 
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            if (epoint.isUnresolved())
-                security.checkConnect(epoint.getHostName(), port);
-            else
-                security.checkConnect(addr.getHostAddress(), port);
-        }
-
         try {
             getImpl().connect(epoint, timeout);
         } catch (SocketTimeoutException e) {
@@ -743,11 +703,6 @@ public class Socket implements java.io.Closeable {
         InetAddress addr = epoint.getAddress();
         int port = epoint.getPort();
         checkAddress (addr, "bind");
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkListen(port);
-        }
         getImpl().bind(addr, port);
         getAndBitwiseOrState(BOUND);
     }
@@ -795,15 +750,9 @@ public class Socket implements java.io.Closeable {
         InetAddress in = null;
         try {
             in = (InetAddress) getImpl().getOption(SocketOptions.SO_BINDADDR);
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null)
-                sm.checkConnect(in.getHostAddress(), -1);
             if (in.isAnyLocalAddress()) {
                 in = InetAddress.anyLocalAddress();
             }
-        } catch (SecurityException e) {
-            in = InetAddress.getLoopbackAddress();
         } catch (Exception e) {
             in = InetAddress.anyLocalAddress(); // "0.0.0.0"
         }
@@ -1854,11 +1803,6 @@ public class Socket implements java.io.Closeable {
     {
         if (factory != null) {
             throw new SocketException("factory already defined");
-        }
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkSetFactory();
         }
         factory = fac;
     }


### PR DESCRIPTION
I'd appreciate a review of this change set removing `SecurityManager` et al. from `java.net.Socket` and `java.net.ServerSocket`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344215](https://bugs.openjdk.org/browse/JDK-8344215): Remove calls to SecurityManager and doPrivileged in java.net.Socket and java.net.ServerSocket after JEP 486 integration (**Sub-task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22254/head:pull/22254` \
`$ git checkout pull/22254`

Update a local copy of the PR: \
`$ git checkout pull/22254` \
`$ git pull https://git.openjdk.org/jdk.git pull/22254/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22254`

View PR using the GUI difftool: \
`$ git pr show -t 22254`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22254.diff">https://git.openjdk.org/jdk/pull/22254.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22254#issuecomment-2486627796)
</details>
