### PR TITLE
8344668: Unnecessary array allocations and copying in TextLine

### DIFF
--- a/src/java.desktop/share/classes/java/awt/font/TextLine.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/font/TextLine.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextLine.java
@@ -1076,7 +1076,7 @@ final class TextLine {
                     pos = chunkLimit;
 
                     ++numComponents;
-                    if (numComponents >= tempComponents.length) {
+                    if (numComponents > tempComponents.length) {
                         tempComponents = expandArray(tempComponents);
                     }
 

--- a/src/java.desktop/share/classes/java/awt/font/TextLine.java
+++ b/src/java.desktop/share/classes/java/awt/font/TextLine.java
@@ -1021,7 +1021,7 @@ final class TextLine {
                     factory.createExtended(font, cm, decorator, startPos, startPos + lmCount);
 
                 ++numComponents;
-                if (numComponents >= components.length) {
+                if (numComponents > components.length) {
                     components = expandArray(components);
                 }
 


### PR DESCRIPTION
When `LineBreakMeasurer` is used to break text into lines, internally it uses `TextMeasurer` and `TextLine` to do the job. In the common case, `TextLine.getComponents(...)` allocates a `TextLineComponent[]` with room for a single array entry, and passes it to `TextLine.createComponentsOnRun(...)`, which fills the array and returns it, optionally resizing to a larger array if necessary, after which the array is resized back down to actual size (if necessary).

Unfortunately `TextLine.createComponentsOnRun(...)` is too eager in allocating larger arrays. In the most common case of a single component, this means that a single-element array is allocated, then a 9-element array is allocated (via `expandArray(...)`), and then another single-element array is allocated (to shrink the array back to actual size). Only one array allocation is necessary in this common case, and no array copying is needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344668](https://bugs.openjdk.org/browse/JDK-8344668): Unnecessary array allocations and copying in TextLine (**Bug** - P5)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) Review applies to [bb7a66ce](https://git.openjdk.org/jdk/pull/22288/files/bb7a66ce7b08a7f50da3194390c1d077a0b1fb81)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22288/head:pull/22288` \
`$ git checkout pull/22288`

Update a local copy of the PR: \
`$ git checkout pull/22288` \
`$ git pull https://git.openjdk.org/jdk.git pull/22288/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22288`

View PR using the GUI difftool: \
`$ git pr show -t 22288`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22288.diff">https://git.openjdk.org/jdk/pull/22288.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22288#issuecomment-2489815395)
</details>
