### PR TITLE
8344355: Register corruption in MacroAssembler::lookup_secondary_supers_table_var: x86-64 only

### DIFF
--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -4912,6 +4912,10 @@ void MacroAssembler::population_count(Register dst, Register src,
     }
     bind(done);
   }
+#ifdef ASSERT
+  mov64(scratch1, 0xCafeBabeDeadBeef);
+  movq(scratch2, scratch1);
+#endif
 }
 
 // Ensure that the inline code and the stub are using the same registers.
@@ -5130,7 +5134,7 @@ void MacroAssembler::lookup_secondary_supers_table_var(Register r_sub_klass,
   jccb(Assembler::equal, L_success);
 
   // Restore slot to its true value
-  xorl(slot, (u1)(Klass::SECONDARY_SUPERS_TABLE_SIZE - 1)); // slot ^ 63 === 63 - slot (mod 64)
+  movb(slot, Address(r_super_klass, Klass::hash_slot_offset()));
 
   // Linear probe. Rotate the bitmap so that the next bit to test is
   // in Bit 1.

--- a/src/hotspot/cpu/x86/macroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/macroAssembler_x86.cpp
@@ -5117,6 +5117,7 @@ void MacroAssembler::lookup_secondary_supers_table_var(Register r_sub_klass,
   const Register r_array_base = *available_regs++;
 
   // Get the first array index that can contain super_klass into r_array_index.
+  // Note: Clobbers r_array_base and slot.
   population_count(r_array_index, r_array_index, /*temp2*/r_array_base, /*temp3*/slot);
 
   // NB! r_array_index is off by 1. It is compensated by keeping r_array_base off by 1 word.


### PR DESCRIPTION
This bug only affects x86-64 machines without a `popcnt` instruction, which basically means pre-SSE4.2 machines. This means that x86-64 processors made around 2010 are affected.

My thanks to everyone who was was involved in bisecting this, particularly Martin Bucholz who seems to be the only one testing on such old hardware.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344355](https://bugs.openjdk.org/browse/JDK-8344355): Register corruption in MacroAssembler::lookup_secondary_supers_table_var: x86-64 only (**Bug** - P4)


### Reviewers
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**) Review applies to [dd2d4b5a](https://git.openjdk.org/jdk/pull/22365/files/dd2d4b5a08a5cd85f416a5d9aa6c77ef1ec70723)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**) Review applies to [dd2d4b5a](https://git.openjdk.org/jdk/pull/22365/files/dd2d4b5a08a5cd85f416a5d9aa6c77ef1ec70723)
 * [Vladimir Ivanov](https://openjdk.org/census#vlivanov) (@iwanowww - **Reviewer**)
 * [Artem Semenov](https://openjdk.org/census#asemenov) (@savoptik - Committer) Review applies to [dd2d4b5a](https://git.openjdk.org/jdk/pull/22365/files/dd2d4b5a08a5cd85f416a5d9aa6c77ef1ec70723)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22365/head:pull/22365` \
`$ git checkout pull/22365`

Update a local copy of the PR: \
`$ git checkout pull/22365` \
`$ git pull https://git.openjdk.org/jdk.git pull/22365/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22365`

View PR using the GUI difftool: \
`$ git pr show -t 22365`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22365.diff">https://git.openjdk.org/jdk/pull/22365.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22365#issuecomment-2498346434)
</details>
