### PR TITLE
8344854: Modernize test/jdk/java/net/URLClassLoader/RemoveJar.java

### DIFF
--- a/test/jdk/java/net/URLClassLoader/RemoveJar.java
+++ b/test/jdk/java/net/URLClassLoader/RemoveJar.java
@@ -104,7 +104,7 @@ public class RemoveJar {
         // Create JAR and URLClassLoader
         Path jar = createJar();
         String path = jar.toAbsolutePath().toString();
-        URL url = new URL("jar", "", "file:" +path  + "!/" + subPath);
+        URL url = new URL("jar", "", "file:" + path + "!/" + subPath);
         URLClassLoader loader = new URLClassLoader(new URL[]{url});
 
         try {


### PR DESCRIPTION
Can I get a review of this test-only cleanup/speedup PR which modernizes the test `RemoveJar.java`.

This test attempts a variety of class loading scenarios on a URLClassLoader and verifies that when the loader is closed, it has released its JAR file (such that it may be deleted on Windows).

Changes in this PR include:

* Converting the test to JUnit 5
* Making it `@Parameterized` instead of using multiple jtreg runs
* Producing the sample class file using the ClassFile API instead calling out to `javac` via ToolProvider
* Packaging the JAR using `JarOutputStream` instead of calling out to the `jar` tool.
* Adding some code and method comments to support understading of what this test does and why 

A nice benefit of this change is that it speeds up the runtime from ~15 seconds to ~1 second on my laptop.

Unfortunately, this test relies on Windows to fail, that is something I plan to look into separately.

Verification: GHA tests pending. (No local Windows dev environment)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344854](https://bugs.openjdk.org/browse/JDK-8344854): Modernize test/jdk/java/net/URLClassLoader/RemoveJar.java (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22319/head:pull/22319` \
`$ git checkout pull/22319`

Update a local copy of the PR: \
`$ git checkout pull/22319` \
`$ git pull https://git.openjdk.org/jdk.git pull/22319/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22319`

View PR using the GUI difftool: \
`$ git pr show -t 22319`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22319.diff">https://git.openjdk.org/jdk/pull/22319.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22319#issuecomment-2493506067)
</details>
