### PR TITLE
8344013: "bad tag in log" assert with +LogCompilation +CITimeVerbose

### DIFF
--- a/src/hotspot/share/opto/compile.cpp
+++ b/src/hotspot/share/opto/compile.cpp
@@ -4335,6 +4335,9 @@ Compile::TracePhase::TracePhase(PhaseTraceId id)
 
 Compile::TracePhase::~TracePhase() {
   if (_compile->failing_internal()) {
+    if (_log != nullptr) {
+      _log->done("phase");
+    }
     return; // timing code, not stressing bailouts.
   }
 #ifdef ASSERT


### PR DESCRIPTION
Hi folks, 

This PR addresses [8344013](https://bugs.openjdk.org/browse/JDK-8344013).

Sometimes the writing to xmlStream is mixed from several threads, and therefore the xmlStream tag stack can end up in a bad state. When this occurs, the VM crashes in `xmlStream::pop_tag` with `assert(false) failed: bad tag in log`. 

In this case, running `java -XX:+LogCompilation -XX:CompileCommand="log,*.*" -XX:+CITimeVerbose -Xcomp -Xbatch -version` , `xmlStream::pop_tag` is expecting to pop the tag `task` but finds `phase` instead. 

I found the issue stems from [8330157](https://bugs.openjdk.org/browse/JDK-8330157). The problematic code is in the destructor for [TracePhase](https://github.com/openjdk/jdk/blame/master/src/hotspot/share/opto/compile.cpp#L4337).

Note how the constructor adds the [phase tag](https://github.com/openjdk/jdk/blame/master/src/hotspot/share/opto/compile.cpp#L4327).

However, in the destructor, if we return early, we don’t pop that tag, leading to the xmlStream tag stack to end up in a bad state. With this patch, I made sure we pop the tag even if we return early. 

Cheers, 
Sonia
