### PR TITLE
7038838: Unspecified NPE in java.net.IDN methods

### DIFF
--- a/src/java.base/share/classes/java/net/IDN.java
+++ b/src/java.base/share/classes/java/net/IDN.java
@@ -66,6 +66,9 @@ import jdk.internal.icu.text.UCharacterIterator;
  * Applications are responsible for taking adequate security measures when using
  * international domain names.
  *
+ * <p>Unless otherwise specified, passing a {@code null} argument to any method
+ * in this class will cause a {@link NullPointerException} to be thrown.
+ *
  * @spec https://www.rfc-editor.org/info/rfc1122
  *      RFC 1122: Requirements for Internet Hosts - Communication Layers
  * @spec https://www.rfc-editor.org/info/rfc1123

--- a/test/jdk/java/net/IDNTest.java
+++ b/test/jdk/java/net/IDNTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2024, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.net.IDN;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+/*
+ * @test
+ * @bug 7038838
+ * @summary verify the behaviour of the methods on java.net.IDN class
+ * @run junit IDNTest
+ */
+public class IDNTest {
+
+    /*
+     * Verify that various methods on the IDN class throw a NullPointerException
+     * for any null parameter.
+     */
+    @Test
+    public void testNullPointerException() throws Exception {
+        assertThrows(NullPointerException.class, () -> IDN.toASCII(null));
+        assertThrows(NullPointerException.class, () -> IDN.toASCII(null, 0));
+        assertThrows(NullPointerException.class, () -> IDN.toUnicode(null));
+        assertThrows(NullPointerException.class, () -> IDN.toUnicode(null, 0));
+    }
+}


### PR DESCRIPTION
Can I please get a review of this doc-only changes which specifies the methods on `java.net.IDN` to throw `NullPointerException` when any argument is null?

This addresses https://bugs.openjdk.org/browse/JDK-7038838. As noted in that issue, the current implementation of these methods already throw a NullPointerException for any null argument. This change now updates the specification to match the current implementation. 

A new jtreg test has been added to verify this behaviour. Note that there already was a `test/jdk/java/net/Socket/IDNTest.java` test but looking what that test does, the history of that test and the location of that test in `java/net/Socket` directory made me believe that it's not meant for testing the `java.net.IDN` class. That's why I created this new test class in `test/jdk/java/net/` directory.

I'll draft a CSR for this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8345260](https://bugs.openjdk.org/browse/JDK-8345260) to be approved

### Issues
 * [JDK-7038838](https://bugs.openjdk.org/browse/JDK-7038838): Unspecified NPE in java.net.IDN methods (**Bug** - P4)
 * [JDK-8345260](https://bugs.openjdk.org/browse/JDK-8345260): Unspecified NPE in java.net.IDN methods (**CSR**)


### Reviewers
 * [Chen Liang](https://openjdk.org/census#liach) (@liach - **Reviewer**)
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk.git pull/22463/head:pull/22463` \
`$ git checkout pull/22463`

Update a local copy of the PR: \
`$ git checkout pull/22463` \
`$ git pull https://git.openjdk.org/jdk.git pull/22463/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22463`

View PR using the GUI difftool: \
`$ git pr show -t 22463`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk/pull/22463.diff">https://git.openjdk.org/jdk/pull/22463.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jdk/pull/22463#issuecomment-2508109417)
</details>
