### PR TITLE
8344882: (bf) Temporary direct buffers should not count against the upper limit on direct buffer memory

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -848,7 +848,7 @@ public abstract sealed class Buffer
                 }
 
                 @Override
-                public ByteBuffer allocateDirectTemporary(int cap) {
+                public ByteBuffer allocateTemporaryDirectBuffer(int cap) {
                     return new DirectByteBuffer(cap, true);
                 }
 

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -848,8 +848,9 @@ public abstract sealed class Buffer
                 }
 
                 @Override
-                public ByteBuffer allocateTemporaryDirectBuffer(int cap) {
-                    return new DirectByteBuffer(cap, true);
+                public ByteBuffer newDirectByteBuffer(int cap) {
+                    long addr = UNSAFE.allocateMemory(cap);
+                    return new DirectByteBuffer(addr, cap);
                 }
 
                 @ForceInline

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -848,8 +848,7 @@ public abstract sealed class Buffer
                 }
 
                 @Override
-                public ByteBuffer newDirectByteBuffer(int cap) {
-                    long addr = UNSAFE.allocateMemory(cap);
+                public ByteBuffer newDirectByteBuffer(long addr, int cap) {
                     return new DirectByteBuffer(addr, cap);
                 }
 

--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -847,6 +847,11 @@ public abstract sealed class Buffer
                     return new HeapByteBuffer(hb, -1, 0, capacity, capacity, offset, segment);
                 }
 
+                @Override
+                public ByteBuffer allocateDirectTemporary(int cap) {
+                    return new DirectByteBuffer(cap, true);
+                }
+
                 @ForceInline
                 @Override
                 public Object getBufferBase(Buffer buffer) {

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -39,9 +39,6 @@ import jdk.internal.misc.ScopedMemoryAccess.ScopedAccessError;
 import jdk.internal.misc.VM;
 import jdk.internal.ref.Cleaner;
 import sun.nio.ch.DirectBuffer;
-#if[byte]
-import jdk.internal.vm.annotation.Stable;
-#end[byte]
 
 #if[rw]
 sealed

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -76,16 +76,14 @@ class Direct$Type$Buffer$RW$$BO$
 
     private @Stable boolean temporary; // defaults to false
 
-    private record Deallocator(long address, long size, int capacity,
-                               boolean temporary) implements Runnable {
+    private record Deallocator(long address, long size, int capacity) implements Runnable {
         private Deallocator {
             assert address != 0;
         }
 
         public void run() {
             UNSAFE.freeMemory(address);
-            if (!temporary)
-                Bits.unreserveMemory(size, capacity);
+            Bits.unreserveMemory(size, capacity);
         }
     }
 
@@ -130,14 +128,16 @@ class Direct$Type$Buffer$RW$$BO$
         } else {
             address = base;
         }
-        try {
-            cleaner = Cleaner.create(this, new Deallocator(base, size, cap, temporary));
-        } catch (Throwable t) {
-            // Prevent leak if the Deallocator or Cleaner fail for any reason
-            UNSAFE.freeMemory(base);
-            if (!temporary)
-                Bits.unreserveMemory(size, cap);
-            throw t;
+        if (!temporary) {
+            try {
+                cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+            } catch (Throwable t) {
+                // Prevent leak if the Deallocator or Cleaner fail for any reason
+                UNSAFE.freeMemory(base);
+                throw t;
+            }
+        } else { // temporary
+            cleaner = null;
         }
         att = null;
 #else[rw]

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -40,6 +40,7 @@ import jdk.internal.misc.VM;
 import jdk.internal.ref.Cleaner;
 import sun.nio.ch.DirectBuffer;
 
+
 #if[rw]
 sealed
 #else[rw]
@@ -98,21 +99,19 @@ class Direct$Type$Buffer$RW$$BO$
 
     // Primary constructor
     //
-    Direct$Type$Buffer$RW$(int cap, boolean temporary) { // package-private
+    Direct$Type$Buffer$RW$(int cap) {                   // package-private
 #if[rw]
         super(-1, 0, cap, cap, null);
         boolean pa = VM.isDirectMemoryPageAligned();
         int ps = Bits.pageSize();
         long size = Math.max(1L, (long)cap + (pa ? ps : 0));
-        if (!temporary)
-            Bits.reserveMemory(size, cap);
+        Bits.reserveMemory(size, cap);
 
         long base = 0;
         try {
             base = UNSAFE.allocateMemory(size);
         } catch (OutOfMemoryError x) {
-            if (!temporary)
-                Bits.unreserveMemory(size, cap);
+            Bits.unreserveMemory(size, cap);
             throw x;
         }
         UNSAFE.setMemory(base, size, (byte) 0);
@@ -122,26 +121,19 @@ class Direct$Type$Buffer$RW$$BO$
         } else {
             address = base;
         }
-        if (!temporary) {
-            try {
-                cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
-            } catch (Throwable t) {
-                // Prevent leak if the Deallocator or Cleaner fail for any reason
-                UNSAFE.freeMemory(base);
-                throw t;
-            }
-        } else { // temporary
-            cleaner = null;
+        try {
+            cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+        } catch (Throwable t) {
+            // Prevent leak if the Deallocator or Cleaner fail for any reason
+            UNSAFE.freeMemory(base);
+            Bits.unreserveMemory(size, cap);
+            throw t;
         }
         att = null;
 #else[rw]
         super(cap);
         this.isReadOnly = true;
 #end[rw]
-    }
-
-    Direct$Type$Buffer$RW$(int cap) { // package-private
-        this(cap, false);
     }
 
 #if[rw]
@@ -167,9 +159,10 @@ class Direct$Type$Buffer$RW$$BO$
     }
 
     // Invoked only by JNI: NewDirectByteBuffer(void*, long)
+    // and JavaNioAccess.newDirectByteBuffer(int).
     // The long-valued capacity is restricted to int range.
     //
-    private Direct$Type$Buffer(long addr, long cap) {
+    Direct$Type$Buffer(long addr, long cap) {
         super(-1, 0, checkCapacity(cap), (int)cap, null);
         address = addr;
         cleaner = null;

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -74,8 +74,6 @@ class Direct$Type$Buffer$RW$$BO$
     // Cached unaligned-access capability
     static final boolean UNALIGNED = Bits.unaligned();
 
-    private @Stable boolean temporary; // defaults to false
-
     private record Deallocator(long address, long size, int capacity) implements Runnable {
         private Deallocator {
             assert address != 0;
@@ -106,7 +104,6 @@ class Direct$Type$Buffer$RW$$BO$
     Direct$Type$Buffer$RW$(int cap, boolean temporary) { // package-private
 #if[rw]
         super(-1, 0, cap, cap, null);
-        this.temporary = temporary;
         boolean pa = VM.isDirectMemoryPageAligned();
         int ps = Bits.pageSize();
         long size = Math.max(1L, (long)cap + (pa ? ps : 0));

--- a/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
+++ b/src/java.base/share/classes/java/nio/Direct-X-Buffer.java.template
@@ -39,7 +39,9 @@ import jdk.internal.misc.ScopedMemoryAccess.ScopedAccessError;
 import jdk.internal.misc.VM;
 import jdk.internal.ref.Cleaner;
 import sun.nio.ch.DirectBuffer;
-
+#if[byte]
+import jdk.internal.vm.annotation.Stable;
+#end[byte]
 
 #if[rw]
 sealed
@@ -72,14 +74,18 @@ class Direct$Type$Buffer$RW$$BO$
     // Cached unaligned-access capability
     static final boolean UNALIGNED = Bits.unaligned();
 
-    private record Deallocator(long address, long size, int capacity) implements Runnable {
+    private @Stable boolean temporary; // defaults to false
+
+    private record Deallocator(long address, long size, int capacity,
+                               boolean temporary) implements Runnable {
         private Deallocator {
             assert address != 0;
         }
 
         public void run() {
             UNSAFE.freeMemory(address);
-            Bits.unreserveMemory(size, capacity);
+            if (!temporary)
+                Bits.unreserveMemory(size, capacity);
         }
     }
 
@@ -99,19 +105,22 @@ class Direct$Type$Buffer$RW$$BO$
 
     // Primary constructor
     //
-    Direct$Type$Buffer$RW$(int cap) {                   // package-private
+    Direct$Type$Buffer$RW$(int cap, boolean temporary) { // package-private
 #if[rw]
         super(-1, 0, cap, cap, null);
+        this.temporary = temporary;
         boolean pa = VM.isDirectMemoryPageAligned();
         int ps = Bits.pageSize();
         long size = Math.max(1L, (long)cap + (pa ? ps : 0));
-        Bits.reserveMemory(size, cap);
+        if (!temporary)
+            Bits.reserveMemory(size, cap);
 
         long base = 0;
         try {
             base = UNSAFE.allocateMemory(size);
         } catch (OutOfMemoryError x) {
-            Bits.unreserveMemory(size, cap);
+            if (!temporary)
+                Bits.unreserveMemory(size, cap);
             throw x;
         }
         UNSAFE.setMemory(base, size, (byte) 0);
@@ -122,11 +131,12 @@ class Direct$Type$Buffer$RW$$BO$
             address = base;
         }
         try {
-            cleaner = Cleaner.create(this, new Deallocator(base, size, cap));
+            cleaner = Cleaner.create(this, new Deallocator(base, size, cap, temporary));
         } catch (Throwable t) {
             // Prevent leak if the Deallocator or Cleaner fail for any reason
             UNSAFE.freeMemory(base);
-            Bits.unreserveMemory(size, cap);
+            if (!temporary)
+                Bits.unreserveMemory(size, cap);
             throw t;
         }
         att = null;
@@ -134,6 +144,10 @@ class Direct$Type$Buffer$RW$$BO$
         super(cap);
         this.isReadOnly = true;
 #end[rw]
+    }
+
+    Direct$Type$Buffer$RW$(int cap) { // package-private
+        this(cap, false);
     }
 
 #if[rw]

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
@@ -70,7 +70,7 @@ public interface JavaNioAccess {
     /**
      * Used by {@code sun.nio.ch.Util}.
      */
-    ByteBuffer newDirectByteBuffer(int cap);
+    ByteBuffer newDirectByteBuffer(long addr, int cap);
 
     /**
      * Used by {@code jdk.internal.foreign.Utils}.

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
@@ -70,7 +70,7 @@ public interface JavaNioAccess {
     /**
      * Used by {@code sun.nio.ch.Util}.
      */
-    ByteBuffer allocateTemporaryDirectBuffer(int cap);
+    ByteBuffer newDirectByteBuffer(int cap);
 
     /**
      * Used by {@code jdk.internal.foreign.Utils}.

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
@@ -70,7 +70,7 @@ public interface JavaNioAccess {
     /**
      * Used by {@code sun.nio.ch.Util}.
      */
-    ByteBuffer allocateDirectTemporary(int cap);
+    ByteBuffer allocateTemporaryDirectBuffer(int cap);
 
     /**
      * Used by {@code jdk.internal.foreign.Utils}.

--- a/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
+++ b/src/java.base/share/classes/jdk/internal/access/JavaNioAccess.java
@@ -68,6 +68,11 @@ public interface JavaNioAccess {
     ByteBuffer newHeapByteBuffer(byte[] hb, int offset, int capacity, MemorySegment segment);
 
     /**
+     * Used by {@code sun.nio.ch.Util}.
+     */
+    ByteBuffer allocateDirectTemporary(int cap);
+
+    /**
      * Used by {@code jdk.internal.foreign.Utils}.
      */
     Object getBufferBase(Buffer bb);

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -325,7 +325,7 @@ public class Util {
      * Frees the memory for the given direct buffer
      */
     private static void free(ByteBuffer buf) {
-        ((DirectBuffer)buf).cleaner().clean();
+        unsafe.freeMemory(((DirectBuffer)buf).address());
     }
 
 

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -225,7 +225,8 @@ public class Util {
         // to remove the buffer from the cache (as this method does
         // below) given that we won't put the new buffer in the cache.
         if (isBufferTooLarge(size)) {
-            return NIO_ACCESS.newDirectByteBuffer(size);
+            long addr = unsafe.allocateMemory(size);
+            return NIO_ACCESS.newDirectByteBuffer(addr, size);
         }
 
         BufferCache cache = bufferCache.get();
@@ -240,7 +241,8 @@ public class Util {
                 buf = cache.removeFirst();
                 free(buf);
             }
-            return NIO_ACCESS.newDirectByteBuffer(size);
+            long addr = unsafe.allocateMemory(size);
+            return NIO_ACCESS.newDirectByteBuffer(addr, size);
         }
     }
 
@@ -251,8 +253,8 @@ public class Util {
     public static ByteBuffer getTemporaryAlignedDirectBuffer(int size,
                                                              int alignment) {
         if (isBufferTooLarge(size)) {
-            return NIO_ACCESS.newDirectByteBuffer(size + alignment - 1)
-                    .alignedSlice(alignment);
+            return getTemporaryDirectBuffer(size + alignment - 1)
+                .alignedSlice(alignment);
         }
 
         BufferCache cache = bufferCache.get();
@@ -267,8 +269,8 @@ public class Util {
                 free(buf);
             }
         }
-        return NIO_ACCESS.newDirectByteBuffer(size + alignment - 1)
-                .alignedSlice(alignment);
+        return getTemporaryDirectBuffer(size + alignment - 1)
+            .alignedSlice(alignment);
     }
 
     /**

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -225,7 +225,7 @@ public class Util {
         // to remove the buffer from the cache (as this method does
         // below) given that we won't put the new buffer in the cache.
         if (isBufferTooLarge(size)) {
-            return NIO_ACCESS.allocateDirectTemporary(size);
+            return NIO_ACCESS.allocateTemporaryDirectBuffer(size);
         }
 
         BufferCache cache = bufferCache.get();
@@ -240,7 +240,7 @@ public class Util {
                 buf = cache.removeFirst();
                 free(buf);
             }
-            return NIO_ACCESS.allocateDirectTemporary(size);
+            return NIO_ACCESS.allocateTemporaryDirectBuffer(size);
         }
     }
 
@@ -251,7 +251,7 @@ public class Util {
     public static ByteBuffer getTemporaryAlignedDirectBuffer(int size,
                                                              int alignment) {
         if (isBufferTooLarge(size)) {
-            return NIO_ACCESS.allocateDirectTemporary(size + alignment - 1)
+            return NIO_ACCESS.allocateTemporaryDirectBuffer(size + alignment - 1)
                     .alignedSlice(alignment);
         }
 
@@ -267,7 +267,7 @@ public class Util {
                 free(buf);
             }
         }
-        return NIO_ACCESS.allocateDirectTemporary(size + alignment - 1)
+        return NIO_ACCESS.allocateTemporaryDirectBuffer(size + alignment - 1)
                 .alignedSlice(alignment);
     }
 

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -281,11 +281,22 @@ public class Util {
     }
 
     /**
+     * Return the underling byte buffer if the given byte buffer is
+     * an aligned slice.
+     */
+    private static ByteBuffer unwrapIfAlignedSlice(ByteBuffer buf) {
+        var parent = (ByteBuffer) ((DirectBuffer) buf).attachment();
+        return (parent != null) ? parent : buf;
+    }
+
+    /**
      * Releases a temporary buffer by returning to the cache or freeing it. If
      * returning to the cache then insert it at the start so that it is
      * likely to be returned by a subsequent call to getTemporaryDirectBuffer.
      */
     static void offerFirstTemporaryDirectBuffer(ByteBuffer buf) {
+        buf = unwrapIfAlignedSlice(buf);
+
         // If the buffer is too large for the cache we don't have to
         // check the cache. We'll just free it.
         if (isBufferTooLarge(buf)) {
@@ -308,6 +319,8 @@ public class Util {
      * cache in same order that they were obtained.
      */
     static void offerLastTemporaryDirectBuffer(ByteBuffer buf) {
+        buf = unwrapIfAlignedSlice(buf);
+
         // If the buffer is too large for the cache we don't have to
         // check the cache. We'll just free it.
         if (isBufferTooLarge(buf)) {

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -36,10 +36,14 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 
+import jdk.internal.access.JavaNioAccess;
+import jdk.internal.access.SharedSecrets;
 import jdk.internal.misc.TerminatingThreadLocal;
 import jdk.internal.misc.Unsafe;
 
 public class Util {
+
+    private static final JavaNioAccess NIO_ACCESS = SharedSecrets.getJavaNioAccess();
 
     // -- Caches --
 
@@ -221,7 +225,7 @@ public class Util {
         // to remove the buffer from the cache (as this method does
         // below) given that we won't put the new buffer in the cache.
         if (isBufferTooLarge(size)) {
-            return ByteBuffer.allocateDirect(size);
+            return NIO_ACCESS.allocateDirectTemporary(size);
         }
 
         BufferCache cache = bufferCache.get();
@@ -236,7 +240,7 @@ public class Util {
                 buf = cache.removeFirst();
                 free(buf);
             }
-            return ByteBuffer.allocateDirect(size);
+            return NIO_ACCESS.allocateDirectTemporary(size);
         }
     }
 
@@ -247,7 +251,7 @@ public class Util {
     public static ByteBuffer getTemporaryAlignedDirectBuffer(int size,
                                                              int alignment) {
         if (isBufferTooLarge(size)) {
-            return ByteBuffer.allocateDirect(size + alignment - 1)
+            return NIO_ACCESS.allocateDirectTemporary(size + alignment - 1)
                     .alignedSlice(alignment);
         }
 
@@ -263,7 +267,7 @@ public class Util {
                 free(buf);
             }
         }
-        return ByteBuffer.allocateDirect(size + alignment - 1)
+        return NIO_ACCESS.allocateDirectTemporary(size + alignment - 1)
                 .alignedSlice(alignment);
     }
 

--- a/src/java.base/share/classes/sun/nio/ch/Util.java
+++ b/src/java.base/share/classes/sun/nio/ch/Util.java
@@ -225,7 +225,7 @@ public class Util {
         // to remove the buffer from the cache (as this method does
         // below) given that we won't put the new buffer in the cache.
         if (isBufferTooLarge(size)) {
-            return NIO_ACCESS.allocateTemporaryDirectBuffer(size);
+            return NIO_ACCESS.newDirectByteBuffer(size);
         }
 
         BufferCache cache = bufferCache.get();
@@ -240,7 +240,7 @@ public class Util {
                 buf = cache.removeFirst();
                 free(buf);
             }
-            return NIO_ACCESS.allocateTemporaryDirectBuffer(size);
+            return NIO_ACCESS.newDirectByteBuffer(size);
         }
     }
 
@@ -251,7 +251,7 @@ public class Util {
     public static ByteBuffer getTemporaryAlignedDirectBuffer(int size,
                                                              int alignment) {
         if (isBufferTooLarge(size)) {
-            return NIO_ACCESS.allocateTemporaryDirectBuffer(size + alignment - 1)
+            return NIO_ACCESS.newDirectByteBuffer(size + alignment - 1)
                     .alignedSlice(alignment);
         }
 
@@ -267,7 +267,7 @@ public class Util {
                 free(buf);
             }
         }
-        return NIO_ACCESS.allocateTemporaryDirectBuffer(size + alignment - 1)
+        return NIO_ACCESS.newDirectByteBuffer(size + alignment - 1)
                 .alignedSlice(alignment);
     }
 

--- a/test/jdk/ProblemList-Virtual.txt
+++ b/test/jdk/ProblemList-Virtual.txt
@@ -69,6 +69,3 @@ java/util/Properties/StoreReproducibilityTest.java 0000000 generic-all
 java/util/Properties/StoreReproducibilityTest.java 0000000 generic-all
 javax/management/ImplementationVersion/ImplVersionTest.java 0000000 generic-all
 javax/management/remote/mandatory/version/ImplVersionTest.java 0000000 generic-all
-
-# Direct buffer memory allocated before test launch
-java/nio/Buffer/LimitDirectMemory.java 8342849 generic-all


### PR DESCRIPTION
Make the memory used by internal temporary direct buffers not count towards the upper limit on direct buffer memory.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8344997](https://bugs.openjdk.org/browse/JDK-8344997) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8344882](https://bugs.openjdk.org/browse/JDK-8344882): (bf) Temporary direct buffers should not count against the upper limit on direct buffer memory (**Enhancement** - P4)
 * [JDK-8344997](https://bugs.openjdk.org/browse/JDK-8344997): (bf) Temporary direct buffers should not count against the upper limit on direct buffer memory (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22339/head:pull/22339` \
`$ git checkout pull/22339`

Update a local copy of the PR: \
`$ git checkout pull/22339` \
`$ git pull https://git.openjdk.org/jdk.git pull/22339/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22339`

View PR using the GUI difftool: \
`$ git pr show -t 22339`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22339.diff">https://git.openjdk.org/jdk/pull/22339.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22339#issuecomment-2495109186)
</details>
