### PR TITLE
8342280: Deprecate for removal java.awt.AWTPermission

### DIFF
--- a/src/java.desktop/share/classes/java/awt/AWTPermission.java
+++ b/src/java.desktop/share/classes/java/awt/AWTPermission.java
@@ -37,6 +37,7 @@ import java.security.BasicPermission;
  * @apiNote
  * This permission cannot be used for controlling access to resources
  * as the Security Manager is no longer supported.
+ * Consequently this class is deprecated for removal in a future release.
  *
  * @see java.security.BasicPermission
  * @see java.security.Permission
@@ -46,7 +47,9 @@ import java.security.BasicPermission;
  *
  * @author Marianne Mueller
  * @author Roland Schemers
+ * @deprecated There is no replacement for this class.
  */
+@Deprecated(since="24", forRemoval=true)
 public final class AWTPermission extends BasicPermission {
 
     /**

--- a/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/Modality.html
@@ -46,7 +46,6 @@
       <li><a href="#ShowHideBlocking">Show/hide blocking</a></li>
       <li><a href="#ModalExclusion">Modal exclusion</a></li>
       <li><a href="#Related">Related AWT features</a></li>
-      <li><a href="#Security">Security</a></li>
       <li><a href="#PlatformSupport">Platform support</a></li>
       <li><a href="#Compatibility">Compatibility</a></li>
       <li><a href="#Examples">Examples</a></li>
@@ -128,7 +127,6 @@
         so a toolkit-modal dialog shown from an applet may affect other
         applets and all windows of the browser instance which embeds the
         Java runtime environment for this toolkit.
-        See the security section below.
     </li></ol>
     <p>
       Modality priority is arranged by the strength of blocking: modeless,
@@ -331,21 +329,8 @@
       If the modal dialog to be hidden does not have focus, the active window remains
       unchanged.
 
-    <a id="Security"></a>
-    <h2>Security</h2>
-
-    <p>
-      A special <code>AWTPermission</code>, <code>"toolkitModality"</code>,
-      is required to show toolkit-modal
-      dialogs. This would prevent, for example, blocking a browser or
-      Java Web Start (JWS) by modal dialogs shown from applets.
-    </p><p>
-      The same permission is required to exclude a window from toolkit modality.
-      This would prevent, for example, a dialog shown from an applet not to be
-      blocked by a browser's or JWS's modal dialog.
-
     <a id="PlatformSupport"></a>
-    </p><h2>Platform support</h2>
+    <h2>Platform support</h2>
 
     <p>
       Two <code>java.awt.Toolkit</code> methods allow you to check whether


### PR DESCRIPTION
This deprecates - for removal - java.awt.AWTPermission which is no longer used anywhere in the JDK implementation

In addition it removes a left over specification mention of it describing AWT Dialog Modality.

CSR for review is here : https://bugs.openjdk.org/browse/JDK-8345003

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8345003](https://bugs.openjdk.org/browse/JDK-8345003) to be approved

### Issues
 * [JDK-8342280](https://bugs.openjdk.org/browse/JDK-8342280): Deprecate for removal java.awt.AWTPermission (**Bug** - P4)
 * [JDK-8345003](https://bugs.openjdk.org/browse/JDK-8345003): Deprecate for removal java.awt.AWTPermission (**CSR**)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22378/head:pull/22378` \
`$ git checkout pull/22378`

Update a local copy of the PR: \
`$ git checkout pull/22378` \
`$ git pull https://git.openjdk.org/jdk.git pull/22378/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22378`

View PR using the GUI difftool: \
`$ git pr show -t 22378`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22378.diff">https://git.openjdk.org/jdk/pull/22378.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22378#issuecomment-2499377504)
</details>
