### PR TITLE
8344994: Remove most uses of RuntimePermission checks in java.desktop

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/eawt/Application.java
+++ b/src/java.desktop/macosx/classes/com/apple/eawt/Application.java
@@ -79,7 +79,6 @@ public class Application {
     static Application sApplication = null;
 
     static {
-        checkSecurity();
         Toolkit.getDefaultToolkit(); // Start AppKit
         if (!Beans.isDesignTime()) {
             nativeInitializeApplicationDelegate();
@@ -88,20 +87,12 @@ public class Application {
         sApplication = new Application();
     }
 
-    private static void checkSecurity() {
-        @SuppressWarnings("removal")
-        final SecurityManager security = System.getSecurityManager();
-        if (security == null) return;
-        security.checkPermission(new RuntimePermission("canProcessApplicationEvents"));
-    }
-
     /**
      * @return the singleton representing this Mac OS X Application
      *
      * @since 1.4
      */
     public static Application getApplication() {
-        checkSecurity();
         return sApplication;
     }
 
@@ -118,7 +109,6 @@ public class Application {
      */
     @Deprecated
     public Application() {
-        checkSecurity();
     }
 
     /**

--- a/src/java.desktop/macosx/classes/com/apple/eio/FileManager.java
+++ b/src/java.desktop/macosx/classes/com/apple/eio/FileManager.java
@@ -254,11 +254,6 @@ public class FileManager {
          * @since 1.4
          */
     public static String findFolder(short domain, int folderType, boolean createIfNeeded) throws FileNotFoundException {
-        @SuppressWarnings("removal")
-        final SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(new RuntimePermission("canExamineFileSystem"));
-        }
 
         final String foundFolder = _findFolder(domain, folderType, createIfNeeded);
         if (foundFolder == null) throw new FileNotFoundException("Can't find folder: " + Integer.toHexString(folderType));
@@ -282,11 +277,6 @@ public class FileManager {
          */
     @Deprecated
     public static void openURL(String url) throws IOException {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPermission(new RuntimePermission("canOpenURLs"));
-        }
         _openURL(url);
     }
     private static native void _openURL(String url) throws IOException;
@@ -334,10 +324,6 @@ public class FileManager {
 
         private static native String getNativeResourceFromBundle(String resourceName, String subDirName, String type) throws FileNotFoundException;
         private static String getResourceFromBundle(String resourceName, String subDirName, String type) throws FileNotFoundException {
-                @SuppressWarnings("removal")
-                final SecurityManager security = System.getSecurityManager();
-                if (security != null) security.checkPermission(new RuntimePermission("canReadBundle"));
-
                 final String resourceFromBundle = getNativeResourceFromBundle(resourceName, subDirName, type);
                 if (resourceFromBundle == null) throw new FileNotFoundException(resourceName);
                 return resourceFromBundle;
@@ -353,9 +339,6 @@ public class FileManager {
          * @since Java for Mac OS X 10.5 Update 2 - 1.5
          */
         public static String getPathToApplicationBundle() {
-                @SuppressWarnings("removal")
-                SecurityManager security = System.getSecurityManager();
-                if (security != null) security.checkPermission(new RuntimePermission("canReadBundle"));
                 return getNativePathToApplicationBundle();
         }
 

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJob.java
@@ -121,7 +121,7 @@ public final class CPrinterJob extends RasterPrinterJob {
             return super.printDialog(attributes);
         }
 
-        return jobSetup(getPageable(), checkAllowedToPrintToFile());
+        return jobSetup(getPageable());
     }
 
     /**
@@ -571,8 +571,8 @@ public final class CPrinterJob extends RasterPrinterJob {
      * dialog.
      * If the dialog is to use a set of attributes, useAttributes is true.
      */
-    private boolean jobSetup(Pageable doc, boolean allowPrintToFile) {
-        CPrinterDialog printerDialog = new CPrinterJobDialog(null, this, doc, allowPrintToFile);
+    private boolean jobSetup(Pageable doc) {
+        CPrinterDialog printerDialog = new CPrinterJobDialog(null, this, doc);
         printerDialog.setVisible(true);
         boolean result = printerDialog.getRetVal();
         printerDialog.dispose();

--- a/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJobDialog.java
+++ b/src/java.desktop/macosx/classes/sun/lwawt/macosx/CPrinterJobDialog.java
@@ -32,12 +32,10 @@ import java.awt.print.*;
 @SuppressWarnings("serial") // JDK implementation class
 final class CPrinterJobDialog extends CPrinterDialog {
     private Pageable fPageable;
-    private boolean fAllowPrintToFile;
 
-    CPrinterJobDialog(Frame parent, CPrinterJob printerJob, Pageable doc, boolean allowPrintToFile) {
+    CPrinterJobDialog(Frame parent, CPrinterJob printerJob, Pageable doc) {
         super(parent, printerJob);
         fPageable = doc;
-        fAllowPrintToFile = allowPrintToFile;
     }
 
     @Override

--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -36,7 +36,6 @@ import java.awt.geom.Rectangle2D;
 import java.awt.peer.FontPeer;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FilePermission;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectOutputStream;
@@ -1230,13 +1229,6 @@ public class Font implements java.io.Serializable
         if (fontFormat != Font.TRUETYPE_FONT &&
             fontFormat != Font.TYPE1_FONT) {
             throw new IllegalArgumentException ("font format not recognized");
-        }
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            FilePermission filePermission =
-                new FilePermission(fontFile.getPath(), "read");
-            sm.checkPermission(filePermission);
         }
         if (!fontFile.canRead()) {
             throw new IOException("Can't read " + fontFile);

--- a/src/java.desktop/share/classes/java/awt/Taskbar.java
+++ b/src/java.desktop/share/classes/java/awt/Taskbar.java
@@ -177,19 +177,6 @@ public class Taskbar {
         }
     }
 
-    /**
-     *  Calls to the security manager's {@code checkPermission} method with
-     *  an {@code RuntimePermission("canProcessApplicationEvents")} permissions.
-     */
-    private void checkEventsProcessingPermission(){
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPermission(new RuntimePermission(
-                    "canProcessApplicationEvents"));
-        }
-    }
-
     private Taskbar() {
         Toolkit defaultToolkit = Toolkit.getDefaultToolkit();
         if (defaultToolkit instanceof SunToolkit) {
@@ -265,7 +252,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#USER_ATTENTION} feature
      */
     public void requestUserAttention(final boolean enabled, final boolean critical) {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.USER_ATTENTION);
         peer.requestUserAttention(enabled, critical);
     }
@@ -282,7 +268,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#USER_ATTENTION_WINDOW} feature
      */
     public void requestWindowUserAttention(Window w) {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.USER_ATTENTION_WINDOW);
         peer.requestWindowUserAttention(w);
     }
@@ -296,7 +281,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#MENU} feature
      */
     public void setMenu(final PopupMenu menu) {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.MENU);
         peer.setMenu(menu);
     }
@@ -309,7 +293,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#MENU} feature
      */
     public PopupMenu getMenu() {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.MENU);
         return peer.getMenu();
     }
@@ -322,7 +305,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#ICON_IMAGE} feature
      */
     public void setIconImage(final Image image) {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.ICON_IMAGE);
         peer.setIconImage(image);
     }
@@ -339,7 +321,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#ICON_IMAGE} feature
      */
     public Image getIconImage() {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.ICON_IMAGE);
         return peer.getIconImage();
     }
@@ -360,7 +341,6 @@ public class Taskbar {
      * or {@link Taskbar.Feature#ICON_BADGE_TEXT} feature
      */
     public void setIconBadge(final String badge) {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.ICON_BADGE_NUMBER);
         peer.setIconBadge(badge);
     }
@@ -380,7 +360,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#ICON_BADGE_IMAGE_WINDOW} feature
      */
     public void setWindowIconBadge(Window w, final Image badge) {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.ICON_BADGE_IMAGE_WINDOW);
         if (w != null) {
             peer.setWindowIconBadge(w, badge);
@@ -396,7 +375,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#PROGRESS_VALUE} feature
      */
     public void setProgressValue(int value) {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.PROGRESS_VALUE);
         peer.setProgressValue(value);
     }
@@ -426,7 +404,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#PROGRESS_VALUE_WINDOW} feature
      */
     public void setWindowProgressValue(Window w, int value) {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.PROGRESS_VALUE_WINDOW);
         if (w != null) {
             peer.setWindowProgressValue(w, value);
@@ -458,7 +435,6 @@ public class Taskbar {
      * does not support the {@link Taskbar.Feature#PROGRESS_STATE_WINDOW} feature
      */
     public void setWindowProgressState(Window w, State state) {
-        checkEventsProcessingPermission();
         checkFeatureSupport(Feature.PROGRESS_STATE_WINDOW);
         if (w != null) {
             peer.setWindowProgressState(w, state);

--- a/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
+++ b/src/java.desktop/share/classes/java/awt/color/ICC_Profile.java
@@ -39,7 +39,6 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FilePermission;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;

--- a/src/java.desktop/share/classes/javax/accessibility/AccessibilityProvider.java
+++ b/src/java.desktop/share/classes/javax/accessibility/AccessibilityProvider.java
@@ -52,37 +52,6 @@ public abstract class AccessibilityProvider {
      * Initializes a new accessibility provider.
      */
     protected AccessibilityProvider() {
-        // Use a permission check when calling a private constructor to check
-        // that the proper security permission has been granted before the
-        // {@code Object} superclass is called. If an exception is thrown before
-        // the {@code Object} superclass is constructed a finalizer in a
-        // subclass of this class will not be run. This protects against a
-        // finalizer vulnerability.
-        this(checkPermission());
-    }
-
-    /**
-     * Allows to check a permission before the {@code Object} is called.
-     *
-     * @param  ignore unused stub to call a {@link #checkPermission()}}
-     */
-    private AccessibilityProvider(Void ignore) { }
-
-    /**
-     * If this code is running with a security manager and if the permission
-     * {@code "accessibilityProvider"} has not been granted
-     * {@code SecurityException} will be thrown.
-     *
-     * @return {@code null} if {@code SecurityException} was not thrown
-     * @throws SecurityException If a security manager has been installed and it
-     *         denies {@link RuntimePermission} {@code "accessibilityProvider"}
-     */
-    private static Void checkPermission() {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null)
-            sm.checkPermission(new RuntimePermission("accessibilityProvider"));
-        return null;
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/imageio/ImageIO.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageIO.java
@@ -169,7 +169,7 @@ public final class ImageIO {
     /**
      * Determines whether the caller has write access to the cache
      * directory, stores the result in the {@code CacheInfo} object,
-     * and returns the decision. 
+     * and returns the decision.
      */
     private static boolean hasCachePermission() {
         Boolean hasPermission = getCacheInfo().getHasPermission();

--- a/src/java.desktop/share/classes/javax/imageio/ImageIO.java
+++ b/src/java.desktop/share/classes/javax/imageio/ImageIO.java
@@ -28,7 +28,6 @@ package javax.imageio;
 import java.awt.image.BufferedImage;
 import java.awt.image.RenderedImage;
 import java.io.File;
-import java.io.FilePermission;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -170,50 +169,13 @@ public final class ImageIO {
     /**
      * Determines whether the caller has write access to the cache
      * directory, stores the result in the {@code CacheInfo} object,
-     * and returns the decision.  This method helps to prevent mysterious
-     * SecurityExceptions to be thrown when this convenience class is used
-     * in an applet, for example.
+     * and returns the decision. 
      */
     private static boolean hasCachePermission() {
         Boolean hasPermission = getCacheInfo().getHasPermission();
-
         if (hasPermission != null) {
             return hasPermission.booleanValue();
         } else {
-            try {
-                @SuppressWarnings("removal")
-                SecurityManager security = System.getSecurityManager();
-                if (security != null) {
-                    File cachedir = getCacheDirectory();
-                    String cachepath;
-
-                    if (cachedir != null) {
-                        cachepath = cachedir.getPath();
-                    } else {
-                        cachepath = getTempDir();
-
-                        if (cachepath == null || cachepath.isEmpty()) {
-                            getCacheInfo().setHasPermission(Boolean.FALSE);
-                            return false;
-                        }
-                    }
-
-                    // we have to check whether we can read, write,
-                    // and delete cache files.
-                    // So, compose cache file path and check it.
-                    String filepath = cachepath;
-                    if (!filepath.endsWith(File.separator)) {
-                        filepath += File.separator;
-                    }
-                    filepath += "*";
-
-                    security.checkPermission(new FilePermission(filepath, "read, write, delete"));
-                }
-            } catch (SecurityException e) {
-                getCacheInfo().setHasPermission(Boolean.FALSE);
-                return false;
-            }
-
             getCacheInfo().setHasPermission(Boolean.TRUE);
             return true;
         }

--- a/src/java.desktop/share/classes/sun/print/PrintJob2D.java
+++ b/src/java.desktop/share/classes/sun/print/PrintJob2D.java
@@ -42,7 +42,6 @@ import java.awt.print.PrinterException;
 import java.awt.print.PrinterJob;
 
 import java.io.File;
-import java.io.FilePermission;
 import java.io.IOException;
 
 import java.net.URI;
@@ -351,7 +350,6 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
         // Verify that the app has access to the file system
         DestinationType dest= this.jobAttributes.getDestination();
         if (dest == DestinationType.FILE) {
-            throwPrintToFile();
 
             // check if given filename is valid
             String destStr = jobAttributes.getFileName();
@@ -1262,19 +1260,6 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
             str = media.toString();
         }
         props.setProperty(PAPERSIZE_PROP, str);
-    }
-
-    private void throwPrintToFile() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        FilePermission printToFilePermission = null;
-        if (security != null) {
-            if (printToFilePermission == null) {
-                printToFilePermission =
-                    new FilePermission("<<ALL FILES>>", "read,write");
-            }
-            security.checkPermission(printToFilePermission);
-        }
     }
 
 }

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -25,8 +25,6 @@
 
 package sun.print;
 
-import java.io.FilePermission;
-
 import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.GraphicsConfiguration;
@@ -255,11 +253,6 @@ public abstract class RasterPrinterJob extends PrinterJob {
     protected boolean performingPrinting = false;
  // MacOSX - made protected so subclasses can reference it.
     protected boolean userCancelled = false;
-
-   /**
-    * Print to file permission variables.
-    */
-    private FilePermission printToFilePermission;
 
     /**
      * List of areas & the graphics state for redrawing
@@ -2499,37 +2492,6 @@ public abstract class RasterPrinterJob extends PrinterJob {
 
         g.setClip(clip);
         g.setPaint(Color.black);
-    }
-
-
-   /**
-    * User dialogs should disable "File" buttons if this returns false.
-    *
-    */
-    public boolean checkAllowedToPrintToFile() {
-        try {
-            throwPrintToFile();
-            return true;
-        } catch (SecurityException e) {
-            return false;
-        }
-    }
-
-    /**
-     * Break this out as it may be useful when we allow API to
-     * specify printing to a file. In that case its probably right
-     * to throw a SecurityException if the permission is not granted
-     */
-    private void throwPrintToFile() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            if (printToFilePermission == null) {
-                printToFilePermission =
-                    new FilePermission("<<ALL FILES>>", "read,write");
-            }
-            security.checkPermission(printToFilePermission);
-        }
     }
 
     /* On-screen drawString renders most control chars as the missing glyph

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
@@ -98,7 +98,6 @@ import sun.print.PrintServiceLookupProvider;
 import sun.print.ServiceDialog;
 
 import java.awt.Frame;
-import java.io.FilePermission;
 
 import sun.java2d.Disposer;
 import sun.java2d.DisposerRecord;
@@ -1904,23 +1903,6 @@ public final class WPrinterJob extends RasterPrinterJob
 
     private int getMediaTrayAttrib() {
         return mAttMediaTray;
-    }
-
-
-
-    private boolean getPrintToFileEnabled() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            FilePermission printToFilePermission =
-                new FilePermission("<<ALL FILES>>", "read,write");
-            try {
-                security.checkPermission(printToFilePermission);
-            } catch (SecurityException e) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private void setNativeAttributes(int flags, int fields, int values) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.cpp
@@ -72,7 +72,6 @@ jmethodID AwtPrintControl::getMinPageID;
 jmethodID AwtPrintControl::getCollateID;
 jmethodID AwtPrintControl::getOrientID;
 jmethodID AwtPrintControl::getQualityID;
-jmethodID AwtPrintControl::getPrintToFileEnabledID;
 jmethodID AwtPrintControl::getPrinterID;
 jmethodID AwtPrintControl::setPrinterID;
 jmethodID AwtPrintControl::getResID;
@@ -368,11 +367,6 @@ void AwtPrintControl::initIDs(JNIEnv *env, jclass cls)
       env->GetMethodID(cls, "getSelectAttrib", "()I");
     DASSERT(AwtPrintControl::getSelectID != NULL);
     CHECK_NULL(AwtPrintControl::getSelectID);
-
-    AwtPrintControl::getPrintToFileEnabledID =
-      env->GetMethodID(cls, "getPrintToFileEnabled", "()Z");
-    DASSERT(AwtPrintControl::getPrintToFileEnabledID != NULL);
-    CHECK_NULL(AwtPrintControl::getPrintToFileEnabledID);
 
     AwtPrintControl::setNativeAttID =
       env->GetMethodID(cls, "setNativeAttributes", "(III)V");
@@ -807,11 +801,6 @@ BOOL AwtPrintControl::InitPrintDialog(JNIEnv *env,
     // SunPageSelection (AWT)
     if (selectType != 0) {
       pd.Flags |= selectType;
-    }
-
-    if (!env->CallBooleanMethod(printCtrl,
-                                AwtPrintControl::getPrintToFileEnabledID)) {
-      pd.Flags |= PD_DISABLEPRINTTOFILE;
     }
 
     if (pd.hDevMode != NULL) {

--- a/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.h
+++ b/src/java.desktop/windows/native/libawt/windows/awt_PrintControl.h
@@ -63,7 +63,6 @@ public:
     static jmethodID getCollateID;
     static jmethodID getOrientID;
     static jmethodID getQualityID;
-    static jmethodID getPrintToFileEnabledID;
     static jmethodID getPrinterID;
     static jmethodID setPrinterID;
     static jmethodID getResID;


### PR DESCRIPTION
More clean up after JEP 486 (SecurityManager disabling).
FilePermission is the most common RuntimePermission checked in java.desktop

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344994](https://bugs.openjdk.org/browse/JDK-8344994): Remove most uses of RuntimePermission checks in java.desktop (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22373/head:pull/22373` \
`$ git checkout pull/22373`

Update a local copy of the PR: \
`$ git checkout pull/22373` \
`$ git pull https://git.openjdk.org/jdk.git pull/22373/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22373`

View PR using the GUI difftool: \
`$ git pr show -t 22373`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22373.diff">https://git.openjdk.org/jdk/pull/22373.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22373#issuecomment-2499121697)
</details>
