### PR TITLE
8344903: Improve error handling TestJhsdbJstackPrintVMLocks.java

### DIFF
--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
@@ -79,7 +79,10 @@ public class TestJhsdbJstackPrintVMLocks {
             }
             throw new RuntimeException("Not able to find lock");
         } finally {
-            LingeredApp.stopApp(theApp);
+            if (theApp.getProcess() != null) {
+                theApp.deleteLock();
+                theApp.getProcess().destroyForcibly();
+            }
         }
     }
 }

--- a/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
+++ b/test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java
@@ -79,7 +79,7 @@ public class TestJhsdbJstackPrintVMLocks {
             }
             throw new RuntimeException("Not able to find lock");
         } finally {
-            theApp.getProcess().destroyForcibly();
+            LingeredApp.stopApp(theApp);
         }
     }
 }


### PR DESCRIPTION
Hi all,
The newly added test `test/hotspot/jtreg/serviceability/sa/TestJhsdbJstackPrintVMLocks.java` intermittent fails `the return value of "jdk.test.lib.apps.LingeredApp.getProcess()" is null`. This PR check `getProcess()` is null or not before invoke `destroyForcibly`. Test-fix only, the change has been verified locally, no risk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344903](https://bugs.openjdk.org/browse/JDK-8344903): Improve error handling TestJhsdbJstackPrintVMLocks.java (**Bug** - P4)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22342/head:pull/22342` \
`$ git checkout pull/22342`

Update a local copy of the PR: \
`$ git checkout pull/22342` \
`$ git pull https://git.openjdk.org/jdk.git pull/22342/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22342`

View PR using the GUI difftool: \
`$ git pr show -t 22342`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22342.diff">https://git.openjdk.org/jdk/pull/22342.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22342#issuecomment-2495475838)
</details>
