### PR TITLE
8337548: Dumping static archive passes is_superclass true for interfaces

### DIFF
--- a/src/hotspot/share/classfile/placeholders.hpp
+++ b/src/hotspot/share/classfile/placeholders.hpp
@@ -60,6 +60,7 @@ class PlaceholderTable : public AllStatic {
   // If entry exists, reuse entry and push SeenThread for classloadAction
   static PlaceholderEntry* find_and_add(Symbol* name, ClassLoaderData* loader_data,
                                         classloadAction action, Symbol* supername,
+                                        bool is_superclass,
                                         JavaThread* thread);
 
   // find_and_remove first removes SeenThread for classloadAction
@@ -93,6 +94,7 @@ class PlaceholderEntry {
                                     // including _definer
                                     // _definer owns token
                                     // queue waits for and returns results from _definer
+  bool              _is_superclass; // entered for super class, not interface
 
   SeenThread* actionToQueue(PlaceholderTable::classloadAction action);
   void set_threadQ(SeenThread* seenthread, PlaceholderTable::classloadAction action);
@@ -110,10 +112,10 @@ class PlaceholderEntry {
  public:
   PlaceholderEntry() :
      _definer(nullptr), _instanceKlass(nullptr),
-     _circularityThreadQ(nullptr), _loadInstanceThreadQ(nullptr), _defineThreadQ(nullptr) { }
+     _circularityThreadQ(nullptr), _loadInstanceThreadQ(nullptr), _defineThreadQ(nullptr), _is_superclass(false) { }
 
   Symbol*            next_klass_name()     const { return _next_klass_name; }
-  void               set_next_klass_name(Symbol* next_klass_name);
+  void               set_next_klass_name(Symbol* next_klass_name, bool is_superclass);
 
   JavaThread*        definer()             const {return _definer; }
   void               set_definer(JavaThread* definer) { _definer = definer; }
@@ -132,6 +134,8 @@ class PlaceholderEntry {
   bool define_class_in_progress() {
     return (_defineThreadQ != nullptr);
   }
+
+  bool is_superclass() const { return _is_superclass; }
 
   // Used for ClassCircularityError checking
   bool check_seen_thread(JavaThread* thread, PlaceholderTable::classloadAction action);

--- a/test/hotspot/gtest/classfile/test_placeholders.cpp
+++ b/test/hotspot/gtest/classfile/test_placeholders.cpp
@@ -53,21 +53,21 @@ TEST_VM(PlaceholderTable, supername) {
     PlaceholderTable::classloadAction define_action = PlaceholderTable::DEFINE_CLASS;
 
     // DefineClass A and D
-    PlaceholderTable::find_and_add(A, loader_data, define_action, nullptr, THREAD);
-    PlaceholderTable::find_and_add(D, loader_data, define_action, nullptr, T2);
+    PlaceholderTable::find_and_add(A, loader_data, define_action, nullptr, false, THREAD);
+    PlaceholderTable::find_and_add(D, loader_data, define_action, nullptr, false, T2);
 
     // Load interfaces first to get supername replaced
-    PlaceholderTable::find_and_add(A, loader_data, super_action, interf, THREAD);
+    PlaceholderTable::find_and_add(A, loader_data, super_action, interf, false, THREAD);
     PlaceholderTable::find_and_remove(A, loader_data, super_action, THREAD);
 
-    PlaceholderTable::find_and_add(D, loader_data, super_action, interf, T2);
+    PlaceholderTable::find_and_add(D, loader_data, super_action, interf, false, T2);
     PlaceholderTable::find_and_remove(D, loader_data, super_action, T2);
 
     ASSERT_EQ(interf->refcount(), 1) << "supername is replaced with null";
 
     // Add placeholder to the table for loading A and super, and D also loading super
-    PlaceholderTable::find_and_add(A, loader_data, super_action, super, THREAD);
-    PlaceholderTable::find_and_add(D, loader_data, super_action, super, T2);
+    PlaceholderTable::find_and_add(A, loader_data, super_action, super, true, THREAD);
+    PlaceholderTable::find_and_add(D, loader_data, super_action, super, true, T2);
 
     // Another thread comes in and finds A loading Super
     PlaceholderEntry* placeholder = PlaceholderTable::get_entry(A, loader_data);
@@ -81,7 +81,7 @@ TEST_VM(PlaceholderTable, supername) {
     super->decrement_refcount();
 
     // handle_parallel_super_load (same thread doesn't assert)
-    PlaceholderTable::find_and_add(A, loader_data, super_action, supername, T2);
+    PlaceholderTable::find_and_add(A, loader_data, super_action, supername, true, T2);
 
     // Refcount should be 3: one in table for class A, one in table for class D
     // and one locally with SymbolHandle keeping it alive


### PR DESCRIPTION
Save the setting of is_superclass in the DETECT_CIRCULARITY placeholder entry with the class name in case handle_parallel_super_load is needed.  This corrects the is_superclass parameter passed to resolve_with_circularity_detection, which is then used by CDS code.

Tested with tier1-7 (in progress).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8337548](https://bugs.openjdk.org/browse/JDK-8337548): Dumping static archive passes is_superclass true for interfaces (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22309/head:pull/22309` \
`$ git checkout pull/22309`

Update a local copy of the PR: \
`$ git checkout pull/22309` \
`$ git pull https://git.openjdk.org/jdk.git pull/22309/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22309`

View PR using the GUI difftool: \
`$ git pr show -t 22309`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22309.diff">https://git.openjdk.org/jdk/pull/22309.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22309#issuecomment-2492395620)
</details>
