### PR TITLE
8344987: Test serviceability/sa/TestJhsdbJstackPrintVMLocks.java fails: NoClassDefFoundError: jdk/test/lib/Utils

### DIFF
--- a/test/hotspot/jtreg/TEST.groups
+++ b/test/hotspot/jtreg/TEST.groups
@@ -490,6 +490,7 @@ hotspot_cds_relocation = \
   runtime/modules/PatchModule/PatchModuleClassList.java \
   runtime/NMT \
   serviceability/sa \
+ -serviceability/sa/TestJhsdbJstackPrintVMLocks.java \
  -runtime/cds/DeterministicDump.java
 
 hotspot_cds_verify_shared_spaces = \


### PR DESCRIPTION
The real bug is
https://bugs.openjdk.org/browse/CODETOOLS-7902847 Class directory of a test case should not be used to compile a library

and the following workaround just excludes the testing group where it fails often. 

There is no plans to update test right now. The jtreg should be fixed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344987](https://bugs.openjdk.org/browse/JDK-8344987): Test serviceability/sa/TestJhsdbJstackPrintVMLocks.java fails: NoClassDefFoundError: jdk/test/lib/Utils (**Bug** - P4)


### Reviewers
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22405/head:pull/22405` \
`$ git checkout pull/22405`

Update a local copy of the PR: \
`$ git checkout pull/22405` \
`$ git pull https://git.openjdk.org/jdk.git pull/22405/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22405`

View PR using the GUI difftool: \
`$ git pr show -t 22405`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22405.diff">https://git.openjdk.org/jdk/pull/22405.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22405#issuecomment-2502526969)
</details>
