### PR TITLE
8339916: AIOOBE due to Math.abs(Integer.MIN_VALUE) in tests

### DIFF
--- a/test/micro/org/openjdk/bench/vm/lang/TypePollution.java
+++ b/test/micro/org/openjdk/bench/vm/lang/TypePollution.java
@@ -178,7 +178,7 @@ public class TypePollution {
             probe ^= probe << 13;   // xorshift
             probe ^= probe >>> 17;
             probe ^= probe << 5;
-            dummy += switch(objectArray[Math.abs(probe) % objectArray.length]) {
+            dummy += switch(objectArray[(probe & Integer.MAX_VALUE) % objectArray.length]) {
             case I01 inst -> 1;
             case I02 inst -> 2;
             case I03 inst -> 3;
@@ -192,7 +192,7 @@ public class TypePollution {
             probe ^= probe << 13;   // xorshift
             probe ^= probe >>> 17;
             probe ^= probe << 5;
-            dummy += switch(objectArray[Math.abs(probe) % objectArray.length]) {
+            dummy += switch(objectArray[(probe & Integer.MAX_VALUE) % objectArray.length]) {
             case I18 inst -> 8;
             case I17 inst -> 7;
             case I16 inst -> 6;


### PR DESCRIPTION
Test bug.

Another bug caused by the result of `Math.abs()` being negative. I also tried `floorMod()`, which would have been cleaner, but it increased the runtime of this extremely time-sensitive benchmark.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8339916](https://bugs.openjdk.org/browse/JDK-8339916): AIOOBE due to Math.abs(Integer.MIN_VALUE) in tests (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22297/head:pull/22297` \
`$ git checkout pull/22297`

Update a local copy of the PR: \
`$ git checkout pull/22297` \
`$ git pull https://git.openjdk.org/jdk.git pull/22297/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22297`

View PR using the GUI difftool: \
`$ git pr show -t 22297`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22297.diff">https://git.openjdk.org/jdk/pull/22297.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22297#issuecomment-2491847317)
</details>
