### PR TITLE
8268145: [macos] Rendering artifacts is seen when text inside the JTable with TableCellEditor having JTextfield

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/laf/AquaCaret.java
+++ b/src/java.desktop/macosx/classes/com/apple/laf/AquaCaret.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -189,20 +189,25 @@ public class AquaCaret extends DefaultCaret
         // intersection of the caret rectangle and the component less the border, if any.
         final Rectangle caretRect = new Rectangle(x, y, width, height);
         final Border border = getComponent().getBorder();
-        if (border != null) {
-            final Rectangle alloc = getComponent().getBounds();
-            alloc.x = alloc.y = 0;
+        final Rectangle alloc = getComponent().getBounds();
+        alloc.x = alloc.y = 0;
+        if (border != null && border.isBorderOpaque()) {
             final Insets borderInsets = border.getBorderInsets(getComponent());
             alloc.x += borderInsets.left;
             alloc.y += borderInsets.top;
             alloc.width -= borderInsets.left + borderInsets.right;
             alloc.height -= borderInsets.top + borderInsets.bottom;
             Rectangle2D.intersect(caretRect, alloc, caretRect);
+            x = caretRect.x;
+            y = caretRect.y;
+            width = Math.max(caretRect.width, 1);
+            height = Math.max(caretRect.height, 1);
+        } else {
+            x = alloc.x;
+            y = alloc.y;
+            width = alloc.width;
+            height = alloc.height;
         }
-        x = caretRect.x;
-        y = caretRect.y;
-        width = Math.max(caretRect.width, 1);
-        height = Math.max(caretRect.height, 1);
         repaint();
     }
 

--- a/test/jdk/javax/swing/JTable/TestCaretArtifact.java
+++ b/test/jdk/javax/swing/JTable/TestCaretArtifact.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8268145
+ * @library /java/awt/regtesthelpers
+ * @build PassFailJFrame
+ * @requires (os.family == "mac")
+ * @summary Verify rendering artifact is not seen moving caret inside
+ *          JTable with TableCellEditor having JTextField 
+ * @run main/manual TestCaretArtifact
+ */
+
+import javax.swing.DefaultCellEditor;
+import javax.swing.JFrame;
+import javax.swing.JTable;
+import javax.swing.JTextField;
+import javax.swing.table.TableCellEditor;
+import javax.swing.table.TableColumn;
+import javax.swing.SwingUtilities;
+
+public class TestCaretArtifact {
+
+    private static final String INSTRUCTIONS = """
+        Double click on "Click Here" textfield so that textfield becomes editable;
+        Press spacebar. Press left arrow button.
+        Do this few times.
+        If artifact is seen, press Fail else press Pass.""";
+
+    public static void  main(String []args) throws Exception {
+         PassFailJFrame.builder()
+                .title("Caret Artifact Instructions")
+                .instructions(INSTRUCTIONS)
+                .columns(35)
+                .testUI(TestCaretArtifact::createUI)
+                .build()
+                .awaitAndCheck();
+    }
+
+
+    public static JFrame createUI()  {
+        TableCellEditor editor = new TestEditor(new JTextField());
+        JTable table = new JTable(new Object[][] {{"click here",
+                "inactive forever"}},
+                new Object[] {"1", "2"});
+
+        JFrame frame = new JFrame();
+        TableColumn column = table.getColumn("1");
+        column.setCellEditor(editor);
+        frame.getContentPane().add("Center", table);
+        frame.setSize(400, 100);
+
+        return frame;
+    }
+
+    static class TestEditor extends DefaultCellEditor {
+        public TestEditor(JTextField tf) {
+            super(tf);
+        }
+        public boolean stopCellEditing() {
+            return false;
+        }
+    }
+}
+

--- a/test/jdk/javax/swing/JTable/TestCaretArtifact.java
+++ b/test/jdk/javax/swing/JTable/TestCaretArtifact.java
@@ -28,7 +28,7 @@
  * @build PassFailJFrame
  * @requires (os.family == "mac")
  * @summary Verify rendering artifact is not seen moving caret inside
- *          JTable with TableCellEditor having JTextField 
+ *          JTable with TableCellEditor having JTextField
  * @run main/manual TestCaretArtifact
  */
 

--- a/test/jdk/javax/swing/JTable/TestCaretArtifact.java
+++ b/test/jdk/javax/swing/JTable/TestCaretArtifact.java
@@ -48,7 +48,7 @@ public class TestCaretArtifact {
         Do this few times.
         If artifact is seen, press Fail else press Pass.""";
 
-    public static void  main(String []args) throws Exception {
+    public static void  main(String[] args) throws Exception {
          PassFailJFrame.builder()
                 .title("Caret Artifact Instructions")
                 .instructions(INSTRUCTIONS)
@@ -65,7 +65,7 @@ public class TestCaretArtifact {
                 "inactive forever"}},
                 new Object[] {"1", "2"});
 
-        JFrame frame = new JFrame();
+        JFrame frame = new JFrame("CaretArtifact");
         TableColumn column = table.getColumn("1");
         column.setCellEditor(editor);
         frame.getContentPane().add("Center", table);


### PR DESCRIPTION
When a textfield is embedded in a TableCellEditor in a JTable in Aqua L&F and space is entered and caret moved back and forth by pressing left/right arrow button, an artifact is seen, which is basically the caret is not properly repainted leaving behind its trails.

When caret is moved, it is repainted every time by "damaging" the area surrounding the caret to cause it to be repainted in a new location. AquaCaret overrides the default "damage" code to intersect the caret area with the border insets so that it does not damage the AquaBorder area..
For TextField case, AquaTextFieldBorder insets is removed from AquaTextField and then intersected with AquaCaret to get the dirry region which is then repainted, so as to not damage the border but it is done irrespective of whether border is shown or not, so proper dirty region is not repainted leaving behind artifacts when the caret is moved around...

Fix is to see if border to be painted is not opaque in which case the proper dirty region is calculated which is then used in repaint logic to repaint the component..

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268145](https://bugs.openjdk.org/browse/JDK-8268145): [macos] Rendering artifacts is seen when text inside the JTable with TableCellEditor having JTextfield (**Bug** - P4)


### Reviewers
 * [Alexander Zuev](https://openjdk.org/census#kizune) (@azuev-java - **Reviewer**)
 * [Abhishek Kumar](https://openjdk.org/census#abhiscxk) (@kumarabhi006 - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22416/head:pull/22416` \
`$ git checkout pull/22416`

Update a local copy of the PR: \
`$ git checkout pull/22416` \
`$ git pull https://git.openjdk.org/jdk.git pull/22416/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22416`

View PR using the GUI difftool: \
`$ git pr show -t 22416`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22416.diff">https://git.openjdk.org/jdk/pull/22416.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22416#issuecomment-2504310941)
</details>
