### PR TITLE
8272339: Update notes section from serialver man page

### DIFF
--- a/src/jdk.compiler/share/man/serialver.md
+++ b/src/jdk.compiler/share/man/serialver.md
@@ -1,5 +1,5 @@
 ---
-# Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 1997, 2024, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -60,15 +60,8 @@ arguments, the `serialver` command prints a usage line.
     application launcher. For example, `-J-Xms48m` sets the startup memory to
     48 MB.
 
-## Notes
+## Warning
 
-The `serialver` command loads and initializes the specified classes in its
-virtual machine, and by default, it doesn't set a security manager. If the
-`serialver` command is to be run with untrusted classes, then a security
-manager can be set with the following option:
-
->   `-J-Djava.security.manager`
-
-When necessary, a security policy can be specified with the following option:
-
->   `-J-Djava.security.policy=`*policy\_file*
+The `serialver` command loads and initializes the specified classes in
+order to determine their `serialVersionUID` values. *DO NOT RUN* `serialver`
+on untrusted classes.


### PR DESCRIPTION
Quick doc-only change. I don't think this needs a CSR, since it contains changes only to the "notes" section, which is non-normative.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8272339](https://bugs.openjdk.org/browse/JDK-8272339): Update notes section from serialver man page (**Bug** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)

### Reviewers without OpenJDK IDs
 * @abdelhak-zaaim (no known openjdk.org user name / role)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22289/head:pull/22289` \
`$ git checkout pull/22289`

Update a local copy of the PR: \
`$ git checkout pull/22289` \
`$ git pull https://git.openjdk.org/jdk.git pull/22289/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22289`

View PR using the GUI difftool: \
`$ git pr show -t 22289`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22289.diff">https://git.openjdk.org/jdk/pull/22289.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22289#issuecomment-2489828150)
</details>
