### PR TITLE
8344652: Remove access control context text from SSLEngine and SSLSession APIs

### DIFF
--- a/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLEngine.java
@@ -377,14 +377,6 @@ import java.util.function.BiFunction;
  *     }
  * </pre></blockquote>
  *
- * <P>
- * Applications might choose to process delegated tasks in different
- * threads.  When an {@code SSLEngine}
- * is created, the current {@link java.security.AccessControlContext}
- * is saved.  All future delegated tasks will be processed using this
- * context:  that is, all access control decisions will be made using the
- * context captured at engine creation.
- *
  * <HR>
  *
  * <B>Concurrency Notes</B>:
@@ -817,9 +809,6 @@ public abstract class SSLEngine {
      * java.lang.Runnable#run() run} operation.  Once the
      * {@code run} method returns, the {@code Runnable} object
      * is no longer needed and may be discarded.
-     * <P>
-     * Delegated tasks run in the {@code AccessControlContext}
-     * in place when this object was created.
      * <P>
      * A call to this method will return each outstanding task
      * exactly once.

--- a/src/java.base/share/classes/javax/net/ssl/SSLSession.java
+++ b/src/java.base/share/classes/javax/net/ssl/SSLSession.java
@@ -148,9 +148,6 @@ public interface SSLSession {
      * replaced.  If the new (or existing) {@code value} implements the
      * {@code SSLSessionBindingListener} interface, the object
      * represented by {@code value} is notified appropriately.
-     * <p>
-     * For security reasons, the same named values may not be
-     * visible across different access control contexts.
      *
      * @param name the name to which the data object will be bound.
      *          This may not be null.
@@ -163,9 +160,6 @@ public interface SSLSession {
     /**
      * Returns the object bound to the given name in the session's
      * application layer data.  Returns null if there is no such binding.
-     * <p>
-     * For security reasons, the same named values may not be
-     * visible across different access control contexts.
      *
      * @param name the name of the binding to find.
      * @return the value bound to that name, or null if the binding does
@@ -181,12 +175,8 @@ public interface SSLSession {
      * bound to the given name.  If the bound existing object
      * implements the {@code SSLSessionBindingListener} interface,
      * it is notified appropriately.
-     * <p>
-     * For security reasons, the same named values may not be
-     * visible across different access control contexts.
      *
-     * @param name the name of the object to remove visible
-     *          across different access control contexts
+     * @param name the name of the object to remove
      * @throws IllegalArgumentException if the argument is null.
      */
     void removeValue(String name);
@@ -195,9 +185,6 @@ public interface SSLSession {
     /**
      * Returns an array of the names of all the application layer
      * data objects bound into the Session.
-     * <p>
-     * For security reasons, the same named values may not be
-     * visible across different access control contexts.
      *
      * @return a non-null (possibly empty) array of names of the objects
      *  bound to this Session.


### PR DESCRIPTION
Some additional text in two `javax.net.ssl` APIs related to access control context was missed as part of JEP 483. This behavior no longer applies now that the Security Manager is permanently disabled and has been removed.

The implementation changes associated with this will be posted in a separate PR for https://bugs.openjdk.org/browse/JDK-8344366.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8344653](https://bugs.openjdk.org/browse/JDK-8344653) to be approved

### Issues
 * [JDK-8344652](https://bugs.openjdk.org/browse/JDK-8344652): Remove access control context text from SSLEngine and SSLSession APIs (**Bug** - P3)
 * [JDK-8344653](https://bugs.openjdk.org/browse/JDK-8344653): Remove access control context text from SSLEngine and SSLSession APIs (**CSR**)


### Reviewers
 * [Jamil Nimeh](https://openjdk.org/census#jnimeh) (@jnimeh - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22299/head:pull/22299` \
`$ git checkout pull/22299`

Update a local copy of the PR: \
`$ git checkout pull/22299` \
`$ git pull https://git.openjdk.org/jdk.git pull/22299/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22299`

View PR using the GUI difftool: \
`$ git pr show -t 22299`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22299.diff">https://git.openjdk.org/jdk/pull/22299.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22299#issuecomment-2491882030)
</details>
