### PR TITLE
8344968: [JVMCI] Add API for reserved global variables

### DIFF
--- a/src/hotspot/share/jvmci/jvmci.cpp
+++ b/src/hotspot/share/jvmci/jvmci.cpp
@@ -53,6 +53,8 @@ StringEventLog* JVMCI::_verbose_events = nullptr;
 volatile intx JVMCI::_first_error_tid = -1;
 volatile int JVMCI::_fatal_log_fd = -1;
 const char* JVMCI::_fatal_log_filename = nullptr;
+volatile jlong JVMCI::_reserved0 = 0L;
+volatile jlong JVMCI::_reserved1 = 0L;
 
 CompilerThread* CompilerThreadCanCallJava::update(JavaThread* current, bool new_state) {
   if (current->is_Compiler_thread()) {

--- a/src/hotspot/share/jvmci/jvmci.hpp
+++ b/src/hotspot/share/jvmci/jvmci.hpp
@@ -126,6 +126,10 @@ class JVMCI : public AllStatic {
     max_EventLog_level = 4
   };
 
+  // Reserved longs for use by JVMCI.
+  static volatile jlong _reserved0;
+  static volatile jlong _reserved1;
+
   // Gets the Thread* value for the current thread or null if it's not available.
   static Thread* current_thread_or_null();
 
@@ -183,6 +187,19 @@ class JVMCI : public AllStatic {
   static bool in_shutdown();
 
   static bool is_compiler_initialized();
+
+  /**
+   * Gets the address of the reserved long field identified by `id`.
+   * Returns 0L if `id` is not 0 or 1.
+   */
+  static address get_reserved_long(int id) {
+    if (id == 0) {
+      return (address) &_reserved0;
+    } else if (id == 1) {
+      return (address) &_reserved1;
+    }
+    return 0L;
+  }
 
   /**
    * Determines if the VM is sufficiently booted to initialize JVMCI.

--- a/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
+++ b/src/hotspot/share/jvmci/jvmciCompilerToVM.cpp
@@ -3228,6 +3228,15 @@ C2V_VMENTRY(void, getOopMapAt, (JNIEnv* env, jobject, ARGUMENT_PAIR(method),
   JVMCIENV->copy_longs_from((jlong*)oop_map_buf, oop_map, 0, nwords);
 C2V_END
 
+C2V_VMENTRY_0(jlong, getAddressOfReservedLong, (JNIEnv* env, jobject, jint id))
+  address a = JVMCI::get_reserved_long(id);
+  if (a != 0L) {
+    return (jlong) a;
+  }
+  THROW_MSG_0(vmSymbols::java_lang_IllegalArgumentException(),
+              err_msg("%d is not a valid reserved long id", id));
+C2V_END
+
 #define CC (char*)  /*cast a literal from (const char*)*/
 #define FN_PTR(f) CAST_FROM_FN_PTR(void*, &(c2v_ ## f))
 
@@ -3390,6 +3399,7 @@ JNINativeMethod CompilerToVM::methods[] = {
   {CC "notifyCompilerInliningEvent",                  CC "(I" HS_METHOD2 HS_METHOD2 "ZLjava/lang/String;I)V",                               FN_PTR(notifyCompilerInliningEvent)},
   {CC "getOopMapAt",                                  CC "(" HS_METHOD2 "I[J)V",                                                            FN_PTR(getOopMapAt)},
   {CC "updateCompilerThreadCanCallJava",              CC "(Z)Z",                                                                            FN_PTR(updateCompilerThreadCanCallJava)},
+  {CC "getAddressOfReservedLong",                     CC "(I)J",                                                                            FN_PTR(getAddressOfReservedLong)},
 };
 
 int CompilerToVM::methods_count() {

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/CompilerToVM.java
@@ -1522,4 +1522,12 @@ final class CompilerToVM {
      * @returns false if no change was made, otherwise true
      */
     native boolean updateCompilerThreadCanCallJava(boolean newState);
+
+    /**
+     * Gets the address of the reserved long global variable identified by {@code id}.
+     * 
+     * @param id must be 0 or 1
+     * @throws IllegalArgumentException if {@code id} is not 0 or 1
+     */
+    native long getAddressOfReservedLong(int id);
 }

--- a/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
+++ b/src/jdk.internal.vm.ci/share/classes/jdk/vm/ci/hotspot/HotSpotJVMCIRuntime.java
@@ -655,6 +655,19 @@ public final class HotSpotJVMCIRuntime implements JVMCIRuntime {
         return compilerToVm.getThreadLocalLong(id);
     }
 
+    /**
+     * Gets the address of the volatile long global variable identified by {@code id}.
+     * The variable is initialized to 0 and is shared by all JVMCI shared library JavaVMs.
+     * It's up to all callers of this method to coordinate on the semantics of a specific
+     * global variable.
+     *
+     * @param id must be 0 or 1
+     * @throws IllegalArgumentException if {@code id} is not 0 or 1
+     */
+    public long getAddressOfReservedLong(int id) {
+        return compilerToVm.getAddressOfReservedLong(id);
+    }
+
     HotSpotResolvedJavaType createClass(Class<?> javaClass) {
         if (javaClass.isPrimitive()) {
             return HotSpotResolvedPrimitiveType.forKind(JavaKind.fromJavaClass(javaClass));


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [ ] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warnings
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/nfkc.nrm)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/ubidi.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.base/share/classes/jdk/internal/icu/impl/data/icudt74b/uprops.icu)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-bw48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-interim48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow16.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow24.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow32.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/sun/awt/resources/security-icon-yellow48.png)
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/windows/native/libawt/windows/security_warning.ico)
&nbsp;⚠️ Patch contains a binary file (src/utils/IdealGraphVisualizer/View/src/main/resources/com/sun/hotspot/igv/view/images/hideDuplicates.png)

### Issue
 * [JDK-8344968](https://bugs.openjdk.org/browse/JDK-8344968): [JVMCI] Add API for reserved global variables (**Enhancement** - P4) ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22366/head:pull/22366` \
`$ git checkout pull/22366`

Update a local copy of the PR: \
`$ git checkout pull/22366` \
`$ git pull https://git.openjdk.org/jdk.git pull/22366/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22366`

View PR using the GUI difftool: \
`$ git pr show -t 22366`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22366.diff">https://git.openjdk.org/jdk/pull/22366.diff</a>

</details>
