### PR TITLE
6726901: JDWP: ReferenceType.GetValues crashes jvm in case non-static fields are passed

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/util.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/util.c
@@ -413,8 +413,20 @@ writeStaticFieldValue(JNIEnv *env, PacketOutputStream *out, jclass clazz,
                       jfieldID field)
 {
     jvmtiError error;
+    jint modifiers;
     char *signature = NULL;
     jbyte typeKey;
+
+    error = fieldModifiers(clazz, field, &modifiers);
+    if (error != JVMTI_ERROR_NONE) {
+        outStream_setError(out, map2jdwpError(error));
+        return;
+    }
+
+    if (!(modifiers & JVM_ACC_STATIC)) {
+        outStream_setError(out, JDWP_ERROR(INVALID_FIELDID));
+        return;
+    }
 
     error = fieldSignature(clazz, field, NULL, &signature, NULL);
     if (error != JVMTI_ERROR_NONE) {

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues002.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package nsk.jdwp.ObjectReference.GetValues;
+
+import java.io.*;
+
+import nsk.share.*;
+import nsk.share.jpda.*;
+import nsk.share.jdwp.*;
+
+/**
+ * Test for JDWP command: ObjectReference.GetValues.
+ *
+ * See getvalues002.README for description of test execution.
+ *
+ * Test is executed by invoking method runIt().
+ * JDWP command is tested in method testCommand().
+ *
+ * @see #runIt()
+ * @see #testCommand()
+ */
+public class getvalues002 {
+
+    // exit status constants
+    static final int JCK_STATUS_BASE = 95;
+    static final int PASSED = 0;
+    static final int FAILED = 2;
+
+    // communication signals constants
+    static final String READY = "ready";
+    static final String QUIT = "quit";
+
+    // package and classes names constants
+    static final String PACKAGE_NAME = "nsk.jdwp.ObjectReference.GetValues";
+    static final String TEST_CLASS_NAME = PACKAGE_NAME + "." + "getvalues002";
+    static final String DEBUGEE_CLASS_NAME = TEST_CLASS_NAME + "a";
+
+    // tested JDWP command constants
+    static final String JDWP_COMMAND_NAME = "ObjectReference.GetValues";
+    static final int JDWP_COMMAND_ID = JDWP.Command.ObjectReference.GetValues;
+
+    // tested class name and signature constants
+    static final String TESTED_CLASS_NAME = DEBUGEE_CLASS_NAME + "$" + "TestedClass";
+    static final String TESTED_CLASS_SIGNATURE = "L" + TESTED_CLASS_NAME.replace('.', '/') + ";";
+
+    // name of the static field in the tested class with the tested object value
+    static final String OBJECT_FIELD_NAME = getvalues002a.OBJECT_FIELD_NAME;
+
+    // error constants
+    static final int INVALID_FIELDID = 25;
+
+    // names of static fields
+    static final Object fields [] = {
+                    "booleanValue",
+                    "byteValue",
+                    "charValue",
+                    "intValue",
+                    "shortValue",
+                    "longValue",
+                    "floatValue",
+                    "doubleValue",
+                    "objectValue",
+                };
+    static final int FIELDS_COUNT = fields.length;
+
+    // usual scaffold objects
+    ArgumentHandler argumentHandler = null;
+    Log log = null;
+    Binder binder = null;
+    Debugee debugee = null;
+    Transport transport = null;
+    IOPipe pipe = null;
+
+    // test passed or not
+    boolean success = true;
+
+    // -------------------------------------------------------------------
+
+    /**
+     * Start test from command line.
+     */
+    public static void main (String argv[]) {
+        int result = run(argv, System.out);
+        if (result != 0) {
+            throw new RuntimeException("Test failed");
+        }
+    }
+
+    /**
+     * Start JCK-compilant test.
+     */
+    public static int run(String argv[], PrintStream out) {
+        return new getvalues002().runIt(argv, out);
+    }
+
+    // -------------------------------------------------------------------
+
+    /**
+     * Perform test execution.
+     */
+    public int runIt(String argv[], PrintStream out) {
+
+        // make log for debugger messages
+        argumentHandler = new ArgumentHandler(argv);
+        log = new Log(out, argumentHandler);
+
+        // execute test and display results
+        try {
+            log.display("\n>>> Preparing debugee for testing \n");
+
+            // launch debugee
+            binder = new Binder(argumentHandler, log);
+            log.display("Launching debugee");
+            debugee = binder.bindToDebugee(DEBUGEE_CLASS_NAME);
+            transport = debugee.getTransport();
+            pipe = debugee.createIOPipe();
+
+            // make debuggee ready for testing
+            prepareDebugee();
+
+            // work with prepared debugee
+            try {
+                log.display("\n>>> Obtaining requred data from debugee \n");
+
+                // query debugee for TypeID of tested class
+                log.display("Getting ReferenceTypeID by signature:\n"
+                            + "  " + TESTED_CLASS_SIGNATURE);
+                long classID = debugee.getReferenceTypeID(TESTED_CLASS_SIGNATURE);
+                log.display("  got classID: " + classID);
+
+                // query debuggee for objectID value from static field
+                log.display("Getting objectID value from static field: "
+                            + OBJECT_FIELD_NAME);
+                long objectID = queryObjectID(classID,
+                            OBJECT_FIELD_NAME, JDWP.Tag.OBJECT);
+                log.display("  got objectID: " + objectID);
+
+                // query debugee for fieldIDs of tested class static fields
+                log.display("Getting fieldIDs the tested class with the tested values");
+                long fieldIDs[] = queryClassFieldIDs(classID);
+
+                // perform testing JDWP command
+                log.display("\n>>> Testing JDWP command \n");
+                for (int i = 0; i < FIELDS_COUNT; i++) {
+                    testCommand(objectID, fieldIDs[i]);
+                }
+            } finally {
+                // quit debugee
+                log.display("\n>>> Finishing test \n");
+                quitDebugee();
+            }
+
+        } catch (Failure e) {
+            log.complain("TEST FAILED: " + e.getMessage());
+            e.printStackTrace(out);
+            success = false;
+        } catch (Exception e) {
+            log.complain("Caught unexpected exception:\n" + e);
+            e.printStackTrace(out);
+            success = false;
+        }
+
+        if (!success) {
+            log.complain("TEST FAILED");
+            return FAILED;
+        }
+
+        out.println("TEST PASSED");
+        return PASSED;
+
+    }
+
+    /**
+     * Prepare debugee for testing and waiting for ready signal.
+     */
+    void prepareDebugee() {
+        // wait for VM_INIT event from debugee
+        log.display("Waiting for VM_INIT event");
+        debugee.waitForVMInit();
+
+        // query debugee for VM-dependent ID sizes
+        log.display("Querying for IDSizes");
+        debugee.queryForIDSizes();
+
+        // resume initially suspended debugee
+        log.display("Resuming debugee VM");
+        debugee.resume();
+
+        // wait for READY signal from debugee
+        log.display("Waiting for signal from debugee: " + READY);
+        String signal = pipe.readln();
+        log.display("Received signal from debugee: " + signal);
+        if (! signal.equals(READY)) {
+            throw new TestBug("Unexpected signal received form debugee: " + signal
+                            + " (expected: " + READY + ")");
+        }
+    }
+
+    /**
+     * Sending debugee signal to quit and waiting for it exits.
+     */
+    void quitDebugee() {
+        // send debugee signal to quit
+        log.display("Sending signal to debugee: " + QUIT);
+        pipe.println(QUIT);
+
+        // wait for debugee exits
+        log.display("Waiting for debugee exits");
+        int code = debugee.waitFor();
+
+        // analize debugee exit status code
+        if (code == JCK_STATUS_BASE + PASSED) {
+            log.display("Debugee PASSED with exit code: " + code);
+        } else {
+            log.complain("Debugee FAILED with exit code: " + code);
+            success = false;
+        }
+    }
+
+    /**
+     * Query debuggee for objectID value of static class field.
+     */
+    long queryObjectID(long classID, String fieldName, byte tag) {
+        // get fieledID for static field (declared in the class)
+        long fieldID = debugee.getClassFieldID(classID, fieldName, true);
+        // get value of the field
+        JDWP.Value value = debugee.getStaticFieldValue(classID, fieldID);
+
+        // check that value has THREAD tag
+        if (value.getTag() != tag) {
+            throw new Failure("Wrong objectID tag received from field \"" + fieldName
+                            + "\": " + value.getTag() + " (expected: " + tag + ")");
+        }
+
+        // extract threadID from the value
+        long objectID = ((Long)value.getValue()).longValue();
+        return objectID;
+    }
+
+    /**
+     * Query debugee for fieldIDs and them into nested_classesIDs array.
+     */
+    long[] queryClassFieldIDs(long typeID) {
+        // create array for expected filedIDs
+        long fieldIDs[] = new long[FIELDS_COUNT];
+        for (int i = 0; i < FIELDS_COUNT; i++) {
+            fieldIDs[i] = 0;
+        }
+
+        // obtain requested fieldIDs form debuggee
+        int count = 0;
+        try {
+            CommandPacket command = new CommandPacket(JDWP.Command.ReferenceType.Fields);
+            command.addReferenceTypeID(typeID);
+            command.setLength();
+
+            ReplyPacket reply = debugee.receiveReplyFor(command);
+            reply.resetPosition();
+
+            long declared = reply.getInt();
+            if (declared < FIELDS_COUNT) {
+                throw new Failure("Too few fields of the tested class returned: " + declared
+                                    + " (expected: at least " + FIELDS_COUNT + ")");
+            }
+
+            for (int i = 0; i < declared; i++ ) {
+                long fieldID = reply.getFieldID();
+                String name = reply.getString();
+                String signature = reply.getString();
+                int modBits = reply.getInt();
+
+                for (int j = 0; j < FIELDS_COUNT; j++) {
+                    if (fields[j].equals(name)) {
+                        fieldIDs[j] = fieldID;
+                        break;
+                    }
+                }
+            }
+
+            if (!reply.isParsed()) {
+                throw new Failure("Extra trailing bytes found in the reply packet at: "
+                                    + reply.currentPosition());
+            }
+
+        } catch (BoundException e) {
+            throw new Failure("Unable to extract field IDs from the reply packet:\n"
+                            + e.getMessage());
+        }
+
+        return fieldIDs;
+    }
+
+    /**
+     * Perform testing JDWP command for specified objectID.
+     */
+    void testCommand(long objectID, long fieldID) {
+        // create command packet
+        log.display("Create command packet:");
+        log.display("Command: " + JDWP_COMMAND_NAME);
+        CommandPacket command = new CommandPacket(JDWP_COMMAND_ID);
+
+        // add out data to the command packet
+        log.display("  objectID: " + objectID);
+        command.addObjectID(objectID);
+        command.addInt(1);
+        log.display("  fieldID: " + fieldID);
+        command.addFieldID(fieldID);
+        command.setLength();
+
+        // send command packet to debugee
+        try {
+            log.display("Sending command packet:\n" + command);
+            transport.write(command);
+        } catch (IOException e) {
+            log.complain("Unable to send command packet:\n" + e);
+            success = false;
+            return;
+        }
+
+        ReplyPacket reply = new ReplyPacket();
+
+        // receive reply packet from debugee
+        try {
+            log.display("Waiting for reply packet");
+            transport.read(reply);
+            log.display("Reply packet received:\n" + reply);
+        } catch (IOException e) {
+            log.complain("Unable to read reply packet:\n" + e);
+            success = false;
+            return;
+        }
+
+        // check reply packet header
+        try{
+            log.display("Checking reply packet header");
+            reply.checkHeader(command.getPacketID(), INVALID_FIELDID);
+        } catch (BoundException e) {
+            log.complain("Bad header of reply packet: " + e.getMessage());
+            success = false;
+        }
+
+        // check for extra data in reply packet
+        reply.resetPosition();
+        if (! reply.isParsed()) {
+            log.complain("Extra trailing bytes found in reply packet at: "
+                        + "0x" + reply.toHexString(reply.currentDataPosition(), 4));
+            success = false;
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues002/TestDescription.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ *
+ * @summary converted from VM Testbase nsk/jdwp/ObjectReference/GetValues/getvalues002.
+ * VM Testbase keywords: [quick, jpda, jdwp]
+ * VM Testbase readme:
+ * DESCRIPTION
+ *     This test performs checking for
+ *         command set: ObjectReference
+ *         command: GetValues
+ *     Test checks that debugee accept the command packet and
+ *     replies with correct reply packet. Also test checks that
+ *     the returned values of requested fields are equal to
+ *     the expected ones.
+ *     Test consists of two compoments:
+ *         debugger: getvalues002
+ *         debuggee: getvalues002a
+ *     First, debugger uses nsk.share support classes to launch debuggee
+ *     and obtain Transport object, that represents JDWP transport channel.
+ *     Also communication channel (IOPipe) is established between
+ *     debugger and debuggee to exchange with synchronization messages.
+ *     Next, debugger obtains from debuggee classID for the tested class and
+ *     objectID as the value of the class static field. Also debugger obtains
+ *     fieldIDs for all tested fields of the class.
+ *     Then, debugger creates command packet for GetValues command with the
+ *     found objectID and a static fieldID as an argument, writes packet
+ *     to the transport channel, and waits for a reply packet.
+ *     When reply packet is received, debugger parses the packet structure
+ *     and checks that the expected error is present. This test is repeated
+ *     for all fields on the class.
+ *     Finally, debugger sends debuggee signal to quit, waits for it exits
+ *     and exits too with the proper exit code.
+ *
+ * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
+ *          /test/lib
+ * @build nsk.jdwp.ObjectReference.GetValues.getvalues002a
+ * @run driver
+ *      nsk.jdwp.ObjectReference.GetValues.getvalues002
+ *      -arch=${os.family}-${os.simpleArch}
+ *      -verbose
+ *      -waittime=5
+ *      -debugee.vmkind=java
+ *      -transport.address=dynamic
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
+ */
+

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ObjectReference/GetValues/getvalues002a.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package nsk.jdwp.ObjectReference.GetValues;
+
+import nsk.share.*;
+import nsk.share.jpda.*;
+import nsk.share.jdwp.*;
+
+import java.io.*;
+
+public class getvalues002a {
+
+    public static final String OBJECT_FIELD_NAME = "object";
+
+    public static void main(String args[]) {
+        getvalues002a _getvalues002a = new getvalues002a();
+        System.exit(getvalues002.JCK_STATUS_BASE + _getvalues002a.runIt(args, System.err));
+    }
+
+    public int runIt(String args[], PrintStream out) {
+        // make log for debugee messages
+        ArgumentHandler argumentHandler = new ArgumentHandler(args);
+        Log log = new Log(out, argumentHandler);
+
+        // make communication pipe to debugger
+        log.display("Creating pipe");
+        IOPipe pipe = argumentHandler.createDebugeeIOPipe(log);
+
+        // ensure tested class loaded
+        log.display("Creating object of tested class");
+        TestedClass.object = new TestedClass();
+
+        // send debugger signal READY
+        log.display("Sending signal to debugger: " + getvalues002.READY);
+        pipe.println(getvalues002.READY);
+
+        // wait for signal QUIT from debugeer
+        log.display("Waiting for signal from debugger: " + getvalues002.QUIT);
+        String signal = pipe.readln();
+        log.display("Received signal from debugger: " + signal);
+
+        // check received signal
+        if (! signal.equals(getvalues002.QUIT)) {
+            log.complain("Unexpected communication signal from debugee: " + signal
+                        + " (expected: " + getvalues002.QUIT + ")");
+            log.display("Debugee FAILED");
+            return getvalues002.FAILED;
+        }
+
+        // exit debugee
+        log.display("Debugee PASSED");
+        return getvalues002.PASSED;
+    }
+
+    // tested class with own static fields values
+    public static class TestedClass {
+
+        // static field with tested object
+        public static TestedClass object = null;
+
+        // fields with tested values
+        private   static boolean       booleanValue = true;
+        private   static final byte    byteValue    = (byte)0x0F;
+        protected static char          charValue    = 'Z';
+        protected static final int     intValue     = 100;
+        public    static short         shortValue   = (short)10;
+        public    static final long    longValue    = (long)1000000;
+                  static float         floatValue   = (float)3.14;
+                  static final double  doubleValue  = (double)2.8e-12;
+                  static TestedClass   objectValue  = null;
+    }
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues002.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues002.java
@@ -1,0 +1,357 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package nsk.jdwp.ReferenceType.GetValues;
+
+import java.io.*;
+
+import nsk.share.*;
+import nsk.share.jpda.*;
+import nsk.share.jdwp.*;
+
+/**
+ * Test for JDWP command: ReferenceType.GetValues.
+ *
+ * See getvalues002.README for description of test execution.
+ *
+ * Test is executed by invoking method runIt().
+ * JDWP command is tested in method testCommand().
+ *
+ * @see #runIt()
+ * @see #testCommand()
+ */
+public class getvalues002 {
+
+    // exit status constants
+    static final int JCK_STATUS_BASE = 95;
+    static final int PASSED = 0;
+    static final int FAILED = 2;
+
+    // communication signals constants
+    static final String READY = "ready";
+    static final String QUIT = "quit";
+
+    // package and classes names constants
+    static final String PACKAGE_NAME = "nsk.jdwp.ReferenceType.GetValues";
+    static final String TEST_CLASS_NAME = PACKAGE_NAME + "." + "getvalues002";
+    static final String DEBUGEE_CLASS_NAME = TEST_CLASS_NAME + "a";
+
+    // tested JDWP command constants
+    static final String JDWP_COMMAND_NAME = "ReferenceType.GetValues";
+    static final int JDWP_COMMAND_ID = JDWP.Command.ReferenceType.GetValues;
+
+    // tested class name and signature constants
+    static final String TESTED_CLASS_NAME = DEBUGEE_CLASS_NAME + "$" + "TestedClass";
+    static final String TESTED_CLASS_SIGNATURE = "L" + TESTED_CLASS_NAME.replace('.', '/') + ";";
+
+    // error constants
+    static final int INVALID_FIELDID = 25;
+
+    // names of instance fields
+    static final Object fields [] = {
+            "booleanValue",
+            "byteValue",
+            "charValue",
+            "intValue",
+            "shortValue",
+            "longValue",
+            "floatValue",
+            "doubleValue",
+            "objectValue",
+    };
+    static final int FIELDS_COUNT = fields.length;
+
+    // field ID's for tested class static fields
+    static final long[] fieldIDs = new long[FIELDS_COUNT];
+
+    // usual scaffold objects
+    ArgumentHandler argumentHandler = null;
+    Log log = null;
+    Binder binder = null;
+    Debugee debugee = null;
+    Transport transport = null;
+    IOPipe pipe = null;
+
+    // test passed or not
+    boolean success = true;
+
+    // -------------------------------------------------------------------
+
+    /**
+     * Start test from command line.
+     */
+    public static void main (String argv[]) {
+        int result = run(argv, System.out);
+        if (result != 0) {
+            throw new RuntimeException("Test failed");
+        }
+    }
+
+    /**
+     * Start JCK-compilant test.
+     */
+    public static int run(String argv[], PrintStream out) {
+        return new getvalues002().runIt(argv, out);
+    }
+
+    // -------------------------------------------------------------------
+
+    /**
+     * Perform test execution.
+     */
+    public int runIt(String argv[], PrintStream out) {
+
+        // make log for debugger messages
+        argumentHandler = new ArgumentHandler(argv);
+        log = new Log(out, argumentHandler);
+
+        // execute test and display results
+        try {
+            log.display("\n>>> Preparing debugee for testing \n");
+
+            // launch debugee
+            binder = new Binder(argumentHandler, log);
+            log.display("Launching debugee");
+            debugee = binder.bindToDebugee(DEBUGEE_CLASS_NAME);
+            transport = debugee.getTransport();
+            pipe = debugee.createIOPipe();
+
+            // make debuggee ready for testing
+            prepareDebugee();
+
+            // work with prepared debugee
+            try {
+                log.display("\n>>> Obtaining requred data from debugee \n");
+
+                // query debugee for TypeID of tested class
+                log.display("Getting ReferenceTypeID by signature:\n"
+                            + "  " + TESTED_CLASS_SIGNATURE);
+                long typeID = debugee.getReferenceTypeID(TESTED_CLASS_SIGNATURE);
+                log.display("  got TypeID: " + typeID);
+
+                // query debugee for fieldIDs of tested class static fields
+                log.display("Getting fieldIDs for static fields of the tested class");
+                queryClassFieldIDs(typeID);
+
+                // perform testing JDWP command
+                log.display("\n>>> Testing JDWP command \n");
+                for (int i = 0; i < FIELDS_COUNT; i++) {
+                    testCommand(typeID, fieldIDs[i]);
+                }
+
+            } finally {
+                // quit debugee
+                log.display("\n>>> Finishing test \n");
+                quitDebugee();
+            }
+
+        } catch (Failure e) {
+            log.complain("TEST FAILED: " + e.getMessage());
+            e.printStackTrace(out);
+            success = false;
+        } catch (Exception e) {
+            log.complain("Caught unexpected exception:\n" + e);
+            e.printStackTrace(out);
+            success = false;
+        }
+
+        if (!success) {
+            log.complain("TEST FAILED");
+            return FAILED;
+        }
+
+        out.println("TEST PASSED");
+        return PASSED;
+
+    }
+
+    /**
+     * Prepare debugee for testing and waiting for ready signal.
+     */
+    void prepareDebugee() {
+        // wait for VM_INIT event from debugee
+        log.display("Waiting for VM_INIT event");
+        debugee.waitForVMInit();
+
+        // query debugee for VM-dependent ID sizes
+        log.display("Querying for IDSizes");
+        debugee.queryForIDSizes();
+
+        // resume initially suspended debugee
+        log.display("Resuming debugee VM");
+        debugee.resume();
+
+        // wait for READY signal from debugee
+        log.display("Waiting for signal from debugee: " + READY);
+        String signal = pipe.readln();
+        log.display("Received signal from debugee: " + signal);
+        if (! signal.equals(READY)) {
+            throw new TestBug("Unexpected signal received form debugee: " + signal
+                            + " (expected: " + READY + ")");
+        }
+    }
+
+    /**
+     * Sending debugee signal to quit and waiting for it exits.
+     */
+    void quitDebugee() {
+        // send debugee signal to quit
+        log.display("Sending signal to debugee: " + QUIT);
+        pipe.println(QUIT);
+
+        // wait for debugee exits
+        log.display("Waiting for debugee exits");
+        int code = debugee.waitFor();
+
+        // analize debugee exit status code
+        if (code == JCK_STATUS_BASE + PASSED) {
+            log.display("Debugee PASSED with exit code: " + code);
+        } else {
+            log.complain("Debugee FAILED with exit code: " + code);
+            success = false;
+        }
+    }
+
+    /**
+     * Query debugee for TypeIDs for nested classes from nested_classes array
+     * and put them into nested_classesIDs array.
+     */
+    void queryClassFieldIDs(long typeID) {
+        for (int i = 0; i < FIELDS_COUNT; i++) {
+            fieldIDs[i] = 0;
+        }
+
+        int count = 0;
+        try {
+            CommandPacket command = new CommandPacket(JDWP.Command.ReferenceType.Fields);
+            command.addReferenceTypeID(typeID);
+            command.setLength();
+
+            ReplyPacket reply = debugee.receiveReplyFor(command);
+            reply.resetPosition();
+
+            long declared = reply.getInt();
+            log.display("  declared: " + declared);
+
+            for (int i = 0; i < declared; i++ ) {
+                long fieldID = reply.getFieldID();
+                String name = reply.getString();
+                String signature = reply.getString();
+                int modBits = reply.getInt();
+
+                boolean found = false;
+                for (int j = 0; j < FIELDS_COUNT; j++) {
+                    if (fields[j].equals(name)) {
+                        if (fieldIDs[j] != 0) {
+                            throw new Failure("Duplicated field name of the tested class returned: " + name);
+                        }
+                        fieldIDs[j] = fieldID;
+                        found = true;
+                        break;
+                    }
+                }
+                if (!found) {
+                    throw new Failure("Unexpected field of the tested class returned: " + name);
+                }
+            }
+
+            if (declared < FIELDS_COUNT) {
+                throw new Failure("Too few fields of the tested class returned: " + declared
+                                    + " (expected: " + FIELDS_COUNT + ")");
+            }
+
+            if (declared > FIELDS_COUNT) {
+                throw new Failure("Too many fields of the tested class returned: " + declared
+                                    + " (expected: " + FIELDS_COUNT + ")");
+            }
+
+            if (!reply.isParsed()) {
+                throw new Failure("Extra trailing bytes found in the reply packet at: "
+                                    + reply.currentPosition());
+            }
+
+        } catch (BoundException e) {
+            throw new Failure("Unable to extract field IDs from the reply packet:\n"
+                            + e.getMessage());
+        }
+    }
+
+    /**
+     * Perform testing JDWP command for specified TypeID.
+     */
+    void testCommand(long typeID, long fieldID) {
+        // create command packet
+        log.display("Create command packet:");
+        log.display("Command: " + JDWP_COMMAND_NAME);
+        CommandPacket command = new CommandPacket(JDWP_COMMAND_ID);
+
+        // add out data to the command packet
+        log.display("  refType: " + typeID);
+        command.addReferenceTypeID(typeID);
+        command.addInt(1);
+        log.display("  fieldID: " + fieldID);
+        command.addFieldID(fieldID);
+        command.setLength();
+
+        // send command packet to debugee
+        try {
+            log.display("Sending command packet:\n" + command);
+            transport.write(command);
+        } catch (IOException e) {
+            log.complain("Unable to send command packet:\n" + e);
+            success = false;
+            return;
+        }
+
+        ReplyPacket reply = new ReplyPacket();
+
+        // receive reply packet from debugee
+        try {
+            log.display("Waiting for reply packet");
+            transport.read(reply);
+            log.display("Reply packet received:\n" + reply);
+        } catch (IOException e) {
+            log.complain("Unable to read reply packet:\n" + e);
+            success = false;
+            return;
+        }
+
+        // check reply packet header
+        try{
+            log.display("Checking reply packet header");
+            reply.checkHeader(command.getPacketID(), INVALID_FIELDID);
+        } catch (BoundException e) {
+            log.complain("Bad header of reply packet: " + e.getMessage());
+            success = false;
+        }
+
+        // check for extra data in reply packet
+        reply.resetPosition();
+        if (! reply.isParsed()) {
+            log.complain("Extra trailing bytes found in reply packet at: "
+                    + "0x" + reply.toHexString(reply.currentDataPosition(), 4));
+            success = false;
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues002/TestDescription.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues002/TestDescription.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ *
+ * @summary converted from VM Testbase nsk/jdwp/ReferenceType/GetValues/getvalues002.
+ * VM Testbase keywords: [quick, jpda, jdwp]
+ * VM Testbase readme:
+ * DESCRIPTION
+ *     This test performs checking for
+ *         command set: ReferenceType
+ *         command: GetValues
+ *     Test checks that debugee accept the command packet and
+ *     replies with correct reply packet. Also test checks that
+ *     the returned values of requested fields are equal to
+ *     the expected ones.
+ *     Test consists of two compoments:
+ *         debugger: getvalues002
+ *         debuggee: getvalues002a
+ *     First, debugger uses nsk.share support classes to launch debuggee
+ *     and obtain Transport object, that represents JDWP transport channel.
+ *     Also communication channel (IOPipe) is established between
+ *     debugger and debuggee to exchange with synchronization messages.
+ *     Next, debugger obtains ReferenceTypeIDs for the tested class from
+ *     debugee, and obtains also fieldIDs for all tested fields of this class.
+ *     Then, debugger creates command packet for GetValues command with the
+ *     found referenceTypeID and list of fieldIDs as arguments, writes packet
+ *     to the transport channel, and waits for a reply packet.
+ *     When reply packet is received, debugger parses the packet structure
+ *     and checks that the expected error is present. This test is repeated
+ *     for all fields on the class.
+ *     Finally, debugger sends debuggee signal to quit, waits for it exits
+ *     and exits too with the proper exit code.
+ *
+ * @library /vmTestbase /test/hotspot/jtreg/vmTestbase
+ *          /test/lib
+ * @build nsk.jdwp.ReferenceType.GetValues.getvalues002a
+ * @run driver
+ *      nsk.jdwp.ReferenceType.GetValues.getvalues002
+ *      -arch=${os.family}-${os.simpleArch}
+ *      -verbose
+ *      -waittime=5
+ *      -debugee.vmkind=java
+ *      -transport.address=dynamic
+ *      -debugee.vmkeys="${test.vm.opts} ${test.java.opts}"
+ */
+

--- a/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues002a.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/jdwp/ReferenceType/GetValues/getvalues002a.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package nsk.jdwp.ReferenceType.GetValues;
+
+import nsk.share.*;
+import nsk.share.jpda.*;
+import nsk.share.jdwp.*;
+
+import java.io.*;
+
+public class getvalues002a {
+
+    public static void main(String args[]) {
+        getvalues002a _getvalues002a = new getvalues002a();
+        System.exit(getvalues002.JCK_STATUS_BASE + _getvalues002a.runIt(args, System.err));
+    }
+
+    public int runIt(String args[], PrintStream out) {
+        //make log for debugee messages
+        ArgumentHandler argumentHandler = new ArgumentHandler(args);
+        Log log = new Log(out, argumentHandler);
+
+        // meke communication pipe to debugger
+        log.display("Creating pipe");
+        IOPipe pipe = argumentHandler.createDebugeeIOPipe(log);
+
+        // ensure tested class loaded
+        log.display("Creating object of tested class");
+        TestedClass foo = new TestedClass();
+
+        // send debugger signal READY
+        log.display("Sending signal to debugger: " + getvalues002.READY);
+        pipe.println(getvalues002.READY);
+
+        // wait for signal QUIT from debugeer
+        log.display("Waiting for signal from debugger: " + getvalues002.QUIT);
+        String signal = pipe.readln();
+        log.display("Received signal from debugger: " + signal);
+
+        // check received signal
+        if (! signal.equals(getvalues002.QUIT)) {
+            log.complain("Unexpected communication signal from debugee: " + signal
+                        + " (expected: " + getvalues002.QUIT + ")");
+            log.display("Debugee FAILED");
+            return getvalues002.FAILED;
+        }
+
+        // exit debugee
+        log.display("Debugee PASSED");
+        return getvalues002.PASSED;
+    }
+
+    // tested class with own static fields values
+    public static class TestedClass {
+        private   boolean       booleanValue = true;
+        private   final byte    byteValue    = (byte)0x0F;
+        protected char          charValue    = 'Z';
+        protected final int     intValue     = 100;
+        public    short         shortValue   = (short)10;
+        public    final long    longValue    = (long)1000000;
+                  float         floatValue   = (float)3.14;
+                  final double  doubleValue  = (double)2.8e-12;
+                  TestedClass   objectValue  = null;
+    }
+}

--- a/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/ReplyPacket.java
+++ b/test/hotspot/jtreg/vmTestbase/nsk/share/jdwp/ReplyPacket.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -127,6 +127,23 @@ public class ReplyPacket extends Packet {
         if (getPacketID() != id) {
             throw new PacketFormatException("Unexpected ID in reply packet header: "
                                             + getPacketID());
+        }
+    }
+
+    /**
+     * Check reply packet header for specified reply ID and error code.
+     *
+     * @throws PacketFormatException if packet header fields have invalid values
+     */
+    public void checkHeader(int id, int error) throws PacketFormatException {
+        if (getPacketID() != id) {
+            throw new PacketFormatException("Unexpected ID in reply packet header: "
+                    + getPacketID());
+        }
+
+        if (getErrorCode() != error) {
+            throw new PacketFormatException("Unexpected error code in reply packet header: "
+                    + getErrorCode());
         }
     }
 


### PR DESCRIPTION
This PR fixes a long-standing bug in JDWP where the access flags of a field are not checked before attempting to read it's value. 

Prior to this change, attempting to read a non-static field would cause a JVM crash, this change corrects that behaviour by returning `INVALID_FIELDID` instead.

This is my first PR to OpenJDK, so please let me know if I've made any mistakes in the process.

Cheers,
Adam

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-6726901](https://bugs.openjdk.org/browse/JDK-6726901): JDWP: ReferenceType.GetValues crashes jvm in case non-static fields are passed (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22280/head:pull/22280` \
`$ git checkout pull/22280`

Update a local copy of the PR: \
`$ git checkout pull/22280` \
`$ git pull https://git.openjdk.org/jdk.git pull/22280/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22280`

View PR using the GUI difftool: \
`$ git pr show -t 22280`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22280.diff">https://git.openjdk.org/jdk/pull/22280.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22280#issuecomment-2489291096)
</details>
