### PR TITLE
8344799: Remove permissions checks from java.awt.Desktop

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -319,8 +319,6 @@ module java.base {
         java.management.rmi,
         java.rmi,
         java.sql.rowset;
-    exports sun.security.action to
-        java.desktop;
     exports sun.security.internal.interfaces to
         jdk.crypto.cryptoki;
     exports sun.security.internal.spec to
@@ -346,7 +344,6 @@ module java.base {
     exports sun.security.tools to
         jdk.jartool;
     exports sun.security.util to
-        java.desktop,
         java.naming,
         java.rmi,
         java.security.jgss,

--- a/src/java.desktop/share/classes/java/awt/Desktop.java
+++ b/src/java.desktop/share/classes/java/awt/Desktop.java
@@ -827,7 +827,6 @@ public class Desktop {
      *
      * @since 9
      */
-    @SuppressWarnings("removal")
     public boolean moveToTrash(File file) {
         file = new File(file.getPath());
         checkActionSupport(Action.MOVE_TO_TRASH);

--- a/src/java.desktop/share/classes/java/awt/Desktop.java
+++ b/src/java.desktop/share/classes/java/awt/Desktop.java
@@ -38,7 +38,6 @@ import java.awt.desktop.QuitStrategy;
 import java.awt.desktop.SystemEventListener;
 import java.awt.peer.DesktopPeer;
 import java.io.File;
-import java.io.FilePermission;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -47,7 +46,6 @@ import java.util.Objects;
 import javax.swing.JMenuBar;
 
 import sun.awt.SunToolkit;
-import sun.security.util.SecurityConstants;
 
 /**
  * The {@code Desktop} class allows interact with various desktop capabilities.
@@ -274,15 +272,6 @@ public class Desktop {
         }
     }
 
-    private void checkEventsProcessingPermission() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission(
-                    "canProcessApplicationEvents"));
-        }
-    }
-
     /**
      * Returns the {@code Desktop} instance of the current
      * desktop context. On some platforms the Desktop API may not be
@@ -395,7 +384,6 @@ public class Desktop {
      */
     public void open(File file) throws IOException {
         file = new File(file.getPath());
-        checkExec();
         checkActionSupport(Action.OPEN);
         checkFileValidation(file);
 
@@ -417,7 +405,6 @@ public class Desktop {
      */
     public void edit(File file) throws IOException {
         file = new File(file.getPath());
-        checkExec();
         checkActionSupport(Action.EDIT);
         file.canWrite();
         checkFileValidation(file);
@@ -443,12 +430,6 @@ public class Desktop {
      */
     public void print(File file) throws IOException {
         file = new File(file.getPath());
-        checkExec();
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPrintJobAccess();
-        }
         checkActionSupport(Action.PRINT);
         checkFileValidation(file);
         if (file.isDirectory()) {
@@ -475,7 +456,6 @@ public class Desktop {
      * @see java.net.URI
      */
     public void browse(URI uri) throws IOException {
-        checkExec();
         checkActionSupport(Action.BROWSE);
         Objects.requireNonNull(uri);
         peer.browse(uri);
@@ -491,7 +471,6 @@ public class Desktop {
      * found, or it fails to be launched
      */
     public void mail() throws IOException {
-        checkExec();
         checkActionSupport(Action.MAIL);
         URI mailtoURI = null;
         try{
@@ -528,7 +507,6 @@ public class Desktop {
      * @see java.net.URI
      */
     public  void mail(URI mailtoURI) throws IOException {
-        checkExec();
         checkActionSupport(Action.MAIL);
         if (mailtoURI == null) throw new NullPointerException();
 
@@ -537,32 +515,6 @@ public class Desktop {
         }
 
         peer.mail(mailtoURI);
-    }
-
-    private void checkExec() throws SecurityException {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new FilePermission("<<ALL FILES>>",
-                    SecurityConstants.FILE_EXECUTE_ACTION));
-        }
-    }
-
-    private void checkRead() throws SecurityException {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new FilePermission("<<ALL FILES>>",
-                    SecurityConstants.FILE_READ_ACTION));
-        }
-    }
-
-    private void checkQuitPermission() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkExit(0);
-        }
     }
 
     /**
@@ -583,7 +535,6 @@ public class Desktop {
      * @since 9
      */
     public void addAppEventListener(final SystemEventListener listener) {
-        checkEventsProcessingPermission();
         peer.addAppEventListener(listener);
     }
 
@@ -605,7 +556,6 @@ public class Desktop {
      * @since 9
      */
     public void removeAppEventListener(final SystemEventListener listener) {
-        checkEventsProcessingPermission();
         peer.removeAppEventListener(listener);
     }
 
@@ -624,7 +574,6 @@ public class Desktop {
      * @since 9
      */
     public void setAboutHandler(final AboutHandler aboutHandler) {
-        checkEventsProcessingPermission();
         checkActionSupport(Action.APP_ABOUT);
         peer.setAboutHandler(aboutHandler);
     }
@@ -644,7 +593,6 @@ public class Desktop {
      * @since 9
      */
     public void setPreferencesHandler(final PreferencesHandler preferencesHandler) {
-        checkEventsProcessingPermission();
         checkActionSupport(Action.APP_PREFERENCES);
         peer.setPreferencesHandler(preferencesHandler);
     }
@@ -668,9 +616,6 @@ public class Desktop {
      * @since 9
      */
     public void setOpenFileHandler(final OpenFilesHandler openFileHandler) {
-        checkEventsProcessingPermission();
-        checkExec();
-        checkRead();
         checkActionSupport(Action.APP_OPEN_FILE);
         peer.setOpenFileHandler(openFileHandler);
     }
@@ -693,12 +638,6 @@ public class Desktop {
      * @since 9
      */
     public void setPrintFileHandler(final PrintFilesHandler printFileHandler) {
-        checkEventsProcessingPermission();
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPrintJobAccess();
-        }
         checkActionSupport(Action.APP_PRINT_FILE);
         peer.setPrintFileHandler(printFileHandler);
     }
@@ -726,8 +665,6 @@ public class Desktop {
      * @since 9
      */
     public void setOpenURIHandler(final OpenURIHandler openURIHandler) {
-        checkEventsProcessingPermission();
-        checkExec();
         checkActionSupport(Action.APP_OPEN_URI);
         peer.setOpenURIHandler(openURIHandler);
     }
@@ -746,8 +683,6 @@ public class Desktop {
      * @since 9
      */
     public void setQuitHandler(final QuitHandler quitHandler) {
-        checkEventsProcessingPermission();
-        checkQuitPermission();
         checkActionSupport(Action.APP_QUIT_HANDLER);
         peer.setQuitHandler(quitHandler);
     }
@@ -762,8 +697,6 @@ public class Desktop {
      * @since 9
      */
     public void setQuitStrategy(final QuitStrategy strategy) {
-        checkEventsProcessingPermission();
-        checkQuitPermission();
         checkActionSupport(Action.APP_QUIT_STRATEGY);
         peer.setQuitStrategy(strategy);
     }
@@ -788,8 +721,6 @@ public class Desktop {
      * @since 9
      */
     public void enableSuddenTermination() {
-        checkEventsProcessingPermission();
-        checkQuitPermission();
         checkActionSupport(Action.APP_SUDDEN_TERMINATION);
         peer.enableSuddenTermination();
     }
@@ -806,8 +737,6 @@ public class Desktop {
      * @since 9
      */
     public void disableSuddenTermination() {
-        checkEventsProcessingPermission();
-        checkQuitPermission();
         checkActionSupport(Action.APP_SUDDEN_TERMINATION);
         peer.disableSuddenTermination();
     }
@@ -822,7 +751,6 @@ public class Desktop {
      * @since 9
      */
     public void requestForeground(final boolean allWindows) {
-        checkEventsProcessingPermission();
         checkActionSupport(Action.APP_REQUEST_FOREGROUND);
         peer.requestForeground(allWindows);
     }
@@ -839,8 +767,6 @@ public class Desktop {
      * @since 9
      */
     public void openHelpViewer() {
-        checkExec();
-        checkEventsProcessingPermission();
         checkActionSupport(Action.APP_HELP_VIEWER);
         peer.openHelpViewer();
     }
@@ -854,7 +780,6 @@ public class Desktop {
      * @since 9
      */
     public void setDefaultMenuBar(final JMenuBar menuBar) {
-        checkEventsProcessingPermission();
         checkActionSupport(Action.APP_MENU_BAR);
 
         if (menuBar != null) {
@@ -881,7 +806,6 @@ public class Desktop {
      */
     public void browseFileDirectory(File file) {
         file = new File(file.getPath());
-        checkExec();
         checkActionSupport(Action.BROWSE_FILE_DIR);
         checkFileValidation(file);
         File parentFile = file.getParentFile();
@@ -906,10 +830,6 @@ public class Desktop {
     @SuppressWarnings("removal")
     public boolean moveToTrash(File file) {
         file = new File(file.getPath());
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkDelete(file.getPath());
-        }
         checkActionSupport(Action.MOVE_TO_TRASH);
         checkFileValidation(file);
         return peer.moveToTrash(file);


### PR DESCRIPTION
Clean up permission checks in java.awt.Desktop class
Also remove no longer needed exports from java.base to java.desktop

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344799](https://bugs.openjdk.org/browse/JDK-8344799): Remove permissions checks from java.awt.Desktop (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22311/head:pull/22311` \
`$ git checkout pull/22311`

Update a local copy of the PR: \
`$ git checkout pull/22311` \
`$ git pull https://git.openjdk.org/jdk.git pull/22311/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22311`

View PR using the GUI difftool: \
`$ git pr show -t 22311`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22311.diff">https://git.openjdk.org/jdk/pull/22311.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22311#issuecomment-2492472924)
</details>
