### PR TITLE
8344954: Linker tests fails on BE platforms after JDK-8340205

### DIFF
--- a/test/jdk/java/foreign/TestLinker.java
+++ b/test/jdk/java/foreign/TestLinker.java
@@ -181,7 +181,7 @@ public class TestLinker extends NativeTestHelper {
         var fd = FunctionDescriptor.of(struct, struct, struct);
         var e = expectThrows(IllegalArgumentException.class, () -> linker.downcallHandle(fd));
         assertEquals(e.getMessage(),
-                "The padding layout x2 was preceded by another padding layout x1 in [b1x1x2i4]");
+                "The padding layout x2 was preceded by another padding layout x1 in " + struct);
     }
 
     @Test
@@ -199,7 +199,7 @@ public class TestLinker extends NativeTestHelper {
         var fd = FunctionDescriptor.of(struct, struct, struct);
         var e = expectThrows(IllegalArgumentException.class, () -> linker.downcallHandle(fd));
         assertEquals(e.getMessage(),
-                "The padding layout x2 was preceded by another padding layout x1 in [b1x1x2x4x8x16[[[4:j8]]|x32]]");
+                "The padding layout x2 was preceded by another padding layout x1 in " + struct);
     }
 
     @Test
@@ -208,7 +208,7 @@ public class TestLinker extends NativeTestHelper {
         var union = MemoryLayout.unionLayout(MemoryLayout.paddingLayout(3), ValueLayout.JAVA_INT);
         var fd = FunctionDescriptor.of(union, union, union);
         var e = expectThrows(IllegalArgumentException.class, () -> linker.downcallHandle(fd));
-        assertEquals(e.getMessage(), "Superfluous padding x3 in [x3|i4]");
+        assertEquals(e.getMessage(), "Superfluous padding x3 in " + union);
     }
 
     @Test
@@ -217,7 +217,7 @@ public class TestLinker extends NativeTestHelper {
         var union = MemoryLayout.unionLayout(MemoryLayout.paddingLayout(4), ValueLayout.JAVA_INT);
         var fd = FunctionDescriptor.of(union, union, union);
         var e = expectThrows(IllegalArgumentException.class, () -> linker.downcallHandle(fd));
-        assertEquals(e.getMessage(), "Superfluous padding x4 in [x4|i4]");
+        assertEquals(e.getMessage(), "Superfluous padding x4 in " + union);
     }
 
     @Test
@@ -226,7 +226,7 @@ public class TestLinker extends NativeTestHelper {
         var union = MemoryLayout.unionLayout(MemoryLayout.paddingLayout(5), ValueLayout.JAVA_INT);
         var fd = FunctionDescriptor.of(union, union, union);
         var e = expectThrows(IllegalArgumentException.class, () -> linker.downcallHandle(fd));
-        assertEquals(e.getMessage(), "Layout '[x5|i4]' has unexpected size: 5 != 4");
+        assertEquals(e.getMessage(), "Layout '" + union + "' has unexpected size: 5 != 4");
     }
 
     @Test
@@ -239,7 +239,7 @@ public class TestLinker extends NativeTestHelper {
                 MemoryLayout.paddingLayout(16));
         var fd = FunctionDescriptor.of(union, union, union);
         var e = expectThrows(IllegalArgumentException.class, () -> linker.downcallHandle(fd));
-        assertEquals(e.getMessage(), "More than one padding in [[3:i4]|j8|x16|x16]");
+        assertEquals(e.getMessage(), "More than one padding in " + union);
     }
 
     @Test


### PR DESCRIPTION
This PR proposes to fix some tests that fails on big-endian platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344954](https://bugs.openjdk.org/browse/JDK-8344954): Linker tests fails on BE platforms after JDK-8340205 (**Bug** - P2)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Amit Kumar](https://openjdk.org/census#amitkumar) (@offamitkumar - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22362/head:pull/22362` \
`$ git checkout pull/22362`

Update a local copy of the PR: \
`$ git checkout pull/22362` \
`$ git pull https://git.openjdk.org/jdk.git pull/22362/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22362`

View PR using the GUI difftool: \
`$ git pr show -t 22362`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22362.diff">https://git.openjdk.org/jdk/pull/22362.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22362#issuecomment-2498239347)
</details>
