### PR TITLE
8344917: Fix recent NULL usage backsliding

### DIFF
--- a/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/templateInterpreterGenerator_aarch64.cpp
@@ -620,7 +620,7 @@ address TemplateInterpreterGenerator::generate_cont_resume_interpreter_adapter()
   // Restore Java expression stack pointer
   __ ldr(rscratch1, Address(rfp, frame::interpreter_frame_last_sp_offset * wordSize));
   __ lea(esp, Address(rfp, rscratch1, Address::lsl(Interpreter::logStackElementSize)));
-  // and NULL it as marker that esp is now tos until next java call
+  // and null it as marker that esp is now tos until next java call
   __ str(zr, Address(rfp, frame::interpreter_frame_last_sp_offset * wordSize));
 
   // Restore machine SP

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -552,7 +552,7 @@ address TemplateInterpreterGenerator::generate_cont_resume_interpreter_adapter()
   // Restore Java expression stack pointer
   __ ld(t0, Address(fp, frame::interpreter_frame_last_sp_offset * wordSize));
   __ shadd(esp, t0, fp, t0, Interpreter::logStackElementSize);
-  // and NULL it as marker that esp is now tos until next java call
+  // and null it as marker that esp is now tos until next java call
   __ sd(zr, Address(fp, frame::interpreter_frame_last_sp_offset * wordSize));
 
   // Restore machine SP

--- a/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
+++ b/src/hotspot/cpu/x86/templateInterpreterGenerator_x86.cpp
@@ -400,7 +400,7 @@ address TemplateInterpreterGenerator::generate_cont_resume_interpreter_adapter()
   // Restore stack bottom
   __ movptr(rcx, Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize));
   __ lea(rsp, Address(rbp, rcx, Address::times_ptr));
-  // and NULL it as marker that esp is now tos until next java call
+  // and null it as marker that esp is now tos until next java call
   __ movptr(Address(rbp, frame::interpreter_frame_last_sp_offset * wordSize), NULL_WORD);
 
   __ jmp(rax);

--- a/src/hotspot/share/cds/archiveUtils.hpp
+++ b/src/hotspot/share/cds/archiveUtils.hpp
@@ -162,7 +162,7 @@ public:
   DumpRegion(const char* name, uintx max_delta = 0)
     : _name(name), _base(nullptr), _top(nullptr), _end(nullptr),
       _max_delta(max_delta), _is_packed(false),
-      _rs(NULL), _vs(NULL) {}
+      _rs(nullptr), _vs(nullptr) {}
 
   char* expand_top_to(char* newtop);
   char* allocate(size_t num_bytes, size_t alignment = 0);

--- a/src/hotspot/share/cds/metaspaceShared.cpp
+++ b/src/hotspot/share/cds/metaspaceShared.cpp
@@ -315,7 +315,7 @@ static GrowableArrayCHeap<OopHandle, mtClassShared>* _extra_interned_strings = n
 // Extra Symbols to be added to the archive
 static GrowableArrayCHeap<Symbol*, mtClassShared>* _extra_symbols = nullptr;
 // Methods managed by SystemDictionary::find_method_handle_intrinsic() to be added to the archive
-static GrowableArray<Method*>* _pending_method_handle_intrinsics = NULL;
+static GrowableArray<Method*>* _pending_method_handle_intrinsics = nullptr;
 
 void MetaspaceShared::read_extra_data(JavaThread* current, const char* filename) {
   _extra_interned_strings = new GrowableArrayCHeap<OopHandle, mtClassShared>(10000);

--- a/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
+++ b/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,7 +54,7 @@ bool BlockLocationPrinter<CollectedHeapT>::print_location(outputStream* st, void
   // Check if addr points into Java heap.
   bool in_heap = CollectedHeapT::heap()->is_in(addr);
   if (in_heap) {
-    // base_oop_or_null() might be unimplemented and return NULL for some GCs/generations
+    // base_oop_or_null() might be unimplemented and return null for some GCs/generations
     oop o = base_oop_or_null(addr);
     if (o != nullptr) {
       if ((void*)o == addr) {

--- a/src/hotspot/share/oops/constantPool.cpp
+++ b/src/hotspot/share/oops/constantPool.cpp
@@ -428,7 +428,7 @@ void ConstantPool::restore_unshareable_info(TRAPS) {
   assert(is_shared(), "should always be set for shared constant pools");
   if (is_for_method_handle_intrinsic()) {
     // See the same check in remove_unshareable_info() below.
-    assert(cache() == NULL, "must not have cpCache");
+    assert(cache() == nullptr, "must not have cpCache");
     return;
   }
   assert(_cache != nullptr, "constant pool _cache should not be null");
@@ -474,7 +474,7 @@ void ConstantPool::remove_unshareable_info() {
     // This CP was created by Method::make_method_handle_intrinsic() and has nothing
     // that need to be removed/restored. It has no cpCache since the intrinsic methods
     // don't have any bytecodes.
-    assert(cache() == NULL, "must not have cpCache");
+    assert(cache() == nullptr, "must not have cpCache");
     return;
   }
 


### PR DESCRIPTION
Please review this trivial fix of some recently introduced uses of NULL in HotSpot.

Testing:
mach5 tier1
GHA sanity tests

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344917](https://bugs.openjdk.org/browse/JDK-8344917): Fix recent NULL usage backsliding (**Enhancement** - P4)


### Reviewers
 * [Johan Sjölen](https://openjdk.org/census#jsjolen) (@jdksjolen - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22348/head:pull/22348` \
`$ git checkout pull/22348`

Update a local copy of the PR: \
`$ git checkout pull/22348` \
`$ git pull https://git.openjdk.org/jdk.git pull/22348/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22348`

View PR using the GUI difftool: \
`$ git pr show -t 22348`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22348.diff">https://git.openjdk.org/jdk/pull/22348.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22348#issuecomment-2495952613)
</details>
