### PR TITLE
8344833: CTW: Make failing on zero classes optional

### DIFF
--- a/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
+++ b/test/hotspot/jtreg/testlibrary/ctw/src/sun/hotspot/tools/ctw/CtwRunner.java
@@ -172,8 +172,14 @@ public class CtwRunner {
 
         long classStart = start(totalClassCount);
         long classStop = stop(totalClassCount);
-
         long classCount = classStop - classStart;
+
+        boolean allowZeroClassCount = Boolean.getBoolean("sun.hotspot.tools.ctw.allow_zero_class_count");
+        if (allowZeroClassCount && classCount == 0L) {
+            System.out.println("WARN: " + target + "(at " + targetPath + ") have not classes. Ignoring.");
+            return;
+        }
+
         Asserts.assertGreaterThan(classCount, 0L,
                 target + "(at " + targetPath + ") does not have any classes");
 


### PR DESCRIPTION
For CTW, zero classes in provided jar is now a failure.
This creates noisy and blocking false positives in fuzzy/mass scale runs, where we use jar archives from random sources, unchecked or randomly generated, etc.

This PR makes this behaviour controllable. Default reaction is a failure, like before.