### PR TITLE
8344891: Remove uses of sun.misc.ReflectUtil in java.desktop

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaUtils.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaUtils.java
@@ -38,7 +38,6 @@ import javax.swing.plaf.UIResource;
 import sun.awt.AppContext;
 
 import sun.lwawt.macosx.CPlatformWindow;
-import sun.reflect.misc.ReflectUtil;
 import sun.swing.SwingUtilities2;
 
 import com.apple.laf.AquaImageFactory.SlicedImageControl;
@@ -174,7 +173,6 @@ final class AquaUtils {
         @SuppressWarnings("deprecation")
         T getInstance() {
             try {
-                ReflectUtil.checkPackageAccess(clazz);
                 return clazz.newInstance();
             } catch (ReflectiveOperationException ignored) {
             }

--- a/src/java.desktop/share/classes/com/sun/beans/finder/ClassFinder.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/ClassFinder.java
@@ -24,8 +24,6 @@
  */
 package com.sun.beans.finder;
 
-import static sun.reflect.misc.ReflectUtil.checkPackageAccess;
-
 /**
  * This is utility class that provides {@code static} methods
  * to find a class with the specified name using the specified class loader.
@@ -56,7 +54,6 @@ public final class ClassFinder {
      * @see Thread#getContextClassLoader()
      */
     public static Class<?> findClass(String name) throws ClassNotFoundException {
-        checkPackageAccess(name);
         try {
             ClassLoader loader = Thread.currentThread().getContextClassLoader();
             if (loader == null) {
@@ -95,7 +92,6 @@ public final class ClassFinder {
      * @see Class#forName(String,boolean,ClassLoader)
      */
     public static Class<?> findClass(String name, ClassLoader loader) throws ClassNotFoundException {
-        checkPackageAccess(name);
         if (loader != null) {
             try {
                 return Class.forName(name, false, loader);

--- a/src/java.desktop/share/classes/com/sun/beans/finder/ConstructorFinder.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/ConstructorFinder.java
@@ -30,7 +30,6 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
 import static com.sun.beans.util.Cache.Kind.SOFT;
-import static sun.reflect.misc.ReflectUtil.isPackageAccessible;
 
 /**
  * This utility class provides {@code static} methods
@@ -81,7 +80,7 @@ public final class ConstructorFinder extends AbstractFinder<Constructor<?>> {
             throw new NoSuchMethodException("Abstract class cannot be instantiated: "
                 + type.getName());
         }
-        if (!Modifier.isPublic(type.getModifiers()) || !isPackageAccessible(type)) {
+        if (!Modifier.isPublic(type.getModifiers())) {
             throw new NoSuchMethodException("Class is not accessible: " + type.getName());
         }
         PrimitiveWrapperMap.replacePrimitivesWithWrappers(args);

--- a/src/java.desktop/share/classes/com/sun/beans/finder/FieldFinder.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/FieldFinder.java
@@ -27,8 +27,6 @@ package com.sun.beans.finder;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 
-import static sun.reflect.misc.ReflectUtil.isPackageAccessible;
-
 /**
  * This utility class provides {@code static} methods
  * to find a public field with specified name
@@ -62,7 +60,7 @@ public final class FieldFinder {
             throw new NoSuchFieldException("Field '" + name + "' is not public");
         }
         type = field.getDeclaringClass();
-        if (!Modifier.isPublic(type.getModifiers()) || !isPackageAccessible(type)) {
+        if (!Modifier.isPublic(type.getModifiers())) {
             throw new NoSuchFieldException("Field '" + name + "' is not accessible");
         }
         return field;

--- a/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/MethodFinder.java
@@ -34,7 +34,6 @@ import java.lang.reflect.Type;
 import java.util.Arrays;
 
 import static com.sun.beans.util.Cache.Kind.SOFT;
-import static sun.reflect.misc.ReflectUtil.isPackageAccessible;
 
 /**
  * This utility class provides {@code static} methods
@@ -79,7 +78,7 @@ public final class MethodFinder extends AbstractFinder<Method> {
 
         try {
             Method method = CACHE.get(signature);
-            return (method == null) || isPackageAccessible(method.getDeclaringClass()) ? method : CACHE.create(signature);
+            return (method == null) ? method : CACHE.create(signature);
         }
         catch (SignatureException exception) {
             throw exception.toNoSuchMethodException("Method '" + name + "' is not found");
@@ -138,7 +137,7 @@ public final class MethodFinder extends AbstractFinder<Method> {
         if (!FinderUtils.isExported(type)) {
             throw new NoSuchMethodException("Method '" + method.getName() + "' is not accessible");
         }
-        if (Modifier.isPublic(type.getModifiers()) && isPackageAccessible(type)) {
+        if (Modifier.isPublic(type.getModifiers())) {
             return method;
         }
         if (Modifier.isStatic(method.getModifiers())) {

--- a/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
+++ b/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
@@ -31,8 +31,6 @@ import java.util.Map;
 
 import com.sun.beans.util.Cache;
 
-import static sun.reflect.misc.ReflectUtil.checkPackageAccess;
-
 public final class ClassInfo {
     private static final ClassInfo DEFAULT = new ClassInfo(null);
     private static final Cache<Class<?>,ClassInfo> CACHE
@@ -48,7 +46,6 @@ public final class ClassInfo {
             return DEFAULT;
         }
         try {
-            checkPackageAccess(type);
             return CACHE.get(type);
         } catch (SecurityException exception) {
             return DEFAULT;

--- a/src/java.desktop/share/classes/com/sun/media/sound/JARSoundbankReader.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/JARSoundbankReader.java
@@ -39,8 +39,6 @@ import javax.sound.midi.InvalidMidiDataException;
 import javax.sound.midi.Soundbank;
 import javax.sound.midi.spi.SoundbankReader;
 
-import sun.reflect.misc.ReflectUtil;
-
 /**
  * JarSoundbankReader is used to read soundbank object from jar files.
  *
@@ -95,7 +93,6 @@ public final class JARSoundbankReader extends SoundbankReader {
                     try {
                         Class<?> c = Class.forName(line.trim(), false, ucl);
                         if (Soundbank.class.isAssignableFrom(c)) {
-                            ReflectUtil.checkPackageAccess(c);
                             Object o = c.newInstance();
                             soundbanks.add((Soundbank) o);
                         }

--- a/src/java.desktop/share/classes/java/beans/DefaultPersistenceDelegate.java
+++ b/src/java.desktop/share/classes/java/beans/DefaultPersistenceDelegate.java
@@ -27,7 +27,7 @@ package java.beans;
 import java.util.*;
 import java.lang.reflect.*;
 import java.util.Objects;
-import sun.reflect.misc.*;
+import sun.reflect.misc.MethodUtil;
 
 
 /**
@@ -222,9 +222,6 @@ public class DefaultPersistenceDelegate extends PersistenceDelegate {
     // Write out the properties of this instance.
     private void initBean(Class<?> type, Object oldInstance, Object newInstance, Encoder out) {
         for (Field field : type.getFields()) {
-            if (!ReflectUtil.isPackageAccessible(field.getDeclaringClass())) {
-                continue;
-            }
             int mod = field.getModifiers();
             if (Modifier.isFinal(mod) || Modifier.isStatic(mod) || Modifier.isTransient(mod)) {
                 continue;

--- a/src/java.desktop/share/classes/java/beans/EventHandler.java
+++ b/src/java.desktop/share/classes/java/beans/EventHandler.java
@@ -30,7 +30,6 @@ import java.lang.reflect.Proxy;
 import java.lang.reflect.Method;
 
 import sun.reflect.misc.MethodUtil;
-import sun.reflect.misc.ReflectUtil;
 
 /**
  * The {@code EventHandler} class provides
@@ -691,7 +690,6 @@ public class EventHandler implements InvocationHandler {
     }
 
     private static ClassLoader getClassLoader(Class<?> type) {
-        ReflectUtil.checkPackageAccess(type);
         ClassLoader loader = type.getClassLoader();
         if (loader == null) {
             loader = Thread.currentThread().getContextClassLoader(); // avoid use of BCP

--- a/src/java.desktop/share/classes/java/beans/Introspector.java
+++ b/src/java.desktop/share/classes/java/beans/Introspector.java
@@ -47,7 +47,6 @@ import com.sun.beans.introspect.EventSetInfo;
 import com.sun.beans.introspect.PropertyInfo;
 import jdk.internal.access.JavaBeansAccess;
 import jdk.internal.access.SharedSecrets;
-import sun.reflect.misc.ReflectUtil;
 
 /**
  * The Introspector class provides a standard way for tools to learn about
@@ -186,9 +185,6 @@ public class Introspector {
     public static BeanInfo getBeanInfo(Class<?> beanClass)
         throws IntrospectionException
     {
-        if (!ReflectUtil.isPackageAccessible(beanClass)) {
-            return (new Introspector(beanClass, null, USE_ALL_BEANINFO)).getBeanInfo();
-        }
         ThreadGroupContext context = ThreadGroupContext.getContext();
         BeanInfo beanInfo = context.getBeanInfo(beanClass);
         if (beanInfo == null) {

--- a/src/java.desktop/share/classes/java/beans/MetaData.java
+++ b/src/java.desktop/share/classes/java/beans/MetaData.java
@@ -50,8 +50,6 @@ import javax.swing.plaf.ColorUIResource;
 
 import sun.swing.PrintColorUIResource;
 
-import static sun.reflect.misc.ReflectUtil.isPackageAccessible;
-
 /*
  * Like the {@code Introspector}, the {@code MetaData} class
  * contains <em>meta</em> objects that describe the way
@@ -749,7 +747,7 @@ static final class java_awt_AWTKeyStroke_PersistenceDelegate extends Persistence
 
 static class StaticFieldsPersistenceDelegate extends PersistenceDelegate {
     protected void installFields(Encoder out, Class<?> cls) {
-        if (Modifier.isPublic(cls.getModifiers()) && isPackageAccessible(cls)) {
+        if (Modifier.isPublic(cls.getModifiers())) {
             Field[] fields = cls.getFields();
             for(int i = 0; i < fields.length; i++) {
                 Field field = fields[i];

--- a/src/java.desktop/share/classes/java/beans/MethodRef.java
+++ b/src/java.desktop/share/classes/java/beans/MethodRef.java
@@ -29,8 +29,6 @@ import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Method;
 
-import static sun.reflect.misc.ReflectUtil.isPackageAccessible;
-
 final class MethodRef {
     private String signature;
     private SoftReference<Method> methodRef;
@@ -68,7 +66,7 @@ final class MethodRef {
             }
             this.methodRef = new SoftReference<>(method);
         }
-        return isPackageAccessible(method.getDeclaringClass()) ? method : null;
+        return method;
     }
 
     private static Method find(Class<?> type, String signature) {

--- a/src/java.desktop/share/classes/java/beans/PropertyDescriptor.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyDescriptor.java
@@ -30,7 +30,6 @@ import java.lang.reflect.Constructor;
 import java.util.Map.Entry;
 
 import com.sun.beans.introspect.PropertyInfo;
-import sun.reflect.misc.ReflectUtil;
 
 /**
  * A PropertyDescriptor describes one property that a Java Bean
@@ -467,8 +466,7 @@ public class PropertyDescriptor extends FeatureDescriptor {
         Object editor = null;
 
         final Class<?> cls = getPropertyEditorClass();
-        if (cls != null && PropertyEditor.class.isAssignableFrom(cls)
-                && ReflectUtil.isPackageAccessible(cls)) {
+        if (cls != null && PropertyEditor.class.isAssignableFrom(cls)) {
             Constructor<?> ctor = null;
             if (bean != null) {
                 try {

--- a/src/java.desktop/share/classes/java/beans/Statement.java
+++ b/src/java.desktop/share/classes/java/beans/Statement.java
@@ -35,8 +35,6 @@ import com.sun.beans.finder.ConstructorFinder;
 import com.sun.beans.finder.MethodFinder;
 import sun.reflect.misc.MethodUtil;
 
-import static sun.reflect.misc.ReflectUtil.checkPackageAccess;
-
 /**
  * A {@code Statement} object represents a primitive statement
  * in which a single method is applied to a target and
@@ -189,13 +187,8 @@ public class Statement {
                 // Class.forName(String className) won't load classes outside
                 // of core from a class inside core. Special
                 // case this method.
-                // checkPackageAccess(name) will be called by ClassFinder
                 return ClassFinder.resolveClass(name, this.loader);
             }
-            // The 3 args Class.forName(String className, boolean, classloader)
-            // requires getClassLoader permission, but we will be stricter and
-            // will require access to the package as well.
-            checkPackageAccess(name);
         }
         Class<?>[] argClasses = new Class<?>[arguments.length];
         for(int i = 0; i < arguments.length; i++) {

--- a/src/java.desktop/share/classes/javax/print/SimpleDoc.java
+++ b/src/java.desktop/share/classes/javax/print/SimpleDoc.java
@@ -108,7 +108,6 @@ public final class SimpleDoc implements Doc {
        Class<?> repClass = null;
        try {
             String className = flavor.getRepresentationClassName();
-            sun.reflect.misc.ReflectUtil.checkPackageAccess(className);
             repClass = Class.forName(className, false,
                               Thread.currentThread().getContextClassLoader());
        } catch (Throwable e) {

--- a/src/java.desktop/share/classes/javax/swing/JEditorPane.java
+++ b/src/java.desktop/share/classes/javax/swing/JEditorPane.java
@@ -94,8 +94,6 @@ import javax.swing.text.html.HTML;
 import javax.swing.text.html.HTMLDocument;
 import javax.swing.text.html.HTMLEditorKit;
 
-import sun.reflect.misc.ReflectUtil;
-
 /**
  * A text component to edit various kinds of content.
  * You can find how-to information and examples of using editor panes in
@@ -1238,7 +1236,6 @@ public class JEditorPane extends JTextComponent {
             try {
                 Class<?> c;
                 if (loader != null) {
-                    ReflectUtil.checkPackageAccess(classname);
                     c = loader.loadClass(classname);
                 } else {
                     // Will only happen if developer has invoked

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -113,7 +113,6 @@ import javax.swing.table.TableRowSorter;
 
 import sun.awt.AWTAccessor;
 import sun.awt.AWTAccessor.MouseEventAccessor;
-import sun.reflect.misc.ReflectUtil;
 import sun.swing.PrintingStatus;
 import sun.swing.SwingUtilities2;
 import sun.swing.SwingUtilities2.Section;
@@ -5585,7 +5584,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                 if (type == Object.class) {
                     type = String.class;
                 }
-                ReflectUtil.checkPackageAccess(type);
                 SwingUtilities2.checkAccess(type.getModifiers());
                 constructor = type.getConstructor(argTypes);
             }

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -24,7 +24,6 @@
  */
 package javax.swing;
 
-import sun.reflect.misc.ReflectUtil;
 import sun.swing.SwingUtilities2;
 import sun.swing.UIAction;
 
@@ -2033,7 +2032,6 @@ public class SwingUtilities implements SwingConstants
 
 
     static Class<?> loadSystemClass(String className) throws ClassNotFoundException {
-        ReflectUtil.checkPackageAccess(className);
         return Class.forName(className, true, Thread.currentThread().
                              getContextClassLoader());
     }

--- a/src/java.desktop/share/classes/javax/swing/UIDefaults.java
+++ b/src/java.desktop/share/classes/javax/swing/UIDefaults.java
@@ -51,7 +51,6 @@ import java.awt.Dimension;
 import java.beans.PropertyChangeListener;
 
 import sun.reflect.misc.MethodUtil;
-import sun.reflect.misc.ReflectUtil;
 import sun.swing.SwingAccessor;
 import sun.swing.SwingUtilities2;
 
@@ -702,7 +701,6 @@ public class UIDefaults extends Hashtable<Object,Object>
         try {
             String className = (String)get(uiClassID);
             if (className != null) {
-                ReflectUtil.checkPackageAccess(className);
 
                 Class<?> cls = (Class)get(className);
                 if (cls == null) {
@@ -1142,7 +1140,6 @@ public class UIDefaults extends Hashtable<Object,Object>
                         cl = ClassLoader.getSystemClassLoader();
                     }
                 }
-                ReflectUtil.checkPackageAccess(className);
                 c = Class.forName(className, true, (ClassLoader)cl);
                 SwingUtilities2.checkAccess(c.getModifiers());
                 if (methodName != null) {

--- a/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
+++ b/src/java.desktop/share/classes/javax/swing/event/EventListenerList.java
@@ -33,8 +33,6 @@ import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.EventListener;
 
-import sun.reflect.misc.ReflectUtil;
-
 /**
  * A class that holds a list of EventListeners.  A single instance
  * can be used to hold all listeners (of all types) for the instance
@@ -303,7 +301,6 @@ public class EventListenerList implements Serializable {
             ClassLoader cl = Thread.currentThread().getContextClassLoader();
             EventListener l = (EventListener)s.readObject();
             String name = (String) listenerTypeOrNull;
-            ReflectUtil.checkPackageAccess(name);
             @SuppressWarnings("unchecked")
             Class<EventListener> tmp = (Class<EventListener>)Class.forName(name, true, cl);
             add(tmp, l);

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthParser.java
@@ -67,7 +67,6 @@ import org.xml.sax.SAXParseException;
 import org.xml.sax.helpers.DefaultHandler;
 
 import com.sun.beans.decoder.DocumentHandler;
-import sun.reflect.misc.ReflectUtil;
 
 class SynthParser extends DefaultHandler {
     //
@@ -646,7 +645,7 @@ class SynthParser extends DefaultHandler {
                     }
                     else {
                         try {
-                            typeClass = ReflectUtil.forName(typeName.substring(
+                            typeClass = Class.forName(typeName.substring(
                                                       0, classIndex));
                         } catch (ClassNotFoundException cnfe) {
                             throw new SAXException("Unknown class: " +

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultFormatter.java
@@ -24,7 +24,6 @@
  */
 package javax.swing.text;
 
-import sun.reflect.misc.ReflectUtil;
 import sun.swing.SwingUtilities2;
 
 import java.io.Serializable;
@@ -248,7 +247,6 @@ public class DefaultFormatter extends JFormattedTextField.AbstractFormatter
             Constructor<?> cons;
 
             try {
-                ReflectUtil.checkPackageAccess(vc);
                 SwingUtilities2.checkAccess(vc.getModifiers());
                 cons = vc.getConstructor(new Class<?>[]{String.class});
 

--- a/src/java.desktop/share/classes/javax/swing/text/NumberFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/NumberFormatter.java
@@ -33,7 +33,6 @@ import java.text.NumberFormat;
 import java.text.ParseException;
 import java.util.Map;
 
-import sun.reflect.misc.ReflectUtil;
 import sun.swing.SwingUtilities2;
 
 /**
@@ -437,7 +436,6 @@ public class NumberFormatter extends InternationalFormatter {
                         valueClass = value.getClass();
                     }
                     try {
-                        ReflectUtil.checkPackageAccess(valueClass);
                         SwingUtilities2.checkAccess(valueClass.getModifiers());
                         Constructor<?> cons = valueClass.getConstructor(
                                               new Class<?>[] { String.class });

--- a/src/java.desktop/share/classes/javax/swing/text/html/ObjectView.java
+++ b/src/java.desktop/share/classes/javax/swing/text/html/ObjectView.java
@@ -31,7 +31,6 @@ import java.beans.*;
 import java.lang.reflect.*;
 
 import sun.reflect.misc.MethodUtil;
-import sun.reflect.misc.ReflectUtil;
 
 /**
  * Component decorator that implements the view interface
@@ -100,7 +99,6 @@ public class ObjectView extends ComponentView  {
         AttributeSet attr = getElement().getAttributes();
         String classname = (String) attr.getAttribute(HTML.Attribute.CLASSID);
         try {
-            ReflectUtil.checkPackageAccess(classname);
             Class<?> c = Class.forName(classname, false,Thread.currentThread().
                                        getContextClassLoader());
             if (Component.class.isAssignableFrom(c)) {


### PR DESCRIPTION
Remove uses of sun.misc.ReflectUtils which checked obsolete permissions

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344891](https://bugs.openjdk.org/browse/JDK-8344891): Remove uses of sun.misc.ReflectUtil in java.desktop (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22335/head:pull/22335` \
`$ git checkout pull/22335`

Update a local copy of the PR: \
`$ git checkout pull/22335` \
`$ git pull https://git.openjdk.org/jdk.git pull/22335/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22335`

View PR using the GUI difftool: \
`$ git pr show -t 22335`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22335.diff">https://git.openjdk.org/jdk/pull/22335.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22335#issuecomment-2494982731)
</details>
