### PR TITLE
8344664: Remove some un-used java/sun.security imports in the java.desktop module

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
@@ -38,7 +38,6 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
-import java.security.AccessController;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -65,7 +64,6 @@ import com.sun.java.swing.plaf.gtk.GTKConstants.PositionType;
 import com.sun.java.swing.plaf.gtk.GTKConstants.StateType;
 import sun.awt.SunToolkit;
 import sun.awt.UNIXToolkit;
-import sun.security.action.GetPropertyAction;
 import sun.swing.AltProcessor;
 import sun.swing.DefaultLayoutStyle;
 import sun.swing.MnemonicHandler;

--- a/src/java.desktop/share/classes/com/sun/media/sound/JARSoundbankReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/JARSoundbankReader.java
@@ -40,7 +40,6 @@ import javax.sound.midi.Soundbank;
 import javax.sound.midi.spi.SoundbankReader;
 
 import sun.reflect.misc.ReflectUtil;
-import sun.security.action.GetBooleanAction;
 
 /**
  * JarSoundbankReader is used to read soundbank object from jar files.

--- a/src/java.desktop/share/classes/com/sun/media/sound/Printer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/Printer.java
@@ -26,8 +26,6 @@
 package com.sun.media.sound;
 
 
-import sun.security.action.GetPropertyAction;
-
 /**
  * Printer allows you to set up global debugging status and print
  * messages accordingly.

--- a/src/java.desktop/share/classes/java/awt/Component.java
+++ b/src/java.desktop/share/classes/java/awt/Component.java
@@ -108,7 +108,6 @@ import sun.java2d.SunGraphics2D;
 import sun.java2d.SunGraphicsEnvironment;
 import sun.java2d.pipe.Region;
 import sun.java2d.pipe.hw.ExtendedBufferCapabilities;
-import sun.security.action.GetPropertyAction;
 import sun.swing.SwingAccessor;
 import sun.util.logging.PlatformLogger;
 

--- a/src/java.desktop/share/classes/java/awt/Container.java
+++ b/src/java.desktop/share/classes/java/awt/Container.java
@@ -50,7 +50,6 @@ import java.io.PrintWriter;
 import java.io.Serial;
 import java.io.Serializable;
 import java.lang.ref.WeakReference;
-import java.security.AccessController;
 import java.util.ArrayList;
 import java.util.EventListener;
 import java.util.HashSet;
@@ -67,7 +66,6 @@ import sun.awt.PeerEvent;
 import sun.awt.SunToolkit;
 import sun.awt.dnd.SunDropTargetEvent;
 import sun.java2d.pipe.Region;
-import sun.security.action.GetBooleanAction;
 import sun.util.logging.PlatformLogger;
 
 /**

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -70,7 +70,6 @@ import sun.awt.DebugSettings;
 import sun.awt.SunToolkit;
 import sun.awt.util.IdentityArrayList;
 import sun.java2d.pipe.Region;
-import sun.security.action.GetPropertyAction;
 import sun.util.logging.PlatformLogger;
 
 /**

--- a/src/java.desktop/share/classes/javax/imageio/ImageIO.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageIO.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Method;
 import java.net.URL;
-import java.security.AccessController;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -50,7 +49,6 @@ import javax.imageio.spi.ServiceRegistry;
 import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
 import sun.awt.AppContext;
-import sun.security.action.GetPropertyAction;
 
 /**
  * A class containing static convenience methods for locating

--- a/src/java.desktop/share/classes/sun/awt/im/InputMethodContext.java
+++ b/src/java.desktop/share/classes/sun/awt/im/InputMethodContext.java
@@ -43,7 +43,6 @@ import java.text.AttributedString;
 import java.text.CharacterIterator;
 import javax.swing.JFrame;
 import sun.awt.InputMethodSupport;
-import sun.security.action.GetPropertyAction;
 
 /**
  * The InputMethodContext class provides methods that input methods

--- a/src/java.desktop/share/classes/sun/awt/util/ThreadGroupUtils.java
+++ b/src/java.desktop/share/classes/sun/awt/util/ThreadGroupUtils.java
@@ -39,7 +39,6 @@ public final class ThreadGroupUtils {
 
     /**
      * Returns a root thread group.
-     * Should be called with {@link sun.security.util.SecurityConstants#MODIFY_THREADGROUP_PERMISSION}
      *
      * @return a root {@code ThreadGroup}
      */

--- a/src/java.desktop/share/classes/sun/font/TrueTypeFont.java
+++ b/src/java.desktop/share/classes/sun/font/TrueTypeFont.java
@@ -45,7 +45,6 @@ import java.util.Map;
 
 import sun.java2d.Disposer;
 import sun.java2d.DisposerRecord;
-import sun.security.action.GetPropertyAction;
 
 /**
  * TrueTypeFont is not called SFntFont because it is not expected

--- a/src/java.desktop/share/classes/sun/java2d/marlin/MarlinUtils.java
+++ b/src/java.desktop/share/classes/sun/java2d/marlin/MarlinUtils.java
@@ -65,7 +65,6 @@ public final class MarlinUtils {
 
     /**
      * Returns a root thread group.
-     * Should be called with {@link sun.security.util.SecurityConstants#MODIFY_THREADGROUP_PERMISSION}
      *
      * @return a root {@code ThreadGroup}
      */

--- a/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/UNIXToolkit.java
@@ -51,15 +51,11 @@ import java.awt.image.WritableRaster;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Arrays;
 
 import sun.awt.X11.XBaseWindow;
-import sun.security.action.GetIntegerAction;
 import com.sun.java.swing.plaf.gtk.GTKConstants.TextDirection;
 import sun.java2d.opengl.OGLRenderQueue;
-import sun.security.action.GetPropertyAction;
 
 public abstract class UNIXToolkit extends SunToolkit
 {

--- a/src/java.desktop/unix/classes/sun/awt/X11InputMethodDescriptor.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11InputMethodDescriptor.java
@@ -30,10 +30,8 @@ import java.awt.Image;
 import java.awt.Toolkit;
 import java.awt.im.spi.InputMethod;
 import java.awt.im.spi.InputMethodDescriptor;
-import java.security.AccessController;
 import java.util.Locale;
 import sun.awt.SunToolkit;
-import sun.security.action.GetPropertyAction;
 
 /**
  * Provides sufficient information about an input method


### PR DESCRIPTION
delete un-used imports and obsolete comments

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344664](https://bugs.openjdk.org/browse/JDK-8344664): Remove some un-used java/sun.security imports in the java.desktop module (**Bug** - P4)


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22286/head:pull/22286` \
`$ git checkout pull/22286`

Update a local copy of the PR: \
`$ git checkout pull/22286` \
`$ git pull https://git.openjdk.org/jdk.git pull/22286/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22286`

View PR using the GUI difftool: \
`$ git pr show -t 22286`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22286.diff">https://git.openjdk.org/jdk/pull/22286.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22286#issuecomment-2489755086)
</details>
