### PR TITLE
8344235: Revisit SecurityManager usage in java.logging after JEP 486 and JEP 491 integration

### DIFF
--- a/src/java.base/share/classes/jdk/internal/logger/LazyLoggers.java
+++ b/src/java.base/share/classes/jdk/internal/logger/LazyLoggers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package jdk.internal.logger;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.function.BiFunction;
 import java.lang.System.LoggerFinder;
 import java.lang.System.Logger;
@@ -43,9 +41,6 @@ import sun.util.logging.PlatformLogger;
  * Lazy Loggers.
  */
 public final class LazyLoggers {
-
-    static final RuntimePermission LOGGERFINDER_PERMISSION =
-                new RuntimePermission("loggerFinder");
 
     private LazyLoggers() {
         throw new InternalError();
@@ -341,7 +336,6 @@ public final class LazyLoggers {
 
     // Do not expose this outside of this package.
     private static volatile LoggerFinder provider;
-    @SuppressWarnings("removal")
     private static LoggerFinder accessLoggerFinder() {
         LoggerFinder prov = provider;
         if (prov == null) {
@@ -350,10 +344,7 @@ public final class LazyLoggers {
             // the result.
             // This is just an optimization to avoid the cost of calling
             // doPrivileged every time.
-            final SecurityManager sm = System.getSecurityManager();
-            prov = sm == null ? LoggerFinder.getLoggerFinder() :
-                AccessController.doPrivileged(
-                        (PrivilegedAction<LoggerFinder>)LoggerFinder::getLoggerFinder);
+            prov = LoggerFinder.getLoggerFinder();
             if (prov instanceof TemporaryLoggerFinder) return prov;
             provider = prov;
         }
@@ -403,17 +394,9 @@ public final class LazyLoggers {
      * @param module  module on behalf of which the logger is created
      * @return  The logger returned by the LoggerFinder.
      */
-    @SuppressWarnings("removal")
     static Logger getLoggerFromFinder(String name, Module module) {
-        final SecurityManager sm = System.getSecurityManager();
-        if (sm == null) {
-            return accessLoggerFinder().getLogger(name, module);
-        } else {
-            return AccessController.doPrivileged((PrivilegedAction<Logger>)
-                    () -> {return accessLoggerFinder().getLogger(name, module);},
-                    null, LOGGERFINDER_PERMISSION);
-        }
-    }
+        return accessLoggerFinder().getLogger(name, module);
+     }
 
     /**
      * Returns a (possibly lazy) Logger for the caller.

--- a/src/java.base/share/classes/jdk/internal/logger/LoggerFinderLoader.java
+++ b/src/java.base/share/classes/jdk/internal/logger/LoggerFinderLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,12 +24,8 @@
  */
 package jdk.internal.logger;
 
-import java.io.FilePermission;
 import java.lang.System.Logger;
 import java.lang.System.LoggerFinder;
-import java.security.AccessController;
-import java.security.Permission;
-import java.security.PrivilegedAction;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.ServiceConfigurationError;
@@ -37,9 +33,6 @@ import java.util.ServiceLoader;
 import java.util.function.BooleanSupplier;
 
 import jdk.internal.vm.annotation.Stable;
-import sun.security.util.SecurityConstants;
-import sun.security.action.GetBooleanAction;
-import sun.security.action.GetPropertyAction;
 
 /**
  * Helper class used to load the {@link java.lang.System.LoggerFinder}.
@@ -47,13 +40,6 @@ import sun.security.action.GetPropertyAction;
 public final class LoggerFinderLoader {
     private static volatile System.LoggerFinder service;
     private static final Object lock = new int[0];
-    static final Permission CLASSLOADER_PERMISSION =
-            SecurityConstants.GET_CLASSLOADER_PERMISSION;
-    static final Permission READ_PERMISSION =
-            new FilePermission("<<ALL FILES>>",
-                    SecurityConstants.FILE_READ_ACTION);
-    public static final RuntimePermission LOGGERFINDER_PERMISSION =
-                new RuntimePermission("loggerFinder");
 
     // This is used to control how the LoggerFinderLoader handles
     // errors when instantiating the LoggerFinder provider.
@@ -63,7 +49,7 @@ public final class LoggerFinderLoader {
     // DEBUG => Do not fail, use plain default (simple logger) implementation,
     //          prints warning and exception stack trace on console.
     // QUIET => Do not fail and stay silent.
-    private static enum ErrorPolicy { ERROR, WARNING, DEBUG, QUIET };
+    private static enum ErrorPolicy { ERROR, WARNING, DEBUG, QUIET }
 
     // This class is static and cannot be instantiated.
     private LoggerFinderLoader() {
@@ -107,8 +93,7 @@ public final class LoggerFinderLoader {
 
     // Get configuration error policy
     private static ErrorPolicy configurationErrorPolicy() {
-        String errorPolicy =
-                GetPropertyAction.privilegedGetProperty("jdk.logger.finder.error");
+        String errorPolicy = System.getProperty("jdk.logger.finder.error");
         if (errorPolicy == null || errorPolicy.isEmpty()) {
             return ErrorPolicy.WARNING;
         }
@@ -122,24 +107,13 @@ public final class LoggerFinderLoader {
     // Whether multiple provider should be considered as an error.
     // This is further submitted to the configuration error policy.
     private static boolean ensureSingletonProvider() {
-        return GetBooleanAction.privilegedGetProperty
-            ("jdk.logger.finder.singleton");
+        return Boolean.getBoolean("jdk.logger.finder.singleton");
     }
 
-    @SuppressWarnings("removal")
     private static Iterator<System.LoggerFinder> findLoggerFinderProviders() {
-        final Iterator<System.LoggerFinder> iterator;
-        if (System.getSecurityManager() == null) {
-            iterator = ServiceLoader.load(System.LoggerFinder.class,
+        final Iterator<System.LoggerFinder> iterator =
+                ServiceLoader.load(System.LoggerFinder.class,
                         ClassLoader.getSystemClassLoader()).iterator();
-        } else {
-            final PrivilegedAction<Iterator<System.LoggerFinder>> pa =
-                    () -> ServiceLoader.load(System.LoggerFinder.class,
-                        ClassLoader.getSystemClassLoader()).iterator();
-            iterator = AccessController.doPrivileged(pa, null,
-                        LOGGERFINDER_PERMISSION, CLASSLOADER_PERMISSION,
-                        READ_PERMISSION);
-        }
         return iterator;
     }
 
@@ -219,25 +193,10 @@ public final class LoggerFinderLoader {
         return result;
     }
 
-    @SuppressWarnings("removal")
     private static System.LoggerFinder loadDefaultImplementation() {
-        final SecurityManager sm = System.getSecurityManager();
-        final Iterator<DefaultLoggerFinder> iterator;
-        if (sm == null) {
-            iterator = ServiceLoader.loadInstalled(DefaultLoggerFinder.class).iterator();
-        } else {
-            // We use limited do privileged here - the minimum set of
-            // permissions required to 'see' the META-INF/services resources
-            // seems to be CLASSLOADER_PERMISSION and READ_PERMISSION.
-            // Note that do privileged is required because
-            // otherwise the SecurityManager will prevent the ServiceLoader
-            // from seeing the installed provider.
-            PrivilegedAction<Iterator<DefaultLoggerFinder>> pa = () ->
-                    ServiceLoader.loadInstalled(DefaultLoggerFinder.class).iterator();
-            iterator = AccessController.doPrivileged(pa, null,
-                    LOGGERFINDER_PERMISSION, CLASSLOADER_PERMISSION,
-                    READ_PERMISSION);
-        }
+        final Iterator<DefaultLoggerFinder> iterator =
+                ServiceLoader.loadInstalled(DefaultLoggerFinder.class).iterator();
+
         DefaultLoggerFinder result = null;
         try {
             // Iterator iterates with the access control context stored
@@ -256,11 +215,6 @@ public final class LoggerFinderLoader {
     }
 
     public static System.LoggerFinder getLoggerFinder() {
-        @SuppressWarnings("removal")
-        final SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(LOGGERFINDER_PERMISSION);
-        }
         return service();
     }
 

--- a/src/java.base/share/classes/jdk/internal/logger/LoggerFinderLoader.java
+++ b/src/java.base/share/classes/jdk/internal/logger/LoggerFinderLoader.java
@@ -111,10 +111,8 @@ public final class LoggerFinderLoader {
     }
 
     private static Iterator<System.LoggerFinder> findLoggerFinderProviders() {
-        final Iterator<System.LoggerFinder> iterator =
-                ServiceLoader.load(System.LoggerFinder.class,
+        return ServiceLoader.load(System.LoggerFinder.class,
                         ClassLoader.getSystemClassLoader()).iterator();
-        return iterator;
     }
 
     public static final class TemporaryLoggerFinder extends LoggerFinder {

--- a/src/java.base/share/classes/jdk/internal/logger/SimpleConsoleLogger.java
+++ b/src/java.base/share/classes/jdk/internal/logger/SimpleConsoleLogger.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,6 @@ import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.lang.StackWalker.StackFrame;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.MissingResourceException;
@@ -39,7 +37,6 @@ import java.util.function.Function;
 import java.lang.System.Logger;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import sun.security.action.GetPropertyAction;
 import sun.util.logging.PlatformLogger;
 import sun.util.logging.PlatformLogger.ConfigurableBridge.LoggerConfiguration;
 
@@ -56,8 +53,7 @@ public class SimpleConsoleLogger extends LoggerConfiguration
             PlatformLogger.toPlatformLevel(DEFAULT_LEVEL);
 
     static Level getDefaultLevel() {
-        String levelName = GetPropertyAction
-                .privilegedGetProperty("jdk.system.logger.level", "INFO");
+        String levelName = System.getProperty("jdk.system.logger.level", "INFO");
         try {
             return Level.valueOf(levelName);
         } catch (IllegalArgumentException iae) {
@@ -202,18 +198,9 @@ public class SimpleConsoleLogger extends LoggerConfiguration
     /*
      * CallerFinder is a stateful predicate.
      */
-    @SuppressWarnings("removal")
     static final class CallerFinder implements Predicate<StackWalker.StackFrame> {
-        private static final StackWalker WALKER;
-        static {
-            final PrivilegedAction<StackWalker> action = new PrivilegedAction<>() {
-                @Override
-                public StackWalker run() {
-                    return StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
-                }
-            };
-            WALKER = AccessController.doPrivileged(action);
-        }
+        private static final StackWalker WALKER =
+                StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
 
         /**
          * Returns StackFrame of the caller's frame.
@@ -439,8 +426,7 @@ public class SimpleConsoleLogger extends LoggerConfiguration
         // Make it easier to wrap Logger...
         private static final String[] skips;
         static {
-            String additionalPkgs =
-                    GetPropertyAction.privilegedGetProperty("jdk.logger.packages");
+            String additionalPkgs = System.getProperty("jdk.logger.packages");
             skips = additionalPkgs == null ? new String[0] : additionalPkgs.split(",");
         }
 
@@ -499,7 +485,7 @@ public class SimpleConsoleLogger extends LoggerConfiguration
             //    jdk/test/java/lang/invoke/lambda/LogGeneratedClassesTest.java
             // to fail - because that test has a testcase which somehow references
             // PlatformLogger and counts the number of generated lambda classes.
-            String format = GetPropertyAction.privilegedGetProperty(key);
+            String format = System.getProperty(key);
 
             if (format == null && defaultPropertyGetter != null) {
                 format = defaultPropertyGetter.apply(key);

--- a/src/java.logging/share/classes/java/util/logging/ConsoleHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/ConsoleHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -78,7 +78,7 @@ public class ConsoleHandler extends StreamHandler {
         // configure with specific defaults for ConsoleHandler
         super(Level.INFO, new SimpleFormatter(), null);
 
-        setOutputStreamPrivileged(System.err);
+        setOutputStream(System.err);
     }
 
     /**

--- a/src/java.logging/share/classes/java/util/logging/Level.java
+++ b/src/java.logging/share/classes/java/util/logging/Level.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,8 +29,6 @@ import java.io.Serial;
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -620,9 +618,7 @@ public class Level implements java.io.Serializable {
         }
 
         private static void registerWithClassLoader(Level customLevel) {
-            PrivilegedAction<ClassLoader> pa = customLevel.getClass()::getClassLoader;
-            @SuppressWarnings("removal")
-            final ClassLoader cl = AccessController.doPrivileged(pa);
+            final ClassLoader cl = customLevel.getClass().getClassLoader();
             CUSTOM_LEVEL_CLV.computeIfAbsent(cl, (c, v) -> new ArrayList<>())
                 .add(customLevel);
         }

--- a/src/java.logging/share/classes/java/util/logging/LogManager.java
+++ b/src/java.logging/share/classes/java/util/logging/LogManager.java
@@ -27,7 +27,6 @@ package java.util.logging;
 
 import java.io.*;
 import java.util.*;
-import java.security.*;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,8 +38,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import jdk.internal.access.JavaAWTAccess;
-import jdk.internal.access.SharedSecrets;
 import sun.util.logging.internal.LoggingProviderImpl;
 import static jdk.internal.logger.DefaultLoggerFinder.isSystem;
 
@@ -218,39 +215,36 @@ public class LogManager {
             Collections.synchronizedMap(new IdentityHashMap<>());
 
     // The global LogManager object
-    @SuppressWarnings("removal")
-    private static final LogManager manager = AccessController.doPrivileged(
-            new PrivilegedAction<LogManager>() {
-                @Override
-                public LogManager run() {
-                    LogManager mgr = null;
-                    String cname = null;
-                    try {
-                        cname = System.getProperty("java.util.logging.manager");
-                        if (cname != null) {
-                            try {
-                                @SuppressWarnings("deprecation")
-                                Object tmp = ClassLoader.getSystemClassLoader()
-                                        .loadClass(cname).newInstance();
-                                mgr = (LogManager) tmp;
-                            } catch (ClassNotFoundException ex) {
-                                @SuppressWarnings("deprecation")
-                                Object tmp = Thread.currentThread()
-                                        .getContextClassLoader().loadClass(cname).newInstance();
-                                mgr = (LogManager) tmp;
-                            }
-                        }
-                    } catch (Exception ex) {
-                        System.err.println("Could not load Logmanager \"" + cname + "\"");
-                        ex.printStackTrace();
-                    }
-                    if (mgr == null) {
-                        mgr = new LogManager();
-                    }
-                    return mgr;
+    private static final LogManager manager = initLogManager();
 
+    private static LogManager initLogManager() {
+        LogManager mgr = null;
+        String cname = null;
+        try {
+            cname = System.getProperty("java.util.logging.manager");
+            if (cname != null) {
+                try {
+                    @SuppressWarnings("deprecation")
+                    Object tmp = ClassLoader.getSystemClassLoader()
+                            .loadClass(cname).newInstance();
+                    mgr = (LogManager) tmp;
+                } catch (ClassNotFoundException ex) {
+                    @SuppressWarnings("deprecation")
+                    Object tmp = Thread.currentThread()
+                            .getContextClassLoader().loadClass(cname).newInstance();
+                    mgr = (LogManager) tmp;
                 }
-            });
+            }
+        } catch (Exception ex) {
+            System.err.println("Could not load Logmanager \"" + cname + "\"");
+            ex.printStackTrace();
+        }
+        if (mgr == null) {
+            mgr = new LogManager();
+        }
+        return mgr;
+    }
+
 
     // This private class is used as a shutdown hook.
     // It does a "reset" to close all open handlers.
@@ -290,11 +284,6 @@ public class LogManager {
      * retrieved by calling LogManager.getLogManager.
      */
     protected LogManager() {
-        this(checkSubclassPermissions());
-    }
-
-    private LogManager(Void checked) {
-
         // Add a shutdown hook to close the global handlers.
         try {
             Runtime.getRuntime().addShutdownHook(new Cleaner());
@@ -302,20 +291,6 @@ public class LogManager {
             // If the VM is already shutting down,
             // We do not need to register shutdownHook.
         }
-    }
-
-    private static Void checkSubclassPermissions() {
-        @SuppressWarnings("removal")
-        final SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            // These permission will be checked in the LogManager constructor,
-            // in order to register the Cleaner() thread as a shutdown hook.
-            // Check them here to avoid the penalty of constructing the object
-            // etc...
-            sm.checkPermission(new RuntimePermission("shutdownHooks"));
-            sm.checkPermission(new RuntimePermission("setContextClassLoader"));
-        }
-        return null;
     }
 
     /**
@@ -380,40 +355,33 @@ public class LogManager {
             // We use initializedCalled to break the recursion.
             initializedCalled = true;
             try {
-                AccessController.doPrivileged(new PrivilegedAction<Object>() {
-                    @Override
-                    public Object run() {
-                        assert rootLogger == null;
-                        assert initializedCalled && !initializationDone;
+                assert rootLogger == null;
+                assert initializedCalled && !initializationDone;
 
-                        // create root logger before reading primordial
-                        // configuration - to ensure that it will be added
-                        // before the global logger, and not after.
-                        final Logger root = owner.rootLogger = owner.new RootLogger();
+                // create root logger before reading primordial
+                // configuration - to ensure that it will be added
+                // before the global logger, and not after.
+                final Logger root = owner.rootLogger = owner.new RootLogger();
 
-                        // Read configuration.
-                        owner.readPrimordialConfiguration();
+                // Read configuration.
+                owner.readPrimordialConfiguration();
 
-                        // Create and retain Logger for the root of the namespace.
-                        owner.addLogger(root);
+                // Create and retain Logger for the root of the namespace.
+                owner.addLogger(root);
 
-                        // Initialize level if not yet initialized
-                        if (!root.isLevelInitialized()) {
-                            root.setLevel(defaultLevel);
-                        }
+                // Initialize level if not yet initialized
+                if (!root.isLevelInitialized()) {
+                    root.setLevel(defaultLevel);
+                }
 
-                        // Adding the global Logger.
-                        // Do not call Logger.getGlobal() here as this might trigger
-                        // subtle inter-dependency issues.
-                        @SuppressWarnings("deprecation")
-                        final Logger global = Logger.global;
+                // Adding the global Logger.
+                // Do not call Logger.getGlobal() here as this might trigger
+                // subtle inter-dependency issues.
+                @SuppressWarnings("deprecation") final Logger global = Logger.global;
 
-                        // Make sure the global logger will be registered in the
-                        // global manager
-                        owner.addLogger(global);
-                        return null;
-                    }
-                });
+                // Make sure the global logger will be registered in the
+                // global manager
+                owner.addLogger(global);
             } finally {
                 initializationDone = true;
             }
@@ -461,29 +429,6 @@ public class LogManager {
     // Loggers are isolated from each AppContext.
     private LoggerContext getUserContext() {
         LoggerContext context = null;
-
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        JavaAWTAccess javaAwtAccess = SharedSecrets.getJavaAWTAccess();
-        if (sm != null && javaAwtAccess != null) {
-            // for each applet, it has its own LoggerContext isolated from others
-            final Object ecx = javaAwtAccess.getAppletContext();
-            if (ecx != null) {
-                synchronized (javaAwtAccess) {
-                    // find the AppContext of the applet code
-                    // will be null if we are in the main app context.
-                    if (contextsMap == null) {
-                        contextsMap = new WeakHashMap<>();
-                    }
-                    context = contextsMap.get(ecx);
-                    if (context == null) {
-                        // Create a new LoggerContext for the applet.
-                        context = new LoggerContext();
-                        contextsMap.put(ecx, context);
-                    }
-                }
-            }
-        }
         // for standalone app, return userContext
         return context != null ? context : userContext;
     }
@@ -552,7 +497,6 @@ public class LogManager {
         return demandSystemLogger(name, resourceBundleName, module);
     }
 
-    @SuppressWarnings("removal")
     Logger demandSystemLogger(String name, String resourceBundleName, Module module) {
         // Add a system logger in the system context's namespace
         final Logger sysLogger = getSystemContext()
@@ -578,14 +522,7 @@ public class LogManager {
         // LogManager will set the sysLogger's handlers via LogManager.addLogger method.
         if (logger != sysLogger) {
             // if logger already exists we merge the two logger configurations.
-            final Logger l = logger;
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    l.mergeWithSystemLogger(sysLogger);
-                    return null;
-                }
-            });
+            logger.mergeWithSystemLogger(sysLogger);
         }
         return sysLogger;
     }
@@ -801,7 +738,7 @@ public class LogManager {
             // the logger's level is already initialized
             Level level = owner.getLevelProperty(name + ".level", null);
             if (level != null && !logger.isLevelInitialized()) {
-                doSetLevel(logger, level);
+                logger.setLevel(level);
             }
 
             // instantiation of the handler is done in the LogManager.addLogger
@@ -826,7 +763,7 @@ public class LogManager {
             }
 
             if (parent != null) {
-                doSetParent(logger, parent);
+               logger.setParent(parent);
             }
             // Walk over the children and tell them we are their new parent.
             node.walkAndSetParent(logger);
@@ -855,22 +792,15 @@ public class LogManager {
 
         // If logger.getUseParentHandlers() returns 'true' and any of the logger's
         // parents have levels or handlers defined, make sure they are instantiated.
-        @SuppressWarnings("removal")
         private void processParentHandlers(final Logger logger, final String name,
                Predicate<Logger> visited) {
             final LogManager owner = getOwner();
-            AccessController.doPrivileged(new PrivilegedAction<Void>() {
-                @Override
-                public Void run() {
-                    if (logger != owner.rootLogger) {
-                        boolean useParent = owner.getBooleanProperty(name + ".useParentHandlers", true);
-                        if (!useParent) {
-                            logger.setUseParentHandlers(false);
-                        }
-                    }
-                    return null;
+            if (logger != owner.rootLogger) {
+                boolean useParent = owner.getBooleanProperty(name + ".useParentHandlers", true);
+                if (!useParent) {
+                    logger.setUseParentHandlers(false);
                 }
-            });
+            }
 
             int ix = 1;
             for (;;) {
@@ -898,7 +828,7 @@ public class LogManager {
                 return root;
             }
             LogNode node = root;
-            while (name.length() > 0) {
+            while (!name.isEmpty()) {
                 int ix = name.indexOf('.');
                 String head;
                 if (ix > 0) {
@@ -961,21 +891,10 @@ public class LogManager {
     }
 
     // Add new per logger handlers.
-    // We need to raise privilege here. All our decisions will
-    // be made based on the logging configuration, which can
-    // only be modified by trusted code.
-    @SuppressWarnings("removal")
     private void loadLoggerHandlers(final Logger logger, final String name,
-                                    final String handlersPropertyName)
-    {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            @Override
-            public Void run() {
-                setLoggerHandlers(logger, name, handlersPropertyName,
-                    createLoggerHandlers(name, handlersPropertyName));
-                return null;
-            }
-        });
+                                    final String handlersPropertyName) {
+        setLoggerHandlers(logger, name, handlersPropertyName,
+                createLoggerHandlers(name, handlersPropertyName));
     }
 
     private void setLoggerHandlers(final Logger logger, final String name,
@@ -1228,45 +1147,6 @@ public class LogManager {
                 && configurationLock.isHeldByCurrentThread();
     }
 
-    // Private method to set a level on a logger.
-    // If necessary, we raise privilege before doing the call.
-    @SuppressWarnings("removal")
-    private static void doSetLevel(final Logger logger, final Level level) {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm == null) {
-            // There is no security manager, so things are easy.
-            logger.setLevel(level);
-            return;
-        }
-        // There is a security manager.  Raise privilege before
-        // calling setLevel.
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
-            @Override
-            public Object run() {
-                logger.setLevel(level);
-                return null;
-            }});
-    }
-
-    // Private method to set a parent on a logger.
-    // If necessary, we raise privilege before doing the setParent call.
-    @SuppressWarnings("removal")
-    private static void doSetParent(final Logger logger, final Logger parent) {
-        SecurityManager sm = System.getSecurityManager();
-        if (sm == null) {
-            // There is no security manager, so things are easy.
-            logger.setParent(parent);
-            return;
-        }
-        // There is a security manager.  Raise privilege before
-        // calling setParent.
-        AccessController.doPrivileged(new PrivilegedAction<Object>() {
-            @Override
-            public Object run() {
-                logger.setParent(parent);
-                return null;
-            }});
-    }
 
     /**
      * Method to find a named logger.
@@ -1350,7 +1230,6 @@ public class LogManager {
      * @throws   IOException if there are IO problems reading the configuration.
      */
     public void readConfiguration() throws IOException {
-        checkPermission();
 
         // if a configuration class is specified, load it and use it.
         String cname = System.getProperty("java.util.logging.config.class");
@@ -1383,7 +1262,7 @@ public class LogManager {
         }
     }
 
-    String getConfigurationFileName() throws IOException {
+    String getConfigurationFileName() {
         String fname = System.getProperty("java.util.logging.config.file");
         if (fname == null) {
             fname = System.getProperty("java.home");
@@ -1413,7 +1292,6 @@ public class LogManager {
      */
 
     public void reset() {
-        checkPermission();
 
         List<CloseOnReset> persistent;
 
@@ -1518,7 +1396,7 @@ public class LogManager {
             String word = hands.substring(ix, end);
             ix = end+1;
             word = word.trim();
-            if (word.length() == 0) {
+            if (word.isEmpty()) {
                 continue;
             }
             result.add(word);
@@ -1553,7 +1431,6 @@ public class LogManager {
      *             {@linkplain java.util.Properties properties file} format.
      */
     public void readConfiguration(InputStream ins) throws IOException {
-        checkPermission();
 
         // We don't want reset() and readConfiguration() to run
         // in parallel.
@@ -1857,7 +1734,6 @@ public class LogManager {
      */
     public void updateConfiguration(Function<String, BiFunction<String,String,String>> mapper)
             throws IOException {
-        checkPermission();
         ensureLogManagerInitialized();
         drainLoggerRefQueueBounded();
 
@@ -2054,7 +1930,6 @@ public class LogManager {
     public void updateConfiguration(InputStream ins,
             Function<String, BiFunction<String,String,String>> mapper)
             throws IOException {
-        checkPermission();
         ensureLogManagerInitialized();
         drainLoggerRefQueueBounded();
 
@@ -2410,16 +2285,6 @@ public class LogManager {
         }
     }
 
-    static final Permission controlPermission =
-            new LoggingPermission("control", null);
-
-    void checkPermission() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkPermission(controlPermission);
-    }
-
     /**
      * Does nothing.
      *
@@ -2456,7 +2321,7 @@ public class LogManager {
                 if (logger == null) {
                     node.walkAndSetParent(parent);
                 } else {
-                    doSetParent(logger, parent);
+                    logger.setParent(parent);
                 }
             }
         }
@@ -2590,19 +2455,8 @@ public class LogManager {
      */
     public LogManager addConfigurationListener(Runnable listener) {
         final Runnable r = Objects.requireNonNull(listener);
-        checkPermission();
-        @SuppressWarnings("removal")
-        final SecurityManager sm = System.getSecurityManager();
-        @SuppressWarnings("removal")
-        final AccessControlContext acc =
-                sm == null ? null : AccessController.getContext();
-        final PrivilegedAction<Void> pa =
-                acc == null ? null : () -> { r.run() ; return null; };
-        @SuppressWarnings("removal")
-        final Runnable pr =
-                acc == null ? r : () -> AccessController.doPrivileged(pa, acc);
         // Will do nothing if already registered.
-        listeners.putIfAbsent(r, pr);
+        listeners.putIfAbsent(r, r);
         return this;
     }
 
@@ -2618,7 +2472,6 @@ public class LogManager {
      */
     public void removeConfigurationListener(Runnable listener) {
         final Runnable key = Objects.requireNonNull(listener);
-        checkPermission();
         listeners.remove(key);
     }
 
@@ -2652,8 +2505,7 @@ public class LogManager {
      * behalf of system and application classes.
      */
     private static final class LoggingProviderAccess
-        implements LoggingProviderImpl.LogManagerAccess,
-                   PrivilegedAction<Void> {
+        implements LoggingProviderImpl.LogManagerAccess {
 
         private LoggingProviderAccess() {
         }
@@ -2684,11 +2536,6 @@ public class LogManager {
             }
             Objects.requireNonNull(name);
             Objects.requireNonNull(module);
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(controlPermission);
-            }
             if (isSystem(module)) {
                 return manager.demandSystemLogger(name,
                     Logger.SYSTEM_LOGGER_RB_NAME, module);
@@ -2697,23 +2544,15 @@ public class LogManager {
             }
         }
 
-        @Override
-        public Void run() {
+        private void init() {
             LoggingProviderImpl.setLogManagerAccess(INSTANCE);
-            return null;
         }
 
         static final LoggingProviderAccess INSTANCE = new LoggingProviderAccess();
     }
 
     static {
-        initStatic();
-    }
-
-    @SuppressWarnings("removal")
-    private static void initStatic() {
-        AccessController.doPrivileged(LoggingProviderAccess.INSTANCE, null,
-                                      controlPermission);
+        LoggingProviderAccess.INSTANCE.init();
     }
 
 }

--- a/src/java.logging/share/classes/java/util/logging/LogRecord.java
+++ b/src/java.logging/share/classes/java/util/logging/LogRecord.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,8 +28,6 @@ import java.time.Instant;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicLong;
 import java.io.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.time.Clock;
 import java.util.function.Predicate;
 import static jdk.internal.logger.SurrogateLogger.isFilteredFrame;
@@ -767,14 +765,10 @@ public class LogRecord implements java.io.Serializable {
     /*
      * CallerFinder is a stateful predicate.
      */
-    @SuppressWarnings("removal")
     static final class CallerFinder implements Predicate<StackWalker.StackFrame> {
-        private static final StackWalker WALKER;
-        static {
-            final PrivilegedAction<StackWalker> action =
-                () -> StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
-            WALKER = AccessController.doPrivileged(action);
-        }
+        private static final StackWalker WALKER =
+                StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
+
 
         /**
          * Returns StackFrame of the caller's frame.

--- a/src/java.logging/share/classes/java/util/logging/LoggingPermission.java
+++ b/src/java.logging/share/classes/java/util/logging/LoggingPermission.java
@@ -26,7 +26,6 @@
 
 package java.util.logging;
 
-import java.security.*;
 
 /**
  * This class is for logging permissions. Currently there is only one

--- a/src/java.logging/share/classes/java/util/logging/MemoryHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/MemoryHandler.java
@@ -178,21 +178,7 @@ public class MemoryHandler extends Handler {
      *                 silently ignored and is not published
      */
     @Override
-    public void publish(LogRecord record) {
-        if (tryUseLock()) {
-            try {
-                publish0(record);
-            } finally {
-                unlock();
-            }
-        } else {
-            synchronized (this) {
-                publish0(record);
-            }
-        }
-    }
-
-    private void publish0(LogRecord record) {
+    public synchronized void publish(LogRecord record) {
         if (!isLoggable(record)) {
             return;
         }
@@ -214,21 +200,7 @@ public class MemoryHandler extends Handler {
      * <p>
      * The buffer is then cleared.
      */
-    public void push() {
-        if (tryUseLock()) {
-            try {
-                push0();
-            } finally {
-                unlock();
-            }
-        } else {
-            synchronized (this) {
-                push0();
-            }
-        }
-    }
-
-    private void push0() {
+    public synchronized void push() {
         for (int i = 0; i < count; i++) {
             int ix = (start+i)%buffer.length;
             LogRecord record = buffer[ix];
@@ -267,25 +239,10 @@ public class MemoryHandler extends Handler {
      *
      * @param newLevel the new value of the {@code pushLevel}
      */
-    public void setPushLevel(Level newLevel) {
-        if (tryUseLock()) {
-            try {
-                setPushLevel0(newLevel);
-            } finally {
-                unlock();
-            }
-        } else {
-            synchronized (this) {
-                setPushLevel0(newLevel);
-            }
-        }
-    }
-
-    private void setPushLevel0(Level newLevel) throws SecurityException {
+    public synchronized void setPushLevel(Level newLevel) {
         if (newLevel == null) {
             throw new NullPointerException();
         }
-        checkPermission();
         pushLevel = newLevel;
     }
 

--- a/src/java.logging/share/classes/java/util/logging/SocketHandler.java
+++ b/src/java.logging/share/classes/java/util/logging/SocketHandler.java
@@ -146,28 +146,14 @@ public class SocketHandler extends StreamHandler {
         sock = new Socket(host, port);
         OutputStream out = sock.getOutputStream();
         BufferedOutputStream bout = new BufferedOutputStream(out);
-        setOutputStreamPrivileged(bout);
+        setOutputStream(bout);
     }
 
     /**
      * Close this output stream.
      */
     @Override
-    public void close() {
-        if (tryUseLock()) {
-            try {
-                close0();
-            } finally {
-                unlock();
-            }
-        } else {
-            synchronized (this) {
-                close0();
-            }
-        }
-    }
-
-    private void close0() throws SecurityException {
+    public synchronized void close() {
         super.close();
         if (sock != null) {
             try {
@@ -186,21 +172,7 @@ public class SocketHandler extends StreamHandler {
      *                 silently ignored and is not published
      */
     @Override
-    public void publish(LogRecord record) {
-        if (tryUseLock()) {
-            try {
-                publish0(record);
-            } finally {
-                unlock();
-            }
-        } else {
-            synchronized (this) {
-                publish0(record);
-            }
-        }
-    }
-
-    private void publish0(LogRecord record) {
+    public synchronized void publish(LogRecord record) {
         if (!isLoggable(record)) {
             return;
         }


### PR DESCRIPTION
This PR remove usage of SecurityManager, doPrivileges, etc... from `java.logging` and `java.base/jdk.internal.logger`

Only notable hack - Logger.checkPermission() no longer checks permissions, but has been renamed into `ensureLogManagerInitialized()` in order to avoid disturbing the initialization sequence of Logger/LogManager.

I am not 100% sure this is still needed - but I remember we had some entanglement issues in the past that had been hard to solve, so it seemed prudent to keep the call:

```
    if (manager == null) {
        manager = LogManager.getLogManager();
    }
```

where `manager` is a private volatile field in Logger.

I also took the opportunity to remove the locking workaround that had been introduced to support Virtual Threads and revert to using synchronized in the Handler classes now that JEP 491 has been integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344235](https://bugs.openjdk.org/browse/JDK-8344235): Revisit SecurityManager usage in java.logging after JEP 486 and JEP 491 integration (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22281/head:pull/22281` \
`$ git checkout pull/22281`

Update a local copy of the PR: \
`$ git checkout pull/22281` \
`$ git pull https://git.openjdk.org/jdk.git pull/22281/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22281`

View PR using the GUI difftool: \
`$ git pr show -t 22281`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22281.diff">https://git.openjdk.org/jdk/pull/22281.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22281#issuecomment-2489411298)
</details>
