### PR TITLE
8344894: Obsolete reference to checking permissions in java.awt.Composite

### DIFF
--- a/src/java.desktop/share/classes/java/awt/Composite.java
+++ b/src/java.desktop/share/classes/java/awt/Composite.java
@@ -53,14 +53,6 @@ import java.awt.image.ColorModel;
  * {@code Graphics2D}, resulting from the modification of
  * the {@code Composite} object after it has been set in the
  * {@code Graphics2D} context.
- * <p>
- * Since this interface must expose the contents of pixels on the
- * target device or image to potentially arbitrary code, the use of
- * custom objects which implement this interface when rendering directly
- * to a screen device is governed by the {@code readDisplayPixels}
- * {@link AWTPermission}.  The permission check will occur when such
- * a custom object is passed to the {@code setComposite} method
- * of a {@code Graphics2D} retrieved from a {@link Component}.
  * @see AlphaComposite
  * @see CompositeContext
  * @see Graphics2D#setComposite


### PR DESCRIPTION
The spec. for java.awt.Composite decsribing permissions should have been updated in the JEP 486 integration but was missed.
Fixing that here. CSR needed of course : https://bugs.openjdk.org/browse/JDK-8344900

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8344900](https://bugs.openjdk.org/browse/JDK-8344900) to be approved

### Issues
 * [JDK-8344894](https://bugs.openjdk.org/browse/JDK-8344894): Obsolete reference to checking permissions in java.awt.Composite (**Bug** - P4)
 * [JDK-8344900](https://bugs.openjdk.org/browse/JDK-8344900): Obsolete reference to checking permissions in java.awt.Composite (**CSR**)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Kevin Rushforth](https://openjdk.org/census#kcr) (@kevinrushforth - Author)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22338/head:pull/22338` \
`$ git checkout pull/22338`

Update a local copy of the PR: \
`$ git checkout pull/22338` \
`$ git pull https://git.openjdk.org/jdk.git pull/22338/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22338`

View PR using the GUI difftool: \
`$ git pr show -t 22338`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22338.diff">https://git.openjdk.org/jdk/pull/22338.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22338#issuecomment-2495097766)
</details>
