### PR TITLE
8344568: Renaming ceil_log2 to log2i_ceil

### DIFF
--- a/src/hotspot/share/classfile/dictionary.cpp
+++ b/src/hotspot/share/classfile/dictionary.cpp
@@ -44,7 +44,7 @@ const size_t REHASH_LEN = 100;
 Dictionary::Dictionary(ClassLoaderData* loader_data, size_t table_size)
   : _number_of_entries(0), _loader_data(loader_data) {
 
-  size_t start_size_log_2 = MAX2(ceil_log2(table_size), 2); // 2 is minimum size even though some dictionaries only have one entry
+  size_t start_size_log_2 = MAX2(log2i_ceil(table_size), 2); // 2 is minimum size even though some dictionaries only have one entry
   size_t current_size = ((size_t)1) << start_size_log_2;
   log_info(class, loader, data)("Dictionary start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                                 current_size, start_size_log_2);

--- a/src/hotspot/share/classfile/stringTable.cpp
+++ b/src/hotspot/share/classfile/stringTable.cpp
@@ -309,7 +309,7 @@ public:
 };
 
 void StringTable::create_table() {
-  size_t start_size_log_2 = ceil_log2(StringTableSize);
+  size_t start_size_log_2 = log2i_ceil(StringTableSize);
   _current_size = ((size_t)1) << start_size_log_2;
   log_trace(stringtable)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                          _current_size, start_size_log_2);

--- a/src/hotspot/share/classfile/symbolTable.cpp
+++ b/src/hotspot/share/classfile/symbolTable.cpp
@@ -212,7 +212,7 @@ private:
 };
 
 void SymbolTable::create_table ()  {
-  size_t start_size_log_2 = ceil_log2(SymbolTableSize);
+  size_t start_size_log_2 = log2i_ceil(SymbolTableSize);
   _current_size = ((size_t)1) << start_size_log_2;
   log_trace(symboltable)("Start size: " SIZE_FORMAT " (" SIZE_FORMAT ")",
                          _current_size, start_size_log_2);

--- a/src/hotspot/share/services/finalizerService.cpp
+++ b/src/hotspot/share/services/finalizerService.cpp
@@ -266,7 +266,7 @@ void FinalizerService::do_concurrent_work(JavaThread* service_thread) {
 
 void FinalizerService::init() {
   assert(_table == nullptr, "invariant");
-  const size_t start_size_log_2 = ceil_log2(DEFAULT_TABLE_SIZE);
+  const size_t start_size_log_2 = log2i_ceil(DEFAULT_TABLE_SIZE);
   _table = new FinalizerHashtable(start_size_log_2, MAX_SIZE, FinalizerHashtable::DEFAULT_GROW_HINT);
 }
 

--- a/src/hotspot/share/services/threadIdTable.cpp
+++ b/src/hotspot/share/services/threadIdTable.cpp
@@ -112,7 +112,7 @@ void ThreadIdTable::lazy_initialize(const ThreadsList *threads) {
 
 void ThreadIdTable::create_table(size_t size) {
   assert(_local_table == nullptr, "Thread table is already created");
-  size_t size_log = ceil_log2(size);
+  size_t size_log = log2i_ceil(size);
   size_t start_size_log =
       size_log > DEFAULT_TABLE_SIZE_LOG ? size_log : DEFAULT_TABLE_SIZE_LOG;
   _current_size = (size_t)1 << start_size_log;

--- a/src/hotspot/share/utilities/powerOfTwo.hpp
+++ b/src/hotspot/share/utilities/powerOfTwo.hpp
@@ -79,6 +79,13 @@ inline int log2i_exact(T value) {
   return count_trailing_zeros(value);
 }
 
+// Ceiling of log2 of a positive, integral value, i.e., smallest i such that value <= 2^i.
+template <typename T, ENABLE_IF(std::is_integral<T>::value)>
+inline int log2i_ceil(T value) {
+  assert(value > 0, "Invalid value");
+  return log2i_graceful(value - 1) + 1;
+}
+
 // Preconditions: value != 0, and the unsigned representation of value is a power of two
 inline int exact_log2(intptr_t value) {
   return log2i_exact((uintptr_t)value);
@@ -118,13 +125,6 @@ template <typename T, ENABLE_IF(std::is_integral<T>::value)>
 inline T next_power_of_2(T value)  {
   assert(value < std::numeric_limits<T>::max(), "Overflow");
   return T(round_up_power_of_2(value + 1));
-}
-
-// Find log2 value greater than this input
-template <typename T, ENABLE_IF(std::is_integral<T>::value)>
-inline int ceil_log2(T value) {
-  assert(value > 0, "Invalid value");
-  return log2i_graceful(value - 1) + 1;
 }
 
 // Return the largest power of two that is a submultiple of the given value.

--- a/test/hotspot/gtest/utilities/test_powerOfTwo.cpp
+++ b/test/hotspot/gtest/utilities/test_powerOfTwo.cpp
@@ -306,43 +306,43 @@ TEST(power_of_2, log2i) {
   check_log2i_variants_for((jlong)0);
 }
 
-template <typename T> void test_ceil_log2() {
-  EXPECT_EQ(ceil_log2(T(1)), 0) << "value = " << T(1);
-  EXPECT_EQ(ceil_log2(T(2)), 1) << "value = " << T(2);
-  EXPECT_EQ(ceil_log2(T(3)), 2) << "value = " << T(3);
-  EXPECT_EQ(ceil_log2(T(4)), 2) << "value = " << T(4);
-  EXPECT_EQ(ceil_log2(T(5)), 3) << "value = " << T(5);
-  EXPECT_EQ(ceil_log2(T(6)), 3) << "value = " << T(6);
-  EXPECT_EQ(ceil_log2(T(7)), 3) << "value = " << T(7);
-  EXPECT_EQ(ceil_log2(T(8)), 3) << "value = " << T(8);
-  EXPECT_EQ(ceil_log2(T(9)), 4) << "value = " << T(9);
-  EXPECT_EQ(ceil_log2(T(10)), 4) << "value = " << T(10);
+template <typename T> void test_log2i_ceil() {
+  EXPECT_EQ(log2i_ceil(T(1)), 0) << "value = " << T(1);
+  EXPECT_EQ(log2i_ceil(T(2)), 1) << "value = " << T(2);
+  EXPECT_EQ(log2i_ceil(T(3)), 2) << "value = " << T(3);
+  EXPECT_EQ(log2i_ceil(T(4)), 2) << "value = " << T(4);
+  EXPECT_EQ(log2i_ceil(T(5)), 3) << "value = " << T(5);
+  EXPECT_EQ(log2i_ceil(T(6)), 3) << "value = " << T(6);
+  EXPECT_EQ(log2i_ceil(T(7)), 3) << "value = " << T(7);
+  EXPECT_EQ(log2i_ceil(T(8)), 3) << "value = " << T(8);
+  EXPECT_EQ(log2i_ceil(T(9)), 4) << "value = " << T(9);
+  EXPECT_EQ(log2i_ceil(T(10)), 4) << "value = " << T(10);
 
   // Test max values
   if (std::is_unsigned<T>::value) {
-    EXPECT_EQ(ceil_log2(std::numeric_limits<T>::max()),
+    EXPECT_EQ(log2i_ceil(std::numeric_limits<T>::max()),
             (int)(sizeof(T) * 8)) << "value = " << std::numeric_limits<T>::max();
   } else {
-    EXPECT_EQ(ceil_log2(std::numeric_limits<T>::max()),
+    EXPECT_EQ(log2i_ceil(std::numeric_limits<T>::max()),
             (int)(sizeof(T) * 8 - 1)) << "value = " << std::numeric_limits<T>::max();
   }
 }
 
-TEST(power_of_2, ceil_log2) {
-  test_ceil_log2<int8_t>();
-  test_ceil_log2<int16_t>();
-  test_ceil_log2<int32_t>();
-  test_ceil_log2<int64_t>();
-  test_ceil_log2<uint8_t>();
-  test_ceil_log2<uint16_t>();
-  test_ceil_log2<uint32_t>();
-  test_ceil_log2<uint64_t>();
+TEST(power_of_2, log2i_ceil) {
+  test_log2i_ceil<int8_t>();
+  test_log2i_ceil<int16_t>();
+  test_log2i_ceil<int32_t>();
+  test_log2i_ceil<int64_t>();
+  test_log2i_ceil<uint8_t>();
+  test_log2i_ceil<uint16_t>();
+  test_log2i_ceil<uint32_t>();
+  test_log2i_ceil<uint64_t>();
 }
 
 #ifdef ASSERT
-TEST_VM_ASSERT_MSG(power_of_2, ceil_log2_invalid,
+TEST_VM_ASSERT_MSG(power_of_2, log2i_ceil_invalid,
     ".*Invalid value") {
-  ceil_log2(0);
+  log2i_ceil(0);
 }
 
 #endif // ASSERT


### PR DESCRIPTION
Hi all, 

This PR addresses [8344568](https://bugs.openjdk.org/browse/JDK-8344568). Should be a straightforward rename and cleanup. 

Thanks, 
Sonia

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344568](https://bugs.openjdk.org/browse/JDK-8344568): Renaming ceil_log2 to log2i_ceil (**Enhancement** - P4)


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22279/head:pull/22279` \
`$ git checkout pull/22279`

Update a local copy of the PR: \
`$ git checkout pull/22279` \
`$ git pull https://git.openjdk.org/jdk.git pull/22279/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22279`

View PR using the GUI difftool: \
`$ git pr show -t 22279`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22279.diff">https://git.openjdk.org/jdk/pull/22279.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22279#issuecomment-2489439234)
</details>
