### PR TITLE
8344855: Remove calls to SecurityManager and doPrivileged  in HTTP related implementation classes in the sun.net and sun.net.www.http packages after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/sun/net/NetProperties.java
+++ b/src/java.base/share/classes/sun/net/NetProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,8 +27,6 @@ package sun.net;
 import jdk.internal.util.StaticProperty;
 
 import java.io.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Properties;
 
 /*
@@ -39,17 +37,10 @@ import java.util.Properties;
  * @author Jean-Christophe Collet
  *
  */
-
-@SuppressWarnings("removal")
 public class NetProperties {
     private static Properties props = new Properties();
     static {
-        AccessController.doPrivileged(
-            new PrivilegedAction<Void>() {
-                public Void run() {
-                    loadDefaultProperties();
-                    return null;
-                }});
+        loadDefaultProperties();
     }
 
     private NetProperties() { };
@@ -82,9 +73,6 @@ public class NetProperties {
      * returns the default value, if it exists, otherwise returns
      * <code>null</code>.
      * @param      key  the property name.
-     * @throws  SecurityException  if a security manager exists and its
-     *          <code>checkPropertiesAccess</code> method doesn't allow access
-     *          to the system properties.
      * @return the <code>String</code> value for the property,
      *         or <code>null</code>
      */
@@ -103,9 +91,6 @@ public class NetProperties {
      * <code>null</code>.
      * @param   key     the property name.
      * @param   defval  the default value to use if the property is not found
-     * @throws  SecurityException  if a security manager exists and its
-     *          <code>checkPropertiesAccess</code> method doesn't allow access
-     *          to the system properties.
      * @return the <code>Integer</code> value for the property,
      *         or <code>null</code>
      */
@@ -131,9 +116,6 @@ public class NetProperties {
      * defined returns the default value, if it exists, otherwise returns
      * <code>null</code>.
      * @param   key     the property name.
-     * @throws  SecurityException  if a security manager exists and its
-     *          <code>checkPropertiesAccess</code> method doesn't allow access
-     *          to the system properties.
      * @return the <code>Boolean</code> value for the property,
      *         or <code>null</code>
      */

--- a/src/java.base/share/classes/sun/net/NetProperties.java
+++ b/src/java.base/share/classes/sun/net/NetProperties.java
@@ -38,10 +38,7 @@ import java.util.Properties;
  *
  */
 public class NetProperties {
-    private static Properties props = new Properties();
-    static {
-        loadDefaultProperties();
-    }
+    private static final Properties props = loadDefaultProperties(new Properties());
 
     private NetProperties() { };
 
@@ -50,7 +47,7 @@ public class NetProperties {
      * Loads the default networking system properties
      * the file is in jre/lib/net.properties
      */
-    private static void loadDefaultProperties() {
+    private static Properties loadDefaultProperties(Properties props) {
         String fname = StaticProperty.javaHome();
         if (fname == null) {
             throw new Error("Can't find java.home ??");
@@ -66,6 +63,7 @@ public class NetProperties {
             // Do nothing. We couldn't find or access the file
             // so we won't have default properties...
         }
+        return props;
     }
 
     /**

--- a/src/java.base/share/classes/sun/net/www/http/HttpCapture.java
+++ b/src/java.base/share/classes/sun/net/www/http/HttpCapture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2009, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,13 +65,8 @@ public class HttpCapture {
 
     private static synchronized void init() {
         initialized = true;
-        @SuppressWarnings("removal")
-        String rulesFile = java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<>() {
-                public String run() {
-                    return NetProperties.get("sun.net.http.captureRules");
-                }
-            });
+
+        String rulesFile = NetProperties.get("sun.net.http.captureRules");
         if (rulesFile != null && !rulesFile.isEmpty()) {
             BufferedReader in;
             try {

--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveCache.java
@@ -30,8 +30,6 @@ import java.io.NotSerializableException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.URL;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -39,7 +37,6 @@ import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
 import jdk.internal.misc.InnocuousThread;
-import sun.security.action.GetIntegerAction;
 import sun.net.www.protocol.http.HttpURLConnection;
 import sun.util.logging.PlatformLogger;
 
@@ -69,10 +66,8 @@ public class KeepAliveCache
 
     static final PlatformLogger logger = HttpURLConnection.getHttpLogger();
 
-    @SuppressWarnings("removal")
     static int getUserKeepAliveSeconds(String type) {
-        int v = AccessController.doPrivileged(
-            new GetIntegerAction(keepAliveProp+type, -1)).intValue();
+        int v = Integer.getInteger(keepAliveProp+type, -1);
         return v < -1 ? -1 : v;
     }
 
@@ -89,12 +84,9 @@ public class KeepAliveCache
      */
     static final int MAX_CONNECTIONS = 5;
     static int result = -1;
-    @SuppressWarnings("removal")
     static int getMaxConnections() {
         if (result == -1) {
-            result = AccessController.doPrivileged(
-                new GetIntegerAction("http.maxConnections", MAX_CONNECTIONS))
-                .intValue();
+            result = Integer.getInteger("http.maxConnections", MAX_CONNECTIONS);
             if (result <= 0) {
                 result = MAX_CONNECTIONS;
             }
@@ -119,7 +111,6 @@ public class KeepAliveCache
      * @param url  The URL contains info about the host and port
      * @param http The HttpClient to be cached
      */
-    @SuppressWarnings("removal")
     public void put(final URL url, Object obj, HttpClient http) {
         // this method may need to close an HttpClient, either because
         // it is not cacheable, or because the cache is at its capacity.
@@ -144,15 +135,10 @@ public class KeepAliveCache
                  * The robustness to get around this is in HttpClient.parseHTTP()
                  */
                 final KeepAliveCache cache = this;
-                AccessController.doPrivileged(new PrivilegedAction<>() {
-                    public Void run() {
-                        keepAliveTimer = InnocuousThread.newSystemThread("Keep-Alive-Timer", cache);
-                        keepAliveTimer.setDaemon(true);
-                        keepAliveTimer.setPriority(Thread.MAX_PRIORITY - 2);
-                        keepAliveTimer.start();
-                        return null;
-                    }
-                });
+                keepAliveTimer = InnocuousThread.newSystemThread("Keep-Alive-Timer", cache);
+                keepAliveTimer.setDaemon(true);
+                keepAliveTimer.setPriority(Thread.MAX_PRIORITY - 2);
+                keepAliveTimer.start();
             }
 
             KeepAliveKey key = new KeepAliveKey(url, obj);

--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveStream.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveStream.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -176,16 +176,10 @@ class KeepAliveStream extends MeteredStream implements Hurryable {
             }
 
             if (startCleanupThread) {
-                java.security.AccessController.doPrivileged(
-                    new java.security.PrivilegedAction<Void>() {
-                    public Void run() {
-                        cleanerThread = InnocuousThread.newSystemThread("Keep-Alive-SocketCleaner", queue);
-                        cleanerThread.setDaemon(true);
-                        cleanerThread.setPriority(Thread.MAX_PRIORITY - 2);
-                        cleanerThread.start();
-                        return null;
-                    }
-                });
+                cleanerThread = InnocuousThread.newSystemThread("Keep-Alive-SocketCleaner", queue);
+                cleanerThread.setDaemon(true);
+                cleanerThread.setPriority(Thread.MAX_PRIORITY - 2);
+                cleanerThread.start();
             }
         } finally {
             queue.unlock();

--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveStreamCleaner.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveStreamCleaner.java
@@ -49,7 +49,7 @@ class KeepAliveStreamCleaner
     implements Runnable
 {
     // maximum amount of remaining data that we will try to clean up
-    protected static final int MAX_DATA_REMAINING;
+    protected static final long MAX_DATA_REMAINING;
 
     // maximum amount of KeepAliveStreams to be queued
     protected static final int MAX_CAPACITY;
@@ -62,7 +62,7 @@ class KeepAliveStreamCleaner
 
     static {
         final String maxDataKey = "http.KeepAlive.remainingData";
-        MAX_DATA_REMAINING = NetProperties.getInteger(maxDataKey, 512) * 1024;
+        MAX_DATA_REMAINING = NetProperties.getInteger(maxDataKey, 512) * 1024L;
 
         final String maxCapacityKey = "http.KeepAlive.queuedConnections";
         MAX_CAPACITY = NetProperties.getInteger(maxCapacityKey, 10);

--- a/src/java.base/share/classes/sun/net/www/http/KeepAliveStreamCleaner.java
+++ b/src/java.base/share/classes/sun/net/www/http/KeepAliveStreamCleaner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,18 +28,16 @@ package sun.net.www.http;
 import java.io.IOException;
 import java.util.LinkedList;
 import sun.net.NetProperties;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * This class is used to cleanup any remaining data that may be on a KeepAliveStream
+ * This class is used to clean up any remaining data that may be on a KeepAliveStream
  * so that the connection can be cached in the KeepAliveCache.
  * Instances of this class can be used as a FIFO queue for KeepAliveCleanerEntry objects.
  * Executing this Runnable removes each KeepAliveCleanerEntry from the Queue, reads
- * the reamining bytes on its KeepAliveStream, and if successful puts the connection in
+ * the remaining bytes on its KeepAliveStream, and if successful puts the connection in
  * the KeepAliveCache.
  *
  * @author Chris Hegarty
@@ -50,7 +48,7 @@ class KeepAliveStreamCleaner
     extends LinkedList<KeepAliveCleanerEntry>
     implements Runnable
 {
-    // maximum amount of remaining data that we will try to cleanup
+    // maximum amount of remaining data that we will try to clean up
     protected static final int MAX_DATA_REMAINING;
 
     // maximum amount of KeepAliveStreams to be queued
@@ -64,22 +62,10 @@ class KeepAliveStreamCleaner
 
     static {
         final String maxDataKey = "http.KeepAlive.remainingData";
-        @SuppressWarnings("removal")
-        int maxData = AccessController.doPrivileged(
-            new PrivilegedAction<Integer>() {
-                public Integer run() {
-                    return NetProperties.getInteger(maxDataKey, 512);
-                }}).intValue() * 1024;
-        MAX_DATA_REMAINING = maxData;
+        MAX_DATA_REMAINING = NetProperties.getInteger(maxDataKey, 512) * 1024;
 
         final String maxCapacityKey = "http.KeepAlive.queuedConnections";
-        @SuppressWarnings("removal")
-        int maxCapacity = AccessController.doPrivileged(
-            new PrivilegedAction<Integer>() {
-                public Integer run() {
-                    return NetProperties.getInteger(maxCapacityKey, 10);
-                }}).intValue();
-        MAX_CAPACITY = maxCapacity;
+        MAX_CAPACITY = NetProperties.getInteger(maxCapacityKey, 10);
 
     }
 


### PR DESCRIPTION
Some further cleaning in the legacy HTTP implementation. 
Usual removal of doPrivileged, GetPropertyAction, checkPermission, etc...

I also took the opportunity to also remove some constructors that were never called in the legacy HttpClient, and to fix some throws signatures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344855](https://bugs.openjdk.org/browse/JDK-8344855): Remove calls to SecurityManager and doPrivileged  in HTTP related implementation classes in the sun.net and sun.net.www.http packages after JEP 486 integration (**Sub-task** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22321/head:pull/22321` \
`$ git checkout pull/22321`

Update a local copy of the PR: \
`$ git checkout pull/22321` \
`$ git pull https://git.openjdk.org/jdk.git pull/22321/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22321`

View PR using the GUI difftool: \
`$ git pr show -t 22321`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22321.diff">https://git.openjdk.org/jdk/pull/22321.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22321#issuecomment-2493716154)
</details>
