### PR TITLE
8344560: Add system property for patched runtime

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2267,7 +2267,11 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
     } else if (match_option(option, "--patch-module=", &tail)) {
       // --patch-module=<module>=<file>(<pathsep><file>)*
       int res = process_patch_mod_option(tail, patch_mod_javabase);
-      if (res != JNI_OK) {
+      if (res == JNI_OK) {
+        // Add jdk.patched system property when processing of args was OK
+        PropertyList_unique_add(&_system_properties, "jdk.patched", "true",
+                                AddProperty, UnwriteableProperty, ExternalProperty);
+      } else {
         return res;
       }
     } else if (match_option(option, "--sun-misc-unsafe-memory-access=", &tail)) {

--- a/test/jdk/java/lang/System/patchedModule/ModulePatcherTest.java
+++ b/test/jdk/java/lang/System/patchedModule/ModulePatcherTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.lang.reflect.Constructor;
+
+/*
+ * @test id=unpatched
+ * @summary Test property jdk.patched for unpatched runtime
+ * @run main/othervm ModulePatcherTest false
+ */
+
+/*
+ * @test id=patched
+ * @summary Test property jdk.patched for patched runtime
+ * @compile --patch-module java.base=${test.src}/patch/java/lang
+ *          ${test.src}/patch/java/lang/TestInteger.java ModulePatcherTest.java
+ * @run main/othervm --patch-module=java.base=${test.classes} ModulePatcherTest true
+ */
+public class ModulePatcherTest {
+
+    private static final String PATCHED_PROPERTY_NAME = "jdk.patched";
+
+    private final boolean expectPatched;
+
+    public ModulePatcherTest(boolean expectPatched) {
+        this.expectPatched = expectPatched;
+    }
+
+    public void runTest() throws Exception {
+        boolean actual = Boolean.getBoolean(PATCHED_PROPERTY_NAME);
+        if (expectPatched) {
+            // Verify we find the TestInteger class from the module patch
+            Class<?> testInt = Class.forName("java.lang.TestInteger");
+            Constructor<?> cons = testInt.getDeclaredConstructor();
+            Object i = cons.newInstance();
+            System.out.println("Found integer class from module patch: " + i.getClass());
+        }
+        if (actual != expectPatched) {
+            String msg = "Expected " + (expectPatched ? "patched" : "unpatched") +
+                         " runtime but detected " + (actual ? "patched" : "unpatched") +
+                         " runtime via property " + PATCHED_PROPERTY_NAME;
+            throw new RuntimeException(msg);
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        if (args.length != 1) {
+            throw new RuntimeException("Invalid test setup. Expected a single boolean argument");
+        }
+        boolean expectPatched = Boolean.parseBoolean(args[0]);
+        ModulePatcherTest t = new ModulePatcherTest(expectPatched);
+        t.runTest();
+    }
+
+}

--- a/test/jdk/java/lang/System/patchedModule/patch/java/lang/TestInteger.java
+++ b/test/jdk/java/lang/System/patchedModule/patch/java/lang/TestInteger.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024, Red Hat, Inc.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package java.lang;
+
+public class TestInteger {
+
+    public static int toInt(String foo) {
+        return Integer.parseInt(foo);
+    }
+
+}


### PR DESCRIPTION
Please review this simple patch which adds a new external system property `jdk.patched` when the runtime has been patched with the `--patch-module` switch. This is useful for two reasons: 1) it allows one to determine at runtime whether or not `--patch-module` has been used (by querying the said property) 2) allows tools, such as `jlink` doing the same without exposing more of the internal properties the JVM sets on initialization.

CSR is forthcoming.

Testing:

- [x] GHA
- [x] New jtreg test 

Thoughts?