### PR TITLE
8344248: Remove Security Manager dependencies from java.security.jgss and jdk.security.jgss modules

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -319,8 +319,7 @@ module java.base {
         java.rmi,
         java.sql.rowset;
     exports sun.security.action to
-        java.desktop,
-        java.security.jgss;
+        java.desktop;
     exports sun.security.internal.interfaces to
         jdk.crypto.cryptoki;
     exports sun.security.internal.spec to

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosPrincipal.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KerberosPrincipal.java
@@ -176,19 +176,6 @@ public final class KerberosPrincipal
             throw new IllegalArgumentException(e.getMessage());
         }
 
-        if (krb5Principal.isRealmDeduced() && !Realm.AUTODEDUCEREALM) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                try {
-                    sm.checkPermission(new ServicePermission(
-                            "@" + krb5Principal.getRealmAsString(), "-"));
-                } catch (SecurityException se) {
-                    // Swallow the actual exception to hide info
-                    throw new SecurityException("Cannot read realm info");
-                }
-            }
-        }
         this.nameType = nameType;
         fullName = krb5Principal.toString();
         realm = krb5Principal.getRealmString();

--- a/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KeyTab.java
+++ b/src/java.security.jgss/share/classes/javax/security/auth/kerberos/KeyTab.java
@@ -26,7 +26,6 @@
 package javax.security.auth.kerberos;
 
 import java.io.File;
-import java.security.AccessControlException;
 import java.util.Objects;
 import sun.security.krb5.EncryptionKey;
 import sun.security.krb5.KerberosSecrets;
@@ -210,20 +209,7 @@ public final class KeyTab {
     // Takes a snapshot of the keytab content. This method is called by
     // JavaxSecurityAuthKerberosAccessImpl so no more private
     sun.security.krb5.internal.ktab.KeyTab takeSnapshot() {
-        try {
-            return sun.security.krb5.internal.ktab.KeyTab.getInstance(file);
-        } catch (@SuppressWarnings("removal") AccessControlException ace) {
-            if (file != null) {
-                // It's OK to show the name if caller specified it
-                throw ace;
-            } else {
-                @SuppressWarnings("removal")
-                AccessControlException ace2 = new AccessControlException(
-                        "Access to default keytab denied (modified exception)");
-                ace2.setStackTrace(ace.getStackTrace());
-                throw ace2;
-            }
-        }
+        return sun.security.krb5.internal.ktab.KeyTab.getInstance(file);
     }
 
     /**

--- a/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
+++ b/src/java.security.jgss/share/classes/sun/net/www/protocol/http/spnego/NegotiatorImpl.java
@@ -35,7 +35,6 @@ import org.ietf.jgss.Oid;
 
 import sun.net.www.protocol.http.HttpCallerInfo;
 import sun.net.www.protocol.http.Negotiator;
-import sun.security.action.GetPropertyAction;
 import sun.security.jgss.GSSManagerImpl;
 import sun.security.jgss.GSSContextImpl;
 import sun.security.jgss.GSSUtil;
@@ -74,8 +73,7 @@ public class NegotiatorImpl extends Negotiator {
             // we can only use Kerberos mech when the scheme is kerberos
             oid = GSSUtil.GSS_KRB5_MECH_OID;
         } else {
-            String pref = GetPropertyAction
-                    .privilegedGetProperty("http.auth.preference", "spnego");
+            String pref = System.getProperty("http.auth.preference", "spnego");
             if (pref.equalsIgnoreCase("kerberos")) {
                 oid = GSSUtil.GSS_KRB5_MECH_OID;
             } else {

--- a/src/java.security.jgss/share/classes/sun/security/jgss/GSSManagerImpl.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/GSSManagerImpl.java
@@ -26,7 +26,6 @@
 package sun.security.jgss;
 
 import org.ietf.jgss.*;
-import sun.security.action.GetBooleanAction;
 import sun.security.jgss.spi.*;
 import java.security.Provider;
 
@@ -37,8 +36,8 @@ import java.security.Provider;
 public class GSSManagerImpl extends GSSManager {
 
     // Undocumented property
-    private static final Boolean USE_NATIVE = GetBooleanAction
-            .privilegedGetProperty("sun.security.jgss.native");
+    private static final Boolean USE_NATIVE =
+            Boolean.getBoolean("sun.security.jgss.native");
 
     private final ProviderList list;
 

--- a/src/java.security.jgss/share/classes/sun/security/jgss/LoginConfigImpl.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/LoginConfigImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,10 @@
 
 package sun.security.jgss;
 
-import java.security.PrivilegedAction;
 import java.util.HashMap;
 import javax.security.auth.login.AppConfigurationEntry;
 import javax.security.auth.login.Configuration;
 import org.ietf.jgss.Oid;
-import sun.security.action.GetPropertyAction;
 
 /**
  * A Configuration implementation especially designed for JGSS.
@@ -49,8 +47,7 @@ public class LoginConfigImpl extends Configuration {
     public static final boolean HTTP_USE_GLOBAL_CREDS;
 
     static {
-        String prop = GetPropertyAction
-                .privilegedGetProperty("http.use.global.creds");
+        String prop = System.getProperty("http.use.global.creds");
         //HTTP_USE_GLOBAL_CREDS = "true".equalsIgnoreCase(prop); // default false
         HTTP_USE_GLOBAL_CREDS = !"false".equalsIgnoreCase(prop); // default true
     }
@@ -62,7 +59,6 @@ public class LoginConfigImpl extends Configuration {
      * @param caller defined in GSSUtil as CALLER_XXX final fields
      * @param mech defined in GSSUtil as XXX_MECH_OID final fields
      */
-    @SuppressWarnings("removal")
     public LoginConfigImpl(GSSCaller caller, Oid mech) {
 
         this.caller = caller;
@@ -72,8 +68,7 @@ public class LoginConfigImpl extends Configuration {
         } else {
             throw new IllegalArgumentException(mech.toString() + " not supported");
         }
-        config = java.security.AccessController.doPrivileged
-                ((PrivilegedAction<Configuration>) Configuration::getConfiguration);
+        config = Configuration.getConfiguration();
     }
 
     /**

--- a/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/ProviderList.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 import sun.security.jgss.spi.*;
 import sun.security.jgss.wrapper.NativeGSSFactory;
 import sun.security.jgss.wrapper.SunNativeProvider;
-import sun.security.action.GetPropertyAction;
 
 /**
  * This class stores the list of providers that this
@@ -102,8 +101,7 @@ public final class ProviderList {
          * with a valid OID value
          */
         Oid defOid = null;
-        String defaultOidStr = GetPropertyAction
-                .privilegedGetProperty("sun.security.jgss.mechanism");
+        String defaultOidStr = System.getProperty("sun.security.jgss.mechanism");
         if (defaultOidStr != null) {
             defOid = GSSUtil.createOid(defaultOidStr);
         }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/SunProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/SunProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package sun.security.jgss;
 
 import java.io.Serial;
 import java.security.Provider;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidParameterException;
 import java.security.ProviderException;
@@ -100,20 +98,16 @@ public final class SunProvider extends Provider {
         }
     }
 
-    @SuppressWarnings("removal")
     public SunProvider() {
         /* We are the Sun JGSS provider */
         super("SunJGSS", PROVIDER_VER, INFO);
 
         final Provider p = this;
-        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-            putService(new ProviderService(p, "GssApiMechanism",
-                       "1.2.840.113554.1.2.2",
-                       "sun.security.jgss.krb5.Krb5MechFactory"));
-            putService(new ProviderService(p, "GssApiMechanism",
-                       "1.3.6.1.5.5.2",
-                       "sun.security.jgss.spnego.SpNegoMechFactory"));
-            return null;
-        });
+        putService(new ProviderService(p, "GssApiMechanism",
+                   "1.2.840.113554.1.2.2",
+                   "sun.security.jgss.krb5.Krb5MechFactory"));
+        putService(new ProviderService(p, "GssApiMechanism",
+                   "1.3.6.1.5.5.2",
+                   "sun.security.jgss.spnego.SpNegoMechFactory"));
     }
 }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/AcceptSecContextToken.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/AcceptSecContextToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import org.ietf.jgss.*;
 import java.io.InputStream;
 import java.io.IOException;
 
-import sun.security.action.GetBooleanAction;
 import sun.security.krb5.*;
 
 class AcceptSecContextToken extends InitialToken {
@@ -44,8 +43,8 @@ class AcceptSecContextToken extends InitialToken {
                                  KrbApReq apReq)
         throws KrbException, IOException, GSSException {
 
-        boolean useSubkey = GetBooleanAction
-                .privilegedGetProperty("sun.security.krb5.acceptor.subkey");
+        boolean useSubkey = Boolean.getBoolean(
+            "sun.security.krb5.acceptor.subkey");
 
         boolean useSequenceNumber = true;
 

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/InitSecContextToken.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/InitSecContextToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import org.ietf.jgss.*;
 import java.io.InputStream;
 import java.io.IOException;
 
-import sun.security.action.GetPropertyAction;
 import sun.security.krb5.*;
 import java.net.InetAddress;
 import sun.security.krb5.internal.AuthorizationData;
@@ -53,7 +52,7 @@ class InitSecContextToken extends InitialToken {
         // property "sun.security.krb5.acceptor.sequence.number.nonmutual",
         // which can be set to "initiator", "zero" or "0".
         String propName = "sun.security.krb5.acceptor.sequence.number.nonmutual";
-        String s = GetPropertyAction.privilegedGetProperty(propName, "initiator");
+        String s = System.getProperty(propName, "initiator");
         if (s.equals("initiator")) {
             ACCEPTOR_USE_INITIATOR_SEQNUM = true;
         } else if (s.equals("zero") || s.equals("0")) {

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/InitialToken.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/InitialToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.jgss.krb5;
 
 import org.ietf.jgss.*;
-import javax.security.auth.kerberos.DelegationPermission;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Inet4Address;
@@ -171,14 +170,6 @@ abstract class InitialToken extends Krb5Token {
                 String realm = delegateTo.getRealmAsString();
                 sb.append(" \"krbtgt/").append(realm).append('@');
                 sb.append(realm).append('\"');
-                @SuppressWarnings("removal")
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                    DelegationPermission perm =
-                        new DelegationPermission(sb.toString());
-                    sm.checkPermission(perm);
-                }
-
 
                 /*
                  * Write 1 in little endian but in two bytes

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5AcceptCredential.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5AcceptCredential.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,8 @@ import org.ietf.jgss.*;
 import sun.security.jgss.GSSCaller;
 import sun.security.jgss.spi.*;
 import sun.security.krb5.*;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
-import java.security.AccessController;
 import javax.security.auth.DestroyFailedException;
+import javax.security.auth.login.LoginException;
 
 /**
  * Implements the krb5 acceptor credential element.
@@ -57,27 +55,22 @@ public class Krb5AcceptCredential
         this.screds = creds;
     }
 
-    @SuppressWarnings("removal")
     static Krb5AcceptCredential getInstance(final GSSCaller caller, Krb5NameElement name)
         throws GSSException {
 
         final String serverPrinc = (name == null? null:
             name.getKrb5PrincipalName().getName());
 
-        ServiceCreds creds;
+        ServiceCreds creds = null;
         try {
-            creds = AccessController.doPrivilegedWithCombiner(
-                        new PrivilegedExceptionAction<ServiceCreds>() {
-                public ServiceCreds run() throws Exception {
-                    return Krb5Util.getServiceCreds(
-                        caller == GSSCaller.CALLER_UNKNOWN ? GSSCaller.CALLER_ACCEPT: caller,
-                        serverPrinc);
-                }});
-        } catch (PrivilegedActionException e) {
+            creds = Krb5Util.getServiceCreds(
+                caller == GSSCaller.CALLER_UNKNOWN ? GSSCaller.CALLER_ACCEPT: caller,
+                serverPrinc);
+        } catch (LoginException e) {
             GSSException ge =
                 new GSSException(GSSException.NO_CRED, -1,
                     "Attempt to obtain new ACCEPT credentials failed!");
-            ge.initCause(e.getException());
+            ge.initCause(e);
             throw ge;
         }
 

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5NameElement.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5NameElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,10 +28,8 @@ package sun.security.jgss.krb5;
 import org.ietf.jgss.*;
 import sun.security.jgss.spi.*;
 import sun.security.krb5.PrincipalName;
-import sun.security.krb5.Realm;
 import sun.security.krb5.KrbException;
 
-import javax.security.auth.kerberos.ServicePermission;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.Provider;
@@ -127,19 +125,6 @@ public class Krb5NameElement
             throw new GSSException(GSSException.BAD_NAME, -1, e.getMessage());
         }
 
-        if (principalName.isRealmDeduced() && !Realm.AUTODEDUCEREALM) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                try {
-                    sm.checkPermission(new ServicePermission(
-                            "@" + principalName.getRealmAsString(), "-"));
-                } catch (SecurityException se) {
-                    // Do not chain the actual exception to hide info
-                    throw new GSSException(GSSException.FAILURE);
-                }
-            }
-        }
         return new Krb5NameElement(principalName, gssNameStr, gssNameType);
     }
 

--- a/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5Util.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/krb5/Krb5Util.java
@@ -59,7 +59,6 @@ public class Krb5Util {
     static KerberosTicket getServiceTicket(GSSCaller caller,
             String clientPrincipal, String serverPrincipal) {
         // Try to get ticket from current Subject
-        @SuppressWarnings("removal")
         Subject currSubj = Subject.current();
         KerberosTicket ticket =
             SubjectComber.find(currSubj, serverPrincipal, clientPrincipal,

--- a/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoContext.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoContext.java
@@ -30,8 +30,6 @@ import java.security.Provider;
 import java.util.Objects;
 
 import org.ietf.jgss.*;
-import sun.security.action.GetBooleanAction;
-import sun.security.action.GetPropertyAction;
 import sun.security.jgss.*;
 import sun.security.jgss.spi.*;
 import sun.security.util.*;
@@ -85,8 +83,8 @@ public class SpNegoContext implements GSSContextSpi {
     private final SpNegoMechFactory factory;
 
     // debug property
-    static final Debug DEBUG = Debug.of("spnego", GetPropertyAction
-            .privilegedGetProperty("sun.security.spnego.debug"));
+    static final Debug DEBUG = Debug.of("spnego",
+            System.getProperty("sun.security.spnego.debug"));
 
     /**
      * Constructor for SpNegoContext to be called on the context initiator's

--- a/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoMechFactory.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/spnego/SpNegoMechFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,10 +28,6 @@ package sun.security.jgss.spnego;
 import org.ietf.jgss.*;
 import sun.security.jgss.*;
 import sun.security.jgss.spi.*;
-import sun.security.jgss.krb5.Krb5MechFactory;
-import sun.security.jgss.krb5.Krb5InitCredential;
-import sun.security.jgss.krb5.Krb5AcceptCredential;
-import sun.security.jgss.krb5.Krb5NameElement;
 import java.security.Provider;
 import java.util.Vector;
 
@@ -75,25 +71,8 @@ public final class SpNegoMechFactory implements MechanismFactory {
             GSSUtil.searchSubject(name, GSS_SPNEGO_MECH_OID,
                 initiate, SpNegoCredElement.class);
 
-        SpNegoCredElement result = ((creds == null || creds.isEmpty()) ?
-                                    null : creds.firstElement());
-
-        // Force permission check before returning the cred to caller
-        if (result != null) {
-            GSSCredentialSpi cred = result.getInternalCred();
-            if (GSSUtil.isKerberosMech(cred.getMechanism())) {
-                if (initiate) {
-                    Krb5InitCredential krbCred = (Krb5InitCredential) cred;
-                    Krb5MechFactory.checkInitCredPermission
-                        ((Krb5NameElement) krbCred.getName());
-                } else {
-                    Krb5AcceptCredential krbCred = (Krb5AcceptCredential) cred;
-                    Krb5MechFactory.checkAcceptCredPermission
-                        ((Krb5NameElement) krbCred.getName(), name);
-                }
-            }
-        }
-        return result;
+        return ((creds == null || creds.isEmpty()) ?
+                null : creds.firstElement());
     }
 
     public SpNegoMechFactory() {

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSNameElement.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/GSSNameElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import sun.security.util.DerInputStream;
 import sun.security.util.DerOutputStream;
 import sun.security.util.ObjectIdentifier;
 
-import javax.security.auth.kerberos.ServicePermission;
 import java.io.IOException;
 import java.lang.ref.Cleaner;
 import java.security.Provider;
@@ -167,29 +166,6 @@ public class GSSNameElement implements GSSNameSpi {
         cleanable = Krb5Util.cleaner.register(this, disposerFor(stub, pName));
 
         setPrintables();
-
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null && !Realm.AUTODEDUCEREALM) {
-            String krbName = getKrbName();
-            int atPos = krbName.lastIndexOf('@');
-            if (atPos != -1) {
-                String atRealm = krbName.substring(atPos);
-                // getNativeNameType() can modify NT_GSS_KRB5_PRINCIPAL to null
-                if ((nameType == null
-                            || nameType.equals(GSSUtil.NT_GSS_KRB5_PRINCIPAL))
-                        && new String(nameBytes).endsWith(atRealm)) {
-                    // Created from Kerberos name with realm, no need to check
-                } else {
-                    try {
-                        sm.checkPermission(new ServicePermission(atRealm, "-"));
-                    } catch (SecurityException se) {
-                        // Do not chain the actual exception to hide info
-                        throw new GSSException(GSSException.FAILURE);
-                    }
-                }
-            }
-        }
 
         if (SunNativeProvider.DEBUG) {
             SunNativeProvider.debug("Imported " + printableName + " w/ type " +

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/Krb5Util.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/Krb5Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@ package sun.security.jgss.wrapper;
 
 import org.ietf.jgss.*;
 import java.lang.ref.Cleaner;
-import javax.security.auth.kerberos.ServicePermission;
 
 /**
  * This class is a utility class for Kerberos related stuff.
@@ -45,21 +44,5 @@ class Krb5Util {
         int atIndex = krbPrinc.indexOf('@');
         String realm = krbPrinc.substring(atIndex + 1);
         return "krbtgt/" + realm + '@' + realm;
-    }
-
-    // Perform the Service Permission check using the specified
-    // <code>target</code> and <code>action</code>
-    static void checkServicePermission(String target, String action) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            if (SunNativeProvider.DEBUG) {
-                SunNativeProvider.debug("Checking ServicePermission(" +
-                        target + ", " + action + ")");
-            }
-            ServicePermission perm =
-                new ServicePermission(target, action);
-            sm.checkPermission(perm);
-        }
     }
 }

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/NativeGSSFactory.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/NativeGSSFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,13 +65,8 @@ public final class NativeGSSFactory implements MechanismFactory {
             }
         }
 
-        GSSCredElement result = ((creds == null || creds.isEmpty()) ?
-                                 null : creds.firstElement());
-        // Force permission check before returning the cred to caller
-        if (result != null) {
-            result.doServicePermCheck();
-        }
-        return result;
+        return ((creds == null || creds.isEmpty()) ?
+                null : creds.firstElement());
     }
 
     public NativeGSSFactory(GSSCaller caller) {

--- a/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
+++ b/src/java.security.jgss/share/classes/sun/security/jgss/wrapper/SunNativeProvider.java
@@ -28,14 +28,10 @@ package sun.security.jgss.wrapper;
 import java.io.Serial;
 import java.util.HashMap;
 import java.security.Provider;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import jdk.internal.util.OperatingSystem;
 import jdk.internal.util.StaticProperty;
 import org.ietf.jgss.Oid;
-import sun.security.action.GetBooleanAction;
-import sun.security.action.PutAllAction;
 import static sun.security.util.SecurityConstants.PROVIDER_VER;
 
 /**
@@ -59,7 +55,7 @@ public final class SunNativeProvider extends Provider {
         "sun.security.jgss.wrapper.NativeGSSFactory";
 
     static final boolean DEBUG =
-        GetBooleanAction.privilegedGetProperty("sun.security.nativegss.debug");
+        Boolean.getBoolean("sun.security.nativegss.debug");
 
     static void debug(String message) {
         if (message == null) {
@@ -68,81 +64,76 @@ public final class SunNativeProvider extends Provider {
         System.err.println(NAME + ": " + message);
     }
 
-    @SuppressWarnings({"removal", "restricted"})
-    private static final HashMap<String, String> MECH_MAP =
-            AccessController.doPrivileged(
-                new PrivilegedAction<>() {
-                    public HashMap<String, String> run() {
-                        try {
-                            // Ensure the InetAddress class is loaded before
-                            // loading j2gss. The library will access this class
-                            // and a deadlock might happen. See JDK-8210373.
-                            Class.forName("java.net.InetAddress");
-                            System.loadLibrary("j2gss");
-                        } catch (ClassNotFoundException | Error err) {
-                            if (DEBUG) {
-                                debug("No j2gss library found!");
-                                err.printStackTrace();
-                            }
-                            return null;
-                        }
-                        String[] gssLibs;
-                        String defaultLib
-                                = System.getProperty("sun.security.jgss.lib");
-                        if (defaultLib == null || defaultLib.trim().equals("")) {
-                            gssLibs = switch (OperatingSystem.current()) {
-                                case LINUX -> new String[]{
-                                        "libgssapi.so",
-                                        "libgssapi_krb5.so",
-                                        "libgssapi_krb5.so.2",
-                                };
-                                case MACOS -> new String[]{
-                                        "libgssapi_krb5.dylib",
-                                        "/usr/lib/sasl2/libgssapiv2.2.so",
-                                };
-                                case WINDOWS -> new String[]{
-                                        // Full path needed, DLL is in jre/bin
-                                        StaticProperty.javaHome() + "\\bin\\sspi_bridge.dll",
-                                };
-                                case AIX -> new String[]{
-                                        "/opt/freeware/lib64/libgssapi_krb5.so",
-                                };
-                                default -> new String[0];
-                            };
-                        } else {
-                            gssLibs = new String[]{ defaultLib };
-                        }
-                        for (String libName: gssLibs) {
-                            if (GSSLibStub.init(libName, DEBUG)) {
-                                if (DEBUG) {
-                                    debug("Loaded GSS library: " + libName);
-                                }
-                                Oid[] mechs = GSSLibStub.indicateMechs();
-                                HashMap<String,String> map = new HashMap<>();
-                                for (int i = 0; i < mechs.length; i++) {
-                                    if (DEBUG) {
-                                        debug("Native MF for " + mechs[i]);
-                                    }
-                                    map.put("GssApiMechanism." + mechs[i],
-                                            MF_CLASS);
-                                }
-                                return map;
-                            }
-                        }
-                        return null;
-                    }
-                });
+    private static final HashMap<String, String> MECH_MAP = constructMechMap();
+
+    @SuppressWarnings("restricted")
+    private static HashMap<String, String> constructMechMap() {
+        try {
+            // Ensure the InetAddress class is loaded before
+            // loading j2gss. The library will access this class
+            // and a deadlock might happen. See JDK-8210373.
+            Class.forName("java.net.InetAddress");
+            System.loadLibrary("j2gss");
+        } catch (ClassNotFoundException | Error err) {
+            if (DEBUG) {
+                debug("No j2gss library found!");
+                err.printStackTrace();
+            }
+            return null;
+        }
+        String[] gssLibs;
+        String defaultLib = System.getProperty("sun.security.jgss.lib");
+        if (defaultLib == null || defaultLib.trim().equals("")) {
+            gssLibs = switch (OperatingSystem.current()) {
+                case LINUX -> new String[]{
+                        "libgssapi.so",
+                        "libgssapi_krb5.so",
+                        "libgssapi_krb5.so.2",
+                };
+                case MACOS -> new String[]{
+                        "libgssapi_krb5.dylib",
+                        "/usr/lib/sasl2/libgssapiv2.2.so",
+                };
+                case WINDOWS -> new String[]{
+                        // Full path needed, DLL is in jre/bin
+                        StaticProperty.javaHome() + "\\bin\\sspi_bridge.dll",
+                };
+                case AIX -> new String[]{
+                        "/opt/freeware/lib64/libgssapi_krb5.so",
+                };
+                default -> new String[0];
+            };
+        } else {
+            gssLibs = new String[]{ defaultLib };
+        }
+        for (String libName: gssLibs) {
+             if (GSSLibStub.init(libName, DEBUG)) {
+                 if (DEBUG) {
+                     debug("Loaded GSS library: " + libName);
+                 }
+                 Oid[] mechs = GSSLibStub.indicateMechs();
+                 HashMap<String,String> map = new HashMap<>();
+                 for (int i = 0; i < mechs.length; i++) {
+                     if (DEBUG) {
+                         debug("Native MF for " + mechs[i]);
+                     }
+                     map.put("GssApiMechanism." + mechs[i], MF_CLASS);
+                 }
+                 return map;
+             }
+         }
+         return null;
+     }
 
     // initialize INSTANCE after MECH_MAP is constructed
     static final Provider INSTANCE = new SunNativeProvider();
 
-    @SuppressWarnings("removal")
     public SunNativeProvider() {
         /* We are the Sun NativeGSS provider */
         super(NAME, PROVIDER_VER, INFO);
 
         if (MECH_MAP != null) {
-            AccessController.doPrivileged(new PutAllAction(this, MECH_MAP));
+            putAll(MECH_MAP);
         }
     }
 }

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Credentials.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Credentials.java
@@ -524,19 +524,13 @@ public class Credentials {
     }
 
 
-    @SuppressWarnings({"removal", "restricted"})
+    @SuppressWarnings("restricted")
     static void ensureLoaded() {
-        java.security.AccessController.doPrivileged(
-                new java.security.PrivilegedAction<Void> () {
-                        public Void run() {
-                                if (OperatingSystem.isMacOS()) {
-                                    System.loadLibrary("osxkrb5");
-                                } else {
-                                    System.loadLibrary("w2k_lsa_auth");
-                                }
-                                return null;
-                        }
-                });
+        if (OperatingSystem.isMacOS()) {
+            System.loadLibrary("osxkrb5");
+        } else {
+            System.loadLibrary("w2k_lsa_auth");
+        }
         alreadyLoaded = true;
     }
 

--- a/src/java.security.jgss/share/classes/sun/security/krb5/KdcComm.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/KdcComm.java
@@ -31,7 +31,6 @@
 
 package sun.security.krb5;
 
-import java.security.PrivilegedAction;
 import java.security.Security;
 import java.util.Locale;
 import sun.security.krb5.internal.Krb5;
@@ -39,9 +38,6 @@ import sun.security.krb5.internal.NetClient;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.StringTokenizer;
-import java.security.AccessController;
-import java.security.PrivilegedExceptionAction;
-import java.security.PrivilegedActionException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -98,13 +94,7 @@ public final class KdcComm {
      * Read global settings
      */
     public static void initStatic() {
-        @SuppressWarnings("removal")
-        String value = AccessController.doPrivileged(
-        new PrivilegedAction<String>() {
-            public String run() {
-                return Security.getProperty("krb5.kdc.bad.policy");
-            }
-        });
+        String value = Security.getProperty("krb5.kdc.bad.policy");
         if (value != null) {
             value = value.toLowerCase(Locale.ENGLISH);
             String[] ss = value.split(":");
@@ -349,81 +339,39 @@ public final class KdcComm {
                                + ", #bytes=" + obuf.length);
         }
 
-        KdcCommunication kdcCommunication =
-            new KdcCommunication(kdc, port, useTCP, timeout, retries, obuf);
-        try {
-            @SuppressWarnings("removal")
-            byte[] ibuf = AccessController.doPrivileged(kdcCommunication);
+        byte[] ibuf = null;
+
+        for (int i=1; i <= retries; i++) {
+            String proto = useTCP?"TCP":"UDP";
             if (DEBUG != null) {
-                DEBUG.println(">>> KrbKdcReq send: #bytes read="
-                        + (ibuf != null ? ibuf.length : 0));
+                DEBUG.println(">>> KDCCommunication: kdc=" + kdc
+                        + " " + proto + ":"
+                        +  port +  ", timeout="
+                        + timeout
+                        + ",Attempt =" + i
+                        + ", #bytes=" + obuf.length);
             }
-            return ibuf;
-        } catch (PrivilegedActionException e) {
-            Exception wrappedException = e.getException();
-            if (wrappedException instanceof IOException) {
-                throw (IOException) wrappedException;
-            } else {
-                throw (KrbException) wrappedException;
-            }
-        }
-    }
-
-    private static class KdcCommunication
-        implements PrivilegedExceptionAction<byte[]> {
-
-        private String kdc;
-        private int port;
-        private boolean useTCP;
-        private int timeout;
-        private int retries;
-        private byte[] obuf;
-
-        public KdcCommunication(String kdc, int port, boolean useTCP,
-                                int timeout, int retries, byte[] obuf) {
-            this.kdc = kdc;
-            this.port = port;
-            this.useTCP = useTCP;
-            this.timeout = timeout;
-            this.retries = retries;
-            this.obuf = obuf;
-        }
-
-        // The caller only casts IOException and KrbException so don't
-        // add any new ones!
-
-        public byte[] run() throws IOException, KrbException {
-
-            byte[] ibuf = null;
-
-            for (int i=1; i <= retries; i++) {
-                String proto = useTCP?"TCP":"UDP";
+            try (NetClient kdcClient = NetClient.getInstance(
+                    proto, kdc, port, timeout)) {
+                kdcClient.send(obuf);
+                ibuf = kdcClient.receive();
+                break;
+            } catch (SocketTimeoutException se) {
                 if (DEBUG != null) {
-                    DEBUG.println(">>> KDCCommunication: kdc=" + kdc
-                            + " " + proto + ":"
-                            +  port +  ", timeout="
-                            + timeout
-                            + ",Attempt =" + i
-                            + ", #bytes=" + obuf.length);
+                    DEBUG.println ("SocketTimeOutException with " +
+                            "attempt: " + i);
                 }
-                try (NetClient kdcClient = NetClient.getInstance(
-                        proto, kdc, port, timeout)) {
-                    kdcClient.send(obuf);
-                    ibuf = kdcClient.receive();
-                    break;
-                } catch (SocketTimeoutException se) {
-                    if (DEBUG != null) {
-                        DEBUG.println ("SocketTimeOutException with " +
-                                "attempt: " + i);
-                    }
-                    if (i == retries) {
-                        ibuf = null;
-                        throw se;
-                    }
+                if (i == retries) {
+                    ibuf = null;
+                    throw se;
                 }
             }
-            return ibuf;
         }
+        if (DEBUG != null) {
+            DEBUG.println(">>> KrbKdcReq send: #bytes read="
+                    + (ibuf != null ? ibuf.length : 0));
+        }
+        return ibuf;
     }
 
     /**

--- a/src/java.security.jgss/share/classes/sun/security/krb5/KrbServiceLocator.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/KrbServiceLocator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2006, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,9 +27,6 @@ package sun.security.krb5;
 
 import sun.security.krb5.internal.Krb5;
 
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
 import java.util.Hashtable;
 import java.util.Random;
@@ -71,7 +68,6 @@ class KrbServiceLocator {
      * @return An ordered list of hostports for the Kerberos service or null if
      *          the service has not been located.
      */
-    @SuppressWarnings("removal")
     static String[] getKerberosService(String realmName) {
 
         // search realm in SRV TXT records
@@ -86,18 +82,8 @@ class KrbServiceLocator {
             if (!(ctx instanceof DirContext)) {
                 return null; // cannot create a DNS context
             }
-            Attributes attrs = null;
-            try {
-                // both connect and accept are needed since DNS is thru UDP
-                attrs = AccessController.doPrivileged(
-                        (PrivilegedExceptionAction<Attributes>)
-                                () -> ((DirContext)ctx).getAttributes(
-                                        dnsUrl, SRV_TXT_ATTR),
-                        null,
-                        new java.net.SocketPermission("*", "connect,accept"));
-            } catch (PrivilegedActionException e) {
-                throw (NamingException)e.getCause();
-            }
+            Attributes attrs = ((DirContext)ctx).getAttributes(
+                                 dnsUrl, SRV_TXT_ATTR);
             Attribute attr;
 
             if (attrs != null && ((attr = attrs.get(SRV_TXT)) != null)) {
@@ -144,7 +130,6 @@ class KrbServiceLocator {
      * @return An ordered list of hostports for the Kerberos service or null if
      *          the service has not been located.
      */
-    @SuppressWarnings("removal")
     static String[] getKerberosService(String realmName, String protocol) {
 
         String dnsUrl = "dns:///_kerberos." + protocol + "." + realmName;
@@ -160,18 +145,8 @@ class KrbServiceLocator {
                 return null; // cannot create a DNS context
             }
 
-            Attributes attrs = null;
-            try {
-                // both connect and accept are needed since DNS is thru UDP
-                attrs = AccessController.doPrivileged(
-                        (PrivilegedExceptionAction<Attributes>)
-                                () -> ((DirContext)ctx).getAttributes(
-                                        dnsUrl, SRV_RR_ATTR),
-                        null,
-                        new java.net.SocketPermission("*", "connect,accept"));
-            } catch (PrivilegedActionException e) {
-                throw (NamingException)e.getCause();
-            }
+            Attributes attrs = ((DirContext)ctx).getAttributes(
+                                 dnsUrl, SRV_RR_ATTR);
 
             Attribute attr;
 

--- a/src/java.security.jgss/share/classes/sun/security/krb5/Realm.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/Realm.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -31,7 +31,6 @@
 
 package sun.security.krb5;
 
-import sun.security.action.GetBooleanAction;
 import sun.security.krb5.internal.Krb5;
 import sun.security.util.*;
 import java.io.IOException;
@@ -48,8 +47,8 @@ import sun.security.krb5.internal.util.KerberosString;
  */
 public class Realm implements Cloneable {
 
-    public static final boolean AUTODEDUCEREALM = GetBooleanAction
-            .privilegedGetProperty("sun.security.krb5.autodeducerealm");
+    public static final boolean AUTODEDUCEREALM =
+            Boolean.getBoolean("sun.security.krb5.autodeducerealm");
 
     private final String realm; // not null nor empty
 

--- a/src/java.security.jgss/share/classes/sun/security/krb5/SCDynamicStoreConfig.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/SCDynamicStoreConfig.java
@@ -45,18 +45,17 @@ public class SCDynamicStoreConfig {
     private static native List<String> getKerberosConfig();
 
     static {
-        @SuppressWarnings({"removal", "restricted"})
-        boolean isMac = java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<Boolean>() {
-                public Boolean run() {
-                    if (OperatingSystem.isMacOS()) {
-                        System.loadLibrary("osxkrb5");
-                        return true;
-                    }
-                    return false;
-                }
-            });
+        boolean isMac = loadLibrary();
         if (isMac) installNotificationCallback();
+    }
+
+    @SuppressWarnings("restricted")
+    private static boolean loadLibrary() {
+        if (OperatingSystem.isMacOS()) {
+            System.loadLibrary("osxkrb5");
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/Krb5.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/Krb5.java
@@ -31,7 +31,6 @@
 
 package sun.security.krb5.internal;
 
-import sun.security.action.GetPropertyAction;
 import sun.security.util.Debug;
 
 import java.util.Hashtable;
@@ -317,8 +316,8 @@ public class Krb5 {
     }
 
     // Warning: used by NativeCreds.c
-    public static final Debug DEBUG = Debug.of("krb5", GetPropertyAction
-            .privilegedGetProperty("sun.security.krb5.debug"));
+    public static final Debug DEBUG = Debug.of("krb5",
+            System.getProperty("sun.security.krb5.debug"));
 
     static {
         errMsgList = new Hashtable<Integer,String> ();

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReplayCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ReplayCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,7 +25,6 @@
 
 package sun.security.krb5.internal;
 
-import sun.security.action.GetPropertyAction;
 import sun.security.krb5.internal.rcache.AuthTimeWithHash;
 import sun.security.krb5.internal.rcache.MemoryCache;
 import sun.security.krb5.internal.rcache.DflCache;
@@ -54,8 +53,7 @@ public abstract class ReplayCache {
         }
     }
     public static ReplayCache getInstance() {
-        String type = GetPropertyAction
-                .privilegedGetProperty("sun.security.krb5.rcache");
+        String type = System.getProperty("sun.security.krb5.rcache");
         return getInstance(type);
     }
 

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/FileCredentialsCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ccache/FileCredentialsCache.java
@@ -34,13 +34,11 @@
 package sun.security.krb5.internal.ccache;
 
 import jdk.internal.util.OperatingSystem;
-import sun.security.action.GetPropertyAction;
 import sun.security.krb5.*;
 import sun.security.krb5.internal.*;
 import sun.security.util.SecurityProperties;
 
 import java.nio.charset.StandardCharsets;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -452,17 +450,12 @@ public class FileCredentialsCache extends CredentialsCache
 
         // The env var can start with TYPE:, we only support FILE: here.
         // http://docs.oracle.com/cd/E19082-01/819-2252/6n4i8rtr3/index.html
-        @SuppressWarnings("removal")
-        String name = java.security.AccessController.doPrivileged(
-                (PrivilegedAction<String>) () -> {
-                    String cache = System.getenv("KRB5CCNAME");
-                    if (cache != null &&
-                            (cache.length() >= 5) &&
-                            cache.regionMatches(true, 0, "FILE:", 0, 5)) {
-                        cache = cache.substring(5);
-                    }
-                    return cache;
-                });
+        String name = System.getenv("KRB5CCNAME");
+        if (name != null &&
+                (name.length() >= 5) &&
+                name.regionMatches(true, 0, "FILE:", 0, 5)) {
+            name = name.substring(5);
+        }
         if (name != null) {
             if (DEBUG != null) {
                 DEBUG.println(">>>KinitOptions cache name is " + name);
@@ -502,12 +495,12 @@ public class FileCredentialsCache extends CredentialsCache
 
         // we did not get the uid;
 
-        String user_name = GetPropertyAction.privilegedGetProperty("user.name");
+        String user_name = System.getProperty("user.name");
 
-        String user_home = GetPropertyAction.privilegedGetProperty("user.home");
+        String user_home = System.getProperty("user.home");
 
         if (user_home == null) {
-            user_home = GetPropertyAction.privilegedGetProperty("user.dir");
+            user_home = System.getProperty("user.dir");
         }
 
         if (user_name != null) {
@@ -556,19 +549,14 @@ public class FileCredentialsCache extends CredentialsCache
         }
         final String[] command = v.toArray(new String[0]);
         try {
-            @SuppressWarnings("removal")
-            Process p =
-                java.security.AccessController.doPrivileged
-                ((PrivilegedAction<Process>) () -> {
-                    try {
-                        return (Runtime.getRuntime().exec(command));
-                    } catch (IOException e) {
-                        if (DEBUG != null) {
-                            e.printStackTrace(DEBUG.getPrintStream());
-                        }
-                        return null;
-                    }
-                });
+            Process p = null;
+            try {
+                p = Runtime.getRuntime().exec(command);
+            } catch (IOException e) {
+                if (DEBUG != null) {
+                    e.printStackTrace(DEBUG.getPrintStream());
+                }
+            }
             if (p == null) {
                 // exception occurred during executing the command
                 return null;

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/Des.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/crypto/Des.java
@@ -38,7 +38,6 @@ import java.security.GeneralSecurityException;
 import javax.crypto.spec.IvParameterSpec;
 import sun.security.krb5.KrbCryptoException;
 import java.util.Arrays;
-import sun.security.action.GetPropertyAction;
 
 public final class Des {
 
@@ -53,8 +52,8 @@ public final class Des {
     // string-to-key encoding. When set, the specified charset
     // name is used. Otherwise, the system default charset.
 
-    private static final String CHARSET = GetPropertyAction
-            .privilegedGetProperty("sun.security.krb5.msinterop.des.s2kcharset");
+    private static final String CHARSET =
+            System.getProperty("sun.security.krb5.msinterop.des.s2kcharset");
 
     private static final long[] bad_keys = {
         0x0101010101010101L, 0xfefefefefefefefeL,

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/ktab/KeyTab.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/ktab/KeyTab.java
@@ -31,7 +31,6 @@
 
 package sun.security.krb5.internal.ktab;
 
-import sun.security.action.GetPropertyAction;
 import sun.security.krb5.*;
 import sun.security.krb5.internal.*;
 import sun.security.krb5.internal.crypto.*;
@@ -211,12 +210,10 @@ public class KeyTab implements KeyTabConstants {
             }
 
             if (kname == null) {
-                String user_home = GetPropertyAction
-                        .privilegedGetProperty("user.home");
+                String user_home = System.getProperty("user.home");
 
                 if (user_home == null) {
-                    user_home = GetPropertyAction
-                            .privilegedGetProperty("user.dir");
+                    user_home = System.getProperty("user.dir");
                 }
 
                 kname = user_home + File.separator  + "krb5.keytab";

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/rcache/AuthTimeWithHash.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/rcache/AuthTimeWithHash.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package sun.security.krb5.internal.rcache;
 
-import sun.security.action.GetBooleanAction;
-
 import java.util.Objects;
 
 /**
@@ -40,7 +38,7 @@ public class AuthTimeWithHash extends AuthTime
     public static final String DEFAULT_HASH_ALG;
 
     static {
-        if (GetBooleanAction.privilegedGetProperty("jdk.krb5.rcache.useMD5")) {
+        if (Boolean.getBoolean("jdk.krb5.rcache.useMD5")) {
             DEFAULT_HASH_ALG = "HASH";
         } else {
             DEFAULT_HASH_ALG = "SHA256";

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/rcache/DflCache.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/rcache/DflCache.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,6 @@ import java.nio.file.StandardOpenOption;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.*;
 
-import sun.security.action.GetPropertyAction;
 import sun.security.krb5.internal.KerberosTime;
 import sun.security.krb5.internal.Krb5;
 import sun.security.krb5.internal.KrbApErrException;
@@ -116,7 +115,7 @@ public class DflCache extends ReplayCache {
     }
 
     private static String defaultPath() {
-        return GetPropertyAction.privilegedGetProperty("java.io.tmpdir");
+        return System.getProperty("java.io.tmpdir");
     }
 
     private static String defaultFile(String server) {

--- a/src/java.security.jgss/share/classes/sun/security/krb5/internal/util/KerberosString.java
+++ b/src/java.security.jgss/share/classes/sun/security/krb5/internal/util/KerberosString.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2019, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.security.krb5.internal.util;
 
 import java.io.IOException;
-import sun.security.action.GetPropertyAction;
 import sun.security.util.DerValue;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
@@ -58,8 +57,8 @@ public final class KerberosString {
     public static final boolean MSNAME;
 
     static {
-        String prop = GetPropertyAction
-                .privilegedGetProperty("sun.security.krb5.msinterop.kstring", "true");
+        String prop =
+            System.getProperty("sun.security.krb5.msinterop.kstring", "true");
         MSNAME = Boolean.parseBoolean(prop);
     }
 

--- a/src/jdk.security.jgss/share/classes/com/sun/security/jgss/ExtendedGSSContextImpl.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/jgss/ExtendedGSSContextImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,12 +41,6 @@ class ExtendedGSSContextImpl extends GSSContextImpl
 
     @Override
     public Object inquireSecContext(InquireType type) throws GSSException {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(
-                    new InquireSecContextPermission(type.toString()));
-        }
         Object output = super.inquireSecContext(type.name());
         if (output != null) {
             if (type == InquireType.KRB5_GET_AUTHZ_DATA) {

--- a/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/JdkSASL.java
+++ b/src/jdk.security.jgss/share/classes/com/sun/security/sasl/gsskerb/JdkSASL.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,8 +24,6 @@
  */
 package com.sun.security.sasl.gsskerb;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.Provider;
 import java.security.NoSuchAlgorithmException;
 import java.security.InvalidParameterException;
@@ -74,19 +72,13 @@ public final class JdkSASL extends Provider {
         }
     }
 
-    @SuppressWarnings("removal")
     public JdkSASL() {
         super("JdkSASL", PROVIDER_VER, info);
 
         final Provider p = this;
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-                putService(new ProviderService(p, "SaslClientFactory",
-                           "GSSAPI", "com.sun.security.sasl.gsskerb.FactoryImpl"));
-                putService(new ProviderService(p, "SaslServerFactory",
-                           "GSSAPI", "com.sun.security.sasl.gsskerb.FactoryImpl"));
-                return null;
-            }
-        });
+        putService(new ProviderService(p, "SaslClientFactory",
+                   "GSSAPI", "com.sun.security.sasl.gsskerb.FactoryImpl"));
+        putService(new ProviderService(p, "SaslServerFactory",
+                   "GSSAPI", "com.sun.security.sasl.gsskerb.FactoryImpl"));
     }
 }


### PR DESCRIPTION
Now that JEP 486 has been integrated, java.security.jgss and jdk.security.jgss implementation dependencies on `System.getSecurityManager` and `AccessController.doPrivileged*` can be removed.

There is an undocumented property named "sun.security.krb5.autodeducerealm" that can probably be removed as it only affected behavior when an SM was enabled; however I have left the code that reads the property as-is and have opened a separate issue to determine if it can be safely removed.