### PR TITLE
8345175: Further cleanup in java.logging and jdk.internal.logger after JEP 486 integration

### DIFF
--- a/src/java.base/share/classes/jdk/internal/logger/LoggerFinderLoader.java
+++ b/src/java.base/share/classes/jdk/internal/logger/LoggerFinderLoader.java
@@ -148,8 +148,6 @@ public final class LoggerFinderLoader {
     private static System.LoggerFinder loadLoggerFinder() {
         System.LoggerFinder result;
         try {
-            // Iterator iterates with the access control context stored
-            // at ServiceLoader creation time.
             final Iterator<System.LoggerFinder> iterator =
                     findLoggerFinderProviders();
             if (iterator.hasNext()) {
@@ -197,8 +195,6 @@ public final class LoggerFinderLoader {
 
         DefaultLoggerFinder result = null;
         try {
-            // Iterator iterates with the access control context stored
-            // at ServiceLoader creation time.
             if (iterator.hasNext()) {
                 result = iterator.next();
             }

--- a/src/java.logging/share/classes/java/util/logging/LogManager.java
+++ b/src/java.logging/share/classes/java/util/logging/LogManager.java
@@ -164,7 +164,7 @@ public class LogManager {
     // LoggerContext for system loggers and user loggers
     private final LoggerContext systemContext = new SystemLoggerContext();
     private final LoggerContext userContext = new LoggerContext();
-    // non final field - make it volatile to make sure that other threads
+    // non-final field - make it volatile to make sure that other threads
     // will see the new value once ensureLogManagerInitialized() has finished
     // executing.
     private volatile Logger rootLogger;
@@ -312,7 +312,6 @@ public class LogManager {
      */
     private boolean initializedCalled = false;
     private volatile boolean initializationDone = false;
-    @SuppressWarnings("removal")
     final void ensureLogManagerInitialized() {
         final LogManager owner = this;
         if (initializationDone || owner != manager) {
@@ -422,15 +421,11 @@ public class LogManager {
         }
     }
 
-    // LoggerContext maps from AppContext
-    private WeakHashMap<Object, LoggerContext> contextsMap = null;
-
     // Returns the LoggerContext for the user code (i.e. application or AppContext).
     // Loggers are isolated from each AppContext.
     private LoggerContext getUserContext() {
-        LoggerContext context = null;
-        // for standalone app, return userContext
-        return context != null ? context : userContext;
+        // return userContext
+        return userContext;
     }
 
     // The system context.
@@ -447,7 +442,7 @@ public class LogManager {
 
     // Find or create a specified logger instance. If a logger has
     // already been created with the given name it is returned.
-    // Otherwise a new logger instance is created and registered
+    // Otherwise, a new logger instance is created and registered
     // in the LogManager global namespace.
     // This method will always return a non-null Logger object.
     // Synchronization is not required here. All synchronization for


### PR DESCRIPTION
A few minor things were missed by JDK-8344235. Some unused variables can be removed, some @SuppressWranings are now redundant and some comments ,mentioning the access control context can be deleted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345175](https://bugs.openjdk.org/browse/JDK-8345175): Further cleanup in java.logging and jdk.internal.logger after JEP 486 integration (**Bug** - P4)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Sean Coffey](https://openjdk.org/census#coffeys) (@coffeys - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22436/head:pull/22436` \
`$ git checkout pull/22436`

Update a local copy of the PR: \
`$ git checkout pull/22436` \
`$ git pull https://git.openjdk.org/jdk.git pull/22436/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22436`

View PR using the GUI difftool: \
`$ git pr show -t 22436`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22436.diff">https://git.openjdk.org/jdk/pull/22436.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22436#issuecomment-2505998194)
</details>
