### PR TITLE
8345102: [s390x/ppc] ShowRegistersOnAssertTest.java fails after 8343756

### DIFF
--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -83,6 +83,8 @@ public class ShowRegistersOnAssertTest {
                                           Pattern.compile("  r0  =.*")};
             } else if (Platform.isPPC()) {
                 pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("pc =.*")};
+            } else {
+                pattern = new Pattern[] { Pattern.compile("Registers:"), null };
             }
             // Pattern match the hs_err_pid file.
             HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -44,7 +44,6 @@ import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.util.regex.Pattern;
 
-import jdk.test.lib.Asserts;
 import jdk.test.lib.process.OutputAnalyzer;
 import jdk.test.lib.Platform;
 import jdk.test.lib.process.ProcessTools;
@@ -71,9 +70,7 @@ public class ShowRegistersOnAssertTest {
         if (show_registers_on_assert) {
             // Extract the hs_err_pid file.
             File hs_err_file = HsErrFileUtils.openHsErrFileFromOutput(output_detail);
-
             Pattern[] pattern = null;
-
             if (Platform.isX64()) {
                 pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("RAX=.*")};
             } else if (Platform.isX86()) {
@@ -87,19 +84,8 @@ public class ShowRegistersOnAssertTest {
             } else if (Platform.isPPC()) {
                 pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("pc =.*")};
             }
-
-            if (Platform.isS390x()) {
-              // On s390x, hs_err file is not complete.
-              try {
-                // Pattern match the hs_err_pid file.
-                HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);
-              } catch (RuntimeException e) {
-                Asserts.assertEquals("hs-err file incomplete (missing END marker.)", e.getMessage());
-              }
-            } else {
-                // Pattern match the hs_err_pid file.
-                HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);
-            }
+            // Pattern match the hs_err_pid file.
+            HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);
         }
     }
 

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -84,7 +84,7 @@ public class ShowRegistersOnAssertTest {
             } else if (Platform.isPPC()) {
                 pattern = new Pattern[] { Pattern.compile("Registers:"), Pattern.compile("pc =.*")};
             } else {
-                pattern = new Pattern[] { Pattern.compile("Registers:"), null };
+                pattern = new Pattern[] { Pattern.compile("Registers:") };
             }
             // Pattern match the hs_err_pid file.
             HsErrFileUtils.checkHsErrFileContent(hs_err_file, pattern, false);

--- a/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/ShowRegistersOnAssertTest.java
@@ -63,7 +63,7 @@ public class ShowRegistersOnAssertTest {
 
         OutputAnalyzer output_detail = new OutputAnalyzer(pb.start());
 
-        // we should have crashed with an internal error. We should definitly NOT have crashed with a segfault
+        // we should have crashed with an internal error. We should definitely NOT have crashed with a segfault
         // (which would be a sign that the assert poison page mechanism does not work).
         output_detail.shouldMatch("# A fatal error has been detected by the Java Runtime Environment:.*");
         output_detail.shouldMatch("# +Internal Error.*");


### PR DESCRIPTION
This PR adds s390 and ppc info in the `ShowRegistersOnAssertTest.java`. 

I did this update on the below information present in hs-err file, present on both platform, basis: 

s390: 
```
General Purpose Registers:
--------------------------
  r0  = 0xffffffffffff8028    r1  = 0x000003ffb41dab90  |  r0  =                  -32728    r1  =           4396773387152  
  r2  = 0x000003ffb340e780    r3  = 0x000002aa2e11fca0  |  r2  =           4396758919040    r3  =           2929940626592  
  r4  = 0x000003ffb3126fe6    r5  = 0x0000000000000004  |  r4  =           4396755873766    r5  =                       4  
  r6  = 0x0000000000000002    r7  = 0x000003ffb5c60700  |  r6  =                       2    r7  =           4396801197824  
  r8  = 0x000003ffa802be10    r9  = 0x000003ffb5c92ce8  |  r8  =           4396570295824    r9  =           4396801404136  
  r10 = 0x000003ffb6b66000    r11 = 0x000003ffacafeaf8  |  r10 =           4396816949248    r11 =           4396648753912  
  r12 = 0x000003ffb37ce400    r13 = 0x000003ffe9ffabbf  |  r12 =           4396762850304    r13 =           4397677390783  
  r14 = 0x000003ffb3126fe6    r15 = 0x000003ffacafeaf8  |  r14 =           4396755873766    r15 =           4396648753912 
```

ppc: 
```
Registers:
pc =0x00007b5eff558b14  lr =0x00007b5eff558af4  ctr=0x00007b5f0083e7b0  
r0 =0x00007b5eff558af4  r1 =0x00007b5efedeaf40  r2 =0x00007b5f00567c00  
r3 =0x00007b5f0019ebd8  r4 =0x00000000000002f0  r5 =0x0000000000000200  
r6 =0x0000000000000000  r7 =0x00007b5f00848dbc  r8 =0x0000000000000017  
r9 =0x00007b5f00900000  r10=0x0000000000000058  r11=0x0000000000000000  
r12=0x00007b5f0083e7b0  r13=0x00007b5efedf68f0  r14=0x00007b5eec1d9e57  
r15=0x00007b5efedecc90  r16=0x00007b5ef802adc0  r17=0x000000000000006a  
r18=0x00007b5efedecd60  r19=0x00007b5eec1551a8  r20=0x0000000000000000  
r21=0x00007b5efedecc30  r22=0x00007b5efedec1b0  r23=0x00007b5efedeb1f8  
r24=0x00007b5efedeb080  r25=0x0000000000000000  r26=0x00007b5efedeb130  
r27=0x00007b5efedeb070  r28=0x0000000000000000  r29=0x00007b5ef802adc0  
r30=0x00007b5efedeb080  r31=0x00007b5efedeaf40  
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345102](https://bugs.openjdk.org/browse/JDK-8345102): [s390x/ppc] ShowRegistersOnAssertTest.java fails after 8343756 (**Bug** - P3)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22427/head:pull/22427` \
`$ git checkout pull/22427`

Update a local copy of the PR: \
`$ git checkout pull/22427` \
`$ git pull https://git.openjdk.org/jdk.git pull/22427/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22427`

View PR using the GUI difftool: \
`$ git pr show -t 22427`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22427.diff">https://git.openjdk.org/jdk/pull/22427.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22427#issuecomment-2505224712)
</details>
