### PR TITLE
8344718: Test runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java fails on Linuxppc64le after JDK-8344239

### DIFF
--- a/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java
@@ -34,12 +34,9 @@
  */
 
 import jdk.test.lib.process.OutputAnalyzer;
-import jdk.test.whitebox.WhiteBox;
+import jdk.test.whitebox.code.Compiler;
 
 public class AddmodsOption {
-
-    private static final WhiteBox WB = WhiteBox.getWhiteBox();
-    private static final boolean isJVMCISupported = WB.getBooleanVMFlag("EnableJVMCI");
 
     public static void main(String[] args) throws Exception {
         final String moduleOption = "jdk.httpserver/sun.net.httpserver.simpleserver.Main";
@@ -143,7 +140,7 @@ public class AddmodsOption {
           .shouldContain("subgraph jdk.internal.module.ArchivedBootLayer is not recorde")
           .shouldHaveExitValue(0);
 
-        if (isJVMCISupported) {
+        if (Compiler.isJVMCIEnabled()) {
             // dump an archive with JVMCI option which indirectly adds the
             // jdk.internal.vm.ci module using the --add-modules option
             archiveName = TestCommon.getNewArchiveName("jvmci-module");


### PR DESCRIPTION
We run on Linux ppc64le into this error

java.lang.ExceptionInInitializerError
at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized0(Native Method)
at java.base/jdk.internal.misc.Unsafe.ensureClassInitialized(Unsafe.java:1166)
at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.ensureClassInitialized(MethodHandleAccessorFactory.java:340)
at java.base/jdk.internal.reflect.MethodHandleAccessorFactory.newMethodAccessor(MethodHandleAccessorFactory.java:71)
at java.base/jdk.internal.reflect.ReflectionFactory.newMethodAccessor(ReflectionFactory.java:141)
at java.base/java.lang.reflect.Method.acquireMethodAccessor(Method.java:711)
at java.base/java.lang.reflect.Method.invoke(Method.java:562)
at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
at java.base/java.lang.Thread.run(Thread.java:1447)
Caused by: java.lang.NullPointerException: Cannot invoke "java.lang.Boolean.booleanValue()" because the return value of "jdk.test.whitebox.WhiteBox.getBooleanVMFlag(String)" is null
at AddmodsOption.<clinit>(AddmodsOption.java:42)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344718](https://bugs.openjdk.org/browse/JDK-8344718): Test runtime/cds/appcds/jigsaw/addmods/AddmodsOption.java fails on Linuxppc64le after JDK-8344239 (**Bug** - P4)


### Reviewers
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22294/head:pull/22294` \
`$ git checkout pull/22294`

Update a local copy of the PR: \
`$ git checkout pull/22294` \
`$ git pull https://git.openjdk.org/jdk.git pull/22294/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22294`

View PR using the GUI difftool: \
`$ git pr show -t 22294`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22294.diff">https://git.openjdk.org/jdk/pull/22294.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22294#issuecomment-2491315156)
</details>
