### PR TITLE
8344861: Disable CheckJNICalls in tests until JDK-8344802 is fixed

### DIFF
--- a/test/jdk/java/lang/String/IndexOf.java
+++ b/test/jdk/java/lang/String/IndexOf.java
@@ -34,7 +34,7 @@
  * @summary test String indexOf() intrinsic
  * @requires vm.cpu.features ~= ".*avx2.*"
  * @requires vm.compiler2.enabled
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xcomp -XX:-TieredCompilation -XX:UseAVX=2 -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:+CheckJNICalls IndexOf
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xcomp -XX:-TieredCompilation -XX:UseAVX=2 -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:-CheckJNICalls IndexOf
  */
 
  public class IndexOf {

--- a/test/jdk/java/lang/String/IndexOf.java
+++ b/test/jdk/java/lang/String/IndexOf.java
@@ -34,7 +34,7 @@
  * @summary test String indexOf() intrinsic
  * @requires vm.cpu.features ~= ".*avx2.*"
  * @requires vm.compiler2.enabled
- * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xcomp -XX:-TieredCompilation -XX:UseAVX=2 -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts IndexOf
+ * @run main/othervm -XX:+IgnoreUnrecognizedVMOptions -Xcomp -XX:-TieredCompilation -XX:UseAVX=2 -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:+CheckJNICalls IndexOf
  */
 
  public class IndexOf {

--- a/test/jdk/java/lang/StringBuffer/ECoreIndexOf.java
+++ b/test/jdk/java/lang/StringBuffer/ECoreIndexOf.java
@@ -34,7 +34,7 @@
  * @summary Test indexOf and lastIndexOf
  * @requires vm.cpu.features ~= ".*avx2.*"
  * @requires vm.compiler2.enabled
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:UseAVX=2 -Xbatch -XX:-TieredCompilation -XX:CompileCommand=dontinline,ECoreIndexOf.indexOfKernel ECoreIndexOf
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:+CheckJNICalls -XX:UseAVX=2 -Xbatch -XX:-TieredCompilation -XX:CompileCommand=dontinline,ECoreIndexOf.indexOfKernel ECoreIndexOf
  * @key randomness
  */
 

--- a/test/jdk/java/lang/StringBuffer/ECoreIndexOf.java
+++ b/test/jdk/java/lang/StringBuffer/ECoreIndexOf.java
@@ -34,7 +34,7 @@
  * @summary Test indexOf and lastIndexOf
  * @requires vm.cpu.features ~= ".*avx2.*"
  * @requires vm.compiler2.enabled
- * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:+CheckJNICalls -XX:UseAVX=2 -Xbatch -XX:-TieredCompilation -XX:CompileCommand=dontinline,ECoreIndexOf.indexOfKernel ECoreIndexOf
+ * @run main/othervm -XX:+UnlockDiagnosticVMOptions -XX:+EnableX86ECoreOpts -XX:-CheckJNICalls -XX:UseAVX=2 -Xbatch -XX:-TieredCompilation -XX:CompileCommand=dontinline,ECoreIndexOf.indexOfKernel ECoreIndexOf
  * @key randomness
  */
 


### PR DESCRIPTION
Some tests specify `-XX:+EnableX86ECoreOpts` which does not work well with `-Xcheck:jni` on Windows. Disable `CheckJNICalls` for now with these tests until [JDK-8344802](https://bugs.openjdk.org/browse/JDK-8344802) is fixed.

Thanks,
Tobias

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344861](https://bugs.openjdk.org/browse/JDK-8344861): Disable CheckJNICalls in tests until JDK-8344802 is fixed (**Sub-task** - P4)


### Reviewers
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22325/head:pull/22325` \
`$ git checkout pull/22325`

Update a local copy of the PR: \
`$ git checkout pull/22325` \
`$ git pull https://git.openjdk.org/jdk.git pull/22325/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22325`

View PR using the GUI difftool: \
`$ git pr show -t 22325`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22325.diff">https://git.openjdk.org/jdk/pull/22325.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22325#issuecomment-2493893470)
</details>
