### PR TITLE
8345217: Parallel: Refactor PSParallelCompact::next_src_region

### DIFF
--- a/src/hotspot/share/gc/parallel/psParallelCompact.cpp
+++ b/src/hotspot/share/gc/parallel/psParallelCompact.cpp
@@ -2137,13 +2137,9 @@ size_t PSParallelCompact::next_src_region(MoveAndUpdateClosure& closure,
   }
 
   if (src_region_ptr < top_region_ptr) {
-    // The next source region is in the current space.  Update src_region_idx
-    // and the source address to match src_region_ptr.
+    // Found the first non-empty region in the same space.
     src_region_idx = sd.region(src_region_ptr);
-    HeapWord* const src_region_addr = sd.region_to_addr(src_region_idx);
-    if (src_region_addr > closure.source()) {
-      closure.set_source(src_region_addr);
-    }
+    closure.set_source(sd.region_to_addr(src_region_idx));
     return src_region_idx;
   }
 
@@ -2167,13 +2163,10 @@ size_t PSParallelCompact::next_src_region(MoveAndUpdateClosure& closure,
       RegionData* cur = sd.region(cur_region);
       if (cur->live_obj_size() > 0) {
         HeapWord* region_start_addr = sd.region_to_addr(cur_region);
-        HeapWord* region_end_addr = region_start_addr + ParallelCompactData::RegionSize;
-        HeapWord* first_live_word = mark_bitmap()->find_obj_beg(region_start_addr, region_end_addr);
-        assert(first_live_word < region_end_addr, "inv");
 
         src_space_id = SpaceId(space_id);
         src_space_top = top;
-        closure.set_source(first_live_word);
+        closure.set_source(region_start_addr);
         return cur_region;
       }
     }


### PR DESCRIPTION
Simple removing some unnecessary calculations in locating the next source-region during full-gc.

Test: tier1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345217](https://bugs.openjdk.org/browse/JDK-8345217): Parallel: Refactor PSParallelCompact::next_src_region (**Enhancement** - P4)


### Reviewers
 * [Thomas Schatzl](https://openjdk.org/census#tschatzl) (@tschatzl - **Reviewer**)
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.org/census#zgu) (@zhengyu123 - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22441/head:pull/22441` \
`$ git checkout pull/22441`

Update a local copy of the PR: \
`$ git checkout pull/22441` \
`$ git pull https://git.openjdk.org/jdk.git pull/22441/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22441`

View PR using the GUI difftool: \
`$ git pr show -t 22441`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22441.diff">https://git.openjdk.org/jdk/pull/22441.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22441#issuecomment-2506367549)
</details>
