### PR TITLE
Add Triple-Star Token

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -1014,8 +1014,17 @@ public class JavaTokenizer extends UnicodeReader {
                 case '\"': // (Spec. 3.10)
                     scanString(pos);
                     break loop;
+
                 default:
-                    if (isSpecial(get())) {
+                    // James contribution
+                    if (accept("***")) {
+                        put("***");
+                        tk = TokenKind.TRIPLESTAR;
+                        break;
+                    }
+
+                    // Original logic
+                    else if (isSpecial(get())) {
                         scanOperator();
                     } else {
                         boolean isJavaIdentifierStart;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavaTokenizer.java
@@ -1020,7 +1020,7 @@ public class JavaTokenizer extends UnicodeReader {
                     if (accept("***")) {
                         put("***");
                         tk = TokenKind.TRIPLESTAR;
-                        break;
+                        break loop;
                     }
 
                     // Original logic

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/Tokens.java
@@ -187,6 +187,7 @@ public class Tokens {
         PLUS("+"),
         SUB("-"),
         STAR("*"),
+        TRIPLESTAR("***"),
         SLASH("/"),
         AMP("&"),
         BAR("|"),

--- a/test/langtools/tools/javac/lexer/JavaLexerTest.java
+++ b/test/langtools/tools/javac/lexer/JavaLexerTest.java
@@ -77,6 +77,8 @@ public class JavaLexerTest {
             new TestTuple(CHARLITERAL,   "\'\\\"\'"),
 
             new TestTuple(IDENTIFIER,    "abc\\u0005def"),
+            new TestTuple(PLUSEQ, "+="),
+            new TestTuple(TRIPLESTAR, "***")
     };
 
     static final TestTuple[] FAILING_TESTS = {

--- a/test/langtools/tools/javac/lexer/JavaLexerTest.java
+++ b/test/langtools/tools/javac/lexer/JavaLexerTest.java
@@ -78,7 +78,9 @@ public class JavaLexerTest {
 
             new TestTuple(IDENTIFIER,    "abc\\u0005def"),
             new TestTuple(PLUSEQ, "+="),
-            new TestTuple(TRIPLESTAR, "***")
+            new TestTuple(TRIPLESTAR, "***"),
+            new TestTuple(STAR, "*"),
+            new TestTuple(STAREQ, "*=")
     };
 
     static final TestTuple[] FAILING_TESTS = {


### PR DESCRIPTION
The goal of this PR is simply to get the `javac` parser to recognize the new "***" token. In order to accomplish this, I added a special sub-case to the tokenizer, so that when a * is encountered, we first attempt to resolve it to the *** token. If that fails, then we fall back to the regular operator handling logic.

Test cases were added to `JavaLexerTest` in order to verify that the new token is recognized, and to verify that other similar tokens are still recognized as expected.