### PR TITLE
8345058: Javac issues different error messages for the modifiers of the requires directive

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4215,6 +4215,9 @@ public class JavacParser implements Parser {
                                 }
                                 isTransitive = true;
                                 break;
+                            } else if (token.name() == names.transitive && isTransitive) {
+                                log.error(DiagnosticFlag.SYNTAX, token.pos, Errors.RepeatedModifier);
+                                break;
                             } else {
                                 break loop;
                             }


### PR DESCRIPTION
javac is issuing different error messages for the modifiers of the `requires` directive. This PR is making javac's output consistent for both modifiers `static` and `transitive`

TIA

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345058](https://bugs.openjdk.org/browse/JDK-8345058): Javac issues different error messages for the modifiers of the requires directive (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22392/head:pull/22392` \
`$ git checkout pull/22392`

Update a local copy of the PR: \
`$ git checkout pull/22392` \
`$ git pull https://git.openjdk.org/jdk.git pull/22392/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22392`

View PR using the GUI difftool: \
`$ git pr show -t 22392`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22392.diff">https://git.openjdk.org/jdk/pull/22392.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22392#issuecomment-2501129240)
</details>
