### PR TITLE
8344363: FullGCForwarding::initialize_flags is called after ObjLayout::initialize

### DIFF
--- a/src/hotspot/share/gc/g1/g1Arguments.cpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.cpp
@@ -244,10 +244,7 @@ void G1Arguments::initialize() {
   if (max_parallel_refinement_threads > UINT_MAX / divisor) {
     vm_exit_during_initialization("Too large parallelism for remembered sets.");
   }
-}
 
-void G1Arguments::initialize_heap_flags_and_sizes() {
-  GCArguments::initialize_heap_flags_and_sizes();
   FullGCForwarding::initialize_flags(heap_reserved_size_bytes());
 }
 

--- a/src/hotspot/share/gc/g1/g1Arguments.hpp
+++ b/src/hotspot/share/gc/g1/g1Arguments.hpp
@@ -39,7 +39,6 @@ class G1Arguments : public GCArguments {
   static void parse_verification_type(const char* type);
 
   virtual void initialize_alignments();
-  virtual void initialize_heap_flags_and_sizes();
 
   virtual void initialize();
   virtual size_t conservative_max_heap_alignment();

--- a/src/hotspot/share/gc/parallel/parallelArguments.cpp
+++ b/src/hotspot/share/gc/parallel/parallelArguments.cpp
@@ -83,6 +83,8 @@ void ParallelArguments::initialize() {
   if (FLAG_IS_DEFAULT(ParallelRefProcEnabled) && ParallelGCThreads > 1) {
     FLAG_SET_DEFAULT(ParallelRefProcEnabled, true);
   }
+
+  FullGCForwarding::initialize_flags(heap_reserved_size_bytes());
 }
 
 // The alignment used for boundary between young gen and old gen
@@ -128,7 +130,6 @@ void ParallelArguments::initialize_heap_flags_and_sizes() {
     // Redo everything from the start
     initialize_heap_flags_and_sizes_one_pass();
   }
-  FullGCForwarding::initialize_flags(heap_reserved_size_bytes());
 }
 
 size_t ParallelArguments::heap_reserved_size_bytes() {

--- a/src/hotspot/share/gc/serial/serialArguments.cpp
+++ b/src/hotspot/share/gc/serial/serialArguments.cpp
@@ -24,12 +24,12 @@
 
 #include "precompiled.hpp"
 #include "gc/shared/fullGCForwarding.hpp"
-#include "gc/shared/genArguments.hpp"
+#include "gc/shared/gcArguments.hpp"
 #include "gc/serial/serialArguments.hpp"
 #include "gc/serial/serialHeap.hpp"
 
 void SerialArguments::initialize() {
-  GenArguments::initialize();
+  GCArguments::initialize();
   FullGCForwarding::initialize_flags(MaxHeapSize);
 }
 

--- a/src/hotspot/share/gc/serial/serialArguments.cpp
+++ b/src/hotspot/share/gc/serial/serialArguments.cpp
@@ -28,8 +28,8 @@
 #include "gc/serial/serialArguments.hpp"
 #include "gc/serial/serialHeap.hpp"
 
-void SerialArguments::initialize_heap_flags_and_sizes() {
-  GenArguments::initialize_heap_flags_and_sizes();
+void SerialArguments::initialize() {
+  GenArguments::initialize();
   FullGCForwarding::initialize_flags(MaxHeapSize);
 }
 

--- a/src/hotspot/share/gc/serial/serialArguments.hpp
+++ b/src/hotspot/share/gc/serial/serialArguments.hpp
@@ -32,7 +32,7 @@ class CollectedHeap;
 class SerialArguments : public GenArguments {
 private:
   virtual CollectedHeap* create_heap();
-  virtual void initialize_heap_flags_and_sizes();
+  virtual void initialize();
 };
 
 #endif // SHARE_GC_SERIAL_SERIALARGUMENTS_HPP

--- a/src/hotspot/share/gc/serial/serialArguments.hpp
+++ b/src/hotspot/share/gc/serial/serialArguments.hpp
@@ -31,8 +31,8 @@ class CollectedHeap;
 
 class SerialArguments : public GenArguments {
 private:
-  virtual CollectedHeap* create_heap();
   virtual void initialize();
+  virtual CollectedHeap* create_heap();
 };
 
 #endif // SHARE_GC_SERIAL_SERIALARGUMENTS_HPP

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.cpp
@@ -176,6 +176,8 @@ void ShenandoahArguments::initialize() {
   if (FLAG_IS_DEFAULT(TLABAllocationWeight)) {
     FLAG_SET_DEFAULT(TLABAllocationWeight, 90);
   }
+
+  FullGCForwarding::initialize_flags(MaxHeapSize);
 }
 
 size_t ShenandoahArguments::conservative_max_heap_alignment() {
@@ -197,11 +199,6 @@ void ShenandoahArguments::initialize_alignments() {
   }
   SpaceAlignment = align;
   HeapAlignment = align;
-}
-
-void ShenandoahArguments::initialize_heap_flags_and_sizes() {
-  GCArguments::initialize_heap_flags_and_sizes();
-  FullGCForwarding::initialize_flags(MaxHeapSize);
 }
 
 CollectedHeap* ShenandoahArguments::create_heap() {

--- a/src/hotspot/share/gc/shenandoah/shenandoahArguments.hpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahArguments.hpp
@@ -35,7 +35,6 @@ private:
 
   virtual void initialize();
   virtual size_t conservative_max_heap_alignment();
-  virtual void initialize_heap_flags_and_sizes();
   virtual CollectedHeap* create_heap();
 };
 

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -869,11 +869,11 @@ jint universe_init() {
   // Initialize CPUTimeCounters object, which must be done before creation of the heap.
   CPUTimeCounters::initialize();
 
+  ObjLayout::initialize();
+
 #ifdef _LP64
   MetaspaceShared::adjust_heap_sizes_for_dumping();
 #endif // _LP64
-
-  ObjLayout::initialize();
 
   GCConfig::arguments()->initialize_heap_sizes();
 

--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -62,6 +62,7 @@
 #include "oops/instanceMirrorKlass.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/objArrayOop.inline.hpp"
+#include "oops/objLayout.hpp"
 #include "oops/oop.inline.hpp"
 #include "oops/oopHandle.inline.hpp"
 #include "oops/typeArrayKlass.hpp"
@@ -871,6 +872,8 @@ jint universe_init() {
 #ifdef _LP64
   MetaspaceShared::adjust_heap_sizes_for_dumping();
 #endif // _LP64
+
+  ObjLayout::initialize();
 
   GCConfig::arguments()->initialize_heap_sizes();
 

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3657,7 +3657,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   return JNI_OK;
 }
 
-void Arguments::setup_compact_headers() {
+void Arguments::set_compact_headers() {
 #ifdef _LP64
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {
     warning("Compact object headers require compressed class pointers. Disabling compact object headers.");
@@ -3695,7 +3695,7 @@ jint Arguments::apply_ergo() {
 
   GCConfig::arguments()->initialize();
 
-  setup_compact_headers();
+  set_compact_headers();
 
   if (UseCompressedClassPointers) {
     CompressedKlassPointers::pre_initialize();

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3654,33 +3654,35 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
     Arguments::print_on(&st);
   }
 
+  return JNI_OK;
+}
+
+void Arguments::setup_compact_headers() {
 #ifdef _LP64
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {
     warning("Compact object headers require compressed class pointers. Disabling compact object headers.");
     FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
-  }
-  if (UseCompactObjectHeaders && LockingMode != LM_LIGHTWEIGHT) {
-    FLAG_SET_DEFAULT(LockingMode, LM_LIGHTWEIGHT);
   }
   if (UseCompactObjectHeaders && !UseObjectMonitorTable) {
     // If UseCompactObjectHeaders is on the command line, turn on UseObjectMonitorTable.
     if (FLAG_IS_CMDLINE(UseCompactObjectHeaders)) {
       FLAG_SET_DEFAULT(UseObjectMonitorTable, true);
 
-    // If UseObjectMonitorTable is on the command line, turn off UseCompactObjectHeaders.
+      // If UseObjectMonitorTable is on the command line, turn off UseCompactObjectHeaders.
     } else if (FLAG_IS_CMDLINE(UseObjectMonitorTable)) {
       FLAG_SET_DEFAULT(UseCompactObjectHeaders, false);
-    // If neither on the command line, the defaults are incompatible, but turn on UseObjectMonitorTable.
+      // If neither on the command line, the defaults are incompatible, but turn on UseObjectMonitorTable.
     } else {
       FLAG_SET_DEFAULT(UseObjectMonitorTable, true);
     }
+  }
+  if (UseCompactObjectHeaders && LockingMode != LM_LIGHTWEIGHT) {
+    FLAG_SET_DEFAULT(LockingMode, LM_LIGHTWEIGHT);
   }
   if (UseCompactObjectHeaders && !UseCompressedClassPointers) {
     FLAG_SET_DEFAULT(UseCompressedClassPointers, true);
   }
 #endif
-
-  return JNI_OK;
 }
 
 jint Arguments::apply_ergo() {
@@ -3692,6 +3694,8 @@ jint Arguments::apply_ergo() {
   set_heap_size();
 
   GCConfig::arguments()->initialize();
+
+  setup_compact_headers();
 
   if (UseCompressedClassPointers) {
     CompressedKlassPointers::pre_initialize();

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -3657,7 +3657,7 @@ jint Arguments::parse(const JavaVMInitArgs* initial_cmd_args) {
   return JNI_OK;
 }
 
-void Arguments::set_compact_headers() {
+void Arguments::set_compact_headers_flags() {
 #ifdef _LP64
   if (UseCompactObjectHeaders && FLAG_IS_CMDLINE(UseCompressedClassPointers) && !UseCompressedClassPointers) {
     warning("Compact object headers require compressed class pointers. Disabling compact object headers.");
@@ -3695,7 +3695,7 @@ jint Arguments::apply_ergo() {
 
   GCConfig::arguments()->initialize();
 
-  set_compact_headers();
+  set_compact_headers_flags();
 
   if (UseCompressedClassPointers) {
     CompressedKlassPointers::pre_initialize();

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -264,7 +264,7 @@ class Arguments : AllStatic {
   static void set_conservative_max_heap_alignment();
   static void set_use_compressed_oops();
   static jint set_ergonomics_flags();
-  static void set_compact_headers();
+  static void set_compact_headers_flags();
   // Limits the given heap size by the maximum amount of virtual
   // memory this process is currently allowed to use. It also takes
   // the virtual-to-physical ratio of the current GC into account.

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -264,6 +264,7 @@ class Arguments : AllStatic {
   static void set_conservative_max_heap_alignment();
   static void set_use_compressed_oops();
   static jint set_ergonomics_flags();
+  static void setup_compact_headers();
   // Limits the given heap size by the maximum amount of virtual
   // memory this process is currently allowed to use. It also takes
   // the virtual-to-physical ratio of the current GC into account.

--- a/src/hotspot/share/runtime/arguments.hpp
+++ b/src/hotspot/share/runtime/arguments.hpp
@@ -264,7 +264,7 @@ class Arguments : AllStatic {
   static void set_conservative_max_heap_alignment();
   static void set_use_compressed_oops();
   static jint set_ergonomics_flags();
-  static void setup_compact_headers();
+  static void set_compact_headers();
   // Limits the given heap size by the maximum amount of virtual
   // memory this process is currently allowed to use. It also takes
   // the virtual-to-physical ratio of the current GC into account.

--- a/src/hotspot/share/runtime/threads.cpp
+++ b/src/hotspot/share/runtime/threads.cpp
@@ -497,9 +497,6 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   // Timing (must come after argument parsing)
   TraceTime timer("Create VM", TRACETIME_LOG(Info, startuptime));
 
-  // Initialize object layout after parsing the args
-  ObjLayout::initialize();
-
   // Initialize the os module after parsing the args
   jint os_init_2_result = os::init_2();
   if (os_init_2_result != JNI_OK) return os_init_2_result;


### PR DESCRIPTION
From the bug description:
ObjLayout::initialize() is called in Arguments::parse(const JavaVMInitArgs*) which sets ObjLayout::_klass_mode. FullGCForwarding::initialize_flags(size_t) is called in init_globals() which seems to be later in the Threads::create_vm(JavaVMInitArgs*, bool*) routine. The latter, however, can unset the UseCompactObjectHeaders flag, which leads to a potential mismatch with ObjLayout::_klass_mode, firing the asserts in ObjLayout::klass_mode().

There is also a related (and somewhat minor) problem: In Arguments::parse() we enable a bunch of stuff when UseCompactObjectHeaders is on (LW locking, but that's the default anyway, and object-monitor-tables, which are otherwise off), but then may disable UseCompactObjectHeaders, e.g. in the GC or when -UseCompressedClassPointers is requested. This then leaves the odd situation that we run without compact headers, but have object monitor tables turned on.

The fix to both issues is:
- First disable UCOH
- and do that in apply_ergo() (e.g. GCs should do it in GCArguments::initialize())
- then enable any flags required by compact headers
- Initialize ObjLayout after all flags are done (it's in the correct place, already)

Testing:
 - [x] tier1 -UCOH (default)
 - [ ] tier1 +UCOH
 - [x] Manual testing several flag combinations

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344363](https://bugs.openjdk.org/browse/JDK-8344363): FullGCForwarding::initialize_flags is called after ObjLayout::initialize (**Bug** - P3)


### Reviewers
 * [Stefan Karlsson](https://openjdk.org/census#stefank) (@stefank - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22255/head:pull/22255` \
`$ git checkout pull/22255`

Update a local copy of the PR: \
`$ git checkout pull/22255` \
`$ git pull https://git.openjdk.org/jdk.git pull/22255/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22255`

View PR using the GUI difftool: \
`$ git pr show -t 22255`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22255.diff">https://git.openjdk.org/jdk/pull/22255.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22255#issuecomment-2488333517)
</details>
