### PR TITLE
8345237: 32-bit Zero builds fail with assert(has_klass_gap()) failed: precondition

### DIFF
--- a/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
+++ b/src/hotspot/share/interpreter/zero/bytecodeInterpreter.cpp
@@ -2013,7 +2013,9 @@ run:
                 oopDesc::release_set_mark(result, ik->prototype_header());
               } else {
                 oopDesc::set_mark(result, markWord::prototype());
-                oopDesc::set_klass_gap(result, 0);
+                if (oopDesc::has_klass_gap()) {
+                  oopDesc::set_klass_gap(result, 0);
+                }
                 oopDesc::release_set_klass(result, ik);
               }
               oop obj = cast_to_oop(result);


### PR DESCRIPTION
[JDK-8305895](https://bugs.openjdk.org/browse/JDK-8305895) started to wrap `oopDesc::set_klass_gap()` calls with `oopDesc::has_klass_gap()`, but missed a spot in Zero. So now 32-bit Zero builds fail like this:

```
=== Output from failing command(s) repeated here ===
* For target buildtools_create_symbols_javac__the.COMPILE_CREATE_SYMBOLS_batch:
#
# A fatal error has been detected by the Java Runtime Environment:
#
# Internal Error (/home/shade/trunks/jdk/src/hotspot/share/oops/oop.inline.hpp:167), pid=1592865, tid=1592897
# assert(has_klass_gap()) failed: precondition
```

Additional testing:
 - [x] Linux x86_32 zero fastdebug build now passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345237](https://bugs.openjdk.org/browse/JDK-8345237): 32-bit Zero builds fail with assert(has_klass_gap()) failed: precondition (**Bug** - P4)


### Reviewers
 * [Hamlin Li](https://openjdk.org/census#mli) (@Hamlin-Li - **Reviewer**)
 * [Julian Waters](https://openjdk.org/census#jwaters) (@TheShermanTanker - Committer)
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22453/head:pull/22453` \
`$ git checkout pull/22453`

Update a local copy of the PR: \
`$ git checkout pull/22453` \
`$ git pull https://git.openjdk.org/jdk.git pull/22453/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22453`

View PR using the GUI difftool: \
`$ git pr show -t 22453`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22453.diff">https://git.openjdk.org/jdk/pull/22453.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22453#issuecomment-2507296594)
</details>
