### PR TITLE
8344526: RISC-V: implement -XX:+VerifyActivationFrameSize

### DIFF
--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -441,7 +441,13 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
                                               Register Rs) {
   // Pay attention to the argument Rs, which is acquiesce in t0.
   if (VerifyActivationFrameSize) {
-    Unimplemented();
+    Label L;
+    sub(t1, fp, esp);
+    int min_frame_size = (frame::link_offset - frame::interpreter_frame_initial_sp_offset) * wordSize;
+    add(t1, t1, -min_frame_size);
+    bgez(t1, L);
+    stop("broken stack frame");
+    bind(L);
   }
   if (verifyoop && state == atos) {
     verify_oop(x10);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -443,9 +443,9 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
   if (VerifyActivationFrameSize) {
     Label L;
     sub(t1, fp, esp);
+    sub(t1, t1, frame::metadata_words * wordSize); // Exclude 2 frame metadata words
     int min_frame_size = (frame::link_offset - frame::interpreter_frame_initial_sp_offset) * wordSize;
     sub(t1, t1, min_frame_size);
-    sub(t1, t1, frame::metadata_words * wordSize); // Exclude 2 frame metadata words
     bgez(t1, L);
     stop("broken stack frame");
     bind(L);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -443,7 +443,6 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
   if (VerifyActivationFrameSize) {
     Label L;
     sub(t1, fp, esp);
-    // Exclude 2 frame metadata words
     int min_frame_size =
       (frame::link_offset - frame::interpreter_frame_initial_sp_offset + frame::metadata_words) * wordSize;
     sub(t1, t1, min_frame_size);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -445,6 +445,7 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
     sub(t1, fp, esp);
     int min_frame_size = (frame::link_offset - frame::interpreter_frame_initial_sp_offset) * wordSize;
     sub(t1, t1, min_frame_size);
+    sub(t1, t1, frame::metadata_words * wordSize); // Exclude 2 frame metadata words
     bgez(t1, L);
     stop("broken stack frame");
     bind(L);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -444,7 +444,7 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
     Label L;
     sub(t1, fp, esp);
     int min_frame_size = (frame::link_offset - frame::interpreter_frame_initial_sp_offset) * wordSize;
-    add(t1, t1, -min_frame_size);
+    sub(t1, t1, min_frame_size);
     bgez(t1, L);
     stop("broken stack frame");
     bind(L);

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -443,8 +443,9 @@ void InterpreterMacroAssembler::dispatch_base(TosState state,
   if (VerifyActivationFrameSize) {
     Label L;
     sub(t1, fp, esp);
-    sub(t1, t1, frame::metadata_words * wordSize); // Exclude 2 frame metadata words
-    int min_frame_size = (frame::link_offset - frame::interpreter_frame_initial_sp_offset) * wordSize;
+    // Exclude 2 frame metadata words
+    int min_frame_size =
+      (frame::link_offset - frame::interpreter_frame_initial_sp_offset + frame::metadata_words) * wordSize;
     sub(t1, t1, min_frame_size);
     bgez(t1, L);
     stop("broken stack frame");


### PR DESCRIPTION
Hi all,
Currently on linux-riscv64 platform the debug VM option `-XX:+VerifyActivationFrameSize` is Unimplemented. I want to implement `-XX:+VerifyActivationFrameSize` to make JVM easier to diagnose. Only effect debug build plus with option `-XX:+VerifyActivationFrameSize`, the change has been verified locally, the risk is low.

Additional testing

- [x] Run SPECjbb2015 with -XX:+VerifyActivationFrameSize option

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344526](https://bugs.openjdk.org/browse/JDK-8344526): RISC-V: implement -XX:+VerifyActivationFrameSize (**Enhancement** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**) Review applies to [bc90d67d](https://git.openjdk.org/jdk/pull/22264/files/bc90d67d0050b14a85b943a2f458721b5b1fcd06)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Contributors
 * Fei Yang `<fyang@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22264/head:pull/22264` \
`$ git checkout pull/22264`

Update a local copy of the PR: \
`$ git checkout pull/22264` \
`$ git pull https://git.openjdk.org/jdk.git pull/22264/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22264`

View PR using the GUI difftool: \
`$ git pr show -t 22264`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22264.diff">https://git.openjdk.org/jdk/pull/22264.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22264#issuecomment-2487253920)
</details>
