### PR TITLE
8345236: RISC-V: Remove revb_h_h_u and revb_h_w_u macro assembler routines

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2461,45 +2461,9 @@ void MacroAssembler::load_long_misaligned(Register dst, Address src, Register tm
   }
 }
 
-// reverse bytes in halfword in lower 16 bits and zero-extend
-// Rd[15:0] = Rs[7:0] Rs[15:8] (zero-extend to 64 bits)
-void MacroAssembler::revb_h_h_u(Register Rd, Register Rs, Register tmp) {
-  if (UseZbb) {
-    rev8(Rd, Rs);
-    srli(Rd, Rd, 48);
-    return;
-  }
-  assert_different_registers(Rs, tmp);
-  assert_different_registers(Rd, tmp);
-  srli(tmp, Rs, 8);
-  andi(tmp, tmp, 0xFF);
-  andi(Rd, Rs, 0xFF);
-  slli(Rd, Rd, 8);
-  orr(Rd, Rd, tmp);
-}
-
-// reverse bytes in halfwords in lower 32 bits and zero-extend
-// Rd[31:0] = Rs[23:16] Rs[31:24] Rs[7:0] Rs[15:8] (zero-extend to 64 bits)
-void MacroAssembler::revb_h_w_u(Register Rd, Register Rs, Register tmp1, Register tmp2) {
-  if (UseZbb) {
-    rev8(Rd, Rs);
-    rori(Rd, Rd, 32);
-    roriw(Rd, Rd, 16);
-    zero_extend(Rd, Rd, 32);
-    return;
-  }
-  assert_different_registers(Rs, tmp1, tmp2);
-  assert_different_registers(Rd, tmp1, tmp2);
-  srli(tmp2, Rs, 16);
-  revb_h_h_u(tmp2, tmp2, tmp1);
-  revb_h_h_u(Rd, Rs, tmp1);
-  slli(tmp2, tmp2, 16);
-  orr(Rd, Rd, tmp2);
-}
-
 // reverse bytes in lower word, sign-extend
 // Rd[32:0] = Rs[7:0] Rs[15:8] Rs[23:16] Rs[31:24]
-void MacroAssembler::revb_w(Register Rd, Register Rs, Register tmp1, Register tmp2) {
+void MacroAssembler::revbw(Register Rd, Register Rs, Register tmp1, Register tmp2) {
   if (UseZbb) {
     rev8(Rd, Rs);
     srai(Rd, Rd, 32);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -912,10 +912,8 @@ public:
   void andn(Register Rd, Register Rs1, Register Rs2);
   void orn(Register Rd, Register Rs1, Register Rs2);
 
-  // revb
-  void revb_h_h_u(Register Rd, Register Rs, Register tmp = t0);                         // reverse bytes in halfword in lower 16 bits, zero-extend
-  void revb_h_w_u(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2 = t1);    // reverse bytes in halfwords in lower 32 bits, zero-extend
-  void revb_w(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2= t1);         // reverse bytes in lower word, sign-extend
+  // reverse bytes
+  void revbw(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2= t1);         // reverse bytes in lower word, sign-extend
   void revb(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2 = t1);          // reverse bytes in doubleword
 
   void ror_imm(Register dst, Register src, uint32_t shift, Register tmp = t0);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -913,8 +913,8 @@ public:
   void orn(Register Rd, Register Rs1, Register Rs2);
 
   // reverse bytes
-  void revbw(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2= t1);         // reverse bytes in lower word, sign-extend
-  void revb(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2 = t1);          // reverse bytes in doubleword
+  void revbw(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2= t1);  // reverse bytes in lower word, sign-extend
+  void revb(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2 = t1);  // reverse bytes in doubleword
 
   void ror_imm(Register dst, Register src, uint32_t shift, Register tmp = t0);
   void rolw_imm(Register dst, Register src, uint32_t, Register tmp = t0);

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -658,8 +658,12 @@ void TemplateTable::aload() {
 }
 
 void TemplateTable::locals_index_wide(Register reg) {
-  __ lhu(reg, at_bcp(2));
-  __ revb_h_h_u(reg, reg); // reverse bytes in half-word and zero-extend
+  assert_different_registers(reg, t1);
+  // Convert the 16-bit value into native byte-ordering and zero-extend
+  __ lbu(reg, at_bcp(2));
+  __ lbu(t1, at_bcp(3));
+  __ slli(reg, reg, 8);
+  __ orr(reg, reg, t1);
   __ neg(reg, reg);
 }
 
@@ -671,8 +675,12 @@ void TemplateTable::wide_iload() {
 
 void TemplateTable::wide_lload() {
   transition(vtos, ltos);
-  __ lhu(x11, at_bcp(2));
-  __ revb_h_h_u(x11, x11); // reverse bytes in half-word and zero-extend
+  // Convert the 16-bit value into native byte-ordering and zero-extend
+  __ lbu(x11, at_bcp(2));
+  __ lbu(t1, at_bcp(3));
+  __ slli(x11, x11, 8);
+  __ orr(x11, x11, t1);
+
   __ slli(x11, x11, LogBytesPerWord);
   __ sub(x11, xlocals, x11);
   __ ld(x10, Address(x11, Interpreter::local_offset_in_bytes(1)));
@@ -686,8 +694,12 @@ void TemplateTable::wide_fload() {
 
 void TemplateTable::wide_dload() {
   transition(vtos, dtos);
-  __ lhu(x11, at_bcp(2));
-  __ revb_h_h_u(x11, x11); // reverse bytes in half-word and zero-extend
+  // Convert the 16-bit value into native byte-ordering and zero-extend
+  __ lbu(x11, at_bcp(2));
+  __ lbu(t1, at_bcp(3));
+  __ slli(x11, x11, 8);
+  __ orr(x11, x11, t1);
+
   __ slli(x11, x11, LogBytesPerWord);
   __ sub(x11, xlocals, x11);
   __ fld(f10, Address(x11, Interpreter::local_offset_in_bytes(1)));
@@ -1471,12 +1483,14 @@ void TemplateTable::iinc() {
 
 void TemplateTable::wide_iinc() {
   transition(vtos, vtos);
-  __ lwu(x11, at_bcp(2)); // get constant and index
-  __ revb_h_w_u(x11, x11); // reverse bytes in half-word (32bit) and zero-extend
-  __ zero_extend(x12, x11, 16);
-  __ neg(x12, x12);
-  __ slli(x11, x11, 32);
-  __ srai(x11, x11, 48);
+  // get constant
+  // Convert the 16-bit value into native byte-ordering and sign-extend
+  __ lb(x11, at_bcp(4));
+  __ lbu(t1, at_bcp(5));
+  __ slli(x11, x11, 8);
+  __ orr(x11, x11, t1);
+
+  locals_index_wide(x12);
   __ ld(x10, iaddress(x12, t0, _masm));
   __ addw(x10, x10, x11);
   __ sd(x10, iaddress(x12, t0, _masm));
@@ -1625,10 +1639,10 @@ void TemplateTable::branch(bool is_jsr, bool is_wide) {
     __ lb(x12, at_bcp(1));
     __ lbu(t1, at_bcp(2));
     __ slli(x12, x12, 8);
-    __ add(x12, x12, t1);
+    __ orr(x12, x12, t1);
   } else {
     __ lwu(x12, at_bcp(1));
-    __ revb_w(x12, x12);
+    __ revbw(x12, x12);
   }
 
   // Handle all the JSR stuff here, then exit.
@@ -1893,8 +1907,8 @@ void TemplateTable::tableswitch() {
   // load lo & hi
   __ lwu(x12, Address(x11, BytesPerInt));
   __ lwu(x13, Address(x11, 2 * BytesPerInt));
-  __ revb_w(x12, x12);
-  __ revb_w(x13, x13);
+  __ revbw(x12, x12);
+  __ revbw(x13, x13);
   // check against lo & hi
   __ blt(x10, x12, default_case);
   __ bgt(x10, x13, default_case);
@@ -1905,7 +1919,7 @@ void TemplateTable::tableswitch() {
   __ profile_switch_case(x10, x11, x12);
   // continue execution
   __ bind(continue_execution);
-  __ revb_w(x13, x13);
+  __ revbw(x13, x13);
   __ add(xbcp, xbcp, x13);
   __ load_unsigned_byte(t0, Address(xbcp));
   __ dispatch_only(vtos, /*generate_poll*/true);
@@ -1925,7 +1939,7 @@ void TemplateTable::fast_linearswitch() {
   transition(itos, vtos);
   Label loop_entry, loop, found, continue_execution;
   // bswap x10 so we can avoid bswapping the table entries
-  __ revb_w(x10, x10);
+  __ revbw(x10, x10);
   // align xbcp
   __ la(x9, at_bcp(BytesPerInt)); // btw: should be able to get rid of
                                     // this instruction (change offsets
@@ -1936,7 +1950,7 @@ void TemplateTable::fast_linearswitch() {
   // Convert the 32-bit npairs (number of pairs) into native byte-ordering
   // We can use sign-extension here because npairs must be greater than or
   // equal to 0 per JVM spec on 'lookupswitch' bytecode.
-  __ revb_w(x11, x11);
+  __ revbw(x11, x11);
   __ j(loop_entry);
   // table search
   __ bind(loop);
@@ -1957,7 +1971,7 @@ void TemplateTable::fast_linearswitch() {
   __ profile_switch_case(x11, x10, x9);
   // continue execution
   __ bind(continue_execution);
-  __ revb_w(x13, x13);
+  __ revbw(x13, x13);
   __ add(xbcp, xbcp, x13);
   __ lbu(t0, Address(xbcp, 0));
   __ dispatch_only(vtos, /*generate_poll*/true);
@@ -2012,7 +2026,7 @@ void TemplateTable::fast_binaryswitch() {
   // Convert the 32-bit npairs (number of pairs) into native byte-ordering
   // We can use sign-extension here because npairs must be greater than or
   // equal to 0 per JVM spec on 'lookupswitch' bytecode.
-  __ revb_w(j, j);
+  __ revbw(j, j);
 
   // And start
   Label entry;
@@ -2030,7 +2044,7 @@ void TemplateTable::fast_binaryswitch() {
     // Convert array[h].match to native byte-ordering before compare
     __ shadd(temp, h, array, temp, 3);
     __ lwu(temp, Address(temp, 0));
-    __ revb_w(temp, temp);
+    __ revbw(temp, temp);
 
     Label L_done, L_greater;
     __ bge(key, temp, L_greater);
@@ -2053,14 +2067,14 @@ void TemplateTable::fast_binaryswitch() {
   // Convert array[i].match to native byte-ordering before compare
   __ shadd(temp, i, array, temp, 3);
   __ lwu(temp, Address(temp, 0));
-  __ revb_w(temp, temp);
+  __ revbw(temp, temp);
   __ bne(key, temp, default_case);
 
   // entry found -> j = offset
   __ shadd(temp, i, array, temp, 3);
   __ lwu(j, Address(temp, BytesPerInt));
   __ profile_switch_case(i, key, array);
-  __ revb_w(j, j);
+  __ revbw(j, j);
 
   __ add(temp, xbcp, j);
   __ load_unsigned_byte(t0, Address(temp, 0));
@@ -2073,7 +2087,7 @@ void TemplateTable::fast_binaryswitch() {
   __ bind(default_case);
   __ profile_switch_default(i);
   __ lwu(j, Address(array, -2 * BytesPerInt));
-  __ revb_w(j, j);
+  __ revbw(j, j);
 
   __ add(temp, xbcp, j);
   __ load_unsigned_byte(t0, Address(temp, 0));


### PR DESCRIPTION
Hi, please consider this cleanup change.

This is a further step after https://bugs.openjdk.org/browse/JDK-8345110.
`revb_h_h_u` and `revb_h_w_u` assembler routines are mainly used to change byte-ordering for one halfword and two halfwords respectively. But the names don't look obvious and the callsites will emit more instructions when Zbb is not available (6 and 14 instructions respectively).

Since we don't have instructions like aarch64 `rev32` or `rev16`, seems more reasonable for us to do the byte-ordering while loading the bytes for these callsites, which also results in less instructions. Similar approach is taken for other places in riscv [1] and other ports like arm [2]. This also renames `revb_w` into `revbw` so that we are more consistent in naming with integer instructions that manipulate 32-bit values like `addiw`.

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/riscv/templateTable_riscv.cpp#L1625
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/cpu/arm/templateTable_arm.cpp#L756

Testing on linux-riscv64 platform.
- [x] tier1 (release)
- [x] non-trivial benchmark workloads like Dacapo, SpecJBB, Renaissance (release)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345236](https://bugs.openjdk.org/browse/JDK-8345236): RISC-V: Remove revb_h_h_u and revb_h_w_u macro assembler routines (**Enhancement** - P4)


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [Feilong Jiang](https://openjdk.org/census#fjiang) (@feilongjiang - Committer)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22452/head:pull/22452` \
`$ git checkout pull/22452`

Update a local copy of the PR: \
`$ git checkout pull/22452` \
`$ git pull https://git.openjdk.org/jdk.git pull/22452/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22452`

View PR using the GUI difftool: \
`$ git pr show -t 22452`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22452.diff">https://git.openjdk.org/jdk/pull/22452.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22452#issuecomment-2507302177)
</details>
