### PR TITLE
8343823: (fs) Files.createLink: inconsistent behavior when creating link to symbolic link

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -990,6 +990,11 @@ public final class Files {
      * be started with implementation specific privileges to create hard links
      * or to create links to directories.
      *
+     * @apiNote
+     * If the {@code existing} parameter is the path to a symbolic link, then
+     * whether the new link is for the target of the symbolic link or for the
+     * symbolic link itself is platform dependent and therefore not specified.
+     *
      * @param   link
      *          the link (directory entry) to create
      * @param   existing

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -982,12 +982,12 @@ public final class Files {
      * The {@code existing} parameter is the path to an existing file. This
      * method creates a new directory entry for the file so that it can be
      * accessed using {@code link} as the path. On some file systems this is
-     * known as creating a "hard link". Whether the file attributes are
-     * maintained for the file or for each directory entry is file system
-     * specific and therefore not specified. If the {@code existing} parameter
+     * known as creating a "hard link". If the {@code existing} parameter
      * is the path to a symbolic link, then whether the new link is for the
      * target of the symbolic link or for the symbolic link itself is platform
-     * dependent and therefore not specified. Typically, a file system requires
+     * dependent and therefore not specified. Whether the file attributes are
+     * maintained for the file or for each directory entry is file system
+     * specific and therefore not specified. Typically, a file system requires
      * that all links (directory entries) for a file be on the same file system.
      * Furthermore, on some platforms, the Java virtual machine may require to
      * be started with implementation specific privileges to create hard links

--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -984,16 +984,14 @@ public final class Files {
      * accessed using {@code link} as the path. On some file systems this is
      * known as creating a "hard link". Whether the file attributes are
      * maintained for the file or for each directory entry is file system
-     * specific and therefore not specified. Typically, a file system requires
+     * specific and therefore not specified. If the {@code existing} parameter
+     * is the path to a symbolic link, then whether the new link is for the
+     * target of the symbolic link or for the symbolic link itself is platform
+     * dependent and therefore not specified. Typically, a file system requires
      * that all links (directory entries) for a file be on the same file system.
      * Furthermore, on some platforms, the Java virtual machine may require to
      * be started with implementation specific privileges to create hard links
      * or to create links to directories.
-     *
-     * @apiNote
-     * If the {@code existing} parameter is the path to a symbolic link, then
-     * whether the new link is for the target of the symbolic link or for the
-     * symbolic link itself is platform dependent and therefore not specified.
      *
      * @param   link
      *          the link (directory entry) to create


### PR DESCRIPTION
Add an API note to `java.nio.file.Files.createLink` to make explicit that the behavior when the target is a symbolic link is unspecified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8344633](https://bugs.openjdk.org/browse/JDK-8344633) to be approved

### Issues
 * [JDK-8343823](https://bugs.openjdk.org/browse/JDK-8343823): (fs) Files.createLink: inconsistent behavior when creating link to symbolic link (**Enhancement** - P4)
 * [JDK-8344633](https://bugs.openjdk.org/browse/JDK-8344633): (fs) Files.createLink: inconsistent behavior when creating link to symbolic link (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22257/head:pull/22257` \
`$ git checkout pull/22257`

Update a local copy of the PR: \
`$ git checkout pull/22257` \
`$ git pull https://git.openjdk.org/jdk.git pull/22257/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22257`

View PR using the GUI difftool: \
`$ git pr show -t 22257`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22257.diff">https://git.openjdk.org/jdk/pull/22257.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22257#issuecomment-2486806700)
</details>
