### PR TITLE
8344555: SM cleanup - drop reflection filter of System.security field

### DIFF
--- a/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
+++ b/src/java.base/share/classes/jdk/internal/reflect/Reflection.java
@@ -61,8 +61,7 @@ public class Reflection {
             Constructor.class, ALL_MEMBERS,
             Field.class, ALL_MEMBERS,
             Method.class, ALL_MEMBERS,
-            Module.class, ALL_MEMBERS,
-            System.class, Set.of("security")
+            Module.class, ALL_MEMBERS
         );
         methodFilterMap = Map.of();
     }


### PR DESCRIPTION
The `java.lang.Sytem.security` field no longer exists; remove it from the filterMap.