### PR TITLE
8344867: Cleanup unneeded qualified exports to java.rmi

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -317,7 +317,6 @@ module java.base {
         java.desktop,
         java.management,
         java.management.rmi,
-        java.rmi,
         java.sql.rowset;
     exports sun.security.internal.interfaces to
         jdk.crypto.cryptoki;
@@ -330,7 +329,6 @@ module java.base {
     exports sun.security.pkcs to
         jdk.jartool;
     exports sun.security.provider to
-        java.rmi,
         java.security.jgss,
         jdk.crypto.cryptoki,
         jdk.security.auth;
@@ -345,7 +343,6 @@ module java.base {
         jdk.jartool;
     exports sun.security.util to
         java.naming,
-        java.rmi,
         java.security.jgss,
         java.security.sasl,
         java.smartcardio,


### PR DESCRIPTION
java.base has a few exports to java.rmi that are no longer needed.
sun.security.util, sun.security.provider, and sun.reflect.misc.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344867](https://bugs.openjdk.org/browse/JDK-8344867): Cleanup unneeded qualified exports to java.rmi (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22329/head:pull/22329` \
`$ git checkout pull/22329`

Update a local copy of the PR: \
`$ git checkout pull/22329` \
`$ git pull https://git.openjdk.org/jdk.git pull/22329/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22329`

View PR using the GUI difftool: \
`$ git pr show -t 22329`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22329.diff">https://git.openjdk.org/jdk/pull/22329.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22329#issuecomment-2494462154)
</details>
