### PR TITLE
[PATCH] Cleanup SoftSynthesizer.getDefaultSoundbank

### DIFF
--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
@@ -797,8 +797,9 @@ public final class SoftSynthesizer implements AudioSynthesizer,
         if (emgSoundbankFile.isFile()) {
             return;
         }
-        FileOutputStream out = new FileOutputStream(emgSoundbankFile);
-        ((SF2Soundbank) defaultSoundBank).save(out);
+        try (FileOutputStream out = new FileOutputStream(emgSoundbankFile)) {
+            ((SF2Soundbank) defaultSoundBank).save(out);
+        }
     }
 
     @Override

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2008, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,11 +30,9 @@ import sun.awt.OSInfo;
 import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -779,35 +777,28 @@ public final class SoftSynthesizer implements AudioSynthesizer,
                 /*
                  * Save generated soundbank to disk for faster future use.
                  */
-                OutputStream out =
-                        ((RunnableAction<OutputStream>) () -> {
-                            try {
-                                File userhome = new File(System
-                                        .getProperty("user.home"), ".gervill");
-                                if (!userhome.isDirectory()) {
-                                    if (!userhome.mkdirs()) {
-                                        return null;
-                                    }
-                                }
-                                File emg_soundbank_file = new File(
-                                        userhome, "soundbank-emg.sf2");
-                                if (emg_soundbank_file.isFile()) {
-                                    return null;
-                                }
-                                return new FileOutputStream(emg_soundbank_file);
-                            } catch (final FileNotFoundException ignored) {
-                            }
-                            return null;
-                        }).run();
-                if (out != null) {
-                    try (out) {
-                        ((SF2Soundbank) defaultSoundBank).save(out);
-                    } catch (final IOException ignored) {
-                    }
+                try {
+                    saveDefaultSoundBank();
+                } catch (IOException ignored) {
                 }
             }
         }
         return defaultSoundBank;
+    }
+
+    private static void saveDefaultSoundBank() throws IOException {
+        File userhome = new File(System.getProperty("user.home"), ".gervill");
+        if (!userhome.isDirectory()) {
+            if (!userhome.mkdirs()) {
+                return;
+            }
+        }
+        File emgSoundbankFile = new File(userhome, "soundbank-emg.sf2");
+        if (emgSoundbankFile.isFile()) {
+            return;
+        }
+        FileOutputStream out = new FileOutputStream(emgSoundbankFile);
+        ((SF2Soundbank) defaultSoundBank).save(out);
     }
 
     @Override


### PR DESCRIPTION
After #22186 there is quite ugly code, which creates lambda and executes it immediately.
Refactoring it into a separate method makes code more readable and easier to understand.

Tested `jdk/javax/sound` on Windows x64 release + Linux x64 release.
```
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR
   jtreg:test/jdk/javax/sound                          411   411     0     0
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22296/head:pull/22296` \
`$ git checkout pull/22296`

Update a local copy of the PR: \
`$ git checkout pull/22296` \
`$ git pull https://git.openjdk.org/jdk.git pull/22296/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22296`

View PR using the GUI difftool: \
`$ git pr show -t 22296`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22296.diff">https://git.openjdk.org/jdk/pull/22296.diff</a>

</details>
