### PR TITLE
8345148: Fix for JDK-8337317 is incomplete

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/HiddenClass/libHiddenClassSigTest.cpp
@@ -351,10 +351,16 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
     return JNI_ERR;
   }
 
-  // enable VM_INIT event notification mode
+  // enable VM_INIT/VM_DEATH event notification modes
   err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_INIT, nullptr);
   if (err != JVMTI_ERROR_NONE) {
-    LOG1("Agent_OnLoad: Error in JVMTI SetEventNotificationMode: %d\n", err);
+    LOG1("Agent_OnLoad: Error in JVMTI SetEventNotificationMode(JVMTI_EVENT_VM_INIT): %d\n", err);
+    failed = true;
+    return JNI_ERR;
+  }
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, nullptr);
+  if (err != JVMTI_ERROR_NONE) {
+    LOG1("Agent_OnLoad: Error in JVMTI SetEventNotificationMode(JVMTI_EVENT_VM_DEATH): %d\n", err);
     failed = true;
     return JNI_ERR;
   }

--- a/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/VMObjectAlloc/libVMObjectAlloc.cpp
@@ -108,6 +108,10 @@ Agent_OnLoad(JavaVM *jvm, char *options, void *reserved) {
   if (err != JVMTI_ERROR_NONE) {
     return JNI_ERR;
   }
+  err = jvmti->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_VM_DEATH, nullptr);
+  if (err != JVMTI_ERROR_NONE) {
+    return JNI_ERR;
+  }
 
   return JNI_OK;
 }


### PR DESCRIPTION
Fix for JDK-8337317 (#20699) updated serviceability/jvmti/HiddenClass and serviceability/jvmti/VMObjectAlloc tests adding guards against JVMTI_ERROR_WRONG_PHASE errors, but missed to enable JVMTI_EVENT_VM_DEATH events.
This fix adds the missed part.

Testing: hotspot/jtreg/serviceability/jvmti on all platforms
Manually verified test outputs contain "VMDeath" notification from VMDeath callback

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345148](https://bugs.openjdk.org/browse/JDK-8345148): Fix for JDK-8337317 is incomplete (**Bug** - P3)


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22426/head:pull/22426` \
`$ git checkout pull/22426`

Update a local copy of the PR: \
`$ git checkout pull/22426` \
`$ git pull https://git.openjdk.org/jdk.git pull/22426/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22426`

View PR using the GUI difftool: \
`$ git pr show -t 22426`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22426.diff">https://git.openjdk.org/jdk/pull/22426.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22426#issuecomment-2505105084)
</details>
