### PR TITLE
JDK-8344303 : Remove usage of URLUtil.getConnectPermission from sun.awt.SunToolkit and sun.awt.image.URLImageSource

### DIFF
--- a/src/java.base/share/classes/module-info.java
+++ b/src/java.base/share/classes/module-info.java
@@ -291,7 +291,6 @@ module java.base {
         java.security.jgss,
         jdk.naming.dns;
     exports sun.net.util to
-        java.desktop,
         java.net.http,
         jdk.jconsole,
         jdk.sctp;

--- a/src/java.base/share/classes/sun/net/util/URLUtil.java
+++ b/src/java.base/share/classes/sun/net/util/URLUtil.java
@@ -25,10 +25,7 @@
 
 package sun.net.util;
 
-import java.io.IOException;
 import java.net.URL;
-import java.net.URLPermission;
-import java.security.Permission;
 import java.util.Locale;
 
 /**
@@ -86,28 +83,6 @@ public class URLUtil {
         }
 
         return strForm.toString();
-    }
-
-    public static Permission getConnectPermission(URL url) throws IOException {
-        String urlStringLowerCase = url.toString().toLowerCase(Locale.ROOT);
-        if (urlStringLowerCase.startsWith("http:") || urlStringLowerCase.startsWith("https:")) {
-            return getURLConnectPermission(url);
-        } else if (urlStringLowerCase.startsWith("jar:http:") || urlStringLowerCase.startsWith("jar:https:")) {
-            String urlString = url.toString();
-            int bangPos = urlString.indexOf("!/");
-            urlString = urlString.substring(4, bangPos > -1 ? bangPos : urlString.length());
-            @SuppressWarnings("deprecation")
-            URL u = new URL(urlString);
-            return getURLConnectPermission(u);
-            // If protocol is HTTP or HTTPS than use URLPermission object
-        } else {
-            return url.openConnection().getPermission();
-        }
-    }
-
-    private static Permission getURLConnectPermission(URL url) {
-        String urlString = url.getProtocol() + "://" + url.getAuthority() + url.getPath();
-        return new URLPermission(urlString);
     }
 }
 

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -98,7 +98,6 @@ import sun.awt.image.MultiResolutionToolkitImage;
 import sun.awt.image.ToolkitImage;
 import sun.awt.image.URLImageSource;
 import sun.font.FontDesignMetrics;
-import sun.net.util.URLUtil;
 import sun.util.logging.PlatformLogger;
 
 import static java.awt.RenderingHints.KEY_TEXT_ANTIALIASING;
@@ -686,7 +685,6 @@ public abstract class SunToolkit extends Toolkit
     static final SoftCache urlImgCache = new SoftCache();
 
     static Image getImageFromHash(Toolkit tk, URL url) {
-        checkPermissions(url);
         synchronized (urlImgCache) {
             String key = url.toString();
             Image img = (Image)urlImgCache.get(key);
@@ -765,7 +763,6 @@ public abstract class SunToolkit extends Toolkit
 
     @Override
     public Image createImage(URL url) {
-        checkPermissions(url);
         return createImage(new URLImageSource(url));
     }
 
@@ -882,7 +879,6 @@ public abstract class SunToolkit extends Toolkit
     @SuppressWarnings("try")
     protected static boolean imageExists(URL url) {
         if (url != null) {
-            checkPermissions(url);
             try (InputStream is = url.openStream()) {
                 return true;
             }catch(IOException e){
@@ -897,22 +893,6 @@ public abstract class SunToolkit extends Toolkit
         SecurityManager security = System.getSecurityManager();
         if (security != null) {
             security.checkRead(filename);
-        }
-    }
-
-    private static void checkPermissions(URL url) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            try {
-                java.security.Permission perm =
-                    URLUtil.getConnectPermission(url);
-                if (perm != null) {
-                    sm.checkPermission(perm);
-                }
-            } catch (java.io.IOException ioe) {
-                sm.checkConnect(url.getHost(), url.getPort());
-            }
         }
     }
 

--- a/src/java.desktop/share/classes/sun/awt/image/URLImageSource.java
+++ b/src/java.desktop/share/classes/sun/awt/image/URLImageSource.java
@@ -31,7 +31,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.net.MalformedURLException;
-import sun.net.util.URLUtil;
 
 public class URLImageSource extends InputStreamImageSource {
     URL url;
@@ -40,21 +39,7 @@ public class URLImageSource extends InputStreamImageSource {
     int actualPort;
 
     public URLImageSource(URL u) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            try {
-                java.security.Permission perm =
-                      URLUtil.getConnectPermission(u);
-                if (perm != null) {
-                    sm.checkPermission(perm);
-                }
-            } catch (java.io.IOException ioe) {
-                sm.checkConnect(u.getHost(), u.getPort());
-            }
-        }
         this.url = u;
-
     }
 
     public URLImageSource(String href) throws MalformedURLException {


### PR DESCRIPTION
sun.awt.SunToolkit and sun.awt.image.URLImageSource are calling sun.net.util.URLUtil.getConnectPermission(URL)
With the SecurityManager gone there's no need to call this method anymore. 

There are other checkPermissions in these 2 files - SunToolkit, URLImageSource but I have removed only those that are related to URLUtil.getConnectPermission(URL). Other checkPermission removal will be handled in a separate issue.

Integrating this PR will allow to proceed with a dependent JBS issue - [JDK-8344180](https://bugs.openjdk.org/browse/JDK-8344180)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344303](https://bugs.openjdk.org/browse/JDK-8344303): Remove usage of URLUtil.getConnectPermission from sun.awt.SunToolkit and sun.awt.image.URLImageSource (**Sub-task** - P4)


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22330/head:pull/22330` \
`$ git checkout pull/22330`

Update a local copy of the PR: \
`$ git checkout pull/22330` \
`$ git pull https://git.openjdk.org/jdk.git pull/22330/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22330`

View PR using the GUI difftool: \
`$ git pr show -t 22330`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22330.diff">https://git.openjdk.org/jdk/pull/22330.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22330#issuecomment-2494525307)
</details>
