### PR TITLE
8344667: Remove most uses of AWT Permissions from the desktop module

### DIFF
--- a/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
+++ b/src/java.desktop/macosx/classes/sun/awt/CGraphicsDevice.java
@@ -25,7 +25,6 @@
 
 package sun.awt;
 
-import java.awt.AWTPermission;
 import java.awt.DisplayMode;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
@@ -61,8 +60,6 @@ public final class CGraphicsDevice extends GraphicsDevice
     private static boolean metalPipelineEnabled = false;
     private static boolean oglPipelineEnabled = false;
 
-
-    private static AWTPermission fullScreenExclusivePermission;
 
     // Save/restore DisplayMode for the Full Screen mode
     private DisplayMode originalMode;
@@ -260,23 +257,6 @@ public final class CGraphicsDevice extends GraphicsDevice
      */
     @Override
     public boolean isFullScreenSupported() {
-        return isFSExclusiveModeAllowed();
-    }
-
-    private static boolean isFSExclusiveModeAllowed() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            if (fullScreenExclusivePermission == null) {
-                fullScreenExclusivePermission =
-                    new AWTPermission("fullScreenExclusive");
-            }
-            try {
-                security.checkPermission(fullScreenExclusivePermission);
-            } catch (SecurityException e) {
-                return false;
-            }
-        }
         return true;
     }
 

--- a/src/java.desktop/share/classes/java/applet/Applet.java
+++ b/src/java.desktop/share/classes/java/applet/Applet.java
@@ -25,7 +25,6 @@
 
 package java.applet;
 
-import java.awt.AWTPermission;
 import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;
 import java.awt.HeadlessException;
@@ -127,12 +126,6 @@ public class Applet extends Panel {
      * @param  stub the new stub
      */
     public final void setStub(AppletStub stub) {
-        if (this.stub != null) {
-            SecurityManager s = System.getSecurityManager();
-            if (s != null) {
-                s.checkPermission(new AWTPermission("setAppletStub"));
-            }
-        }
         this.stub = stub;
     }
 

--- a/src/java.desktop/share/classes/java/awt/Dialog.java
+++ b/src/java.desktop/share/classes/java/awt/Dialog.java
@@ -33,7 +33,6 @@ import java.awt.peer.DialogPeer;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serial;
-import java.security.AccessControlException;
 import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -42,7 +41,6 @@ import javax.accessibility.AccessibleRole;
 import javax.accessibility.AccessibleState;
 import javax.accessibility.AccessibleStateSet;
 
-import sun.awt.AWTPermissions;
 import sun.awt.AppContext;
 import sun.awt.SunToolkit;
 import sun.awt.util.IdentityArrayList;
@@ -844,8 +842,6 @@ public class Dialog extends Window {
             return;
         }
 
-        checkModalityPermission(type);
-
         modalityType = type;
         modal = (modalityType != ModalityType.MODELESS);
     }
@@ -1561,16 +1557,6 @@ public class Dialog extends Window {
         }
     }
 
-    private void checkModalityPermission(ModalityType mt) {
-        if (mt == ModalityType.TOOLKIT_MODAL) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(AWTPermissions.TOOLKIT_MODALITY_PERMISSION);
-            }
-        }
-    }
-
     /**
      * Reads serializable fields from stream.
      *
@@ -1591,12 +1577,6 @@ public class Dialog extends Window {
             s.readFields();
 
         ModalityType localModalityType = (ModalityType)fields.get("modalityType", null);
-
-        try {
-            checkModalityPermission(localModalityType);
-        } catch (@SuppressWarnings("removal") AccessControlException ace) {
-            localModalityType = DEFAULT_MODALITY_TYPE;
-        }
 
         // in 1.5 or earlier modalityType was absent, so use "modal" instead
         if (localModalityType == null) {

--- a/src/java.desktop/share/classes/java/awt/MouseInfo.java
+++ b/src/java.desktop/share/classes/java/awt/MouseInfo.java
@@ -25,7 +25,6 @@
 
 package java.awt;
 
-import sun.awt.AWTPermissions;
 import sun.awt.ComponentFactory;
 
 /**
@@ -64,12 +63,6 @@ public class MouseInfo {
     public static PointerInfo getPointerInfo() throws HeadlessException {
         if (GraphicsEnvironment.isHeadless()) {
             throw new HeadlessException();
-        }
-
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.WATCH_MOUSE_PERMISSION);
         }
 
         Toolkit toolkit = Toolkit.getDefaultToolkit();

--- a/src/java.desktop/share/classes/java/awt/Robot.java
+++ b/src/java.desktop/share/classes/java/awt/Robot.java
@@ -37,7 +37,6 @@ import java.awt.image.Raster;
 import java.awt.image.WritableRaster;
 import java.awt.peer.RobotPeer;
 
-import sun.awt.AWTPermissions;
 import sun.awt.ComponentFactory;
 import sun.awt.SunToolkit;
 import sun.awt.image.SunWritableRaster;
@@ -163,7 +162,6 @@ public class Robot {
     }
 
     private void init(GraphicsDevice screen) throws AWTException {
-        checkRobotAllowed();
         Toolkit toolkit = Toolkit.getDefaultToolkit();
         if (toolkit instanceof ComponentFactory) {
             peer = ((ComponentFactory)toolkit).createRobot(screen);
@@ -191,15 +189,6 @@ public class Robot {
             InputEvent.BUTTON2_DOWN_MASK|
             InputEvent.BUTTON3_DOWN_MASK;
         LEGAL_BUTTON_MASK = tmpMask;
-    }
-
-    /* determine if the security policy allows Robot's to be created */
-    private static void checkRobotAllowed() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.CREATE_ROBOT_PERMISSION);
-        }
     }
 
     /**
@@ -437,7 +426,6 @@ public class Robot {
      * @return  Color of the pixel
      */
     public synchronized Color getPixelColor(int x, int y) {
-        checkScreenCaptureAllowed();
         Point point = peer.useAbsoluteCoordinates() ? toDeviceSpaceAbs(x, y)
                                                     : toDeviceSpace(x, y);
         return new Color(peer.getRGBPixel(point.x, point.y));
@@ -517,8 +505,6 @@ public class Robot {
 
     private synchronized BufferedImage[]
             createCompatibleImage(Rectangle screenRect, boolean isHiDPI) {
-
-        checkScreenCaptureAllowed();
 
         checkValidRect(screenRect);
 
@@ -632,14 +618,6 @@ public class Robot {
     private static void checkValidRect(Rectangle rect) {
         if (rect.width <= 0 || rect.height <= 0) {
             throw new IllegalArgumentException("Rectangle width and height must be > 0");
-        }
-    }
-
-    private static void checkScreenCaptureAllowed() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.READ_DISPLAY_PIXELS_PERMISSION);
         }
     }
 

--- a/src/java.desktop/share/classes/java/awt/SystemTray.java
+++ b/src/java.desktop/share/classes/java/awt/SystemTray.java
@@ -32,7 +32,6 @@ import java.beans.PropertyChangeSupport;
 import java.util.Vector;
 
 import sun.awt.AWTAccessor;
-import sun.awt.AWTPermissions;
 import sun.awt.AppContext;
 import sun.awt.HeadlessToolkit;
 import sun.awt.SunToolkit;
@@ -160,7 +159,6 @@ public class SystemTray {
      * @see #isSupported
      */
     public static SystemTray getSystemTray() {
-        checkSystemTrayAllowed();
         if (GraphicsEnvironment.isHeadless()) {
             throw new HeadlessException();
         }
@@ -491,14 +489,6 @@ public class SystemTray {
             } else if (toolkit instanceof HeadlessToolkit) {
                 peer = ((HeadlessToolkit)Toolkit.getDefaultToolkit()).createSystemTray(this);
             }
-        }
-    }
-
-    static void checkSystemTrayAllowed() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.ACCESS_SYSTEM_TRAY_PERMISSION);
         }
     }
 

--- a/src/java.desktop/share/classes/java/awt/Toolkit.java
+++ b/src/java.desktop/share/classes/java/awt/Toolkit.java
@@ -72,7 +72,6 @@ import java.util.stream.Collectors;
 import javax.accessibility.AccessibilityProvider;
 
 import sun.awt.AWTAccessor;
-import sun.awt.AWTPermissions;
 import sun.awt.AppContext;
 import sun.awt.HeadlessToolkit;
 import sun.awt.PeerEvent;
@@ -1360,11 +1359,6 @@ public abstract class Toolkit {
      * @return    the {@code EventQueue} object
     */
     public final EventQueue getSystemEventQueue() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.CHECK_AWT_EVENTQUEUE_PERMISSION);
-        }
         return getSystemEventQueueImpl();
     }
 
@@ -1690,11 +1684,6 @@ public abstract class Toolkit {
         if (localL == null) {
             return;
         }
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-          security.checkPermission(AWTPermissions.ALL_AWT_EVENTS_PERMISSION);
-        }
         synchronized (this) {
             SelectiveAWTEventListener selectiveListener =
                 listener2SelectiveListener.get(localL);
@@ -1750,11 +1739,6 @@ public abstract class Toolkit {
         if (listener == null) {
             return;
         }
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.ALL_AWT_EVENTS_PERMISSION);
-        }
 
         synchronized (this) {
             SelectiveAWTEventListener selectiveListener =
@@ -1807,11 +1791,6 @@ public abstract class Toolkit {
      * @since 1.4
      */
     public AWTEventListener[] getAWTEventListeners() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.ALL_AWT_EVENTS_PERMISSION);
-        }
         synchronized (this) {
             EventListener[] la = ToolkitEventMulticaster.getListeners(eventListener,AWTEventListener.class);
 
@@ -1851,11 +1830,6 @@ public abstract class Toolkit {
      * @since 1.4
      */
     public AWTEventListener[] getAWTEventListeners(long eventMask) {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.ALL_AWT_EVENTS_PERMISSION);
-        }
         synchronized (this) {
             EventListener[] la = ToolkitEventMulticaster.getListeners(eventListener,AWTEventListener.class);
 

--- a/src/java.desktop/share/classes/java/awt/TrayIcon.java
+++ b/src/java.desktop/share/classes/java/awt/TrayIcon.java
@@ -118,9 +118,8 @@ public class TrayIcon {
     }
 
     private TrayIcon()
-      throws UnsupportedOperationException, HeadlessException, SecurityException
+      throws UnsupportedOperationException, HeadlessException
     {
-        SystemTray.checkSystemTrayAllowed();
         if (GraphicsEnvironment.isHeadless()) {
             throw new HeadlessException();
         }

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -64,7 +64,6 @@ import javax.accessibility.AccessibleState;
 import javax.accessibility.AccessibleStateSet;
 
 import sun.awt.AWTAccessor;
-import sun.awt.AWTPermissions;
 import sun.awt.AppContext;
 import sun.awt.DebugSettings;
 import sun.awt.SunToolkit;
@@ -1627,13 +1626,6 @@ public class Window extends Container implements Accessible {
         if (modalExclusionType == exclusionType) {
             return;
         }
-        if (exclusionType == Dialog.ModalExclusionType.TOOLKIT_EXCLUDE) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(AWTPermissions.TOOLKIT_MODALITY_PERMISSION);
-            }
-        }
         modalExclusionType = exclusionType;
 
         // if we want on-fly changes, we need to uncomment the lines below
@@ -2169,12 +2161,6 @@ public class Window extends Container implements Accessible {
      * @since 1.5
      */
     public final void setAlwaysOnTop(boolean alwaysOnTop) {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.SET_WINDOW_ALWAYS_ON_TOP_PERMISSION);
-        }
-
         boolean oldAlwaysOnTop;
         synchronized(this) {
             oldAlwaysOnTop = this.alwaysOnTop;

--- a/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
@@ -1096,12 +1096,8 @@ public class JInternalFrame extends JComponent implements
           fireInternalFrameEvent(InternalFrameEvent.INTERNAL_FRAME_ACTIVATED);
         else {
           fireInternalFrameEvent(InternalFrameEvent.INTERNAL_FRAME_DEACTIVATED);
-          try {
-              java.awt.Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(
+          java.awt.Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(
                                                new sun.awt.UngrabEvent(this));
-          } catch (SecurityException e) {
-              this.dispatchEvent(new sun.awt.UngrabEvent(this));
-          }
         }
         repaint();
     }

--- a/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
+++ b/src/java.desktop/share/classes/javax/swing/SwingUtilities.java
@@ -1970,14 +1970,6 @@ public class SwingUtilities implements SwingConstants
         public void show() {
             // This frame can never be shown
         }
-        public void dispose() {
-            try {
-                getToolkit().getSystemEventQueue();
-                super.dispose();
-            } catch (Exception e) {
-                // untrusted code not allowed to dispose
-            }
-        }
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameTitlePane.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicInternalFrameTitlePane.java
@@ -528,12 +528,7 @@ public class BasicInternalFrameTitlePane extends JComponent
     protected void postClosingEvent(JInternalFrame frame) {
         InternalFrameEvent e = new InternalFrameEvent(
             frame, InternalFrameEvent.INTERNAL_FRAME_CLOSING);
-        // Try posting event, unless there's a SecurityManager.
-        try {
-            Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(e);
-        } catch (SecurityException se) {
-            frame.dispatchEvent(e);
-        }
+        Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(e);
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/AWTPermissions.java
+++ b/src/java.desktop/share/classes/sun/awt/AWTPermissions.java
@@ -35,28 +35,4 @@ public final class AWTPermissions {
 
     public static final AWTPermission ACCESS_CLIPBOARD_PERMISSION =
         new AWTPermission("accessClipboard");
-
-    public static final AWTPermission CHECK_AWT_EVENTQUEUE_PERMISSION =
-        new AWTPermission("accessEventQueue");
-
-    public static final AWTPermission TOOLKIT_MODALITY_PERMISSION =
-        new AWTPermission("toolkitModality");
-
-    public static final AWTPermission READ_DISPLAY_PIXELS_PERMISSION =
-        new AWTPermission("readDisplayPixels");
-
-    public static final AWTPermission CREATE_ROBOT_PERMISSION =
-        new AWTPermission("createRobot");
-
-    public static final AWTPermission WATCH_MOUSE_PERMISSION =
-        new AWTPermission("watchMousePointer");
-
-    public static final AWTPermission SET_WINDOW_ALWAYS_ON_TOP_PERMISSION =
-        new AWTPermission("setWindowAlwaysOnTop");
-
-    public static final AWTPermission ALL_AWT_EVENTS_PERMISSION =
-        new AWTPermission("listenToAllAWTEvents");
-
-    public static final AWTPermission ACCESS_SYSTEM_TRAY_PERMISSION =
-        new AWTPermission("accessSystemTray");
 }

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -1082,22 +1082,9 @@ public abstract class SunToolkit extends Toolkit
 
     /**
      * Returns whether popup is allowed to be shown above the task bar.
-     * This is a default implementation of this method, which checks
-     * corresponding security permission.
      */
     public boolean canPopupOverlapTaskBar() {
-        boolean result = true;
-        try {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                sm.checkPermission(AWTPermissions.SET_WINDOW_ALWAYS_ON_TOP_PERMISSION);
-            }
-        } catch (SecurityException se) {
-            // There is no permission to show popups over the task bar
-            result = false;
-        }
-        return result;
+        return true;
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/image/BufImgSurfaceData.java
+++ b/src/java.desktop/share/classes/sun/awt/image/BufImgSurfaceData.java
@@ -437,11 +437,6 @@ public class BufImgSurfaceData extends SurfaceData {
         return new Rectangle(bufImg.getWidth(), bufImg.getHeight());
     }
 
-    protected void checkCustomComposite() {
-        // BufferedImages always allow Custom Composite objects since
-        // their pixels are immediately retrievable anyway.
-    }
-
     /**
      * Returns destination Image associated with this SurfaceData.
      */

--- a/src/java.desktop/share/classes/sun/java2d/NullSurfaceData.java
+++ b/src/java.desktop/share/classes/sun/java2d/NullSurfaceData.java
@@ -131,15 +131,6 @@ public class NullSurfaceData extends SurfaceData {
     }
 
     /**
-     * Performs Security Permissions checks to see if a Custom
-     * Composite object should be allowed access to the pixels
-     * of this surface.
-     */
-    protected void checkCustomComposite() {
-        return;
-    }
-
-    /**
      * Performs a copyarea within this surface.  Returns
      * false if there is no algorithm to perform the copyarea
      * given the current settings of the SunGraphics2D.

--- a/src/java.desktop/share/classes/sun/java2d/SunGraphics2D.java
+++ b/src/java.desktop/share/classes/sun/java2d/SunGraphics2D.java
@@ -974,7 +974,6 @@ public final class SunGraphics2D
         } else if (comp == null) {
             throw new IllegalArgumentException("null Composite");
         } else {
-            surfaceData.checkCustomComposite();
             newCompState = COMP_CUSTOM;
             newCompType = CompositeType.General;
         }

--- a/src/java.desktop/share/classes/sun/java2d/SurfaceData.java
+++ b/src/java.desktop/share/classes/sun/java2d/SurfaceData.java
@@ -1002,25 +1002,6 @@ public abstract class SurfaceData
      */
     public abstract Rectangle getBounds();
 
-    static java.security.Permission compPermission;
-
-    /**
-     * Performs Security Permissions checks to see if a Custom
-     * Composite object should be allowed access to the pixels
-     * of this surface.
-     */
-    protected void checkCustomComposite() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            if (compPermission == null) {
-                compPermission =
-                    new java.awt.AWTPermission("readDisplayPixels");
-            }
-            sm.checkPermission(compPermission);
-        }
-    }
-
     /**
      * Fetches private field IndexColorModel.allgrayopaque
      * which is true when all palette entries in the color

--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsDevice.java
@@ -25,7 +25,6 @@
 
 package sun.awt;
 
-import java.awt.AWTPermission;
 import java.awt.DisplayMode;
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsDevice;
@@ -65,7 +64,6 @@ public final class X11GraphicsDevice extends GraphicsDevice
     private volatile int screen;
     Map<SurfaceType, SurfaceManager.ProxyCache> x11ProxyCacheMap = Collections.synchronizedMap(new HashMap<>());
 
-    private static AWTPermission fullScreenExclusivePermission;
     private static Boolean xrandrExtSupported;
     private SunDisplayChanger topLevels = new SunDisplayChanger();
     private DisplayMode origDisplayMode;
@@ -335,23 +333,7 @@ public final class X11GraphicsDevice extends GraphicsDevice
 
     @Override
     public boolean isFullScreenSupported() {
-        boolean fsAvailable = isXrandrExtensionSupported();
-        if (fsAvailable) {
-            @SuppressWarnings("removal")
-            SecurityManager security = System.getSecurityManager();
-            if (security != null) {
-                if (fullScreenExclusivePermission == null) {
-                    fullScreenExclusivePermission =
-                        new AWTPermission("fullScreenExclusive");
-                }
-                try {
-                    security.checkPermission(fullScreenExclusivePermission);
-                } catch (SecurityException e) {
-                    return false;
-                }
-            }
-        }
-        return fsAvailable;
+        return isXrandrExtensionSupported();
     }
 
     @Override

--- a/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
+++ b/src/java.desktop/windows/classes/sun/awt/Win32GraphicsDevice.java
@@ -25,7 +25,6 @@
 
 package sun.awt;
 
-import java.awt.AWTPermission;
 import java.awt.DisplayMode;
 import java.awt.EventQueue;
 import java.awt.Frame;
@@ -81,7 +80,6 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
     // pipelines which are mutually exclusive with opengl, for which
     // pixel formats were added in the first place
     protected static boolean pfDisabled;
-    private static AWTPermission fullScreenExclusivePermission;
     // the original display mode we had before entering the fullscreen
     // mode
     private DisplayMode defaultDisplayMode;
@@ -349,29 +347,12 @@ public class Win32GraphicsDevice extends GraphicsDevice implements
                     getLocalGraphicsEnvironment().getDefaultScreenDevice());
     }
 
-    private static boolean isFSExclusiveModeAllowed() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            if (fullScreenExclusivePermission == null) {
-                fullScreenExclusivePermission =
-                    new AWTPermission("fullScreenExclusive");
-            }
-            try {
-                security.checkPermission(fullScreenExclusivePermission);
-            } catch (SecurityException e) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     /**
      * returns true unless we're not allowed to use fullscreen mode.
      */
     @Override
     public boolean isFullScreenSupported() {
-        return isFSExclusiveModeAllowed();
+        return true;
     }
 
     @Override

--- a/test/jdk/lib/client/ExtendedRobot.java
+++ b/test/jdk/lib/client/ExtendedRobot.java
@@ -68,11 +68,8 @@ public class ExtendedRobot extends Robot {
      * @throws  AWTException if the platform configuration does not allow low-level input
      *          control. This exception is always thrown when
      *          GraphicsEnvironment.isHeadless() returns true
-     * @throws  SecurityException if {@code createRobot} permission is not granted
      *
      * @see     java.awt.GraphicsEnvironment#isHeadless
-     * @see     SecurityManager#checkPermission
-     * @see     java.awt.AWTPermission
      */
     public ExtendedRobot() throws AWTException {
         super();
@@ -99,12 +96,9 @@ public class ExtendedRobot extends Robot {
      *          GraphicsEnvironment.isHeadless() returns true.
      * @throws  IllegalArgumentException if {@code screen} is not a screen
      *          GraphicsDevice.
-     * @throws  SecurityException if {@code createRobot} permission is not granted
      *
      * @see     java.awt.GraphicsEnvironment#isHeadless
      * @see     GraphicsDevice
-     * @see     SecurityManager#checkPermission
-     * @see     java.awt.AWTPermission
      */
     public ExtendedRobot(GraphicsDevice screen) throws AWTException {
         super(screen);


### PR DESCRIPTION
This removes most uses of AWTPermission in the desktop module.
clipboard will be handled separately because it is less straightforward.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344667](https://bugs.openjdk.org/browse/JDK-8344667): Remove most uses of AWT Permissions from the desktop module (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22350/head:pull/22350` \
`$ git checkout pull/22350`

Update a local copy of the PR: \
`$ git checkout pull/22350` \
`$ git pull https://git.openjdk.org/jdk.git pull/22350/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22350`

View PR using the GUI difftool: \
`$ git pr show -t 22350`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22350.diff">https://git.openjdk.org/jdk/pull/22350.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22350#issuecomment-2496388784)
</details>
