### PR TITLE
8344916: RISC-V: Misaligned access in array fill stub

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2112,7 +2112,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // Remaining count is less than 8 bytes. Fill it by a single store.
     // Note that the total length is no less than 8 bytes.
-    if (t == T_BYTE || t == T_SHORT) {
+    if (!AvoidUnalignedAccesses && (t == T_BYTE || t == T_SHORT)) {
       __ beqz(count, L_exit1);
       __ shadd(to, count, to, tmp_reg, shift); // points to the end
       __ sd(value, Address(to, -8)); // overwrite some elements


### PR DESCRIPTION
Hi, Please review this small change.

In `generate_fill`, we fill the remaining elements by a single 8-byte store when the remaining count is less than 8 bytes in size after `fill_words`. This may overwrite some elements and create misaligned access. While it's not an issue for mordern CPUs with fast misaligned access, this does affect performance on CPUs where misaligned access is emulated by a trap handler and thus is very slow. async-profiler tells 2.8% of `jshort_fill` in flame graph when sampling Specjbb2005 on these platforms.

In this particular case, the copy address `to` is 8-byte aligned after `fill_words`. So if `AvoidUnalignedAccesses` is true, one choice would be directing control to `L_fill_elements` which avoids alignment issue while filling the remaining elements.

Test on linux-riscv64 platform:
- [x] tier1-3 (release)
- [x] 2.5% Specjbb2005 performance benefit on both HiFive Unmatched and Premier P550 SBCs.
- [x] No obvious performance impact witnessed on other platforms like BFI-F3 or Pioneer box (-XX:+AvoidUnalignedAccesses).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344916](https://bugs.openjdk.org/browse/JDK-8344916): RISC-V: Misaligned access in array fill stub (**Enhancement** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22347/head:pull/22347` \
`$ git checkout pull/22347`

Update a local copy of the PR: \
`$ git checkout pull/22347` \
`$ git pull https://git.openjdk.org/jdk.git pull/22347/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22347`

View PR using the GUI difftool: \
`$ git pr show -t 22347`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22347.diff">https://git.openjdk.org/jdk/pull/22347.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22347#issuecomment-2496546520)
</details>
