### PR TITLE
8344911: Introduce test utility for asserting file open status

### DIFF
--- a/test/lib-test/jdk/test/lib/util/OpenFilesTest.java
+++ b/test/lib-test/jdk/test/lib/util/OpenFilesTest.java
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.*;
+import java.nio.channels.Channel;
+import java.nio.channels.FileChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Stream;
+
+import static jdk.test.lib.Asserts.assertNotNull;
+import static jdk.test.lib.Asserts.assertTrue;
+import static jdk.test.lib.util.OpenFiles.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/*
+ * @test
+ * @summary verify functionality of the OpenFilesAgent Java agent
+ * @library /test/lib
+ * @build jdk.test.lib.util.OpenFilesAgent jdk.test.lib.util.OpenFiles
+ * @run driver jdk.test.lib.util.OpenFilesAgent
+ * @run junit/othervm -javaagent:OpenFilesAgent.jar OpenFilesTest
+ */
+public class OpenFilesTest {
+
+    private Path file = Path.of("testfile.txt");
+
+    @BeforeEach
+    public void setup() throws IOException {
+        Files.createFile(file);
+    }
+
+    @AfterEach
+    public void cleanup() throws IOException {
+        Files.delete(file);
+    }
+
+    // Provide file APIs to exercise tests on
+    public static Stream<Arguments> arguments() {
+        return Stream.of(
+                Arguments.of(new FileInputStreamResource()),
+                Arguments.of(new FileOutputStreamResource()),
+                Arguments.of(new RandomAccessFileResource()),
+                Arguments.of(new FilesNewByteChannelResource()),
+                Arguments.of(new FilesNewInputStreamResource()),
+                Arguments.of(new FilesNewOutputStreamResource()),
+                Arguments.of(new FileChannelResource())
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    public void shouldDetectOpenAndClose(Resource resource) throws IOException {
+        // Sanity check
+        assertClosed(file);
+
+        // Open the file
+        resource.open(file);
+
+        // Verify open status
+        assertOpen(file);
+        assertOpen(file.toFile());
+        assertOpen(file.toAbsolutePath());
+        assertOpen(file.toString());
+        assertOpenIf(true, file);
+
+        // Close the file
+        resource.close();
+
+        // Verify closed status
+        assertClosed(file);
+        assertClosed(file.toFile());
+        assertClosed(file.toAbsolutePath());
+        assertClosed(file.toString());
+        assertOpenIf(false, file);
+
+    }
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    public void shouldRejectOpenAndClose(Resource resource) throws IOException {
+        // Sanity checks
+        assertClosed(file);
+
+        // Open the file
+        resource.open(file);
+
+        // Fail closed status
+        assertThrows(AssertionError.class, () -> {
+            assertClosed(file);
+        });
+        assertThrows(AssertionError.class, () -> {
+            assertClosed(file.toFile());
+        });
+        assertThrows(AssertionError.class, () -> {
+            assertClosed(file.toAbsolutePath());
+        });
+        assertThrows(AssertionError.class, () -> {
+            assertClosed(file.toString());
+        });
+
+        // Close the file
+        resource.close();
+
+        // Fail open status
+        assertThrows(AssertionError.class, () -> {
+            assertOpen(file);
+        });
+        assertThrows(AssertionError.class, () -> {
+            assertOpen(file.toFile());
+        });
+        assertThrows(AssertionError.class, () -> {
+            assertOpen(file.toAbsolutePath());
+        });
+        assertThrows(AssertionError.class, () -> {
+            assertOpen(file.toString());
+        });
+    }
+
+    @ParameterizedTest
+    @MethodSource("arguments")
+    public void shouldCaptureOpeningStackTrace(Resource resource) throws IOException {
+
+        // Open the file
+        resource.open(file);
+
+        // Capture an AssertionError
+        AssertionError e = assertThrows(AssertionError.class, () -> assertClosed(file));
+
+        // Close file up
+        resource.close();
+        assertClosed(file);
+
+        // The cause is the capture
+        Throwable capture = e.getCause();
+        assertNotNull(capture);
+
+        // Message should include a mention of the file path
+        assertTrue(capture.getMessage().contains(file.toString()),
+                "Expected capture to mention file " + file.toString());
+
+        // Stack trace should include this method
+        assertStackTraceIncludes(capture, getClass(), "shouldCaptureOpeningStackTrace");
+
+        // Stack trace should include Resource.open
+        assertStackTraceIncludes(capture, resource.getClass(), "open");
+    }
+
+    // Assert that a method is found in the stack trace of the given Throwable
+    private void assertStackTraceIncludes(Throwable capture, Class<?> clazz, String methodName) {
+        for (StackTraceElement se : capture.getStackTrace()) {
+            if (se.getClassName().equals(clazz.getName()) && se.getMethodName().equals(methodName)) {
+                return;
+            }
+        }
+        fail("Expected stack trace to include " + clazz.getName() + "." + methodName);
+    }
+
+    // Abstraction for APIs which can open and close files
+    interface Resource {
+        void open(Path path) throws IOException;
+        void close() throws IOException;
+    }
+
+    static class FileInputStreamResource implements Resource {
+        private FileInputStream fis;
+
+        @Override
+        public void open(Path path) throws IOException {
+            this.fis = new FileInputStream(path.toFile());
+        }
+
+        @Override
+        public void close() throws IOException {
+            fis.close();
+        }
+    }
+
+    static class FileOutputStreamResource implements Resource {
+        private FileOutputStream fis;
+
+        @Override
+        public void open(Path path) throws IOException {
+            this.fis = new FileOutputStream(path.toFile());
+        }
+
+        @Override
+        public void close() throws IOException {
+            fis.close();
+        }
+    }
+
+    static class RandomAccessFileResource implements Resource {
+        private RandomAccessFile raf;
+
+        @Override
+        public void open(Path path) throws IOException {
+            this.raf = new RandomAccessFile(path.toFile(), "r");
+        }
+
+        @Override
+        public void close() throws IOException {
+            raf.close();
+        }
+    }
+
+    private static class FileChannelResource implements Resource{
+
+        private Channel channel;
+
+        @Override
+        public void open(Path path) throws IOException {
+            channel = FileChannel.open(path);
+        }
+
+        @Override
+        public void close() throws IOException {
+            channel.close();
+        }
+    }
+
+    private static class FilesNewByteChannelResource implements Resource {
+
+        private Channel channel;
+
+        @Override
+        public void open(Path path) throws IOException {
+            channel = Files.newByteChannel(path);
+        }
+
+        @Override
+        public void close() throws IOException {
+            channel.close();
+        }
+    }
+
+    private static class FilesNewOutputStreamResource implements Resource {
+
+        private OutputStream stream;
+
+        @Override
+        public void open(Path path) throws IOException {
+            stream = Files.newOutputStream(path);
+        }
+
+        @Override
+        public void close() throws IOException {
+            stream.close();
+        }
+    }
+
+    private static class FilesNewInputStreamResource implements Resource {
+
+        private InputStream stream;
+
+        @Override
+        public void open(Path path) throws IOException {
+            stream = Files.newInputStream(path);
+        }
+
+        @Override
+        public void close() throws IOException {
+            stream.close();
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/util/OpenFiles.java
+++ b/test/lib/jdk/test/lib/util/OpenFiles.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.util;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * API for registering files as opened or closed (from code instrumented by agent)
+ * and for asserting open status for a file (from tests).
+ */
+public class OpenFiles {
+
+    private static Map<String, Map<Object, Throwable>> paths = new HashMap<>();
+    private static Map<Object, String> files = new HashMap<>();
+
+    /**
+     * Register a file path as being opened by the given Object
+     *
+     * @param file the file to register as opened
+     * @param object the object opening the file
+     */
+    public static void openFile(String path, Object object) {
+        openFile(Path.of(path), object);
+    }
+
+    /**
+     * Register a file as being opened by the given Object
+     *
+     * @param file the file to register as opened
+     * @param object the object opening the file
+     */
+    public static void openFile(File file,  Object object) {
+        openFile(file.getAbsolutePath(), object);
+    }
+
+    /**
+     * Register a file as being opened by the given Object
+     *
+     * @param file the file to register as opened
+     * @param object the object opening the file
+     */
+    public static synchronized void openFile(Path file, Object object) {
+        String path = file.toAbsolutePath().toString();
+        if (!paths.containsKey(path)) {
+            paths.put(path, new HashMap<>());
+        }
+        paths.get(path).put(object, new Throwable("Opening stack trace of " + path));
+        files.put(object, path);
+    }
+
+    /**
+     * Close the file opened by the given object
+     * @param object the object opening the file
+     */
+    public synchronized static void closeFile(Object object) {
+        String path = files.get(object);
+        if (path != null) {
+            files.remove(object);
+            Map<Object, Throwable> opens = paths.get(path);
+            if (opens != null) {
+                opens.remove(object);
+                if (opens.isEmpty()) {
+                    paths.remove(path);
+                }
+            }
+        }
+    }
+
+    /**
+     * Assert that the given {@code File} is closed
+     *
+     * @param file the {@code File} to check
+     */
+    public static void assertClosed(File file) {
+        assertClosed(file.toPath());
+    }
+
+    /**
+     * Assert that the given file path is closed
+     *
+     * @param file the file path to check
+     */
+    public static void assertClosed(String path) {
+        assertClosed(Path.of(path));
+    }
+
+    /**
+     * Assert that the given {@code Path} is closed
+     *
+     * @param file the {@code Path} to check
+     */
+    public static synchronized void assertClosed(Path file) {
+        String path = file.toAbsolutePath().toString();
+        Map<Object, Throwable> opens = paths.get(path);
+        if (opens != null && !opens.isEmpty()) {
+            for (var e : opens.entrySet()) {
+                Object open = e.getKey();
+                Throwable stacktrace = e.getValue();
+                throw new AssertionError("Expected file to be closed: " + path, stacktrace);
+            }
+        }
+    }
+
+    /**
+     * Assert that the given {@code File} is open
+     *
+     * @param file the {@code File} to check
+     */
+    public static void assertOpen(File file) {
+        assertOpen(file.toPath());
+    }
+
+    /**
+     * Assert that the given absolute file path is open
+     *
+     * @param file the path of the file to check
+     */
+    public  static void assertOpen(String path) {
+        assertOpen(Path.of(path));
+    }
+
+    /**
+     * Assert that the given {@code Path} is open
+     *
+     * @param file the {@code File} to check
+     */
+    public static synchronized void assertOpen(Path file) {
+        String path = file.toAbsolutePath().toString();
+        Map<Object, Throwable> opens = paths.get(path);
+        if (opens == null || opens.isEmpty()) {
+            throw new AssertionError("Expected file to be open: " + path);
+        }
+    }
+
+    /**
+     * If {@code expectOpen} is true, assert that the given {@code File}
+     * is open, otherwise assert that it is closed.
+     *
+     * @param expectOpen true if the file should be open
+     * @param file the {@code File} to check
+     */
+    public static void assertOpenIf(boolean expectOpen, File file) {
+        assertOpenIf(expectOpen, file.toPath());
+    }
+
+    /**
+     * If {@code expectOpen} is true, assert that the given {@code Path}
+     * is open, otherwise assert that it is closed.
+     *
+     * @param expectOpen true if the file should be open
+     * @param file the {@code Path} to check
+     */
+    public static void assertOpenIf(boolean expectOpen, Path file) {
+        assertOpenIf(expectOpen, file.toAbsolutePath().toString());
+    }
+
+    /**
+     * If {@code expectOpen} is true, assert that the file with the given
+     * absolute path is open, otherwise assert that it is closed.
+     *
+     * @param expectOpen true if the file should be open
+     * @param file the path of the file to check
+     */
+    public static void assertOpenIf(boolean expectOpen, String path) {
+        if (expectOpen) {
+            assertOpen(path);
+        } else {
+            assertClosed(path);
+        }
+    }
+}

--- a/test/lib/jdk/test/lib/util/OpenFilesAgent.java
+++ b/test/lib/jdk/test/lib/util/OpenFilesAgent.java
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package jdk.test.lib.util;
+
+import java.io.*;
+import java.lang.classfile.ClassFile;
+import java.lang.classfile.ClassModel;
+import java.lang.classfile.CodeBuilder;
+import java.lang.classfile.CodeElement;
+import java.lang.classfile.CodeTransform;
+import java.lang.classfile.MethodModel;
+import java.lang.classfile.MethodTransform;
+import java.lang.classfile.Opcode;
+import java.lang.classfile.TypeKind;
+import java.lang.classfile.instruction.InvokeInstruction;
+import java.lang.classfile.instruction.ReturnInstruction;
+import java.lang.constant.ClassDesc;
+import java.lang.constant.MethodTypeDesc;
+import java.lang.instrument.ClassFileTransformer;
+import java.lang.instrument.IllegalClassFormatException;
+import java.lang.instrument.Instrumentation;
+import java.lang.instrument.UnmodifiableClassException;
+import java.net.URL;
+import java.security.ProtectionDomain;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.Attributes;
+import java.util.jar.*;
+
+import static java.lang.constant.ConstantDescs.*;
+
+/**
+ * Java agent which instruments the opening and closing of files.
+ * <p>
+ * Supported file APIs include: java.io.FileInputStream, java.io.FileOutputStream,
+ * java.io.RandomAccessFile, java.nio.file.Files and java.nio.channels.FileChannel
+ * <p>
+ * The main method in this class is used by tests as a driver to produce agent JAR files.
+ * <p>
+ * A typical jtreg configuration looks like:
+ *
+ * @library /test/lib
+ * @run driver jdk.test.lib.util.OpenFilesAgent
+ * @run junit/othervm -javaagent:OpenFilesAgent.jar SomeTest
+ * <p>
+ * See {@link OpenFiles} for an assertion API to use in testing
+ *
+ * @see OpenFiles
+ */
+public class OpenFilesAgent {
+
+    // Run from jtreg tests as a driver to produce agent and registry JARs
+    public static void main(String[] args) throws IOException {
+
+        Manifest man = new Manifest();
+        Attributes attrs = man.getMainAttributes();
+        attrs.put(Attributes.Name.MANIFEST_VERSION, "1.0");
+
+        createJar("OpenFiles.jar", man, OpenFiles.class);
+
+        attrs.put(new Attributes.Name("Premain-Class"), OpenFilesAgent.class.getName());
+        attrs.putValue("Can-Retransform-Classes", "true");
+
+        createJar("OpenFilesAgent.jar", man, OpenFilesAgent.class);
+    }
+
+
+    // Initialize the agent
+    public static void premain(String args, Instrumentation instrumentation) throws IOException, UnmodifiableClassException {
+
+        File registryJarFile = new File("OpenFiles.jar");
+        if (registryJarFile.exists()) {
+            JarFile registryJar = new JarFile(registryJarFile);
+            // OpenFiles must be visible to the boot class loader
+            instrumentation.appendToBootstrapClassLoaderSearch(registryJar);
+            // Register out class file transformer
+            instrumentation.addTransformer(new TrackOpenFilesTransformer(), true);
+
+            // Check if any class we want to transform is already loaded
+            Set<Class<?>> toRetransform = new HashSet<>();
+            var names = Set.of("java.io.RandomAccessFile",
+                    "java.io.FileInputStream",
+                    "java.io.FileOutputStream",
+                    "sun.nio.ch.FileChannelImpl");
+            for (Class clazz : instrumentation.getAllLoadedClasses()) {
+                if (names.contains(clazz.getName())) {
+                    toRetransform.add(clazz);
+                }
+            }
+            instrumentation.retransformClasses(toRetransform.toArray(Class[]::new));
+        } else {
+            System.err.println("Registry JAR file not found: " + registryJarFile.getAbsolutePath());
+        }
+    }
+
+    /**
+     * Create a JAR file containing the class file for the given class, including
+     * any nested classes.
+     *
+     * @param filename name of the JAR file to produce
+     * @param man      the Manifest for the JAR file
+     * @param clazz    the class file to create a JAR file for
+     * @throws IOException if an error occurs
+     */
+    private static void createJar(String filename, Manifest man, Class<?> clazz) throws IOException {
+        URL classFileResource = clazz.getResource(clazz.getSimpleName() + ".class");
+
+        File[] files = new File(classFileResource.getFile()).getParentFile().listFiles();
+
+        String dir = clazz.getPackage().getName().replace('.', '/') + "/";
+
+        try (var out = new BufferedOutputStream(new FileOutputStream(new File(filename)));
+             var jo = new JarOutputStream(out, man)) {
+            if (files != null) {
+                for (File file : files) {
+                    String name = file.getName();
+                    if (name.equals(clazz.getSimpleName() + ".class") ||
+                            name.startsWith(clazz.getSimpleName() + "$")) {
+                        jo.putNextEntry(new JarEntry(dir + name));
+                        try (var in = new FileInputStream(file)) {
+                            in.transferTo(jo);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static class TrackOpenFilesTransformer implements ClassFileTransformer {
+
+        static final ClassDesc CD_Registry = ClassDesc.of("jdk.test.lib.util.OpenFiles");
+        static final ClassDesc CD_File = ClassDesc.of("java.io.File");
+        static final ClassDesc CD_FileDescriptor = ClassDesc.of("java.io.FileDescriptor");
+        static final ClassDesc CD_Closeable = ClassDesc.of("java.io.Closeable");
+        static final ClassDesc CD_FileChannel = ClassDesc.of("java.nio.channels.FileChannel");
+
+        static final MethodTypeDesc MD_openFile = MethodTypeDesc.of(CD_void, CD_File, CD_Object);
+        static final MethodTypeDesc MD_openString = MethodTypeDesc.of(CD_void, CD_String, CD_Object);
+        static final MethodTypeDesc MD_closeFile = MethodTypeDesc.of(CD_void, CD_Object);
+        static final MethodTypeDesc MD_fisOpen = MethodTypeDesc.of(CD_void, CD_String);
+        static final MethodTypeDesc MD_fosOpen = MethodTypeDesc.of(CD_void, CD_String, CD_boolean);
+        static final MethodTypeDesc MD_rafInit = MethodTypeDesc.of(CD_void, CD_File, CD_String, CD_boolean);
+        static final MethodTypeDesc MD_fcImplOpen = MethodTypeDesc.of(CD_FileChannel,
+                CD_FileDescriptor,
+                CD_String,
+                CD_boolean,
+                CD_boolean,
+                CD_boolean,
+                CD_boolean,
+                CD_Closeable);
+
+        @Override
+        public byte[] transform(Module module,
+                                ClassLoader loader,
+                                String className,
+                                Class<?> classBeingRedefined,
+                                ProtectionDomain protectionDomain,
+                                byte[] classfileBuffer) throws IllegalClassFormatException {
+
+            try {
+                return switch (className) {
+                    case "java/io/RandomAccessFile" ->
+                            transformRandomAccessFile(classfileBuffer);
+                    case "java/io/FileInputStream" ->
+                            transformFileInputStream(classfileBuffer);
+                    case "java/io/FileOutputStream" ->
+                            transformFileOutputStream(classfileBuffer);
+                    case "sun/nio/ch/FileChannelImpl" ->
+                            transformFileChannelImpl(classfileBuffer);
+                    default -> null;
+                };
+            } catch (Throwable e) {
+                System.err.println("Error transforming class " + className);
+                e.printStackTrace();
+                return null;
+            }
+        }
+
+        // Instrument RandomAccessFile to call OpenFiles::openFile, OpenFiles::closeFile
+        byte[] transformRandomAccessFile(byte[] classfileBuffer) {
+            ClassFile cf = ClassFile.of();
+            ClassModel mod = cf.parse(classfileBuffer);
+            return cf.transformClass(mod, (cb, ce) -> {
+                switch (ce) {
+                    // Constructor RandomAccessFile(File, String, boolean)
+                    case MethodModel method
+                            when method.methodName().equalsString("<init>")
+                            && method.methodTypeSymbol().equals(MD_rafInit) ->
+
+                            cb.transformMethod(method, MethodTransform.transformingCode(
+                                    (builder, element) -> {
+                                        switch (element) {
+                                            // Call openFile before RETURN
+                                            case ReturnInstruction ri -> {
+                                                builder.aload(1) // File
+                                                        .aload(0)        // RandomAccessFile (this)
+                                                        .invokestatic(CD_Registry, "openFile", MD_openFile)
+                                                        .with(ri);
+                                            }
+
+                                            default -> builder.with(element);
+                                        }
+
+                                    }));
+
+                    // RandomAccessFile::close
+                    case MethodModel method
+                            when method.methodName().equalsString("close")
+                            && method.methodTypeSymbol().equals(MTD_void) ->
+
+                            cb.transformMethod(method, MethodTransform.transformingCode(
+                                    (builder, element) -> {
+                                        switch (element) {
+                                            // Call close before RETURN
+                                            case ReturnInstruction ri -> {
+                                                builder.aload(0)        // RandomAccessFile (this)
+                                                        .invokestatic(CD_Registry, "closeFile", MD_closeFile)
+                                                        .with(ri);
+                                            }
+
+                                            default -> builder.with(element);
+                                        }
+
+                                    }));
+
+                    default -> cb.accept(ce);
+                }
+            });
+        }
+
+
+        // Instrument FileInputStream to call OpenFiles::openFile, OpenFiles::closeFile
+        byte[] transformFileInputStream(byte[] classfileBuffer) {
+            ClassFile cf = ClassFile.of();
+            ClassModel mod = cf.parse(classfileBuffer);
+            return cf.transformClass(mod, (cb, ce) -> {
+                switch (ce) {
+                    // FileInputStream::open(String)
+                    case MethodModel method
+                            when method.methodName().equalsString("open")
+                            && method.methodTypeSymbol().equals(MD_fisOpen) ->
+
+                            cb.transformMethod(method, MethodTransform.transformingCode(
+                                    (builder, element) -> {
+                                        switch (element) {
+                                            // Call openFile before RETURN
+                                            case ReturnInstruction ri -> {
+                                                builder.aload(1) // String
+                                                        .aload(0)        // FileInputStream (this)
+                                                        .invokestatic(CD_Registry, "openFile", MD_openString)
+                                                        .with(ri);
+                                            }
+
+                                            default -> builder.with(element);
+                                        }
+
+                                    }));
+
+                    // FileInputStream::close
+                    case MethodModel method
+                            when method.methodName().equalsString("close")
+                            && method.methodTypeSymbol().equals(MTD_void) ->
+
+                            cb.transformMethod(method, MethodTransform.transformingCode(
+                                    (builder, element) -> {
+                                        switch (element) {
+                                            // Call close before RETURN
+                                            case ReturnInstruction ri -> {
+                                                builder.aload(0)        // FileInputStream (this)
+                                                        .invokestatic(CD_Registry, "closeFile", MD_closeFile)
+                                                        .with(ri);
+                                            }
+
+                                            default -> builder.with(element);
+                                        }
+
+                                    }));
+
+                    default -> cb.accept(ce);
+                }
+            });
+        }
+
+        // Instrument FileOutputStream to call OpenFiles::openFile, OpenFiles::closeFile
+        byte[] transformFileOutputStream(byte[] classfileBuffer) {
+            ClassFile cf = ClassFile.of();
+            ClassModel mod = cf.parse(classfileBuffer);
+            return cf.transformClass(mod, (cb, ce) -> {
+                switch (ce) {
+                    // FileInputStream::open(String)
+                    case MethodModel method
+                            when method.methodName().equalsString("open")
+                            && method.methodTypeSymbol().equals(MD_fosOpen) ->
+
+                            cb.transformMethod(method, MethodTransform.transformingCode(
+                                    (builder, element) -> {
+                                        switch (element) {
+                                            // Call openFile before RETURN
+                                            case ReturnInstruction ri -> {
+                                                builder.aload(1) // String
+                                                        .aload(0)        // FileOutputStream (this)
+                                                        .invokestatic(CD_Registry, "openFile", MD_openString)
+                                                        .with(ri);
+                                            }
+
+                                            default -> builder.with(element);
+                                        }
+
+                                    }));
+
+                    // FileInputStream::close
+                    case MethodModel method
+                            when method.methodName().equalsString("close")
+                            && method.methodTypeSymbol().equals(MTD_void) ->
+
+                            cb.transformMethod(method, MethodTransform.transformingCode(
+                                    (builder, element) -> {
+                                        switch (element) {
+                                            // Call close before RETURN
+                                            case ReturnInstruction ri -> {
+                                                builder.aload(0)        // FileOutputStream (this)
+                                                        .invokestatic(CD_Registry, "closeFile", MD_closeFile)
+                                                        .with(ri);
+                                            }
+
+                                            default -> builder.with(element);
+                                        }
+
+                                    }));
+
+                    default -> cb.accept(ce);
+                }
+            });
+        }
+
+
+        // Instrument FileChannelImpl::open and FileChannelImpl:closeImpl
+        byte[] transformFileChannelImpl(byte[] classfileBuffer) {
+            ClassFile cf = ClassFile.of();
+            ClassModel mod = cf.parse(classfileBuffer);
+            return cf.transformClass(mod, (cb, ce) -> {
+                switch (ce) {
+                    // FileChannelImpl::open(Path, Set, FileAttributes)
+                    case MethodModel method
+                            when method.methodName().equalsString("open")
+                            && method.methodTypeSymbol().equals(MD_fcImplOpen) ->
+
+                            cb.transformMethod(method, MethodTransform.transformingCode(
+                                    (builder, element) -> {
+                                        switch (element) {
+                                            // Call openFile before RETURN
+                                            case ReturnInstruction ri -> {
+                                                builder.dup() // FileChannel
+                                                        .aload(1) // String path
+                                                        .swap()
+                                                        .invokestatic(CD_Registry, "openFile", MD_openString)
+                                                        .with(ri);
+                                            }
+
+                                            default -> builder.with(element);
+                                        }
+
+                                    }));
+
+
+                    case MethodModel method
+                            when method.methodName().equalsString("implCloseChannel")
+                            && method.methodTypeSymbol().equals(MTD_void) ->
+
+                            cb.transformMethod(method, MethodTransform.transformingCode(
+                                    (builder, element) -> {
+                                        switch (element) {
+                                            // Call close before RETURN
+                                            case ReturnInstruction ri -> {
+                                                builder.aload(0)        // FileChannel (this)
+                                                        .invokestatic(CD_Registry, "closeFile", MD_closeFile)
+                                                        .with(ri);
+                                            }
+                                            default -> builder.with(element);
+                                        }
+
+                                    }));
+
+                    default -> cb.accept(ce);
+                }
+            });
+        }
+    }
+}


### PR DESCRIPTION
Please review this PR which  adds a utility API in the test libraries to assert whether a file is currently open.

Several OpenJDK  tests currently rely on approximations to check this, including deletion (fails only on Windows), or checking `/proc/<pid>/fd` (Works only on Linux). These approximations are blunt instruments, it would be better to have an exact cross platform solution for this need to check if a file is open or closed.

Verification: With `OpenFilesTest` temporarily in tier1, GHA completed successfully across platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344911](https://bugs.openjdk.org/browse/JDK-8344911): Introduce test utility for asserting file open status (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22343/head:pull/22343` \
`$ git checkout pull/22343`

Update a local copy of the PR: \
`$ git checkout pull/22343` \
`$ git pull https://git.openjdk.org/jdk.git pull/22343/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22343`

View PR using the GUI difftool: \
`$ git pr show -t 22343`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22343.diff">https://git.openjdk.org/jdk/pull/22343.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22343#issuecomment-2498489571)
</details>
