### PR TITLE
8344798: Shenandoah: Use more descriptive variable names in shPhaseTimings.cpp

### DIFF
--- a/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
+++ b/src/hotspot/share/gc/shenandoah/shenandoahPhaseTimings.cpp
@@ -185,33 +185,33 @@ void ShenandoahPhaseTimings::flush_par_workers_to_cycle() {
   for (uint pi = 0; pi < _num_phases; pi++) {
     Phase phase = Phase(pi);
     if (is_worker_phase(phase)) {
-      double s = uninitialized();
+      double sum = uninitialized();
       for (uint i = 1; i < _num_par_phases; i++) {
         ShenandoahWorkerData* wd = worker_data(phase, ParPhase(i));
-        double ws = uninitialized();
+        double worker_sum = uninitialized();
         for (uint c = 0; c < _max_workers; c++) {
-          double v = wd->get(c);
-          if (v != ShenandoahWorkerData::uninitialized()) {
-            if (ws == uninitialized()) {
-              ws = v;
+          double worker_time = wd->get(c);
+          if (worker_time != ShenandoahWorkerData::uninitialized()) {
+            if (worker_sum == uninitialized()) {
+              worker_sum = worker_time;
             } else {
-              ws += v;
+              worker_sum += worker_time;
             }
           }
         }
-        if (ws != uninitialized()) {
+        if (worker_sum != uninitialized()) {
           // add to each line in phase
-          set_cycle_data(Phase(phase + i + 1), ws);
-          if (s == uninitialized()) {
-            s = ws;
+          set_cycle_data(Phase(phase + i + 1), worker_sum);
+          if (sum == uninitialized()) {
+            sum = worker_sum;
           } else {
-            s += ws;
+            sum += worker_sum;
           }
         }
       }
-      if (s != uninitialized()) {
+      if (sum != uninitialized()) {
         // add to total for phase
-        set_cycle_data(Phase(phase + 1), s);
+        set_cycle_data(Phase(phase + 1), sum);
       }
     }
   }


### PR DESCRIPTION
The single letter variable names make some of this code harder to read.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344798](https://bugs.openjdk.org/browse/JDK-8344798): Shenandoah: Use more descriptive variable names in shPhaseTimings.cpp (**Task** - P4)


### Reviewers
 * [Y. Srinivas Ramakrishna](https://openjdk.org/census#ysr) (@ysramakrishna - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22310/head:pull/22310` \
`$ git checkout pull/22310`

Update a local copy of the PR: \
`$ git checkout pull/22310` \
`$ git pull https://git.openjdk.org/jdk.git pull/22310/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22310`

View PR using the GUI difftool: \
`$ git pr show -t 22310`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22310.diff">https://git.openjdk.org/jdk/pull/22310.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22310#issuecomment-2492459721)
</details>
