### PR TITLE
8345173: BlockLocationPrinter::print_location misses a ResourceMark

### DIFF
--- a/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
+++ b/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
@@ -51,6 +51,7 @@ oop BlockLocationPrinter<CollectedHeapT>::base_oop_or_null(void* addr) {
 
 template <typename CollectedHeapT>
 bool BlockLocationPrinter<CollectedHeapT>::print_location(outputStream* st, void* addr) {
+  ResourceMark rm;
   // Check if addr points into Java heap.
   bool in_heap = CollectedHeapT::heap()->is_in(addr);
   if (in_heap) {

--- a/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
+++ b/src/hotspot/share/gc/shared/locationPrinter.inline.hpp
@@ -27,6 +27,7 @@
 
 #include "gc/shared/locationPrinter.hpp"
 
+#include "memory/resourceArea.inline.hpp"
 #include "oops/compressedOops.inline.hpp"
 #include "oops/oopsHierarchy.hpp"
 


### PR DESCRIPTION
Hi all,

  please review this small change that adds a missing `ResourceMark` to `BlockLocationPrinter`; it can be called at very arbitrary places (e.g. the stop() method of MacroAssembler), and without this change it might fail with a "Missing ResourceMark error - possible memory leak" error instead of providing the stop() output (and then faiiling).

Testing: local testing, after the change the ResourceMark crash goes away, gha

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345173](https://bugs.openjdk.org/browse/JDK-8345173): BlockLocationPrinter::print_location misses a ResourceMark (**Bug** - P5)


### Reviewers
 * [Stefan Johansson](https://openjdk.org/census#sjohanss) (@kstefanj - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22455/head:pull/22455` \
`$ git checkout pull/22455`

Update a local copy of the PR: \
`$ git checkout pull/22455` \
`$ git pull https://git.openjdk.org/jdk.git pull/22455/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22455`

View PR using the GUI difftool: \
`$ git pr show -t 22455`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22455.diff">https://git.openjdk.org/jdk/pull/22455.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22455#issuecomment-2507433885)
</details>
