### PR TITLE
JDK-8344935: [ubsan]: javaThread.hpp:1241:52: runtime error: load of value 9831830, which is not a valid value for type 'freeze_result'

### DIFF
--- a/src/hotspot/share/runtime/javaThread.cpp
+++ b/src/hotspot/share/runtime/javaThread.cpp
@@ -518,6 +518,10 @@ JavaThread::JavaThread(MemTag mem_tag) :
 
   _SleepEvent(ParkEvent::Allocate(this)),
 
+#if INCLUDE_JFR
+  _last_freeze_fail_result(freeze_ok),
+#endif
+
   _lock_stack(this),
   _om_cache(this) {
   set_jni_functions(jni_functions());


### PR DESCRIPTION
Seems we miss initialization of  _last_freeze_fail_result in the  JavaThread constructor, this should be added.
Causes otherwise ubsan issues in the test  java/lang/Thread/virtual/MonitorEnterExit.java#Xcomp-TieredStopAtLevel1-LM_LEGACY 

/priv/jenkins/client-home/workspace/openjdk-jdk-weekly-linux_x86_64-opt/jdk/src/hotspot/share/runtime/javaThread.hpp:1241:52: runtime error: load of value 9831830, which is not a valid value for type 'freeze_result'
    #0 0x7f5edef378eb in JavaThread::last_freeze_fail_result() src/hotspot/share/runtime/javaThread.hpp:1241
    #1 0x7f5edef378eb in JVM_VirtualThreadPinnedEvent src/hotspot/share/prims/jvm.cpp:3805