### PR TITLE
8344778: javac is not generating the ConstantValue attribute for non-final static fields

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/Symbol.java
@@ -1812,12 +1812,16 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
         }
 
         public Object getConstValue() {
+            return getConstValue(false);
+        }
+
+        public Object getConstValue(boolean nonFinalOK) {
             // TODO: Consider if getConstValue and getConstantValue can be collapsed
             if (data == ElementKind.EXCEPTION_PARAMETER ||
-                data == ElementKind.RESOURCE_VARIABLE) {
+                    data == ElementKind.RESOURCE_VARIABLE) {
                 return null;
             } else if (data instanceof Callable<?> callableData) {
-                // In this case, this is a final variable, with an as
+                // In this case, this is a variable, with an as
                 // yet unevaluated initializer.
                 data = null; // to make sure we don't evaluate this twice.
                 try {
@@ -1826,7 +1830,7 @@ public abstract class Symbol extends AnnoConstruct implements PoolConstant, Elem
                     throw new AssertionError(ex);
                 }
             }
-            return data;
+            return isFinal() || (nonFinalOK && !isFinal()) ? data : null;
         }
 
         public void setData(Object data) {

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Attr.java
@@ -1304,7 +1304,7 @@ public class Attr extends JCTree.Visitor {
             chk.checkDeprecatedAnnotation(tree.pos(), v);
 
             if (tree.init != null) {
-                if ((v.flags_field & FINAL) == 0 ||
+                if ((!v.isFinal() && ((v.flags_field & STATIC) == 0 || v.owner.kind != TYP)) ||
                     !memberEnter.needsLazyConstValue(tree.init)) {
                     // Not a compile-time constant
                     // Attribute initializer in a new environment

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/MemberEnter.java
@@ -297,7 +297,7 @@ public class MemberEnter extends JCTree.Visitor {
         tree.sym = v;
         if (tree.init != null) {
             v.flags_field |= HASINIT;
-            if ((v.flags_field & FINAL) != 0 &&
+            if ((v.isFinal() || ((v.flags_field & STATIC) != 0 && v.owner.kind == TYP)) &&
                 needsLazyConstValue(tree.init)) {
                 Env<AttrContext> initEnv = getInitEnv(tree, env);
                 initEnv.info.enclVar = v;

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassReader.java
@@ -898,10 +898,6 @@ public class ClassReader {
             new AttributeReader(names.ConstantValue, V45_3, MEMBER_ATTRIBUTE) {
                 protected void read(Symbol sym, int attrLen) {
                     Object v = poolReader.getConstant(nextChar());
-                    // Ignore ConstantValue attribute if field not final.
-                    if ((sym.flags() & FINAL) == 0) {
-                        return;
-                    }
                     VarSymbol var = (VarSymbol) sym;
                     switch (var.type.getTag()) {
                        case BOOLEAN:

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/ClassWriter.java
@@ -984,9 +984,9 @@ public class ClassWriter extends ClassFile {
         databuf.appendChar(poolWriter.putDescriptor(v));
         int acountIdx = beginAttrs();
         int acount = 0;
-        if (v.getConstValue() != null) {
+        if (v.getConstValue(true) != null) {
             int alenIdx = writeAttr(names.ConstantValue);
-            databuf.appendChar(poolWriter.putConstant(v.getConstValue()));
+            databuf.appendChar(poolWriter.putConstant(v.getConstValue(true)));
             endAttr(alenIdx);
             acount++;
         }

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/jvm/Gen.java
@@ -457,7 +457,7 @@ public class Gen extends JCTree.Visitor {
                         initCode.append(init);
                         endPosTable.replaceTree(vdef, init);
                         initTAs.addAll(getAndRemoveNonFieldTAs(sym));
-                    } else if (sym.getConstValue() == null) {
+                    } else if (sym.getConstValue(true) == null) {
                         // Initialize class (static) variables only if
                         // they are not compile-time constants.
                         JCStatement init = make.at(vdef.pos).
@@ -466,7 +466,7 @@ public class Gen extends JCTree.Visitor {
                         endPosTable.replaceTree(vdef, init);
                         clinitTAs.addAll(getAndRemoveNonFieldTAs(sym));
                     } else {
-                        checkStringConstant(vdef.init.pos(), sym.getConstValue());
+                        checkStringConstant(vdef.init.pos(), sym.getConstValue(true));
                         /* if the init contains a reference to an external class, add it to the
                          * constant's pool
                          */
@@ -1056,7 +1056,7 @@ public class Gen extends JCTree.Visitor {
     public void visitVarDef(JCVariableDecl tree) {
         VarSymbol v = tree.sym;
         if (tree.init != null) {
-            checkStringConstant(tree.init.pos(), v.getConstValue());
+            checkStringConstant(tree.init.pos(), v.getConstValue(true));
             if (v.getConstValue() == null || varDebugInfo) {
                 Assert.check(code.isStatementStart());
                 code.newLocal(v);

--- a/test/langtools/tools/javac/classwriter/ExtraAttributes.java
+++ b/test/langtools/tools/javac/classwriter/ExtraAttributes.java
@@ -78,7 +78,7 @@ public class ExtraAttributes implements Plugin {
         Path src = Path.of("src");
             tb.writeJavaFiles(src,
                     "public class HelloWorld {\n"
-                    + "    public static String message = \"Hello World!\";\n"
+                    + "    public static Object message = \"Hello World!\";\n"
                     + "    public static void main(String... args) {\n"
                     + "        System.out.println(message);\n"
                     + "    }\n"


### PR DESCRIPTION
still a work in progress

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change requires CSR request [JDK-8344780](https://bugs.openjdk.org/browse/JDK-8344780) to be approved

### Warning
&nbsp;⚠️ Found leading lowercase letter in issue title for `8344778: javac is not generating the ConstantValue attribute for non-final static fields`

### Issues
 * [JDK-8344778](https://bugs.openjdk.org/browse/JDK-8344778): javac is not generating the ConstantValue attribute for non-final static fields (**Bug** - P4)
 * [JDK-8344780](https://bugs.openjdk.org/browse/JDK-8344780): javac is not generating the ConstantValue attribute for non-final static fields (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22367/head:pull/22367` \
`$ git checkout pull/22367`

Update a local copy of the PR: \
`$ git checkout pull/22367` \
`$ git pull https://git.openjdk.org/jdk.git pull/22367/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22367`

View PR using the GUI difftool: \
`$ git pr show -t 22367`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22367.diff">https://git.openjdk.org/jdk/pull/22367.diff</a>

</details>
