### PR TITLE
8344788: Specify that the access control context parameters of Subject.doAsPrivileged are ignored

### DIFF
--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -474,8 +474,8 @@ public final class Subject implements java.io.Serializable {
     /**
      * Perform privileged work as a particular {@code Subject}.
      *
-     * <p> This method ignores the {@code acc} argument, launches {@code action},
-     * and binds {@code subject} to the period of its execution.
+     * <p> This method launches {@code action} and binds {@code subject} to
+     * the period of its execution.
      *
      * @param subject the {@code Subject} that the specified
      *                  {@code action} will run as.  This parameter
@@ -487,8 +487,7 @@ public final class Subject implements java.io.Serializable {
      * @param action the code to be run as the specified
      *                  {@code Subject}.
      *
-     * @param acc the {@code AccessControlContext} to be tied to the
-     *                  specified <i>subject</i> and <i>action</i>.
+     * @param acc ignored
      *
      * @return the value returned by the PrivilegedAction's
      *                  {@code run} method.
@@ -540,8 +539,8 @@ public final class Subject implements java.io.Serializable {
     /**
      * Perform privileged work as a particular {@code Subject}.
      *
-     * <p> This method ignores the {@code acc} argument, launches {@code action},
-     * and binds {@code subject} to the period of its execution.
+     * <p> This method launches {@code action} and binds {@code subject} to
+     * the period of its execution.
      *
      * @param subject the {@code Subject} that the specified
      *                  {@code action} will run as.  This parameter
@@ -553,8 +552,7 @@ public final class Subject implements java.io.Serializable {
      * @param action the code to be run as the specified
      *                  {@code Subject}.
      *
-     * @param acc the {@code AccessControlContext} to be tied to the
-     *                  specified <i>subject</i> and <i>action</i>.
+     * @param acc ignored
      *
      * @return the value returned by the
      *                  PrivilegedExceptionAction's {@code run} method.


### PR DESCRIPTION
Specify that the access control context parameters of `Subject.doAsPrivileged` are ignored. This spec update was missed as part of JEP 486.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8344794](https://bugs.openjdk.org/browse/JDK-8344794) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8344788](https://bugs.openjdk.org/browse/JDK-8344788): Specify that the access control context parameters of Subject.doAsPrivileged are ignored (**Bug** - P3)
 * [JDK-8344794](https://bugs.openjdk.org/browse/JDK-8344794): Specify that the access control context parameters of Subject.doAsPrivileged are ignored (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22312/head:pull/22312` \
`$ git checkout pull/22312`

Update a local copy of the PR: \
`$ git checkout pull/22312` \
`$ git pull https://git.openjdk.org/jdk.git pull/22312/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22312`

View PR using the GUI difftool: \
`$ git pr show -t 22312`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22312.diff">https://git.openjdk.org/jdk/pull/22312.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22312#issuecomment-2492502263)
</details>
