### PR TITLE
8345143: Remove uses of SecurityManager in the java.desktop module

### DIFF
--- a/src/java.desktop/macosx/classes/com/apple/eio/FileManager.java
+++ b/src/java.desktop/macosx/classes/com/apple/eio/FileManager.java
@@ -130,11 +130,6 @@ public class FileManager {
          * @since 1.4
          */
     public static void setFileTypeAndCreator(String filename, int type, int creator) throws IOException {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkWrite(filename);
-        }
         _setFileTypeAndCreator(filename, type, creator);
     }
         private static native void _setFileTypeAndCreator(String filename, int type, int creator) throws IOException;
@@ -145,11 +140,6 @@ public class FileManager {
          * @since 1.4
          */
     public static void setFileType(String filename, int type) throws IOException {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkWrite(filename);
-        }
         _setFileType(filename, type);
         }
     private static native void _setFileType(String filename, int type) throws IOException;
@@ -160,11 +150,6 @@ public class FileManager {
          * @since 1.4
          */
     public static void setFileCreator(String filename, int creator) throws IOException {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkWrite(filename);
-        }
         _setFileCreator(filename, creator);
     }
     private static native void _setFileCreator(String filename, int creator) throws IOException;
@@ -175,11 +160,6 @@ public class FileManager {
          * @since 1.4
          */
     public static int getFileType(String filename) throws IOException {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkRead(filename);
-        }
         return _getFileType(filename);
     }
     private static native int _getFileType(String filename) throws IOException;
@@ -190,11 +170,6 @@ public class FileManager {
          * @since 1.4
          */
     public static int getFileCreator(String filename) throws IOException {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkRead(filename);
-        }
         return _getFileCreator(filename);
     }
     private static native int _getFileCreator(String filename) throws IOException;
@@ -358,10 +333,6 @@ public class FileManager {
                 if (file == null) throw new FileNotFoundException();
                 final String fileName = file.getAbsolutePath();
 
-                @SuppressWarnings("removal")
-                final SecurityManager security = System.getSecurityManager();
-                if (security != null) security.checkDelete(fileName);
-
                 return _moveToTrash(fileName);
         }
 
@@ -381,10 +352,6 @@ public class FileManager {
         public static boolean revealInFinder(final File file) throws FileNotFoundException {
                 if (file == null || !file.exists()) throw new FileNotFoundException();
                 final String fileName = file.getAbsolutePath();
-
-                @SuppressWarnings("removal")
-                final SecurityManager security = System.getSecurityManager();
-                if (security != null) security.checkRead(fileName);
 
                 return _revealInFinder(fileName);
         }

--- a/src/java.desktop/share/classes/com/sun/beans/finder/ClassFinder.java
+++ b/src/java.desktop/share/classes/com/sun/beans/finder/ClassFinder.java
@@ -64,7 +64,7 @@ public final class ClassFinder {
                 return Class.forName(name, false, loader);
             }
 
-        } catch (ClassNotFoundException | SecurityException exception) {
+        } catch (ClassNotFoundException exception) {
             // use current class loader instead
         }
         return Class.forName(name);
@@ -95,7 +95,7 @@ public final class ClassFinder {
         if (loader != null) {
             try {
                 return Class.forName(name, false, loader);
-            } catch (ClassNotFoundException | SecurityException exception) {
+            } catch (ClassNotFoundException exception) {
                 // use default class loader instead
             }
         }

--- a/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
+++ b/src/java.desktop/share/classes/com/sun/beans/introspect/ClassInfo.java
@@ -45,11 +45,7 @@ public final class ClassInfo {
         if (type == null) {
             return DEFAULT;
         }
-        try {
-            return CACHE.get(type);
-        } catch (SecurityException exception) {
-            return DEFAULT;
-        }
+        return CACHE.get(type);
     }
 
     public static void clear() {

--- a/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
+++ b/src/java.desktop/share/classes/com/sun/java/swing/plaf/gtk/GTKStyle.java
@@ -27,7 +27,6 @@ package com.sun.java.swing.plaf.gtk;
 
 import java.awt.*;
 import java.lang.reflect.*;
-import java.security.*;
 import java.util.*;
 import javax.swing.*;
 import javax.swing.plaf.*;

--- a/src/java.desktop/share/classes/com/sun/media/sound/AudioSynthesizer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/AudioSynthesizer.java
@@ -89,8 +89,6 @@ public interface AudioSynthesizer extends Synthesizer {
      *
      * @throws MidiUnavailableException thrown if the synthesizer cannot be
      * opened due to resource restrictions.
-     * @throws SecurityException thrown if the synthesizer cannot be
-     * opened due to security restrictions.
      *
      * @see #close
      * @see #isOpen
@@ -119,8 +117,6 @@ public interface AudioSynthesizer extends Synthesizer {
      *
      * @throws MidiUnavailableException thrown if the synthesizer cannot be
      * opened due to resource restrictions.
-     * @throws SecurityException thrown if the synthesizer cannot be
-     * opened due to security restrictions.
      *
      * @see #close
      * @see #isOpen

--- a/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
+++ b/src/java.desktop/share/classes/com/sun/media/sound/SoftSynthesizer.java
@@ -1111,7 +1111,7 @@ public final class SoftSynthesizer implements AudioSynthesizer,
                         line = testline;
                     } else {
                         // can throw LineUnavailableException,
-                        // IllegalArgumentException, SecurityException
+                        // IllegalArgumentException
                         line = AudioSystem.getSourceDataLine(getFormat());
                     }
                 }
@@ -1122,7 +1122,7 @@ public final class SoftSynthesizer implements AudioSynthesizer,
                     int bufferSize = getFormat().getFrameSize()
                         * (int)(getFormat().getFrameRate() * (latency/1000000f));
                     // can throw LineUnavailableException,
-                    // IllegalArgumentException, SecurityException
+                    // IllegalArgumentException
                     line.open(getFormat(), bufferSize);
 
                     // Remember that we opened that line
@@ -1166,8 +1166,7 @@ public final class SoftSynthesizer implements AudioSynthesizer,
                     weakstream.sourceDataLine = sourceDataLine;
                 }
 
-            } catch (final LineUnavailableException | SecurityException
-                    | IllegalArgumentException e) {
+            } catch (final LineUnavailableException | IllegalArgumentException e) {
                 if (isOpen()) {
                     close();
                 }

--- a/src/java.desktop/share/classes/java/awt/Font.java
+++ b/src/java.desktop/share/classes/java/awt/Font.java
@@ -893,23 +893,8 @@ public class Font implements java.io.Serializable
      * If a thread can create temp files anyway, no point in counting
      * font bytes.
      */
-    @SuppressWarnings("removal")
     private static boolean hasTempPermission() {
-
-        if (System.getSecurityManager() == null) {
-            return true;
-        }
-        File f = null;
-        boolean hasPerm = false;
-        try {
-            f = Files.createTempFile("+~JT", ".tmp").toFile();
-            f.delete();
-            f = null;
-            hasPerm = true;
-        } catch (Throwable t) {
-            /* inc. any kind of SecurityException */
-        }
-        return hasPerm;
+        return true;
     }
 
 
@@ -1757,11 +1742,7 @@ public class Font implements java.io.Serializable
      * @see #decode(String)
      */
     public static Font getFont(String nm, Font font) {
-        String str = null;
-        try {
-            str =System.getProperty(nm);
-        } catch(SecurityException e) {
-        }
+        String str = System.getProperty(nm);
         if (str == null) {
             return font;
         }

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -598,10 +598,7 @@ public class Window extends Container implements Accessible {
         if (owner != null) {
             owner.addOwnedWindow(weakThis);
             if (owner.isAlwaysOnTop()) {
-                try {
-                    setAlwaysOnTop(true);
-                } catch (SecurityException ignore) {
-                }
+                setAlwaysOnTop(true);
             }
         }
 
@@ -1305,10 +1302,7 @@ public class Window extends Container implements Accessible {
     // to insure that it cannot be overridden by client subclasses.
     final void toBack_NoClientCode() {
         if(isAlwaysOnTop()) {
-            try {
-                setAlwaysOnTop(false);
-            }catch(SecurityException e) {
-            }
+            setAlwaysOnTop(false);
         }
         if (visible) {
             WindowPeer peer = (WindowPeer)this.peer;
@@ -2191,10 +2185,7 @@ public class Window extends Container implements Accessible {
         for (WeakReference<Window> ref : ownedWindowArray) {
             Window window = ref.get();
             if (window != null) {
-                try {
-                    window.setAlwaysOnTop(alwaysOnTop);
-                } catch (SecurityException ignore) {
-                }
+                window.setAlwaysOnTop(alwaysOnTop);
             }
         }
     }

--- a/src/java.desktop/share/classes/java/awt/Window.java
+++ b/src/java.desktop/share/classes/java/awt/Window.java
@@ -3023,7 +3023,7 @@ public class Window extends Container implements Accessible {
          setModalExclusionType(et); // since 6.0
          boolean aot = f.get("alwaysOnTop", false);
          if(aot) {
-             setAlwaysOnTop(aot); // since 1.5; subject to permission check
+             setAlwaysOnTop(aot);
          }
          shape = (Shape)f.get("shape", null);
          opacity = (Float)f.get("opacity", 1.0f);

--- a/src/java.desktop/share/classes/java/beans/Beans.java
+++ b/src/java.desktop/share/classes/java/beans/Beans.java
@@ -189,12 +189,7 @@ public class Beans {
         // Note that calls on the system class loader will
         // look in the bootstrap class loader first.
         if (cls == null) {
-            try {
-                cls = ClassLoader.getSystemClassLoader();
-            } catch (SecurityException ex) {
-                // We're not allowed to access the system class loader.
-                // Drop through.
-            }
+            cls = ClassLoader.getSystemClassLoader();
         }
 
         // Try to find a serialized object with this name
@@ -438,11 +433,6 @@ public class Beans {
      */
 
     public static void setDesignTime(boolean isDesignTime) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPropertiesAccess();
-        }
         ThreadGroupContext.getContext().setDesignTime(isDesignTime);
     }
 
@@ -454,11 +444,6 @@ public class Beans {
      */
 
     public static void setGuiAvailable(boolean isGuiAvailable) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPropertiesAccess();
-        }
         ThreadGroupContext.getContext().setGuiAvailable(isGuiAvailable);
     }
 }

--- a/src/java.desktop/share/classes/java/beans/Introspector.java
+++ b/src/java.desktop/share/classes/java/beans/Introspector.java
@@ -335,11 +335,6 @@ public class Introspector {
      */
 
     public static void setBeanInfoSearchPath(String[] path) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPropertiesAccess();
-        }
         ThreadGroupContext.getContext().getBeanInfoFinder().setPackages(path);
     }
 

--- a/src/java.desktop/share/classes/java/beans/PropertyEditorManager.java
+++ b/src/java.desktop/share/classes/java/beans/PropertyEditorManager.java
@@ -71,11 +71,6 @@ public class PropertyEditorManager {
      * @param editorClass  the class object of the editor class
      */
     public static void registerEditor(Class<?> targetType, Class<?> editorClass) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPropertiesAccess();
-        }
         ThreadGroupContext.getContext().getPropertyEditorFinder().register(targetType, editorClass);
     }
 
@@ -109,11 +104,6 @@ public class PropertyEditorManager {
      * @param path  Array of package names.
      */
     public static void setEditorSearchPath(String[] path) {
-        @SuppressWarnings("removal")
-        SecurityManager sm = System.getSecurityManager();
-        if (sm != null) {
-            sm.checkPropertiesAccess();
-        }
         ThreadGroupContext.getContext().getPropertyEditorFinder().setPackages(path);
     }
 }

--- a/src/java.desktop/share/classes/javax/imageio/spi/IIORegistry.java
+++ b/src/java.desktop/share/classes/javax/imageio/spi/IIORegistry.java
@@ -162,7 +162,6 @@ public final class IIORegistry extends ServiceRegistry {
      * @see javax.imageio.ImageIO#scanForPlugins
      * @see ClassLoader#getResources
      */
-    @SuppressWarnings("removal")
     public void registerApplicationClasspathSpis() {
         // FIX: load only from application classpath
 
@@ -175,22 +174,8 @@ public final class IIORegistry extends ServiceRegistry {
             Iterator<IIOServiceProvider> riter =
                     ServiceLoader.load(c, loader).iterator();
             while (riter.hasNext()) {
-                try {
-                    // Note that the next() call is required to be inside
-                    // the try/catch block; see 6342404.
-                    IIOServiceProvider r = riter.next();
-                    registerServiceProvider(r);
-                } catch (ServiceConfigurationError err) {
-                    if (System.getSecurityManager() != null) {
-                        // In the applet case, we will catch the  error so
-                        // registration of other plugins can  proceed
-                        err.printStackTrace();
-                    } else {
-                        // In the application case, we will  throw the
-                        // error to indicate app/system  misconfiguration
-                        throw err;
-                    }
-                }
+                IIOServiceProvider r = riter.next();
+                registerServiceProvider(r);
             }
         }
     }

--- a/src/java.desktop/share/classes/javax/sound/midi/Synthesizer.java
+++ b/src/java.desktop/share/classes/javax/sound/midi/Synthesizer.java
@@ -345,10 +345,8 @@ public interface Synthesizer extends MidiDevice {
      *
      * @throws MidiUnavailableException if the receiver is cannot be opened,
      *         usually because the MIDI device is in use by another application
-     * @throws SecurityException if the receiver cannot be opened due to
-     *         security restrictions
      */
-    //  abstract void open() throws MidiUnavailableException, SecurityException;
+    //  abstract void open() throws MidiUnavailableException;
 
     /**
      * Closes the receiver.

--- a/src/java.desktop/share/classes/javax/swing/DefaultListCellRenderer.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultListCellRenderer.java
@@ -100,20 +100,14 @@ public class DefaultListCellRenderer extends JLabel
         setName("List.cellRenderer");
     }
 
-    @SuppressWarnings("removal")
     private Border getNoFocusBorder() {
         Border border = DefaultLookup.getBorder(this, ui, "List.cellNoFocusBorder");
-        if (System.getSecurityManager() != null) {
-            if (border != null) return border;
-            return SAFE_NO_FOCUS_BORDER;
-        } else {
-            if (border != null &&
-                    (noFocusBorder == null ||
-                    noFocusBorder == DEFAULT_NO_FOCUS_BORDER)) {
-                return border;
-            }
-            return noFocusBorder;
+        if (border != null &&
+                (noFocusBorder == null ||
+                noFocusBorder == DEFAULT_NO_FOCUS_BORDER)) {
+            return border;
         }
+        return noFocusBorder;
     }
 
     public Component getListCellRendererComponent(

--- a/src/java.desktop/share/classes/javax/swing/DefaultListCellRenderer.java
+++ b/src/java.desktop/share/classes/javax/swing/DefaultListCellRenderer.java
@@ -82,7 +82,6 @@ public class DefaultListCellRenderer extends JLabel
     * <code>getListCellRendererComponent</code> method and set the border
     * of the returned component directly.
     */
-    private static final Border SAFE_NO_FOCUS_BORDER = new EmptyBorder(1, 1, 1, 1);
     private static final Border DEFAULT_NO_FOCUS_BORDER = new EmptyBorder(1, 1, 1, 1);
     /**
      * No focus border

--- a/src/java.desktop/share/classes/javax/swing/FocusManager.java
+++ b/src/java.desktop/share/classes/javax/swing/FocusManager.java
@@ -99,10 +99,6 @@ public abstract class FocusManager extends DefaultKeyboardFocusManager {
      * @see java.awt.DefaultKeyboardFocusManager
      */
     public static void setCurrentManager(FocusManager aFocusManager) {
-        // Note: This method is not backward-compatible with 1.3 and earlier
-        // releases. It now throws a SecurityException in an applet, whereas
-        // in previous releases, it did not. This issue was discussed at
-        // length, and ultimately approved by Hans.
         KeyboardFocusManager toSet =
             (aFocusManager instanceof DelegatingDefaultFocusManager)
                 ? ((DelegatingDefaultFocusManager)aFocusManager).getDelegate()

--- a/src/java.desktop/share/classes/javax/swing/JFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JFrame.java
@@ -380,13 +380,6 @@ public class JFrame  extends Frame implements WindowConstants,
                     + " DISPOSE_ON_CLOSE, or EXIT_ON_CLOSE");
         }
 
-        if (operation == EXIT_ON_CLOSE) {
-            @SuppressWarnings("removal")
-            SecurityManager security = System.getSecurityManager();
-            if (security != null) {
-                security.checkExit(0);
-            }
-        }
         if (this.defaultCloseOperation != operation) {
             int oldValue = this.defaultCloseOperation;
             this.defaultCloseOperation = operation;

--- a/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
+++ b/src/java.desktop/share/classes/javax/swing/JInternalFrame.java
@@ -1781,12 +1781,8 @@ public class JInternalFrame extends JComponent implements
           isClosed = true;
         }
         fireInternalFrameEvent(InternalFrameEvent.INTERNAL_FRAME_CLOSED);
-        try {
-            java.awt.Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(
-                    new sun.awt.UngrabEvent(this));
-        } catch (SecurityException e) {
-            this.dispatchEvent(new sun.awt.UngrabEvent(this));
-        }
+        java.awt.Toolkit.getDefaultToolkit().getSystemEventQueue().postEvent(
+                new sun.awt.UngrabEvent(this));
     }
 
     /**

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -6364,9 +6364,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
             }
         }
 
-        // Get a PrinterJob.
-        // Do this before anything with side-effects since it may throw a
-        // security exception - in which case we don't want to do anything else.
         final PrinterJob job = PrinterJob.getPrinterJob();
 
         if (isEditing()) {

--- a/src/java.desktop/share/classes/javax/swing/JTable.java
+++ b/src/java.desktop/share/classes/javax/swing/JTable.java
@@ -5560,7 +5560,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                     return super.stopCellEditing();
                 }
 
-                SwingUtilities2.checkAccess(constructor.getModifiers());
                 value = constructor.newInstance(new Object[]{s});
             }
             catch (Exception e) {
@@ -5584,7 +5583,6 @@ public class JTable extends JComponent implements TableModelListener, Scrollable
                 if (type == Object.class) {
                     type = String.class;
                 }
-                SwingUtilities2.checkAccess(type.getModifiers());
                 constructor = type.getConstructor(argTypes);
             }
             catch (Exception e) {

--- a/src/java.desktop/share/classes/javax/swing/Popup.java
+++ b/src/java.desktop/share/classes/javax/swing/Popup.java
@@ -242,9 +242,6 @@ public class Popup {
             // Popups are typically transient and most likely won't benefit
             // from true double buffering.  Turn it off here.
             getRootPane().setUseTrueDoubleBuffering(false);
-            // Try to set "always-on-top" for the popup window.
-            // Applets usually don't have sufficient permissions to do it.
-            // In this case simply ignore the exception.
             setAlwaysOnTop(true);
         }
 

--- a/src/java.desktop/share/classes/javax/swing/Popup.java
+++ b/src/java.desktop/share/classes/javax/swing/Popup.java
@@ -245,12 +245,7 @@ public class Popup {
             // Try to set "always-on-top" for the popup window.
             // Applets usually don't have sufficient permissions to do it.
             // In this case simply ignore the exception.
-            try {
-                setAlwaysOnTop(true);
-            } catch (SecurityException se) {
-                // setAlwaysOnTop is restricted,
-                // the exception is ignored
-            }
+            setAlwaysOnTop(true);
         }
 
         public void update(Graphics g) {

--- a/src/java.desktop/share/classes/javax/swing/TimerQueue.java
+++ b/src/java.desktop/share/classes/javax/swing/TimerQueue.java
@@ -176,7 +176,7 @@ class TimerQueue implements Runnable
                                 addTimer(delayedTimer);
                             }
                         }
-    
+ 
                         // Allow run other threads on systems without kernel threads
                         timer.getLock().newCondition().awaitNanos(1);
                     } finally {

--- a/src/java.desktop/share/classes/javax/swing/TimerQueue.java
+++ b/src/java.desktop/share/classes/javax/swing/TimerQueue.java
@@ -176,7 +176,7 @@ class TimerQueue implements Runnable
                                 addTimer(delayedTimer);
                             }
                         }
- 
+
                         // Allow run other threads on systems without kernel threads
                         timer.getLock().newCondition().awaitNanos(1);
                     } finally {

--- a/src/java.desktop/share/classes/javax/swing/TimerQueue.java
+++ b/src/java.desktop/share/classes/javax/swing/TimerQueue.java
@@ -158,31 +158,27 @@ class TimerQueue implements Runnable
                     DelayedTimer runningTimer = queue.take();
                     Timer timer = runningTimer.getTimer();
                     timer.getLock().lock();
-                    try {
-                        DelayedTimer delayedTimer = timer.delayedTimer;
-                        if (delayedTimer == runningTimer) {
-                            /*
-                             * Timer is not removed (delayedTimer != null)
-                             * or not removed and added (runningTimer == delayedTimer)
-                             * after we get it from the queue and before the
-                             * lock on the timer is acquired
-                             */
-                            timer.post(); // have timer post an event
-                            timer.delayedTimer = null;
-                            if (timer.isRepeats()) {
-                                delayedTimer.setTime(now()
-                                    + TimeUnit.MILLISECONDS.toNanos(
-                                          timer.getDelay()));
-                                addTimer(delayedTimer);
-                            }
+                    DelayedTimer delayedTimer = timer.delayedTimer;
+                    if (delayedTimer == runningTimer) {
+                        /*
+                         * Timer is not removed (delayedTimer != null)
+                         * or not removed and added (runningTimer == delayedTimer)
+                         * after we get it from the queue and before the
+                         * lock on the timer is acquired
+                         */
+                        timer.post(); // have timer post an event
+                        timer.delayedTimer = null;
+                        if (timer.isRepeats()) {
+                            delayedTimer.setTime(now()
+                                + TimeUnit.MILLISECONDS.toNanos(
+                                      timer.getDelay()));
+                            addTimer(delayedTimer);
                         }
-
-                        // Allow run other threads on systems without kernel threads
-                        timer.getLock().newCondition().awaitNanos(1);
-                    } catch (SecurityException ignore) {
-                    } finally {
-                        timer.getLock().unlock();
                     }
+
+                    // Allow run other threads on systems without kernel threads
+                    timer.getLock().newCondition().awaitNanos(1);
+                    timer.getLock().unlock();
                 } catch (InterruptedException ie) {
                     // Shouldn't ignore InterruptedExceptions here, so AppContext
                     // is disposed gracefully, see 6799345 for details

--- a/src/java.desktop/share/classes/javax/swing/UIDefaults.java
+++ b/src/java.desktop/share/classes/javax/swing/UIDefaults.java
@@ -1141,7 +1141,6 @@ public class UIDefaults extends Hashtable<Object,Object>
                     }
                 }
                 c = Class.forName(className, true, (ClassLoader)cl);
-                SwingUtilities2.checkAccess(c.getModifiers());
                 if (methodName != null) {
                     Class<?>[] types = getClassArray(args);
                     Method m = c.getMethod(methodName, types);
@@ -1149,7 +1148,6 @@ public class UIDefaults extends Hashtable<Object,Object>
                 } else {
                     Class<?>[] types = getClassArray(args);
                     Constructor<?> constructor = c.getConstructor(types);
-                    SwingUtilities2.checkAccess(constructor.getModifiers());
                     return constructor.newInstance(args);
                 }
             } catch(Exception e) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxRenderer.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxRenderer.java
@@ -70,11 +70,7 @@ implements ListCellRenderer<Object>, Serializable {
 
     @SuppressWarnings("removal")
     private static Border getNoFocusBorder() {
-        if (System.getSecurityManager() != null) {
-            return SAFE_NO_FOCUS_BORDER;
-        } else {
-            return noFocusBorder;
-        }
+        return noFocusBorder;
     }
 
     public Dimension getPreferredSize() {

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxRenderer.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicComboBoxRenderer.java
@@ -57,7 +57,6 @@ implements ListCellRenderer<Object>, Serializable {
     * the <code>setBorder</code> method.
     */
     protected static Border noFocusBorder = new EmptyBorder(1, 1, 1, 1);
-    private static final Border SAFE_NO_FOCUS_BORDER = new EmptyBorder(1, 1, 1, 1);
 
     /**
      * Constructs a new instance of {@code BasicComboBoxRenderer}.
@@ -68,7 +67,6 @@ implements ListCellRenderer<Object>, Serializable {
         setBorder(getNoFocusBorder());
     }
 
-    @SuppressWarnings("removal")
     private static Border getNoFocusBorder() {
         return noFocusBorder;
     }

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLabelUI.java
@@ -66,7 +66,6 @@ public class BasicLabelUI extends LabelUI implements  PropertyChangeListener
     * name in defaults table under the key "LabelUI".
     */
     protected static BasicLabelUI labelUI = new BasicLabelUI();
-    private static final Object BASIC_LABEL_UI_KEY = new Object();
 
     private Rectangle paintIconR = new Rectangle();
     private Rectangle paintTextR = new Rectangle();

--- a/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/basic/BasicLabelUI.java
@@ -466,18 +466,7 @@ public class BasicLabelUI extends LabelUI implements  PropertyChangeListener
      * @param c a component
      * @return an instance of {@code BasicLabelUI}
      */
-    @SuppressWarnings("removal")
     public static ComponentUI createUI(JComponent c) {
-        if (System.getSecurityManager() != null) {
-            AppContext appContext = AppContext.getAppContext();
-            BasicLabelUI safeBasicLabelUI =
-                    (BasicLabelUI) appContext.get(BASIC_LABEL_UI_KEY);
-            if (safeBasicLabelUI == null) {
-                safeBasicLabelUI = new BasicLabelUI();
-                appContext.put(BASIC_LABEL_UI_KEY, safeBasicLabelUI);
-            }
-            return safeBasicLabelUI;
-        }
         return labelUI;
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLabelUI.java
@@ -54,8 +54,6 @@ public class MetalLabelUI extends BasicLabelUI
     */
     protected static MetalLabelUI metalLabelUI = new MetalLabelUI();
 
-    private static final Object METAL_LABEL_UI_KEY = new Object();
-
     /**
      * Constructs a {@code MetalLabelUI}.
      */

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLabelUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLabelUI.java
@@ -67,18 +67,7 @@ public class MetalLabelUI extends BasicLabelUI
      * @param c a component
      * @return an instance of {@code MetalLabelUI}
      */
-    @SuppressWarnings("removal")
     public static ComponentUI createUI(JComponent c) {
-        if (System.getSecurityManager() != null) {
-            AppContext appContext = AppContext.getAppContext();
-            MetalLabelUI safeMetalLabelUI =
-                    (MetalLabelUI) appContext.get(METAL_LABEL_UI_KEY);
-            if (safeMetalLabelUI == null) {
-                safeMetalLabelUI = new MetalLabelUI();
-                appContext.put(METAL_LABEL_UI_KEY, safeMetalLabelUI);
-            }
-            return safeMetalLabelUI;
-        }
         return metalLabelUI;
     }
 

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalSliderUI.java
@@ -130,22 +130,12 @@ public class MetalSliderUI extends BasicSliderUI {
         super( null );
     }
 
-    @SuppressWarnings("removal")
     private static Icon getHorizThumbIcon() {
-        if (System.getSecurityManager() != null) {
-            return SAFE_HORIZ_THUMB_ICON;
-        } else {
-            return horizThumbIcon;
-        }
+        return horizThumbIcon;
     }
 
-    @SuppressWarnings("removal")
     private static Icon getVertThumbIcon() {
-        if (System.getSecurityManager() != null) {
-            return SAFE_VERT_THUMB_ICON;
-        } else {
-            return vertThumbIcon;
-        }
+        return vertThumbIcon;
     }
 
     public void installUI( JComponent c ) {

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalSliderUI.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalSliderUI.java
@@ -105,9 +105,6 @@ public class MetalSliderUI extends BasicSliderUI {
     */
     protected static Icon vertThumbIcon;
 
-    private static Icon SAFE_HORIZ_THUMB_ICON;
-    private static Icon SAFE_VERT_THUMB_ICON;
-
     /**
      * Property for {@code JSlider.isFilled}.
      */
@@ -141,10 +138,8 @@ public class MetalSliderUI extends BasicSliderUI {
     public void installUI( JComponent c ) {
         trackWidth = ((Integer)UIManager.get( "Slider.trackWidth" )).intValue();
         tickLength = safeLength = ((Integer)UIManager.get( "Slider.majorTickLength" )).intValue();
-        horizThumbIcon = SAFE_HORIZ_THUMB_ICON =
-                UIManager.getIcon( "Slider.horizontalThumbIcon" );
-        vertThumbIcon = SAFE_VERT_THUMB_ICON =
-                UIManager.getIcon( "Slider.verticalThumbIcon" );
+        horizThumbIcon = UIManager.getIcon( "Slider.horizontalThumbIcon" );
+        vertThumbIcon = UIManager.getIcon( "Slider.verticalThumbIcon" );
 
         super.installUI( c );
 

--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableCellRenderer.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableCellRenderer.java
@@ -93,7 +93,6 @@ public class DefaultTableCellRenderer extends JLabel
     * <code>getTableCellRendererComponent</code> method and set the border
     * of the returned component directly.
     */
-    private static final Border SAFE_NO_FOCUS_BORDER = new EmptyBorder(1, 1, 1, 1);
     private static final Border DEFAULT_NO_FOCUS_BORDER = new EmptyBorder(1, 1, 1, 1);
     /**
      * A border without focus.

--- a/src/java.desktop/share/classes/javax/swing/table/DefaultTableCellRenderer.java
+++ b/src/java.desktop/share/classes/javax/swing/table/DefaultTableCellRenderer.java
@@ -117,13 +117,9 @@ public class DefaultTableCellRenderer extends JLabel
         setName("Table.cellRenderer");
     }
 
-    @SuppressWarnings("removal")
     private Border getNoFocusBorder() {
         Border border = DefaultLookup.getBorder(this, ui, "Table.cellNoFocusBorder");
-        if (System.getSecurityManager() != null) {
-            if (border != null) return border;
-            return SAFE_NO_FOCUS_BORDER;
-        } else if (border != null) {
+        if (border != null) {
             if (noFocusBorder == null || noFocusBorder == DEFAULT_NO_FOCUS_BORDER) {
                 return border;
             }

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultCaret.java
@@ -1431,8 +1431,6 @@ public class DefaultCaret extends Rectangle implements Caret, FocusListener, Mou
             return component.getToolkit().getSystemSelection();
         } catch (HeadlessException he) {
             // do nothing... there is no system clipboard
-        } catch (SecurityException se) {
-            // do nothing... there is no allowed system clipboard
         }
         return null;
     }

--- a/src/java.desktop/share/classes/javax/swing/text/DefaultFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/DefaultFormatter.java
@@ -247,7 +247,6 @@ public class DefaultFormatter extends JFormattedTextField.AbstractFormatter
             Constructor<?> cons;
 
             try {
-                SwingUtilities2.checkAccess(vc.getModifiers());
                 cons = vc.getConstructor(new Class<?>[]{String.class});
 
             } catch (NoSuchMethodException nsme) {
@@ -256,7 +255,6 @@ public class DefaultFormatter extends JFormattedTextField.AbstractFormatter
 
             if (cons != null) {
                 try {
-                    SwingUtilities2.checkAccess(cons.getModifiers());
                     return cons.newInstance(new Object[] { string });
                 } catch (Throwable ex) {
                     throw new ParseException("Error creating instance", 0);

--- a/src/java.desktop/share/classes/javax/swing/text/NumberFormatter.java
+++ b/src/java.desktop/share/classes/javax/swing/text/NumberFormatter.java
@@ -436,11 +436,9 @@ public class NumberFormatter extends InternationalFormatter {
                         valueClass = value.getClass();
                     }
                     try {
-                        SwingUtilities2.checkAccess(valueClass.getModifiers());
                         Constructor<?> cons = valueClass.getConstructor(
                                               new Class<?>[] { String.class });
                         if (cons != null) {
-                            SwingUtilities2.checkAccess(cons.getModifiers());
                             return cons.newInstance(new Object[]{string});
                         }
                     } catch (Throwable ex) { }

--- a/src/java.desktop/share/classes/sun/awt/OSInfo.java
+++ b/src/java.desktop/share/classes/sun/awt/OSInfo.java
@@ -101,7 +101,7 @@ public class OSInfo {
         };
     }
 
-    public static WindowsVersion getWindowsVersion() throws SecurityException {
+    public static WindowsVersion getWindowsVersion() {
         String osVersion = System.getProperty(OS_VERSION);
 
         if (osVersion == null) {

--- a/src/java.desktop/share/classes/sun/awt/OSInfo.java
+++ b/src/java.desktop/share/classes/sun/awt/OSInfo.java
@@ -64,7 +64,7 @@ public class OSInfo {
     private static final Map<String, WindowsVersion> windowsVersionMap = new HashMap<String, OSInfo.WindowsVersion>();
 
     // Cache the OSType for getOSType()
-    private static final OSType CURRENT_OSTYPE = getOSTypeImpl();  // No DoPriv needed
+    private static final OSType CURRENT_OSTYPE = getOSTypeImpl();
 
 
     static {

--- a/src/java.desktop/share/classes/sun/awt/SunToolkit.java
+++ b/src/java.desktop/share/classes/sun/awt/SunToolkit.java
@@ -701,7 +701,6 @@ public abstract class SunToolkit extends Toolkit
 
     static Image getImageFromHash(Toolkit tk,
                                                String filename) {
-        checkPermissions(filename);
         synchronized (fileImgCache) {
             Image img = (Image)fileImgCache.get(filename);
             if (img == null) {
@@ -757,7 +756,6 @@ public abstract class SunToolkit extends Toolkit
 
     @Override
     public Image createImage(String filename) {
-        checkPermissions(filename);
         return createImage(new FileImageSource(filename));
     }
 
@@ -870,7 +868,6 @@ public abstract class SunToolkit extends Toolkit
 
     protected static boolean imageExists(String filename) {
         if (filename != null) {
-            checkPermissions(filename);
             return new File(filename).exists();
         }
         return false;
@@ -886,14 +883,6 @@ public abstract class SunToolkit extends Toolkit
             }
         }
         return false;
-    }
-
-    private static void checkPermissions(String filename) {
-        @SuppressWarnings("removal")
-        SecurityManager security = System.getSecurityManager();
-        if (security != null) {
-            security.checkRead(filename);
-        }
     }
 
     /**

--- a/src/java.desktop/share/classes/sun/awt/util/PerformanceLogger.java
+++ b/src/java.desktop/share/classes/sun/awt/util/PerformanceLogger.java
@@ -126,9 +126,7 @@ public class PerformanceLogger {
 
     /**
      * Returns status of whether logging is enabled or not.  This is
-     * provided as a convenience method so that users do not have to
-     * perform the same GetPropertyAction check as above to determine whether
-     * to enable performance logging.
+     * provided as a convenience method.
      */
     public static boolean loggingEnabled() {
         return perfLoggingOn;

--- a/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
+++ b/src/java.desktop/share/classes/sun/swing/SwingUtilities2.java
@@ -1462,20 +1462,6 @@ public class SwingUtilities2 {
        return !GraphicsEnvironment.isHeadless();
    }
 
-    /**
-     * Utility method that throws SecurityException if SecurityManager is set
-     * and modifiers are not public
-     *
-     * @param modifiers a set of modifiers
-     */
-    @SuppressWarnings("removal")
-    public static void checkAccess(int modifiers) {
-        if (System.getSecurityManager() != null
-                && !Modifier.isPublic(modifiers)) {
-            throw new SecurityException("Resource is not accessible");
-        }
-    }
-
     public static String displayPropertiesToCSS(Font font, Color fg) {
         StringBuilder rule = new StringBuilder("body {");
         if (font != null) {

--- a/test/jdk/lib/client/ExtendedRobot.java
+++ b/test/jdk/lib/client/ExtendedRobot.java
@@ -57,11 +57,6 @@ public class ExtendedRobot extends Robot {
 
     private final int syncDelay = DEFAULT_SYNC_DELAY;
 
-    //TODO: uncomment three lines below after moving functionality to java.awt.Robot
-    //{
-    //    syncDelay = AccessController.doPrivileged(new GetIntegerAction("java.awt.robotdelay", DEFAULT_SYNC_DELAY));
-    //}
-
     /**
      * Constructs an ExtendedRobot object in the coordinate system of the primary screen.
      *


### PR DESCRIPTION
Remove SecurityManager related code in the desktop module that is not covered by other PRs

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345143](https://bugs.openjdk.org/browse/JDK-8345143): Remove uses of SecurityManager in the java.desktop module (**Bug** - P4)


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Harshitha Onkar](https://openjdk.org/census#honkar) (@honkar-jdk - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22424/head:pull/22424` \
`$ git checkout pull/22424`

Update a local copy of the PR: \
`$ git checkout pull/22424` \
`$ git pull https://git.openjdk.org/jdk.git pull/22424/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22424`

View PR using the GUI difftool: \
`$ git pr show -t 22424`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22424.diff">https://git.openjdk.org/jdk/pull/22424.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22424#issuecomment-2505054232)
</details>
