### PR TITLE
8343747: C2: TestReplicateAtConv.java crashes with -XX:MaxVectorSize=8

### DIFF
--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -1466,6 +1466,9 @@ bool VectorCastNode::implemented(int opc, uint vlen, BasicType src_type, BasicTy
   if (is_java_primitive(dst_type) &&
       is_java_primitive(src_type) &&
       (vlen > 1) && is_power_of_2(vlen) &&
+      // In rare case, the input to the VectorCast could be a Replicate node. We need to make sure creating is supported:
+      // check the src_type:
+      VectorNode::vector_size_supported_auto_vectorization(src_type, vlen) &&
       VectorNode::vector_size_supported_auto_vectorization(dst_type, vlen)) {
     int vopc = VectorCastNode::opcode(opc, src_type);
     return vopc > 0 && Matcher::match_rule_supported_auto_vectorization(vopc, vlen, dst_type);

--- a/test/hotspot/jtreg/compiler/vectorization/TestReplicateAtConv.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReplicateAtConv.java
@@ -26,6 +26,7 @@
  * @bug 8341834
  * @summary C2 compilation fails with "bad AD file" due to Replicate
  * @run main/othervm -XX:CompileCommand=compileonly,TestReplicateAtConv::test -Xcomp TestReplicateAtConv
+ * @run main/othervm -XX:CompileCommand=compileonly,TestReplicateAtConv::test -Xcomp -XX:MaxVectorSize=8 TestReplicateAtConv
  */
 
 public class TestReplicateAtConv {

--- a/test/hotspot/jtreg/compiler/vectorization/TestReplicateAtConv.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReplicateAtConv.java
@@ -23,8 +23,8 @@
 
 /**
  * @test
- * @bug 8341834
- * @summary C2 compilation fails with "bad AD file" due to Replicate
+ * @bug 8341834 8343747
+ * @summary Replicate node at a VectorCast (ConvL2I) causes superword to fail
  * @run main/othervm -XX:CompileCommand=compileonly,TestReplicateAtConv::test -Xcomp TestReplicateAtConv
  * @run main/othervm -XX:CompileCommand=compileonly,TestReplicateAtConv::test -Xcomp -XX:MaxVectorSize=8 TestReplicateAtConv
  */


### PR DESCRIPTION
Crash occurs when attempting to create a `Replicate` node that's input
to a `VectorCast` node (for a `ConvL2I`) that's not supported by the
platform (when run with `MaxVectorSize=8`). I think the pack for the
`VectorCast` should be filtered out earlier as not implemented and I
propose adding a test to `VectorCastNode::implemented()` for the type
of its input to handle that corner case.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8343747](https://bugs.openjdk.org/browse/JDK-8343747): C2: TestReplicateAtConv.java crashes with -XX:MaxVectorSize=8 (**Bug** - P3)(⚠️ The fixVersion in this issue is [24] but the fixVersion in .jcheck/conf is 25, a new backport will be created when this pr is integrated.)


### Reviewers
 * [Emanuel Peter](https://openjdk.org/census#epeter) (@eme64 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22442/head:pull/22442` \
`$ git checkout pull/22442`

Update a local copy of the PR: \
`$ git checkout pull/22442` \
`$ git pull https://git.openjdk.org/jdk.git pull/22442/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22442`

View PR using the GUI difftool: \
`$ git pr show -t 22442`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22442.diff">https://git.openjdk.org/jdk/pull/22442.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22442#issuecomment-2506384702)
</details>
