### PR TITLE
8294432: Add provisions to calculate hash values from MemorySegments

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -157,6 +157,21 @@ public final class SegmentBulkOperations {
     }
 
     @ForceInline
+    public static int contentHash(AbstractMemorySegmentImpl segment, long fromOffset, long toOffset) {
+        final long length = toOffset - fromOffset;
+        segment.checkBounds(fromOffset, length);
+        // The state has to be checked explicitly for zero-length segments
+        segment.scope.checkValidState();
+        int result = 1;
+        final long begin = segment.unsafeGetOffset() + fromOffset;
+        final long end = begin + length;
+        for (long i = begin; i < end; i++) {
+            result = 31 * result + SCOPED_MEMORY_ACCESS.getByte(segment.sessionImpl(), segment.unsafeGetBase(), i);
+        }
+        return result;
+    }
+
+    @ForceInline
     public static long mismatch(AbstractMemorySegmentImpl src, long srcFromOffset, long srcToOffset,
                                 AbstractMemorySegmentImpl dst, long dstFromOffset, long dstToOffset) {
         final long srcBytes = srcToOffset - srcFromOffset;

--- a/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/SegmentBulkOperations.java
@@ -162,16 +162,36 @@ public final class SegmentBulkOperations {
             0x0000001f, 0x000003c1, 0x0000745f, 0x000e1781,
             0x01b4d89f, 0x34e63b41, 0x67e12cdf, 0x94446f01};
 
-    /* A polynomial 32-bit hash code method roughly equivalent to:
-
-        final long length = toOffset - fromOffset;
-        segment.checkBounds(fromOffset, length);
-        int result = 1;
-        for (long i = fromOffset; i < toOffset; i++) {
-            result = 31 * result + nativeSegment.get(JAVA_BYTE, i);
-        }
-        return result;
-    */
+    /**
+     * {@return a 32-bit hash value calculated from the content in the provided
+     *          {@code segment} between the provided offsets}
+     * <p>
+     * The method is implemented as a 32-bit polynomial hash function equivalent to:
+     * {@snippet lang=java :
+     *     final long length = toOffset - fromOffset;
+     *     segment.checkBounds(fromOffset, length);
+     *     int result = 1;
+     *     for (long i = fromOffset; i < toOffset; i++) {
+     *         result = 31 * result + segment.get(JAVA_BYTE, i);
+     *     }
+     *     return result;
+     * }
+     * but is potentially more performant.
+     *
+     * @param segment    from which a content hash should be computed
+     * @param fromOffset starting offset (inclusive) in the segment
+     * @param toOffset   ending offset (non-inclusive) in the segment
+     * @throws WrongThreadException if this method is called from a thread {@code T},
+     *         such that {@code srcSegment.isAccessibleBy(T) == false}
+     * @throws IllegalStateException if the {@linkplain MemorySegment#scope() scope}
+     *         associated with {@code segment} is not
+     *         {@linkplain MemorySegment.Scope#isAlive() alive}
+     * @throws IndexOutOfBoundsException if either {@code fromOffset} or {@code toOffset}
+     *                                   are {@code > segment.byteSize}
+     * @throws IndexOutOfBoundsException if either {@code fromOffset} or {@code toOffset}
+     *                                   are {@code < 0}
+     * @throws IndexOutOfBoundsException if {@code toOffset - fromOffset} is {@code < 0}
+     */
     @ForceInline
     public static int contentHash(AbstractMemorySegmentImpl segment, long fromOffset, long toOffset) {
         final long length = toOffset - fromOffset;

--- a/test/jdk/java/foreign/TestSegmentBulkOperationsContentHash.java
+++ b/test/jdk/java/foreign/TestSegmentBulkOperationsContentHash.java
@@ -30,9 +30,7 @@
 
 import jdk.internal.foreign.AbstractMemorySegmentImpl;
 import jdk.internal.foreign.SegmentBulkOperations;
-import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -93,7 +91,13 @@ final class TestSegmentBulkOperationsContentHash {
             assertThrows(IndexOutOfBoundsException.class,
                     () -> hash(segment, 0, segment.byteSize() + 1));
             assertThrows(IndexOutOfBoundsException.class,
+                    () -> hash(segment, 0, -1));
+            assertThrows(IndexOutOfBoundsException.class,
                     () -> hash(segment, -1, 0));
+            if (len > 2) {
+                assertThrows(IndexOutOfBoundsException.class,
+                        () -> hash(segment, 2, 1));
+            }
         }
     }
 

--- a/test/jdk/java/foreign/TestSegmentBulkOperationsContentHash.java
+++ b/test/jdk/java/foreign/TestSegmentBulkOperationsContentHash.java
@@ -94,9 +94,6 @@ final class TestSegmentBulkOperationsContentHash {
         var arena = Arena.ofConfined();
         var segment = arena.allocate(len);
         arena.close();
-
-        System.out.println("segment.scope().isAlive() = " + segment.scope().isAlive());
-
         assertThrows(IllegalStateException.class, () -> hash(segment));
     }
 

--- a/test/jdk/java/foreign/TestSegmentBulkOperationsContentHash.java
+++ b/test/jdk/java/foreign/TestSegmentBulkOperationsContentHash.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @summary Test SegmentBulkOperations::contentHash
+ * @modules java.base/jdk.internal.foreign
+ * @run junit TestSegmentBulkOperationsContentHash
+ */
+
+import jdk.internal.foreign.AbstractMemorySegmentImpl;
+import jdk.internal.foreign.SegmentBulkOperations;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.util.Arrays;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+final class TestSegmentBulkOperationsContentHash {
+
+    @ParameterizedTest
+    @MethodSource("sizes")
+    void testFill(int len) {
+        try (var arena = Arena.ofConfined()) {
+            var segment = arena.allocate(len);
+            int hash = hash(segment);
+            int expected = Arrays.hashCode(segment.toArray(ValueLayout.JAVA_BYTE));
+            assertEquals(expected, hash);
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("sizes")
+    void testOutOfBounds(int len) {
+        try (var arena = Arena.ofConfined()) {
+            var segment = arena.allocate(10);
+            assertThrows(IndexOutOfBoundsException.class,
+                    () -> hash(segment, 0, segment.byteSize() + 1));
+            assertThrows(IndexOutOfBoundsException.class,
+                    () -> hash(segment, -1, 0));
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("sizes")
+    void testConfinement(int len) {
+        try (var arena = Arena.ofConfined()) {
+            var segment = arena.allocate(10);
+            AtomicReference<RuntimeException> ex = new AtomicReference<>();
+            CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+                try {
+                    hash(segment);
+                } catch (RuntimeException e) {
+                    ex.set(e);
+                }
+            });
+            future.join();
+            assertInstanceOf(WrongThreadException.class, ex.get());
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("sizes")
+    void testScope(int len) {
+        var arena = Arena.ofConfined();
+        var segment = arena.allocate(len);
+        arena.close();
+
+        System.out.println("segment.scope().isAlive() = " + segment.scope().isAlive());
+
+        assertThrows(IllegalStateException.class, () -> hash(segment));
+    }
+
+    private static int hash(MemorySegment segment) {
+        return hash(segment, 0, segment.byteSize());
+    }
+
+    private static int hash(MemorySegment segment, long offset, long length) {
+        return SegmentBulkOperations.contentHash((AbstractMemorySegmentImpl) segment, offset, length);
+    }
+
+    private static final int MAX_SIZE = 1 << 10;
+
+    private static Stream<Arguments> sizes() {
+        return IntStream.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 23, 32, 63, 128, 256, 511, MAX_SIZE)
+                .boxed()
+                .map(Arguments::of);
+    }
+
+}

--- a/test/jdk/java/foreign/TestSegmentBulkOperationsContentHash.java
+++ b/test/jdk/java/foreign/TestSegmentBulkOperationsContentHash.java
@@ -62,7 +62,7 @@ final class TestSegmentBulkOperationsContentHash {
     @MethodSource("sizes")
     void testOutOfBounds(int len) {
         try (var arena = Arena.ofConfined()) {
-            var segment = arena.allocate(10);
+            var segment = arena.allocate(len);
             assertThrows(IndexOutOfBoundsException.class,
                     () -> hash(segment, 0, segment.byteSize() + 1));
             assertThrows(IndexOutOfBoundsException.class,
@@ -74,7 +74,7 @@ final class TestSegmentBulkOperationsContentHash {
     @MethodSource("sizes")
     void testConfinement(int len) {
         try (var arena = Arena.ofConfined()) {
-            var segment = arena.allocate(10);
+            var segment = arena.allocate(len);
             AtomicReference<RuntimeException> ex = new AtomicReference<>();
             CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
                 try {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkHash.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkHash.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ *  This code is free software; you can redistribute it and/or modify it
+ *  under the terms of the GNU General Public License version 2 only, as
+ *  published by the Free Software Foundation.
+ *
+ *  This code is distributed in the hope that it will be useful, but WITHOUT
+ *  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ *  version 2 for more details (a copy is included in the LICENSE file that
+ *  accompanied this code).
+ *
+ *  You should have received a copy of the GNU General Public License version
+ *  2 along with this work; if not, write to the Free Software Foundation,
+ *  Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ *   Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ *  or visit www.oracle.com if you need additional information or have any
+ *  questions.
+ *
+ */
+
+package org.openjdk.bench.java.lang.foreign;
+
+import jdk.internal.foreign.AbstractMemorySegmentImpl;
+import jdk.internal.foreign.SegmentBulkOperations;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import static java.lang.foreign.ValueLayout.JAVA_BYTE;
+
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 5, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
+@State(Scope.Thread)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Fork(value = 3, jvmArgs = {"--add-exports=java.base/jdk.internal.foreign=ALL-UNNAMED", "--enable-native-access=ALL-UNNAMED"})
+public class SegmentBulkHash {
+
+    @Param({"64"})
+    public int ELEM_SIZE;
+
+    byte[] array;
+    MemorySegment heapSegment;
+    MemorySegment nativeSegment;
+
+    @Setup
+    public void setup() {
+        // Always use the same alignment regardless of size
+        nativeSegment = Arena.ofAuto().allocate(ELEM_SIZE,16);
+        var rnd = new Random(42);
+        for (int i = 0; i < ELEM_SIZE; i++) {
+            nativeSegment.set(JAVA_BYTE, i, (byte) rnd.nextInt(Byte.MIN_VALUE, Byte.MAX_VALUE));
+        }
+        array = nativeSegment.toArray(JAVA_BYTE);
+        heapSegment = MemorySegment.ofArray(array);
+    }
+
+    @Benchmark
+    public int array() {
+        return Arrays.hashCode(array);
+    }
+
+    @Benchmark
+    public int heapSegment() {
+        return SegmentBulkOperations.contentHash((AbstractMemorySegmentImpl) heapSegment, 0, ELEM_SIZE);
+    }
+
+    @Benchmark
+    public int nativeSegment() {
+        return SegmentBulkOperations.contentHash((AbstractMemorySegmentImpl) nativeSegment, 0, ELEM_SIZE);
+    }
+
+    @Benchmark
+    public int nativeSegmentJava() {
+        int result = 1;
+        for (long i = 0; i < ELEM_SIZE; i++) {
+            result = 31 * result + nativeSegment.get(JAVA_BYTE, i);
+        }
+        return result;
+    }
+
+}
+

--- a/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkHash.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkHash.java
@@ -58,19 +58,19 @@ public class SegmentBulkHash {
     public int ELEM_SIZE;
 
     byte[] array;
-    MemorySegment heapSegment;
-    MemorySegment nativeSegment;
+    AbstractMemorySegmentImpl heapSegment;
+    AbstractMemorySegmentImpl nativeSegment;
 
     @Setup
     public void setup() {
         // Always use the same alignment regardless of size
-        nativeSegment = Arena.ofAuto().allocate(ELEM_SIZE,16);
+        nativeSegment = (AbstractMemorySegmentImpl) Arena.ofAuto().allocate(ELEM_SIZE, 16);
         var rnd = new Random(42);
         for (int i = 0; i < ELEM_SIZE; i++) {
             nativeSegment.set(JAVA_BYTE, i, (byte) rnd.nextInt(Byte.MIN_VALUE, Byte.MAX_VALUE));
         }
         array = nativeSegment.toArray(JAVA_BYTE);
-        heapSegment = MemorySegment.ofArray(array);
+        heapSegment = (AbstractMemorySegmentImpl) MemorySegment.ofArray(array);
     }
 
     @Benchmark
@@ -80,12 +80,12 @@ public class SegmentBulkHash {
 
     @Benchmark
     public int heapSegment() {
-        return SegmentBulkOperations.contentHash((AbstractMemorySegmentImpl) heapSegment, 0, ELEM_SIZE);
+        return SegmentBulkOperations.contentHash(heapSegment, 0, ELEM_SIZE);
     }
 
     @Benchmark
     public int nativeSegment() {
-        return SegmentBulkOperations.contentHash((AbstractMemorySegmentImpl) nativeSegment, 0, ELEM_SIZE);
+        return SegmentBulkOperations.contentHash(nativeSegment, 0, ELEM_SIZE);
     }
 
     @Benchmark

--- a/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkHash.java
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/SegmentBulkHash.java
@@ -51,10 +51,10 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
 @Measurement(iterations = 10, time = 500, timeUnit = TimeUnit.MILLISECONDS)
 @State(Scope.Thread)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
-@Fork(value = 3, jvmArgs = {"--add-exports=java.base/jdk.internal.foreign=ALL-UNNAMED", "--enable-native-access=ALL-UNNAMED"})
+@Fork(value = 3, jvmArgs = {"--add-exports=java.base/jdk.internal.foreign=ALL-UNNAMED"})
 public class SegmentBulkHash {
 
-    @Param({"64"})
+    @Param({"8", "64"})
     public int ELEM_SIZE;
 
     byte[] array;


### PR DESCRIPTION
This PR proposes adding a _JDK-internal_ method for calculating hash codes for content in a `MemorySegment`.

The internal method uses a polynomial 32-bit hash function equivalent to `Arrays::hashCode`. The new method is almost two times faster than naïvely iterating over individual bytes for larger regions. Also, it is more lean on inlining space compared to a naïve loop.


```
Benchmark                          (ELEM_SIZE)  Mode  Cnt   Score   Error  Units
SegmentBulkHash.array                        8  avgt   30   2.645 ? 0.078  ns/op
SegmentBulkHash.array                       64  avgt   30   6.062 ? 0.171  ns/op
SegmentBulkHash.heapSegment                  8  avgt   30   4.181 ? 0.145  ns/op
SegmentBulkHash.heapSegment                 64  avgt   30  25.716 ? 1.043  ns/op
SegmentBulkHash.nativeSegment                8  avgt   30   3.939 ? 0.150  ns/op
SegmentBulkHash.nativeSegment               64  avgt   30  23.262 ? 0.694  ns/op
SegmentBulkHash.nativeSegmentJava            8  avgt   30   5.219 ? 0.183  ns/op    <- Naïve iteration
SegmentBulkHash.nativeSegmentJava           64  avgt   30  39.668 ? 1.040  ns/op    <- Naïve iteration
```

![image](https://github.com/user-attachments/assets/5646cf21-b202-4dce-9555-e460f9df4cb6)


If internal JDK code uses this method, it will automatically benefit from future performance improvements that can be implemented once the Vector API becomes available.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8294432](https://bugs.openjdk.org/browse/JDK-8294432): Add provisions to calculate hash values from MemorySegments (**Enhancement** - P3)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22364/head:pull/22364` \
`$ git checkout pull/22364`

Update a local copy of the PR: \
`$ git checkout pull/22364` \
`$ git pull https://git.openjdk.org/jdk.git pull/22364/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22364`

View PR using the GUI difftool: \
`$ git pr show -t 22364`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22364.diff">https://git.openjdk.org/jdk/pull/22364.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22364#issuecomment-2500533850)
</details>
