### PR TITLE
8344577: Virtual thread tests are timing out on some macOS systems

### DIFF
--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenBlocking.java
@@ -42,6 +42,7 @@
 import java.time.Instant;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicBoolean;
+import jdk.test.lib.Platform;
 import jdk.test.lib.thread.VThreadRunner;   // ensureParallelism requires jdk.management
 
 public class GetStackTraceALotWhenBlocking {
@@ -50,7 +51,14 @@ public class GetStackTraceALotWhenBlocking {
         // need at least two carriers
         VThreadRunner.ensureParallelism(2);
 
-        int iterations = args.length > 0 ? Integer.parseInt(args[0]) : 100_000;
+        int iterations;
+        int value = Integer.parseInt(args[0]);
+        if (Platform.isOSX() && Platform.isX64()) {
+            // reduced iterations on macosx-x64
+            iterations = Math.max(value / 4, 1);
+        } else {
+            iterations = value;
+        }
 
         var done = new AtomicBoolean();
         var lock = new Object();

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWhenPinned.java
@@ -42,6 +42,7 @@
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import jdk.test.lib.Platform;
 import jdk.test.lib.thread.VThreadRunner;   // ensureParallelism requires jdk.management
 import jdk.test.lib.thread.VThreadPinner;
 
@@ -53,7 +54,15 @@ public class GetStackTraceALotWhenPinned {
             VThreadRunner.ensureParallelism(2);
         }
 
-        int iterations = Integer.parseInt(args[0]);
+        int iterations;
+        int value = Integer.parseInt(args[0]);
+        if (Platform.isOSX() && Platform.isX64()) {
+            // reduced iterations on macosx-x64
+            iterations = Math.max(value / 4, 1);
+        } else {
+            iterations = value;
+        }
+
         var barrier = new Barrier(2);
 
         // Start a virtual thread that loops doing Thread.yield and parking while pinned.

--- a/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/GetStackTraceALotWithTimedWait.java
@@ -25,13 +25,13 @@
  * @test
  * @summary Stress test Thread.getStackTrace on a virtual thread in timed-Object.wait
  * @requires vm.debug != true
- * @run main/othervm GetStackTraceALotWithTimedWait 100000
+ * @run main GetStackTraceALotWithTimedWait 100000
  */
 
 /*
  * @test
  * @requires vm.debug == true
- * @run main/othervm GetStackTraceALotWithTimedWait 50000
+ * @run main GetStackTraceALotWithTimedWait 50000
  */
 
 import java.time.Instant;

--- a/test/jdk/java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/LotsOfContendedMonitorEnter.java
@@ -26,7 +26,7 @@
  * @summary Test virtual threads entering a lot of monitors with contention
  * @requires vm.opt.LockingMode != 1
  * @library /test/lib
- * @run main/othervm LotsOfContendedMonitorEnter
+ * @run main LotsOfContendedMonitorEnter
  */
 
 /*

--- a/test/jdk/java/lang/Thread/virtual/stress/LotsOfUncontendedMonitorEnter.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/LotsOfUncontendedMonitorEnter.java
@@ -25,7 +25,7 @@
  * @test id=default
  * @summary Test virtual thread entering (and reentering) a lot of monitors with no contention
  * @library /test/lib
- * @run main/othervm LotsOfUncontendedMonitorEnter
+ * @run main LotsOfUncontendedMonitorEnter
  */
 
 /*

--- a/test/jdk/java/lang/Thread/virtual/stress/SleepALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/SleepALot.java
@@ -25,7 +25,7 @@
  * @test
  * @summary Stress test Thread.sleep
  * @requires vm.debug != true & vm.continuations
- * @run main/othervm SleepALot 500000
+ * @run main SleepALot 500000
  */
 
 /*

--- a/test/jdk/java/lang/Thread/virtual/stress/TimedWaitALot.java
+++ b/test/jdk/java/lang/Thread/virtual/stress/TimedWaitALot.java
@@ -24,28 +24,28 @@
 /*
  * @test id=timeout
  * @summary Stress test timed-Object.wait
- * @run main/othervm TimedWaitALot 200
+ * @run main TimedWaitALot 200
  */
 
 /*
  * @test id=timeout-notify
  * @summary Test timed-Object.wait where the waiting thread is awakened with Object.notify
  *     at around the same time that the timeout expires.
- * @run main/othervm TimedWaitALot 200 true false
+ * @run main TimedWaitALot 150 true false
  */
 
 /*
  * @test id=timeout-interrupt
  * @summary Test timed-Object.wait where the waiting thread is awakened with Thread.interrupt
  *     at around the same time that the timeout expires.
- * @run main/othervm TimedWaitALot 200 false true
+ * @run main TimedWaitALot 150 false true
  */
 
 /*
  * @test id=timeout-notify-interrupt
  * @summary Test timed-Object.wait where the waiting thread is awakened with Object.notify
  *     and Thread.interrupt at around the same time that the timeout expires.
- * @run main/othervm TimedWaitALot 100 true true
+ * @run main TimedWaitALot 100 true true
  */
 
 import java.time.Instant;


### PR DESCRIPTION
As part of JEP 491, and prep for (e.g. 8336254), we added more tests to test/jdk/java/lang/Thread/virtual to stress several critical areas. A few of these tests can take a long time on older macos-x64 hardware, esp. those with HT enabled as jtreg -concurrency gets computed to a high value. Some of these tests have spinning threads and end up competing with other tests. This directory used to have a TEST.properties with  exclusive.dirs=. to prevent these tests running concurrently with each other but we decided to remove it when the number of tests increased (at one point, tests were waiting several minutes to execute because they couldn't run concurrently with other tests in the directory).

This PR proposes a few adjustments:

- Dial down 3 tests (GetStackTraceALotWhenBlocking, GetStackTraceALotWhenPinned.java, and ParkALot) on macosx-x64. This is done in the test main to avoid doubling the number of test descriptions on these tests.
- Dial down 2 runs of one test (TimedWaitALot #timeout-notify #timeout-interrupt) on all platforms. No change to the other 2 runs of this test.
- Add progress output/tracing to ParkALot.
- Remove "/othervm" from a few tests where that don't need it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344577](https://bugs.openjdk.org/browse/JDK-8344577): Virtual thread tests are timing out on some macOS systems (**Bug** - P4)


### Reviewers
 * [Jaikiran Pai](https://openjdk.org/census#jpai) (@jaikiran - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22357/head:pull/22357` \
`$ git checkout pull/22357`

Update a local copy of the PR: \
`$ git checkout pull/22357` \
`$ git pull https://git.openjdk.org/jdk.git pull/22357/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22357`

View PR using the GUI difftool: \
`$ git pr show -t 22357`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22357.diff">https://git.openjdk.org/jdk/pull/22357.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22357#issuecomment-2497277679)
</details>
