### PR TITLE
8336356: [s390x] preserve Vector Register before using for string compress / expand

### DIFF
--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
@@ -84,7 +84,9 @@ void C2_MacroAssembler::load_narrow_klass_compact_c2(Register dst, Address src) 
 // If precise is false, a few characters more than indicated by the return value may have been
 // written to the dst array. In any failure case, The result value indexes the first invalid character.
 unsigned int C2_MacroAssembler::string_compress(Register result, Register src, Register dst, Register cnt,
-                                                Register tmp,    bool precise, bool toASCII) {
+                                                Register tmp, bool precise, bool toASCII, VectorRegister v16, VectorRegister v17,
+                                                VectorRegister v18, VectorRegister v19, VectorRegister v20, VectorRegister v21,
+                                                VectorRegister v22, VectorRegister v23) {
   assert_different_registers(Z_R0, Z_R1, result, src, dst, cnt, tmp);
 
   unsigned short char_mask = 0xff00;  // all selected bits must be '0' for a char to be valid
@@ -169,7 +171,6 @@ unsigned int C2_MacroAssembler::string_compress(Register result, Register src, R
 #endif
   clear_reg(Z_R0);                         // make sure register is properly initialized.
 
-#if 0
   if (VM_Version::has_VectorFacility()) {
     const int  min_vcnt     = 32;          // Minimum #characters required to use vector instructions.
                                            // Otherwise just do nothing in vector mode.
@@ -178,12 +179,12 @@ unsigned int C2_MacroAssembler::string_compress(Register result, Register src, R
     const int  log_min_vcnt = exact_log2(min_vcnt);
     Label      VectorLoop, VectorDone, VectorBreak;
 
-    VectorRegister Vtmp1      = Z_V16;
-    VectorRegister Vtmp2      = Z_V17;
-    VectorRegister Vmask      = Z_V18;
-    VectorRegister Vzero      = Z_V19;
-    VectorRegister Vsrc_first = Z_V20;
-    VectorRegister Vsrc_last  = Z_V23;
+    VectorRegister Vtmp1      = v16;
+    VectorRegister Vtmp2      = v17;
+    VectorRegister Vmask      = v18;
+    VectorRegister Vzero      = v19;
+    VectorRegister Vsrc_first = v20;
+    VectorRegister Vsrc_last  = v23;
 
     assert((Vsrc_last->encoding() - Vsrc_first->encoding() + 1) == min_vcnt/8, "logic error");
     assert(VM_Version::has_DistinctOpnds(), "Assumption when has_VectorFacility()");
@@ -199,8 +200,8 @@ unsigned int C2_MacroAssembler::string_compress(Register result, Register src, R
       add2reg(Rsrc, min_vcnt*2);
 
       //---<  check for incompatible character  >---
-      z_vo(Vtmp1, Z_V20, Z_V21);
-      z_vo(Vtmp2, Z_V22, Z_V23);
+      z_vo(Vtmp1, v20, v21);
+      z_vo(Vtmp2, v22, v23);
       z_vo(Vtmp1, Vtmp1, Vtmp2);
       z_vn(Vtmp1, Vtmp1, Vmask);
       z_vceqhs(Vtmp1, Vtmp1, Vzero);       // all bits selected by mask must be zero for successful compress.
@@ -208,8 +209,8 @@ unsigned int C2_MacroAssembler::string_compress(Register result, Register src, R
                                            // re-process data from current iteration in break handler.
 
       //---<  pack & store characters  >---
-      z_vpkh(Vtmp1, Z_V20, Z_V21);         // pack (src1, src2) -> tmp1
-      z_vpkh(Vtmp2, Z_V22, Z_V23);         // pack (src3, src4) -> tmp2
+      z_vpkh(Vtmp1, v20, v21);         // pack (src1, src2) -> tmp1
+      z_vpkh(Vtmp2, v22, v23);         // pack (src3, src4) -> tmp2
       z_vstm(Vtmp1, Vtmp2, 0, Rdst);       // store packed string
       add2reg(Rdst, min_vcnt);
 
@@ -224,7 +225,6 @@ unsigned int C2_MacroAssembler::string_compress(Register result, Register src, R
 
     bind(VectorDone);
   }
-#endif
 
   {
     const int  min_cnt     =  8;           // Minimum #characters required to use unrolled loop.
@@ -419,7 +419,9 @@ unsigned int C2_MacroAssembler::string_inflate_trot(Register src, Register dst, 
 // Note:
 //   cnt is signed int. Do not rely on high word!
 //       counts # characters, not bytes.
-unsigned int C2_MacroAssembler::string_inflate(Register src, Register dst, Register cnt, Register tmp) {
+unsigned int C2_MacroAssembler::string_inflate(Register src, Register dst, Register cnt, Register tmp,
+                                               VectorRegister v20, VectorRegister v21, VectorRegister v22,
+                                               VectorRegister v23, VectorRegister v24, VectorRegister v25) {
   assert_different_registers(Z_R0, Z_R1, src, dst, cnt, tmp);
 
   BLOCK_COMMENT("string_inflate {");
@@ -463,7 +465,6 @@ unsigned int C2_MacroAssembler::string_inflate(Register src, Register dst, Regis
 #endif
   clear_reg(Z_R0);                         // make sure register is properly initialized.
 
-#if 0
   if (VM_Version::has_VectorFacility()) {
     const int  min_vcnt     = 32;          // Minimum #characters required to use vector instructions.
                                            // Otherwise just do nothing in vector mode.
@@ -478,21 +479,20 @@ unsigned int C2_MacroAssembler::string_inflate(Register src, Register dst, Regis
     z_sllg(Z_R0, Rix, log_min_vcnt);       // remember #chars that will be processed by vector loop
 
     bind(VectorLoop);
-      z_vlm(Z_V20, Z_V21, 0, Rsrc);        // get next 32 characters (single-byte)
+      z_vlm(v20, v21, 0, Rsrc);        // get next 32 characters (single-byte)
       add2reg(Rsrc, min_vcnt);
 
-      z_vuplhb(Z_V22, Z_V20);              // V2 <- (expand) V0(high)
-      z_vupllb(Z_V23, Z_V20);              // V3 <- (expand) V0(low)
-      z_vuplhb(Z_V24, Z_V21);              // V4 <- (expand) V1(high)
-      z_vupllb(Z_V25, Z_V21);              // V5 <- (expand) V1(low)
-      z_vstm(Z_V22, Z_V25, 0, Rdst);       // store next 32 bytes
+      z_vuplhb(v22, v20);              // V2 <- (expand) V0(high)
+      z_vupllb(v23, v20);              // V3 <- (expand) V0(low)
+      z_vuplhb(v24, v21);              // V4 <- (expand) V1(high)
+      z_vupllb(v25, v21);              // V5 <- (expand) V1(low)
+      z_vstm(v22, v25, 0, Rdst);       // store next 32 bytes
       add2reg(Rdst, min_vcnt*2);
 
       z_brct(Rix, VectorLoop);
 
     bind(VectorDone);
   }
-#endif
 
   const int  min_cnt     =  8;             // Minimum #characters required to use unrolled scalar loop.
                                            // Otherwise just do nothing in unrolled scalar mode.
@@ -611,7 +611,9 @@ unsigned int C2_MacroAssembler::string_inflate(Register src, Register dst, Regis
 //   Kills:    tmp, Z_R0, Z_R1.
 // Note:
 //   len is signed int. Counts # characters, not bytes.
-unsigned int C2_MacroAssembler::string_inflate_const(Register src, Register dst, Register tmp, int len) {
+unsigned int C2_MacroAssembler::string_inflate_const(Register src, Register dst, Register tmp, int len ,
+                                                     VectorRegister v20, VectorRegister v21, VectorRegister v22,
+                                                     VectorRegister v23, VectorRegister v24, VectorRegister v25) {
   assert_different_registers(Z_R0, Z_R1, src, dst, tmp);
 
   BLOCK_COMMENT("string_inflate_const {");
@@ -627,7 +629,6 @@ unsigned int C2_MacroAssembler::string_inflate_const(Register src, Register dst,
   bool       restore_inputs = false;
   bool       workreg_clear  = false;
 
-#if 0
   if ((len >= 32) && VM_Version::has_VectorFacility()) {
     const int  min_vcnt     = 32;          // Minimum #characters required to use vector instructions.
                                            // Otherwise just do nothing in vector mode.
@@ -638,12 +639,12 @@ unsigned int C2_MacroAssembler::string_inflate_const(Register src, Register dst,
     Label      VectorLoop;
 
     if (iterations == 1) {
-      z_vlm(Z_V20, Z_V21, 0+src_off, Rsrc);  // get next 32 characters (single-byte)
-      z_vuplhb(Z_V22, Z_V20);                // V2 <- (expand) V0(high)
-      z_vupllb(Z_V23, Z_V20);                // V3 <- (expand) V0(low)
-      z_vuplhb(Z_V24, Z_V21);                // V4 <- (expand) V1(high)
-      z_vupllb(Z_V25, Z_V21);                // V5 <- (expand) V1(low)
-      z_vstm(Z_V22, Z_V25, 0+dst_off, Rdst); // store next 32 bytes
+      z_vlm(v20, v21, 0+src_off, Rsrc);  // get next 32 characters (single-byte)
+      z_vuplhb(v22, v20);                // V2 <- (expand) V0(high)
+      z_vupllb(v23, v20);                // V3 <- (expand) V0(low)
+      z_vuplhb(v24, v21);                // V4 <- (expand) V1(high)
+      z_vupllb(v25, v21);                // V5 <- (expand) V1(low)
+      z_vstm(v22, v25, 0+dst_off, Rdst); // store next 32 bytes
 
       src_off += min_vcnt;
       dst_off += min_vcnt*2;
@@ -652,14 +653,14 @@ unsigned int C2_MacroAssembler::string_inflate_const(Register src, Register dst,
 
       z_lgfi(Rix, len>>log_min_vcnt);
       bind(VectorLoop);
-        z_vlm(Z_V20, Z_V21, 0, Rsrc);        // get next 32 characters (single-byte)
+        z_vlm(v20, v21, 0, Rsrc);        // get next 32 characters (single-byte)
         add2reg(Rsrc, min_vcnt);
 
-        z_vuplhb(Z_V22, Z_V20);              // V2 <- (expand) V0(high)
-        z_vupllb(Z_V23, Z_V20);              // V3 <- (expand) V0(low)
-        z_vuplhb(Z_V24, Z_V21);              // V4 <- (expand) V1(high)
-        z_vupllb(Z_V25, Z_V21);              // V5 <- (expand) V1(low)
-        z_vstm(Z_V22, Z_V25, 0, Rdst);       // store next 32 bytes
+        z_vuplhb(v22, v20);              // V2 <- (expand) V0(high)
+        z_vupllb(v23, v20);              // V3 <- (expand) V0(low)
+        z_vuplhb(v24, v21);              // V4 <- (expand) V1(high)
+        z_vupllb(v25, v21);              // V5 <- (expand) V1(low)
+        z_vstm(v22, v25, 0, Rdst);       // store next 32 bytes
         add2reg(Rdst, min_vcnt*2);
 
         z_brct(Rix, VectorLoop);
@@ -675,15 +676,14 @@ unsigned int C2_MacroAssembler::string_inflate_const(Register src, Register dst,
     nprocessed             += iterations << log_min_vcnt;
     assert(iterations == 1, "must be!");
 
-    z_vl(Z_V20, 0+src_off, Z_R0, Rsrc);    // get next 16 characters (single-byte)
-    z_vuplhb(Z_V22, Z_V20);                // V2 <- (expand) V0(high)
-    z_vupllb(Z_V23, Z_V20);                // V3 <- (expand) V0(low)
-    z_vstm(Z_V22, Z_V23, 0+dst_off, Rdst); // store next 32 bytes
+    z_vl(v20, 0+src_off, Z_R0, Rsrc);    // get next 16 characters (single-byte)
+    z_vuplhb(v22, v20);                // V2 <- (expand) V0(high)
+    z_vupllb(v23, v20);                // V3 <- (expand) V0(low)
+    z_vstm(v22, v23, 0+dst_off, Rdst); // store next 32 bytes
 
     src_off += min_vcnt;
     dst_off += min_vcnt*2;
   }
-#endif
 
   if ((len-nprocessed) > 8) {
     const int  min_cnt     =  8;           // Minimum #characters required to use unrolled scalar loop.

--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
@@ -44,10 +44,10 @@
   //   Kills:    tmp, Z_R0, Z_R1.
   //   Early clobber: result.
   //   Boolean precise controls accuracy of result value.
-  unsigned int string_compress(Register result, Register src, Register dst, Register cnt,
-                               Register tmp, bool precise, bool toASCII, VectorRegister v16, VectorRegister v17,
-                               VectorRegister v18, VectorRegister v19, VectorRegister v20, VectorRegister v21,
-                               VectorRegister v22, VectorRegister v23);
+  unsigned int string_compress(Register result, Register Rsrc, Register Rdst, Register Rcnt,
+                               Register tmp, bool precise, bool toASCII, VectorRegister Vtmp1, VectorRegister Vtmp2,
+                               VectorRegister Vmask, VectorRegister Vzero, VectorRegister Vsrc_first, VectorRegister v21,
+                               VectorRegister v22, VectorRegister Vsrc_last);
 
   // Inflate byte[] to char[].
   unsigned int string_inflate_trot(Register src, Register dst, Register cnt, Register tmp);

--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.hpp
@@ -45,7 +45,9 @@
   //   Early clobber: result.
   //   Boolean precise controls accuracy of result value.
   unsigned int string_compress(Register result, Register src, Register dst, Register cnt,
-                               Register tmp,    bool precise, bool toASCII);
+                               Register tmp, bool precise, bool toASCII, VectorRegister v16, VectorRegister v17,
+                               VectorRegister v18, VectorRegister v19, VectorRegister v20, VectorRegister v21,
+                               VectorRegister v22, VectorRegister v23);
 
   // Inflate byte[] to char[].
   unsigned int string_inflate_trot(Register src, Register dst, Register cnt, Register tmp);
@@ -54,14 +56,16 @@
   //   Restores: src, dst
   //   Uses:     cnt
   //   Kills:    tmp, Z_R0, Z_R1.
-  unsigned int string_inflate(Register src, Register dst, Register cnt, Register tmp);
+  unsigned int string_inflate(Register src, Register dst, Register cnt, Register tmp, VectorRegister v20, VectorRegister v21,
+                              VectorRegister v22, VectorRegister v23, VectorRegister v24, VectorRegister v25);
 
   // Inflate byte[] to char[], length known at compile time.
   //   Restores: src, dst
   //   Kills:    tmp, Z_R0, Z_R1.
   // Note:
   //   len is signed int. Counts # characters, not bytes.
-  unsigned int string_inflate_const(Register src, Register dst, Register tmp, int len);
+  unsigned int string_inflate_const(Register src, Register dst, Register tmp, int len , VectorRegister v20, VectorRegister v21,
+                                    VectorRegister v22, VectorRegister v23, VectorRegister v24, VectorRegister v25);
 
   unsigned int count_positives(Register result, Register src, Register cnt, Register tmp);
 

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -10600,8 +10600,8 @@ instruct string_compress(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tm
   ins_encode %{
     __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
                        $tmp$$Register, true, false, $v16$$VectorRegister, $v17$$VectorRegister, $v18$$VectorRegister,
-                     $v19$$VectorRegister, $v20$$VectorRegister, $v21$$VectorRegister, $v22$$VectorRegister,
-                     $v23$$VectorRegister);
+                       $v19$$VectorRegister, $v20$$VectorRegister, $v21$$VectorRegister, $v22$$VectorRegister,
+                       $v23$$VectorRegister);
   %}
   ins_pipe(pipe_class_dummy);
 %}
@@ -10673,8 +10673,8 @@ instruct encode_iso_array(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI t
   ins_encode %{
     __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
                        $tmp$$Register, true, false, $v16$$VectorRegister, $v17$$VectorRegister, $v18$$VectorRegister,
-                     $v19$$VectorRegister, $v20$$VectorRegister, $v21$$VectorRegister, $v22$$VectorRegister,
-                     $v23$$VectorRegister);
+                       $v19$$VectorRegister, $v20$$VectorRegister, $v21$$VectorRegister, $v22$$VectorRegister,
+                       $v23$$VectorRegister);
   %}
   ins_pipe(pipe_class_dummy);
 %}
@@ -10691,8 +10691,8 @@ instruct encode_ascii_array(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI
   ins_encode %{
     __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
                        $tmp$$Register, true, true, $v16$$VectorRegister, $v17$$VectorRegister, $v18$$VectorRegister,
-                     $v19$$VectorRegister, $v20$$VectorRegister, $v21$$VectorRegister, $v22$$VectorRegister,
-                     $v23$$VectorRegister);
+                       $v19$$VectorRegister, $v20$$VectorRegister, $v21$$VectorRegister, $v22$$VectorRegister,
+                       $v23$$VectorRegister);
   %}
   ins_pipe(pipe_class_dummy);
 %}

--- a/src/hotspot/cpu/s390/s390.ad
+++ b/src/hotspot/cpu/s390/s390.ad
@@ -762,6 +762,56 @@ reg_class z_v_reg(
 	Z_VR31, Z_VR31_H, Z_VR31_J, Z_VR31_K
 );
 
+// class for vector register v16
+reg_class z_vreg_16(
+   Z_VR16, Z_VR16_H, Z_VR16_J, Z_VR16_K
+);
+
+// class for vector register v17
+reg_class z_vreg_17(
+   Z_VR17, Z_VR17_H, Z_VR17_J, Z_VR17_K
+);
+
+// class for vector register v18
+reg_class z_vreg_18(
+    Z_VR18, Z_VR18_H, Z_VR18_J, Z_VR18_K
+);
+
+// class for vector register v19
+reg_class z_vreg_19(
+    Z_VR19, Z_VR19_H, Z_VR19_J, Z_VR19_K
+);
+
+// class for vector register v20
+reg_class z_vreg_20(
+    Z_VR20, Z_VR20_H, Z_VR20_J, Z_VR20_K
+);
+
+// class for vector register v21
+reg_class z_vreg_21(
+    Z_VR21, Z_VR21_H, Z_VR21_J, Z_VR21_K
+);
+
+// class for vector register v22
+reg_class z_vreg_22(
+    Z_VR22, Z_VR22_H, Z_VR22_J, Z_VR22_K
+);
+
+// class for vector register v23
+reg_class z_vreg_23(
+    Z_VR23, Z_VR23_H, Z_VR23_J, Z_VR23_K
+);
+
+// class for vector register v24
+reg_class z_vreg_24(
+    Z_VR24, Z_VR24_H, Z_VR24_J, Z_VR24_K
+);
+
+// class for vector register v25
+reg_class z_vreg_25(
+    Z_VR25, Z_VR25_H, Z_VR25_J, Z_VR25_K
+);
+
 %}
 
 //----------DEFINITION BLOCK---------------------------------------------------
@@ -2686,11 +2736,89 @@ ins_attrib ins_should_rematerialize(false);
 operand vecX() %{
   constraint(ALLOC_IN_RC(z_v_reg));
   match(VecX);
-
+  match(v16TempReg);
+  match(v17TempReg);
+  match(v18TempReg);
+  match(v19TempReg);
+  match(v20TempReg);
+  match(v21TempReg);
+  match(v22TempReg);
+  match(v23TempReg);
+  match(v24TempReg);
+  match(v25TempReg);
   format %{ %}
   interface(REG_INTER);
 %}
 
+operand v16TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_16));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand v17TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_17));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand v18TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_18));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand v19TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_19));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand v20TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_20));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand v21TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_21));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand v22TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_22));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand v23TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_23));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand v24TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_24));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
+
+operand v25TempReg() %{
+  constraint(ALLOC_IN_RC(z_vreg_25));
+  match(VecX);
+  format %{ %}
+  interface(REG_INTER);
+%}
 
 //----------------------------------------------
 // SIGNED (shorter than INT) immediate operands
@@ -10463,14 +10591,17 @@ instruct indexOf_UL(iRegP haystack, rarg2RegI haycnt, iRegP needle, rarg5RegI ne
 %}
 
 // char[] to byte[] compression
-instruct string_compress(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tmp, flagsReg cr) %{
+instruct string_compress(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tmp, v16TempReg v16, v17TempReg v17, v18TempReg v18,
+                         v19TempReg v19, v20TempReg v20, v21TempReg v21, v22TempReg v22, v23TempReg v23, flagsReg cr) %{
   match(Set result (StrCompressedCopy src (Binary dst len)));
-  effect(TEMP_DEF result, TEMP tmp, KILL cr); // R0, R1 are killed, too.
+  effect(TEMP_DEF result, TEMP tmp, TEMP v16, TEMP v17, TEMP v18, TEMP v19, TEMP v20, TEMP v21, TEMP v22, TEMP v23, KILL cr); // R0, R1 are killed, too.
   ins_cost(300);
   format %{ "String Compress $src->$dst($len) -> $result" %}
   ins_encode %{
     __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
-                       $tmp$$Register, true, false);
+                       $tmp$$Register, true, false, $v16$$VectorRegister, $v17$$VectorRegister, $v18$$VectorRegister,
+                     $v19$$VectorRegister, $v20$$VectorRegister, $v21$$VectorRegister, $v22$$VectorRegister,
+                     $v23$$VectorRegister);
   %}
   ins_pipe(pipe_class_dummy);
 %}
@@ -10489,25 +10620,31 @@ instruct string_compress(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tm
 //%}
 
 // byte[] to char[] inflation
-instruct string_inflate(Universe dummy, iRegP src, iRegP dst, iRegI len, iRegI tmp, flagsReg cr) %{
+instruct string_inflate(Universe dummy, iRegP src, iRegP dst, iRegI len, iRegI tmp, v20TempReg v20, v21TempReg v21, v22TempReg v22, v23TempReg v23,
+                        v24TempReg v24, v25TempReg v25, flagsReg cr) %{
   match(Set dummy (StrInflatedCopy src (Binary dst len)));
-  effect(TEMP tmp, KILL cr); // R0, R1 are killed, too.
+  effect(TEMP tmp, TEMP v20, TEMP v21, TEMP v22, TEMP v23, TEMP v24, TEMP v25, KILL cr); // R0, R1 are killed, too.
   ins_cost(300);
   format %{ "String Inflate $src->$dst($len)" %}
   ins_encode %{
-    __ string_inflate($src$$Register, $dst$$Register, $len$$Register, $tmp$$Register);
+    __ string_inflate($src$$Register, $dst$$Register, $len$$Register, $tmp$$Register, $v20$$VectorRegister,
+                      $v21$$VectorRegister, $v22$$VectorRegister, $v23$$VectorRegister, $v24$$VectorRegister,
+                      $v25$$VectorRegister);
   %}
   ins_pipe(pipe_class_dummy);
 %}
 
 // byte[] to char[] inflation
-instruct string_inflate_const(Universe dummy, iRegP src, iRegP dst, iRegI tmp, immI len, flagsReg cr) %{
+instruct string_inflate_const(Universe dummy, iRegP src, iRegP dst, iRegI tmp, immI len, v20TempReg v20, v21TempReg v21, v22TempReg v22, v23TempReg v23,
+                              v24TempReg v24, v25TempReg v25, flagsReg cr) %{
   match(Set dummy (StrInflatedCopy src (Binary dst len)));
-  effect(TEMP tmp, KILL cr); // R0, R1 are killed, too.
+  effect(TEMP tmp, TEMP v20, TEMP v21, TEMP v22, TEMP v23, TEMP v24, TEMP v25, KILL cr); // R0, R1 are killed, too.
   ins_cost(300);
   format %{ "String Inflate (constLen) $src->$dst($len)" %}
   ins_encode %{
-    __ string_inflate_const($src$$Register, $dst$$Register, $tmp$$Register, $len$$constant);
+    __ string_inflate_const($src$$Register, $dst$$Register, $tmp$$Register, $len$$constant , $v20$$VectorRegister,
+                            $v21$$VectorRegister, $v22$$VectorRegister, $v23$$VectorRegister, $v24$$VectorRegister,
+                            $v25$$VectorRegister);
   %}
   ins_pipe(pipe_class_dummy);
 %}
@@ -10525,29 +10662,37 @@ instruct count_positives(iRegP ary1, iRegI len, iRegI result, iRegI tmp, flagsRe
 %}
 
 // encode char[] to byte[] in ISO_8859_1
-instruct encode_iso_array(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tmp, flagsReg cr) %{
+instruct encode_iso_array(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tmp, v16TempReg v16, v17TempReg v17, v18TempReg v18, v19TempReg v19, v20TempReg v20, v21TempReg v21,
+			 v22TempReg v22, v23TempReg v23, flagsReg cr) %{
   predicate(!((EncodeISOArrayNode*)n)->is_ascii());
   match(Set result (EncodeISOArray src (Binary dst len)));
-  effect(TEMP_DEF result, TEMP tmp, KILL cr); // R0, R1 are killed, too.
+  effect(TEMP_DEF result, TEMP tmp, TEMP v16, TEMP v17, TEMP v18, TEMP v19,
+	       TEMP v20, TEMP v21, TEMP v22, TEMP v23, KILL cr); // R0, R1 are killed, too.
   ins_cost(300);
   format %{ "Encode iso array $src->$dst($len) -> $result" %}
   ins_encode %{
     __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
-                       $tmp$$Register, true, false);
+                       $tmp$$Register, true, false, $v16$$VectorRegister, $v17$$VectorRegister, $v18$$VectorRegister,
+                     $v19$$VectorRegister, $v20$$VectorRegister, $v21$$VectorRegister, $v22$$VectorRegister,
+                     $v23$$VectorRegister);
   %}
   ins_pipe(pipe_class_dummy);
 %}
 
 // encode char[] to byte[] in ASCII
-instruct encode_ascii_array(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tmp, flagsReg cr) %{
+instruct encode_ascii_array(iRegP src, iRegP dst, iRegI result, iRegI len, iRegI tmp, v16TempReg v16, v17TempReg v17, v18TempReg v18, v19TempReg v19, v20TempReg v20, v21TempReg v21,
+			 v22TempReg v22, v23TempReg v23, flagsReg cr) %{
   predicate(((EncodeISOArrayNode*)n)->is_ascii());
   match(Set result (EncodeISOArray src (Binary dst len)));
-  effect(TEMP_DEF result, TEMP tmp, KILL cr); // R0, R1 are killed, too.
+  effect(TEMP_DEF result, TEMP tmp, TEMP v16, TEMP v17, TEMP v18, TEMP v19,
+	       TEMP v20, TEMP v21, TEMP v22, TEMP v23, KILL cr); // R0, R1 are killed, too.
   ins_cost(300);
   format %{ "Encode ascii array $src->$dst($len) -> $result" %}
   ins_encode %{
     __ string_compress($result$$Register, $src$$Register, $dst$$Register, $len$$Register,
-                       $tmp$$Register, true, true);
+                       $tmp$$Register, true, true, $v16$$VectorRegister, $v17$$VectorRegister, $v18$$VectorRegister,
+                     $v19$$VectorRegister, $v20$$VectorRegister, $v21$$VectorRegister, $v22$$VectorRegister,
+                     $v23$$VectorRegister);
   %}
   ins_pipe(pipe_class_dummy);
 %}


### PR DESCRIPTION
This PR adds `TEMP` effect for the vector register, allotted by register allocator, used in the string compress/expand intrinsic. Also it enabled the Vector computation part of those intrinsics which was disabled by https://github.com/openjdk/jdk/pull/18162

tier1 test, which also includes string intrinsic tests `compiler/intrinsics/string/` are clean. No regression seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8336356](https://bugs.openjdk.org/browse/JDK-8336356): [s390x] preserve Vector Register before using for string compress / expand (**Enhancement** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**) Review applies to [a01706dd](https://git.openjdk.org/jdk/pull/22354/files/a01706dd92a248b4f8ddb47ed651752c0249c4f2)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22354/head:pull/22354` \
`$ git checkout pull/22354`

Update a local copy of the PR: \
`$ git checkout pull/22354` \
`$ git pull https://git.openjdk.org/jdk.git pull/22354/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22354`

View PR using the GUI difftool: \
`$ git pr show -t 22354`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22354.diff">https://git.openjdk.org/jdk/pull/22354.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22354#issuecomment-2497868735)
</details>
