### PR TITLE
8344569: SwingUtilities2.makeIcon_Unprivileged is obsolete

### DIFF
--- a/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/LookAndFeel.java
@@ -469,7 +469,7 @@ public abstract class LookAndFeel
      * @see Class#getResourceAsStream(String)
      */
     public static Object makeIcon(final Class<?> baseClass, final String gifFile) {
-        return SwingUtilities2.makeIcon_Unprivileged(baseClass, baseClass, gifFile);
+        return SwingUtilities2.makeIcon(baseClass, baseClass, gifFile);
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -1671,42 +1671,8 @@ public class SwingUtilities2 {
     public static Object makeIcon(final Class<?> baseClass,
                                   final Class<?> rootClass,
                                   final String imageFile) {
-        return makeIcon(baseClass, rootClass, imageFile, true);
-    }
-
-    /**
-     * Utility method that creates a {@code UIDefaults.LazyValue} that
-     * creates an {@code ImageIcon} {@code UIResource} for the
-     * specified image file name. The image is loaded using
-     * {@code getResourceAsStream}, starting with a call to that method
-     * on the base class parameter. If it cannot be found, searching will
-     * continue through the base class' inheritance hierarchy, up to and
-     * including {@code rootClass}.
-     *
-     * Finds an image with a given name without privileges enabled.
-     *
-     * @param baseClass the first class to use in searching for the resource
-     * @param rootClass an ancestor of {@code baseClass} to finish the
-     *                  search at
-     * @param imageFile the name of the file to be found
-     * @return a lazy value that creates the {@code ImageIcon}
-     *         {@code UIResource} for the image,
-     *         or null if it cannot be found
-     */
-    public static Object makeIcon_Unprivileged(final Class<?> baseClass,
-                                  final Class<?> rootClass,
-                                  final String imageFile) {
-        return makeIcon(baseClass, rootClass, imageFile, false);
-    }
-
-    private static Object makeIcon(final Class<?> baseClass,
-                                  final Class<?> rootClass,
-                                  final String imageFile,
-                                  final boolean enablePrivileges) {
         return (UIDefaults.LazyValue) (table) -> {
-            byte[] buffer = enablePrivileges ?
-                    getIconBytes(baseClass, rootClass, imageFile)
-                    : getIconBytes(baseClass, rootClass, imageFile);
+            byte[] buffer = getIconBytes(baseClass, rootClass, imageFile);
 
             if (buffer == null) {
                 return null;


### PR DESCRIPTION
makeIcon_unPrivileged is no longer needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344569](https://bugs.openjdk.org/browse/JDK-8344569): SwingUtilities2.makeIcon_Unprivileged is obsolete (**Bug** - P4)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22290/head:pull/22290` \
`$ git checkout pull/22290`

Update a local copy of the PR: \
`$ git checkout pull/22290` \
`$ git pull https://git.openjdk.org/jdk.git pull/22290/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22290`

View PR using the GUI difftool: \
`$ git pr show -t 22290`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22290.diff">https://git.openjdk.org/jdk/pull/22290.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22290#issuecomment-2490076926)
</details>
