### PR TITLE
AARCH64: VM crashes with -NearCpool +UseShenandoahGC options

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.hpp
@@ -1420,7 +1420,7 @@ public:
       ldr(dest, const_addr);
     } else {
       uint64_t offset;
-      adrp(dest, InternalAddress(const_addr.target()), offset);
+      adrp(dest, const_addr, offset);
       ldr(dest, Address(dest, offset));
     }
   }

--- a/src/hotspot/cpu/aarch64/relocInfo_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/relocInfo_aarch64.cpp
@@ -42,7 +42,7 @@ void Relocation::pd_set_data_value(address x, bool verify_only) {
   case relocInfo::oop_type:
     {
       oop_Relocation *reloc = (oop_Relocation *)this;
-      if (NativeInstruction::is_ldr_literal_at(addr())) {
+      if (NativeInstruction::is_ldr_literal_at(addr()) || NativeInstruction::is_adrp_at(addr())) {
         address constptr = (address)code()->oop_addr_at(reloc->oop_index());
         bytes = MacroAssembler::pd_patch_instruction_size(addr(), constptr);
         assert(*(address*)constptr == x, "error in oop relocation");


### PR DESCRIPTION
Here is the fix for the problem:

- MacroAssembler::adrp should use oop_Relocation from movoop (call stack: MacroAssembler::movoop -> MacroAssembler::ldr_constant -> MacroAssembler::adrp -> code_section::relocate).
- Relocation::pd_set_data_value should account for the adrp+ldr sequence.

I have the following questions:

- Is the NearCpool JVM option truly necessary? How is it used?
- Although NearCpool is described as being related to the constant pool, it appears to be applied in loading nmethod.oops() rather than directly in constant pool loading.

Note. The same issue is reproduced on riscv platform.

A related change: https://github.com/openjdk/jdk/pull/21276

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22448/head:pull/22448` \
`$ git checkout pull/22448`

Update a local copy of the PR: \
`$ git checkout pull/22448` \
`$ git pull https://git.openjdk.org/jdk.git pull/22448/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22448`

View PR using the GUI difftool: \
`$ git pr show -t 22448`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22448.diff">https://git.openjdk.org/jdk/pull/22448.diff</a>

</details>
