### PR TITLE
8344912: Sharpen the return type of various internal methods in jdk.internal.foreign

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -121,7 +121,7 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     @CallerSensitive
-    public final NativeMemorySegmentImpl reinterpret(long newSize, Arena arena, Consumer<MemorySegment> cleanup) {
+    public final MemorySegment reinterpret(long newSize, Arena arena, Consumer<MemorySegment> cleanup) {
         Objects.requireNonNull(arena);
         return reinterpretInternal(Reflection.getCallerClass(), newSize,
                 MemorySessionImpl.toMemorySession(arena), cleanup);
@@ -129,13 +129,13 @@ public abstract sealed class AbstractMemorySegmentImpl
 
     @Override
     @CallerSensitive
-    public final NativeMemorySegmentImpl reinterpret(long newSize) {
+    public final MemorySegment reinterpret(long newSize) {
         return reinterpretInternal(Reflection.getCallerClass(), newSize, scope, null);
     }
 
     @Override
     @CallerSensitive
-    public final NativeMemorySegmentImpl reinterpret(Arena arena, Consumer<MemorySegment> cleanup) {
+    public final MemorySegment reinterpret(Arena arena, Consumer<MemorySegment> cleanup) {
         Objects.requireNonNull(arena);
         return reinterpretInternal(Reflection.getCallerClass(), byteSize(),
                 MemorySessionImpl.toMemorySession(arena), cleanup);
@@ -570,7 +570,7 @@ public abstract sealed class AbstractMemorySegmentImpl
                             MemorySegment dstSegment, ValueLayout dstElementLayout, long dstOffset,
                             long elementCount) {
 
-        Utils.checkNonNegativeArgument(elementCount, "elementCount");
+        Utils.checkNonNegativeIndex(elementCount, "elementCount");
         AbstractMemorySegmentImpl srcImpl = (AbstractMemorySegmentImpl)srcSegment;
         AbstractMemorySegmentImpl dstImpl = (AbstractMemorySegmentImpl)dstSegment;
         if (srcElementLayout.byteSize() != dstElementLayout.byteSize()) {
@@ -602,7 +602,7 @@ public abstract sealed class AbstractMemorySegmentImpl
     public static void copy(MemorySegment srcSegment, ValueLayout srcLayout, long srcOffset,
                             Object dstArray, int dstIndex,
                             int elementCount) {
-        Utils.checkNonNegativeArgument(elementCount, "elementCount");
+        Utils.checkNonNegativeIndex(elementCount, "elementCount");
         var dstInfo = Utils.BaseAndScale.of(dstArray);
         if (dstArray.getClass().componentType() != srcLayout.carrier()) {
             throw new IllegalArgumentException("Incompatible value layout: " + srcLayout);

--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,14 +50,15 @@ public final class ArenaImpl implements Arena {
         session.close();
     }
 
-    public MemorySegment allocateNoInit(long byteSize, long byteAlignment) {
+    public NativeMemorySegmentImpl allocateNoInit(long byteSize, long byteAlignment) {
         Utils.checkAllocationSizeAndAlign(byteSize, byteAlignment);
         return SegmentFactories.allocateSegment(byteSize, byteAlignment, session, shouldReserveMemory);
     }
 
     @Override
-    public MemorySegment allocate(long byteSize, long byteAlignment) {
-        MemorySegment segment = allocateNoInit(byteSize, byteAlignment);
-        return segment.fill((byte)0);
+    public NativeMemorySegmentImpl allocate(long byteSize, long byteAlignment) {
+        NativeMemorySegmentImpl segment = allocateNoInit(byteSize, byteAlignment);
+        segment.fill((byte)0);
+        return segment;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MappedMemorySegmentImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@ import jdk.internal.misc.ScopedMemoryAccess;
  * memory mapped segment, such as the file descriptor associated with the mapping. This information is crucial
  * in order to correctly reconstruct a byte buffer object from the segment (see {@link #makeByteBuffer()}).
  */
-final class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
+public final class MappedMemorySegmentImpl extends NativeMemorySegmentImpl {
 
     private final UnmapperProxy unmapper;
 

--- a/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/MemorySessionImpl.java
@@ -85,7 +85,7 @@ public abstract sealed class MemorySessionImpl
 
     int acquireCount;
 
-    public Arena asArena() {
+    public ArenaImpl asArena() {
         return new ArenaImpl(this);
     }
 

--- a/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/NativeMemorySegmentImpl.java
@@ -36,7 +36,7 @@ import jdk.internal.vm.annotation.ForceInline;
  * Implementation for native memory segments. A native memory segment is essentially a wrapper around
  * a native long address.
  */
-sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl permits MappedMemorySegmentImpl {
+public sealed class NativeMemorySegmentImpl extends AbstractMemorySegmentImpl permits MappedMemorySegmentImpl {
 
     final long min;
 

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -106,7 +106,7 @@ public final class SegmentBulkOperations {
                             AbstractMemorySegmentImpl dst, long dstOffset,
                             long size) {
 
-        Utils.checkNonNegativeArgument(size, "size");
+        Utils.checkNonNegativeIndex(size, "size");
         // Implicit null check for src and dst
         src.checkAccess(srcOffset, size, true);
         dst.checkAccess(dstOffset, size, false);

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -62,7 +62,7 @@ public final class SegmentBulkOperations {
         dst.checkReadOnly(false);
         if (dst.length == 0) {
             // Implicit state check
-            dst.checkValidState();
+            dst.sessionImpl().checkValidState();
         } else if (dst.length < NATIVE_THRESHOLD_FILL) {
             // 0 <= length < FILL_NATIVE_LIMIT : 0...0X...XXXX
 
@@ -106,7 +106,7 @@ public final class SegmentBulkOperations {
                             AbstractMemorySegmentImpl dst, long dstOffset,
                             long size) {
 
-        Utils.checkNonNegativeIndex(size, "size");
+        Utils.checkNonNegativeArgument(size, "size");
         // Implicit null check for src and dst
         src.checkAccess(srcOffset, size, true);
         dst.checkAccess(dstOffset, size, false);

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentFactories.java
@@ -57,11 +57,9 @@ public class SegmentFactories {
     // associated with MemorySegment::ofAddress.
 
     @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min,
-                                                           long byteSize,
-                                                           MemorySessionImpl sessionImpl,
-                                                           boolean readOnly,
-                                                           Runnable action) {
+    public static NativeMemorySegmentImpl makeNativeSegmentUnchecked(long min, long byteSize,
+                                                                     MemorySessionImpl sessionImpl,
+                                                                     boolean readOnly, Runnable action) {
         ensureInitialized();
         if (action == null) {
             sessionImpl.checkValidState();
@@ -72,19 +70,19 @@ public class SegmentFactories {
     }
 
     @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize, MemorySessionImpl sessionImpl) {
+    public static NativeMemorySegmentImpl makeNativeSegmentUnchecked(long min, long byteSize, MemorySessionImpl sessionImpl) {
         ensureInitialized();
         sessionImpl.checkValidState();
         return new NativeMemorySegmentImpl(min, byteSize, false, sessionImpl);
     }
 
     @ForceInline
-    public static MemorySegment makeNativeSegmentUnchecked(long min, long byteSize) {
+    public static NativeMemorySegmentImpl makeNativeSegmentUnchecked(long min, long byteSize) {
         ensureInitialized();
         return new NativeMemorySegmentImpl(min, byteSize, false, MemorySessionImpl.GLOBAL_SESSION);
     }
 
-    public static MemorySegment fromArray(byte[] arr) {
+    public static OfByte fromArray(byte[] arr) {
         ensureInitialized();
         Objects.requireNonNull(arr);
         long byteSize = (long)arr.length * Utils.BaseAndScale.BYTE.scale();
@@ -92,7 +90,7 @@ public class SegmentFactories {
                 MemorySessionImpl.createHeap(arr));
     }
 
-    public static MemorySegment fromArray(short[] arr) {
+    public static OfShort fromArray(short[] arr) {
         ensureInitialized();
         Objects.requireNonNull(arr);
         long byteSize = (long)arr.length * Utils.BaseAndScale.SHORT.scale();
@@ -100,7 +98,7 @@ public class SegmentFactories {
                 MemorySessionImpl.createHeap(arr));
     }
 
-    public static MemorySegment fromArray(int[] arr) {
+    public static OfInt fromArray(int[] arr) {
         ensureInitialized();
         Objects.requireNonNull(arr);
         long byteSize = (long)arr.length * Utils.BaseAndScale.INT.scale();
@@ -108,7 +106,7 @@ public class SegmentFactories {
                 MemorySessionImpl.createHeap(arr));
     }
 
-    public static MemorySegment fromArray(char[] arr) {
+    public static OfChar fromArray(char[] arr) {
         ensureInitialized();
         Objects.requireNonNull(arr);
         long byteSize = (long)arr.length * Utils.BaseAndScale.CHAR.scale();
@@ -116,7 +114,7 @@ public class SegmentFactories {
                 MemorySessionImpl.createHeap(arr));
     }
 
-    public static MemorySegment fromArray(float[] arr) {
+    public static OfFloat fromArray(float[] arr) {
         ensureInitialized();
         Objects.requireNonNull(arr);
         long byteSize = (long)arr.length * Utils.BaseAndScale.FLOAT.scale();
@@ -124,7 +122,7 @@ public class SegmentFactories {
                 MemorySessionImpl.createHeap(arr));
     }
 
-    public static MemorySegment fromArray(double[] arr) {
+    public static OfDouble fromArray(double[] arr) {
         ensureInitialized();
         Objects.requireNonNull(arr);
         long byteSize = (long)arr.length * Utils.BaseAndScale.DOUBLE.scale();
@@ -132,7 +130,7 @@ public class SegmentFactories {
                 MemorySessionImpl.createHeap(arr));
     }
 
-    public static MemorySegment fromArray(long[] arr) {
+    public static OfLong fromArray(long[] arr) {
         ensureInitialized();
         Objects.requireNonNull(arr);
         long byteSize = (long)arr.length * Utils.BaseAndScale.LONG.scale();
@@ -142,64 +140,43 @@ public class SegmentFactories {
 
     // Buffer conversion factories
 
-    public static AbstractMemorySegmentImpl arrayOfByteSegment(Object base,
-                                                               long offset,
-                                                               long length,
-                                                               boolean readOnly,
-                                                               MemorySessionImpl bufferScope) {
-        return new HeapMemorySegmentImpl.OfByte(offset, base, length, readOnly, bufferScope);
+    public static OfByte arrayOfByteSegment(Object base, long offset, long length,
+                                            boolean readOnly, MemorySessionImpl bufferScope) {
+        return new OfByte(offset, base, length, readOnly, bufferScope);
     }
 
-    public static AbstractMemorySegmentImpl arrayOfShortSegment(Object base,
-                                                                long offset,
-                                                                long length,
-                                                                boolean readOnly,
-                                                                MemorySessionImpl bufferScope) {
-        return new HeapMemorySegmentImpl.OfShort(offset, base, length, readOnly, bufferScope);
+    public static OfShort arrayOfShortSegment(Object base, long offset, long length,
+                                              boolean readOnly, MemorySessionImpl bufferScope) {
+        return new OfShort(offset, base, length, readOnly, bufferScope);
     }
 
-    public static AbstractMemorySegmentImpl arrayOfCharSegment(Object base,
-                                                               long offset,
-                                                               long length,
-                                                               boolean readOnly,
-                                                               MemorySessionImpl bufferScope) {
-        return new HeapMemorySegmentImpl.OfChar(offset, base, length, readOnly, bufferScope);
+    public static OfChar arrayOfCharSegment(Object base, long offset, long length,
+                                            boolean readOnly, MemorySessionImpl bufferScope) {
+        return new OfChar(offset, base, length, readOnly, bufferScope);
     }
 
-    public static AbstractMemorySegmentImpl arrayOfIntSegment(Object base,
-                                                              long offset,
-                                                              long length,
-                                                              boolean readOnly,
-                                                              MemorySessionImpl bufferScope) {
-        return new HeapMemorySegmentImpl.OfInt(offset, base, length, readOnly, bufferScope);
+    public static OfInt arrayOfIntSegment(Object base, long offset, long length,
+                                          boolean readOnly, MemorySessionImpl bufferScope) {
+        return new OfInt(offset, base, length, readOnly, bufferScope);
     }
 
-    public static AbstractMemorySegmentImpl arrayOfFloatSegment(Object base,
-                                                                long offset,
-                                                                long length,
-                                                                boolean readOnly,
-                                                                MemorySessionImpl bufferScope) {
-        return new HeapMemorySegmentImpl.OfFloat(offset, base, length, readOnly, bufferScope);
+    public static OfFloat arrayOfFloatSegment(Object base, long offset, long length,
+                                              boolean readOnly, MemorySessionImpl bufferScope) {
+        return new OfFloat(offset, base, length, readOnly, bufferScope);
     }
 
-    public static AbstractMemorySegmentImpl arrayOfLongSegment(Object base,
-                                                               long offset,
-                                                               long length,
-                                                               boolean readOnly,
-                                                               MemorySessionImpl bufferScope) {
-        return new HeapMemorySegmentImpl.OfLong(offset, base, length, readOnly, bufferScope);
+    public static OfLong arrayOfLongSegment(Object base, long offset, long length,
+                                            boolean readOnly, MemorySessionImpl bufferScope) {
+        return new OfLong(offset, base, length, readOnly, bufferScope);
     }
 
-    public static AbstractMemorySegmentImpl arrayOfDoubleSegment(Object base,
-                                                                 long offset,
-                                                                 long length,
-                                                                 boolean readOnly,
-                                                                 MemorySessionImpl bufferScope) {
-        return new HeapMemorySegmentImpl.OfDouble(offset, base, length, readOnly, bufferScope);
+    public static OfDouble arrayOfDoubleSegment(Object base, long offset, long length,
+                                                boolean readOnly, MemorySessionImpl bufferScope) {
+        return new OfDouble(offset, base, length, readOnly, bufferScope);
     }
 
-    public static MemorySegment allocateSegment(long byteSize, long byteAlignment, MemorySessionImpl sessionImpl,
-                                                  boolean shouldReserve) {
+    public static NativeMemorySegmentImpl allocateSegment(long byteSize, long byteAlignment, MemorySessionImpl sessionImpl,
+                                                          boolean shouldReserve) {
         ensureInitialized();
         sessionImpl.checkValidState();
         if (VM.isDirectMemoryPageAligned()) {
@@ -215,7 +192,7 @@ public class SegmentFactories {
 
         long buf = allocateMemoryWrapper(alignedSize);
         long alignedBuf = Utils.alignUp(buf, byteAlignment);
-        AbstractMemorySegmentImpl segment = new NativeMemorySegmentImpl(buf, alignedSize,
+        NativeMemorySegmentImpl segment = new NativeMemorySegmentImpl(buf, alignedSize,
                 false, sessionImpl);
         sessionImpl.addOrCleanupIfFail(new MemorySessionImpl.ResourceList.ResourceCleanup() {
             @Override
@@ -228,7 +205,7 @@ public class SegmentFactories {
         });
         if (alignedSize != byteSize) {
             long delta = alignedBuf - buf;
-            segment = segment.asSlice(delta, byteSize);
+            segment = (NativeMemorySegmentImpl) segment.asSlice(delta, byteSize);
         }
         return segment;
     }
@@ -241,10 +218,10 @@ public class SegmentFactories {
         }
     }
 
-    public static MemorySegment mapSegment(long size, UnmapperProxy unmapper, boolean readOnly, MemorySessionImpl sessionImpl) {
+    public static MappedMemorySegmentImpl mapSegment(long size, UnmapperProxy unmapper, boolean readOnly, MemorySessionImpl sessionImpl) {
         ensureInitialized();
         if (unmapper != null) {
-            AbstractMemorySegmentImpl segment =
+            MappedMemorySegmentImpl segment =
                     new MappedMemorySegmentImpl(unmapper.address(), unmapper, size,
                             readOnly, sessionImpl);
             MemorySessionImpl.ResourceList.ResourceCleanup resource =

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -230,13 +230,6 @@ public final class Utils {
         }
     }
 
-    @ForceInline
-    public static void checkNonNegativeIndex(long value, String name) {
-        if (value < 0) {
-            throw new IndexOutOfBoundsException("The provided " + name + " is negative: " + value);
-        }
-    }
-
     private static long computePadding(long offset, long align) {
         boolean isAligned = offset == 0 || offset % align == 0;
         if (isAligned) {

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -230,6 +230,13 @@ public final class Utils {
         }
     }
 
+    @ForceInline
+    public static void checkNonNegativeIndex(long value, String name) {
+        if (value < 0) {
+            throw new IndexOutOfBoundsException("The provided " + name + " is negative: " + value);
+        }
+    }
+
     private static long computePadding(long offset, long align) {
         boolean isAligned = offset == 0 || offset % align == 0;
         if (isAligned) {

--- a/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/abi/fallback/FallbackLinker.java
@@ -46,7 +46,6 @@ import java.lang.invoke.MethodHandles;
 import static java.lang.invoke.MethodHandles.foldArguments;
 import java.lang.invoke.MethodType;
 import java.lang.ref.Reference;
-import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Hi,

This patch sharpens the return types of various internal methods. This helps the compiler to have better information when the corresponding methods are not inlined.

Please take a look and leave your reviews, thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344912](https://bugs.openjdk.org/browse/JDK-8344912): Sharpen the return type of various internal methods in jdk.internal.foreign (**Enhancement** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22344/head:pull/22344` \
`$ git checkout pull/22344`

Update a local copy of the PR: \
`$ git checkout pull/22344` \
`$ git pull https://git.openjdk.org/jdk.git pull/22344/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22344`

View PR using the GUI difftool: \
`$ git pr show -t 22344`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22344.diff">https://git.openjdk.org/jdk/pull/22344.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22344#issuecomment-2495532375)
</details>
