### PR TITLE
8334493: Remove SecurityManager Permissions infrastructure from DiagnosticCommands

### DIFF
--- a/src/hotspot/os/linux/mallocInfoDcmd.hpp
+++ b/src/hotspot/os/linux/mallocInfoDcmd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,10 +40,6 @@ public:
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = { "java.lang.management.ManagementPermission", "monitor", nullptr };
-    return p;
   }
   void execute(DCmdSource source, TRAPS) override;
 };

--- a/src/hotspot/os/linux/trimCHeapDCmd.hpp
+++ b/src/hotspot/os/linux/trimCHeapDCmd.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021 SAP SE. All rights reserved.
- * Copyright (c) 2021, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -41,10 +41,6 @@ public:
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = { "java.lang.management.ManagementPermission", "control", nullptr };
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };

--- a/src/hotspot/share/classfile/classLoaderHierarchyDCmd.hpp
+++ b/src/hotspot/share/classfile/classLoaderHierarchyDCmd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -45,11 +45,6 @@ public:
   }
   static const char* impact() {
       return "Medium: Depends on number of class loaders and classes loaded.";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   static int num_arguments() { return 3; }
   virtual void execute(DCmdSource source, TRAPS);

--- a/src/hotspot/share/classfile/classLoaderStats.hpp
+++ b/src/hotspot/share/classfile/classLoaderStats.hpp
@@ -58,12 +58,6 @@ public:
   static int num_arguments() {
     return 0;
   }
-
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
 };
 
 

--- a/src/hotspot/share/jfr/dcmd/jfrDcmds.hpp
+++ b/src/hotspot/share/jfr/dcmd/jfrDcmds.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -59,10 +59,6 @@ class JfrStartFlightRecordingDCmd : public JfrDCmd {
   static const char* impact() {
     return "Medium: Depending on the settings for a recording, the impact can range from low to high.";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "monitor", nullptr};
-    return p;
-  }
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdStart";
   }
@@ -83,10 +79,6 @@ class JfrDumpFlightRecordingDCmd : public JfrDCmd {
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "monitor", nullptr};
-    return p;
   }
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdDump";
@@ -109,10 +101,6 @@ class JfrCheckFlightRecordingDCmd : public JfrDCmd {
   static const char* impact() {
     return "Low";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "monitor", nullptr};
-    return p;
-  }
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdCheck";
   }
@@ -133,10 +121,6 @@ class JfrStopFlightRecordingDCmd : public JfrDCmd {
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "monitor", nullptr};
-    return p;
   }
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdStop";
@@ -159,10 +143,6 @@ class JfrViewFlightRecordingDCmd : public JfrDCmd {
   static const char* impact() {
     return "Medium";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "monitor", nullptr};
-    return p;
-  }
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdView";
   }
@@ -183,10 +163,6 @@ class JfrQueryFlightRecordingDCmd : public JfrDCmd {
   }
   static const char* impact() {
     return "Medium";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "monitor", nullptr};
-    return p;
   }
   virtual const char* javaClass() const {
     return "jdk/jfr/internal/dcmd/DCmdQuery";
@@ -224,10 +200,6 @@ class JfrConfigureFlightRecorderDCmd : public DCmdWithParser {
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "monitor", nullptr};
-    return p;
   }
   static int num_arguments() { return 10; }
   virtual void execute(DCmdSource source, TRAPS);

--- a/src/hotspot/share/logging/logDiagnosticCommand.hpp
+++ b/src/hotspot/share/logging/logDiagnosticCommand.hpp
@@ -58,11 +58,6 @@ class LogDiagnosticCommand : public DCmdWithParser {
   static const char* description() {
     return "Lists current log configuration, enables/disables/configures a log output, or rotates all logs.";
   }
-
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "control", nullptr};
-    return p;
-  }
 };
 
 #endif // SHARE_LOGGING_LOGDIAGNOSTICCOMMAND_HPP

--- a/src/hotspot/share/memory/metaspace/metaspaceDCmd.hpp
+++ b/src/hotspot/share/memory/metaspace/metaspaceDCmd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018, 2020 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -51,11 +51,6 @@ public:
   }
   static const char* impact() {
       return "Medium: Depends on number of classes loaded.";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   static int num_arguments() { return 8; }
   virtual void execute(DCmdSource source, TRAPS);

--- a/src/hotspot/share/nmt/nmtDCmd.hpp
+++ b/src/hotspot/share/nmt/nmtDCmd.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -52,11 +52,6 @@ class NMTDCmd: public DCmdWithParser {
   }
   static const char* impact() {
     return "Medium";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 

--- a/src/hotspot/share/services/diagnosticCommand.cpp
+++ b/src/hotspot/share/services/diagnosticCommand.cpp
@@ -151,8 +151,7 @@ void DCmd::register_dcmds(){
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<CompilationMemoryStatisticDCmd>(full_export, true, false));
 
   // Enhanced JMX Agent Support
-  // These commands won't be exported via the DiagnosticCommandMBean until an
-  // appropriate permission is created for them
+  // These commands not currently exported via the DiagnosticCommandMBean
   uint32_t jmx_agent_export_flags = DCmd_Source_Internal | DCmd_Source_AttachAPI;
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<JMXStartRemoteDCmd>(jmx_agent_export_flags, true,false));
   DCmdFactory::register_DCmdFactory(new DCmdFactoryImpl<JMXStartLocalDCmd>(jmx_agent_export_flags, true,false));

--- a/src/hotspot/share/services/diagnosticCommand.hpp
+++ b/src/hotspot/share/services/diagnosticCommand.hpp
@@ -64,11 +64,6 @@ public:
     return "Print JVM version information.";
   }
   static const char* impact() { return "Low"; }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.util.PropertyPermission",
-                        "java.vm.version", "read"};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -80,11 +75,6 @@ public:
     return "Print the command line used to start this VM instance.";
   }
   static const char* impact() { return "Low"; }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS) {
     Arguments::print_on(_output);
   }
@@ -100,11 +90,6 @@ public:
     }
     static const char* impact() {
       return "Low";
-    }
-    static const JavaPermission permission() {
-      JavaPermission p = {"java.util.PropertyPermission",
-                          "*", "read"};
-      return p;
     }
     virtual void execute(DCmdSource source, TRAPS);
 };
@@ -122,11 +107,6 @@ public:
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -146,11 +126,6 @@ public:
   static const char* impact() {
     return "Low";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "control", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -163,11 +138,6 @@ public:
   }
   static const char* impact() {
     return "High";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -186,11 +156,6 @@ public:
     return "Load JVMTI native agent.";
   }
   static const char* impact() { return "Low"; }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "control", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 #endif // INCLUDE_JVMTI
@@ -207,11 +172,6 @@ public:
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -240,11 +200,6 @@ public:
     return "Print information about JVM environment and status.";
   }
   static const char* impact() { return "Low"; }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -284,11 +239,6 @@ public:
   static const char* impact() {
     return "Medium";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-      "monitor", nullptr};
-      return p;
-  }
 
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -302,11 +252,6 @@ public:
   }
   static const char* impact() {
     return "Medium";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-      "monitor", nullptr};
-      return p;
   }
 
   virtual void execute(DCmdSource source, TRAPS);
@@ -334,11 +279,6 @@ public:
     return "High: Depends on Java heap size and content. "
            "Request a full GC unless the '-all' option is specified.";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 #endif // INCLUDE_SERVICES
@@ -359,11 +299,6 @@ public:
   }
   static const char* impact() {
     return "High: Depends on Java heap size and content.";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -387,11 +322,6 @@ public:
   static const char* impact() {
       return "Medium: Depends on number of loaded classes.";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -412,11 +342,6 @@ public:
   static const char* impact() {
     return "Medium: Pause time depends on number of loaded classes";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 #endif // INCLUDE_CDS
@@ -435,11 +360,6 @@ public:
   }
   static const char* impact() {
     return "Medium: Depends on the number of threads.";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -546,12 +466,6 @@ public:
     return "Print the management agent status.";
   }
 
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
-
   virtual void execute(DCmdSource source, TRAPS);
 
 };
@@ -567,11 +481,6 @@ public:
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -592,11 +501,6 @@ public:
   static const char* impact() {
     return "Low";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 #endif // LINUX
@@ -613,11 +517,6 @@ public:
   static const char* impact() {
     return "Medium";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -632,11 +531,6 @@ public:
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -659,11 +553,6 @@ public:
     return "Low: Depends on code heap size and content. "
            "Holds CodeCache_lock during analysis step, usually sub-second duration.";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 //---<  END  >--- CodeHeap State Analytics.
@@ -680,11 +569,6 @@ public:
   static const char* impact() {
     return "Low";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -699,11 +583,6 @@ public:
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "control", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -723,11 +602,6 @@ public:
   static const char* impact() {
     return "Low";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "control", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -742,11 +616,6 @@ public:
   }
   static const char* impact() {
     return "Low";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "control", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -809,11 +678,6 @@ public:
   static const char* impact() {
     return "Medium: Depends on Java content.";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -831,11 +695,6 @@ public:
   }
   static const char* impact() {
     return "Medium: Depends on Java content.";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -855,11 +714,6 @@ public:
   static const char* impact() {
       return "Medium: Depends on Java content.";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -877,11 +731,6 @@ public:
   }
   static const char* impact() {
       return "Medium: Depends on number of loaded classes.";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -901,11 +750,6 @@ public:
   }
   static const char* impact() {
     return "Low: Depends on event log size. ";
-  }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
   }
   virtual void execute(DCmdSource source, TRAPS);
 };
@@ -929,10 +773,6 @@ public:
   static const char* impact() {
     return "Medium: Depends on the number of threads.";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission", "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -952,11 +792,6 @@ public:
   static const char* impact() {
     return "Medium: Pause time depends on number of compiled methods";
   }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "monitor", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -970,11 +805,6 @@ public:
     return "Prints an annotated process memory map of the VM process (linux and Windows only).";
   }
   static const char* impact() { return "Medium; can be high for very large java heaps."; }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "control", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 
@@ -988,11 +818,6 @@ public:
     return "Dumps an annotated process memory map to an output file (linux and Windows only).";
   }
   static const char* impact() { return "Medium; can be high for very large java heaps."; }
-  static const JavaPermission permission() {
-    JavaPermission p = {"java.lang.management.ManagementPermission",
-                        "control", nullptr};
-    return p;
-  }
   virtual void execute(DCmdSource source, TRAPS);
 };
 

--- a/src/hotspot/share/services/diagnosticFramework.cpp
+++ b/src/hotspot/share/services/diagnosticFramework.cpp
@@ -587,7 +587,7 @@ GrowableArray<DCmdInfo*>* DCmdFactory::DCmdInfo_list(DCmdSource source ) {
     if (!factory->is_hidden() && (factory->export_flags() & source)) {
       array->append(new DCmdInfo(factory->name(),
                     factory->description(), factory->impact(),
-                    factory->permission(), factory->num_arguments(),
+                    factory->num_arguments(),
                     factory->is_enabled()));
     }
     factory = factory->next();

--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -2013,10 +2013,6 @@ JVM_ENTRY(void, jmm_GetDiagnosticCommandInfo(JNIEnv *env, jobjectArray cmds,
     infoArray[i].name = info->name();
     infoArray[i].description = info->description();
     infoArray[i].impact = info->impact();
-    JavaPermission p = info->permission();
-    infoArray[i].permission_class = p._class;
-    infoArray[i].permission_name = p._name;
-    infoArray[i].permission_action = p._action;
     infoArray[i].num_arguments = info->num_arguments();
     infoArray[i].enabled = info->is_enabled();
   }

--- a/src/jdk.management/share/classes/com/sun/management/DiagnosticCommandMBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/DiagnosticCommandMBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -136,26 +136,6 @@ import javax.management.DynamicMBean;
  *   <tr>
  *     <th scope="row">dcmd.enabled</th><td>boolean</td>
  *     <td>True if the diagnostic command is enabled, false otherwise</td>
- *   </tr>
- *   <tr>
- *     <th scope="row">dcmd.permissionClass</th><td>String</td>
- *     <td>Some diagnostic command might require a specific permission to be
- *          executed, in addition to the MBeanPermission to invoke their
- *          associated MBean operation. This field returns the fully qualified
- *          name of the permission class or null if no permission is required
- *   </td>
- *   </tr>
- *   <tr>
- *     <th scope="row">dcmd.permissionName</th><td>String</td>
- *     <td>The fist argument of the permission required to execute this
- *          diagnostic command or null if no permission is required</td>
- *   </tr>
- *   <tr>
- *     <th scope="row">dcmd.permissionAction</th><td>String</td>
- *     <td>The second argument of the permission required to execute this
- *          diagnostic command or null if the permission constructor has only
- *          one argument (like the ManagementPermission) or if no permission
- *          is required</td>
  *   </tr>
  *   <tr>
  *     <th scope="row">dcmd.arguments</th><td>Descriptor</td>

--- a/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandImpl.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandImpl.java
@@ -28,7 +28,6 @@ package com.sun.management.internal;
 import com.sun.management.DiagnosticCommandMBean;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.security.Permission;
 import java.util.*;
 import javax.management.Attribute;
 import javax.management.AttributeList;
@@ -104,58 +103,16 @@ public class DiagnosticCommandImpl extends NotificationEmitterSupport
         String name;
         String cmd;
         DiagnosticCommandInfo info;
-        Permission permission;
 
         Wrapper(String name, String cmd, DiagnosticCommandInfo info)
                 throws InstantiationException {
             this.name = name;
             this.cmd = cmd;
             this.info = info;
-            this.permission = null;
             Exception cause = null;
-            if (info.getPermissionClass() != null) {
-                try {
-                    Class<?> c = Class.forName(info.getPermissionClass());
-                    if (info.getPermissionAction() == null) {
-                        try {
-                            Constructor<?> constructor = c.getConstructor(String.class);
-                            permission = (Permission) constructor.newInstance(info.getPermissionName());
-
-                        } catch (InstantiationException | IllegalAccessException
-                                | IllegalArgumentException | InvocationTargetException
-                                | NoSuchMethodException | SecurityException ex) {
-                            cause = ex;
-                        }
-                    }
-                    if (permission == null) {
-                        try {
-                            Constructor<?> constructor = c.getConstructor(String.class, String.class);
-                            permission = (Permission) constructor.newInstance(
-                                    info.getPermissionName(),
-                                    info.getPermissionAction());
-                        } catch (InstantiationException | IllegalAccessException
-                                | IllegalArgumentException | InvocationTargetException
-                                | NoSuchMethodException | SecurityException ex) {
-                            cause = ex;
-                        }
-                    }
-                } catch (ClassNotFoundException ex) { }
-                if (permission == null) {
-                    InstantiationException iex =
-                            new InstantiationException("Unable to instantiate required permission");
-                    iex.initCause(cause);
-                }
-            }
         }
 
         public String execute(String[] args) {
-            if (permission != null) {
-                @SuppressWarnings("removal")
-                SecurityManager sm = System.getSecurityManager();
-                if (sm != null) {
-                    sm.checkPermission(permission);
-                }
-            }
             if(args == null) {
                 return executeDiagnosticCommand(cmd);
             } else {
@@ -304,9 +261,6 @@ public class DiagnosticCommandImpl extends NotificationEmitterSupport
         map.put("dcmd.name", w.info.getName());
         map.put("dcmd.description", w.info.getDescription());
         map.put("dcmd.vmImpact", w.info.getImpact());
-        map.put("dcmd.permissionClass", w.info.getPermissionClass());
-        map.put("dcmd.permissionName", w.info.getPermissionName());
-        map.put("dcmd.permissionAction", w.info.getPermissionAction());
         map.put("dcmd.enabled", w.info.isEnabled());
         StringBuilder sb = new StringBuilder();
         sb.append("help ");

--- a/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandInfo.java
+++ b/src/jdk.management/share/classes/com/sun/management/internal/DiagnosticCommandInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,9 +38,6 @@ class DiagnosticCommandInfo {
     private final String name;
     private final String description;
     private final String impact;
-    private final String permissionClass;
-    private final String permissionName;
-    private final String permissionAction;
     private final boolean enabled;
     private final List<DiagnosticCommandArgumentInfo> arguments;
 
@@ -74,43 +71,6 @@ class DiagnosticCommandInfo {
     }
 
     /**
-     * Returns the name of the permission class required to be allowed
-     *         to invoke the diagnostic command, or null if no permission
-     *         is required.
-     *
-     * @return the name of the permission class name required to be allowed
-     *         to invoke the diagnostic command, or null if no permission
-     *         is required
-     */
-    String getPermissionClass() {
-        return permissionClass;
-    }
-
-    /**
-     * Returns the permission name required to be allowed to invoke the
-     *         diagnostic command, or null if no permission is required.
-     *
-     * @return the permission name required to be allowed to invoke the
-     *         diagnostic command, or null if no permission is required
-     */
-    String getPermissionName() {
-        return permissionName;
-    }
-
-    /**
-     * Returns the permission action required to be allowed to invoke the
-     *         diagnostic command, or null if no permission is required or
-     *         if the permission has no action specified.
-     *
-     * @return the permission action required to be allowed to invoke the
-     *         diagnostic command, or null if no permission is required or
-     *         if the permission has no action specified
-     */
-    String getPermissionAction() {
-        return permissionAction;
-    }
-
-    /**
      * Returns {@code true} if the diagnostic command is enabled,
      *         {@code false} otherwise. The enabled/disabled
      *         status of a diagnostic command can evolve during
@@ -134,17 +94,13 @@ class DiagnosticCommandInfo {
     }
 
     DiagnosticCommandInfo(String name, String description,
-                                    String impact, String permissionClass,
-                                    String permissionName, String permissionAction,
+                                    String impact,
                                     boolean enabled,
                                     List<DiagnosticCommandArgumentInfo> arguments)
     {
         this.name = name;
         this.description = description;
         this.impact = impact;
-        this.permissionClass = permissionClass;
-        this.permissionName = permissionName;
-        this.permissionAction = permissionAction;
         this.enabled = enabled;
         this.arguments = arguments;
     }

--- a/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
+++ b/src/jdk.management/share/native/libmanagement_ext/DiagnosticCommandImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -191,10 +191,9 @@ Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommandInfo
   }
   jmm_interface_management_ext->GetDiagnosticCommandInfo(env, commands, dcmd_info_array);
   for (i=0; i<num_commands; i++) {
-      // Ensure capacity for 6 + 3 local refs:
+      // Ensure capacity for 6 local refs:
       //  6 => jname, jdesc, jimpact, cmd, args, obj
-      //  3 => permission class, name, action
-      (*env)->PushLocalFrame(env, 6 + 3);
+      (*env)->PushLocalFrame(env, 6);
 
       cmd = (*env)->GetObjectArrayElement(env, commands, i);
       args = getDiagnosticCommandArgumentInfoArray(env,
@@ -218,11 +217,8 @@ Java_com_sun_management_internal_DiagnosticCommandImpl_getDiagnosticCommandInfo
 
       obj = JNU_NewObjectByName(env,
                                 "com/sun/management/internal/DiagnosticCommandInfo",
-                                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;)V",
+                                "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/util/List;)V",
                                 jname, jdesc, jimpact,
-                                dcmd_info_array[i].permission_class==NULL?NULL:(*env)->NewStringUTF(env,dcmd_info_array[i].permission_class),
-                                dcmd_info_array[i].permission_name==NULL?NULL:(*env)->NewStringUTF(env,dcmd_info_array[i].permission_name),
-                                dcmd_info_array[i].permission_action==NULL?NULL:(*env)->NewStringUTF(env,dcmd_info_array[i].permission_action),
                                 dcmd_info_array[i].enabled,
                                 args);
       if (obj == NULL) {


### PR DESCRIPTION
Remove redundant SecurityManager Permission  references
(following on from JDK-8338411: Implement JEP 486: Permanently Disable the Security Manager).
