### PR TITLE
8345234: Build system erroneously treats 32-bit x86 Zero as deprecated

### DIFF
--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -666,7 +666,10 @@ AC_DEFUN([PLATFORM_CHECK_DEPRECATION],
 [
   AC_ARG_ENABLE(deprecated-ports, [AS_HELP_STRING([--enable-deprecated-ports@<:@=yes/no@:>@],
       [Suppress the error when configuring for a deprecated port @<:@no@:>@])])
-  if test "x$OPENJDK_TARGET_CPU" = xx86; then
+  # Unfortunately, variants have not been parsed yet, so we have to check the configure option
+  # directly. Allow only the directly specified Zero variant, treat any other mix as containing
+  # something non-Zero.
+  if test "x$OPENJDK_TARGET_CPU" = xx86 && test "x$with_jvm_variants" != xzero; then
     if test "x$enable_deprecated_ports" = "xyes"; then
       AC_MSG_WARN([The 32-bit x86 port is deprecated and may be removed in a future release.])
     else


### PR DESCRIPTION
The checks added by [JDK-8344093](https://bugs.openjdk.org/browse/JDK-8344093) are apparently too broad: configuring `--with-jvm-variants=zero` says the port is deprecated, while it is actually not. I should have checked it with [JDK-8344093](https://bugs.openjdk.org/browse/JDK-8344093), mea culpa. I now see this issue while migrating my CIs to build x86-zero instead of x86-server.

Additional tests:
 - [x] Linux x86_32 server, configure fails by default
 - [x] Linux x86_32 server, configure passes with `--enable-deprecated-ports=yes`
 - [x] Linux x86_32 zero, configure passes by default

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345234](https://bugs.openjdk.org/browse/JDK-8345234): Build system erroneously treats 32-bit x86 Zero as deprecated (**Bug** - P4)


### Reviewers
 * [Magnus Ihse Bursie](https://openjdk.org/census#ihse) (@magicus - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22450/head:pull/22450` \
`$ git checkout pull/22450`

Update a local copy of the PR: \
`$ git checkout pull/22450` \
`$ git pull https://git.openjdk.org/jdk.git pull/22450/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22450`

View PR using the GUI difftool: \
`$ git pr show -t 22450`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22450.diff">https://git.openjdk.org/jdk/pull/22450.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22450#issuecomment-2507237144)
</details>
