### PR TITLE
8344904: Interned strings in old classes are not stored in CDS archive

### DIFF
--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -1014,9 +1014,7 @@ void VM_PopulateDumpSharedSpace::dump_java_heap_objects(GrowableArray<Klass*>* k
     Klass* k = klasses->at(i);
     if (k->is_instance_klass()) {
       InstanceKlass* ik = InstanceKlass::cast(k);
-      if (ik->is_linked()) {
-        ik->constants()->add_dumped_interned_strings();
-      }
+      ik->constants()->add_dumped_interned_strings();
     }
   }
   if (_extra_interned_strings != nullptr) {

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -408,8 +408,8 @@ void ConstantPool::add_dumped_interned_strings() {
   InstanceKlass* ik = pool_holder();
   if (!ik->is_linked()) {
     // resolved_references() doesn't exist yet, so we have no resolved CONSTANT_String entries. However,
-    // Some static final fields may have default values that were initialized when the class was parsed.
-    // We need to enter those into the CDS archived strings table.
+    // some static final fields may have default values that were initialized when the class was parsed.
+    // We need to enter those into the CDS archive strings table.
     for (JavaFieldStream fs(ik); !fs.done(); fs.next()) {
       if (fs.access_flags().is_static()) {
         fieldDescriptor& fd = fs.field_descriptor();

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -53,6 +53,7 @@
 #include "oops/array.hpp"
 #include "oops/constantPool.inline.hpp"
 #include "oops/cpCache.inline.hpp"
+#include "oops/fieldStreams.inline.hpp"
 #include "oops/instanceKlass.hpp"
 #include "oops/klass.inline.hpp"
 #include "oops/objArrayKlass.hpp"
@@ -61,6 +62,7 @@
 #include "oops/typeArrayOop.inline.hpp"
 #include "prims/jvmtiExport.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/fieldDescriptor.inline.hpp"
 #include "runtime/handles.inline.hpp"
 #include "runtime/init.hpp"
 #include "runtime/javaCalls.hpp"
@@ -403,18 +405,38 @@ void ConstantPool::find_required_hidden_classes() {
 }
 
 void ConstantPool::add_dumped_interned_strings() {
-  objArrayOop rr = resolved_references();
-  if (rr != nullptr) {
-    int rr_len = rr->length();
-    for (int i = 0; i < rr_len; i++) {
-      oop p = rr->obj_at(i);
-      if (java_lang_String::is_instance(p) &&
-          !ArchiveHeapWriter::is_string_too_large_to_archive(p)) {
-        HeapShared::add_to_dumped_interned_strings(p);
+  InstanceKlass* ik = pool_holder();
+  if (!ik->is_linked()) {
+    // resolved_references() doesn't exist yet, so we have no resolved CONSTANT_String entries. However,
+    // Some static final fields may have default values that were initialized when the class was parsed.
+    // We need to enter those into the CDS archived strings table.
+    for (JavaFieldStream fs(ik); !fs.done(); fs.next()) {
+      if (fs.access_flags().is_static()) {
+        fieldDescriptor& fd = fs.field_descriptor();
+        if (fd.field_type() == T_OBJECT) {
+          int offset = fd.offset();
+          check_and_add_dumped_interned_string(ik->java_mirror()->obj_field(offset));
+        }
+      }
+    }
+  } else {
+    objArrayOop rr = resolved_references();
+    if (rr != nullptr) {
+      int rr_len = rr->length();
+      for (int i = 0; i < rr_len; i++) {
+        check_and_add_dumped_interned_string(rr->obj_at(i));
       }
     }
   }
 }
+
+void ConstantPool::check_and_add_dumped_interned_string(oop obj) {
+  if (obj != nullptr && java_lang_String::is_instance(obj) &&
+      !ArchiveHeapWriter::is_string_too_large_to_archive(obj)) {
+    HeapShared::add_to_dumped_interned_strings(obj);
+  }
+}
+
 #endif
 
 #if INCLUDE_CDS

--- a/src/hotspot/share/oops/constantPool.hpp
+++ b/src/hotspot/share/oops/constantPool.hpp
@@ -162,6 +162,7 @@ class ConstantPool : public Metadata {
     assert(is_within_bounds(cp_index), "index out of bounds");
     return (jdouble*) &base()[cp_index];
   }
+  static void check_and_add_dumped_interned_string(oop obj);
 
   ConstantPool(Array<u1>* tags);
   ConstantPool();

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/OldClassWithStaticString.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/OldClassWithStaticString.jasm
@@ -24,6 +24,8 @@
 
 /*
 
+// Compiled from this source, but we want the version to be 49.0 to use the old verifier.
+
 class OldClassWithStaticString {
     static final String s = "xxxx123yyyy456";
     static final String t = "OldClassWithStaticString";

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/OldClassWithStaticString.jasm
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/OldClassWithStaticString.jasm
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/*
+
+class OldClassWithStaticString {
+    static final String s = "xxxx123yyyy456";
+    static final String t = "OldClassWithStaticString";
+}
+
+*/
+
+public super class OldClassWithStaticString
+    version 49:0
+{
+    public static final Field s:"Ljava/lang/String;" = String "xxxx123yyyy456";
+    public static final Field t:"Ljava/lang/String;" = String "OldClassWithStaticString";
+
+    Method "<init>":"()V"
+        stack 1 locals 1
+    {
+        aload_0;
+        invokespecial Method java/lang/Object."<init>":"()V";
+        return;
+    }
+}

--- a/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/StaticStringInOldClass.java
+++ b/test/hotspot/jtreg/runtime/cds/appcds/sharedStrings/StaticStringInOldClass.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+/**
+ * @test
+ * @bug 8344904
+ * @summary make sure all interned strings in old classes are archived.
+ * @requires vm.cds.write.archived.java.heap
+ * @library /test/lib /test/hotspot/jtreg/runtime/cds/appcds
+ * @build OldClassWithStaticString
+ * @build StaticStringInOldClass
+ * @run driver jdk.test.lib.helpers.ClassFileInstaller
+ *                 -jar StaticStringInOldClass.jar StaticStringInOldClass StaticStringInOldClassApp OldClassWithStaticString
+ * @run driver StaticStringInOldClass
+ */
+
+import java.lang.reflect.Field;
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.helpers.ClassFileInstaller;
+
+public class StaticStringInOldClass {
+    static final String appClass = StaticStringInOldClassApp.class.getName();
+    static String[] classes = {
+        appClass,
+        OldClassWithStaticString.class.getName(),
+    };
+
+    public static void main(String[] args) throws Exception {
+        String appJar = ClassFileInstaller.getJarPath("StaticStringInOldClass.jar");
+        OutputAnalyzer output;
+        output = TestCommon.testDump(appJar, TestCommon.list(classes));
+        output = TestCommon.exec(appJar, appClass);
+        TestCommon.checkExec(output, "Hello");
+    }
+}
+
+class StaticStringInOldClassApp {
+    static String a = "xxxx123";
+    public static void main(String args[]) throws Exception {
+        System.out.println("Hello");
+        String x = (a + "yyyy456").intern();
+        Class c = OldClassWithStaticString.class;
+        Field f = c.getField("s");
+        String y = (String)(f.get(null));
+        if (x != y) {
+            throw new RuntimeException("Interned strings not equal: " +
+                                       "\"" + x + "\" @ " + System.identityHashCode(x) + " vs " +
+                                       "\"" + y + "\" @ " + System.identityHashCode(y));
+        }
+    }
+}


### PR DESCRIPTION
Before this fix, CDS will only archive interned strings that are reachable from `ConstantPool::resolved_references()`, which is created only after a class is linked. However, old classes are not linked, so we didn't archive their interned strings.

It's possible for the Java mirror of an (unlinked) old class to point to interned strings. E.g.,

```
public super class OldClassWithStaticString
    version 49:0
{
    public static final Field s:"Ljava/lang/String;" = String "xxxx123yyyy456";
```

The 's' field is initialized during class file parsing, so we must intern the `"xxxx123yyyy456"` string.

The fix is to collect interned strings from the static fields of unlinked classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344904](https://bugs.openjdk.org/browse/JDK-8344904): Interned strings in old classes are not stored in CDS archive (**Bug** - P3)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Calvin Cheung](https://openjdk.org/census#ccheung) (@calvinccheung - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22340/head:pull/22340` \
`$ git checkout pull/22340`

Update a local copy of the PR: \
`$ git checkout pull/22340` \
`$ git pull https://git.openjdk.org/jdk.git pull/22340/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22340`

View PR using the GUI difftool: \
`$ git pr show -t 22340`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22340.diff">https://git.openjdk.org/jdk/pull/22340.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22340#issuecomment-2495272523)
</details>
