### PR TITLE
8345177: RISC-V: Add gtests for cmpxchg

### DIFF
--- a/test/hotspot/gtest/riscv/test_assembler_riscv.cpp
+++ b/test/hotspot/gtest/riscv/test_assembler_riscv.cpp
@@ -47,8 +47,7 @@ class CmovTester {
       _masm.mv(c_rarg0, c_rarg2);
       _masm.ret();
     }
-    _masm.flush();
-    OrderAccess::cross_modify_fence();
+    _masm.flush(); // icache invalidate
     int64_t ret = ((zicond_func)entry)(a0, a1, a2, a3);
     ASSERT_EQ(ret, result);
     BufferBlob::free(bb);
@@ -149,8 +148,7 @@ class CmpxchgTester {
       }
       _masm.ret();
     }
-    _masm.flush();
-    OrderAccess::cross_modify_fence();
+    _masm.flush(); // icache invalidate
     TESTSIZE ret = ((cmpxchg_func)entry)(addr, expected, new_value, result);
     BufferBlob::free(bb);
     return ret;

--- a/test/hotspot/gtest/riscv/test_assembler_riscv.cpp
+++ b/test/hotspot/gtest/riscv/test_assembler_riscv.cpp
@@ -106,4 +106,160 @@ TEST_VM(RiscV, cmov) {
   }
 }
 
+template <typename TESTSIZE, Assembler::operand_size ASMSIZE>
+class CmpxchgTester {
+ public:
+  typedef TESTSIZE (*cmpxchg_func)(intptr_t addr, TESTSIZE expected, TESTSIZE new_value, TESTSIZE result);
+  
+  static TESTSIZE base_cmpxchg(int variant, intptr_t addr, TESTSIZE expected, TESTSIZE new_value, TESTSIZE result, bool boolean_result = false) {
+    BufferBlob* bb = BufferBlob::create("riscvTest", 128);
+    CodeBuffer code(bb);
+    MacroAssembler _masm(&code);
+    address entry = _masm.pc();
+    {
+      switch(variant) {
+        default:
+          _masm.cmpxchg(/*addr*/ c_rarg0, /*expected*/ c_rarg1, /*new_value*/c_rarg2,
+                        ASMSIZE, Assembler::relaxed, Assembler::relaxed,
+                        /*result*/ c_rarg3, boolean_result);
+          _masm.mv(c_rarg0, c_rarg3);
+          break;
+        case 1:
+          // expected == result
+          _masm.cmpxchg(/*addr*/ c_rarg0, /*expected*/ c_rarg1, /*new_value*/c_rarg2,
+                        ASMSIZE, Assembler::relaxed, Assembler::relaxed,
+                        /*result*/ c_rarg1, boolean_result);
+          _masm.mv(c_rarg0, c_rarg1);
+          break;
+        case 2:
+          // new_value == result
+          _masm.cmpxchg(/*addr*/ c_rarg0, /*expected*/ c_rarg1, /*new_value*/c_rarg2,
+                        ASMSIZE, Assembler::relaxed, Assembler::relaxed,
+                        /*result*/ c_rarg2, boolean_result);
+          _masm.mv(c_rarg0, c_rarg2);
+          break;
+        case 3:
+          // expected == new_value
+          _masm.cmpxchg(/*addr*/ c_rarg0, /*expected*/ c_rarg1, /*new_value*/ c_rarg1,
+                        ASMSIZE, Assembler::relaxed, Assembler::relaxed,
+                        /*result*/ c_rarg2, boolean_result);
+          _masm.mv(c_rarg0, c_rarg2);
+          break;
+
+      }
+      _masm.ret();
+    }
+    _masm.flush();
+    OrderAccess::cross_modify_fence();
+    TESTSIZE ret = ((cmpxchg_func)entry)(addr, expected, new_value, result);
+    BufferBlob::free(bb);
+    return ret;
+  }
+};
+
+template <typename TESTSIZE, Assembler::operand_size ASMSIZE>
+void plain_cmpxchg_test(int variant, TESTSIZE dv, TESTSIZE ex, TESTSIZE nv, TESTSIZE eret, TESTSIZE edata, bool bv) {
+  TESTSIZE data = dv;
+  TESTSIZE ret = CmpxchgTester<TESTSIZE, ASMSIZE>::base_cmpxchg(variant, (intptr_t)&data, ex, nv, /* dummy */ 67, bv);
+  ASSERT_EQ(ret,  eret);
+  ASSERT_EQ(data, edata);
+}
+
+template <typename TESTSIZE, Assembler::operand_size ASMSIZE>
+void run_plain_cmpxchg_tests() {
+  // Normal
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   0 /* variant */ , 1337 /* start value*/,
+                                        1337 /* expected */,   42 /* new value */,
+                                        1337 /* return */    , 42 /* end value*/, false /* boolean ret*/);
+
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   0 /* variant */ , 1337 /* start value*/,
+                                        1336 /* expected */,   42 /* new value */,
+                                        1337 /* return */  , 1337 /* end value*/, false /* boolean ret*/);
+  
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   0 /* variant */ , 1337 /* start value*/,
+                                        1337 /* expected */,   42 /* new value */,
+                                           1 /* return */    , 42 /* end value*/, true /* boolean ret*/);
+
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   0 /* variant */ , 1337 /* start value*/,
+                                        1336 /* expected */,   42 /* new value */,
+                                           0 /* return */  , 1337 /* end value*/, true /* boolean ret*/);
+  
+  // result == expected register
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   1 /* variant */ , 1337 /* start value*/,
+                                        1337 /* expected */,   42 /* new value */,
+                                        1337 /* return */    , 42 /* end value*/, false /* boolean ret*/);
+
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   1 /* variant */ , 1337 /* start value*/,
+                                        1336 /* expected */,   42 /* new value */,
+                                        1337 /* return */  , 1337 /* end value*/, false /* boolean ret*/);
+  
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   1 /* variant */ , 1337 /* start value*/,
+                                        1337 /* expected */,   42 /* new value */,
+                                           1 /* return */    , 42 /* end value*/, true /* boolean ret*/);
+
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   1 /* variant */ , 1337 /* start value*/,
+                                        1336 /* expected */,   42 /* new value */,
+                                           0 /* return */  , 1337 /* end value*/, true /* boolean ret*/);
+  
+  // new_value == result register
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   2 /* variant */ , 1337 /* start value*/,
+                                        1337 /* expected */,   42 /* new value */,
+                                        1337 /* return */    , 42 /* end value*/, false /* boolean ret*/);
+
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   2 /* variant */ , 1337 /* start value*/,
+                                        1336 /* expected */,   42 /* new value */,
+                                        1337 /* return */  , 1337 /* end value*/, false /* boolean ret*/);
+  
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   2 /* variant */ , 1337 /* start value*/,
+                                        1337 /* expected */,   42 /* new value */,
+                                           1 /* return */    , 42 /* end value*/, true /* boolean ret*/);
+
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   2 /* variant */ , 1337 /* start value*/,
+                                        1336 /* expected */,   42 /* new value */,
+                                           0 /* return */  , 1337 /* end value*/, true /* boolean ret*/);
+  
+  // expected == new_value register
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   3 /* variant */ , 1337 /* start value*/,
+                                        1337 /* expected */,   42 /* new value */,
+                                        1337 /* return */  , 1337 /* end value*/, false /* boolean ret*/);
+
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   3 /* variant */ , 1337 /* start value*/,
+                                        1336 /* expected */,   42 /* new value */,
+                                        1337 /* return */  , 1337 /* end value*/, false /* boolean ret*/);
+  
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   3 /* variant */ , 1337 /* start value*/,
+                                        1337 /* expected */,   42 /* new value */,
+                                           1 /* return */  , 1337 /* end value*/, true /* boolean ret*/);
+
+  plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   3 /* variant */ , 1337 /* start value*/,
+                                        1336 /* expected */,   42 /* new value */,
+                                           0 /* return */  , 1337 /* end value*/, true /* boolean ret*/);
+}
+
+TEST_VM(RiscV, cmpxchg_int64_plain_lr_sc) {
+  bool zacas = UseZacas;
+  UseZacas = false;
+  run_plain_cmpxchg_tests<int64_t, Assembler::int64>();
+  UseZacas = zacas;
+}
+
+TEST_VM(RiscV, cmpxchg_int64_plain_maybe_zacas) {
+  if (UseZacas) {
+    run_plain_cmpxchg_tests<int64_t, Assembler::int64>();
+  }
+}
+
+TEST_VM(RiscV, cmpxchg_int32_plain_lr_sc) {
+  bool zacas = UseZacas;
+  UseZacas = false;
+  run_plain_cmpxchg_tests<int32_t, Assembler::int32>();
+  UseZacas = zacas;
+}
+
+TEST_VM(RiscV, cmpxchg_int32_plain_maybe_zacas) {
+  if (UseZacas) {
+    run_plain_cmpxchg_tests<int32_t, Assembler::int32>();
+  }
+}
+
 #endif  // RISCV

--- a/test/hotspot/gtest/riscv/test_assembler_riscv.cpp
+++ b/test/hotspot/gtest/riscv/test_assembler_riscv.cpp
@@ -110,7 +110,7 @@ template <typename TESTSIZE, Assembler::operand_size ASMSIZE>
 class CmpxchgTester {
  public:
   typedef TESTSIZE (*cmpxchg_func)(intptr_t addr, TESTSIZE expected, TESTSIZE new_value, TESTSIZE result);
-  
+
   static TESTSIZE base_cmpxchg(int variant, intptr_t addr, TESTSIZE expected, TESTSIZE new_value, TESTSIZE result, bool boolean_result = false) {
     BufferBlob* bb = BufferBlob::create("riscvTest", 128);
     CodeBuffer code(bb);
@@ -175,7 +175,7 @@ void run_plain_cmpxchg_tests() {
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   0 /* variant */ , 1337 /* start value*/,
                                         1336 /* expected */,   42 /* new value */,
                                         1337 /* return */  , 1337 /* end value*/, false /* boolean ret*/);
-  
+
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   0 /* variant */ , 1337 /* start value*/,
                                         1337 /* expected */,   42 /* new value */,
                                            1 /* return */    , 42 /* end value*/, true /* boolean ret*/);
@@ -183,7 +183,7 @@ void run_plain_cmpxchg_tests() {
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   0 /* variant */ , 1337 /* start value*/,
                                         1336 /* expected */,   42 /* new value */,
                                            0 /* return */  , 1337 /* end value*/, true /* boolean ret*/);
-  
+
   // result == expected register
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   1 /* variant */ , 1337 /* start value*/,
                                         1337 /* expected */,   42 /* new value */,
@@ -192,7 +192,7 @@ void run_plain_cmpxchg_tests() {
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   1 /* variant */ , 1337 /* start value*/,
                                         1336 /* expected */,   42 /* new value */,
                                         1337 /* return */  , 1337 /* end value*/, false /* boolean ret*/);
-  
+
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   1 /* variant */ , 1337 /* start value*/,
                                         1337 /* expected */,   42 /* new value */,
                                            1 /* return */    , 42 /* end value*/, true /* boolean ret*/);
@@ -200,7 +200,7 @@ void run_plain_cmpxchg_tests() {
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   1 /* variant */ , 1337 /* start value*/,
                                         1336 /* expected */,   42 /* new value */,
                                            0 /* return */  , 1337 /* end value*/, true /* boolean ret*/);
-  
+
   // new_value == result register
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   2 /* variant */ , 1337 /* start value*/,
                                         1337 /* expected */,   42 /* new value */,
@@ -209,7 +209,7 @@ void run_plain_cmpxchg_tests() {
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   2 /* variant */ , 1337 /* start value*/,
                                         1336 /* expected */,   42 /* new value */,
                                         1337 /* return */  , 1337 /* end value*/, false /* boolean ret*/);
-  
+
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   2 /* variant */ , 1337 /* start value*/,
                                         1337 /* expected */,   42 /* new value */,
                                            1 /* return */    , 42 /* end value*/, true /* boolean ret*/);
@@ -217,7 +217,7 @@ void run_plain_cmpxchg_tests() {
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   2 /* variant */ , 1337 /* start value*/,
                                         1336 /* expected */,   42 /* new value */,
                                            0 /* return */  , 1337 /* end value*/, true /* boolean ret*/);
-  
+
   // expected == new_value register
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   3 /* variant */ , 1337 /* start value*/,
                                         1337 /* expected */,   42 /* new value */,
@@ -226,7 +226,7 @@ void run_plain_cmpxchg_tests() {
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   3 /* variant */ , 1337 /* start value*/,
                                         1336 /* expected */,   42 /* new value */,
                                         1337 /* return */  , 1337 /* end value*/, false /* boolean ret*/);
-  
+
   plain_cmpxchg_test<TESTSIZE, ASMSIZE>(   3 /* variant */ , 1337 /* start value*/,
                                         1337 /* expected */,   42 /* new value */,
                                            1 /* return */  , 1337 /* end value*/, true /* boolean ret*/);


### PR DESCRIPTION
Hi, please consider.

This adds tests to some of the base cases.
Focusing on the cases when we pass in same register in some of the argument. (variant 0,1,2,3)
```
Note: Google Test filter = *RiscV.cmpxchg*
[==========] Running 4 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 4 tests from RiscV
[ RUN      ] RiscV.cmpxchg_int64_plain_lr_sc_vm
[       OK ] RiscV.cmpxchg_int64_plain_lr_sc_vm (2 ms)
[ RUN      ] RiscV.cmpxchg_int64_plain_maybe_zacas_vm
[       OK ] RiscV.cmpxchg_int64_plain_maybe_zacas_vm (0 ms)
[ RUN      ] RiscV.cmpxchg_int32_plain_lr_sc_vm
[       OK ] RiscV.cmpxchg_int32_plain_lr_sc_vm (0 ms)
[ RUN      ] RiscV.cmpxchg_int32_plain_maybe_zacas_vm
[       OK ] RiscV.cmpxchg_int32_plain_maybe_zacas_vm (0 ms)
[----------] 4 tests from RiscV (20806 ms total)

[----------] Global test environment tear-down
[==========] 4 tests from 1 test suite ran. (20809 ms total)
[  PASSED  ] 4 tests.
```

Executed with `-XX:+UnlockExperimentalVMOptions -XX:+UseZacas`

Thanks, Robbin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345177](https://bugs.openjdk.org/browse/JDK-8345177): RISC-V: Add gtests for cmpxchg (**Sub-task** - P4)


### Reviewers
 * [Fei Yang](https://openjdk.org/census#fyang) (@RealFYang - **Reviewer**)
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22437/head:pull/22437` \
`$ git checkout pull/22437`

Update a local copy of the PR: \
`$ git checkout pull/22437` \
`$ git pull https://git.openjdk.org/jdk.git pull/22437/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22437`

View PR using the GUI difftool: \
`$ git pr show -t 22437`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22437.diff">https://git.openjdk.org/jdk/pull/22437.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22437#issuecomment-2506200919)
</details>
