### PR TITLE
8344236: Revisit SecurityManager usage in jdk.net after JEP 486 integration

### DIFF
--- a/src/jdk.net/aix/classes/jdk/net/AIXSocketOptions.java
+++ b/src/jdk.net/aix/classes/jdk/net/AIXSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,10 @@ package jdk.net;
 import java.net.SocketException;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.GroupPrincipal;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import jdk.net.ExtendedSocketOptions.PlatformSocketOptions;
 import sun.nio.fs.UnixUserPrincipals;
 
-@SuppressWarnings({"removal", "restricted"})
+@SuppressWarnings("restricted")
 class AIXSocketOptions extends PlatformSocketOptions {
 
     public AIXSocketOptions() {
@@ -131,13 +129,6 @@ class AIXSocketOptions extends PlatformSocketOptions {
     private static native boolean keepAliveOptionsSupported0();
     private static native boolean quickAckSupported0();
     static {
-        if (System.getSecurityManager() == null) {
-            System.loadLibrary("extnet");
-        } else {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                System.loadLibrary("extnet");
-                return null;
-            });
-        }
+        System.loadLibrary("extnet");
     }
 }

--- a/src/jdk.net/linux/classes/jdk/net/LinuxSocketOptions.java
+++ b/src/jdk.net/linux/classes/jdk/net/LinuxSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,10 @@ package jdk.net;
 import java.net.SocketException;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.GroupPrincipal;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import jdk.net.ExtendedSocketOptions.PlatformSocketOptions;
 import sun.nio.fs.UnixUserPrincipals;
 
-@SuppressWarnings({"removal", "restricted"})
+@SuppressWarnings("restricted")
 class LinuxSocketOptions extends PlatformSocketOptions {
 
     public LinuxSocketOptions() {
@@ -143,14 +141,7 @@ class LinuxSocketOptions extends PlatformSocketOptions {
     private static native boolean incomingNapiIdSupported0();
     private static native int getIncomingNapiId0(int fd) throws SocketException;
     static {
-        if (System.getSecurityManager() == null) {
-            System.loadLibrary("extnet");
-        } else {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                System.loadLibrary("extnet");
-                return null;
-            });
-        }
+        System.loadLibrary("extnet");
     }
 }
 

--- a/src/jdk.net/macosx/classes/jdk/net/MacOSXSocketOptions.java
+++ b/src/jdk.net/macosx/classes/jdk/net/MacOSXSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,10 @@ package jdk.net;
 import java.net.SocketException;
 import java.nio.file.attribute.UserPrincipal;
 import java.nio.file.attribute.GroupPrincipal;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import jdk.net.ExtendedSocketOptions.PlatformSocketOptions;
 import sun.nio.fs.UnixUserPrincipals;
 
-@SuppressWarnings({"removal", "restricted"})
+@SuppressWarnings("restricted")
 class MacOSXSocketOptions extends PlatformSocketOptions {
 
     public MacOSXSocketOptions() {
@@ -116,13 +114,6 @@ class MacOSXSocketOptions extends PlatformSocketOptions {
     private static native boolean ipDontFragmentSupported0();
 
     static {
-        if (System.getSecurityManager() == null) {
-            System.loadLibrary("extnet");
-        } else {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                System.loadLibrary("extnet");
-                return null;
-            });
-        }
+        System.loadLibrary("extnet");
     }
 }

--- a/src/jdk.net/share/classes/jdk/nio/Channels.java
+++ b/src/jdk.net/share/classes/jdk/nio/Channels.java
@@ -148,13 +148,6 @@ public final class Channels {
         if (!fd.valid())
             throw new IllegalArgumentException("file descriptor is not valid");
 
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkRead(fd);
-            sm.checkWrite(fd);
-        }
-
         SelectorProvider provider = SelectorProvider.provider();
         if (!(provider instanceof SelectorProviderImpl))
             throw new UnsupportedOperationException("custom SelectorProvider");

--- a/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
+++ b/src/jdk.net/windows/classes/jdk/net/WindowsSocketOptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,10 @@
 package jdk.net;
 
 import java.net.SocketException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import jdk.net.ExtendedSocketOptions.PlatformSocketOptions;
 
 
-@SuppressWarnings({"removal", "restricted"})
+@SuppressWarnings("restricted")
 class WindowsSocketOptions extends PlatformSocketOptions {
 
     public WindowsSocketOptions() {
@@ -97,13 +95,6 @@ class WindowsSocketOptions extends PlatformSocketOptions {
     private static native int getTcpKeepAliveIntvl0(int fd) throws SocketException;
 
     static {
-        if (System.getSecurityManager() == null) {
-            System.loadLibrary("extnet");
-        } else {
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
-                System.loadLibrary("extnet");
-                return null;
-            });
-        }
+        System.loadLibrary("extnet");
     }
 }


### PR DESCRIPTION
Can I please get a review of this change which removes the usages of `SecurityManager` related APIs from the `jdk.net` module? This addresses https://bugs.openjdk.org/browse/JDK-8344236.

No new tests have been added and existing tests in tier1, tier2 and tier3 have completed without any related failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344236](https://bugs.openjdk.org/browse/JDK-8344236): Revisit SecurityManager usage in jdk.net after JEP 486 integration (**Bug** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22274/head:pull/22274` \
`$ git checkout pull/22274`

Update a local copy of the PR: \
`$ git checkout pull/22274` \
`$ git pull https://git.openjdk.org/jdk.git pull/22274/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22274`

View PR using the GUI difftool: \
`$ git pr show -t 22274`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22274.diff">https://git.openjdk.org/jdk/pull/22274.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22274#issuecomment-2488368991)
</details>
