### PR TITLE
8344857: Remove calls to SecurityManager and doPrivileged  in SocketExceptions and URLJarFile in the sun.net package after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/sun/net/util/SocketExceptions.java
+++ b/src/java.base/share/classes/sun/net/util/SocketExceptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -30,8 +30,6 @@ import java.lang.reflect.Constructor;
 import java.net.InetSocketAddress;
 import java.net.UnixDomainSocketAddress;
 import java.net.SocketAddress;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import sun.security.util.SecurityProperties;
 
@@ -83,22 +81,16 @@ public final class SocketExceptions {
     // return a new instance of the same type with the given detail
     // msg, or if the type doesn't support detail msgs, return given
     // instance.
-
-    @SuppressWarnings("removal")
-    private static IOException create(IOException e, String msg) {
-        return AccessController.doPrivileged(new PrivilegedAction<IOException>() {
-            public IOException run() {
-                try {
-                    Class<?> clazz = e.getClass();
-                    Constructor<?> ctor = clazz.getConstructor(String.class);
-                    IOException e1 = (IOException)(ctor.newInstance(msg));
-                    e1.setStackTrace(e.getStackTrace());
-                    return e1;
-                } catch (Exception e0) {
-                    // Some eg AsynchronousCloseException have no detail msg
-                    return e;
-                }
-            }
-        });
+    private static IOException create(final IOException e, final String msg) {
+        try {
+            Class<?> clazz = e.getClass();
+            Constructor<?> ctor = clazz.getConstructor(String.class);
+            IOException e1 = (IOException)(ctor.newInstance(msg));
+            e1.setStackTrace(e.getStackTrace());
+            return e1;
+        } catch (Exception e0) {
+            // Some eg AsynchronousCloseException have no detail msg
+            return e;
+        }
     }
 }


### PR DESCRIPTION
Can I please get a review of this change which cleans up the usages of SecurityManager APIs from a couple of `sun.net` packages? This addresses https://bugs.openjdk.org/browse/JDK-8344857.

No new tests have been added and existing tests in tier1, tier2 and tier3 continue to pass.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344857](https://bugs.openjdk.org/browse/JDK-8344857): Remove calls to SecurityManager and doPrivileged  in SocketExceptions and URLJarFile in the sun.net package after JEP 486 integration (**Sub-task** - P4)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22352/head:pull/22352` \
`$ git checkout pull/22352`

Update a local copy of the PR: \
`$ git checkout pull/22352` \
`$ git pull https://git.openjdk.org/jdk.git pull/22352/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22352`

View PR using the GUI difftool: \
`$ git pr show -t 22352`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22352.diff">https://git.openjdk.org/jdk/pull/22352.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22352#issuecomment-2496459903)
</details>
