### PR TITLE
8345154: IGV: Show Parse and Assertion Predicate type as extra label

### DIFF
--- a/src/hotspot/share/opto/ifnode.cpp
+++ b/src/hotspot/share/opto/ifnode.cpp
@@ -2213,10 +2213,10 @@ void ParsePredicateNode::dump_spec(outputStream* st) const {
       st->print("Loop ");
       break;
     case Deoptimization::DeoptReason::Reason_profile_predicate:
-      st->print("Profiled_Loop ");
+      st->print("Profiled Loop ");
       break;
     case Deoptimization::DeoptReason::Reason_loop_limit_check:
-      st->print("Loop_Limit_Check ");
+      st->print("Loop Limit Check ");
       break;
     default:
       fatal("unknown kind");

--- a/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/customNodeInfo.filter
+++ b/src/utils/IdealGraphVisualizer/ServerCompiler/src/main/resources/com/sun/hotspot/igv/servercompiler/filters/customNodeInfo.filter
@@ -34,3 +34,27 @@ editProperty(matches("name", "CallLeafDirect|CallLeafDirectVector|CallLeafNoFPDi
 // Show pre/main/post at CountedLoopNodes.
 editProperty(hasProperty("loop_kind"), ["loop_kind"], "extra_label",
              function(loop_kind) { return loop_kind[0]; });
+
+// Show Parse Predicate type.
+function parsePredicateInfo(dump_spec) {
+  // It's easier to match with ".*" because type "Loop" can also be found in type "Loop Limit Check" and "Profiled Loop".
+  // Matching with ".*" also requires us to exclude the optional "#useless" string at the end.
+  var predicateMatch = /#(.*)(#useless)?/.exec(dump_spec);
+  if (predicateMatch != null) {
+     return predicateMatch[1].trim();
+  }
+  return null;
+}
+editProperty(matches("name", "ParsePredicate"), ["dump_spec"], "extra_label",
+             function(dump_spec) { return parsePredicateInfo(dump_spec[0]);});
+
+// Show Assertion Predicate type.
+function assertionPredicateInfo(dump_spec) {
+  var predicateMatch = /#((Init|Last) Value Assertion Predicate)/.exec(dump_spec);
+  if (predicateMatch != null) {
+     return predicateMatch[1];
+  }
+  return null;
+}
+editProperty(matches("name", "If|RangeCheck"), ["dump_spec"], "extra_label",
+             function(dump_spec) { return assertionPredicateInfo(dump_spec[0]);});


### PR DESCRIPTION
`ParsePredicate` and `If/RangeCheck` nodes for Assertion Predicates dump their respective type to the `dump_spec` string. We can parse this info and show it in the "Show custom node info" filter as done for other nodes already:

![Screenshot from 2024-11-28 08-16-23](https://github.com/user-attachments/assets/0de53873-8aa2-47b9-9275-d90c05deecd3)

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345154](https://bugs.openjdk.org/browse/JDK-8345154): IGV: Show Parse and Assertion Predicate type as extra label (**Enhancement** - P4)


### Reviewers
 * [Roberto Castañeda Lozano](https://openjdk.org/census#rcastanedalo) (@robcasloz - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22428/head:pull/22428` \
`$ git checkout pull/22428`

Update a local copy of the PR: \
`$ git checkout pull/22428` \
`$ git pull https://git.openjdk.org/jdk.git pull/22428/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22428`

View PR using the GUI difftool: \
`$ git pr show -t 22428`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22428.diff">https://git.openjdk.org/jdk/pull/22428.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22428#issuecomment-2505439087)
</details>
