### PR TITLE
8344382: RISC-V: CASandCAEwithNegExpected fails with Zacas

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1146,10 +1146,9 @@ public:
                     enum operand_size size,
                     Assembler::Aqrl acquire, Assembler::Aqrl release,
                     Register result);
-  void cmpxchg_narrow_value_helper(Register addr, Register expected,
-                                   Register new_val,
+  void cmpxchg_narrow_value_helper(Register addr, Register expected, Register new_val,
                                    enum operand_size size,
-                                   Register tmp1, Register tmp2, Register tmp3);
+                                   Register shift, Register mask, Register aligned_addr);
   void cmpxchg_narrow_value(Register addr, Register expected,
                             Register new_val,
                             enum operand_size size,


### PR DESCRIPTION
Hi, please consider.

There are two issues with narrow amocas:
- weak_cmpxchg_narrow_value don't load from aligned address.
- cmpxchg_narrow_value compared new to loaded value, not to expected value.

This addresses these two issues and makes some minor cleanups by:
- Weak and strong are now identical for easier debugging (and in futre code sharing).
- t1 was set by cmpxchg_narrow_value_helper but not passed.
- To free up a register, not_mask is now a scratch register. Hence if amocas fails we need to re-create not mask.
- Subjective change: a register containing temporary value is best named scratch, as the register it self is not temporary.

Same as other PR, here be dragons.
But with a working baseline we can start improving this code.

Passes test/hotspot/jtreg/compiler/unsafe/ with +/-UseZacas.
And I'm running tier1 +/-UseZacas (I'll run tests over the weekend).

Thanks, Robbin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344382](https://bugs.openjdk.org/browse/JDK-8344382): RISC-V: CASandCAEwithNegExpected fails with Zacas (**Bug** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22293/head:pull/22293` \
`$ git checkout pull/22293`

Update a local copy of the PR: \
`$ git checkout pull/22293` \
`$ git pull https://git.openjdk.org/jdk.git pull/22293/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22293`

View PR using the GUI difftool: \
`$ git pr show -t 22293`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22293.diff">https://git.openjdk.org/jdk/pull/22293.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22293#issuecomment-2491284831)
</details>
