### PR TITLE
8344256: Clean up obsolete code in java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
@@ -43,7 +43,6 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FilePermission;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;

--- a/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
+++ b/src/java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java
@@ -62,7 +62,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.charset.UnsupportedCharsetException;
-import java.security.ProtectionDomain;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -756,7 +755,7 @@ search:
             (String.class.equals(flavor.getRepresentationClass()) &&
              DataFlavorUtil.isFlavorCharsetTextType(flavor) && isTextFormat(format))) {
 
-            String str = removeSuspectedData(flavor, contents, (String)obj);
+            String str = (String)obj;
 
             return translateTransferableString(
                 str,
@@ -869,9 +868,7 @@ search:
 
             final List<?> list = (List<?>)obj;
 
-            final ProtectionDomain userProtectionDomain = getUserProtectionDomain(contents);
-
-            final ArrayList<String> fileList = castToFiles(list, userProtectionDomain);
+            final ArrayList<String> fileList = castToFiles(list);
 
             try (ByteArrayOutputStream bos = convertFileListToBytes(fileList)) {
                 theByteArray = bos.toByteArray();
@@ -896,8 +893,7 @@ search:
                 targetCharset = "UTF-8";
             }
             final List<?> list = (List<?>)obj;
-            final ProtectionDomain userProtectionDomain = getUserProtectionDomain(contents);
-            final ArrayList<String> fileList = castToFiles(list, userProtectionDomain);
+            final ArrayList<String> fileList = castToFiles(list);
             final ArrayList<String> uriList = new ArrayList<>(fileList.size());
             for (String fileObject : fileList) {
                 final URI uri = new File(fileObject).toURI();
@@ -979,69 +975,12 @@ search:
 
     protected abstract ByteArrayOutputStream convertFileListToBytes(ArrayList<String> fileList) throws IOException;
 
-    @SuppressWarnings("removal")
-    private String removeSuspectedData(DataFlavor flavor, final Transferable contents, final String str)
-    {
-        if (null == System.getSecurityManager()
-            || !flavor.isMimeTypeEqual("text/uri-list"))
-        {
-            return str;
-        }
-
-        final ProtectionDomain userProtectionDomain = getUserProtectionDomain(contents);
-        StringBuilder allowedFiles = new StringBuilder(str.length());
-        String [] uriArray = str.split("(\\s)+");
-
-        for (String fileName : uriArray)
-        {
-            File file = new File(fileName);
-            if (file.exists() &&
-                !(isFileInWebstartedCache(file) ||
-                isForbiddenToRead(file, userProtectionDomain)))
-            {
-                if (0 != allowedFiles.length())
-                {
-                    allowedFiles.append("\\r\\n");
-                }
-
-                allowedFiles.append(fileName);
-            }
-        }
-        return allowedFiles.toString();
-    }
-
-    private static ProtectionDomain getUserProtectionDomain(Transferable contents) {
-        return contents.getClass().getProtectionDomain();
-    }
-
-    private boolean isForbiddenToRead (File file, ProtectionDomain protectionDomain)
-    {
-        if (null == protectionDomain) {
-            return false;
-        }
-        try {
-            FilePermission filePermission =
-                    new FilePermission(file.getCanonicalPath(), "read, delete");
-            if (protectionDomain.implies(filePermission)) {
-                return false;
-            }
-        } catch (IOException e) {}
-
-        return true;
-    }
-
-    @SuppressWarnings("removal")
-    private ArrayList<String> castToFiles(final List<?> files,
-                                          final ProtectionDomain userProtectionDomain) throws IOException {
+    private ArrayList<String> castToFiles(final List<?> files) throws IOException {
         ArrayList<String> fileList = new ArrayList<>();
         for (Object fileObject : files)
         {
             File file = castToFile(fileObject);
-            if (file != null &&
-                (null == System.getSecurityManager() ||
-                !(isFileInWebstartedCache(file) ||
-                isForbiddenToRead(file, userProtectionDomain))))
-            {
+            if (file != null) {
                 fileList.add(file.getCanonicalPath());
             }
         }
@@ -1061,43 +1000,6 @@ search:
         }
         return new File(filePath);
     }
-
-    private static final String[] DEPLOYMENT_CACHE_PROPERTIES = {
-        "deployment.system.cachedir",
-        "deployment.user.cachedir",
-        "deployment.javaws.cachedir",
-        "deployment.javapi.cachedir"
-    };
-
-    private static final ArrayList <File> deploymentCacheDirectoryList = new ArrayList<>();
-
-    private static boolean isFileInWebstartedCache(File f) {
-
-        if (deploymentCacheDirectoryList.isEmpty()) {
-            for (String cacheDirectoryProperty : DEPLOYMENT_CACHE_PROPERTIES) {
-                String cacheDirectoryPath = System.getProperty(cacheDirectoryProperty);
-                if (cacheDirectoryPath != null) {
-                    try {
-                        File cacheDirectory = (new File(cacheDirectoryPath)).getCanonicalFile();
-                        if (cacheDirectory != null) {
-                            deploymentCacheDirectoryList.add(cacheDirectory);
-                        }
-                    } catch (IOException ioe) {}
-                }
-            }
-        }
-
-        for (File deploymentCacheDirectory : deploymentCacheDirectoryList) {
-            for (File dir = f; dir != null; dir = dir.getParentFile()) {
-                if (dir.equals(deploymentCacheDirectory)) {
-                    return true;
-                }
-            }
-        }
-
-        return false;
-    }
-
 
     public Object translateBytes(byte[] bytes, DataFlavor flavor,
                                  long format, Transferable localeTransferable)


### PR DESCRIPTION
Clean up obsolete code in DataTransferer.java
The main aim here was to get rid of ProtectionDomain and other SM related usage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344256](https://bugs.openjdk.org/browse/JDK-8344256): Clean up obsolete code in java.desktop/share/classes/sun/awt/datatransfer/DataTransferer.java (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**) Review applies to [37072de3](https://git.openjdk.org/jdk/pull/22381/files/37072de36dafe25e9c6fe21d8f51775532fa694d)
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22381/head:pull/22381` \
`$ git checkout pull/22381`

Update a local copy of the PR: \
`$ git checkout pull/22381` \
`$ git pull https://git.openjdk.org/jdk.git pull/22381/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22381`

View PR using the GUI difftool: \
`$ git pr show -t 22381`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22381.diff">https://git.openjdk.org/jdk/pull/22381.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22381#issuecomment-2499806440)
</details>
