### PR TITLE
8345119: Some java/foreign tests wrongly assume aligned memory

### DIFF
--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019, 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2019, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -171,7 +171,7 @@ public class TestByteBuffer {
     @Test
     public void testOffheap() {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment segment = arena.allocate(tuples);;
+            MemorySegment segment = arena.allocate(tuples);
             initTuples(segment, tuples.elementCount());
 
             ByteBuffer bb = segment.asByteBuffer();
@@ -385,7 +385,7 @@ public class TestByteBuffer {
     public void testScopedBuffer(Function<ByteBuffer, Buffer> bufferFactory, @NoInjection Method method, Object[] args) {
         Buffer bb;
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment segment = arena.allocate(bytes);;
+            MemorySegment segment = arena.allocate(bytes);
             bb = bufferFactory.apply(segment.asByteBuffer());
         }
         //outside of session!!
@@ -411,7 +411,7 @@ public class TestByteBuffer {
     public void testScopedBufferAndVarHandle(VarHandle bufferHandle) {
         ByteBuffer bb;
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment segment = arena.allocate(bytes);;
+            MemorySegment segment = arena.allocate(bytes, Long.BYTES);
             bb = segment.asByteBuffer();
             for (Map.Entry<MethodHandle, Object[]> e : varHandleMembers(bb, bufferHandle).entrySet()) {
                 MethodHandle handle = e.getKey().bindTo(bufferHandle)
@@ -445,7 +445,7 @@ public class TestByteBuffer {
     @Test(dataProvider = "bufferOps")
     public void testDirectBuffer(Function<ByteBuffer, Buffer> bufferFactory, @NoInjection Method method, Object[] args) {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment segment = arena.allocate(bytes);;
+            MemorySegment segment = arena.allocate(bytes);
             Buffer bb = bufferFactory.apply(segment.asByteBuffer());
             assertTrue(bb.isDirect());
             DirectBuffer directBuffer = ((DirectBuffer)bb);
@@ -458,7 +458,7 @@ public class TestByteBuffer {
     @Test(dataProvider="resizeOps")
     public void testResizeOffheap(Consumer<MemorySegment> checker, Consumer<MemorySegment> initializer, SequenceLayout seq) {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment segment = arena.allocate(seq);;
+            MemorySegment segment = arena.allocate(seq);
             initializer.accept(segment);
             checker.accept(segment);
         }
@@ -496,7 +496,7 @@ public class TestByteBuffer {
     @Test(dataProvider="resizeOps")
     public void testResizeRoundtripNative(Consumer<MemorySegment> checker, Consumer<MemorySegment> initializer, SequenceLayout seq) {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment segment = arena.allocate(seq);;
+            MemorySegment segment = arena.allocate(seq);
             initializer.accept(segment);
             MemorySegment second = MemorySegment.ofBuffer(segment.asByteBuffer());
             checker.accept(second);
@@ -507,7 +507,7 @@ public class TestByteBuffer {
     public void testBufferOnClosedSession() {
         MemorySegment leaked;
         try (Arena arena = Arena.ofConfined()) {
-            leaked = arena.allocate(bytes);;
+            leaked = arena.allocate(bytes);
         }
         ByteBuffer byteBuffer = leaked.asByteBuffer(); // ok
         byteBuffer.get(); // should throw
@@ -615,7 +615,7 @@ public class TestByteBuffer {
         checkByteArrayAlignment(seq.elementLayout());
         int bytes = (int)seq.byteSize();
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment nativeArray = arena.allocate(bytes, 1);;
+            MemorySegment nativeArray = arena.allocate(bytes, 1);
             MemorySegment heapArray = MemorySegment.ofArray(new byte[bytes]);
             initializer.accept(heapArray);
             nativeArray.copyFrom(heapArray);
@@ -628,7 +628,7 @@ public class TestByteBuffer {
         checkByteArrayAlignment(seq.elementLayout());
         int bytes = (int)seq.byteSize();
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment nativeArray = arena.allocate(seq);;
+            MemorySegment nativeArray = arena.allocate(seq);
             MemorySegment heapArray = MemorySegment.ofArray(new byte[bytes]);
             initializer.accept(nativeArray);
             heapArray.copyFrom(nativeArray);
@@ -700,7 +700,7 @@ public class TestByteBuffer {
     @Test
     public void testRoundTripAccess() {
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment ms = arena.allocate(4, 1);;
+            MemorySegment ms = arena.allocate(4, 1);
             MemorySegment msNoAccess = ms.asReadOnly();
             MemorySegment msRoundTrip = MemorySegment.ofBuffer(msNoAccess.asByteBuffer());
             assertEquals(msRoundTrip.scope(), ms.scope());
@@ -741,7 +741,7 @@ public class TestByteBuffer {
         tmp.deleteOnExit();
         try (FileChannel channel = FileChannel.open(tmp.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE) ;
             Arena arena = arenaSupplier.get()) {
-            MemorySegment segment = arena.allocate(10, 1);;
+            MemorySegment segment = arena.allocate(10, 1);
             for (int i = 0; i < 10; i++) {
                 segment.set(JAVA_BYTE, i, (byte) i);
             }
@@ -780,7 +780,7 @@ public class TestByteBuffer {
     @Test
     public void buffersAndArraysFromSlices() {
         try (Arena arena = Arena.ofShared()) {
-            MemorySegment segment = arena.allocate(16, 1);;
+            MemorySegment segment = arena.allocate(16, 1);
             int newSize = 8;
             var slice = segment.asSlice(4, newSize);
 
@@ -798,7 +798,7 @@ public class TestByteBuffer {
     @Test
     public void viewsFromSharedSegment() {
         try (Arena arena = Arena.ofShared()) {
-            MemorySegment segment = arena.allocate(16, 1);;
+            MemorySegment segment = arena.allocate(16, 1);
             var byteBuffer = segment.asByteBuffer();
             byteBuffer.asReadOnlyBuffer();
             byteBuffer.slice(0, 8);

--- a/test/jdk/java/foreign/TestDereferencePath.java
+++ b/test/jdk/java/foreign/TestDereferencePath.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  *  This code is free software; you can redistribute it and/or modify it
@@ -173,7 +173,7 @@ public class TestDereferencePath {
             ValueLayout.ADDRESS.withTargetLayout(ValueLayout.JAVA_INT).withName("x"));
 
         try (Arena arena = Arena.ofConfined()) {
-            MemorySegment segment = arena.allocate(struct.byteSize() + 1).asSlice(1);
+            MemorySegment segment = arena.allocate(struct.byteSize() + 1, struct.byteAlignment()).asSlice(1);
             VarHandle vhX = struct.varHandle(PathElement.groupElement("x"), PathElement.dereferenceElement());
             vhX.set(segment, 0L, 42); // should throw
         }


### PR DESCRIPTION
Hi,

This patch resolves some issues I found that the tests wrongly assume sufficient alignment from the segment returned by `Arena::allocate`.

Please take a look and leave your reviews, thanks a lot.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345119](https://bugs.openjdk.org/browse/JDK-8345119): Some java/foreign tests wrongly assume aligned memory (**Bug** - P4)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22415/head:pull/22415` \
`$ git checkout pull/22415`

Update a local copy of the PR: \
`$ git checkout pull/22415` \
`$ git pull https://git.openjdk.org/jdk.git pull/22415/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22415`

View PR using the GUI difftool: \
`$ git pr show -t 22415`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22415.diff">https://git.openjdk.org/jdk/pull/22415.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22415#issuecomment-2504283057)
</details>
