### PR TITLE
8345015: Remove unused method lookup_time_t_function

### DIFF
--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
@@ -250,23 +250,6 @@ static int statx_wrapper(int dirfd, const char *restrict pathname, int flags,
 }
 #endif
 
-#if defined(__linux__) && defined(__arm__)
-/**
- * Lookup functions with time_t parameter. Try to use 64 bit symbol
- * if sizeof(time_t) exceeds 32 bit.
- */
-static void* lookup_time_t_function(const char* symbol, const char* symbol64) {
-    void *func_ptr = NULL;
-    if (sizeof(time_t) > 4) {
-        func_ptr = dlsym(RTLD_DEFAULT, symbol64);
-    }
-    if (func_ptr == NULL) {
-        return dlsym(RTLD_DEFAULT, symbol);
-    }
-    return func_ptr;
-}
-#endif
-
 /**
  * Call this to throw an internal UnixException when a system/library
  * call fails


### PR DESCRIPTION
With JDK-8343785 all usages of this method have been eliminated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345015](https://bugs.openjdk.org/browse/JDK-8345015): Remove unused method lookup_time_t_function (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22383/head:pull/22383` \
`$ git checkout pull/22383`

Update a local copy of the PR: \
`$ git checkout pull/22383` \
`$ git pull https://git.openjdk.org/jdk.git pull/22383/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22383`

View PR using the GUI difftool: \
`$ git pr show -t 22383`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22383.diff">https://git.openjdk.org/jdk/pull/22383.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22383#issuecomment-2499873530)
</details>
