### PR TITLE
8345218: Clean out references to windows-x86 in jib profiles

### DIFF
--- a/make/conf/jib-profiles.js
+++ b/make/conf/jib-profiles.js
@@ -241,7 +241,7 @@ var getJibProfilesCommon = function (input, data) {
     // List of the main profile names used for iteration
     common.main_profile_names = [
         "linux-x64", "linux-x86", "macosx-x64", "macosx-aarch64",
-        "windows-x64", "windows-x86", "windows-aarch64",
+        "windows-x64", "windows-aarch64",
         "linux-aarch64", "linux-arm32", "linux-ppc64le", "linux-s390x",
         "linux-riscv64"
     ];
@@ -463,15 +463,6 @@ var getJibProfilesProfiles = function (input, common, data) {
             target_cpu: "x64",
             dependencies: ["devkit", "gtest", "pandoc"],
             configure_args: concat(common.configure_args_64bit),
-        },
-
-        "windows-x86": {
-            target_os: "windows",
-            target_cpu: "x86",
-            build_cpu: "x64",
-            dependencies: ["devkit", "gtest"],
-            configure_args: concat(common.configure_args_32bit,
-                "--enable-deprecated-ports"),
         },
 
         "windows-aarch64": {
@@ -714,10 +705,6 @@ var getJibProfilesProfiles = function (input, common, data) {
         },
         "windows-x64": {
             platform: "windows-x64",
-            jdk_suffix: "zip",
-        },
-        "windows-x86": {
-            platform: "windows-x86",
             jdk_suffix: "zip",
         },
         "windows-aarch64": {


### PR DESCRIPTION
I forgot to remove the references to windows-x86 in the JIB profiles in [JDK-8339783](https://bugs.openjdk.org/browse/JDK-8339783).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345218](https://bugs.openjdk.org/browse/JDK-8345218): Clean out references to windows-x86 in jib profiles (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22443/head:pull/22443` \
`$ git checkout pull/22443`

Update a local copy of the PR: \
`$ git checkout pull/22443` \
`$ git pull https://git.openjdk.org/jdk.git pull/22443/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22443`

View PR using the GUI difftool: \
`$ git pr show -t 22443`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22443.diff">https://git.openjdk.org/jdk/pull/22443.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22443#issuecomment-2506397606)
</details>
