### PR TITLE
8344967: Some tests in TestFill do not use the test parameter

### DIFF
--- a/test/jdk/java/foreign/TestFill.java
+++ b/test/jdk/java/foreign/TestFill.java
@@ -87,7 +87,7 @@ final class TestFill {
     @MethodSource("sizes")
     void testReadOnly(int len) {
         try (var arena = Arena.ofConfined()) {
-            var segment = arena.allocate(10).asReadOnly();
+            var segment = arena.allocate(len).asReadOnly();
             assertThrows(IllegalArgumentException.class, () -> segment.fill(VALUE));
         }
     }
@@ -96,7 +96,7 @@ final class TestFill {
     @MethodSource("sizes")
     void testConfinement(int len) {
         try (var arena = Arena.ofConfined()) {
-            var segment = arena.allocate(10);
+            var segment = arena.allocate(len);
             AtomicReference<RuntimeException> ex = new AtomicReference<>();
             CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
                 try {


### PR DESCRIPTION
This trivial PR proposes to use the parameter length for two tests as originally intended.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8344967](https://bugs.openjdk.org/browse/JDK-8344967): Some tests in TestFill do not use the test parameter (**Bug** - P5)


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22413/head:pull/22413` \
`$ git checkout pull/22413`

Update a local copy of the PR: \
`$ git checkout pull/22413` \
`$ git pull https://git.openjdk.org/jdk.git pull/22413/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22413`

View PR using the GUI difftool: \
`$ git pr show -t 22413`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22413.diff">https://git.openjdk.org/jdk/pull/22413.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22413#issuecomment-2504179821)
</details>
