### PR TITLE
8345223: Remove doPrivileged in java.base/unix/classes/sun/net and java.base/macosx/classes/java/net classes after JEP 486 integration

### DIFF
--- a/src/java.base/macosx/classes/java/net/DefaultInterface.java
+++ b/src/java.base/macosx/classes/java/net/DefaultInterface.java
@@ -25,8 +25,6 @@
 
 package java.net;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Enumeration;
 import java.io.IOException;
 
@@ -105,9 +103,7 @@ class DefaultInterface {
                     continue;
 
                 boolean ip4 = false, ip6 = false, isNonLinkLocal = false;
-                PrivilegedAction<Enumeration<InetAddress>> pa = ni::getInetAddresses;
-                @SuppressWarnings("removal")
-                Enumeration<InetAddress> addrs = AccessController.doPrivileged(pa);
+                Enumeration<InetAddress> addrs = ni.getInetAddresses();
                 while (addrs.hasMoreElements()) {
                     InetAddress addr = addrs.nextElement();
                     if (!addr.isAnyLocalAddress()) {

--- a/src/java.base/unix/classes/sun/net/dns/ResolverConfigurationImpl.java
+++ b/src/java.base/unix/classes/sun/net/dns/ResolverConfigurationImpl.java
@@ -117,7 +117,6 @@ public final class ResolverConfigurationImpl
 
     // Load DNS configuration from OS
 
-    @SuppressWarnings("removal")
     private void loadConfig() {
         assert Thread.holdsLock(lock);
 
@@ -130,15 +129,9 @@ public final class ResolverConfigurationImpl
         }
 
         // get the name servers from /etc/resolv.conf
-        nameservers =
-            java.security.AccessController.doPrivileged(
-                new java.security.PrivilegedAction<>() {
-                    public ArrayList<String> run() {
-                        // typically MAXNS is 3 but we've picked 5 here
-                        // to allow for additional servers if required.
-                        return resolvconf("nameserver", 1, 5);
-                    } /* run */
-                });
+        // typically MAXNS is 3 but we've picked 5 here
+        // to allow for additional servers if required.
+        nameservers = resolvconf("nameserver", 1, 5);
 
         // get the search list (or domain)
         searchlist = getSearchList();
@@ -149,54 +142,19 @@ public final class ResolverConfigurationImpl
 
 
     // obtain search list or local domain
-
-    @SuppressWarnings("removal")
     private ArrayList<String> getSearchList() {
-
-        ArrayList<String> sl;
 
         // first try the search keyword in /etc/resolv.conf
 
-        sl = java.security.AccessController.doPrivileged(
-                 new java.security.PrivilegedAction<>() {
-                    public ArrayList<String> run() {
-                        ArrayList<String> ll;
-
-                        // first try search keyword (max 6 domains)
-                        ll = resolvconf("search", 6, 1);
-                        if (ll.size() > 0) {
-                            return ll;
-                        }
-
-                        return null;
-
-                    } /* run */
-
-                });
-        if (sl != null) {
-            return sl;
-        }
+        // first try search keyword (max 6 domains)
+        ArrayList<String> sl = resolvconf("search", 6, 1);
+        if (sl.size() > 0) return sl;
 
         // No search keyword so use local domain
 
         // try domain keyword in /etc/resolv.conf
-
-        sl = java.security.AccessController.doPrivileged(
-                 new java.security.PrivilegedAction<>() {
-                    public ArrayList<String> run() {
-                        ArrayList<String> ll;
-
-                        ll = resolvconf("domain", 1, 1);
-                        if (ll.size() > 0) {
-                            return ll;
-                        }
-                        return null;
-
-                    } /* run */
-                });
-        if (sl != null) {
-            return sl;
-        }
+        sl = resolvconf("domain", 1, 1);
+        if (sl.size() > 0) return sl;
 
         // no local domain so try fallback (RPC) domain or
         // hostName

--- a/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
+++ b/src/java.base/unix/classes/sun/net/www/protocol/http/ntlm/NTLMAuthentication.java
@@ -72,13 +72,14 @@ import sun.security.action.GetPropertyAction;
 public final class NTLMAuthentication extends AuthenticationInfo {
 
     private static final NTLMAuthenticationCallback NTLMAuthCallback =
-        NTLMAuthenticationCallback.getNTLMAuthenticationCallback();
+            NTLMAuthenticationCallback.getNTLMAuthenticationCallback();
 
     private String hostname;
     /* Domain to use if not specified by user */
     private static final String defaultDomain;
     /* Whether cache is enabled for NTLM */
     private static final boolean ntlmCache;
+
     static {
         Properties props = GetPropertyAction.privilegedGetProperties();
         defaultDomain = props.getProperty("http.auth.ntlm.domain", "");
@@ -86,7 +87,7 @@ public final class NTLMAuthentication extends AuthenticationInfo {
         ntlmCache = Boolean.parseBoolean(ntlmCacheProp);
     }
 
-    public static boolean supportsTransparentAuth () {
+    public static boolean supportsTransparentAuth() {
         return false;
     }
 
@@ -100,23 +101,6 @@ public final class NTLMAuthentication extends AuthenticationInfo {
             return NTLMAuthCallback.isTrustedSite(url);
         return false;
     }
-
-    @SuppressWarnings("removal")
-    private void init0() {
-
-        hostname = java.security.AccessController.doPrivileged(
-            new java.security.PrivilegedAction<>() {
-            public String run() {
-                String localhost;
-                try {
-                    localhost = InetAddress.getLocalHost().getHostName();
-                } catch (UnknownHostException e) {
-                     localhost = "localhost";
-                }
-                return localhost;
-            }
-        });
-    };
 
     PasswordAuthentication pw;
 
@@ -150,7 +134,11 @@ public final class NTLMAuthentication extends AuthenticationInfo {
             username = s.substring (i+1);
         }
         password = pw.getPassword();
-        init0();
+        try {
+            hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            hostname = "localhost";
+        }
         try {
             String version = GetPropertyAction.privilegedGetProperty("ntlm.version");
             client = new Client(version, hostname, username, ntdomain, password);


### PR DESCRIPTION
Some doPrivileged were missed in some net classes when working on previous cleanups.
