### PR TITLE
8345247: Deproblemlist test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java

### DIFF
--- a/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
+++ b/test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2024, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -51,9 +51,8 @@ public class bug8075609 {
             SwingUtilities.invokeAndWait(bug8075609::createAndShowGUI);
 
             robot = new Robot();
-            Thread.sleep(100);
             robot.waitForIdle();
-
+            robot.delay(1000);
             robot.setAutoDelay(100);
 
             // Radio button group tab key test


### PR DESCRIPTION
test/jdk/javax/swing/JRadioButton/8075609/bug8075609.java is not failing in OCI but still listed in PL.
Removing as it is passing in OCI ubuntu22.04 system..Tested for 50 iterations in OCI..