### PR TITLE
8345248: Module name 'transitive' not accepted for `requires transitive`

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/parser/JavacParser.java
@@ -4208,15 +4208,15 @@ public class JavacParser implements Parser {
                 while (true) {
                     switch (token.kind) {
                         case IDENTIFIER:
-                            if (token.name() == names.transitive && !isTransitive) {
+                            if (token.name() == names.transitive) {
                                 Token t1 = S.token(1);
                                 if (t1.kind == SEMI || t1.kind == DOT) {
                                     break loop;
                                 }
+                                if (isTransitive) {
+                                    log.error(DiagnosticFlag.SYNTAX, token.pos, Errors.RepeatedModifier);
+                                }
                                 isTransitive = true;
-                                break;
-                            } else if (token.name() == names.transitive && isTransitive) {
-                                log.error(DiagnosticFlag.SYNTAX, token.pos, Errors.RepeatedModifier);
                                 break;
                             } else {
                                 break loop;

--- a/test/langtools/tools/javac/modules/RequiresTransitiveTest.java
+++ b/test/langtools/tools/javac/modules/RequiresTransitiveTest.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8345248
  * @summary tests for "requires transitive"
  * @library /tools/lib
  * @modules
@@ -34,6 +35,8 @@
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Objects;
 
 import toolbox.JavacTask;
 import toolbox.Task;
@@ -254,6 +257,106 @@ public class RequiresTransitiveTest extends ModuleTestBase {
         for (String e: expect) {
             if (!log.contains(e))
                 throw new Exception("expected output not found: " + e);
+        }
+    }
+
+    @Test //JDK-8345248:
+    public void testTransitiveModuleName(Path base) throws Exception {
+        Path lib = base.resolve("lib");
+        Path libSrc = lib.resolve("src");
+        Path transitive = libSrc.resolve("transitive");
+        tb.writeJavaFiles(transitive,
+                """
+                module transitive {
+                }
+                """
+        );
+        Path transitiveA = libSrc.resolve("transitive.a");
+        tb.writeJavaFiles(transitiveA,
+                """
+                module transitive.a {
+                }
+                """
+        );
+
+        Path libClasses = lib.resolve("classes");
+        Files.createDirectories(libClasses);
+
+        new JavacTask(tb, Task.Mode.CMDLINE)
+                .options("--module-source-path", libSrc.toString())
+                .files(findJavaFiles(libSrc))
+                .outdir(libClasses)
+                .run()
+                .writeAll();
+
+        Path src = base.resolve("src");
+        Path classes = base.resolve("classes");
+
+        Files.createDirectories(classes);
+
+        tb.writeJavaFiles(src,
+                """
+                module m {
+                    requires transitive;
+                    requires transitive.a;
+                }
+                """
+        );
+
+        new JavacTask(tb, Task.Mode.CMDLINE)
+                .options("--module-path", libClasses.toString())
+                .sourcepath(src)
+                .files(findJavaFiles(src))
+                .outdir(classes)
+                .run()
+                .writeAll();
+
+        tb.writeJavaFiles(src,
+                """
+                module m {
+                    requires transitive transitive;
+                    requires transitive transitive.a;
+                }
+                """
+        );
+
+        new JavacTask(tb, Task.Mode.CMDLINE)
+                .options("--module-path", libClasses.toString())
+                .sourcepath(src)
+                .files(findJavaFiles(src))
+                .outdir(classes)
+                .run()
+                .writeAll();
+
+        tb.writeJavaFiles(src,
+                """
+                module m {
+                    requires transitive transitive transitive;
+                    requires transitive transitive transitive.a;
+                }
+                """
+        );
+
+        List<String> log = new JavacTask(tb, Task.Mode.CMDLINE)
+                .options("--module-path", libClasses.toString(),
+                         "-XDrawDiagnostics")
+                .sourcepath(src)
+                .files(findJavaFiles(src))
+                .outdir(classes)
+                .run()
+                .writeAll()
+                .getOutputLines(Task.OutputKind.DIRECT);
+
+
+        List<String> expected = List.of(
+                "module-info.java:2:25: compiler.err.repeated.modifier",
+                "module-info.java:3:25: compiler.err.repeated.modifier",
+                "2 errors"
+        );
+
+        if (!Objects.equals(expected, log)) {
+            throw new Exception("expected: " + expected +
+                                ", but got: " + log);
         }
     }
 }

--- a/test/langtools/tools/javac/modules/RequiresTransitiveTest.java
+++ b/test/langtools/tools/javac/modules/RequiresTransitiveTest.java
@@ -343,7 +343,7 @@ public class RequiresTransitiveTest extends ModuleTestBase {
                 .sourcepath(src)
                 .files(findJavaFiles(src))
                 .outdir(classes)
-                .run()
+                .run(Task.Expect.FAIL)
                 .writeAll()
                 .getOutputLines(Task.OutputKind.DIRECT);
 


### PR DESCRIPTION
Considering module named `transitive`, it should be possible to write: `requires transitive;`, which works, and also `requires transitive transitive;`, which currently does not work:
```
$ javac -d out/ --module-source-path . transitive/module-info.java test/module-info.java
test/module-info.java:2: error: repeated modifier
    requires transitive transitive;
                        ^
test/module-info.java:2: error: <identifier> expected
    requires transitive transitive;
                                  ^
2 errors
```

The proposed solution is to properly handle lookahead if the transitive flag has already been seen.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8345248](https://bugs.openjdk.org/browse/JDK-8345248): Module name 'transitive' not accepted for `requires transitive` (**Bug** - P2)


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22460/head:pull/22460` \
`$ git checkout pull/22460`

Update a local copy of the PR: \
`$ git checkout pull/22460` \
`$ git pull https://git.openjdk.org/jdk.git pull/22460/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22460`

View PR using the GUI difftool: \
`$ git pr show -t 22460`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22460.diff">https://git.openjdk.org/jdk/pull/22460.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22460#issuecomment-2507914360)
</details>
