### PR TITLE
8345159: RISCV: Fix -Wzero-as-null-pointer-constant warning in emit_static_call_stub

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -785,7 +785,7 @@ void MacroAssembler::emit_static_call_stub() {
 
   // Jump to the entry point of the c2i stub.
   int32_t offset = 0;
-  movptr(t1, 0, offset, t0); // lui + lui + slli + add
+  movptr2(t1, 0, offset, t0); // lui + lui + slli + add
   jr(t1, offset);
 }
 


### PR DESCRIPTION
Please review this change to RISCV code to remove a
-Wzero-as-null-pointer-constant warning in MacroAssembler::emit_static_call_stub.

It was calling MacroAssembler::movptr with the second (address) argument being
a literal 0. Rather than changing it to use nullptr for that argument, I've
instead changed it to call the movptr2 helper function, which takes the target
address as a unint64_t. This eliminates the conversion of 0 to a pointer and
then back to an integer 0. It seemed to me more natural to use that helper
directly, as it was presumed that was what ended up being called anyway. But
the riscv porters should weigh in on whether that's a good approach to dealing
with this case.

Testing: GHA sanity tests, which includes building for linux-riscv64.  I don't
have the capability to run tests for this platform, so hoping someone from the
riscv porters can do more testing.

/label add hotspot-compiler
/label add porters

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345159](https://bugs.openjdk.org/browse/JDK-8345159): RISCV: Fix -Wzero-as-null-pointer-constant warning in emit_static_call_stub (**Enhancement** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22435/head:pull/22435` \
`$ git checkout pull/22435`

Update a local copy of the PR: \
`$ git checkout pull/22435` \
`$ git pull https://git.openjdk.org/jdk.git pull/22435/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22435`

View PR using the GUI difftool: \
`$ git pr show -t 22435`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22435.diff">https://git.openjdk.org/jdk/pull/22435.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22435#issuecomment-2505973811)
</details>
