### PR TITLE
8344219: Remove calls to SecurityManager and doPrivileged in java.net.SocksSocketImpl after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/java/net/SocksSocketImpl.java
+++ b/src/java.base/share/classes/java/net/SocksSocketImpl.java
@@ -29,7 +29,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.BufferedOutputStream;
 import java.nio.charset.StandardCharsets;
-import java.security.AccessController;
 import java.util.Iterator;
 
 import jdk.internal.util.StaticProperty;
@@ -49,8 +48,6 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
     private InetSocketAddress external_address;
     private boolean useV4 = false;
     private Socket cmdsock = null;
-    private InputStream cmdIn = null;
-    private OutputStream cmdOut = null;
 
     SocksSocketImpl(SocketImpl delegate) {
         super(delegate);
@@ -73,32 +70,6 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
             return true;
         }
         return DefaultProxySelector.socksProxyVersion() == 4;
-    }
-
-    @SuppressWarnings("removal")
-    private synchronized void privilegedConnect(final String host,
-                                              final int port,
-                                              final int timeout)
-        throws IOException
-    {
-        try {
-            AccessController.doPrivileged(
-                new java.security.PrivilegedExceptionAction<>() {
-                    public Void run() throws IOException {
-                              superConnectServer(host, port, timeout);
-                              cmdIn = getInputStream();
-                              cmdOut = getOutputStream();
-                              return null;
-                          }
-                      });
-        } catch (java.security.PrivilegedActionException pae) {
-            throw (IOException) pae.getException();
-        }
-    }
-
-    private void superConnectServer(String host, int port,
-                                    int timeout) throws IOException {
-        delegate.connect(new InetSocketAddress(host, port), timeout);
     }
 
     private static int remainingMillis(long deadlineMillis) throws IOException {
@@ -151,15 +122,8 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
             String userName;
             String password = null;
             final InetAddress addr = InetAddress.getByName(server);
-            @SuppressWarnings("removal")
-            PasswordAuthentication pw =
-                java.security.AccessController.doPrivileged(
-                    new java.security.PrivilegedAction<>() {
-                        public PasswordAuthentication run() {
-                                return Authenticator.requestPasswordAuthentication(
-                                       server, addr, serverPort, "SOCKS5", "SOCKS authentication", null);
-                            }
-                        });
+            PasswordAuthentication pw = Authenticator.requestPasswordAuthentication(
+                    server, addr, serverPort, "SOCKS5", "SOCKS authentication", null);
             if (pw != null) {
                 userName = pw.getUserName();
                 password = new String(pw.getPassword());
@@ -250,8 +214,6 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
      * @param   endpoint        the {@code SocketAddress} to connect to.
      * @param   timeout         the timeout value in milliseconds
      * @throws  IOException     if the connection can't be established.
-     * @throws  SecurityException if there is a security manager and it
-     *                          doesn't allow the connection
      * @throws  IllegalArgumentException if endpoint is null or a
      *          SocketAddress subclass not supported by this socket
      */
@@ -266,29 +228,15 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
             deadlineMillis = finish < 0 ? Long.MAX_VALUE : finish;
         }
 
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
         if (!(endpoint instanceof InetSocketAddress epoint))
             throw new IllegalArgumentException("Unsupported address type");
-        if (security != null) {
-            if (epoint.isUnresolved())
-                security.checkConnect(epoint.getHostName(),
-                                      epoint.getPort());
-            else
-                security.checkConnect(epoint.getAddress().getHostAddress(),
-                                      epoint.getPort());
-        }
+
         if (server == null) {
             // This is the general case
             // server is not null only when the socket was created with a
             // specified proxy in which case it does bypass the ProxySelector
             @SuppressWarnings("removal")
-            ProxySelector sel = java.security.AccessController.doPrivileged(
-                new java.security.PrivilegedAction<>() {
-                    public ProxySelector run() {
-                            return ProxySelector.getDefault();
-                        }
-                    });
+            ProxySelector sel = ProxySelector.getDefault();
             if (sel == null) {
                 /*
                  * No default proxySelector --> direct connection
@@ -337,7 +285,7 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
 
                 // Connects to the SOCKS server
                 try {
-                    privilegedConnect(server, serverPort, remainingMillis(deadlineMillis));
+                    delegate.connect(new InetSocketAddress(server, serverPort), remainingMillis(deadlineMillis));
                     // Worked, let's get outta here
                     break;
                 } catch (IOException e) {
@@ -361,15 +309,14 @@ class SocksSocketImpl extends DelegatingSocketImpl implements SocksConsts {
         } else {
             // Connects to the SOCKS server
             try {
-                privilegedConnect(server, serverPort, remainingMillis(deadlineMillis));
+                delegate.connect(new InetSocketAddress(server, serverPort), remainingMillis(deadlineMillis));
             } catch (IOException e) {
                 throw new SocketException(e.getMessage(), e);
             }
         }
 
-        // cmdIn & cmdOut were initialized during the privilegedConnect() call
-        BufferedOutputStream out = new BufferedOutputStream(cmdOut, 512);
-        InputStream in = cmdIn;
+        BufferedOutputStream out = new BufferedOutputStream(getOutputStream(), 512);
+        InputStream in = getInputStream();
 
         if (useV4) {
             // SOCKS Protocol version 4 doesn't know how to deal with


### PR DESCRIPTION
Removes `SecurityManager` et al. from `SocksSocketImpl`. `tier2` tests have passed – CI run link is available in the ticket.