### PR TITLE
8205051: Poor Performance with UseNUMA when cpu and memory nodes are misaligned

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4488,13 +4488,7 @@ void os::Linux::numa_init() {
   // bitmask when externally configured to run on all or fewer nodes.
 
   if (!Linux::libnuma_init()) {
-    if ((UseNUMA && FLAG_IS_CMDLINE(UseNUMA)) ||
-        (UseNUMAInterleaving && FLAG_IS_CMDLINE(UseNUMAInterleaving))) {
-      // Only issue a warning if the user explicitly asked for NUMA support
-      log_warning(os)("NUMA support is disabled as libnuma failed to initialize");
-    }
-    FLAG_SET_ERGO(UseNUMA, false);
-    FLAG_SET_ERGO(UseNUMAInterleaving, false); // Also depends on libnuma.
+    disable_numa("NUMA support is disabled as libnuma failed to initialize");
   } else {
     Linux::set_configured_numa_policy(Linux::identify_numa_policy());
     if (Linux::numa_max_node() < 1) {

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -3273,7 +3273,7 @@ bool os::Linux::libnuma_init() {
         set_numa_nodes_ptr((struct bitmask **)libnuma_dlsym(handle, "numa_nodes_ptr"));
         set_numa_interleave_bitmask(_numa_get_interleave_mask());
         set_numa_membind_bitmask(_numa_get_membind());
-	set_numa_cpunodebind_bitmask(_numa_get_run_node_mask());
+        set_numa_cpunodebind_bitmask(_numa_get_run_node_mask());
         // Create an index -> node mapping, since nodes are not always consecutive
         _nindex_to_node = new (mtInternal) GrowableArray<int>(0, mtInternal);
         rebuild_nindex_to_node_map();
@@ -4495,16 +4495,16 @@ void os::Linux::numa_init() {
     Linux::set_configured_numa_policy(Linux::identify_numa_policy());
     if ((Linux::numa_max_node() < 1) || Linux::is_bound_to_single_node() ||
         (!Linux::is_running_in_interleave_mode() && Linux::_numa_membind_bitmask != nullptr &&
-	Linux::_numa_cpunodebind_bitmask != nullptr &&
-	!_numa_bitmask_equal(Linux::_numa_membind_bitmask, Linux::_numa_cpunodebind_bitmask)) ||
-	(Linux::is_running_in_interleave_mode() && Linux::_numa_interleave_bitmask != nullptr &&
-	Linux::_numa_cpunodebind_bitmask != nullptr &&
-	!_numa_bitmask_equal(Linux::_numa_interleave_bitmask, Linux::_numa_cpunodebind_bitmask))) {
+        Linux::_numa_cpunodebind_bitmask != nullptr &&
+        !_numa_bitmask_equal(Linux::_numa_membind_bitmask, Linux::_numa_cpunodebind_bitmask)) ||
+        (Linux::is_running_in_interleave_mode() && Linux::_numa_interleave_bitmask != nullptr &&
+        Linux::_numa_cpunodebind_bitmask != nullptr &&
+        !_numa_bitmask_equal(Linux::_numa_interleave_bitmask, Linux::_numa_cpunodebind_bitmask))) {
       // If there's only one node (they start from 0) or if the process
       // is bound explicitly to a single node using membind, disable NUMA
       if (UseNUMA && FLAG_IS_CMDLINE(UseNUMA))
-	warning("UseNUMA is disabled as the process bound to a single numa node"
-		" or cpu and memory nodes are not aligned");
+        warning("UseNUMA is disabled as the process bound to a single numa node"
+                " or cpu and memory nodes are not aligned");
       FLAG_SET_ERGO(UseNUMA, false);
     } else {
       LogTarget(Info,os) log;

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4488,7 +4488,7 @@ void os::Linux::numa_init() {
   // bitmask when externally configured to run on all or fewer nodes.
 
   if (!Linux::libnuma_init()) {
-    disable_numa("NUMA support is disabled as libnuma failed to initialize");
+    disable_numa("Failed to initialize libnuma");
   } else {
     Linux::set_configured_numa_policy(Linux::identify_numa_policy());
     if (Linux::numa_max_node() < 1) {

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -204,10 +204,12 @@ class os::Linux {
   typedef void (*numa_interleave_memory_v2_func_t)(void *start, size_t size, struct bitmask* mask);
   typedef struct bitmask* (*numa_get_membind_func_t)(void);
   typedef struct bitmask* (*numa_get_interleave_mask_func_t)(void);
+  typedef struct bitmask* (*numa_get_run_node_mask_func_t)(void);
   typedef long (*numa_move_pages_func_t)(int pid, unsigned long count, void **pages, const int *nodes, int *status, int flags);
   typedef void (*numa_set_preferred_func_t)(int node);
   typedef void (*numa_set_bind_policy_func_t)(int policy);
   typedef int (*numa_bitmask_isbitset_func_t)(struct bitmask *bmp, unsigned int n);
+  typedef int (*numa_bitmask_equal_func_t)(struct bitmask *bmp1, struct bitmask *bmp2);
   typedef int (*numa_distance_func_t)(int node1, int node2);
 
   static sched_getcpu_func_t _sched_getcpu;
@@ -221,8 +223,10 @@ class os::Linux {
   static numa_interleave_memory_v2_func_t _numa_interleave_memory_v2;
   static numa_set_bind_policy_func_t _numa_set_bind_policy;
   static numa_bitmask_isbitset_func_t _numa_bitmask_isbitset;
+  static numa_bitmask_equal_func_t _numa_bitmask_equal;
   static numa_distance_func_t _numa_distance;
   static numa_get_membind_func_t _numa_get_membind;
+  static numa_get_run_node_mask_func_t _numa_get_run_node_mask;
   static numa_get_interleave_mask_func_t _numa_get_interleave_mask;
   static numa_move_pages_func_t _numa_move_pages;
   static numa_set_preferred_func_t _numa_set_preferred;
@@ -231,6 +235,7 @@ class os::Linux {
   static struct bitmask* _numa_nodes_ptr;
   static struct bitmask* _numa_interleave_bitmask;
   static struct bitmask* _numa_membind_bitmask;
+  static struct bitmask* _numa_cpunodebind_bitmask;
 
   static void set_sched_getcpu(sched_getcpu_func_t func) { _sched_getcpu = func; }
   static void set_numa_node_to_cpus(numa_node_to_cpus_func_t func) { _numa_node_to_cpus = func; }
@@ -243,8 +248,10 @@ class os::Linux {
   static void set_numa_interleave_memory_v2(numa_interleave_memory_v2_func_t func) { _numa_interleave_memory_v2 = func; }
   static void set_numa_set_bind_policy(numa_set_bind_policy_func_t func) { _numa_set_bind_policy = func; }
   static void set_numa_bitmask_isbitset(numa_bitmask_isbitset_func_t func) { _numa_bitmask_isbitset = func; }
+  static void set_numa_bitmask_equal(numa_bitmask_equal_func_t func) { _numa_bitmask_equal = func; }
   static void set_numa_distance(numa_distance_func_t func) { _numa_distance = func; }
   static void set_numa_get_membind(numa_get_membind_func_t func) { _numa_get_membind = func; }
+  static void set_numa_get_run_node_mask(numa_get_run_node_mask_func_t func) { _numa_get_run_node_mask = func; }
   static void set_numa_get_interleave_mask(numa_get_interleave_mask_func_t func) { _numa_get_interleave_mask = func; }
   static void set_numa_move_pages(numa_move_pages_func_t func) { _numa_move_pages = func; }
   static void set_numa_set_preferred(numa_set_preferred_func_t func) { _numa_set_preferred = func; }
@@ -253,6 +260,7 @@ class os::Linux {
   static void set_numa_nodes_ptr(struct bitmask **ptr) { _numa_nodes_ptr = (ptr == nullptr ? nullptr : *ptr); }
   static void set_numa_interleave_bitmask(struct bitmask* ptr)     { _numa_interleave_bitmask = ptr ;   }
   static void set_numa_membind_bitmask(struct bitmask* ptr)        { _numa_membind_bitmask = ptr ;      }
+  static void set_numa_cpunodebind_bitmask(struct bitmask* ptr)        { _numa_cpunodebind_bitmask = ptr ;      }
   static int sched_getcpu_syscall(void);
 
   enum NumaAllocationPolicy{

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -367,8 +367,8 @@ class os::Linux {
     }
     return false;
   }
-  // Check if bound to only one numa node.
-  // Returns true if bound to a single numa node, otherwise returns false.
+  // Check if memory is bound to only one numa node.
+  // Returns true if memory is bound to a single numa node, otherwise returns false.
   static bool is_bound_to_single_mem_node() {
     int nodes = 0;
     unsigned int node = 0;

--- a/src/hotspot/os/linux/os_linux.hpp
+++ b/src/hotspot/os/linux/os_linux.hpp
@@ -193,6 +193,7 @@ class os::Linux {
  private:
   static void numa_init();
 
+  static void disable_numa(const char* reason);
   typedef int (*sched_getcpu_func_t)(void);
   typedef int (*numa_node_to_cpus_func_t)(int node, unsigned long *buffer, int bufferlen);
   typedef int (*numa_node_to_cpus_v2_func_t)(int node, void *mask);


### PR DESCRIPTION
Hi All,

The PR handles the performance issues related to flag UseNUMA. We disable the UseNUMA flag when the process gets invoked with incorrect node alignment.
We check the cpunodebind and membind(or interleave for interleave policy) bitmask equality and disable UseNUMA when they are not equal.
For example on a 4 NUMA node system:
0123 Node Number
1100  cpunodebind bitmask
1111 membind bitmask 
Disable UseNUMA as CPU and memory bitmask are not equal.

0123 Node Number  
1100  cpunodebind bitmask
1100 membind bitmask 
Enable UseNUMA as CPU and memory bitmask are equal.

This covers all the cases with all policies and tested this with below command
numactl --cpunodebind=0,1 --localalloc java -Xlog:gc*=info -XX:+UseParallelGC -XX:+UseNUMA -version

For localalloc and preferred policies the membind bitmask returns true for all nodes, hence if cpunodebind is not bound to all nodes then the UseNUMA will be disabled.

This PR covers disabling the UseNUMA flag for all GC's hence we observed an improvement of ~25% on G1GC , ~20% on ZGC and ~7-8% on PGC in both throughput  and latency on SPECjbb2015 on a 2 NUMA node SRF-SP system with 6Group configuration.

Please review and provide your valuable comments.

Thanks,
Swati Sharma
Intel

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8205051](https://bugs.openjdk.org/browse/JDK-8205051): Poor Performance with UseNUMA when cpu and memory nodes are misaligned (**Bug** - P4)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)

### Contributors
 * Derek White `<drwhite@openjdk.org>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22395/head:pull/22395` \
`$ git checkout pull/22395`

Update a local copy of the PR: \
`$ git checkout pull/22395` \
`$ git pull https://git.openjdk.org/jdk.git pull/22395/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22395`

View PR using the GUI difftool: \
`$ git pr show -t 22395`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22395.diff">https://git.openjdk.org/jdk/pull/22395.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22395#issuecomment-2503585377)
</details>
