### PR TITLE
8344856: Remove calls to SecurityManager and doPrivileged in subclasses of URLConnection in the sun.net package after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/sun/net/www/protocol/ftp/FtpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/ftp/FtpURLConnection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1994, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1994, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.base/share/classes/sun/net/www/protocol/ftp/FtpURLConnection.java
+++ b/src/java.base/share/classes/sun/net/www/protocol/ftp/FtpURLConnection.java
@@ -43,7 +43,6 @@ import java.net.ProxySelector;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.security.Permission;
-import java.util.Properties;
 import sun.net.NetworkClient;
 import sun.net.util.IPAddressUtil;
 import sun.net.www.MessageHeader;
@@ -53,7 +52,6 @@ import sun.net.www.protocol.http.HttpURLConnection;
 import sun.net.ftp.FtpClient;
 import sun.net.ftp.FtpProtocolException;
 import sun.net.www.ParseUtil;
-import sun.security.action.GetPropertyAction;
 
 
 /**
@@ -227,12 +225,7 @@ public class FtpURLConnection extends URLConnection {
              * Do we have to use a proxy?
              */
             @SuppressWarnings("removal")
-            ProxySelector sel = java.security.AccessController.doPrivileged(
-                    new java.security.PrivilegedAction<ProxySelector>() {
-                        public ProxySelector run() {
-                            return ProxySelector.getDefault();
-                        }
-                    });
+            ProxySelector sel = ProxySelector.getDefault();
             if (sel != null) {
                 URI uri = sun.net.www.ParseUtil.toURI(url);
                 final List<Proxy> proxies;
@@ -293,10 +286,8 @@ public class FtpURLConnection extends URLConnection {
 
         if (user == null) {
             user = "anonymous";
-            Properties props = GetPropertyAction.privilegedGetProperties();
-            String vers = props.getProperty("java.version");
-            password = props.getProperty("ftp.protocol.user",
-                    "Java" + vers + "@");
+            String vers = System.getProperty("java.version");
+            password = System.getProperty("ftp.protocol.user", "Java" + vers + "@");
         }
         try {
             ftp = FtpClient.create();


### PR DESCRIPTION
This change set, addressing [8344856](https://bugs.openjdk.org/browse/JDK-8344856), removes `SecurityManager` and friends from `sun.net.FtpURLConnection`. This is the only leftover from `SM` cleanup in the subclasses of `URLConnection` in the `sun.net` package. Successful `tier1..3` CI runs on b02813b048ec63479c49e74ca6326a00409dd34f are shared in the ticket.