### PR TITLE
8344525: Fix leftover ExceptionOccurred in java.base

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -650,7 +650,7 @@ JavaMain(void* _args)
      * The launcher's exit code (in the absence of calls to
      * System.exit) will be non-zero if main threw an exception.
      */
-    if (ret && (*env)->ExceptionOccurred(env) == NULL) {
+    if (ret && !(*env)->ExceptionCheck(env)) {
         // main method was invoked and no exception was thrown from it,
         // return success.
         ret = 0;

--- a/src/java.base/share/native/libzip/Deflater.c
+++ b/src/java.base/share/native/libzip/Deflater.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -197,14 +197,14 @@ Java_java_util_zip_Deflater_deflateBytesBytes(JNIEnv *env, jobject this, jlong a
     jint res;
 
     if (input == NULL) {
-        if (inputLen != 0 && (*env)->ExceptionOccurred(env) == NULL)
+        if (inputLen != 0 && !(*env)->ExceptionCheck(env))
             JNU_ThrowOutOfMemoryError(env, 0);
         return 0L;
     }
     output = (*env)->GetPrimitiveArrayCritical(env, outputArray, 0);
     if (output == NULL) {
         (*env)->ReleasePrimitiveArrayCritical(env, inputArray, input, 0);
-        if (outputLen != 0 && (*env)->ExceptionOccurred(env) == NULL)
+        if (outputLen != 0 && !(*env)->ExceptionCheck(env))
             JNU_ThrowOutOfMemoryError(env, 0);
         return 0L;
     }
@@ -231,7 +231,7 @@ Java_java_util_zip_Deflater_deflateBytesBuffer(JNIEnv *env, jobject this, jlong 
     jlong retVal;
     jint res;
     if (input == NULL) {
-        if (inputLen != 0 && (*env)->ExceptionOccurred(env) == NULL)
+        if (inputLen != 0 && !(*env)->ExceptionCheck(env))
             JNU_ThrowOutOfMemoryError(env, 0);
         return 0L;
     }
@@ -257,7 +257,7 @@ Java_java_util_zip_Deflater_deflateBufferBytes(JNIEnv *env, jobject this, jlong 
     jlong retVal;
     jint res;
     if (output == NULL) {
-        if (outputLen != 0 && (*env)->ExceptionOccurred(env) == NULL)
+        if (outputLen != 0 && !(*env)->ExceptionCheck(env))
             JNU_ThrowOutOfMemoryError(env, 0);
         return 0L;
     }

--- a/src/java.base/share/native/libzip/Inflater.c
+++ b/src/java.base/share/native/libzip/Inflater.c
@@ -194,14 +194,14 @@ Java_java_util_zip_Inflater_inflateBytesBytes(JNIEnv *env, jobject this, jlong a
     jlong retVal;
 
     if (input == NULL) {
-        if (inputLen != 0 && (*env)->ExceptionOccurred(env) == NULL)
+        if (inputLen != 0 && !(*env)->ExceptionCheck(env))
             JNU_ThrowOutOfMemoryError(env, 0);
         return 0L;
     }
     output = (*env)->GetPrimitiveArrayCritical(env, outputArray, 0);
     if (output == NULL) {
         (*env)->ReleasePrimitiveArrayCritical(env, inputArray, input, 0);
-        if (outputLen != 0 && (*env)->ExceptionOccurred(env) == NULL)
+        if (outputLen != 0 && !(*env)->ExceptionCheck(env))
             JNU_ThrowOutOfMemoryError(env, 0);
         return 0L;
     }
@@ -227,7 +227,7 @@ Java_java_util_zip_Inflater_inflateBytesBuffer(JNIEnv *env, jobject this, jlong 
     jlong retVal;
 
     if (input == NULL) {
-        if (inputLen != 0 && (*env)->ExceptionOccurred(env) == NULL)
+        if (inputLen != 0 && !(*env)->ExceptionCheck(env))
             JNU_ThrowOutOfMemoryError(env, 0);
         return 0L;
     }
@@ -252,7 +252,7 @@ Java_java_util_zip_Inflater_inflateBufferBytes(JNIEnv *env, jobject this, jlong 
     jlong retVal;
 
     if (output == NULL) {
-        if (outputLen != 0 && (*env)->ExceptionOccurred(env) == NULL)
+        if (outputLen != 0 && !(*env)->ExceptionCheck(env))
             JNU_ThrowOutOfMemoryError(env, 0);
         return 0L;
     }

--- a/src/java.base/windows/native/libjava/io_util_md.c
+++ b/src/java.base/windows/native/libjava/io_util_md.c
@@ -537,7 +537,7 @@ fileDescriptorClose(JNIEnv *env, jobject this)
 {
     FD fd = (*env)->GetLongField(env, this, IO_handle_fdID);
     HANDLE h = (HANDLE)fd;
-    if ((*env)->ExceptionOccurred(env)) {
+    if ((*env)->ExceptionCheck(env)) {
         return;
     }
 
@@ -552,7 +552,7 @@ fileDescriptorClose(JNIEnv *env, jobject this)
      * taking extra precaution over here.
      */
     (*env)->SetLongField(env, this, IO_handle_fdID, -1);
-    if ((*env)->ExceptionOccurred(env)) {
+    if ((*env)->ExceptionCheck(env)) {
         return;
     }
 

--- a/src/java.base/windows/native/libnet/net_util_md.c
+++ b/src/java.base/windows/native/libnet/net_util_md.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -143,7 +143,7 @@ NET_ThrowNew(JNIEnv *env, int errorNum, char *msg)
     /*
      * If exception already throw then don't overwrite it.
      */
-    if ((*env)->ExceptionOccurred(env)) {
+    if ((*env)->ExceptionCheck(env)) {
         return;
     }
 

--- a/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
+++ b/src/java.base/windows/native/libnio/ch/UnixDomainSockets.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,7 +48,7 @@ jbyteArray sockaddrToUnixAddressBytes(JNIEnv *env, struct sockaddr_un *sa, sockl
         jbyteArray name = (*env)->NewByteArray(env, namelen);
         if (name != NULL) {
             (*env)->SetByteArrayRegion(env, name, 0, namelen, (jbyte*)sa->sun_path);
-            if ((*env)->ExceptionOccurred(env)) {
+            if ((*env)->ExceptionCheck(env)) {
                 return NULL;
             }
         }


### PR DESCRIPTION
Please review this PR which removes the leftover ocurrences of incorrect JNI `ExceptionOccurred(env)` usage within _java.base_. 

This PR also includes 9 cases of `if (ExceptionOccurred(env) == NULL)`. While these occurrences are fine and were intentionally not removed during the first pass, it would be consistent with the other related JNI ExceptionOccurred cleanups to include them here as well. Making the swap also avoids creating the `jthrowable` reference in the first place (even if automatically freed later).

After this patch, the remaining instances of `ExceptionOccurred(env)` within _j.base_ are used with intent to create the `jthrowable` reference.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344525](https://bugs.openjdk.org/browse/JDK-8344525): Fix leftover ExceptionOccurred in java.base (**Sub-task** - P4)


### Reviewers
 * [Laurent Bourgès](https://openjdk.org/census#lbourges) (@bourgesl - Committer)
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22266/head:pull/22266` \
`$ git checkout pull/22266`

Update a local copy of the PR: \
`$ git checkout pull/22266` \
`$ git pull https://git.openjdk.org/jdk.git pull/22266/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22266`

View PR using the GUI difftool: \
`$ git pr show -t 22266`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22266.diff">https://git.openjdk.org/jdk/pull/22266.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22266#issuecomment-2487250900)
</details>
