### PR TITLE
8343653: [s390x] Replace load/store sequence with move instruction

### DIFF
--- a/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c1_MacroAssembler_s390.cpp
@@ -178,8 +178,9 @@ void C1_MacroAssembler::try_allocate(
 void C1_MacroAssembler::initialize_header(Register obj, Register klass, Register len, Register Rzero, Register t1) {
   assert_different_registers(obj, klass, len, t1, Rzero);
   if (UseCompactObjectHeaders) {
-    z_lg(t1, Address(klass, in_bytes(Klass::prototype_header_offset())));
-    z_stg(t1, Address(obj, oopDesc::mark_offset_in_bytes()));
+    z_mvc(Address(obj, oopDesc::mark_offset_in_bytes()),  /* move to */
+          Address(klass, in_bytes(Klass::prototype_header_offset())), /* move from */
+          sizeof(markWord) /* size of data to move */);
   } else {
     load_const_optimized(t1, (intx)markWord::prototype().value());
     z_stg(t1, Address(obj, oopDesc::mark_offset_in_bytes()));

--- a/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/c2_MacroAssembler_s390.cpp
@@ -46,7 +46,7 @@ void C2_MacroAssembler::load_narrow_klass_compact_c2(Register dst, Address src) 
   // The incoming address is pointing into obj-start + klass_offset_in_bytes. We need to extract
   // obj-start, so that we can load from the object's mark-word instead.
   z_lg(dst, src.plus_disp(-oopDesc::klass_offset_in_bytes()));
-  z_srlg(dst, dst, markWord::klass_shift); // TODO: could be z_sra
+  z_srlg(dst, dst, markWord::klass_shift);
 }
 
 //------------------------------------------------------

--- a/src/hotspot/cpu/s390/macroAssembler_s390.cpp
+++ b/src/hotspot/cpu/s390/macroAssembler_s390.cpp
@@ -3673,8 +3673,8 @@ void MacroAssembler::compiler_fast_unlock_object(Register oop, Register box, Reg
   // Set owner to null.
   // Release to satisfy the JMM
   z_release();
-  z_lghi(temp, 0);
-  z_stg(temp, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner), currentHeader);
+  z_mvghi(Address(currentHeader, OM_OFFSET_NO_MONITOR_VALUE_TAG(owner)), 0);
+
   // We need a full fence after clearing owner to avoid stranding.
   z_fence();
 
@@ -6555,8 +6555,7 @@ void MacroAssembler::compiler_fast_unlock_lightweight_object(Register obj, Regis
     // Set owner to null.
     // Release to satisfy the JMM
     z_release();
-    z_lghi(tmp2, 0);
-    z_stg(tmp2 /*=0*/, owner_address);
+    z_mvghi(owner_address, 0);
     // We need a full fence after clearing owner to avoid stranding.
     z_fence();
 

--- a/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
+++ b/src/hotspot/cpu/s390/sharedRuntime_s390.cpp
@@ -2538,8 +2538,11 @@ static void push_skeleton_frames(MacroAssembler* masm, bool deopt,
 
   // Set the top frame's return pc.
   __ add2reg(pcs_reg, wordSize);
-  __ z_lg(Z_R0_scratch, 0, pcs_reg);
-  __ z_stg(Z_R0_scratch, _z_abi(return_pc), Z_SP);
+  __ z_mvc(
+          Address(Z_SP, _z_abi(return_pc)), /* move to */
+          Address(pcs_reg, 0), /* move from */
+          sizeof(uint64_t) /* how much, size of return_pc from z_common_abi */
+      );
   BLOCK_COMMENT("} push_skeleton_frames");
 }
 

--- a/src/hotspot/cpu/s390/templateTable_s390.cpp
+++ b/src/hotspot/cpu/s390/templateTable_s390.cpp
@@ -3980,8 +3980,10 @@ void TemplateTable::_new() {
     // Initialize object header only.
     __ bind(initialize_header);
     if (UseCompactObjectHeaders) {
-      __ z_lg(tmp, Address(iklass, in_bytes(Klass::prototype_header_offset())));
-      __ z_stg(tmp, Address(RallocatedObject, oopDesc::mark_offset_in_bytes()));
+      __ z_mvc(Address(RallocatedObject, oopDesc::mark_offset_in_bytes()), // move to
+               Address(iklass, in_bytes(Klass::prototype_header_offset())), // move from
+               sizeof(markWord) // how much to move
+              );
     } else {
       __ store_const(Address(RallocatedObject, oopDesc::mark_offset_in_bytes()),
                      (long) markWord::prototype().value());


### PR DESCRIPTION
Replaces load+store with mvc/mvghi instruction for in-memory operation. Tier1 test are clean except `ShowRegistersOnAssertTest.java` failure, but it failed on head stream also. I am doing git bisect to figure out what's going with that test.  

update: did a git bisect and found bad commit, so I have opened [JDK-8345102](https://bugs.openjdk.org/browse/JDK-8345102)

Testing: 
- tier1 test with no flag 
- tier1 with -XX:+UseCompactObjectHeaders

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343653](https://bugs.openjdk.org/browse/JDK-8343653): [s390x] Replace load/store sequence with move instruction (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22408/head:pull/22408` \
`$ git checkout pull/22408`

Update a local copy of the PR: \
`$ git checkout pull/22408` \
`$ git pull https://git.openjdk.org/jdk.git pull/22408/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22408`

View PR using the GUI difftool: \
`$ git pr show -t 22408`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22408.diff">https://git.openjdk.org/jdk/pull/22408.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22408#issuecomment-2503294482)
</details>
