### PR TITLE
8344896: Remove obsolete checks for AWTPermission accessClipboard

### DIFF
--- a/src/java.desktop/macosx/classes/sun/lwawt/LWToolkit.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/LWToolkit.java
@@ -407,12 +407,6 @@ public abstract class LWToolkit extends SunToolkit implements Runnable {
 
     @Override
     public final Clipboard getSystemClipboard() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.ACCESS_CLIPBOARD_PERMISSION);
-        }
-
         synchronized (this) {
             if (clipboard == null) {
                 clipboard = createPlatformClipboard();

--- a/src/java.desktop/share/classes/java/awt/TextComponent.java
+++ b/src/java.desktop/share/classes/java/awt/TextComponent.java
@@ -44,7 +44,6 @@ import javax.accessibility.AccessibleStateSet;
 import javax.accessibility.AccessibleText;
 import javax.swing.text.AttributeSet;
 
-import sun.awt.AWTPermissions;
 import sun.awt.InputMethodSupport;
 
 /**
@@ -742,20 +741,6 @@ public sealed class TextComponent extends Component implements Accessible
             str += ",editable";
         }
         return str + ",selection=" + getSelectionStart() + "-" + getSelectionEnd();
-    }
-
-    /**
-     * Assigns a valid value to the canAccessClipboard instance variable.
-     */
-    private boolean canAccessClipboard() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm == null) return true;
-        try {
-            sm.checkPermission(AWTPermissions.ACCESS_CLIPBOARD_PERMISSION);
-            return true;
-        } catch (SecurityException e) {}
-        return false;
     }
 
     /*

--- a/src/java.desktop/share/classes/java/awt/event/InputEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InputEvent.java
@@ -313,6 +313,7 @@ public abstract sealed class InputEvent extends ComponentEvent
     /*
      * A flag that indicates that this instance can be used to access
      * the system clipboard.
+     * This should be false in a headless environment, true in a headful one.
      */
     private transient boolean canAccessSystemClipboard;
 
@@ -385,26 +386,7 @@ public abstract sealed class InputEvent extends ComponentEvent
     }
 
     private boolean canAccessSystemClipboard() {
-        boolean b = false;
-
-        if (!GraphicsEnvironment.isHeadless()) {
-            @SuppressWarnings("removal")
-            SecurityManager sm = System.getSecurityManager();
-            if (sm != null) {
-                try {
-                    sm.checkPermission(AWTPermissions.ACCESS_CLIPBOARD_PERMISSION);
-                    b = true;
-                } catch (SecurityException se) {
-                    if (logger.isLoggable(PlatformLogger.Level.FINE)) {
-                        logger.fine("InputEvent.canAccessSystemClipboard() got SecurityException ", se);
-                    }
-                }
-            } else {
-                b = true;
-            }
-        }
-
-        return b;
+        return !GraphicsEnvironment.isHeadless();
     }
 
     /**

--- a/src/java.desktop/share/classes/java/awt/event/InputEvent.java
+++ b/src/java.desktop/share/classes/java/awt/event/InputEvent.java
@@ -33,7 +33,6 @@ import java.io.Serial;
 import java.util.Arrays;
 
 import sun.awt.AWTAccessor;
-import sun.awt.AWTPermissions;
 import sun.util.logging.PlatformLogger;
 
 /**

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -467,12 +467,10 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
                 // mouse 1 behavior
                 if(nclicks == 1) {
                     selectedWordEvent = null;
-                } else if(nclicks == 2
-                          && SwingUtilities2.canEventAccessSystemClipboard(e)) {
+                } else if (nclicks == 2) {
                     selectWord(e);
                     selectedWordEvent = null;
-                } else if(nclicks == 3
-                          && SwingUtilities2.canEventAccessSystemClipboard(e)) {
+                } else if (nclicks == 3) {
                     Action a = null;
                     ActionMap map = getComponent().getActionMap();
                     if (map != null) {
@@ -489,8 +487,7 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
                 }
             } else if (SwingUtilities.isMiddleMouseButton(e)) {
                 // mouse 2 behavior
-                if (nclicks == 1 && component.isEditable() && component.isEnabled()
-                    && SwingUtilities2.canEventAccessSystemClipboard(e)) {
+                if (nclicks == 1 && component.isEditable() && component.isEnabled()) {
                     // paste system selection, if it exists
                     JTextComponent c = (JTextComponent) e.getSource();
                     if (c != null) {
@@ -547,8 +544,7 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
             } else {
                 shouldHandleRelease = false;
                 adjustCaretAndFocus(e);
-                if (nclicks == 2
-                    && SwingUtilities2.canEventAccessSystemClipboard(e)) {
+                if (nclicks == 2) {
                     selectWord(e);
                 }
             }
@@ -1394,9 +1390,6 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
     }
 
     private void updateSystemSelection() {
-        if ( ! SwingUtilities2.canCurrentEventAccessSystemClipboard() ) {
-            return;
-        }
         if (this.dot != this.mark && component != null && component.hasFocus()) {
             Clipboard clip = getSystemSelection();
             if (clip != null) {

--- a/src/java.desktop/share/classes/sun/awt/dnd/SunDropTargetContextPeer.java
+++ b/src/java.desktop/share/classes/sun/awt/dnd/SunDropTargetContextPeer.java
@@ -224,18 +224,6 @@ public abstract class SunDropTargetContextPeer implements DropTargetContextPeer,
         InvalidDnDOperationException
     {
 
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        try {
-            if (!dropInProcess && sm != null) {
-                sm.checkPermission(AWTPermissions.ACCESS_CLIPBOARD_PERMISSION);
-            }
-        } catch (Exception e) {
-            Thread currentThread = Thread.currentThread();
-            currentThread.getUncaughtExceptionHandler().uncaughtException(currentThread, e);
-            return null;
-        }
-
         Long lFormat = null;
         Transferable localTransferable = local;
 

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -189,10 +189,6 @@ public class SwingUtilities2 {
     public static final StringUIClientPropertyKey BASICMENUITEMUI_MAX_TEXT_OFFSET =
         new StringUIClientPropertyKey ("maxTextOffset");
 
-    // security stuff
-    private static final String UntrustedClipboardAccess =
-        "UNTRUSTED_CLIPBOARD_ACCESS_KEY";
-
     //all access to  charsBuffer is to be synchronized on charsBufferLock
     private static final int CHAR_BUFFER_SIZE = 100;
     private static final Object charsBufferLock = new Object();
@@ -1458,123 +1454,14 @@ public class SwingUtilities2 {
         }
     }
 
-    /*
-     * here goes the fix for 4856343 [Problem with applet interaction
-     * with system selection clipboard]
-     *
-     * NOTE. In case isTrustedContext() no checking
-     * are to be performed
-     */
-
     /**
-    * checks the security permissions for accessing system clipboard
-    *
-    * for untrusted context (see isTrustedContext) checks the
-    * permissions for the current event being handled
+    * checks if the system clipboard can be accessed.
+    * This is true in a headful environment, false in a headless one
     *
     */
    public static boolean canAccessSystemClipboard() {
-       boolean canAccess = false;
-       if (!GraphicsEnvironment.isHeadless()) {
-           @SuppressWarnings("removal")
-           SecurityManager sm = System.getSecurityManager();
-           if (sm == null) {
-               canAccess = true;
-           } else {
-               try {
-                   sm.checkPermission(AWTPermissions.ACCESS_CLIPBOARD_PERMISSION);
-                   canAccess = true;
-               } catch (SecurityException e) {
-               }
-               if (canAccess && ! isTrustedContext()) {
-                   canAccess = canCurrentEventAccessSystemClipboard(true);
-               }
-           }
-       }
-       return canAccess;
+       return !GraphicsEnvironment.isHeadless();
    }
-    /**
-    * Returns true if EventQueue.getCurrentEvent() has the permissions to
-     * access the system clipboard
-     */
-    public static boolean canCurrentEventAccessSystemClipboard() {
-        return  isTrustedContext()
-            || canCurrentEventAccessSystemClipboard(false);
-    }
-
-    /**
-     * Returns true if the given event has permissions to access the
-     * system clipboard
-     *
-     * @param e AWTEvent to check
-     */
-    public static boolean canEventAccessSystemClipboard(AWTEvent e) {
-        return isTrustedContext()
-            || canEventAccessSystemClipboard(e, false);
-    }
-
-    /**
-     * Returns true if the given event is current gesture for
-     * accessing clipboard
-     *
-     * @param ie InputEvent to check
-     */
-    @SuppressWarnings("deprecation")
-    private static boolean isAccessClipboardGesture(InputEvent ie) {
-        boolean allowedGesture = false;
-        if (ie instanceof KeyEvent) { //we can validate only keyboard gestures
-            KeyEvent ke = (KeyEvent)ie;
-            int keyCode = ke.getKeyCode();
-            int keyModifiers = ke.getModifiers();
-            switch(keyCode) {
-            case KeyEvent.VK_C:
-            case KeyEvent.VK_V:
-            case KeyEvent.VK_X:
-                allowedGesture = (keyModifiers == InputEvent.CTRL_MASK);
-                break;
-            case KeyEvent.VK_INSERT:
-                allowedGesture = (keyModifiers == InputEvent.CTRL_MASK ||
-                                  keyModifiers == InputEvent.SHIFT_MASK);
-                break;
-            case KeyEvent.VK_COPY:
-            case KeyEvent.VK_PASTE:
-            case KeyEvent.VK_CUT:
-                allowedGesture = true;
-                break;
-            case KeyEvent.VK_DELETE:
-                allowedGesture = ( keyModifiers == InputEvent.SHIFT_MASK);
-                break;
-            }
-        }
-        return allowedGesture;
-    }
-
-    /**
-     * Returns true if e has the permissions to
-     * access the system clipboard and if it is allowed gesture (if
-     * checkGesture is true)
-     *
-     * @param e AWTEvent to check
-     * @param checkGesture boolean
-     */
-    private static boolean canEventAccessSystemClipboard(AWTEvent e,
-                                                        boolean checkGesture) {
-        if (EventQueue.isDispatchThread()) {
-            /*
-             * Checking event permissions makes sense only for event
-             * dispatching thread
-             */
-            if (e instanceof InputEvent
-                && (! checkGesture || isAccessClipboardGesture((InputEvent)e))) {
-                return AWTAccessor.getInputEventAccessor().
-                        canAccessSystemClipboard((InputEvent) e);
-            } else {
-                return false;
-            }
-        } else {
-            return true;
-        }
-    }
 
     /**
      * Utility method that throws SecurityException if SecurityManager is set
@@ -1588,31 +1475,6 @@ public class SwingUtilities2 {
                 && !Modifier.isPublic(modifiers)) {
             throw new SecurityException("Resource is not accessible");
         }
-    }
-
-    /**
-     * Returns true if EventQueue.getCurrentEvent() has the permissions to
-     * access the system clipboard and if it is allowed gesture (if
-     * checkGesture true)
-     *
-     * @param checkGesture boolean
-     */
-    private static boolean canCurrentEventAccessSystemClipboard(boolean
-                                                               checkGesture) {
-        AWTEvent event = EventQueue.getCurrentEvent();
-        return canEventAccessSystemClipboard(event, checkGesture);
-    }
-
-    /**
-     * see RFE 5012841 [Per AppContect security permissions] for the
-     * details
-     *
-     */
-    @SuppressWarnings("removal")
-    private static boolean isTrustedContext() {
-        return (System.getSecurityManager() == null)
-            || (AppContext.getAppContext().
-                get(UntrustedClipboardAccess) == null);
     }
 
     public static String displayPropertiesToCSS(Font font, Color fg) {

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -114,7 +114,6 @@ import java.beans.PropertyChangeListener;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Hashtable;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Map;
@@ -129,7 +128,6 @@ import javax.swing.LookAndFeel;
 import javax.swing.UIDefaults;
 
 import sun.awt.AWTAccessor;
-import sun.awt.AWTPermissions;
 import sun.awt.AppContext;
 import sun.awt.DisplayChangedListener;
 import sun.awt.LightweightFrame;

--- a/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java
@@ -1233,11 +1233,6 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
 
     @Override
     public  Clipboard getSystemClipboard() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.ACCESS_CLIPBOARD_PERMISSION);
-        }
         synchronized (this) {
             if (clipboard == null) {
                 clipboard = new XClipboard("System", "CLIPBOARD");
@@ -1248,11 +1243,6 @@ public final class XToolkit extends UNIXToolkit implements Runnable {
 
     @Override
     public Clipboard getSystemSelection() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.ACCESS_CLIPBOARD_PERMISSION);
-        }
         synchronized (this) {
             if (selection == null) {
                 selection = new XClipboard("Selection", "PRIMARY");

--- a/src/java.desktop/windows/classes/sun/awt/windows/WTextComponentPeer.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WTextComponentPeer.java
@@ -32,10 +32,6 @@ import java.awt.event.TextEvent;
 abstract
 class WTextComponentPeer extends WComponentPeer implements TextComponentPeer {
 
-    static {
-        initIDs();
-    }
-
     // TextComponentPeer implementation
 
     @Override
@@ -106,11 +102,6 @@ class WTextComponentPeer extends WComponentPeer implements TextComponentPeer {
     public void valueChanged() {
         postEvent(new TextEvent(target, TextEvent.TEXT_VALUE_CHANGED));
     }
-
-    /**
-     * Initialize JNI field and method IDs
-     */
-    private static native void initIDs();
 
     @Override
     public boolean shouldClearRectBeforePaint() {

--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -678,11 +678,6 @@ public final class WToolkit extends SunToolkit implements Runnable {
 
     @Override
     public Clipboard getSystemClipboard() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(AWTPermissions.ACCESS_CLIPBOARD_PERMISSION);
-        }
         synchronized (this) {
             if (clipboard == null) {
                 clipboard = new WClipboard();

--- a/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WToolkit.java
@@ -123,7 +123,6 @@ import javax.swing.text.JTextComponent;
 
 import sun.awt.AWTAccessor;
 import sun.awt.AWTAutoShutdown;
-import sun.awt.AWTPermissions;
 import sun.awt.AppContext;
 import sun.awt.DisplayChangedListener;
 import sun.awt.LightweightFrame;

--- a/src/java.desktop/windows/native/libawt/windows/awt_TextComponent.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_TextComponent.h
@@ -41,7 +41,6 @@
 
 class AwtTextComponent : public AwtComponent {
 public:
-    static jmethodID canAccessClipboardMID;
 
     AwtTextComponent();
 


### PR DESCRIPTION
This removes the SecurityManager related checks for clipboard access  and methods which exist solely to support that.

One interesting thing is that there are two places where a method "canAccessSystemClipboard()"  was not only about the SM. 
In SwingUtilities and InputEvent it would return false in headless mode, regardless of whether there is an SM.
This means I have left the methods in place, behaving the same as before in headless mode.
We may be able to further simplify this later  but it will be clearer with the SM-only logic removed and out of scope for this fix.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344896](https://bugs.openjdk.org/browse/JDK-8344896): Remove obsolete checks for AWTPermission accessClipboard (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22356/head:pull/22356` \
`$ git checkout pull/22356`

Update a local copy of the PR: \
`$ git checkout pull/22356` \
`$ git pull https://git.openjdk.org/jdk.git pull/22356/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22356`

View PR using the GUI difftool: \
`$ git pr show -t 22356`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22356.diff">https://git.openjdk.org/jdk/pull/22356.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22356#issuecomment-2497020926)
</details>
