### PR TITLE
8345050: Fix -Wzero-as-null-pointer warning in MemPointer ctor

### DIFF
--- a/src/hotspot/share/opto/mempointer.hpp
+++ b/src/hotspot/share/opto/mempointer.hpp
@@ -596,7 +596,7 @@ public:
     if (_trace.is_trace_pointer()) {
       tty->print_cr("MemPointer::MemPointer:");
       tty->print("mem: "); mem->dump();
-      _mem->in(MemNode::Address)->dump_bfs(5, 0, "d");
+      _mem->in(MemNode::Address)->dump_bfs(5, nullptr, "d");
       _decomposed_form.print_on(tty);
     }
 #endif


### PR DESCRIPTION
Please review this trivial change to use nullptr instead of a literal 0 in a
call to Node::dump_bfs by the MemPointer ctor.

Testing: mach5 tier1

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345050](https://bugs.openjdk.org/browse/JDK-8345050): Fix -Wzero-as-null-pointer warning in MemPointer ctor (**Enhancement** - P4)


### Reviewers
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22388/head:pull/22388` \
`$ git checkout pull/22388`

Update a local copy of the PR: \
`$ git checkout pull/22388` \
`$ git pull https://git.openjdk.org/jdk.git pull/22388/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22388`

View PR using the GUI difftool: \
`$ git pr show -t 22388`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22388.diff">https://git.openjdk.org/jdk/pull/22388.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22388#issuecomment-2500316503)
</details>
