### PR TITLE
8344479: Declare MetaspaceObj::operator delete to be deleted

### DIFF
--- a/src/hotspot/share/memory/allocation.hpp
+++ b/src/hotspot/share/memory/allocation.hpp
@@ -353,7 +353,7 @@ class MetaspaceObj {
   void* operator new(size_t size, ClassLoaderData* loader_data,
                      size_t word_size,
                      Type type) throw();
-  void operator delete(void* p) { ShouldNotCallThis(); }
+  void operator delete(void* p) = delete;
 
   // Declare a *static* method with the same signature in any subclass of MetaspaceObj
   // that should be read-only by default. See symbol.hpp for an example. This function


### PR DESCRIPTION
Please review this trivial change to delete the MetaspaceObj::operator delete method.

Sanity tested with tier1 on supported platforms.

