### PR TITLE
8344066: Remove SecurityManager uses from the jdk.accessibility module

### DIFF
--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AWTEventMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/AWTEventMonitor.java
@@ -29,7 +29,6 @@ import java.awt.*;
 import java.awt.event.*;
 import javax.swing.*;
 import javax.swing.event.*;
-import sun.awt.AWTPermissions;
 
 /**
  * <P>The {@code AWTEventMonitor} implements a suite of listeners that are
@@ -85,17 +84,6 @@ public class AWTEventMonitor {
         return componentWithFocus;
     }
 
-    /*
-     * Check permissions
-     */
-    private static void checkInstallPermission() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.ALL_AWT_EVENTS_PERMISSION);
-        }
-    }
-
     /**
      * Adds the specified listener to receive all {@link EventID#COMPONENT COMPONENT}
      * events on each component instance in the Java Virtual Machine as they occur.
@@ -108,7 +96,6 @@ public class AWTEventMonitor {
      */
     public static void addComponentListener(ComponentListener l) {
         if (componentListener == null) {
-            checkInstallPermission();
             awtListener.installListeners(EventID.COMPONENT);
         }
         componentListener = AWTEventMulticaster.add(componentListener, l);
@@ -190,7 +177,6 @@ public class AWTEventMonitor {
      */
     public static void addKeyListener(KeyListener l) {
         if (keyListener == null) {
-            checkInstallPermission();
             awtListener.installListeners(EventID.KEY);
         }
         keyListener = AWTEventMulticaster.add(keyListener, l);
@@ -222,7 +208,6 @@ public class AWTEventMonitor {
      */
     public static void addMouseListener(MouseListener l) {
         if (mouseListener == null) {
-            checkInstallPermission();
             awtListener.installListeners(EventID.MOUSE);
         }
         mouseListener = AWTEventMulticaster.add(mouseListener, l);
@@ -254,7 +239,6 @@ public class AWTEventMonitor {
      */
     public static void addMouseMotionListener(MouseMotionListener l) {
         if (mouseMotionListener == null) {
-            checkInstallPermission();
             awtListener.installListeners(EventID.MOTION);
         }
         mouseMotionListener = AWTEventMulticaster.add(mouseMotionListener, l);
@@ -286,7 +270,6 @@ public class AWTEventMonitor {
      */
     public static void addWindowListener(WindowListener l) {
         if (windowListener == null) {
-            checkInstallPermission();
             awtListener.installListeners(EventID.WINDOW);
         }
         windowListener = AWTEventMulticaster.add(windowListener, l);
@@ -318,7 +301,6 @@ public class AWTEventMonitor {
      */
     public static void addActionListener(ActionListener l) {
         if (actionListener == null) {
-            checkInstallPermission();
             awtListener.installListeners(EventID.ACTION);
         }
         actionListener = AWTEventMulticaster.add(actionListener, l);
@@ -351,7 +333,6 @@ public class AWTEventMonitor {
      */
     public static void addAdjustmentListener(AdjustmentListener l) {
         if (adjustmentListener == null) {
-            checkInstallPermission();
             awtListener.installListeners(EventID.ADJUSTMENT);
         }
         adjustmentListener = AWTEventMulticaster.add(adjustmentListener, l);
@@ -383,7 +364,6 @@ public class AWTEventMonitor {
      */
     public static void addItemListener(ItemListener l) {
         if (itemListener == null) {
-            checkInstallPermission();
             awtListener.installListeners(EventID.ITEM);
         }
         itemListener = AWTEventMulticaster.add(itemListener, l);
@@ -415,7 +395,6 @@ public class AWTEventMonitor {
      */
     public static void addTextListener(TextListener l) {
         if (textListener == null) {
-            checkInstallPermission();
             awtListener.installListeners(EventID.TEXT);
         }
         textListener = AWTEventMulticaster.add(textListener, l);

--- a/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/EventQueueMonitor.java
+++ b/src/jdk.accessibility/share/classes/com/sun/java/accessibility/util/EventQueueMonitor.java
@@ -29,8 +29,6 @@ import java.util.*;
 import java.awt.*;
 import java.awt.event.*;
 import javax.accessibility.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 /**
  * The {@code EventQueueMonitor} class provides key core functionality for Assistive
@@ -142,24 +140,16 @@ public class EventQueueMonitor
     /**
      * Tell the {@code EventQueueMonitor} to start listening for events.
      */
-    @SuppressWarnings("removal")
     public static void maybeInitialize() {
         if (cedt == null) {
-            java.security.AccessController.doPrivileged(
-                new java.security.PrivilegedAction<Void>() {
-                    public Void run() {
-                        try {
-                            long eventMask = AWTEvent.WINDOW_EVENT_MASK |
-                                AWTEvent.FOCUS_EVENT_MASK |
-                                AWTEvent.MOUSE_MOTION_EVENT_MASK;
+            try {
+                long eventMask = AWTEvent.WINDOW_EVENT_MASK |
+                        AWTEvent.FOCUS_EVENT_MASK |
+                        AWTEvent.MOUSE_MOTION_EVENT_MASK;
 
-                            Toolkit.getDefaultToolkit().addAWTEventListener(new EventQueueMonitor(), eventMask);
-                        } catch (Exception e) {
-                        }
-                        return null;
-                    }
-                }
-            );
+                Toolkit.getDefaultToolkit().addAWTEventListener(new EventQueueMonitor(), eventMask);
+            } catch (Exception e) {
+            }
         }
     }
 

--- a/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
+++ b/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
@@ -160,44 +160,23 @@ public final class AccessBridge {
         initStatic();
     }
 
-    @SuppressWarnings({"removal", "restricted"})
+    @SuppressWarnings("restricted")
     private static void initStatic() {
         // Load the appropriate DLLs
         boolean is32on64 = false;
         if (System.getProperty("os.arch").equals("x86")) {
             // 32 bit JRE
             // Load jabsysinfo.dll so can determine Win bitness
-            java.security.AccessController.doPrivileged(
-                new java.security.PrivilegedAction<Void>() {
-                    public Void run() {
-                        System.loadLibrary("jabsysinfo");
-                        return null;
-                    }
-                }, null, new java.lang.RuntimePermission("loadLibrary.jabsysinfo")
-            );
+            System.loadLibrary("jabsysinfo");
             if (isSysWow()) {
                 // 32 bit JRE on 64 bit OS
                 is32on64 = true;
-                java.security.AccessController.doPrivileged(
-                    new java.security.PrivilegedAction<Void>() {
-                        public Void run() {
-                            System.loadLibrary("javaaccessbridge-32");
-                            return null;
-                        }
-                    }, null, new java.lang.RuntimePermission("loadLibrary.javaaccessbridge-32")
-                );
+                System.loadLibrary("javaaccessbridge-32");
             }
         }
         if (!is32on64) {
             // 32 bit JRE on 32 bit OS or 64 bit JRE on 64 bit OS
-            java.security.AccessController.doPrivileged(
-                new java.security.PrivilegedAction<Void>() {
-                    public Void run() {
-                        System.loadLibrary("javaaccessbridge");
-                        return null;
-                    }
-                }, null, new java.lang.RuntimePermission("loadLibrary.javaaccessbridge")
-            );
+            System.loadLibrary("javaaccessbridge");
         }
     }
 


### PR DESCRIPTION
Since JEP 486 : Permanently Disable the Security Manager [JDK-8338625](https://bugs.openjdk.org/browse/JDK-8338625)
is now integrated, calls to java.security.AccessController.doPrivileged  and SecurityManager.checkPermission are obsolete and can be removed.

This PR takes care of the files in the jdk.accessibility module.

Tested swingset2 application with JAWS to verify a11y functionality on component. CI testing looks ok.
