### PR TITLE
8344766: AES/CTR slow at big payloads

### DIFF
--- a/src/java.base/share/classes/com/sun/crypto/provider/CounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CounterMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/com/sun/crypto/provider/CounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CounterMode.java
@@ -185,7 +185,7 @@ class CounterMode extends FeedbackCipher {
         ArrayUtil.nullAndBoundsCheck(out, outOff, len);
 
         int processed = 0;
-        for (;  len > chunkSize; inOff += chunkSize, outOff += chunkSize, 
+        for (;  len > chunkSize; inOff += chunkSize, outOff += chunkSize,
             len -= chunkSize) {
             processed += implCrypt(in, inOff, chunkSize, out, outOff);
         }

--- a/src/java.base/share/classes/com/sun/crypto/provider/CounterMode.java
+++ b/src/java.base/share/classes/com/sun/crypto/provider/CounterMode.java
@@ -53,6 +53,10 @@ class CounterMode extends FeedbackCipher {
     // number of bytes in encryptedCounter already used up
     private int used;
 
+    // chunkSize is a multiple of block size and used to divide up
+    // input data to trigger the intrinsic.
+    private final int chunkSize;
+
     // variables for save/restore calls
     private byte[] counterSave = null;
     private byte[] encryptedCounterSave = null;
@@ -62,6 +66,7 @@ class CounterMode extends FeedbackCipher {
         super(embeddedCipher);
         counter = new byte[blockSize];
         encryptedCounter = new byte[blockSize];
+        chunkSize = blockSize * 6400;
     }
 
     /**
@@ -178,7 +183,17 @@ class CounterMode extends FeedbackCipher {
 
         ArrayUtil.nullAndBoundsCheck(in, inOff, len);
         ArrayUtil.nullAndBoundsCheck(out, outOff, len);
-        return implCrypt(in, inOff, len, out, outOff);
+
+        int processed = 0;
+        for (;  len > chunkSize; inOff += chunkSize, outOff += chunkSize, 
+            len -= chunkSize) {
+            processed += implCrypt(in, inOff, chunkSize, out, outOff);
+        }
+        // note: above loop always leaves some data to process (more than zero,
+        // less than or equal to chunkSize) so this last call can be
+        // unconditional
+        processed += implCrypt(in, inOff, len, out, outOff);
+        return processed;
     }
 
     // Implementation of crpyt() method. Possibly replaced with a compiler intrinsic.


### PR DESCRIPTION
This is a follow up to https://github.com/openjdk/jdk/pull/22086 for AES/CTR

Before:
```
Benchmark                (algorithm)  (dataSize)  (keyLength)  (provider)   Mode  Cnt    Score    Error  Units
AESBench.decrypt   AES/CTR/NoPadding    30000000          128      SunJCE  thrpt    3   16.491 ±  0.356  ops/s
AESBench.decrypt2  AES/CTR/NoPadding    30000000          128      SunJCE  thrpt    3   16.899 ±  0.013  ops/s
AESBench.encrypt   AES/CTR/NoPadding    30000000          128      SunJCE  thrpt    3   16.477 ±  1.006  ops/s
AESBench.encrypt2  AES/CTR/NoPadding    30000000          128      SunJCE  thrpt    3   16.921 ±  0.038  ops/s
```
After:
```
Benchmark                (algorithm)  (dataSize)  (keyLength)  (provider)   Mode  Cnt    Score   Error  Units
AESBench.decrypt   AES/CTR/NoPadding    30000000          128      SunJCE  thrpt    3  218.910 ± 1.991  ops/s
AESBench.decrypt2  AES/CTR/NoPadding    30000000          128      SunJCE  thrpt    3  426.414 ± 2.988  ops/s
AESBench.encrypt   AES/CTR/NoPadding    30000000          128      SunJCE  thrpt    3  218.882 ± 2.446  ops/s
AESBench.encrypt2  AES/CTR/NoPadding    30000000          128      SunJCE  thrpt    3  425.402 ± 4.205  ops/s
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344766](https://bugs.openjdk.org/browse/JDK-8344766): AES/CTR slow at big payloads (**Enhancement** - P4)


### Reviewers
 * [Anthony Scarpino](https://openjdk.org/census#ascarpino) (@ascarpino - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22300/head:pull/22300` \
`$ git checkout pull/22300`

Update a local copy of the PR: \
`$ git checkout pull/22300` \
`$ git pull https://git.openjdk.org/jdk.git pull/22300/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22300`

View PR using the GUI difftool: \
`$ git pr show -t 22300`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22300.diff">https://git.openjdk.org/jdk/pull/22300.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22300#issuecomment-2492011333)
</details>
