### PR TITLE
8344844: ciReplay tests fail with -XX:+UseCompactObjectHeaders because CDS is disabled since JDK-8341553

### DIFF
--- a/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/CiReplayBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,6 +30,9 @@ import jdk.test.lib.Utils;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.process.ProcessTools;
 import jdk.test.lib.util.CoreUtils;
+import jdk.test.whitebox.WhiteBox;
+
+import jtreg.SkippedException;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -126,6 +129,11 @@ public abstract class CiReplayBase {
     }
 
     public void runTest(boolean needCoreDump, String... args) {
+        // The CiReplay tests don't work properly when CDS is disabled
+        boolean cdsEnabled = WhiteBox.getWhiteBox().isSharingEnabled();
+        if (!cdsEnabled) {
+            throw new SkippedException("CDS is not available for this JDK.");
+        }
         cleanup();
         if (generateReplay(needCoreDump, args)) {
             testAction();

--- a/test/hotspot/jtreg/compiler/ciReplay/InliningBase.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/InliningBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,6 +24,9 @@
 package compiler.ciReplay;
 
 import jdk.test.lib.Asserts;
+import jdk.test.whitebox.WhiteBox;
+
+import jtreg.SkippedException;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -51,6 +54,11 @@ public abstract class InliningBase extends DumpReplayBase {
     }
 
     protected void runTest() {
+        // The CiReplay tests don't work properly when CDS is disabled
+        boolean cdsEnabled = WhiteBox.getWhiteBox().isSharingEnabled();
+        if (!cdsEnabled) {
+            throw new SkippedException("CDS is not available for this JDK.");
+        }
         runTest(commandLineNormal.toArray(new String[0]));
     }
 

--- a/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
+++ b/test/hotspot/jtreg/compiler/ciReplay/TestInliningProtectionDomain.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,10 @@
  * @summary Testing that ciReplay inlining does not fail with unresolved signature classes.
  * @requires vm.flightRecorder != true & vm.compMode != "Xint" & vm.compMode != "Xcomp" & vm.debug == true & vm.compiler2.enabled
  * @modules java.base/jdk.internal.misc
- * @run driver compiler.ciReplay.TestInliningProtectionDomain
+ * @build jdk.test.whitebox.WhiteBox
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller jdk.test.whitebox.WhiteBox
+ * @run main/othervm -Xbootclasspath/a:. -XX:+UnlockDiagnosticVMOptions -XX:+WhiteBoxAPI
+ *      compiler.ciReplay.TestInliningProtectionDomain
  */
 
 package compiler.ciReplay;


### PR DESCRIPTION
[JDK-8341553](https://bugs.openjdk.org/browse/JDK-8341553) disabled CDS for `-XX:+UseCompactObjectHeaders`. It's a known issue that the ciReplay tests don't work well if CDS is disabled, see [JDK-8316526](https://bugs.openjdk.org/browse/JDK-8316526), so I'll exclude the tests from running when CDS is disabled for now.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344844](https://bugs.openjdk.org/browse/JDK-8344844): ciReplay tests fail with -XX:+UseCompactObjectHeaders because CDS is disabled since JDK-8341553 (**Bug** - P4)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22317/head:pull/22317` \
`$ git checkout pull/22317`

Update a local copy of the PR: \
`$ git checkout pull/22317` \
`$ git pull https://git.openjdk.org/jdk.git pull/22317/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22317`

View PR using the GUI difftool: \
`$ git pr show -t 22317`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22317.diff">https://git.openjdk.org/jdk/pull/22317.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22317#issuecomment-2493442388)
</details>
