### PR TITLE
8344659: Some uses of GetPropertyAction were not removed from java.io and java.nio

### DIFF
--- a/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystem.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package sun.nio.fs;
 
 import java.util.regex.Pattern;
-import sun.security.action.GetPropertyAction;
 
 import static sun.nio.fs.MacOSXNativeDispatcher.*;
 
@@ -43,7 +42,7 @@ class MacOSXFileSystem extends BsdFileSystem {
 
     static {
         final String name = PROPERTY_NORMALIZE_FILE_PATHS;
-        String value = GetPropertyAction.privilegedGetProperty(name);
+        String value = System.getProperty(name);
         NORMALIZE_FILE_PATHS = (value != null)
             && ("".equals(value) || Boolean.parseBoolean(value));
     }

--- a/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystemProvider.java
+++ b/src/java.base/macosx/classes/sun/nio/fs/MacOSXFileSystemProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.nio.fs;
 import java.nio.file.Path;
 import java.nio.file.spi.FileTypeDetector;
 import jdk.internal.util.StaticProperty;
-import sun.security.action.GetPropertyAction;
 
 /**
  * MacOSX implementation of FileSystemProvider

--- a/src/java.base/share/classes/java/io/Console.java
+++ b/src/java.base/share/classes/java/io/Console.java
@@ -33,7 +33,6 @@ import jdk.internal.io.JdkConsoleImpl;
 import jdk.internal.io.JdkConsoleProvider;
 import jdk.internal.javac.PreviewFeature;
 import sun.nio.cs.UTF_8;
-import sun.security.action.GetPropertyAction;
 
 /**
  * Methods to access the character-based console device, if any, associated
@@ -646,7 +645,7 @@ public sealed class Console implements Flushable permits ProxyingConsole {
 
     private static final boolean istty = istty();
     static final Charset CHARSET =
-        Charset.forName(GetPropertyAction.privilegedGetProperty("stdout.encoding"), UTF_8.INSTANCE);
+        Charset.forName(System.getProperty("stdout.encoding"), UTF_8.INSTANCE);
     private static final Console cons = instantiateConsole();
     static {
         // Set up JavaIOAccess in SharedSecrets

--- a/src/java.base/share/classes/sun/nio/ch/Poller.java
+++ b/src/java.base/share/classes/sun/nio/ch/Poller.java
@@ -36,7 +36,6 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
 import jdk.internal.misc.InnocuousThread;
-import sun.security.action.GetPropertyAction;
 
 /**
  * Polls file descriptors. Virtual threads invoke the poll method to park
@@ -305,7 +304,7 @@ public abstract class Poller {
         Pollers() throws IOException {
             PollerProvider provider = PollerProvider.provider();
             Poller.Mode mode;
-            String s = GetPropertyAction.privilegedGetProperty("jdk.pollerMode");
+            String s = System.getProperty("jdk.pollerMode");
             if (s != null) {
                 if (s.equalsIgnoreCase(Mode.SYSTEM_THREADS.name()) || s.equals("1")) {
                     mode = Mode.SYSTEM_THREADS;
@@ -418,7 +417,7 @@ public abstract class Poller {
          * is not a power of 2.
          */
         private static int pollerCount(String propName, int defaultCount) {
-            String s = GetPropertyAction.privilegedGetProperty(propName);
+            String s = System.getProperty(propName);
             int count = (s != null) ? Integer.parseInt(s) : defaultCount;
 
             // check power of 2

--- a/src/java.base/share/classes/sun/nio/cs/GB18030.java
+++ b/src/java.base/share/classes/sun/nio/cs/GB18030.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -36,7 +36,6 @@ import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
 import jdk.internal.misc.VM;
 import sun.nio.cs.Surrogate;
-import sun.security.action.GetPropertyAction;
 
 public class GB18030
     extends Charset
@@ -49,7 +48,7 @@ public class GB18030
     // as the system property is not ready to be read in that case.
     static final boolean IS_2000 =
         VM.initLevel() >= 1 &&
-        "2000".equals(GetPropertyAction.privilegedGetProperty("jdk.charset.GB18030", ""));
+        "2000".equals(System.getProperty("jdk.charset.GB18030", ""));
 
     public GB18030() {
         super("GB18030", StandardCharsets.aliases_GB18030());

--- a/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
+++ b/src/java.base/share/classes/sun/nio/fs/AbstractWatchKey.java
@@ -29,7 +29,6 @@ import java.nio.file.*;
 import java.util.*;
 
 import jdk.internal.util.ArraysSupport;
-import sun.security.action.GetPropertyAction;
 
 /**
  * Base implementation class for watch keys.
@@ -44,7 +43,7 @@ abstract class AbstractWatchKey implements WatchKey {
      */
     static final int MAX_EVENT_LIST_SIZE;
     static {
-        String rawValue = GetPropertyAction.privilegedGetProperty(
+        String rawValue = System.getProperty(
             "jdk.nio.file.WatchService.maxEventsPerPoll",
             String.valueOf(DEFAULT_MAX_EVENT_LIST_SIZE));
         int intValue;

--- a/src/java.base/share/classes/sun/nio/fs/Util.java
+++ b/src/java.base/share/classes/sun/nio/fs/Util.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.nio.fs;
 import java.util.*;
 import java.nio.file.*;
 import java.nio.charset.Charset;
-import sun.security.action.GetPropertyAction;
 
 /**
  * Utility methods
@@ -38,7 +37,7 @@ class Util {
     private Util() { }
 
     private static final Charset jnuEncoding = Charset.forName(
-        GetPropertyAction.privilegedGetProperty("sun.jnu.encoding"));
+        System.getProperty("sun.jnu.encoding"));
 
     /**
      * Returns {@code Charset} corresponding to the sun.jnu.encoding property

--- a/src/java.base/share/classes/sun/nio/fs/Util.java
+++ b/src/java.base/share/classes/sun/nio/fs/Util.java
@@ -28,6 +28,7 @@ package sun.nio.fs;
 import java.util.*;
 import java.nio.file.*;
 import java.nio.charset.Charset;
+import jdk.internal.util.StaticProperty;
 
 /**
  * Utility methods
@@ -37,7 +38,7 @@ class Util {
     private Util() { }
 
     private static final Charset jnuEncoding = Charset.forName(
-        System.getProperty("sun.jnu.encoding"));
+        StaticProperty.jnuEncoding());
 
     /**
      * Returns {@code Charset} corresponding to the sun.jnu.encoding property

--- a/src/java.base/windows/classes/sun/nio/ch/FileDispatcherImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/FileDispatcherImpl.java
@@ -31,7 +31,6 @@ import java.io.IOException;
 import java.nio.CharBuffer;
 import jdk.internal.access.JavaIOFileDescriptorAccess;
 import jdk.internal.access.SharedSecrets;
-import sun.security.action.GetPropertyAction;
 
 class FileDispatcherImpl extends FileDispatcher {
     private static final int MAP_INVALID = -1;
@@ -189,8 +188,8 @@ class FileDispatcherImpl extends FileDispatcher {
     }
 
     static boolean isFastFileTransferRequested() {
-        String fileTransferProp = GetPropertyAction
-                .privilegedGetProperty("jdk.nio.enableFastFileTransfer", "false");
+        String fileTransferProp =
+                System.getProperty("jdk.nio.enableFastFileTransfer", "false");
         return fileTransferProp.isEmpty() ? true : Boolean.parseBoolean(fileTransferProp);
     }
 

--- a/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
+++ b/src/java.base/windows/classes/sun/nio/fs/WindowsFileAttributes.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,6 @@ package sun.nio.fs;
 import java.nio.file.attribute.*;
 import java.util.concurrent.TimeUnit;
 import jdk.internal.misc.Unsafe;
-import sun.security.action.GetPropertyAction;
 
 import static sun.nio.fs.WindowsNativeDispatcher.*;
 import static sun.nio.fs.WindowsConstants.*;
@@ -115,8 +114,8 @@ class WindowsFileAttributes
     // indicates if accurate metadata is required (interesting on NTFS only)
     private static final boolean ensureAccurateMetadata;
     static {
-        String propValue = GetPropertyAction.privilegedGetProperty(
-            "sun.nio.fs.ensureAccurateMetadata", "false");
+        String propValue =
+            System.getProperty("sun.nio.fs.ensureAccurateMetadata", "false");
         ensureAccurateMetadata = propValue.isEmpty() ? true : Boolean.parseBoolean(propValue);
     }
 


### PR DESCRIPTION
Remove some occurrences of `GetPropertyAction` overlooked in #22219 and #22132.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344659](https://bugs.openjdk.org/browse/JDK-8344659): Some uses of GetPropertyAction were not removed from java.io and java.nio (**Bug** - P4)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22285/head:pull/22285` \
`$ git checkout pull/22285`

Update a local copy of the PR: \
`$ git checkout pull/22285` \
`$ git pull https://git.openjdk.org/jdk.git pull/22285/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22285`

View PR using the GUI difftool: \
`$ git pr show -t 22285`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22285.diff">https://git.openjdk.org/jdk/pull/22285.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22285#issuecomment-2489723923)
</details>
