### PR TITLE
8342281: Deprecate for removal javax.sound.sampled.AudioPermission

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/DirectAudioDevice.java
@@ -404,10 +404,6 @@ final class DirectAudioDevice extends AbstractMixer {
             // $$fb part of fix for 4679187: Clip.open() throws unexpected Exceptions
             Toolkit.isFullySpecifiedAudioFormat(format);
 
-            // check for record permission
-            if (!isSource) {
-                JSSecurityManager.checkRecordPermission();
-            }
             int encoding = PCM;
             if (format.getEncoding().equals(AudioFormat.Encoding.ULAW)) {
                 encoding = ULAW;
@@ -509,11 +505,6 @@ final class DirectAudioDevice extends AbstractMixer {
 
         @Override
         void implStart() {
-            // check for record permission
-            if (!isSource) {
-                JSSecurityManager.checkRecordPermission();
-            }
-
             synchronized (lockNative)
             {
                 nStart(id, isSource);
@@ -538,11 +529,6 @@ final class DirectAudioDevice extends AbstractMixer {
 
         @Override
         void implStop() {
-            // check for record permission
-            if (!isSource) {
-                JSSecurityManager.checkRecordPermission();
-            }
-
             if (monitoring) {
                 getEventDispatcher().removeLineMonitor(this);
                 monitoring = false;
@@ -565,11 +551,6 @@ final class DirectAudioDevice extends AbstractMixer {
 
         @Override
         void implClose() {
-            // check for record permission
-            if (!isSource) {
-                JSSecurityManager.checkRecordPermission();
-            }
-
             // be sure to remove this monitor
             if (monitoring) {
                 getEventDispatcher().removeLineMonitor(this);

--- a/src/java.desktop/share/classes/com/sun/media/sound/JSSecurityManager.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/JSSecurityManager.java
@@ -35,11 +35,9 @@ import java.util.List;
 import java.util.Properties;
 import java.util.ServiceLoader;
 
-import javax.sound.sampled.AudioPermission;
-
-/** Managing security in the Java Sound implementation.
- * This class contains all code that uses and is used by
- * SecurityManager
+/**
+ * Historically this class managed ensuring privileges to access resources
+ * it is still used to get those resources but no longer does checks.
  *
  * @author Matthias Pfisterer
  */
@@ -48,14 +46,6 @@ final class JSSecurityManager {
     /** Prevent instantiation.
      */
     private JSSecurityManager() {
-    }
-
-    static void checkRecordPermission() throws SecurityException {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new AudioPermission("record"));
-        }
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/sound/sampled/AudioPermission.java
+++ b/src/java.desktop/share/classes/javax/sound/sampled/AudioPermission.java
@@ -40,10 +40,13 @@ import java.security.BasicPermission;
  * @apiNote
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
+ * Consequently this class is deprecated and may be removed in a future release.
  *
  * @author Kara Kytle
  * @since 1.3
+ * @deprecated There is no replacement for this class.
  */
+@Deprecated(since="24", forRemoval=true)
 public class AudioPermission extends BasicPermission {
 
     /**

--- a/test/jdk/javax/sound/sampled/Lines/GetLine.java
+++ b/test/jdk/javax/sound/sampled/Lines/GetLine.java
@@ -21,7 +21,6 @@
  * questions.
  */
 
-import javax.sound.sampled.AudioPermission;
 import javax.sound.sampled.AudioSystem;
 import javax.sound.sampled.DataLine;
 import javax.sound.sampled.Line;
@@ -34,18 +33,6 @@ import javax.sound.sampled.SourceDataLine;
  * @summary REGRESSION: IAE for supported line in AudioSystem.getLine()
  */
 public class GetLine {
-
-    static boolean isSoundAccessDenied = false;
-    static {
-        SecurityManager securityManager = System.getSecurityManager();
-        if (securityManager != null) {
-            try {
-                securityManager.checkPermission(new AudioPermission("*"));
-            } catch (SecurityException e) {
-                isSoundAccessDenied = true;
-            }
-        }
-    }
 
     static final int STATUS_PASSED = 0;
     static final int STATUS_FAILED = 2;

--- a/test/jdk/javax/sound/sampled/Lines/GetLine.java
+++ b/test/jdk/javax/sound/sampled/Lines/GetLine.java
@@ -67,9 +67,6 @@ public class GetLine {
         }
         try {
             l = AudioSystem.getLine(infos[0]);
-        } catch(SecurityException lue) {
-            log.println("SecurityException");
-            return STATUS_PASSED;
         } catch (LineUnavailableException e1) {
             log.println("LUE");
             return STATUS_PASSED;


### PR DESCRIPTION
Deprecate AudioPermission for removal.

I found a test that uses it and updated it.

The CSR needs to be reviewed too : https://bugs.openjdk.org/browse/JDK-8344658

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8344658](https://bugs.openjdk.org/browse/JDK-8344658) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8342281](https://bugs.openjdk.org/browse/JDK-8342281): Deprecate for removal javax.sound.sampled.AudioPermission (**Bug** - P4)
 * [JDK-8344658](https://bugs.openjdk.org/browse/JDK-8344658): Deprecate for removal javax.sound.sampled.AudioPermission (**CSR**)


### Reviewers
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) Review applies to [2e9e4ec2](https://git.openjdk.org/jdk/pull/22284/files/2e9e4ec2154a685befdd7f9797038d195250c3fa)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22284/head:pull/22284` \
`$ git checkout pull/22284`

Update a local copy of the PR: \
`$ git checkout pull/22284` \
`$ git pull https://git.openjdk.org/jdk.git pull/22284/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22284`

View PR using the GUI difftool: \
`$ git pr show -t 22284`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22284.diff">https://git.openjdk.org/jdk/pull/22284.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22284#issuecomment-2489662911)
</details>
