### PR TITLE
8340731: Cleanup remaining IA64 references in hotspot code

### DIFF
--- a/src/hotspot/os/bsd/os_bsd.cpp
+++ b/src/hotspot/os/bsd/os_bsd.cpp
@@ -229,8 +229,6 @@ size_t os::rss() {
 // Cpu architecture string
 #if   defined(ZERO)
 static char cpu_arch[] = ZERO_LIBARCH;
-#elif defined(IA64)
-static char cpu_arch[] = "ia64";
 #elif defined(IA32)
 static char cpu_arch[] = "i386";
 #elif defined(AMD64)
@@ -1192,8 +1190,6 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   static  Elf32_Half running_arch_code=EM_386;
   #elif   (defined AMD64)
   static  Elf32_Half running_arch_code=EM_X86_64;
-  #elif  (defined IA64)
-  static  Elf32_Half running_arch_code=EM_IA_64;
   #elif  (defined __powerpc64__)
   static  Elf32_Half running_arch_code=EM_PPC64;
   #elif  (defined __powerpc__)
@@ -1214,7 +1210,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   static  Elf32_Half running_arch_code=EM_68K;
   #else
     #error Method os::dll_load requires that one of following is defined:\
-         IA32, AMD64, IA64, __powerpc__, ARM, S390, ALPHA, MIPS, MIPSEL, PARISC, M68K
+         IA32, AMD64, __powerpc__, ARM, S390, ALPHA, MIPS, MIPSEL, PARISC, M68K
   #endif
 
   // Identify compatibility class for VM's architecture and library's architecture

--- a/src/hotspot/os/linux/hugepages.cpp
+++ b/src/hotspot/os/linux/hugepages.cpp
@@ -55,8 +55,7 @@ static size_t scan_default_hugepagesize() {
 
   // large_page_size on Linux is used to round up heap size. x86 uses either
   // 2M or 4M page, depending on whether PAE (Physical Address Extensions)
-  // mode is enabled. AMD64/EM64T uses 2M page in 64bit mode. IA64 can use
-  // page as large as 1G.
+  // mode is enabled. AMD64/EM64T uses 2M page in 64bit mode.
   //
   // Here we try to figure out page size by parsing /proc/meminfo and looking
   // for a line with the following format:

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -461,26 +461,17 @@ bool os::Linux::get_tick_information(CPUPerfTicks* pticks, int which_logical_cpu
 }
 
 #ifndef SYS_gettid
-// i386: 224, ia64: 1105, amd64: 186, sparc: 143
-  #ifdef __ia64__
-    #define SYS_gettid 1105
+// i386: 224, amd64: 186, sparc: 143
+  #if defined(__i386__)
+    #define SYS_gettid 224
+  #elif defined(__amd64__)
+    #define SYS_gettid 186
+  #elif defined(__sparc__)
+    #define SYS_gettid 143
   #else
-    #ifdef __i386__
-      #define SYS_gettid 224
-    #else
-      #ifdef __amd64__
-        #define SYS_gettid 186
-      #else
-        #ifdef __sparc__
-          #define SYS_gettid 143
-        #else
-          #error define gettid for the arch
-        #endif
-      #endif
-    #endif
+    #error "Define SYS_gettid for this architecture"
   #endif
-#endif
-
+#endif // SYS_gettid
 
 // pid_t gettid()
 //
@@ -1778,8 +1769,6 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   static  Elf32_Half running_arch_code=EM_386;
 #elif   (defined AMD64) || (defined X32)
   static  Elf32_Half running_arch_code=EM_X86_64;
-#elif  (defined IA64)
-  static  Elf32_Half running_arch_code=EM_IA_64;
 #elif  (defined __sparc) && (defined _LP64)
   static  Elf32_Half running_arch_code=EM_SPARCV9;
 #elif  (defined __sparc) && (!defined _LP64)
@@ -1812,7 +1801,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
   static  Elf32_Half running_arch_code=EM_LOONGARCH;
 #else
     #error Method os::dll_load requires that one of following is defined:\
-        AARCH64, ALPHA, ARM, AMD64, IA32, IA64, LOONGARCH64, M68K, MIPS, MIPSEL, PARISC, __powerpc__, __powerpc64__, RISCV, S390, SH, __sparc
+        AARCH64, ALPHA, ARM, AMD64, IA32, LOONGARCH64, M68K, MIPS, MIPSEL, PARISC, __powerpc__, __powerpc64__, RISCV, S390, SH, __sparc
 #endif
 
   // Identify compatibility class for VM's architecture and library's architecture
@@ -2719,8 +2708,6 @@ void os::get_summary_cpu_info(char* cpuinfo, size_t length) {
   strncpy(cpuinfo, "ARM", length);
 #elif defined(IA32)
   strncpy(cpuinfo, "x86_32", length);
-#elif defined(IA64)
-  strncpy(cpuinfo, "IA64", length);
 #elif defined(PPC)
   strncpy(cpuinfo, "PPC64", length);
 #elif defined(RISCV)

--- a/src/hotspot/os/posix/signals_posix.cpp
+++ b/src/hotspot/os/posix/signals_posix.cpp
@@ -961,10 +961,6 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
     { SIGILL,  ILL_PRVREG,   "ILL_PRVREG",   "Privileged register." },
     { SIGILL,  ILL_COPROC,   "ILL_COPROC",   "Coprocessor error." },
     { SIGILL,  ILL_BADSTK,   "ILL_BADSTK",   "Internal stack error." },
-#if defined(IA64) && defined(LINUX)
-    { SIGILL,  ILL_BADIADDR, "ILL_BADIADDR", "Unimplemented instruction address" },
-    { SIGILL,  ILL_BREAK,    "ILL_BREAK",    "Application Break instruction" },
-#endif
     { SIGFPE,  FPE_INTDIV,   "FPE_INTDIV",   "Integer divide by zero." },
     { SIGFPE,  FPE_INTOVF,   "FPE_INTOVF",   "Integer overflow." },
     { SIGFPE,  FPE_FLTDIV,   "FPE_FLTDIV",   "Floating-point divide by zero." },
@@ -978,9 +974,6 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
 #if defined(AIX)
     // no explanation found what keyerr would be
     { SIGSEGV, SEGV_KEYERR,  "SEGV_KEYERR",  "key error" },
-#endif
-#if defined(IA64) && !defined(AIX)
-    { SIGSEGV, SEGV_PSTKOVF, "SEGV_PSTKOVF", "Paragraph stack overflow" },
 #endif
     { SIGBUS,  BUS_ADRALN,   "BUS_ADRALN",   "Invalid address alignment." },
     { SIGBUS,  BUS_ADRERR,   "BUS_ADRERR",   "Nonexistent physical address." },

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -956,7 +956,6 @@ void PhaseChaitin::gather_lrg_masks( bool after_aggressive ) {
           // Each entry is reg_pressure_per_value,number_of_regs
           //         RegL  RegI  RegFlags   RegF RegD    INTPRESSURE  FLOATPRESSURE
           // IA32     2     1     1          1    1          6           6
-          // IA64     1     1     1          1    1         50          41
           // SPARC    2     2     2          2    2         48 (24)     52 (26)
           // SPARCV9  2     2     2          2    2         48 (24)     52 (26)
           // AMD64    1     1     1          1    1         14          15

--- a/src/hotspot/share/opto/generateOptoStub.cpp
+++ b/src/hotspot/share/opto/generateOptoStub.cpp
@@ -224,10 +224,6 @@ void GraphKit::gen_stub(address C_function,
   store_to_memory(control(), adr_sp, null(), T_ADDRESS, MemNode::unordered);
   // Clear last_Java_pc
   store_to_memory(control(), adr_last_Java_pc, null(), T_ADDRESS, MemNode::unordered);
-#if (defined(IA64) && !defined(AIX))
-  Node* adr_last_Java_fp = basic_plus_adr(top(), thread, in_bytes(JavaThread::last_Java_fp_offset()));
-  store_to_memory(control(), adr_last_Java_fp, null(), T_ADDRESS, MemNode::unordered);
-#endif
 
   // For is-fancy-jump, the C-return value is also the branch target
   Node* target = map()->in(TypeFunc::Parms);

--- a/src/hotspot/share/opto/memnode.hpp
+++ b/src/hotspot/share/opto/memnode.hpp
@@ -196,7 +196,7 @@ private:
   // non-pinned LoadNode by the pinned LoadNode.
   ControlDependency _control_dependency;
 
-  // On platforms with weak memory ordering (e.g., PPC, Ia64) we distinguish
+  // On platforms with weak memory ordering (e.g., PPC) we distinguish
   // loads that can be reordered, and such requiring acquire semantics to
   // adhere to the Java specification.  The required behaviour is stored in
   // this field.
@@ -566,7 +566,7 @@ public:
 // Store value; requires Store, Address and Value
 class StoreNode : public MemNode {
 private:
-  // On platforms with weak memory ordering (e.g., PPC, Ia64) we distinguish
+  // On platforms with weak memory ordering (e.g., PPC) we distinguish
   // stores that can be reordered, and such requiring release semantics to
   // adhere to the Java specification.  The required behaviour is stored in
   // this field.

--- a/src/hotspot/share/opto/output.cpp
+++ b/src/hotspot/share/opto/output.cpp
@@ -383,7 +383,7 @@ bool PhaseOutput::need_stack_bang(int frame_size_in_bytes) const {
 bool PhaseOutput::need_register_stack_bang() const {
   // Determine if we need to generate a register stack overflow check.
   // This is only used on architectures which have split register
-  // and memory stacks (ie. IA64).
+  // and memory stacks.
   // Bang if the method is not a stub function and has java calls
   return (C->stub_function() == nullptr && C->has_java_calls());
 }

--- a/src/hotspot/share/runtime/abstract_vm_version.cpp
+++ b/src/hotspot/share/runtime/abstract_vm_version.cpp
@@ -187,7 +187,6 @@ const char* Abstract_VM_Version::vm_release() {
 #define CPU      AARCH64_ONLY("aarch64")         \
                  AMD64_ONLY("amd64")             \
                  IA32_ONLY("x86")                \
-                 IA64_ONLY("ia64")               \
                  S390_ONLY("s390")               \
                  RISCV64_ONLY("riscv64")
 #endif // !ZERO

--- a/src/hotspot/share/runtime/deoptimization.cpp
+++ b/src/hotspot/share/runtime/deoptimization.cpp
@@ -607,9 +607,6 @@ Deoptimization::UnrollBlock* Deoptimization::fetch_unroll_info_helper(JavaThread
   // where it will be very difficult to figure out what went wrong. Better
   // to die an early death here than some very obscure death later when the
   // trail is cold.
-  // Note: on ia64 this guarantee can be fooled by frames with no memory stack
-  // in that it will fail to detect a problem when there is one. This needs
-  // more work in tiger timeframe.
   guarantee(array->unextended_sp() == unpack_sp, "vframe_array_head must contain the vframeArray to unpack");
 
   int number_of_frames = array->frames();
@@ -2342,8 +2339,7 @@ JRT_ENTRY(void, Deoptimization::uncommon_trap_inner(JavaThread* current, jint tr
     }
 
     // Setting +ProfileTraps fixes the following, on all platforms:
-    // 4852688: ProfileInterpreter is off by default for ia64.  The result is
-    // infinite heroic-opt-uncommon-trap/deopt/recompile cycles, since the
+    // The result is infinite heroic-opt-uncommon-trap/deopt/recompile cycles, since the
     // recompile relies on a MethodData* to record heroic opt failures.
 
     // Whether the interpreter is producing MDO data or not, we also need

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -164,6 +164,7 @@ class frame {
   void   patch_pc(Thread* thread, address pc);
 
   // Every frame needs to return a unique id which distinguishes it from all other frames.
+  // For sparc and ia32 use sp.
   // No real frame should have an id() of null so it is a distinguishing value for an unmatchable frame.
   // We also have relationals which allow comparing a frame to another frame's id() allowing
   // us to distinguish younger (more recent activation) from older (less recent activations)

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -164,10 +164,8 @@ class frame {
   void   patch_pc(Thread* thread, address pc);
 
   // Every frame needs to return a unique id which distinguishes it from all other frames.
-  // For sparc and ia32 use sp. ia64 can have memory frames that are empty so multiple frames
-  // will have identical sp values. For ia64 the bsp (fp) value will serve. No real frame
-  // should have an id() of null so it is a distinguishing value for an unmatchable frame.
-  // We also have relationals which allow comparing a frame to anoth frame's id() allow
+  // No real frame should have an id() of null so it is a distinguishing value for an unmatchable frame.
+  // We also have relationals which allow comparing a frame to another frame's id() allow
   // us to distinguish younger (more recent activation) from older (less recent activations)
   // A null id is only valid when comparing for equality.
 

--- a/src/hotspot/share/runtime/frame.hpp
+++ b/src/hotspot/share/runtime/frame.hpp
@@ -165,7 +165,7 @@ class frame {
 
   // Every frame needs to return a unique id which distinguishes it from all other frames.
   // No real frame should have an id() of null so it is a distinguishing value for an unmatchable frame.
-  // We also have relationals which allow comparing a frame to another frame's id() allow
+  // We also have relationals which allow comparing a frame to another frame's id() allowing
   // us to distinguish younger (more recent activation) from older (less recent activations)
   // A null id is only valid when comparing for equality.
 

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -115,6 +115,7 @@ JavaCallWrapper::~JavaCallWrapper() {
   // Old thread-local info. has been restored. We are not back in the VM.
   ThreadStateTransition::transition_from_java(_thread, _thread_in_vm);
 
+  // State has been restored now make the anchor frame visible for the profiler.
   _thread->frame_anchor()->copy(&_anchor);
 
   // Release handles after we are marked as being inside the VM again, since this

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -118,7 +118,7 @@ JavaCallWrapper::~JavaCallWrapper() {
   // State has been restored now make the anchor frame visible for the profiler.
   // Do this after the transition because this allows us to put an assert
   // the Java->vm transition which checks to see that stack is not walkable
-  // on sparc/ia64 which will catch violations of the resetting of last_Java_frame
+  // which will catch violations of the resetting of last_Java_frame
   // invariants (i.e. _flags always cleared on return to Java)
 
   _thread->frame_anchor()->copy(&_anchor);

--- a/src/hotspot/share/runtime/javaCalls.cpp
+++ b/src/hotspot/share/runtime/javaCalls.cpp
@@ -115,12 +115,6 @@ JavaCallWrapper::~JavaCallWrapper() {
   // Old thread-local info. has been restored. We are not back in the VM.
   ThreadStateTransition::transition_from_java(_thread, _thread_in_vm);
 
-  // State has been restored now make the anchor frame visible for the profiler.
-  // Do this after the transition because this allows us to put an assert
-  // the Java->vm transition which checks to see that stack is not walkable
-  // which will catch violations of the resetting of last_Java_frame
-  // invariants (i.e. _flags always cleared on return to Java)
-
   _thread->frame_anchor()->copy(&_anchor);
 
   // Release handles after we are marked as being inside the VM again, since this

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -855,7 +855,7 @@ class os: AllStatic {
   // We don't attempt to become a debugger, so we only follow frames if that
   // does not require a lookup in the unwind table, which is part of the binary
   // file but may be unsafe to read after a fatal error. So on x86, we can
-  // only walk stack if %ebp is used as frame pointer;
+  // only walk stack if %ebp is used as frame pointer.
   static bool is_first_C_frame(frame *fr);
   static frame get_sender_for_C_frame(frame *fr);
 

--- a/src/hotspot/share/runtime/os.hpp
+++ b/src/hotspot/share/runtime/os.hpp
@@ -855,8 +855,7 @@ class os: AllStatic {
   // We don't attempt to become a debugger, so we only follow frames if that
   // does not require a lookup in the unwind table, which is part of the binary
   // file but may be unsafe to read after a fatal error. So on x86, we can
-  // only walk stack if %ebp is used as frame pointer; on ia64, it's not
-  // possible to walk C stack without having the unwind table.
+  // only walk stack if %ebp is used as frame pointer;
   static bool is_first_C_frame(frame *fr);
   static frame get_sender_for_C_frame(frame *fr);
 

--- a/src/hotspot/share/runtime/relocator.cpp
+++ b/src/hotspot/share/runtime/relocator.cpp
@@ -200,7 +200,7 @@ bool Relocator::handle_code_changes() {
 bool Relocator::is_opcode_lookupswitch(Bytecodes::Code bc) {
   switch (bc) {
     case Bytecodes::_tableswitch:       return false;
-    case Bytecodes::_lookupswitch:                   // not rewritten on ia64
+    case Bytecodes::_lookupswitch:
     case Bytecodes::_fast_linearswitch:              // rewritten _lookupswitch
     case Bytecodes::_fast_binaryswitch: return true; // rewritten _lookupswitch
     default: ShouldNotReachHere();

--- a/src/hotspot/share/utilities/elfFuncDescTable.cpp
+++ b/src/hotspot/share/utilities/elfFuncDescTable.cpp
@@ -34,11 +34,10 @@ ElfFuncDescTable::ElfFuncDescTable(FILE* file, Elf_Shdr shdr, int index) :
   _section(file, shdr), _file(file), _index(index) {
   assert(file, "null file handle");
   // The actual function address (i.e. function entry point) is always the
-  // first value in the function descriptor (on IA64 and PPC64 they look as follows):
+  // first value in the function descriptor (on PPC64 they look as follows):
   // PPC64: [function entry point, TOC pointer, environment pointer]
-  // IA64 : [function entry point, GP (global pointer) value]
   // Unfortunately 'shdr.sh_entsize' doesn't always seem to contain this size (it's zero on PPC64) so we can't assert
-  // assert(IA64_ONLY(2) PPC64_ONLY(3) * sizeof(address) == shdr.sh_entsize, "Size mismatch for '.opd' section entries");
+  // assert(PPC64_ONLY(3) * sizeof(address) == shdr.sh_entsize, "Size mismatch for '.opd' section entries");
 
   _status = _section.status();
 }

--- a/src/hotspot/share/utilities/elfFuncDescTable.hpp
+++ b/src/hotspot/share/utilities/elfFuncDescTable.hpp
@@ -35,9 +35,8 @@
 
 /*
 
-On PowerPC-64 (and other architectures like for example IA64) a pointer to a
-function is not just a plain code address, but instead a pointer to a so called
-function descriptor (which is simply a structure containing 3 pointers).
+On PowerPC-64 a pointer to a function is not just a plain code address,
+but instead a pointer to a so-called function descriptor (which is simply a structure containing 3 pointers).
 This fact is also reflected in the ELF ABI for PowerPC-64.
 
 On architectures like x86 or SPARC, the ELF symbol table contains the start

--- a/src/hotspot/share/utilities/elfFuncDescTable.hpp
+++ b/src/hotspot/share/utilities/elfFuncDescTable.hpp
@@ -35,8 +35,8 @@
 
 /*
 
-On PowerPC-64 a pointer to a function is not just a plain code address,
-but instead a pointer to a so-called function descriptor (which is simply a structure containing 3 pointers).
+On PowerPC-64 a pointer to a function is not just a plain code address, but instead a pointer
+to a so-called function descriptor (which is simply a structure containing 3 pointers).
 This fact is also reflected in the ELF ABI for PowerPC-64.
 
 On architectures like x86 or SPARC, the ELF symbol table contains the start

--- a/src/hotspot/share/utilities/macros.hpp
+++ b/src/hotspot/share/utilities/macros.hpp
@@ -458,18 +458,6 @@
 #define NOT_IA32(code) code
 #endif
 
-// This is a REALLY BIG HACK, but on AIX <sys/systemcfg.h> unconditionally defines IA64.
-// At least on AIX 7.1 this is a real problem because 'systemcfg.h' is indirectly included
-// by 'pthread.h' and other common system headers.
-
-#if defined(IA64) && !defined(AIX)
-#define IA64_ONLY(code) code
-#define NOT_IA64(code)
-#else
-#define IA64_ONLY(code)
-#define NOT_IA64(code) code
-#endif
-
 #ifdef AMD64
 #define AMD64_ONLY(code) code
 #define NOT_AMD64(code)


### PR DESCRIPTION
This PR cleans up `IA64` entries form hotspot codebase. 

As mentioned in the JBS, I left `zero` component as-it-is: 
```
./cpu/zero/bytecodeInterpreter_zero.hpp:31:#if defined(PPC) || defined(IA64)
./os_cpu/linux_zero/os_linux_zero.cpp:350:#ifdef IA64
./os_cpu/linux_zero/os_linux_zero.cpp:351:    // IA64 has two stacks sharing the same area of memory, a normal
./os_cpu/linux_zero/os_linux_zero.cpp:360:#endif // IA64
```

Fastdebug VM Build on Mac-M1 & Linux/s390x is fine. Tests are in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8340731](https://bugs.openjdk.org/browse/JDK-8340731): Cleanup remaining IA64 references in hotspot code (**Enhancement** - P4)


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Andrew Haley](https://openjdk.org/census#aph) (@theRealAph - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22382/head:pull/22382` \
`$ git checkout pull/22382`

Update a local copy of the PR: \
`$ git checkout pull/22382` \
`$ git pull https://git.openjdk.org/jdk.git pull/22382/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22382`

View PR using the GUI difftool: \
`$ git pr show -t 22382`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22382.diff">https://git.openjdk.org/jdk/pull/22382.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22382#issuecomment-2499809221)
</details>
