### PR TITLE
8344949: javax.security.auth.Subject.SecureSet.writeObject does not do a security check anymore

### DIFF
--- a/src/java.base/share/classes/javax/security/auth/Subject.java
+++ b/src/java.base/share/classes/javax/security/auth/Subject.java
@@ -1418,12 +1418,6 @@ public final class Subject implements java.io.Serializable {
         /**
          * Writes this object out to a stream (i.e., serializes it).
          *
-         * @serialData If this is a private credential set,
-         *      a security check is performed to ensure that
-         *      the caller has permission to access each credential
-         *      in the set.  If the security check passes,
-         *      the set is serialized.
-         *
          * @param  oos the {@code ObjectOutputStream} to which data is written
          * @throws IOException if an I/O error occurs
          */


### PR DESCRIPTION
The Serial Data section of `javax.security.auth.Subject.SecureSet.writeObject()` should be removed as it no longer does a security check now that the Security Manager is permanently disabled.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Change requires CSR request [JDK-8344950](https://bugs.openjdk.org/browse/JDK-8344950) to be approved
- [x] Commit message must refer to an issue

### Issues
 * [JDK-8344949](https://bugs.openjdk.org/browse/JDK-8344949): javax.security.auth.Subject.SecureSet.writeObject does not do a security check anymore (**Bug** - P3)
 * [JDK-8344950](https://bugs.openjdk.org/browse/JDK-8344950): javax.security.auth.Subject.SecureSet.writeObject does not do a security check anymore (**CSR**)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22390/head:pull/22390` \
`$ git checkout pull/22390`

Update a local copy of the PR: \
`$ git checkout pull/22390` \
`$ git pull https://git.openjdk.org/jdk.git pull/22390/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22390`

View PR using the GUI difftool: \
`$ git pr show -t 22390`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22390.diff">https://git.openjdk.org/jdk/pull/22390.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22390#issuecomment-2500818910)
</details>
