### PR TITLE
8304674: File java.c compile error with -fsanitize=address -O0

### DIFF
--- a/src/java.base/share/native/libjli/java.c
+++ b/src/java.base/share/native/libjli/java.c
@@ -660,6 +660,7 @@ JavaMain(void* _args)
         ret = 1;
     }
     LEAVE();
+    return ret;
 }
 
 /*


### PR DESCRIPTION
Hi all,
File `src/java.base/share/native/libjli/java.c` compile `error: control reaches end of non-void function [-Werror=return-type]` with gcc options `-fsanitize=address -O0`. The function `int JavaMain(void* _args)` in this file will execute `return ret` in `LEAVE()` macro, but gcc with -O0 is not smart enough to recognized that the function already has `return` statement before at the end of function.
This PR add final return statement make gcc with options `-fsanitize=address -O0` happy, to make jdk compile success with configure option `--enable-asan` by slowdebug mode. The added `return ret` make no sence because the `LEAVE()` macro make sure that function will execute `returun ret` statement at java.c:348.  So I think this change is no risk.

Additional testing:

- [x]   jtreg tests(include tier1/2/3 etc.) with linux-x64 release build
- [x]   jtreg tests(include tier1/2/3 etc.) with linux-x64 fastdebug build
- [x]   jtreg tests(include tier1/2/3 etc.) with linux-aarch64 release build
- [x]   jtreg tests(include tier1/2/3 etc.) with linux-aarch64 fastdebug build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8304674](https://bugs.openjdk.org/browse/JDK-8304674): File java.c compile error with -fsanitize=address -O0 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22355/head:pull/22355` \
`$ git checkout pull/22355`

Update a local copy of the PR: \
`$ git checkout pull/22355` \
`$ git pull https://git.openjdk.org/jdk.git pull/22355/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22355`

View PR using the GUI difftool: \
`$ git pr show -t 22355`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22355.diff">https://git.openjdk.org/jdk/pull/22355.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22355#issuecomment-2496961333)
</details>
