### PR TITLE
8344925: translet-name ignored, when package-name is also set via TransformerFactory.setAttribute

### DIFF
--- a/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
+++ b/src/java.xml/share/classes/com/sun/org/apache/xalan/internal/xsltc/trax/TransformerFactoryImpl.java
@@ -1000,6 +1000,9 @@ public class TransformerFactoryImpl
         // Set the attributes for translet generation
         int outputType = XSLTC.BYTEARRAY_OUTPUT;
         if (_generateTranslet || _autoTranslet) {
+            if (_packageName != null)
+                xsltc.setPackageName(_packageName);
+
             // Set the translet name
             xsltc.setClassName(getTransletBaseName(source));
 
@@ -1015,9 +1018,6 @@ public class TransformerFactoryImpl
                         xsltc.setDestDirectory(xslDir);
                 }
             }
-
-            if (_packageName != null)
-                xsltc.setPackageName(_packageName);
 
             if (_jarFileName != null) {
                 xsltc.setJarFileName(_jarFileName);


### PR DESCRIPTION
…String)

This bug seems from the improper handling of package and class name initialization in `XSLTC` since there is a default value of  `_packageName` with `die.verwandlung`. This fix is just adjusting to call `setPackageName` before `setClassName`.

I've done the tire1 and tire2 tests. The tire1 tests passed and tire2 reports

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR  
>> jtreg:test/hotspot/jtreg:tier2                      745   744     1     0 <<
>> jtreg:test/jdk:tier2                               4142  4137     2     3 <<
   jtreg:test/langtools:tier2                           12    12     0     0  
   jtreg:test/jaxp:tier2                               514   514     0     0  
   jtreg:test/docs:tier2                                 1     1     0     0  
==============================
TEST FAILURE
```

The failed tests are
```
JT Harness : Tests that failed
runtime/Thread/ThreadCountLimit.java#id0: Stress test that reaches the process limit for thread count, or time limit.

JT Harness : Tests that failed
java/net/InetAddress/CheckJNI.java: java -Xcheck:jni failing in net code on Solaris / [Datagram]Socket.getLocalAddress() failure
java/net/Socket/LinkLocal.java: Connecting to a link-local IPv6 address should not causes a SocketException to be thrown.

JT Harness : Tests that had errors
java/net/URL/EarlyOrDelayedParsing.java: URL built-in protocol handlers should parse the URL early to avoid constructing URLs for which openConnection would later throw an exception, when possible.
java/net/ipv6tests/UdpTest.java: IPv6 support for Windows XP and 2003 server.
java/nio/channels/DatagramChannel/SendReceiveMaxSize.java: Check that it is possible to send and receive datagrams of maximum size on macOS.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8344925](https://bugs.openjdk.org/browse/JDK-8344925)

### Warning
&nbsp;⚠️ Patch contains a binary file (src/java.desktop/share/classes/javax/swing/text/doc-files/Document-insert.gif)

### Issue
 * [JDK-8344925](https://bugs.openjdk.org/browse/JDK-8344925): translet-name ignored when package-name is also set (**Bug** - P4) ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is already resolved. Consider making this a "backport pull request" by setting the PR title to `Backport <hash>` with the hash of the original commit. See [Backports](https://wiki.openjdk.org/display/SKARA/Backports).


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22425/head:pull/22425` \
`$ git checkout pull/22425`

Update a local copy of the PR: \
`$ git checkout pull/22425` \
`$ git pull https://git.openjdk.org/jdk.git pull/22425/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22425`

View PR using the GUI difftool: \
`$ git pr show -t 22425`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22425.diff">https://git.openjdk.org/jdk/pull/22425.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22425#issuecomment-2611097252)
</details>
