### PR TITLE
8345142: Remove uses of SecurityManager in Printing related classes

### DIFF
--- a/src/java.desktop/share/classes/java/awt/print/PrinterJob.java
+++ b/src/java.desktop/share/classes/java/awt/print/PrinterJob.java
@@ -64,11 +64,6 @@ public abstract class PrinterJob {
      * @return a new {@code PrinterJob}.
      */
     public static PrinterJob getPrinterJob() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPrintJobAccess();
-        }
         return sun.print.PlatformPrinterJobProxy.getPrinterJob();
     }
 

--- a/src/java.desktop/share/classes/javax/print/PrintServiceLookup.java
+++ b/src/java.desktop/share/classes/javax/print/PrintServiceLookup.java
@@ -393,16 +393,7 @@ public abstract class PrintServiceLookup {
         /*
          * add any directly registered services
          */
-        ArrayList<PrintService> registeredServices = null;
-        try {
-          @SuppressWarnings("removal")
-          SecurityManager security = System.getSecurityManager();
-          if (security != null) {
-            security.checkPrintJobAccess();
-          }
-          registeredServices = getRegisteredServices();
-        } catch (SecurityException se) {
-        }
+        ArrayList<PrintService> registeredServices = getRegisteredServices();
         if (registeredServices != null) {
             PrintService[] services = registeredServices.toArray(
                            new PrintService[registeredServices.size()]);
@@ -458,16 +449,7 @@ public abstract class PrintServiceLookup {
         /*
          * add any directly registered services
          */
-        ArrayList<PrintService> registeredServices = null;
-        try {
-          @SuppressWarnings("removal")
-          SecurityManager security = System.getSecurityManager();
-          if (security != null) {
-            security.checkPrintJobAccess();
-          }
-          registeredServices = getRegisteredServices();
-        } catch (Exception e) {
-        }
+        ArrayList<PrintService> registeredServices = getRegisteredServices();
         if (registeredServices != null) {
             PrintService[] services =
                 registeredServices.toArray(new PrintService[registeredServices.size()]);

--- a/src/java.desktop/share/classes/javax/print/ServiceUI.java
+++ b/src/java.desktop/share/classes/javax/print/ServiceUI.java
@@ -203,10 +203,7 @@ public class ServiceUI {
                                                  flavor, attributes,
                                                  owner);
         if (setOnTop) {
-            try {
-                dialog.setAlwaysOnTop(true);
-            } catch (SecurityException e) {
-            }
+            dialog.setAlwaysOnTop(true);
         }
         Rectangle dlgBounds = dialog.getBounds();
 

--- a/src/java.desktop/share/classes/sun/print/PSStreamPrintJob.java
+++ b/src/java.desktop/share/classes/sun/print/PSStreamPrintJob.java
@@ -434,12 +434,7 @@ public class PSStreamPrintJob implements CancelablePrintJob {
         }
 
         /* add the user name to the job */
-        String userName = "";
-        try {
-          userName = System.getProperty("user.name");
-        } catch (SecurityException se) {
-        }
-
+        String userName = System.getProperty("user.name");
         if (userName == null || userName.isEmpty()) {
             RequestingUserName ruName =
                 (RequestingUserName)reqSet.get(RequestingUserName.class);

--- a/src/java.desktop/share/classes/sun/print/PrintJob2D.java
+++ b/src/java.desktop/share/classes/sun/print/PrintJob2D.java
@@ -310,12 +310,6 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
                                 JobAttributes jobAttributes,
                                 PageAttributes pageAttributes) {
 
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPrintJobAccess();
-        }
-
         if (frame == null &&
             (jobAttributes == null ||
              jobAttributes.getDialog() == DialogType.NATIVE)) {
@@ -366,11 +360,6 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
                 } catch (IOException ioe) {
                     throw new IllegalArgumentException("Cannot write to file:"+
                                                        destStr);
-                } catch (SecurityException se) {
-                    //There is already file read/write access so at this point
-                    // only delete access is denied.  Just ignore it because in
-                    // most cases the file created in createNewFile gets overwritten
-                    // anyway.
                 }
 
                  File pFile = f.getParentFile();
@@ -676,29 +665,18 @@ public class PrintJob2D extends PrintJob implements Printable, Runnable {
                 attributes.add(defaultDest);
             } else {
                 URI uri = null;
-                try {
-                    if (fileName != null) {
-                        if (fileName.isEmpty()) {
-                            fileName = ".";
-                        }
-                    } else {
-                        // defaultDest should not be null.  The following code
-                        // is only added to safeguard against a possible
-                        // buggy implementation of a PrintService having a
-                        // null default Destination.
-                        fileName = "out.prn";
+                if (fileName != null) {
+                    if (fileName.isEmpty()) {
+                        fileName = ".";
                     }
-                    uri = (new File(fileName)).toURI();
-                } catch (SecurityException se) {
-                    try {
-                        // '\\' file separator is illegal character in opaque
-                        // part and causes URISyntaxException, so we replace
-                        // it with '/'
-                        fileName = fileName.replace('\\', '/');
-                        uri = new URI("file:"+fileName);
-                    } catch (URISyntaxException e) {
-                    }
+                } else {
+                    // defaultDest should not be null.  The following code
+                    // is only added to safeguard against a possible
+                    // buggy implementation of a PrintService having a
+                    // null default Destination.
+                    fileName = "out.prn";
                 }
+                uri = (new File(fileName)).toURI();
                 if (uri != null) {
                     attributes.add(new Destination(uri));
                 }

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -816,10 +816,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
                                            DocFlavor.SERVICE_FORMATTED.PAGEABLE,
                                            attributes, w);
         if (setOnTop) {
-            try {
-                pageDialog.setAlwaysOnTop(true);
-            } catch (SecurityException e) {
-            }
+            pageDialog.setAlwaysOnTop(true);
         }
 
         Rectangle dlgBounds = pageDialog.getBounds();
@@ -1311,11 +1308,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
             (!fidelity && userName != null)) {
             userNameAttr = userName.getValue();
         } else {
-            try {
-                userNameAttr = getUserName();
-            } catch (SecurityException e) {
-                userNameAttr = "";
-            }
+            userNameAttr = getUserName();
         }
 
         /* OpenBook is used internally only when app uses Printable.
@@ -1654,11 +1647,6 @@ public abstract class RasterPrinterJob extends PrinterJob {
         } catch (IOException ioe) {
             throw new PrinterException("Cannot write to file:"+
                                        dest);
-        } catch (SecurityException se) {
-            //There is already file read/write access so at this point
-            // only delete access is denied.  Just ignore it because in
-            // most cases the file created in createNewFile gets overwritten
-            // anyway.
         }
 
         File pFile = f.getParentFile();
@@ -1831,11 +1819,7 @@ public abstract class RasterPrinterJob extends PrinterJob {
         if  (userNameAttr != null) {
             return userNameAttr;
         } else {
-            try {
-                return  getUserName();
-            } catch (SecurityException e) {
-                return "";
-            }
+            return getUserName();
         }
     }
 

--- a/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
+++ b/src/java.desktop/share/classes/sun/print/RasterPrinterJob.java
@@ -945,15 +945,6 @@ public abstract class RasterPrinterJob extends PrinterJob {
 
         }
 
-        /* A security check has already been performed in the
-         * java.awt.print.printerJob.getPrinterJob method.
-         * So by the time we get here, it is OK for the current thread
-         * to print either to a file (from a Dialog we control!) or
-         * to a chosen printer.
-         *
-         * We raise privilege when we put up the dialog, to avoid
-         * the "warning applet window" banner.
-         */
         GraphicsConfiguration grCfg = null;
         Window w = KeyboardFocusManager.getCurrentKeyboardFocusManager().getActiveWindow();
         if (w != null) {
@@ -1806,7 +1797,6 @@ public abstract class RasterPrinterJob extends PrinterJob {
 
     /**
      * Get the name of the printing user.
-     * The caller must have security permission to read system properties.
      */
     public String getUserName() {
         return System.getProperty("user.name");

--- a/src/java.desktop/share/classes/sun/print/ServiceDialog.java
+++ b/src/java.desktop/share/classes/sun/print/ServiceDialog.java
@@ -169,10 +169,7 @@ public class ServiceDialog extends JDialog implements ActionListener {
              * on top property
              */
             if ((getOwner() == null) || (owner.getOwner() != getOwner())) {
-                try {
-                    setAlwaysOnTop(true);
-                } catch (SecurityException e) {
-                }
+                setAlwaysOnTop(true);
             }
         }
         Container c = getContentPane();
@@ -255,10 +252,7 @@ public class ServiceDialog extends JDialog implements ActionListener {
             /* See comments in same block in initPrintDialog */
             DialogOwner owner = (DialogOwner)attributes.get(DialogOwner.class);
             if ((getOwner() == null) || (owner.getOwner() != getOwner())) {
-                try {
-                    setAlwaysOnTop(true);
-                } catch (SecurityException e) {
-                }
+                setAlwaysOnTop(true);
             }
         }
 
@@ -2937,13 +2931,7 @@ public class ServiceDialog extends JDialog implements ActionListener {
     private static class ValidatingFileChooser extends JFileChooser {
         public void approveSelection() {
             File selected = getSelectedFile();
-            boolean exists;
-
-            try {
-                exists = selected.exists();
-            } catch (SecurityException e) {
-                exists = false;
-            }
+            boolean exists = selected.exists();
 
             if (exists) {
                 int val;
@@ -2966,11 +2954,6 @@ public class ServiceDialog extends JDialog implements ActionListener {
                                    getMsg("dialog.owtitle"),
                                    JOptionPane.WARNING_MESSAGE);
                 return;
-            } catch (SecurityException se) {
-                //There is already file read/write access so at this point
-                // only delete access is denied.  Just ignore it because in
-                // most cases the file created in createNewFile gets
-                // overwritten anyway.
             }
             File pFile = selected.getParentFile();
             if ((selected.exists() &&

--- a/src/java.desktop/share/classes/sun/print/ServiceNotifier.java
+++ b/src/java.desktop/share/classes/sun/print/ServiceNotifier.java
@@ -55,12 +55,9 @@ class ServiceNotifier extends Thread {
         super(null, null, service.getName() + " notifier", 0, false);
         this.service = service;
         listeners = new Vector<>();
-        try {
-              setPriority(Thread.NORM_PRIORITY-1);
-              setDaemon(true);
-              start();
-        } catch (SecurityException e) {
-        }
+        setPriority(Thread.NORM_PRIORITY-1);
+        setDaemon(true);
+        start();
     }
 
     void addListener(PrintServiceAttributeListener listener) {
@@ -93,10 +90,7 @@ class ServiceNotifier extends Thread {
      * immediate notification of listeners.
      */
     void wake() {
-        try {
-            interrupt();
-        } catch (SecurityException e) {
-        }
+        interrupt();
     }
 
    /* A heuristic is used to calculate sleep time.

--- a/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
+++ b/src/java.desktop/unix/classes/sun/print/IPPPrintService.java
@@ -511,11 +511,6 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
 
 
     public DocPrintJob createPrintJob() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPrintJobAccess();
-        }
         // REMIND: create IPPPrintJob
         return new UnixPrintJob(this);
     }
@@ -587,15 +582,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
             if (flavor == null ||
                 flavor.equals(DocFlavor.SERVICE_FORMATTED.PAGEABLE) ||
                 flavor.equals(DocFlavor.SERVICE_FORMATTED.PRINTABLE)) {
-                try {
                     return new Destination((new File("out.ps")).toURI());
-                } catch (SecurityException se) {
-                    try {
-                        return new Destination(new URI("file:out.ps"));
-                    } catch (URISyntaxException e) {
-                        return null;
-                    }
-                }
             }
             return null;
         } else if (category == Fidelity.class) {
@@ -797,11 +784,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
                 return null;
             }
         } else if (category == RequestingUserName.class) {
-            String userName = "";
-            try {
-              userName = System.getProperty("user.name", "");
-            } catch (SecurityException se) {
-            }
+            String userName = System.getProperty("user.name", "");
             return new RequestingUserName(userName, null);
         } else if (category == Sides.class) {
             // The printer takes care of Sides so if short-edge
@@ -1574,15 +1557,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
         } else if (category == Chromaticity.class) {
             return Chromaticity.COLOR;
         } else if (category == Destination.class) {
-            try {
-                return new Destination((new File("out.ps")).toURI());
-            } catch (SecurityException se) {
-                try {
-                    return new Destination(new URI("file:out.ps"));
-                } catch (URISyntaxException e) {
-                    return null;
-                }
-            }
+            return new Destination((new File("out.ps")).toURI());
         } else if (category == Fidelity.class) {
             return Fidelity.FIDELITY_FALSE;
         } else if (category == Finishings.class) {
@@ -1674,11 +1649,7 @@ public class IPPPrintService implements PrintService, SunPrinterJobService {
                 return new PageRanges(1, Integer.MAX_VALUE);
             }
         } else if (category == RequestingUserName.class) {
-            String userName = "";
-            try {
-              userName = System.getProperty("user.name", "");
-            } catch (SecurityException se) {
-            }
+            String userName = System.getProperty("user.name", "");
             return new RequestingUserName(userName, null);
         } else if (category == SheetCollate.class) {
             return SheetCollate.UNCOLLATED;

--- a/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/unix/classes/sun/print/PrintServiceLookupProvider.java
@@ -210,12 +210,6 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
      * lead people to assume its guaranteed.
      */
     public synchronized PrintService[] getPrintServices() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPrintJobAccess();
-        }
-
         if (printServices == null || !pollServices) {
             refreshServices();
         }
@@ -549,11 +543,6 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
      */
     public PrintService[] getPrintServices(DocFlavor flavor,
                                            AttributeSet attributes) {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-          security.checkPrintJobAccess();
-        }
         PrintRequestAttributeSet requestSet = null;
         PrintServiceAttributeSet serviceSet = null;
 
@@ -613,22 +602,11 @@ public class PrintServiceLookupProvider extends PrintServiceLookup
     public MultiDocPrintService[]
         getMultiDocPrintServices(DocFlavor[] flavors,
                                  AttributeSet attributes) {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-          security.checkPrintJobAccess();
-        }
         return new MultiDocPrintService[0];
     }
 
 
     public synchronized PrintService getDefaultPrintService() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-          security.checkPrintJobAccess();
-        }
-
         // clear defaultPrintService
         defaultPrintService = null;
         String psuri = null;

--- a/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
+++ b/src/java.desktop/unix/classes/sun/print/UnixPrintJob.java
@@ -707,12 +707,7 @@ public class UnixPrintJob implements CancelablePrintJob {
         }
 
         /* add the user name to the job */
-        String userName = "";
-        try {
-          userName = System.getProperty("user.name");
-        } catch (SecurityException se) {
-        }
-
+        String userName = System.getProperty("user.name");
         if (userName == null || userName.isEmpty()) {
             RequestingUserName ruName =
                 (RequestingUserName)reqSet.get(RequestingUserName.class);
@@ -790,17 +785,6 @@ public class UnixPrintJob implements CancelablePrintJob {
                         mDestination = (new File(uri)).getPath();
                     } catch (Exception e) {
                         throw new PrintException(e);
-                    }
-                    // check write access
-                    @SuppressWarnings("removal")
-                    SecurityManager security = System.getSecurityManager();
-                    if (security != null) {
-                      try {
-                        security.checkWrite(mDestination);
-                      } catch (SecurityException se) {
-                        notifyEvent(PrintJobEvent.JOB_FAILED);
-                        throw new PrintException(se);
-                      }
                     }
                 }
             } else if (category == JobSheets.class) {

--- a/src/java.desktop/unix/classes/sun/print/UnixPrintService.java
+++ b/src/java.desktop/unix/classes/sun/print/UnixPrintService.java
@@ -416,11 +416,6 @@ public class UnixPrintService implements PrintService, AttributeUpdater,
     }
 
     public DocPrintJob createPrintJob() {
-      @SuppressWarnings("removal")
-      SecurityManager security = System.getSecurityManager();
-      if (security != null) {
-        security.checkPrintJobAccess();
-      }
         return new UnixPrintJob(this);
     }
 
@@ -627,15 +622,7 @@ public class UnixPrintService implements PrintService, AttributeUpdater,
         } else if (category == Chromaticity.class) {
             return Chromaticity.COLOR;
         } else if (category == Destination.class) {
-            try {
-                return new Destination((new File("out.ps")).toURI());
-            } catch (SecurityException se) {
-                try {
-                    return new Destination(new URI("file:out.ps"));
-                } catch (URISyntaxException e) {
-                    return null;
-                }
-            }
+            return new Destination((new File("out.ps")).toURI());
         } else if (category == Fidelity.class) {
             return Fidelity.FIDELITY_FALSE;
         } else if (category == JobName.class) {
@@ -672,11 +659,7 @@ public class UnixPrintService implements PrintService, AttributeUpdater,
         } else if (category == PageRanges.class) {
             return new PageRanges(1, Integer.MAX_VALUE);
         } else if (category == RequestingUserName.class) {
-            String userName = "";
-            try {
-              userName = System.getProperty("user.name", "");
-            } catch (SecurityException se) {
-            }
+            String userName = System.getProperty("user.name", "");
             return new RequestingUserName(userName, null);
         } else if (category == SheetCollate.class) {
             return SheetCollate.UNCOLLATED;
@@ -733,15 +716,7 @@ public class UnixPrintService implements PrintService, AttributeUpdater,
                 return null;
             }
         } else if (category == Destination.class) {
-            try {
                 return new Destination((new File("out.ps")).toURI());
-            } catch (SecurityException se) {
-                try {
-                    return new Destination(new URI("file:out.ps"));
-                } catch (URISyntaxException e) {
-                    return null;
-                }
-            }
         } else if (category == JobName.class) {
             return new JobName("Java Printing", null);
         } else if (category == JobSheets.class) {
@@ -750,11 +725,7 @@ public class UnixPrintService implements PrintService, AttributeUpdater,
             arr[1] = JobSheets.STANDARD;
             return arr;
         } else if (category == RequestingUserName.class) {
-            String userName = "";
-            try {
-              userName = System.getProperty("user.name", "");
-            } catch (SecurityException se) {
-            }
+            String userName = System.getProperty("user.name", "");
             return new RequestingUserName(userName, null);
         } else if (category == OrientationRequested.class) {
             if (flavor == null || isServiceFormattedFlavor(flavor)) {

--- a/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
+++ b/src/java.desktop/windows/classes/sun/awt/windows/WPrinterJob.java
@@ -1913,16 +1913,7 @@ public final class WPrinterJob extends RasterPrinterJob
             Destination destPrn = (Destination)attributes.get(
                                                  Destination.class);
             if (destPrn == null) {
-                try {
-                    attributes.add(new Destination(
-                                               new File("./out.prn").toURI()));
-                } catch (SecurityException se) {
-                    try {
-                        attributes.add(new Destination(
-                                                new URI("file:out.prn")));
-                    } catch (URISyntaxException e) {
-                    }
-                }
+                attributes.add(new Destination(new File("./out.prn").toURI()));
             }
         } else {
             attributes.remove(Destination.class);

--- a/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
+++ b/src/java.desktop/windows/classes/sun/print/PrintServiceLookupProvider.java
@@ -106,11 +106,6 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
      * lead people to assume its guaranteed.
      */
     public synchronized PrintService[] getPrintServices() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkPrintJobAccess();
-        }
         if (printServices == null) {
             refreshServices();
         }
@@ -207,11 +202,6 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
     public PrintService[] getPrintServices(DocFlavor flavor,
                                            AttributeSet attributes) {
 
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-          security.checkPrintJobAccess();
-        }
         PrintRequestAttributeSet requestSet = null;
         PrintServiceAttributeSet serviceSet = null;
 
@@ -273,22 +263,11 @@ public class PrintServiceLookupProvider extends PrintServiceLookup {
     public MultiDocPrintService[]
         getMultiDocPrintServices(DocFlavor[] flavors,
                                  AttributeSet attributes) {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-          security.checkPrintJobAccess();
-        }
         return new MultiDocPrintService[0];
     }
 
 
     public synchronized PrintService getDefaultPrintService() {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-          security.checkPrintJobAccess();
-        }
-
 
         // Windows does not have notification for a change in default
         // so we always get the latest.

--- a/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
+++ b/src/java.desktop/windows/classes/sun/print/Win32PrintJob.java
@@ -592,11 +592,7 @@ public class Win32PrintJob implements CancelablePrintJob {
         }
 
         /* add the user name to the job */
-        String userName = "";
-        try {
-          userName = System.getProperty("user.name");
-        } catch (SecurityException se) {
-        }
+        String userName = System.getProperty("user.name");
 
         if (userName == null || userName.isEmpty()) {
             RequestingUserName ruName =
@@ -673,17 +669,6 @@ public class Win32PrintJob implements CancelablePrintJob {
                   mDestination = (new File(uri)).getPath();
                 } catch (Exception e) {
                   throw new PrintException(e);
-                }
-                // check write access
-                @SuppressWarnings("removal")
-                SecurityManager security = System.getSecurityManager();
-                if (security != null) {
-                  try {
-                    security.checkWrite(mDestination);
-                  } catch (SecurityException se) {
-                    notifyEvent(PrintJobEvent.JOB_FAILED);
-                    throw new PrintException(se);
-                  }
                 }
               }
             } else if (category == JobName.class) {

--- a/src/java.desktop/windows/classes/sun/print/Win32PrintService.java
+++ b/src/java.desktop/windows/classes/sun/print/Win32PrintService.java
@@ -858,11 +858,6 @@ public class Win32PrintService implements PrintService, AttributeUpdater,
     }
 
     public DocPrintJob createPrintJob() {
-      @SuppressWarnings("removal")
-      SecurityManager security = System.getSecurityManager();
-      if (security != null) {
-        security.checkPrintJobAccess();
-      }
         return new Win32PrintJob(this);
     }
 
@@ -1174,15 +1169,7 @@ public class Win32PrintService implements PrintService, AttributeUpdater,
         } else if (category == SunAlternateMedia.class) {
             return null;
         } else if (category == Destination.class) {
-            try {
-                return new Destination((new File("out.prn")).toURI());
-            } catch (SecurityException se) {
-                try {
-                    return new Destination(new URI("file:out.prn"));
-                } catch (URISyntaxException e) {
-                    return null;
-                }
-            }
+            return new Destination((new File("out.prn")).toURI());
         } else if (category == Sides.class) {
             switch(defSides) {
             case DMDUP_VERTICAL :
@@ -1223,11 +1210,7 @@ public class Win32PrintService implements PrintService, AttributeUpdater,
                 }
             }
         } else if (category == RequestingUserName.class) {
-            String userName = "";
-            try {
-              userName = System.getProperty("user.name", "");
-            } catch (SecurityException se) {
-            }
+            String userName = System.getProperty("user.name", "");
             return new RequestingUserName(userName, null);
         } else if (category == SheetCollate.class) {
             if (defCollate == DMCOLLATE_TRUE) {
@@ -1302,11 +1285,7 @@ public class Win32PrintService implements PrintService, AttributeUpdater,
         if (category == JobName.class) {
             return new JobName("Java Printing", null);
         } else if (category == RequestingUserName.class) {
-          String userName = "";
-          try {
-            userName = System.getProperty("user.name", "");
-          } catch (SecurityException se) {
-          }
+            String userName = System.getProperty("user.name", "");
             return new RequestingUserName(userName, null);
         } else if (category == ColorSupported.class) {
             int caps = getPrinterCapabilities();
@@ -1343,15 +1322,7 @@ public class Win32PrintService implements PrintService, AttributeUpdater,
                 return null;
             }
         } else if (category == Destination.class) {
-            try {
-                return new Destination((new File("out.prn")).toURI());
-            } catch (SecurityException se) {
-                try {
-                    return new Destination(new URI("file:out.prn"));
-                } catch (URISyntaxException e) {
-                    return null;
-                }
-            }
+            return new Destination((new File("out.prn")).toURI());
         } else if (category == OrientationRequested.class) {
             if (flavor == null ||
                 flavor.equals(DocFlavor.SERVICE_FORMATTED.PAGEABLE) ||


### PR DESCRIPTION
Remove uses of and references to SecurityManager from the printing code

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345142](https://bugs.openjdk.org/browse/JDK-8345142): Remove uses of SecurityManager in Printing related classes (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Prasanta Sadhukhan](https://openjdk.org/census#psadhukhan) (@prsadhuk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22422/head:pull/22422` \
`$ git checkout pull/22422`

Update a local copy of the PR: \
`$ git checkout pull/22422` \
`$ git pull https://git.openjdk.org/jdk.git pull/22422/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22422`

View PR using the GUI difftool: \
`$ git pr show -t 22422`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22422.diff">https://git.openjdk.org/jdk/pull/22422.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22422#issuecomment-2505048947)
</details>
