### PR TITLE
8345141: Remove uses of SecurityManager in ShellFolder related classes

### DIFF
--- a/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
+++ b/src/java.desktop/share/classes/sun/awt/shell/ShellFolder.java
@@ -232,7 +232,7 @@ public abstract class ShellFolder extends File {
                 managerClass = null;
             }
         // swallow the exceptions below and use default shell folder
-        } catch (ClassNotFoundException | SecurityException | NullPointerException e) {
+        } catch (ClassNotFoundException | NullPointerException e) {
         }
 
         if (managerClass == null) {

--- a/src/java.desktop/share/classes/sun/awt/shell/ShellFolderManager.java
+++ b/src/java.desktop/share/classes/sun/awt/shell/ShellFolderManager.java
@@ -28,8 +28,6 @@ package sun.awt.shell;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.concurrent.Callable;
-import java.util.stream.Stream;
-
 
 /**
  * @author Michael Martak

--- a/src/java.desktop/share/classes/sun/awt/shell/ShellFolderManager.java
+++ b/src/java.desktop/share/classes/sun/awt/shell/ShellFolderManager.java
@@ -70,13 +70,13 @@ class ShellFolderManager {
             // Return the default shellfolder for a new filechooser
             File homeDir = new File(System.getProperty("user.home"));
             try {
-                return checkFile(createShellFolder(homeDir));
+                return createShellFolder(homeDir);
             } catch (FileNotFoundException e) {
-                return checkFile(homeDir);
+                return homeDir;
             }
         } else if (key.equals("roots")) {
             // The root(s) of the displayable hierarchy
-            return checkFiles(File.listRoots());
+            return File.listRoots();
         } else if (key.equals("fileChooserComboBoxFolders")) {
             // Return an array of ShellFolders representing the list to
             // show by default in the file chooser's combobox
@@ -86,42 +86,10 @@ class ShellFolderManager {
             // folders, such as Desktop, Documents, History, Network, Home, etc.
             // This is used in the shortcut panel of the filechooser on Windows 2000
             // and Windows Me
-            return checkFiles(new File[] { (File)get("fileChooserDefaultFolder") });
+            return new File[] { (File)get("fileChooserDefaultFolder") };
         }
 
         return null;
-    }
-
-    private static File checkFile(File f) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        return (sm == null || f == null) ? f : checkFile(f, sm);
-    }
-
-    private static File checkFile(File f, @SuppressWarnings("removal") SecurityManager sm) {
-        try {
-            sm.checkRead(f.getPath());
-            if (f instanceof ShellFolder) {
-                ShellFolder sf = (ShellFolder)f;
-                if (sf.isLink()) {
-                    sm.checkRead(sf.getLinkLocation().getPath());
-                }
-            }
-            return f;
-        } catch (SecurityException | FileNotFoundException e) {
-            return null;
-        }
-    }
-
-    private static File[] checkFiles(File[] fs) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        return (sm == null || fs == null) ? fs : checkFiles(Stream.of(fs), sm);
-    }
-
-    private static File[] checkFiles(Stream<File> fs, @SuppressWarnings("removal") SecurityManager sm) {
-        return fs.filter(f -> f != null && checkFile(f, sm) != null)
-                 .toArray(File[]::new);
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/swing/FilePane.java
+++ b/src/java.desktop/share/classes/sun/swing/FilePane.java
@@ -2119,24 +2119,20 @@ public class FilePane extends JPanel implements PropertyChangeListener {
             return false;
         }
 
-        try {
-            if (f instanceof ShellFolder) {
-                return f.canWrite();
-            } else {
-                if (usesShellFolder(getFileChooser())) {
-                    try {
-                        return ShellFolder.getShellFolder(f).canWrite();
-                    } catch (FileNotFoundException ex) {
-                        // File doesn't exist
-                        return false;
-                    }
-                } else {
-                    // Ordinary file
-                    return f.canWrite();
+        if (f instanceof ShellFolder) {
+            return f.canWrite();
+        } else {
+            if (usesShellFolder(getFileChooser())) {
+                try {
+                    return ShellFolder.getShellFolder(f).canWrite();
+                } catch (FileNotFoundException ex) {
+                    // File doesn't exist
+                    return false;
                 }
+            } else {
+                // Ordinary file
+                return f.canWrite();
             }
-        } catch (SecurityException e) {
-            return false;
         }
     }
 

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolder2.java
@@ -666,13 +666,6 @@ final class Win32ShellFolder2 extends ShellFolder {
                 return getFileSystemPath0(csidl);
             }
         }, IOException.class);
-        if (path != null) {
-            @SuppressWarnings("removal")
-            SecurityManager security = System.getSecurityManager();
-            if (security != null) {
-                security.checkRead(path);
-            }
-        }
         return path;
     }
 
@@ -750,11 +743,6 @@ final class Win32ShellFolder2 extends ShellFolder {
      *         {@code null} if this shellfolder does not denote a directory.
      */
     public File[] listFiles(final boolean includeHiddenFiles) {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkRead(getPath());
-        }
 
         try {
             File[] files = invoke(new Callable<File[]>() {
@@ -813,7 +801,7 @@ final class Win32ShellFolder2 extends ShellFolder {
                 }
             }, InterruptedException.class);
 
-            return Win32ShellFolderManager2.checkFiles(files);
+            return files;
         } catch (InterruptedException e) {
             return new File[0];
         }

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
@@ -42,7 +42,6 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Stream;
 
 import sun.awt.OSInfo;
 import sun.awt.util.ThreadGroupUtils;

--- a/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
+++ b/src/java.desktop/windows/classes/sun/awt/shell/Win32ShellFolderManager2.java
@@ -167,9 +167,6 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
         if (desktop == null) {
             try {
                 desktop = new Win32ShellFolder2(DESKTOP);
-            } catch (final SecurityException ignored) {
-                // Ignore, the message may have sensitive information, not
-                // accessible other ways
             } catch (IOException | InterruptedException e) {
                 if (log.isLoggable(PlatformLogger.Level.WARNING)) {
                     log.warning("Cannot access 'Desktop'", e);
@@ -183,9 +180,6 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
         if (drives == null) {
             try {
                 drives = new Win32ShellFolder2(DRIVES);
-            } catch (final SecurityException ignored) {
-                // Ignore, the message may have sensitive information, not
-                // accessible other ways
             } catch (IOException | InterruptedException e) {
                 if (log.isLoggable(PlatformLogger.Level.WARNING)) {
                     log.warning("Cannot access 'Drives'", e);
@@ -202,9 +196,6 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
                 if (path != null) {
                     recent = createShellFolder(getDesktop(), new File(path));
                 }
-            } catch (final SecurityException ignored) {
-                // Ignore, the message may have sensitive information, not
-                // accessible other ways
             } catch (InterruptedException | IOException e) {
                 if (log.isLoggable(PlatformLogger.Level.WARNING)) {
                     log.warning("Cannot access 'Recent'", e);
@@ -218,9 +209,6 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
         if (network == null) {
             try {
                 network = new Win32ShellFolder2(NETWORK);
-            } catch (final SecurityException ignored) {
-                // Ignore, the message may have sensitive information, not
-                // accessible other ways
             } catch (IOException | InterruptedException e) {
                 if (log.isLoggable(PlatformLogger.Level.WARNING)) {
                     log.warning("Cannot access 'Network'", e);
@@ -244,9 +232,6 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
                         personal.setIsPersonal();
                     }
                 }
-            } catch (final SecurityException ignored) {
-                // Ignore, the message may have sensitive information, not
-                // accessible other ways
             } catch (InterruptedException | IOException e) {
                 if (log.isLoggable(PlatformLogger.Level.WARNING)) {
                     log.warning("Cannot access 'Personal'", e);
@@ -287,7 +272,7 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
             if (file == null) {
                 file = getDesktop();
             }
-            return checkFile(file);
+            return file;
         } else if (key.equals("roots")) {
             // Should be "History" and "Desktop" ?
             if (roots == null) {
@@ -298,11 +283,11 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
                     roots = (File[])super.get(key);
                 }
             }
-            return checkFiles(roots);
+            return roots;
         } else if (key.equals("fileChooserComboBoxFolders")) {
             Win32ShellFolder2 desktop = getDesktop();
 
-            if (desktop != null && checkFile(desktop) != null) {
+            if (desktop != null) {
                 ArrayList<File> folders = new ArrayList<File>();
                 Win32ShellFolder2 drives = getDrives();
 
@@ -313,7 +298,7 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
 
                 folders.add(desktop);
                 // Add all second level folders
-                File[] secondLevelFolders = checkFiles(desktop.listFiles());
+                File[] secondLevelFolders = desktop.listFiles();
                 Arrays.sort(secondLevelFolders);
                 for (File secondLevelFolder : secondLevelFolders) {
                     Win32ShellFolder2 folder = (Win32ShellFolder2) secondLevelFolder;
@@ -321,7 +306,7 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
                         folders.add(folder);
                         // Add third level for "My Computer"
                         if (folder.equals(drives)) {
-                            File[] thirdLevelFolders = checkFiles(folder.listFiles());
+                            File[] thirdLevelFolders = folder.listFiles();
                             if (thirdLevelFolders != null && thirdLevelFolders.length > 0) {
                                 List<File> thirdLevelFoldersList = Arrays.asList(thirdLevelFolders);
 
@@ -331,7 +316,7 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
                         }
                     }
                 }
-                return checkFiles(folders);
+                return folders.toArray(new File[folders.size()]);
             } else {
                 return super.get(key);
             }
@@ -374,7 +359,7 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
                     }
                 }
             }
-            return checkFiles(folders);
+            return folders.toArray(new File[folders.size()]);
         } else if (key.startsWith("fileChooserIcon ")) {
             String name = key.substring(key.indexOf(" ") + 1);
 
@@ -419,53 +404,6 @@ final class Win32ShellFolderManager2 extends ShellFolderManager {
             }
         }
         return null;
-    }
-
-    private static File checkFile(File file) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        return (sm == null || file == null) ? file : checkFile(file, sm);
-    }
-
-    private static File checkFile(File file, @SuppressWarnings("removal") SecurityManager sm) {
-        try {
-            sm.checkRead(file.getPath());
-
-            if (file instanceof Win32ShellFolder2) {
-                Win32ShellFolder2 f = (Win32ShellFolder2)file;
-                if (f.isLink()) {
-                    Win32ShellFolder2 link = (Win32ShellFolder2)f.getLinkLocation();
-                    if (link != null)
-                        sm.checkRead(link.getPath());
-                }
-            }
-            return file;
-        } catch (SecurityException se) {
-            return null;
-        }
-    }
-
-    static File[] checkFiles(File[] files) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm == null || files == null || files.length == 0) {
-            return files;
-        }
-        return checkFiles(Arrays.stream(files), sm);
-    }
-
-    private static File[] checkFiles(List<File> files) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm == null || files.isEmpty()) {
-            return files.toArray(new File[files.size()]);
-        }
-        return checkFiles(files.stream(), sm);
-    }
-
-    private static File[] checkFiles(Stream<File> filesStream, @SuppressWarnings("removal") SecurityManager sm) {
-        return filesStream.filter((file) -> checkFile(file, sm) != null)
-                .toArray(File[]::new);
     }
 
     /**


### PR DESCRIPTION
Remove SecurityManager related code from Swing filechooser implementation

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345141](https://bugs.openjdk.org/browse/JDK-8345141): Remove uses of SecurityManager in ShellFolder related classes (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22423/head:pull/22423` \
`$ git checkout pull/22423`

Update a local copy of the PR: \
`$ git checkout pull/22423` \
`$ git pull https://git.openjdk.org/jdk.git pull/22423/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22423`

View PR using the GUI difftool: \
`$ git pr show -t 22423`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22423.diff">https://git.openjdk.org/jdk/pull/22423.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22423#issuecomment-2505052582)
</details>
