### PR TITLE
8345145: Display javap LineNumberTable and LocalVariableTable iff disassembled code output with `-c` or `-v`

### DIFF
--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/ClassWriter.java
@@ -574,10 +574,8 @@ public class ClassWriter extends BasicWriter {
 
         if (options.showAllAttrs) {
             attrWriter.write(m.attributes());
-        } else if (code != null) {
-            if (options.showDisassembled || options.showLineAndLocalVariableTables) {
-                codeWriter.writeMinimal(code);
-            }
+        } else if (code != null && options.showDisassembled) {
+            codeWriter.writeMinimal(code);
         }
 
         indent(-1);

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/CodeWriter.java
@@ -266,11 +266,8 @@ public class CodeWriter extends BasicWriter {
     }
 
     private void writeMinimalMode(CodeAttribute attr) {
-        if (options.showDisassembled) {
-            writeInstrs(attr);
-            writeExceptionTable(attr);
-        }
-
+        writeInstrs(attr);
+        writeExceptionTable(attr);
         if (options.showLineAndLocalVariableTables) {
             writeLineAndLocalVariableTables(attr);
         }

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/JavapTask.java
@@ -549,6 +549,10 @@ public class JavapTask implements DisassemblerTool.DisassemblerTask, Messages {
             throw new BadArgs("err.incompatible.options", sb);
         }
 
+        if (!options.showDisassembled && !options.verbose && options.showLineAndLocalVariableTables) {
+            reportWarning("err.incompatible.options", "-l without -c, line number and local variable tables will not be printed");
+        }
+
         if ((classes == null || classes.size() == 0) &&
                 !(noArgs || options.help || options.version || options.fullVersion)) {
             throw new BadArgs("err.no.classes.specified");

--- a/src/jdk.jdeps/share/classes/com/sun/tools/javap/resources/javap.properties
+++ b/src/jdk.jdeps/share/classes/com/sun/tools/javap/resources/javap.properties
@@ -74,7 +74,7 @@ main.opt.v=\
 \  -v  -verbose                     Print additional information
 
 main.opt.l=\
-\  -l                               Print line number and local variable tables
+\  -l                               Print line number and local variable tables, works in combination with -c
 
 main.opt.public=\
 \  -public                          Show only public classes and members

--- a/test/langtools/tools/javap/ClassWriterNoLineVariableTableTest.java
+++ b/test/langtools/tools/javap/ClassWriterNoLineVariableTableTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8345145
+ * @summary javap should not print LineNumberTable/LocalVariableTable (-l) without disassembled code (-c).
+ * @compile -g ClassWriterNoLineVariableTableTest.java
+ * @run junit ClassWriterNoLineVariableTableTest
+ * @modules jdk.jdeps/com.sun.tools.javap
+ */
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ClassWriterNoLineVariableTableTest {
+    String expectedErrorOutput = "Warning: bad combination of options: -l without -c, line number and local variable tables will not be printed";
+
+    @Test
+    public void testJavapWithoutCodeAttribute() {
+        String output = javap("-l");
+        assertContains(output, expectedErrorOutput,
+            "javap should throw warning, when -l used without -c or -v");
+        assertNotContains(output, "LineNumberTable",
+            "There should be no LineNumberTable output when javap is provided l without -c or -v");
+        assertNotContains(output, "LocalVariableTable",
+            "There should be no LineNumberTable output when javap is provided l without -c or -v");
+    }
+
+    @ParameterizedTest(name = "Test javap with fixed option -l and varying option: {0}")
+    @ValueSource(strings = {"-v", "-c"})
+    public void testJavapWithCodeAttribute(String addedOption) {
+        String output = javap("-l", addedOption);
+        assertNotContains(output, expectedErrorOutput,
+            "There should be no warning when javap is provided -l and " + addedOption);
+        assertContains(output, "LineNumberTable",
+            "There should be LineNumberTable output when javap is provided -l and " + addedOption);
+        assertContains(output, "LocalVariableTable",
+            "There should be LocalVariableTable output when javap is provided -l and " + addedOption);
+    }
+
+    private static void assertContains(String actual, String expectedSubstring, String message) {
+        assertTrue(actual.contains(expectedSubstring),
+            message + " - Expected '" + actual + "' to contain '" + expectedSubstring + "'");
+    }
+
+    private static void assertNotContains(String actual, String expectedSubstring, String message) {
+        assertFalse(actual.contains(expectedSubstring),
+            message + " - Expected '" + actual + "' not to contain '" + expectedSubstring + "'");
+    }
+
+    private String javap(String... args) {
+        StringWriter sw = new StringWriter();
+        PrintWriter out = new PrintWriter(sw);
+
+        String[] fullArgs = new String[args.length + 1];
+        System.arraycopy(args, 0, fullArgs, 0, args.length);
+        fullArgs[args.length] = System.getProperty("test.classes") + "/RandomLoop8345145.class";
+
+        int rc = com.sun.tools.javap.Main.run(fullArgs, out);
+        if (rc != 0)
+            throw new Error("javap failed. rc=" + rc);
+        out.close();
+        System.out.println(sw);
+        return sw.toString();
+    }
+}
+
+class RandomLoop8345145 {
+    public void randomLoop() {
+        int x = 5;
+        for (int i = 0; i < 10; i++) {
+            x*=2;
+        }
+    }
+}

--- a/test/langtools/tools/javap/ClassWriterTableIndentTest.java
+++ b/test/langtools/tools/javap/ClassWriterTableIndentTest.java
@@ -52,7 +52,7 @@ public class ClassWriterTableIndentTest {
          *        line 145: 14
          * ...
          */
-        List<String[]> runArgsList = List.of(new String[]{"-c", "-l"}, new String[]{"-v"}, new String[]{"-l"});
+        List<String[]> runArgsList = List.of(new String[]{"-c", "-l"}, new String[]{"-v"});
         for (String[] runArgs : runArgsList) {
             String output = javap(runArgs);
             int methodIntent = findNthMatchPrecedingSpaces(output, "public void emptyLoop();", 0);

--- a/test/langtools/tools/javap/T4459541.java
+++ b/test/langtools/tools/javap/T4459541.java
@@ -90,7 +90,7 @@ public class T4459541 {
     String javap(File f) {
         StringWriter sw = new StringWriter();
         PrintWriter out = new PrintWriter(sw);
-        int rc = com.sun.tools.javap.Main.run(new String[] { "-l", f.getPath() }, out);
+        int rc = com.sun.tools.javap.Main.run(new String[] { "-l", "-c", f.getPath() }, out);
         if (rc != 0)
             throw new Error("javap failed. rc=" + rc);
         out.close();

--- a/test/langtools/tools/javap/T8032814.java
+++ b/test/langtools/tools/javap/T8032814.java
@@ -45,7 +45,7 @@ public class T8032814 {
                 + clazz.getDeclaredMethods().length;
         test(clazz, 0);
         test(clazz, count, "-v");
-        test(clazz, count, "-l");
+        test(clazz, count, "-c", "-l");
         test(clazz, count, "-v", "-l");
 
         if (errors > 0)


### PR DESCRIPTION
This PR includes a suggested change in behaviour of `javap -l` without `-v` or `-c`.
Previously it was possible to print `LineNumberTable` and `LocalVariableTable` without disassembled code output. This didn't make much sense, as there is no context for this output. This PR proposes to output a warning for this case, as well as not print the `LineNumberTable`and `LocalVariableTable` attrubutes. They are nested attributes of the `CodeAttribute` and thus should only be printed if the `CodeAttribute`  is also printed.

Small changes were also made to existing tests, which seem unproblematic to adjust.

<details>
<summary>Before: `javac -l EmptyLoop`</summary>

```
Compiled from "EmptyLoop.java"
public class EmptyLoop {
  public EmptyLoop();
    Code:
      LineNumberTable:
        line 1: 0

  public void emptyLoop();
    Code:
      LineNumberTable:
        line 3: 0
        line 5: 14
}
```

</details>

<details>
<summary>After: `javac -l EmptyLoop`</summary>

```
Warning: bad combination of options: -l without -c - line number and local variable tables will not be printed
Compiled from "EmptyLoop.java"
public class EmptyLoop {
  public EmptyLoop();

  public void emptyLoop();
}
```

</details>

Stems from discussion in: https://github.com/openjdk/jdk/pull/22359

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345145](https://bugs.openjdk.org/browse/JDK-8345145): Display javap LineNumberTable and LocalVariableTable iff disassembled code output with `-c` or `-v` (**Enhancement** - P5)


### Reviewers
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22434/head:pull/22434` \
`$ git checkout pull/22434`

Update a local copy of the PR: \
`$ git checkout pull/22434` \
`$ git pull https://git.openjdk.org/jdk.git pull/22434/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22434`

View PR using the GUI difftool: \
`$ git pr show -t 22434`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22434.diff">https://git.openjdk.org/jdk/pull/22434.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22434#issuecomment-2505913596)
</details>
