### PR TITLE
8035271: Incorrect indentation of LineNumberTable/LocalVariableTable/Exception table/LocalVariableTypeTable/StackMapTable/RuntimeVisibleTypeAnnotations in verbose mode

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
@@ -575,11 +575,8 @@ public class ClassWriter extends BasicWriter {
         if (options.showAllAttrs) {
             attrWriter.write(m.attributes());
         } else if (code != null) {
-            if (options.showDisassembled) {
+            if (options.showDisassembled || options.showLineAndLocalVariableTables) {
                 codeWriter.writeMinimal(code);
-            }
-            if (options.showLineAndLocalVariableTables) {
-                codeWriter.writeLineAndLocalVariableTables(code, options.showDisassembled);
             }
         }
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
@@ -578,12 +578,8 @@ public class ClassWriter extends BasicWriter {
             if (options.showDisassembled) {
                 codeWriter.writeMinimal(code);
             }
-
             if (options.showLineAndLocalVariableTables) {
-                code.findAttribute(Attributes.lineNumberTable())
-                        .ifPresent(a -> attrWriter.write(a, code));
-                code.findAttribute(Attributes.localVariableTable())
-                        .ifPresent(a -> attrWriter.write(a, code));
+                codeWriter.writeLineAndLocalVariableTables(code, options.showDisassembled);
             }
         }
 

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
@@ -25,16 +25,13 @@
 
 package com.sun.tools.javap;
 
+import java.lang.classfile.*;
 import java.util.ArrayList;
 import java.util.List;
 
 import java.util.Locale;
 import java.util.stream.Collectors;
-import java.lang.classfile.ClassFile;
-import java.lang.classfile.Opcode;
 import java.lang.classfile.constantpool.*;
-import java.lang.classfile.Instruction;
-import java.lang.classfile.MethodModel;
 import java.lang.classfile.attribute.CodeAttribute;
 import java.lang.classfile.instruction.*;
 
@@ -75,6 +72,19 @@ public class CodeWriter extends BasicWriter {
 
     void writeMinimal(CodeAttribute attr) {
         writeInternal(attr, true);
+    }
+
+    void writeLineAndLocalVariableTables(CodeAttribute attr, boolean indent) {
+        if (indent) {
+            indent(+1);
+        }
+        attr.findAttribute(Attributes.lineNumberTable())
+            .ifPresent(a -> attrWriter.write(a, attr));
+        attr.findAttribute(Attributes.localVariableTable())
+            .ifPresent(a -> attrWriter.write(a, attr));
+        if (indent) {
+            indent(-1);
+        }
     }
 
     public void writeVerboseHeader(CodeAttribute attr) {

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
@@ -74,19 +74,6 @@ public class CodeWriter extends BasicWriter {
         writeInternal(attr, true);
     }
 
-    void writeLineAndLocalVariableTables(CodeAttribute attr, boolean indent) {
-        if (indent) {
-            indent(+1);
-        }
-        attr.findAttribute(Attributes.lineNumberTable())
-            .ifPresent(a -> attrWriter.write(a, attr));
-        attr.findAttribute(Attributes.localVariableTable())
-            .ifPresent(a -> attrWriter.write(a, attr));
-        if (indent) {
-            indent(-1);
-        }
-    }
-
     public void writeVerboseHeader(CodeAttribute attr) {
         MethodModel method = attr.parent().get();
         int n = method.methodTypeSymbol().parameterCount();
@@ -270,15 +257,37 @@ public class CodeWriter extends BasicWriter {
     private void writeInternal(CodeAttribute attr, boolean minimal) {
         println("Code:");
         indent(+1);
-        if (!minimal) {
-            writeVerboseHeader(attr);
-        }
-        writeInstrs(attr);
-        writeExceptionTable(attr);
-        if (!minimal) {
-            attrWriter.write(attr.attributes(), attr);
+        if (minimal) {
+            writeMinimalMode(attr);
+        } else {
+            writeVerboseMode(attr);
         }
         indent(-1);
+    }
+
+    private void writeMinimalMode(CodeAttribute attr) {
+        if (options.showDisassembled) {
+            writeInstrs(attr);
+            writeExceptionTable(attr);
+        }
+
+        if (options.showLineAndLocalVariableTables) {
+            writeLineAndLocalVariableTables(attr);
+        }
+    }
+
+    private void writeVerboseMode(CodeAttribute attr) {
+        writeVerboseHeader(attr);
+        writeInstrs(attr);
+        writeExceptionTable(attr);
+        attrWriter.write(attr.attributes(), attr);
+    }
+
+    private void writeLineAndLocalVariableTables(CodeAttribute attr) {
+        attr.findAttribute(Attributes.lineNumberTable())
+            .ifPresent(a -> attrWriter.write(a, attr));
+        attr.findAttribute(Attributes.localVariableTable())
+            .ifPresent(a -> attrWriter.write(a, attr));
     }
 
     private AttributeWriter attrWriter;

--- a/test/langtools/tools/javap/ClassWriterTableIndentTest.java
+++ b/test/langtools/tools/javap/ClassWriterTableIndentTest.java
@@ -40,43 +40,27 @@ public class ClassWriterTableIndentTest {
     }
 
     public void run() {
-        runJavapWithCodeBlock();
-        runJavapWithoutCodeBlock();
-
-        if (errors > 0) {
-            throw new Error(errors + " found.");
-        }
-    }
-
-    private void runJavapWithCodeBlock() {
         /*
          * Partial expected output within a larger file. There exists another "Code: " section above, and thus we
          * select the second occurrence in `findNthMatchPrecedingSpaces(output, "Code:", 1);`
          * ...
          *  public void emptyLoop();
          *    Code:
-         *         0: iconst_0
-         *         ...
-         *         14: return
+         *       ...
          *      LineNumberTable:
          *        line 143: 0
          *        line 145: 14
          * ...
          */
-        List<String[]> runArgsList = List.of(new String[] {"-c", "-l"}, new String[] {"-v"});
-        for (String[] runArgs: runArgsList) {
+        List<String[]> runArgsList = List.of(new String[]{"-c", "-l"}, new String[]{"-v"}, new String[]{"-l"});
+        for (String[] runArgs : runArgsList) {
             String output = javap(runArgs);
             int methodIntent = findNthMatchPrecedingSpaces(output, "public void emptyLoop();", 0);
             int codeHeaderIndent = findNthMatchPrecedingSpaces(output, "Code:", 1);
             int detailIndent = findNthMatchPrecedingSpaces(output, "LineNumberTable:", 1);
-            int bytecodeIndent = findNthMatchPrecedingSpaces(output, "0: iconst_0", 0);
 
             if (codeHeaderIndent - methodIntent != 2) {
                 indentError(2, codeHeaderIndent - methodIntent, "Code block", "method header", runArgs);
-            }
-
-            if (bytecodeIndent - codeHeaderIndent != 5) {
-                indentError(5, bytecodeIndent - codeHeaderIndent, "Bytecode", "code header", runArgs);
             }
 
             if (detailIndent - codeHeaderIndent != 2) {
@@ -87,25 +71,8 @@ public class ClassWriterTableIndentTest {
                 indentError(4, detailIndent - methodIntent, "LineNumberTable", "method header");
             }
         }
-    }
-
-    private void runJavapWithoutCodeBlock() {
-        /*
-         * Partial expected output within a larger file. There exists another "LineNumberTable: " section above, and
-         * thus we select the second occurrence in `findNthMatchPrecedingSpaces(output, "LineNumberTable:", 1);`
-         * ...
-         *  public void emptyLoop();
-         *    LineNumberTable:
-         *      line 143: 0
-         *      line 145: 14
-         * ...
-         */
-        String output = javap("-l");
-        int methodIntent = findNthMatchPrecedingSpaces(output, "public void emptyLoop();", 0);
-        int detailIndent = findNthMatchPrecedingSpaces(output, "LineNumberTable:", 1);
-
-        if (detailIndent - methodIntent != 2) {
-            indentError(2, detailIndent - methodIntent, "LineNumberTable", "method header");
+        if (errors > 0) {
+            throw new Error(errors + " found.");
         }
     }
 

--- a/test/langtools/tools/javap/ClassWriterTableIndentTest.java
+++ b/test/langtools/tools/javap/ClassWriterTableIndentTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8035271
+ * @summary javap incorrect indentation when LineNumberTable and LocalVariableTable written via ClassWriter
+ * @run main ClassWriterTableIndentTest
+ * @modules jdk.jdeps/com.sun.tools.javap
+ */
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Arrays;
+import java.util.List;
+
+public class ClassWriterTableIndentTest {
+    public static void main(String[] args) {
+        new ClassWriterTableIndentTest().run();
+    }
+
+    public void run() {
+        runJavapWithCodeBlock();
+        runJavapWithoutCodeBlock();
+
+        if (errors > 0) {
+            throw new Error(errors + " found.");
+        }
+    }
+
+    private void runJavapWithCodeBlock() {
+        /*
+         * Partial expected output within a larger file. There exists another "Code: " section above, and thus we
+         * select the second occurrence in `findNthMatchPrecedingSpaces(output, "Code:", 1);`
+         * ...
+         *  public void emptyLoop();
+         *    Code:
+         *         0: iconst_0
+         *         ...
+         *         14: return
+         *      LineNumberTable:
+         *        line 143: 0
+         *        line 145: 14
+         * ...
+         */
+        List<String[]> runArgsList = List.of(new String[] {"-c", "-l"}, new String[] {"-v"});
+        for (String[] runArgs: runArgsList) {
+            String output = javap(runArgs);
+            int methodIntent = findNthMatchPrecedingSpaces(output, "public void emptyLoop();", 0);
+            int codeHeaderIndent = findNthMatchPrecedingSpaces(output, "Code:", 1);
+            int detailIndent = findNthMatchPrecedingSpaces(output, "LineNumberTable:", 1);
+            int bytecodeIndent = findNthMatchPrecedingSpaces(output, "0: iconst_0", 0);
+
+            if (codeHeaderIndent - methodIntent != 2) {
+                indentError(2, codeHeaderIndent - methodIntent, "Code block", "method header", runArgs);
+            }
+
+            if (bytecodeIndent - codeHeaderIndent != 5) {
+                indentError(5, bytecodeIndent - codeHeaderIndent, "Bytecode", "code header", runArgs);
+            }
+
+            if (detailIndent - codeHeaderIndent != 2) {
+                indentError(2, detailIndent - codeHeaderIndent, "LineNumberTable", "code header", runArgs);
+            }
+
+            if (detailIndent - methodIntent != 4) {
+                indentError(4, detailIndent - methodIntent, "LineNumberTable", "method header");
+            }
+        }
+    }
+
+    private void runJavapWithoutCodeBlock() {
+        /*
+         * Partial expected output within a larger file. There exists another "LineNumberTable: " section above, and
+         * thus we select the second occurrence in `findNthMatchPrecedingSpaces(output, "LineNumberTable:", 1);`
+         * ...
+         *  public void emptyLoop();
+         *    LineNumberTable:
+         *      line 143: 0
+         *      line 145: 14
+         * ...
+         */
+        String output = javap("-l");
+        int methodIntent = findNthMatchPrecedingSpaces(output, "public void emptyLoop();", 0);
+        int detailIndent = findNthMatchPrecedingSpaces(output, "LineNumberTable:", 1);
+
+        if (detailIndent - methodIntent != 2) {
+            indentError(2, detailIndent - methodIntent, "LineNumberTable", "method header");
+        }
+    }
+
+    private String javap(String... args) {
+        StringWriter sw = new StringWriter();
+        PrintWriter out = new PrintWriter(sw);
+
+        String[] fullArgs = new String[args.length + 1];
+        System.arraycopy(args, 0, fullArgs, 0, args.length);
+        fullArgs[args.length] = System.getProperty("test.classes") + "/EmptyLoop8035271.class";
+
+        int rc = com.sun.tools.javap.Main.run(fullArgs, out);
+        if (rc != 0)
+            throw new Error("javap failed. rc=" + rc);
+        out.close();
+        System.out.println(sw);
+        return sw.toString();
+    }
+
+    public static int findNthMatchPrecedingSpaces(String inputString, String searchString, int occurrence) {
+        String[] lines = inputString.split(System.lineSeparator());
+        int count = 0;
+        for (String line : lines) {
+            if (line.trim().startsWith(searchString)) {
+                if (count == occurrence) {
+                    return line.indexOf(searchString);
+                }
+                count++;
+            }
+        }
+        throw new IllegalArgumentException("Could not find " + searchString + " in " + inputString);
+    }
+
+    void indentError(int expected, int actual, String toCompare, String referencePoint, String... args) {
+        System.err.println(toCompare + " is not indented correctly with respect to " + referencePoint + ". Expected "
+            + expected + " but got " + actual + " for args: " + Arrays.toString(args));
+        errors++;
+    }
+
+    int errors;
+}
+
+class EmptyLoop8035271 {
+    public void emptyLoop() {
+        for (int i = 0; i < 10; i++) {
+        }
+    }
+}


### PR DESCRIPTION
Very similar and related to: https://bugs.openjdk.org/browse/JDK-8034066

This PR includes changes to ensure the indentation of `LineNumberTable` and `LocalVariableTable` behave in the same way both for the `javap -verbose` and `javap -l -c` case. Prior to this PR, for the `javap -l -c` case the `LineNumberTable` and `LocalVariableTable` attributes are not indented with regard to the `Code: ` header.

The only case, where no extra indentation is added is for `javap -l` without `-c` -- As it does not make sense to indent if there is no `Code:` header to indent relative to. I am not sure if there is a use case for `-l` without `-c`, but would leave this functionality as is.

## Current behaviour of javap previously differed with and without -verbose in the following way:

### Case: `javap -l -c EmptyLoop.class`

```
...
  public void emptyLoop();
    Code:
       0: iconst_0
       ...
      14: return
    LineNumberTable:
      line 3: 0
      line 5: 14
...
```

### Case: `javap -verbose EmptyLoop.class`

```
...
  public void emptyLoop();
    descriptor: ()V
    flags: (0x0001) ACC_PUBLIC
    Code:
      stack=2, locals=2, args_size=1
         0: iconst_0
         ...
        14: return
      LineNumberTable:
        line 3: 0
        line 5: 14
...
```

## New behaviour:
### Case: `javap -l -c EmptyLoop.class`
```
...
  public void emptyLoop();
    Code:
         0: iconst_0
         ...
        14: return
      LineNumberTable:
        line 3: 0
        line 5: 14
...
```


## Open Questions
### Add code header for only `-l` case?
Currently for `-l` without `-c` things look as follows:

```
...
  public void emptyLoop();
    LineNumberTable:
      line 3: 0
      line 5: 14
...
```

One could also imagine making the output:
```
...
  public void emptyLoop();
    Code:
      LineNumberTable:
        line 3: 0
        line 5: 14
...
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 2 [Reviewers](https://openjdk.org/bylaws#reviewer))

### Issue
 * [JDK-8035271](https://bugs.openjdk.org/browse/JDK-8035271): Incorrect indentation of LineNumberTable/LocalVariableTable/Exception table/LocalVariableTypeTable/StackMapTable/RuntimeVisibleTypeAnnotations in verbose mode (**Bug** - P5)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22359/head:pull/22359` \
`$ git checkout pull/22359`

Update a local copy of the PR: \
`$ git checkout pull/22359` \
`$ git pull https://git.openjdk.org/jdk.git pull/22359/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22359`

View PR using the GUI difftool: \
`$ git pr show -t 22359`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22359.diff">https://git.openjdk.org/jdk/pull/22359.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22359#issuecomment-2497965205)
</details>
