### PR TITLE
8344992: Remove Security Manager dependencies from java.security.cert API and implementations

### DIFF
--- a/src/java.base/share/classes/java/security/cert/CertPathBuilder.java
+++ b/src/java.base/share/classes/java/security/cert/CertPathBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,9 @@
 
 package java.security.cert;
 
-import java.security.AccessController;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.PrivilegedAction;
 import java.security.Provider;
 import java.security.Security;
 import java.util.Objects;
@@ -317,10 +315,7 @@ public class CertPathBuilder {
      * {@literal "PKIX"} if no such property exists.
      */
     public static final String getDefaultType() {
-        @SuppressWarnings("removal")
-        String cpbtype =
-            AccessController.doPrivileged((PrivilegedAction<String>) () ->
-                    Security.getProperty(CPB_TYPE));
+        String cpbtype = Security.getProperty(CPB_TYPE);
         return (cpbtype == null) ? "PKIX" : cpbtype;
     }
 

--- a/src/java.base/share/classes/java/security/cert/CertPathValidator.java
+++ b/src/java.base/share/classes/java/security/cert/CertPathValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,9 @@
 
 package java.security.cert;
 
-import java.security.AccessController;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.PrivilegedAction;
 import java.security.Provider;
 import java.security.Security;
 import java.util.Objects;
@@ -329,10 +327,7 @@ public class CertPathValidator {
      * {@literal "PKIX"} if no such property exists.
      */
     public static final String getDefaultType() {
-        @SuppressWarnings("removal")
-        String cpvtype =
-            AccessController.doPrivileged((PrivilegedAction<String>) () ->
-                    Security.getProperty(CPV_TYPE));
+        String cpvtype = Security.getProperty(CPV_TYPE);
         return (cpvtype == null) ? "PKIX" : cpvtype;
     }
 

--- a/src/java.base/share/classes/java/security/cert/CertStore.java
+++ b/src/java.base/share/classes/java/security/cert/CertStore.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2000, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2000, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,11 +25,9 @@
 
 package java.security.cert;
 
-import java.security.AccessController;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.PrivilegedAction;
 import java.security.Provider;
 import java.security.Security;
 import java.util.Collection;
@@ -426,11 +424,8 @@ public class CertStore {
      * {@code certstore.type} security property, or the string
      * {@literal "LDAP"} if no such property exists.
      */
-    @SuppressWarnings("removal")
     public static final String getDefaultType() {
-        String cstype;
-        cstype = AccessController.doPrivileged((PrivilegedAction<String>) () ->
-                Security.getProperty(CERTSTORE_TYPE));
+        String cstype = Security.getProperty(CERTSTORE_TYPE);
         if (cstype == null) {
             cstype = "LDAP";
         }

--- a/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/Builder.java
@@ -30,7 +30,6 @@ import java.security.GeneralSecurityException;
 import java.security.cert.*;
 import java.util.*;
 
-import sun.security.action.GetBooleanAction;
 import sun.security.provider.certpath.PKIX.BuilderParams;
 import sun.security.util.Debug;
 
@@ -55,8 +54,8 @@ abstract class Builder {
      * Authority Information Access extension shall be enabled. Currently
      * disabled by default for compatibility reasons.
      */
-    static final boolean USE_AIA = GetBooleanAction
-            .privilegedGetProperty("com.sun.security.enableAIAcaIssuers");
+    static final boolean USE_AIA =
+            Boolean.getBoolean("com.sun.security.enableAIAcaIssuers");
 
     /**
      * Initialize the builder with the input parameters.

--- a/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/OCSPResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,6 @@ import java.util.Set;
 import javax.security.auth.x500.X500Principal;
 
 import sun.security.util.HexDumpEncoder;
-import sun.security.action.GetIntegerAction;
 import sun.security.x509.*;
 import sun.security.util.*;
 
@@ -161,9 +160,7 @@ public final class OCSPResponse {
      * value is negative, set the skew to the default.
      */
     private static int initializeClockSkew() {
-        @SuppressWarnings("removal")
-        Integer tmp = java.security.AccessController.doPrivileged(
-                new GetIntegerAction("com.sun.security.ocsp.clockSkew"));
+        Integer tmp = Integer.getInteger("com.sun.security.ocsp.clockSkew");
         if (tmp == null || tmp < 0) {
             return DEFAULT_MAX_CLOCK_SKEW;
         }

--- a/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
+++ b/src/java.base/share/classes/sun/security/provider/certpath/RevocationChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,10 +29,8 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.security.AccessController;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivilegedAction;
 import java.security.PublicKey;
 import java.security.Security;
 import java.security.cert.CertPathValidatorException.BasicReason;
@@ -181,34 +179,21 @@ class RevocationChecker extends PKIXRevocationChecker {
         }
     }
 
-    @SuppressWarnings("removal")
     private static RevocationProperties getRevocationProperties() {
-        return AccessController.doPrivileged(
-            new PrivilegedAction<RevocationProperties>() {
-                public RevocationProperties run() {
-                    RevocationProperties rp = new RevocationProperties();
-                    String onlyEE = Security.getProperty(
-                        "com.sun.security.onlyCheckRevocationOfEECert");
-                    rp.onlyEE = onlyEE != null
-                                && onlyEE.equalsIgnoreCase("true");
-                    String ocspEnabled = Security.getProperty("ocsp.enable");
-                    rp.ocspEnabled = ocspEnabled != null
-                                     && ocspEnabled.equalsIgnoreCase("true");
-                    rp.ocspUrl = Security.getProperty("ocsp.responderURL");
-                    rp.ocspSubject
-                        = Security.getProperty("ocsp.responderCertSubjectName");
-                    rp.ocspIssuer
-                        = Security.getProperty("ocsp.responderCertIssuerName");
-                    rp.ocspSerial
-                        = Security.getProperty("ocsp.responderCertSerialNumber");
-                    rp.crlDPEnabled
-                        = Boolean.getBoolean("com.sun.security.enableCRLDP");
-                    rp.ocspNonce
-                        = Boolean.getBoolean("jdk.security.certpath.ocspNonce");
-                    return rp;
-                }
-            }
-        );
+        RevocationProperties rp = new RevocationProperties();
+        String onlyEE = Security.getProperty(
+            "com.sun.security.onlyCheckRevocationOfEECert");
+        rp.onlyEE = onlyEE != null && onlyEE.equalsIgnoreCase("true");
+        String ocspEnabled = Security.getProperty("ocsp.enable");
+        rp.ocspEnabled = ocspEnabled != null
+                         && ocspEnabled.equalsIgnoreCase("true");
+        rp.ocspUrl = Security.getProperty("ocsp.responderURL");
+        rp.ocspSubject = Security.getProperty("ocsp.responderCertSubjectName");
+        rp.ocspIssuer = Security.getProperty("ocsp.responderCertIssuerName");
+        rp.ocspSerial = Security.getProperty("ocsp.responderCertSerialNumber");
+        rp.crlDPEnabled = Boolean.getBoolean("com.sun.security.enableCRLDP");
+        rp.ocspNonce = Boolean.getBoolean("jdk.security.certpath.ocspNonce");
+        return rp;
     }
 
     private static X509Certificate getResponderCert(RevocationProperties rp,

--- a/src/java.base/share/classes/sun/security/util/SecurityProperties.java
+++ b/src/java.base/share/classes/sun/security/util/SecurityProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2024, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2018 SAP SE. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
@@ -51,7 +51,7 @@ public class SecurityProperties {
         }
     }
 
-    private static String getOverridableProperty(String propName) {
+    public static String getOverridableProperty(String propName) {
         String val = System.getProperty(propName);
         if (val == null) {
             return Security.getProperty(propName);

--- a/src/java.base/share/classes/sun/security/util/UntrustedCertificates.java
+++ b/src/java.base/share/classes/sun/security/util/UntrustedCertificates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,8 +25,6 @@
 package sun.security.util;
 
 import java.io.*;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.cert.X509Certificate;
 import java.util.Properties;
 
@@ -50,22 +48,15 @@ public final class UntrustedCertificates {
     private static final String algorithm;
 
     static {
-        @SuppressWarnings("removal")
-        var dummy = AccessController.doPrivileged(new PrivilegedAction<Void>() {
-            @Override
-            public Void run() {
-                File f = new File(StaticProperty.javaHome(),
-                        "lib/security/blocked.certs");
-                try (FileInputStream fin = new FileInputStream(f)) {
-                    props.load(fin);
-                } catch (IOException fnfe) {
-                    if (debug != null) {
-                        debug.println("Error parsing blocked.certs");
-                    }
-                }
-                return null;
+        File f = new File(StaticProperty.javaHome(),
+                "lib/security/blocked.certs");
+        try (FileInputStream fin = new FileInputStream(f)) {
+            props.load(fin);
+        } catch (IOException fnfe) {
+            if (debug != null) {
+                debug.println("Error parsing blocked.certs");
             }
-        });
+        }
         algorithm = props.getProperty(ALGORITHM_KEY);
     }
 

--- a/src/java.base/share/classes/sun/security/validator/CADistrustPolicy.java
+++ b/src/java.base/share/classes/sun/security/validator/CADistrustPolicy.java
@@ -24,8 +24,6 @@
  */
 package sun.security.validator;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.security.Security;
 import java.security.cert.X509Certificate;
 import java.util.EnumSet;
@@ -86,15 +84,8 @@ enum CADistrustPolicy {
     // The policies set in the jdk.security.caDistrustPolicies property.
     static final EnumSet<CADistrustPolicy> POLICIES = parseProperty();
     private static EnumSet<CADistrustPolicy> parseProperty() {
-        @SuppressWarnings("removal")
-        String property = AccessController.doPrivileged(
-            new PrivilegedAction<>() {
-                @Override
-                public String run() {
-                    return Security.getProperty(
-                        "jdk.security.caDistrustPolicies");
-                }
-            });
+        String property = Security.getProperty(
+                "jdk.security.caDistrustPolicies");
         EnumSet<CADistrustPolicy> set = EnumSet.noneOf(CADistrustPolicy.class);
         // if property is null or empty, the restrictions are not enforced
         if (property == null || property.isEmpty()) {

--- a/src/java.base/share/classes/sun/security/validator/PKIXValidator.java
+++ b/src/java.base/share/classes/sun/security/validator/PKIXValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.security.*;
 import java.security.cert.*;
 import java.util.*;
 import javax.security.auth.x500.X500Principal;
-import sun.security.action.GetBooleanAction;
 import sun.security.provider.certpath.AlgorithmChecker;
 import sun.security.provider.certpath.PKIXExtendedParameters;
 import sun.security.util.SecurityProperties;
@@ -56,8 +55,8 @@ public final class PKIXValidator extends Validator {
      * manager. Typically, this will only work if the PKIX implementation
      * supports CRL distribution points as we do not manually set up CertStores.
      */
-    private static final boolean checkTLSRevocation = GetBooleanAction
-            .privilegedGetProperty("com.sun.net.ssl.checkRevocation");
+    private static final boolean checkTLSRevocation =
+            Boolean.getBoolean("com.sun.net.ssl.checkRevocation");
 
     /**
      * System or security property that if set (or set to "true"), allows trust
@@ -67,7 +66,7 @@ public final class PKIXValidator extends Validator {
     private static final boolean ALLOW_NON_CA_ANCHOR = allowNonCaAnchor();
     private static boolean allowNonCaAnchor() {
         String prop = SecurityProperties
-                .privilegedGetOverridable("jdk.security.allowNonCaAnchor");
+                .getOverridableProperty("jdk.security.allowNonCaAnchor");
         return prop != null && (prop.isEmpty() || prop.equalsIgnoreCase("true"));
     }
 

--- a/src/java.base/share/classes/sun/security/x509/AVA.java
+++ b/src/java.base/share/classes/sun/security/x509/AVA.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1996, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1996, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -33,7 +33,6 @@ import java.util.*;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import sun.security.action.GetBooleanAction;
 import sun.security.util.*;
 import sun.security.pkcs.PKCS9Attribute;
 
@@ -64,8 +63,8 @@ public class AVA implements DerEncoder {
     // See CR 6391482: if enabled this flag preserves the old but incorrect
     // PrintableString encoding for DomainComponent. It may need to be set to
     // avoid breaking preexisting certificates generated with sun.security APIs.
-    private static final boolean PRESERVE_OLD_DC_ENCODING = GetBooleanAction
-            .privilegedGetProperty("com.sun.security.preserveOldDCEncoding");
+    private static final boolean PRESERVE_OLD_DC_ENCODING =
+            Boolean.getBoolean("com.sun.security.preserveOldDCEncoding");
 
     /**
      * DEFAULT format allows both RFC1779 and RFC2253 syntax and


### PR DESCRIPTION
Now that JEP 486 has been integrated, `java.security.cert` API and impl dependencies on  `AccessController.doPrivileged` can be removed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344992](https://bugs.openjdk.org/browse/JDK-8344992): Remove Security Manager dependencies from java.security.cert API and implementations (**Sub-task** - P3)


### Reviewers
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)
 * [Hai-May Chao](https://openjdk.org/census#hchao) (@haimaychao - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22372/head:pull/22372` \
`$ git checkout pull/22372`

Update a local copy of the PR: \
`$ git checkout pull/22372` \
`$ git pull https://git.openjdk.org/jdk.git pull/22372/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22372`

View PR using the GUI difftool: \
`$ git pr show -t 22372`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22372.diff">https://git.openjdk.org/jdk/pull/22372.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22372#issuecomment-2499114131)
</details>
