### PR TITLE
8345004: [BACKOUT] GTK & Nimbus LAF: Tabbed pane's background color is not expected one when change the opaque checkbox.

### DIFF
--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKLookAndFeel.java
@@ -356,8 +356,6 @@ public class GTKLookAndFeel extends SynthLookAndFeel {
         Double defaultCaretAspectRatio = Double.valueOf(0.025);
         Color caretColor = table.getColor("caretColor");
         Color controlText = table.getColor("controlText");
-        Color tabbedPaneBg = new ColorUIResource(238, 238, 238);
-        Color unselectedTabColor = new ColorUIResource(255, 255, 255);
 
         Object fieldInputMap = new UIDefaults.LazyInputMap(new Object[] {
                        "ctrl C", DefaultEditorKit.copyAction,
@@ -1029,11 +1027,6 @@ public class GTKLookAndFeel extends SynthLookAndFeel {
             "TabbedPane.selectedLabelShift", 3,
             "TabbedPane.font", new FontLazyValue(Region.TABBED_PANE),
             "TabbedPane.selectedTabPadInsets", new InsetsUIResource(2, 2, 0, 1),
-            "TabbedPane.selected", tabbedPaneBg,
-            "TabbedPane.contentOpaque", Boolean.TRUE,
-            "TabbedPane.tabsOpaque", Boolean.TRUE,
-            "TabbedPane.contentAreaColor", tabbedPaneBg,
-            "TabbedPane.unselectedBackground", unselectedTabColor,
 
             "Table.scrollPaneBorder", zeroBorder,
             "Table.background", tableBg,

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKPainter.java
@@ -935,27 +935,22 @@ class GTKPainter extends SynthPainter {
                                            Graphics g,
                                            int x, int y, int w, int h,
                                            int tabIndex) {
+        Region id = context.getRegion();
+        int state = context.getComponentState();
+        int gtkState = ((state & SynthConstants.SELECTED) != 0 ?
+                SynthConstants.ENABLED : SynthConstants.PRESSED);
         JTabbedPane pane = (JTabbedPane)context.getComponent();
-        if (UIManager.getBoolean("TabbedPane.tabsOpaque") || pane.isOpaque()) {
-            Region id = context.getRegion();
-            int state = context.getComponentState();
-            int gtkState = ((state & SynthConstants.SELECTED) != 0 ?
-                    SynthConstants.ENABLED : SynthConstants.PRESSED);
-            int placement = pane.getTabPlacement();
+        int placement = pane.getTabPlacement();
 
-            // Fill the tab rect area
-            g.fillRect(x, y, w, h);
-
-            synchronized (UNIXToolkit.GTK_LOCK) {
-                if (!ENGINE.paintCachedImage(g, x, y, w, h,
-                        id, gtkState, placement, tabIndex)) {
-                    PositionType side = POSITIONS[placement - 1];
-                    ENGINE.startPainting(g, x, y, w, h,
-                            id, gtkState, placement, tabIndex);
-                    ENGINE.paintExtension(g, context, id, gtkState,
-                            ShadowType.OUT, "tab", x, y, w, h, side, tabIndex);
-                    ENGINE.finishPainting();
-                }
+        synchronized (UNIXToolkit.GTK_LOCK) {
+            if (!ENGINE.paintCachedImage(g, x, y, w, h,
+                    id, gtkState, placement, tabIndex)) {
+                PositionType side = POSITIONS[placement - 1];
+                ENGINE.startPainting(g, x, y, w, h,
+                        id, gtkState, placement, tabIndex);
+                ENGINE.paintExtension(g, context, id, gtkState,
+                        ShadowType.OUT, "tab", x, y, w, h, side, tabIndex);
+                ENGINE.finishPainting();
             }
         }
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/SynthPainterImpl.java
@@ -2111,27 +2111,24 @@ class SynthPainterImpl extends SynthPainter {
     public void paintTabbedPaneTabBackground(SynthContext context, Graphics g,
                                          int x, int y, int w, int h,
                                          int tabIndex, int orientation) {
-        JTabbedPane pane = (JTabbedPane)context.getComponent();
-        if (UIManager.getBoolean("TabbedPane.tabsOpaque") || pane.isOpaque()) {
-            if (orientation == JTabbedPane.LEFT) {
-                AffineTransform transform = new AffineTransform();
-                transform.scale(-1, 1);
-                transform.rotate(Math.toRadians(90));
-                paintBackground(context, g, y, x, h, w, transform);
-            } else if (orientation == JTabbedPane.RIGHT) {
-                AffineTransform transform = new AffineTransform();
-                transform.rotate(Math.toRadians(90));
-                transform.translate(0, -(x + w));
-                paintBackground(context, g, y, 0, h, w, transform);
-            } else if (orientation == JTabbedPane.BOTTOM) {
-                AffineTransform transform = new AffineTransform();
-                transform.translate(x, y);
-                transform.scale(1, -1);
-                transform.translate(0, -h);
-                paintBackground(context, g, 0, 0, w, h, transform);
-            } else {
-                paintBackground(context, g, x, y, w, h, null);
-            }
+        if (orientation == JTabbedPane.LEFT) {
+            AffineTransform transform = new AffineTransform();
+            transform.scale(-1, 1);
+            transform.rotate(Math.toRadians(90));
+            paintBackground(context, g, y, x, h, w, transform);
+        } else if (orientation == JTabbedPane.RIGHT) {
+            AffineTransform transform = new AffineTransform();
+            transform.rotate(Math.toRadians(90));
+            transform.translate(0, -(x + w));
+            paintBackground(context, g, y, 0, h, w, transform);
+        } else if (orientation == JTabbedPane.BOTTOM) {
+            AffineTransform transform = new AffineTransform();
+            transform.translate(x, y);
+            transform.scale(1, -1);
+            transform.translate(0, -h);
+            paintBackground(context, g, 0, 0, w, h, transform);
+        } else {
+            paintBackground(context, g, x, y, w, h, null);
         }
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
+++ b/src/java.desktop/share/classes/javax/swing/plaf/nimbus/skin.laf
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
- Copyright (c) 1998, 2024, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it
@@ -82,9 +82,6 @@
       </uiColor>
       <uiColor name="nimbusDisabledText">
          <matte red="142" green="143" blue="145" alpha="255" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0"/>
-      </uiColor>
-      <uiColor name="nimbusTabbedPaneContentArea">
-         <matte red="238" green="238" blue="238" alpha="255" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0"/>
       </uiColor>
       <uiColor name="nimbusLightBackground">
          <matte red="255" green="255" blue="255" alpha="255" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0"/>
@@ -21649,11 +21646,6 @@
                <uiProperty name="tabOverlap" type="INT" value="-1"/>
                <uiProperty name="extendTabsToBase" type="BOOLEAN" value="true"/>
                <uiProperty name="useBasicArrows" type="BOOLEAN" value="true"/>
-               <uiProperty name="contentOpaque" type="BOOLEAN" value="true"/>
-               <uiProperty name="tabsOpaque" type="BOOLEAN" value="true"/>
-               <uiProperty name="contentAreaColor" type="COLOR">
-                  <matte red="238" green="238" blue="238" alpha="255" uiDefaultParentName="nimbusTabbedPaneContentArea" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0"/>
-               </uiProperty>
                <uiProperty name="shadow" type="COLOR">
                   <matte red="142" green="143" blue="145" alpha="255" uiDefaultParentName="nimbusDisabledText" hueOffset="0.0" saturationOffset="0.0" brightnessOffset="0.0" alphaOffset="0"/>
                </uiProperty>

--- a/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTabbedPaneUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/synth/SynthTabbedPaneUI.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2024, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,6 @@
 package javax.swing.plaf.synth;
 
 import java.awt.Component;
-import java.awt.Color;
 import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
@@ -122,12 +121,6 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
 
     private boolean selectedTabIsPressed = false;
 
-    // Background color for selected tab and content pane
-    private Color selectColor;
-    // Background color for unselected tabs
-    private Color unselectedBackground;
-    private boolean contentOpaque = true;
-
     /**
      *
      * Constructs a {@code SynthTabbedPaneUI}.
@@ -153,9 +146,6 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
      */
     @Override
     protected void installDefaults() {
-        selectColor = UIManager.getColor("TabbedPane.selected");
-        contentOpaque = UIManager.getBoolean("TabbedPane.contentOpaque");
-        unselectedBackground = UIManager.getColor("TabbedPane.unselectedBackground");
         updateStyle(tabPane);
     }
 
@@ -647,12 +637,6 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
             }
         }
 
-        if (isSelected) {
-            g.setColor(selectColor);
-        } else {
-            g.setColor(getUnselectedBackgroundAt(tabIndex));
-        }
-
         tabContext.getPainter().paintTabbedPaneTabBackground(tabContext, g,
                 x, y, width, height, tabIndex, placement);
         tabContext.getPainter().paintTabbedPaneTabBorder(tabContext, g,
@@ -673,14 +657,6 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
             paintText(ss, g, tabPlacement, font, metrics,
                     tabIndex, clippedTitle, textRect, isSelected);
         }
-    }
-
-    private Color getUnselectedBackgroundAt(int index) {
-        Color color = tabPane.getBackgroundAt(index);
-        if (color instanceof UIResource && unselectedBackground != null) {
-            return unselectedBackground;
-        }
-        return color;
     }
 
     private void layoutLabel(SynthContext ss, int tabPlacement,
@@ -760,21 +736,6 @@ public class SynthTabbedPaneUI extends BasicTabbedPaneUI
               h -= (y - insets.top);
         }
         SynthLookAndFeel.updateSubregion(ss, g, new Rectangle(x, y, w, h));
-
-        if (tabPane.getTabCount() > 0 && (contentOpaque || tabPane.isOpaque())) {
-            // Fill region behind content area
-            Color color = UIManager.getColor("TabbedPane.contentAreaColor");
-            if (color != null) {
-                g.setColor(color);
-            } else if (selectColor == null || selectedIndex == -1) {
-                g.setColor(tabPane.getBackground());
-            } else {
-                g.setColor(selectColor);
-            }
-            // fill content area rect for both GTK and Nimbus LAF here
-            g.fillRect(x, y, w, h);
-        }
-
         ss.getPainter().paintTabbedPaneContentBackground(ss, g, x, y,
                                                            w, h);
         ss.getPainter().paintTabbedPaneContentBorder(ss, g, x, y, w, h);

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -791,6 +791,7 @@ jdk/jfr/jvm/TestWaste.java                                      8282427 generic-
 javax/swing/JFileChooser/6698013/bug6698013.java 8024419 macosx-all
 javax/swing/JColorChooser/8065098/bug8065098.java 8065647 macosx-all
 javax/swing/JTabbedPane/4666224/bug4666224.java 8144124  macosx-all
+javax/swing/JTabbedPane/TestJTabbedPaneOpaqueColor.java 8345090 windows-all,linux-all
 javax/swing/SwingUtilities/TestTextPosInPrint.java 8227025 windows-all
 
 java/awt/event/MouseEvent/SpuriousExitEnter/SpuriousExitEnter_1.java 7131438,8022539 generic-all


### PR DESCRIPTION
The fix for [JDK-8226990](https://bugs.openjdk.org/browse/JDK-8226990) causes regression in dark theme for GTK L&F on Ubuntu system and that results in manual test failures identified recently.

Few of the changes made in [JDK-8226990](https://bugs.openjdk.org/browse/JDK-8226990) is further modified in [JDK-8335130](https://bugs.openjdk.org/browse/JDK-8335130).

Backing out the overall fix to prevent any regression.

CI testing after revert is fine.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Warning
&nbsp;⚠️ Found trailing period in issue title for `8345004: [BACKOUT] GTK & Nimbus LAF: Tabbed pane's background color is not expected one when change the opaque checkbox.`

### Issue
 * [JDK-8345004](https://bugs.openjdk.org/browse/JDK-8345004): [BACKOUT] GTK &amp; Nimbus LAF: Tabbed pane's background color is not expected one when change the opaque checkbox. (**Bug** - P2)


### Reviewers
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22379/head:pull/22379` \
`$ git checkout pull/22379`

Update a local copy of the PR: \
`$ git checkout pull/22379` \
`$ git pull https://git.openjdk.org/jdk.git pull/22379/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22379`

View PR using the GUI difftool: \
`$ git pr show -t 22379`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22379.diff">https://git.openjdk.org/jdk/pull/22379.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22379#issuecomment-2499694213)
</details>
