### PR TITLE
8344763: cpCache print_on doesn't handle nulls

### DIFF
--- a/src/hotspot/share/oops/cpCache.cpp
+++ b/src/hotspot/share/oops/cpCache.cpp
@@ -829,9 +829,15 @@ oop ConstantPoolCache::appendix_if_resolved(ResolvedMethodEntry* method_entry) c
 void ConstantPoolCache::print_on(outputStream* st) const {
   st->print_cr("%s", internal_name());
   // print constant pool cache entries
-  print_resolved_field_entries(st);
-  print_resolved_method_entries(st);
-  print_resolved_indy_entries(st);
+  if (_resolved_field_entries != nullptr) {
+    print_resolved_field_entries(st);
+  }
+  if (_resolved_method_entries != nullptr) {
+    print_resolved_method_entries(st);
+  }
+  if (_resolved_indy_entries != nullptr) {
+    print_resolved_indy_entries(st);
+  }
 }
 
 void ConstantPoolCache::print_resolved_field_entries(outputStream* st) const {


### PR DESCRIPTION
A change to remove some more security manager code, resulted in java.lang.System not having any more indy instructions so the gtest test_cpCache_output.cpp was crashing because of missing null checks.  Please review this trivial change to add in null checks.  The test doesn't verify that there are indys so doesn't need to be fixed.

Tested with gtest and upcoming security manager change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344763](https://bugs.openjdk.org/browse/JDK-8344763): cpCache print_on doesn't handle nulls (**Bug** - P4)


### Reviewers
 * [Matias Saavedra Silva](https://openjdk.org/census#matsaave) (@matias9927 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22298/head:pull/22298` \
`$ git checkout pull/22298`

Update a local copy of the PR: \
`$ git checkout pull/22298` \
`$ git pull https://git.openjdk.org/jdk.git pull/22298/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22298`

View PR using the GUI difftool: \
`$ git pr show -t 22298`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22298.diff">https://git.openjdk.org/jdk/pull/22298.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22298#issuecomment-2491867698)
</details>
