### PR TITLE
8344607: Link Time Optimization - basic support for clang

### DIFF
--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -174,6 +174,9 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
         -fno-fat-lto-objects
     JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto=auto \
         -fuse-linker-plugin -fno-strict-aliasing
+  else ifeq ($(call isCompiler, clang), true)
+    JVM_CFLAGS_FEATURES += -flto -fno-strict-aliasing
+    JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto -fno-strict-aliasing
   else ifeq ($(call isCompiler, microsoft), true)
     JVM_CFLAGS_FEATURES += -GL
     JVM_LDFLAGS_FEATURES += -LTCG:INCREMENTAL

--- a/make/hotspot/lib/JvmFeatures.gmk
+++ b/make/hotspot/lib/JvmFeatures.gmk
@@ -176,6 +176,9 @@ ifeq ($(call check-jvm-feature, link-time-opt), true)
         -fuse-linker-plugin -fno-strict-aliasing
   else ifeq ($(call isCompiler, clang), true)
     JVM_CFLAGS_FEATURES += -flto -fno-strict-aliasing
+    ifeq ($(call isBuildOs, aix), true)
+      JVM_CFLAGS_FEATURES += -ffat-lto-objects
+    endif
     JVM_LDFLAGS_FEATURES += $(CXX_O_FLAG_HIGHEST_JVM) -flto -fno-strict-aliasing
   else ifeq ($(call isCompiler, microsoft), true)
     JVM_CFLAGS_FEATURES += -GL

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -501,6 +501,8 @@ static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
 }
 
 extern "C" {
+  // wait function, should not be inlined; and causes trouble with linktime optimization
+  NOINLINE
   int SpinPause() {
     // We don't use StubRoutines::aarch64::spin_wait stub in order to
     // avoid a costly call to os::current_thread_enable_wx() on MacOS.

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -502,7 +502,7 @@ static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
 
 extern "C" {
   // wait function, should not be inlined; and causes trouble with linktime optimization
-  NOINLINE
+  // NOINLINE
   int SpinPause() {
     // We don't use StubRoutines::aarch64::spin_wait stub in order to
     // avoid a costly call to os::current_thread_enable_wx() on MacOS.
@@ -525,14 +525,14 @@ extern "C" {
                                       // to entry for case SpinWait::NOP
         "  add  %[d], %[d], %[o]  \n"
         "  br   %[d]              \n"
-        "  b    SpinPause_return  \n" // case SpinWait::NONE  (-1)
+        "  b    1f  \n" // case SpinWait::NONE  (-1)
         "  nop                    \n" // padding
         "  nop                    \n" // case SpinWait::NOP   ( 0)
-        "  b    SpinPause_return  \n"
+        "  b    1f  \n"
         "  isb                    \n" // case SpinWait::ISB   ( 1)
-        "  b    SpinPause_return  \n"
+        "  b    1f  \n"
         "  yield                  \n" // case SpinWait::YIELD ( 2)
-        "SpinPause_return:        \n"
+        "1:        \n"
         : [d]"=&r"(br_dst)
         : [o]"r"(off)
         : "memory");

--- a/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
+++ b/src/hotspot/os_cpu/bsd_aarch64/os_bsd_aarch64.cpp
@@ -501,8 +501,7 @@ static inline void atomic_copy64(const volatile void *src, volatile void *dst) {
 }
 
 extern "C" {
-  // wait function, should not be inlined; and causes trouble with linktime optimization
-  // NOINLINE
+  // needs local assembler label '1:' to avoid trouble when using linktime optimization
   int SpinPause() {
     // We don't use StubRoutines::aarch64::spin_wait stub in order to
     // avoid a costly call to os::current_thread_enable_wx() on MacOS.
@@ -525,12 +524,12 @@ extern "C" {
                                       // to entry for case SpinWait::NOP
         "  add  %[d], %[d], %[o]  \n"
         "  br   %[d]              \n"
-        "  b    1f  \n" // case SpinWait::NONE  (-1)
+        "  b    1f                \n" // case SpinWait::NONE  (-1)
         "  nop                    \n" // padding
         "  nop                    \n" // case SpinWait::NOP   ( 0)
-        "  b    1f  \n"
+        "  b    1f                \n"
         "  isb                    \n" // case SpinWait::ISB   ( 1)
-        "  b    1f  \n"
+        "  b    1f                \n"
         "  yield                  \n" // case SpinWait::YIELD ( 2)
         "1:        \n"
         : [d]"=&r"(br_dst)


### PR DESCRIPTION
Support the clang toolchain when link time optimization is configured.
Please note that this is NOT intended to enable lto by default and NOT to fix all possible clang-supporting builds or test issues .

It works on my Linux x86_64 SUSE 15 test machine with  clang15.0.7, also on macOS with Xcode 13.1 devkit  and Xcode 15.4 .

To be able to build on macOS with Xcode, I had to deal with one issue.  The lto-link process runs into this error 

```
ld: <inline asm>:11:1: symbol 'SpinPause_return' is already defined
SpinPause_return:        
^
for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

Seems that when building with LTO,  the  inline assembler code in SpinPause() is not handled well. In the lto inlining the label  SpinPause_return is generated multiple times and causes an 'already defined' error. This goes away when adding NOINLINE to this function.
Linux/clang did not show this issue, probably the toolchain there does not have the error.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed (2 reviews required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer), 1 [Author](https://openjdk.org/bylaws#author))

### Issue
 * [JDK-8344607](https://bugs.openjdk.org/browse/JDK-8344607): Link Time Optimization - basic support for clang (**Bug** - P4)


### Reviewers
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**) Review applies to [68bb4ccc](https://git.openjdk.org/jdk/pull/22412/files/68bb4ccca5d09bc264924c51a6fd1a906d0469b1)
 * [Joachim Kern](https://openjdk.org/census#jkern) (@JoKern65 - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22412/head:pull/22412` \
`$ git checkout pull/22412`

Update a local copy of the PR: \
`$ git checkout pull/22412` \
`$ git pull https://git.openjdk.org/jdk.git pull/22412/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22412`

View PR using the GUI difftool: \
`$ git pr show -t 22412`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22412.diff">https://git.openjdk.org/jdk/pull/22412.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22412#issuecomment-2504143801)
</details>
