### PR TITLE
8344898: SM cleanup of java.base sun/util calendar, locale, cldr, and resources

### DIFF
--- a/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
+++ b/src/java.base/share/classes/sun/util/calendar/ZoneInfoFile.java
@@ -33,8 +33,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StreamCorruptedException;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -212,23 +210,17 @@ public final class ZoneInfoFile {
         loadTZDB();
     }
 
-    @SuppressWarnings("removal")
     private static void loadTZDB() {
-        AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            public Void run() {
-                try {
-                    String libDir = StaticProperty.javaHome() + File.separator + "lib";
-                    try (DataInputStream dis = new DataInputStream(
-                             new BufferedInputStream(new FileInputStream(
-                                 new File(libDir, "tzdb.dat"))))) {
-                        load(dis);
-                    }
-                } catch (Exception x) {
-                    throw new Error(x);
-                }
-                return null;
+        try {
+            String libDir = StaticProperty.javaHome() + File.separator + "lib";
+            try (DataInputStream dis = new DataInputStream(
+                     new BufferedInputStream(new FileInputStream(
+                         new File(libDir, "tzdb.dat"))))) {
+                load(dis);
             }
-        });
+        } catch (Exception x) {
+            throw new Error(x);
+        }
     }
 
     /**

--- a/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/cldr/CLDRLocaleProviderAdapter.java
@@ -25,10 +25,6 @@
 
 package sun.util.cldr;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.text.spi.BreakIteratorProvider;
 import java.text.spi.CollatorProvider;
 import java.util.Arrays;
@@ -75,24 +71,14 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
         parentLocalesMap.put(Locale.US, Locale.US);
     }
 
-    @SuppressWarnings("removal")
     public CLDRLocaleProviderAdapter() {
-        LocaleDataMetaInfo nbmi;
-
-        try {
-            nbmi = AccessController.doPrivileged((PrivilegedExceptionAction<LocaleDataMetaInfo>) () -> {
-                for (LocaleDataMetaInfo ldmi : ServiceLoader.loadInstalled(LocaleDataMetaInfo.class)) {
-                    if (ldmi.getType() == Type.CLDR) {
-                        return ldmi;
-                    }
-                }
-                return null;
-            });
-        } catch (PrivilegedActionException pae) {
-            throw new InternalError(pae.getCause());
+        for (LocaleDataMetaInfo ldmi : ServiceLoader.loadInstalled(LocaleDataMetaInfo.class)) {
+            if (ldmi.getType() == Type.CLDR) {
+                nonBaseMetaInfo = ldmi;
+                return;
+            }
         }
-
-        nonBaseMetaInfo = nbmi;
+        nonBaseMetaInfo = null;
     }
 
     /**
@@ -112,12 +98,9 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
     @Override
     public CalendarDataProvider getCalendarDataProvider() {
         if (calendarDataProvider == null) {
-            @SuppressWarnings("removal")
-            CalendarDataProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<CalendarDataProvider>) () ->
-                    new CLDRCalendarDataProviderImpl(
+            CalendarDataProvider provider = new CLDRCalendarDataProviderImpl(
                         getAdapterType(),
-                        getLanguageTagSet("CalendarData")));
+                        getLanguageTagSet("CalendarData"));
 
             synchronized (this) {
                 if (calendarDataProvider == null) {
@@ -131,12 +114,9 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
     @Override
     public CalendarNameProvider getCalendarNameProvider() {
         if (calendarNameProvider == null) {
-            @SuppressWarnings("removal")
-            CalendarNameProvider provider = AccessController.doPrivileged(
-                    (PrivilegedAction<CalendarNameProvider>) ()
-                    -> new CLDRCalendarNameProviderImpl(
+            CalendarNameProvider provider = new CLDRCalendarNameProviderImpl(
                             getAdapterType(),
-                            getLanguageTagSet("FormatData")));
+                            getLanguageTagSet("FormatData"));
 
             synchronized (this) {
                 if (calendarNameProvider == null) {
@@ -155,12 +135,9 @@ public class CLDRLocaleProviderAdapter extends JRELocaleProviderAdapter {
     @Override
     public TimeZoneNameProvider getTimeZoneNameProvider() {
         if (timeZoneNameProvider == null) {
-            @SuppressWarnings("removal")
-            TimeZoneNameProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<TimeZoneNameProvider>) () ->
-                    new CLDRTimeZoneNameProviderImpl(
+            TimeZoneNameProvider provider = new CLDRTimeZoneNameProviderImpl(
                         getAdapterType(),
-                        getLanguageTagSet("TimeZoneNames")));
+                        getLanguageTagSet("TimeZoneNames"));
 
             synchronized (this) {
                 if (timeZoneNameProvider == null) {

--- a/src/java.base/share/classes/sun/util/locale/provider/AuxLocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/AuxLocaleProviderAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 
 package sun.util.locale.provider;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.text.spi.BreakIteratorProvider;
 import java.text.spi.CollatorProvider;
 import java.text.spi.DateFormatProvider;
@@ -186,9 +184,7 @@ public abstract class AuxLocaleProviderAdapter extends LocaleProviderAdapter {
      * A dummy locale service provider that indicates there is no
      * provider available
      */
-    @SuppressWarnings("removal")
-    private static final NullProvider NULL_PROVIDER = AccessController.doPrivileged(
-        (PrivilegedAction<NullProvider>) () -> new NullProvider());
+    private static final NullProvider NULL_PROVIDER = new NullProvider();
 
     private static class NullProvider extends LocaleServiceProvider {
         @Override

--- a/src/java.base/share/classes/sun/util/locale/provider/FallbackLocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/FallbackLocaleProviderAdapter.java
@@ -25,8 +25,6 @@
 
 package sun.util.locale.provider;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.text.spi.BreakIteratorProvider;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -85,12 +83,9 @@ public class FallbackLocaleProviderAdapter extends JRELocaleProviderAdapter {
     // In order to correctly report supported locales
     public BreakIteratorProvider getBreakIteratorProvider() {
         if (breakIteratorProvider == null) {
-            @SuppressWarnings("removal")
-            BreakIteratorProvider provider = AccessController.doPrivileged(
-                    (PrivilegedAction<BreakIteratorProvider>) () ->
-                            new BreakIteratorProviderImpl(
+            BreakIteratorProvider provider = new BreakIteratorProviderImpl(
                                     getAdapterType(),
-                                    getLanguageTagSet("BreakIteratorRules")));
+                                    getLanguageTagSet("BreakIteratorRules"));
 
             synchronized (this) {
                 if (breakIteratorProvider == null) {

--- a/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
+++ b/src/java.base/share/classes/sun/util/locale/provider/JRELocaleProviderAdapter.java
@@ -25,10 +25,6 @@
 
 package sun.util.locale.provider;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.text.spi.BreakIteratorProvider;
 import java.text.spi.CollatorProvider;
 import java.text.spi.DateFormatProvider;
@@ -139,12 +135,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public BreakIteratorProvider getBreakIteratorProvider() {
         if (breakIteratorProvider == null) {
-            @SuppressWarnings("removal")
-            BreakIteratorProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<BreakIteratorProvider>) () ->
-                    new BreakIteratorProviderImpl(
-                        getAdapterType(),
-                        getLanguageTagSet("FormatData")));
+            BreakIteratorProvider provider = new BreakIteratorProviderImpl(
+                    getAdapterType(),
+                    getLanguageTagSet("FormatData"));
 
             synchronized (this) {
                 if (breakIteratorProvider == null) {
@@ -158,12 +151,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public CollatorProvider getCollatorProvider() {
         if (collatorProvider == null) {
-            @SuppressWarnings("removal")
-            CollatorProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<CollatorProvider>) () ->
-                    new CollatorProviderImpl(
-                        getAdapterType(),
-                        getLanguageTagSet("CollationData")));
+            CollatorProvider provider = new CollatorProviderImpl(
+                    getAdapterType(),
+                    getLanguageTagSet("CollationData"));
 
             synchronized (this) {
                 if (collatorProvider == null) {
@@ -177,12 +167,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public DateFormatProvider getDateFormatProvider() {
         if (dateFormatProvider == null) {
-            @SuppressWarnings("removal")
-            DateFormatProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<DateFormatProvider>) () ->
-                    new DateFormatProviderImpl(
-                        getAdapterType(),
-                        getLanguageTagSet("FormatData")));
+            DateFormatProvider provider = new DateFormatProviderImpl(
+                    getAdapterType(),
+                    getLanguageTagSet("FormatData"));
 
             synchronized (this) {
                 if (dateFormatProvider == null) {
@@ -196,12 +183,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public DateFormatSymbolsProvider getDateFormatSymbolsProvider() {
         if (dateFormatSymbolsProvider == null) {
-            @SuppressWarnings("removal")
-            DateFormatSymbolsProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<DateFormatSymbolsProvider>) () ->
-                    new DateFormatSymbolsProviderImpl(
-                        getAdapterType(),
-                        getLanguageTagSet("FormatData")));
+            DateFormatSymbolsProvider provider = new DateFormatSymbolsProviderImpl(
+                    getAdapterType(),
+                    getLanguageTagSet("FormatData"));
 
             synchronized (this) {
                 if (dateFormatSymbolsProvider == null) {
@@ -215,12 +199,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public DecimalFormatSymbolsProvider getDecimalFormatSymbolsProvider() {
         if (decimalFormatSymbolsProvider == null) {
-            @SuppressWarnings("removal")
-            DecimalFormatSymbolsProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<DecimalFormatSymbolsProvider>) () ->
-                    new DecimalFormatSymbolsProviderImpl(
-                        getAdapterType(),
-                        getLanguageTagSet("FormatData")));
+            DecimalFormatSymbolsProvider provider = new DecimalFormatSymbolsProviderImpl(
+                    getAdapterType(),
+                    getLanguageTagSet("FormatData"));
 
             synchronized (this) {
                 if (decimalFormatSymbolsProvider == null) {
@@ -234,12 +215,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public NumberFormatProvider getNumberFormatProvider() {
         if (numberFormatProvider == null) {
-            @SuppressWarnings("removal")
-            NumberFormatProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<NumberFormatProvider>) () ->
-                    new NumberFormatProviderImpl(
+            NumberFormatProvider provider = new NumberFormatProviderImpl(
                         getAdapterType(),
-                        getLanguageTagSet("FormatData")));
+                        getLanguageTagSet("FormatData"));
 
             synchronized (this) {
                 if (numberFormatProvider == null) {
@@ -256,12 +234,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public CurrencyNameProvider getCurrencyNameProvider() {
         if (currencyNameProvider == null) {
-            @SuppressWarnings("removal")
-            CurrencyNameProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<CurrencyNameProvider>) () ->
-                    new CurrencyNameProviderImpl(
+            CurrencyNameProvider provider = new CurrencyNameProviderImpl(
                         getAdapterType(),
-                        getLanguageTagSet("CurrencyNames")));
+                        getLanguageTagSet("CurrencyNames"));
 
             synchronized (this) {
                 if (currencyNameProvider == null) {
@@ -275,12 +250,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public LocaleNameProvider getLocaleNameProvider() {
         if (localeNameProvider == null) {
-            @SuppressWarnings("removal")
-            LocaleNameProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<LocaleNameProvider>) () ->
-                    new LocaleNameProviderImpl(
+            LocaleNameProvider provider = new LocaleNameProviderImpl(
                         getAdapterType(),
-                        getLanguageTagSet("LocaleNames")));
+                        getLanguageTagSet("LocaleNames"));
 
             synchronized (this) {
                 if (localeNameProvider == null) {
@@ -294,12 +266,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public TimeZoneNameProvider getTimeZoneNameProvider() {
         if (timeZoneNameProvider == null) {
-            @SuppressWarnings("removal")
-            TimeZoneNameProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<TimeZoneNameProvider>) () ->
-                    new TimeZoneNameProviderImpl(
+            TimeZoneNameProvider provider = new TimeZoneNameProviderImpl(
                         getAdapterType(),
-                        getLanguageTagSet("TimeZoneNames")));
+                        getLanguageTagSet("TimeZoneNames"));
 
             synchronized (this) {
                 if (timeZoneNameProvider == null) {
@@ -313,12 +282,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public CalendarDataProvider getCalendarDataProvider() {
         if (calendarDataProvider == null) {
-            @SuppressWarnings("removal")
-            CalendarDataProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<CalendarDataProvider>) () ->
-                    new CalendarDataProviderImpl(
+            CalendarDataProvider provider = new CalendarDataProviderImpl(
                         getAdapterType(),
-                        getLanguageTagSet("CalendarData")));
+                        getLanguageTagSet("CalendarData"));
 
             synchronized (this) {
                 if (calendarDataProvider == null) {
@@ -332,12 +298,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public CalendarNameProvider getCalendarNameProvider() {
         if (calendarNameProvider == null) {
-            @SuppressWarnings("removal")
-            CalendarNameProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<CalendarNameProvider>) () ->
-                    new CalendarNameProviderImpl(
+            CalendarNameProvider provider = new CalendarNameProviderImpl(
                         getAdapterType(),
-                        getLanguageTagSet("FormatData")));
+                        getLanguageTagSet("FormatData"));
 
             synchronized (this) {
                 if (calendarNameProvider == null) {
@@ -354,12 +317,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public CalendarProvider getCalendarProvider() {
         if (calendarProvider == null) {
-            @SuppressWarnings("removal")
-            CalendarProvider provider = AccessController.doPrivileged(
-                (PrivilegedAction<CalendarProvider>) () ->
-                    new CalendarProviderImpl(
+            CalendarProvider provider = new CalendarProviderImpl(
                         getAdapterType(),
-                        getLanguageTagSet("CalendarData")));
+                        getLanguageTagSet("CalendarData"));
 
             synchronized (this) {
                 if (calendarProvider == null) {
@@ -376,12 +336,9 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
     @Override
     public JavaTimeDateTimePatternProvider getJavaTimeDateTimePatternProvider() {
         if (javaTimeDateTimePatternProvider == null) {
-            @SuppressWarnings("removal")
-            JavaTimeDateTimePatternProvider provider = AccessController.doPrivileged(
-                    (PrivilegedAction<JavaTimeDateTimePatternProvider>) ()
-                    -> new JavaTimeDateTimePatternImpl(
+            JavaTimeDateTimePatternProvider provider = new JavaTimeDateTimePatternImpl(
                             getAdapterType(),
-                            getLanguageTagSet("FormatData")));
+                            getLanguageTagSet("FormatData"));
 
             synchronized (this) {
                 if (javaTimeDateTimePatternProvider == null) {
@@ -461,30 +418,23 @@ public class JRELocaleProviderAdapter extends LocaleProviderAdapter implements R
         String supportedLocaleString = BaseLocaleDataMetaInfo.getSupportedLocaleString(category);
 
         // Use ServiceLoader to dynamically acquire installed locales' tags.
-        try {
-            @SuppressWarnings("removal")
-            String nonBaseTags = AccessController.doPrivileged((PrivilegedExceptionAction<String>) () -> {
-                StringBuilder tags = new StringBuilder();
-                for (LocaleDataMetaInfo ldmi :
-                        ServiceLoader.loadInstalled(LocaleDataMetaInfo.class)) {
-                    if (ldmi.getType() == LocaleProviderAdapter.Type.JRE) {
-                        String t = ldmi.availableLanguageTags(category);
-                        if (t != null) {
-                            if (!tags.isEmpty()) {
-                                tags.append(' ');
-                            }
-                            tags.append(t);
-                        }
+        StringBuilder tags = new StringBuilder();
+        for (LocaleDataMetaInfo ldmi :
+                ServiceLoader.loadInstalled(LocaleDataMetaInfo.class)) {
+            if (ldmi.getType() == LocaleProviderAdapter.Type.JRE) {
+                String t = ldmi.availableLanguageTags(category);
+                if (t != null) {
+                    if (!tags.isEmpty()) {
+                        tags.append(' ');
                     }
+                    tags.append(t);
                 }
-                return tags.toString();
-            });
-
-            if (nonBaseTags != null) {
-                supportedLocaleString += " " + nonBaseTags;
             }
-        } catch (PrivilegedActionException pae) {
-            throw new InternalError(pae.getCause());
+        }
+        String nonBaseTags = tags.toString();
+
+        if (nonBaseTags != null) {
+            supportedLocaleString += " " + nonBaseTags;
         }
 
         return supportedLocaleString;

--- a/src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java
+++ b/src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java
@@ -69,7 +69,7 @@ public abstract class BreakIteratorResourceBundle extends ResourceBundle {
         String path = getClass().getPackageName().replace('.', '/')
                       + '/' + info.getString(key);
         byte[] data;
-        try (InputStream is = getClass().getModule().getResourceAsStream(path);) {
+        try (InputStream is = getClass().getModule().getResourceAsStream(path)) {
             data = is.readAllBytes();
         } catch (Exception e) {
             throw new InternalError("Can't load " + path, e);

--- a/src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java
+++ b/src/java.base/share/classes/sun/util/resources/BreakIteratorResourceBundle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,9 +26,6 @@
 package sun.util.resources;
 
 import java.io.InputStream;
-import java.security.AccessController;
-import java.security.PrivilegedActionException;
-import java.security.PrivilegedExceptionAction;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.ResourceBundle;
@@ -72,25 +69,12 @@ public abstract class BreakIteratorResourceBundle extends ResourceBundle {
         String path = getClass().getPackageName().replace('.', '/')
                       + '/' + info.getString(key);
         byte[] data;
-        try (InputStream is = getResourceAsStream(path)) {
+        try (InputStream is = getClass().getModule().getResourceAsStream(path);) {
             data = is.readAllBytes();
         } catch (Exception e) {
             throw new InternalError("Can't load " + path, e);
         }
         return data;
-    }
-
-    @SuppressWarnings("removal")
-    private InputStream getResourceAsStream(String path) throws Exception {
-        PrivilegedExceptionAction<InputStream> pa;
-        pa = () -> getClass().getModule().getResourceAsStream(path);
-        InputStream is;
-        try {
-            is = AccessController.doPrivileged(pa);
-        } catch (PrivilegedActionException e) {
-            throw e.getException();
-        }
-        return is;
     }
 
     @Override

--- a/src/java.base/share/classes/sun/util/resources/Bundles.java
+++ b/src/java.base/share/classes/sun/util/resources/Bundles.java
@@ -265,7 +265,7 @@ public abstract class Bundles {
                 if (bundle != null) {
                     return bundle;
                 }
-            } catch (ServiceConfigurationError | SecurityException e) {
+            } catch (ServiceConfigurationError e) {
                 if (cacheKey != null) {
                     cacheKey.setCause(e);
                 }

--- a/src/java.base/share/classes/sun/util/resources/Bundles.java
+++ b/src/java.base/share/classes/sun/util/resources/Bundles.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -42,8 +42,6 @@ package sun.util.resources;
 
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.SoftReference;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.List;
@@ -255,32 +253,25 @@ public abstract class Bundles {
     /**
      * Loads ResourceBundle from service providers.
      */
-    @SuppressWarnings("removal")
     private static ResourceBundle loadBundleFromProviders(String baseName,
                                                           Locale locale,
                                                           ServiceLoader<ResourceBundleProvider> providers,
                                                           CacheKey cacheKey)
     {
-        return AccessController.doPrivileged(
-                new PrivilegedAction<>() {
-                    public ResourceBundle run() {
-                        for (Iterator<ResourceBundleProvider> itr = providers.iterator(); itr.hasNext(); ) {
-                            try {
-                                ResourceBundleProvider provider = itr.next();
-                                ResourceBundle bundle = provider.getBundle(baseName, locale);
-                                if (bundle != null) {
-                                    return bundle;
-                                }
-                            } catch (ServiceConfigurationError | SecurityException e) {
-                                if (cacheKey != null) {
-                                    cacheKey.setCause(e);
-                                }
-                            }
-                        }
-                        return null;
-                    }
-                });
-
+        for (Iterator<ResourceBundleProvider> itr = providers.iterator(); itr.hasNext(); ) {
+            try {
+                ResourceBundleProvider provider = itr.next();
+                ResourceBundle bundle = provider.getBundle(baseName, locale);
+                if (bundle != null) {
+                    return bundle;
+                }
+            } catch (ServiceConfigurationError | SecurityException e) {
+                if (cacheKey != null) {
+                    cacheKey.setCause(e);
+                }
+            }
+        }
+        return null;
     }
 
     private static boolean isValidBundle(ResourceBundle bundle) {

--- a/src/java.base/share/classes/sun/util/resources/LocaleData.java
+++ b/src/java.base/share/classes/sun/util/resources/LocaleData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -40,8 +40,6 @@
 
 package sun.util.resources;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -177,31 +175,19 @@ public class LocaleData {
         return getBundle(type.getTextResourcesPackage() + ".FormatData", locale);
     }
 
-    @SuppressWarnings("removal")
     public static ResourceBundle getBundle(final String baseName, final Locale locale) {
-        return AccessController.doPrivileged(new PrivilegedAction<>() {
-            @Override
-            public ResourceBundle run() {
-                return Bundles.of(baseName, locale, LocaleDataStrategy.INSTANCE);
-            }
-        });
+        return Bundles.of(baseName, locale, LocaleDataStrategy.INSTANCE);
     }
 
-    @SuppressWarnings("removal")
     private static OpenListResourceBundle getSupplementary(final String baseName, final Locale locale) {
-        return AccessController.doPrivileged(new PrivilegedAction<>() {
-           @Override
-           public OpenListResourceBundle run() {
-               OpenListResourceBundle rb = null;
-               try {
-                   rb = (OpenListResourceBundle) Bundles.of(baseName, locale,
-                                                            SupplementaryStrategy.INSTANCE);
-               } catch (MissingResourceException e) {
-                   // return null if no supplementary is available
-               }
-               return rb;
-           }
-        });
+       OpenListResourceBundle rb = null;
+       try {
+           rb = (OpenListResourceBundle) Bundles.of(baseName, locale,
+                                                    SupplementaryStrategy.INSTANCE);
+       } catch (MissingResourceException e) {
+           // return null if no supplementary is available
+       }
+       return rb;
     }
 
     private abstract static class LocaleDataResourceBundleProvider


### PR DESCRIPTION
Cleanup of doPrivileged in:
    sun.util.calendar
    sun.util.local/provider
    sun.util.cldr
    sun.util.resources

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344898](https://bugs.openjdk.org/browse/JDK-8344898): SM cleanup of java.base sun/util calendar, locale, cldr, and resources (**Bug** - P4)


### Reviewers
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22336/head:pull/22336` \
`$ git checkout pull/22336`

Update a local copy of the PR: \
`$ git checkout pull/22336` \
`$ git pull https://git.openjdk.org/jdk.git pull/22336/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22336`

View PR using the GUI difftool: \
`$ git pr show -t 22336`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22336.diff">https://git.openjdk.org/jdk/pull/22336.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22336#issuecomment-2495077842)
</details>
