### PR TITLE
8235786: Javadoc for com/sun/net/httpserver/HttpExchange.java#setAttribute is unclear

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -233,9 +233,8 @@ public abstract class HttpExchange implements AutoCloseable, Request {
     public abstract String getProtocol();
 
     /**
-     * {@return the attribute's value from this exchange's
-     * {@linkplain HttpContext#getAttributes() context attributes}, or {@code null} if either
-     * the attribute isn't set or the attribute value is {@code null}}
+     * Returns the attribute's value from this exchange's
+     * {@linkplain HttpContext#getAttributes() context attributes}.
      *
      * @apiNote {@link Filter} modules may store arbitrary objects as attributes through
      * {@code HttpExchange} instances as an out-of-band communication mechanism. Other filters
@@ -245,6 +244,8 @@ public abstract class HttpExchange implements AutoCloseable, Request {
      * available.
      *
      * @param name the name of the attribute to retrieve
+     * @return the attribute's value or {@code null} if either the attribute isn't set
+     *         or the attribute value is {@code null}
      * @throws NullPointerException if name is {@code null}
      */
     public abstract Object getAttribute(String name);

--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/HttpExchange.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -233,22 +233,28 @@ public abstract class HttpExchange implements AutoCloseable, Request {
     public abstract String getProtocol();
 
     /**
-     * {@link Filter} modules may store arbitrary objects with {@code HttpExchange}
-     * instances as an out-of-band communication mechanism. Other filters
+     * {@return the attribute's value from this exchange's
+     * {@linkplain HttpContext#getAttributes() context attributes}, or {@code null} if either
+     * the attribute isn't set or the attribute value is {@code null}}
+     *
+     * @apiNote {@link Filter} modules may store arbitrary objects as attributes through
+     * {@code HttpExchange} instances as an out-of-band communication mechanism. Other filters
      * or the exchange handler may then access these objects.
      *
      * <p> Each {@code Filter} class will document the attributes which they make
      * available.
      *
      * @param name the name of the attribute to retrieve
-     * @return the attribute object, or {@code null} if it does not exist
      * @throws NullPointerException if name is {@code null}
      */
     public abstract Object getAttribute(String name);
 
     /**
-     * {@link Filter} modules may store arbitrary objects with {@code HttpExchange}
-     * instances as an out-of-band communication mechanism. Other filters
+     * Sets an attribute with the given {@code name} and {@code value} in this exchange's
+     * {@linkplain HttpContext#getAttributes() context attributes}.
+     *
+     * @apiNote {@link Filter} modules may store arbitrary objects as attributes through
+     * {@code HttpExchange} instances as an out-of-band communication mechanism. Other filters
      * or the exchange handler may then access these objects.
      *
      * <p> Each {@code Filter} class will document the attributes which they make

--- a/test/jdk/com/sun/net/httpserver/ExchangeAttributeTest.java
+++ b/test/jdk/com/sun/net/httpserver/ExchangeAttributeTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2023, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,16 +23,19 @@
 
 /*
  * @test
- * @bug 8288109
+ * @bug 8288109 8235786
  * @summary Tests for HttpExchange set/getAttribute
  * @library /test/lib
  * @run junit/othervm ExchangeAttributeTest
  */
 
+import com.sun.net.httpserver.Filter;
+import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import jdk.test.lib.net.URIBuilder;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -53,44 +56,87 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class ExchangeAttributeTest {
 
-    static final InetAddress LOOPBACK_ADDR = InetAddress.getLoopbackAddress();
-    static final boolean ENABLE_LOGGING = true;
-    static final Logger logger = Logger.getLogger("com.sun.net.httpserver");
+    private static final InetAddress LOOPBACK_ADDR = InetAddress.getLoopbackAddress();
+    private static final boolean ENABLE_LOGGING = true;
+    private static final Logger logger = Logger.getLogger("com.sun.net.httpserver");
+
+    private static HttpServer server;
 
     @BeforeAll
-    public static void setup() {
+    public static void setup() throws Exception {
         if (ENABLE_LOGGING) {
             ConsoleHandler ch = new ConsoleHandler();
             logger.setLevel(Level.ALL);
             ch.setLevel(Level.ALL);
             logger.addHandler(ch);
         }
+        server = HttpServer.create(new InetSocketAddress(LOOPBACK_ADDR, 0), 10);
+        server.createContext("/normal", new AttribHandler());
+        final HttpContext filteredCtx = server.createContext("/filtered", new AttribHandler());
+        filteredCtx.getFilters().add(new AttributeAddingFilter());
+        server.start();
+        System.out.println("Server started at " + server.getAddress());
     }
 
+    @AfterAll
+    public static void afterAll() {
+        if (server != null) {
+            System.out.println("Stopping server " + server.getAddress());
+            server.stop(0);
+        }
+    }
+
+    /*
+     * Verifies that HttpExchange.setAttribute() allows for null value.
+     */
     @Test
-    public void testExchangeAttributes() throws Exception {
-        var handler = new AttribHandler();
-        var server = HttpServer.create(new InetSocketAddress(LOOPBACK_ADDR,0), 10);
-        server.createContext("/", handler);
-        server.start();
-        try {
-            var client = HttpClient.newBuilder().proxy(NO_PROXY).build();
-            var request = HttpRequest.newBuilder(uri(server, "")).build();
+    public void testNullAttributeValue() throws Exception {
+        try (var client = HttpClient.newBuilder().proxy(NO_PROXY).build()) {
+            var request = HttpRequest.newBuilder(uri(server, "/normal", null)).build();
             var response = client.send(request, HttpResponse.BodyHandlers.ofString());
             assertEquals(200, response.statusCode());
-        } finally {
-            server.stop(0);
+        }
+    }
+
+    /*
+     * Verifies that an attribute set on one exchange is accessible to another exchange that
+     * belongs to the same HttpContext.
+     */
+    @Test
+    public void testSharedAttribute() throws Exception {
+        try (var client = HttpClient.newBuilder().proxy(NO_PROXY).build()) {
+            final var firstReq = HttpRequest.newBuilder(uri(server, "/filtered", "firstreq"))
+                    .build();
+            System.out.println("issuing request " + firstReq);
+            final var firstResp = client.send(firstReq, HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, firstResp.statusCode());
+
+            // issue the second request
+            final var secondReq = HttpRequest.newBuilder(uri(server, "/filtered", "secondreq"))
+                    .build();
+            System.out.println("issuing request " + secondReq);
+            final var secondResp = client.send(secondReq, HttpResponse.BodyHandlers.ofString());
+            assertEquals(200, secondResp.statusCode());
+
+            // verify that the filter was invoked for both the requests. the filter internally
+            // does the setAttribute() and getAttribute() and asserts that the attribute value
+            // set by the first exchange was available through the second exchange.
+            assertTrue(AttributeAddingFilter.filteredFirstReq, "Filter wasn't invoked for "
+                    + firstReq.uri());
+            assertTrue(AttributeAddingFilter.filteredSecondReq, "Filter wasn't invoked for "
+                    + secondReq.uri());
         }
     }
 
     // --- infra ---
 
-    static URI uri(HttpServer server, String path) throws URISyntaxException {
+    static URI uri(HttpServer server, String path, String query) throws URISyntaxException {
         return URIBuilder.newBuilder()
                 .scheme("http")
                 .loopback()
                 .port(server.getAddress().getPort())
                 .path(path)
+                .query(query)
                 .build();
     }
 
@@ -110,6 +156,56 @@ public class ExchangeAttributeTest {
                 t.printStackTrace();
                 exchange.sendResponseHeaders(500, -1);
             }
+        }
+    }
+
+    private static final class AttributeAddingFilter extends Filter {
+
+        private static final String ATTR_NAME ="foo-bar";
+        private static final String ATTR_VAL ="hello-world";
+        private static volatile boolean filteredFirstReq;
+        private static volatile boolean filteredSecondReq;
+
+        @Override
+        public void doFilter(final HttpExchange exchange, final Chain chain) throws IOException {
+            if (exchange.getRequestURI().getQuery().contains("firstreq")) {
+                filteredFirstReq = true;
+                // add a request attribute through the exchange, for this first request
+                // and at the same time verify that the attribute doesn't already exist
+                final Object attrVal = exchange.getAttribute(ATTR_NAME);
+                if (attrVal != null) {
+                    throw new IOException("attribute " + ATTR_NAME + " with value: " + attrVal
+                            + " unexpectedly present in exchange: " + exchange.getRequestURI());
+                }
+                // set the value
+                exchange.setAttribute(ATTR_NAME, ATTR_VAL);
+                System.out.println(exchange.getRequestURI() + " set attribute "
+                        + ATTR_NAME + "=" + ATTR_VAL);
+            } else if (exchange.getRequestURI().getQuery().contains("secondreq")) {
+                filteredSecondReq = true;
+                // verify the attribute is already set and the value is the expected one.
+                final Object attrVal = exchange.getAttribute(ATTR_NAME);
+                if (attrVal == null) {
+                    throw new IOException("attribute " + ATTR_NAME + " is missing in exchange: "
+                            + exchange.getRequestURI());
+                }
+                if (!ATTR_VAL.equals(attrVal)) {
+                    throw new IOException("unexpected value: " + attrVal + " for attribute "
+                            + ATTR_NAME + " in exchange: " + exchange.getRequestURI());
+                }
+                System.out.println(exchange.getRequestURI() + " found attribute "
+                        + ATTR_NAME + "=" + attrVal);
+            } else {
+                // unexpected request
+                throw new IOException("unexpected request " + exchange.getRequestURI());
+            }
+            // let the request proceed
+            chain.doFilter(exchange);
+        }
+
+        @Override
+        public String description() {
+            return "AttributeAddingFilter";
         }
     }
 }


### PR DESCRIPTION
Can I please get a review of this doc-only change which proposes to clarify the behaviour of `com.sun.net.httpserver.HttpExchange.setAttribute()` and `com.sun.net.httpserver.HttpExchange.getAttribute()` methods?

As noted in https://bugs.openjdk.org/browse/JDK-8235786, it's not clear from the javadoc of these methods that the attributes that are set or retrieved through the exchange are actually those that belong to the entire `com.sun.net.httpserver.HttpContext` and thus are shared by all exchanges.

The commit in this PR specifies this behaviour to match the current implementation. I'll file a CSR once we settle on the text.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8345243](https://bugs.openjdk.org/browse/JDK-8345243) to be approved

### Issues
 * [JDK-8235786](https://bugs.openjdk.org/browse/JDK-8235786): Javadoc for com/sun/net/httpserver/HttpExchange.java#setAttribute is unclear (**Bug** - P4)
 * [JDK-8345243](https://bugs.openjdk.org/browse/JDK-8345243): Javadoc for com/sun/net/httpserver/HttpExchange.java#setAttribute is unclear (**CSR**)


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22454/head:pull/22454` \
`$ git checkout pull/22454`

Update a local copy of the PR: \
`$ git checkout pull/22454` \
`$ git pull https://git.openjdk.org/jdk.git pull/22454/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22454`

View PR using the GUI difftool: \
`$ git pr show -t 22454`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22454.diff">https://git.openjdk.org/jdk/pull/22454.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22454#issuecomment-2507393293)
</details>
