### PR TITLE
8344727: [JVMCI] Export the CompileBroker compilation activity mode for Truffle compiler control

### DIFF
--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3223,6 +3223,10 @@ C2V_VMENTRY(void, getOopMapAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(method),
   JVMCIENV->copy_longs_from((jlong*)oop_map_buf, oop_map, 0, nwords);
 C2V_END
 
+C2V_VMENTRY_0(jint, getCompilationActivityMode, (JNIEnv* env, jobject))
+  return CompileBroker::get_compilation_activity_mode();
+}
+
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &(c2v_ ## f))
 
@@ -3385,6 +3389,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "notifyCompilerInliningEvent",                  CC "(I" HS_METHOD2 HS_METHOD2 "ZLjava/lang/String;I)V",                               FN_PTR(notifyCompilerInliningEvent)},
   {CC "getOopMapAt",                                  CC "(" HS_METHOD2 "I[J)V",                                                            FN_PTR(getOopMapAt)},
   {CC "updateCompilerThreadCanCallJava",              CC "(Z)Z",                                                                            FN_PTR(updateCompilerThreadCanCallJava)},
+  {CC "getCompilationActivityMode",                   CC "()I",                                                                             FN_PTR(getCompilationActivityMode)},
 };
 
 int CompilerToVM::methods_count() {

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -1522,4 +1522,10 @@ final class CompilerToVM {
      * @returns false if no change was made, otherwise true
      */
     native boolean updateCompilerThreadCanCallJava(boolean newState);
+
+    /**
+     * Returns the current {@code CompileBroker} compilation activity mode which is one of:
+     * {@code stop_compilation = 0}, {@code run_compilation = 1} or {@code shutdown_compilation = 2}
+     */
+    native int getCompilationActivityMode();
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -1488,4 +1488,12 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         exitHotSpot(status);
         throw JVMCIError.shouldNotReachHere();
     }
+
+    /**
+     * Returns HotSpot's {@code CompileBroker} compilation activity mode which is one of:
+     * {@code stop_compilation = 0}, {@code run_compilation = 1} or {@code shutdown_compilation = 2}
+     */
+    public int getCompilationActivityMode() {
+        return compilerToVm.getCompilationActivityMode();
+    }
 }


### PR DESCRIPTION
Truffle compilations run in "hosted" mode, i.e. the Truffle runtimes triggers compilations independently of HotSpot's [`CompileBroker`](https://github.com/openjdk/jdk/blob/8f22db23a50fe537d8ef369e92f0d5f9970d98f0/src/hotspot/share/compiler/compileBroker.hpp). But the results of Truffle compilations are still stored as ordinary nmethods in HotSpot's code cache (with the help of the JVMCI method `jdk.vm.ci.hotspot.HotSpotCodeCacheProvider::installCode()`). The regular JIT compilers are controlled by the `CompileBroker` which is aware of the code cache occupancy. If the code cache runs full, the `CompileBroker` temporary pauses any subsequent JIT compilations until the code cache gets swept (if running with `-XX:+UseCodeCacheFlushing -XX:+MethodFlushing` which is the default) or completely shuts down the JIT compilers if running with `-XX:+UseCodeCacheFlushing`.

Truffle compiled methods can contribute significantly to the overall code cache occupancy and they can trigger JIT compilation stalls if they fill the code cache up. But the Truffle framework itself is neither aware of the current code cache occupancy, nor of the compilation activity of the `CompileBroker`. If Truffle tries to install a compiled method through JVMCI and the code cache is full, it will silently fail. Currently Truffle interprets such failures as transient errors and basically ignores it. Whenever the corresponding method gets hot again (usually immediately at the next invocation), Truffle will recompile it again just to fail again in the nmethod installation step, if the code cache is still full.

When the code cache is tight, this can lead to situations, where Truffle is unnecessarily and repeatedly compiling methods which can't be installed in the code cache but produce a significant CPU load. Instead, Truffle should poll HotSpot's `CompileBroker` compilation activity and pause compilations for the time the `CompileBroker` is pausing JIT compilations (or completely shutdown Truffle compilations if the `CompileBroker` shut down the JIT compilers). In order to make this possible, JVMCI should export the CompileBroker compilation activity mode (i.e. `stop_compilation`, `run_compilation` or `shutdown_compilation`).

The corresponding Truffle change is tracked under [#10133: Implement Truffle compiler control based on HotSpot's CompileBroker compilation activity](https://github.com/oracle/graal/issues/10133).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344727](https://bugs.openjdk.org/browse/JDK-8344727): [JVMCI] Export the CompileBroker compilation activity mode for Truffle compiler control (**Enhancement** - P4)


### Reviewers
 * [Doug Simon](https://openjdk.org/census#dnsimon) (@dougxc - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22295/head:pull/22295` \
`$ git checkout pull/22295`

Update a local copy of the PR: \
`$ git checkout pull/22295` \
`$ git pull https://git.openjdk.org/jdk.git pull/22295/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22295`

View PR using the GUI difftool: \
`$ git pr show -t 22295`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22295.diff">https://git.openjdk.org/jdk/pull/22295.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22295#issuecomment-2491738160)
</details>
